### PR TITLE
Write animated values into the `ComputedValues` structures when animations complete or are interrupted.

### DIFF
--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::collections::hash_state::DefaultState;
 use std::rc::Rc;
 use std::sync::mpsc::{Sender, channel};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use style::selector_matching::Stylist;
 use url::Url;
 use util::mem::HeapSizeOf;
@@ -120,7 +120,10 @@ pub struct SharedLayoutContext {
     pub visible_rects: Arc<HashMap<LayerId, Rect<Au>, DefaultState<FnvHasher>>>,
 
     /// The animations that are currently running.
-    pub running_animations: Arc<HashMap<OpaqueNode, Vec<Animation>>>,
+    pub running_animations: Arc<RwLock<HashMap<OpaqueNode, Vec<Animation>>>>,
+
+    /// The list of animations that have expired since the last style recalculation.
+    pub expired_animations: Arc<RwLock<HashMap<OpaqueNode, Vec<Animation>>>>,
 
     /// Why is this reflow occurring
     pub goal: ReflowGoal,

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -5,6 +5,7 @@
 #![feature(box_syntax)]
 #![feature(cell_extras)]
 #![feature(custom_derive)]
+#![feature(drain)]
 #![feature(hashmap_hasher)]
 #![feature(mpsc_select)]
 #![feature(plugin)]


### PR DESCRIPTION
This adds a new pair of reader-writer locks. I measured the performance
of style recalculation on Wikipedia and the overhead of the locks was
not measurable.

Closes #7816.

cc @paulrouget 

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8670)

<!-- Reviewable:end -->
