### PR TITLE
Remove `#[allow(raw_pointer_derive)]` attributes

### DIFF
--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -62,7 +62,6 @@ pub struct CallbackInterface {
 
 /// A common base class for representing IDL callback function and
 /// callback interface types.
-#[allow(raw_pointer_derive)]
 #[derive(JSTraceable)]
 struct CallbackObject {
     /// The underlying `JSObject`.

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -20,7 +20,7 @@ pub fn reflect_dom_object<T: Reflectable>(obj: Box<T>,
 }
 
 /// A struct to store a reference to the reflector of a DOM object.
-#[allow(raw_pointer_derive, unrooted_must_root)]
+#[allow(unrooted_must_root)]
 #[must_root]
 #[servo_lang = "reflector"]
 #[derive(HeapSizeOf)]

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -53,7 +53,6 @@ use util::mem::HeapSizeOf;
 use util::str::jsstring_to_str;
 
 /// Proxy handler for a WindowProxy.
-#[allow(raw_pointer_derive)]
 pub struct WindowProxyHandler(pub *const libc::c_void);
 
 impl HeapSizeOf for WindowProxyHandler {
@@ -63,7 +62,6 @@ impl HeapSizeOf for WindowProxyHandler {
     }
 }
 
-#[allow(raw_pointer_derive)]
 #[derive(JSTraceable, HeapSizeOf)]
 /// Static data associated with a global object.
 pub struct GlobalStaticData {
@@ -142,7 +140,6 @@ pub struct NativePropertyHooks {
 }
 
 /// The struct that holds inheritance information for DOM object reflectors.
-#[allow(raw_pointer_derive)]
 #[derive(Copy, Clone)]
 pub struct DOMClass {
     /// A list of interfaces that this object implements, in order of decreasing

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -17,7 +17,6 @@ use std::slice;
 use std::vec::Vec;
 
 #[dom_struct]
-#[allow(raw_pointer_derive)]
 pub struct ImageData {
     reflector_: Reflector,
     width: u32,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -179,7 +179,6 @@ pub struct SharedLayoutData {
 }
 
 /// Encapsulates the abstract layout data.
-#[allow(raw_pointer_derive)]
 #[derive(HeapSizeOf)]
 pub struct LayoutData {
     _shared_data: SharedLayoutData,
@@ -2319,7 +2318,6 @@ impl NodeMethods for Node {
 /// The address of a node known to be valid. These are sent from script to layout,
 /// and are also used in the HTML parser interface.
 
-#[allow(raw_pointer_derive)]
 #[derive(Clone, PartialEq, Eq, Copy)]
 pub struct TrustedNodeAddress(pub *const c_void);
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -46,7 +46,6 @@ use util::mem::HeapSizeOf;
 
 /// The address of a node. Layout sends these back. They must be validated via
 /// `from_untrusted_node_address` before they can be used, because we do not trust layout.
-#[allow(raw_pointer_derive)]
 #[derive(Copy, Clone, Debug)]
 pub struct UntrustedNodeAddress(pub *const c_void);
 unsafe impl Send for UntrustedNodeAddress {}

--- a/ports/cef/window.rs
+++ b/ports/cef/window.rs
@@ -46,7 +46,6 @@ use self::x11::xlib::{XInitThreads,XOpenDisplay};
 pub static mut DISPLAY: *mut c_void = 0 as *mut c_void;
 
 /// The type of an off-screen window.
-#[allow(raw_pointer_derive)]
 #[derive(Clone)]
 pub struct Window {
     cef_browser: RefCell<Option<CefBrowser>>,


### PR DESCRIPTION
The attributes are unused.

Fixes #8699.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8701)

<!-- Reviewable:end -->
