### PR TITLE
 Avoid re-validating the same attribute name multiple times 

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1216,23 +1216,24 @@ impl ElementMethods for Element {
 
     // https://dom.spec.whatwg.org/#dom-element-setattribute
     fn SetAttribute(&self, name: DOMString, value: DOMString) -> ErrorResult {
-        // Step 1.
-        if xml_name_type(&name) == InvalidXMLName {
-            return Err(Error::InvalidCharacter);
-        }
-
-
         // Step 2.
         let name = self.parsed_name_dont_atomize(name);
 
-        // Interning strings is expensive, so first check if we already have an
-        // attribute with the given name.
+        // Interning strings is expensive, as is validating that the attribute
+        // name is valid, so first check if we already have an attribute with
+        // the given name. If we do, then it has already been interned and
+        // validated by someone else.
         let attr = self.get_first_matching_attribute(|attr| attr.name().as_slice() == &*name);
         if let Some(attr) = attr {
             // Step 3-5.
             let value = self.parse_attribute(&ns!(""), attr.name(), value);
             attr.set_value(value, self);
             return Ok(());
+        }
+
+        // Step 1.
+        if xml_name_type(&name) == InvalidXMLName {
+            return Err(Error::InvalidCharacter);
         }
 
         // Step 3-5.

--- a/tests/wpt/web-platform-tests/dom/nodes/attributes.html
+++ b/tests/wpt/web-platform-tests/dom/nodes/attributes.html
@@ -459,4 +459,17 @@ test(function() {
   var el2 = document.createElement("div");
   assert_throws("INUSE_ATTRIBUTE_ERR", function(){el2.setAttributeNode(attrNode)});
 }, "setAttributeNode on bound attribute should throw InUseAttributeError")
+
+test(function() {
+  var e = document.body;
+
+  e.setAttributeNS(null, "FOO", "bar");
+  assert_equals(e.getAttributeNS(null, "FOO"), "bar");
+  assert_equals(e.getAttributeNS(null, "foo"), null);
+
+  e.setAttribute("FOO", "quux");
+  assert_equals(e.getAttributeNS(null, "FOO"), "bar");
+  assert_equals(e.getAttributeNS(null, "foo"), "quux");
+}, "setAttribute and setAttributeNS have different capitalization behavior")
+
 </script>


### PR DESCRIPTION
If the name given to setAttribute names an attribute that already exists, then
it must have already been validated as a valid attribute name. In this case, we
can skip validation, which shows up fairly heavily on profiles.

Dromaeo DOM attributes is largely unchanged: From 2721.35 runs/s to 2727.40 runs/s.

`setAttribute` in a loop (micro benchmark from #8645) gets a little bump: From 4540 ms to 4400 ms.

Depends on #8645.

Not 100% clear this is a valid optimization, see https://github.com/servo/servo/issues/6906#issuecomment-159388883.

Given that, and the relatively lackluster speedups, this may not be worth merging.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8668)

<!-- Reviewable:end -->
