### PR TITLE
Use thread::sleep instead of deprecated sleep_ms

### DIFF
--- a/components/compositing/scrolling.rs
+++ b/components/compositing/scrolling.rs
@@ -6,13 +6,15 @@
 
 use compositor_task::{CompositorProxy, Msg};
 use std::sync::mpsc::{Receiver, Sender, channel};
-use std::thread::{Builder, sleep_ms};
+use std::thread::{self, Builder};
+use std::u32;
 use time;
+use util::time::duration_from_nanoseconds;
 
 /// The amount of time in nanoseconds that we give to the painting thread to paint new tiles upon
 /// processing a scroll event that caused new tiles to be revealed. When this expires, we give up
 /// and composite anyway (showing a "checkerboard") to avoid dropping the frame.
-static TIMEOUT: i64 = 12_000_000;
+static TIMEOUT: u64 = 12_000_000;
 
 pub struct ScrollingTimerProxy {
     sender: Sender<ToScrollingTimerMsg>,
@@ -55,9 +57,9 @@ impl ScrollingTimerProxy {
 impl ScrollingTimer {
     pub fn run(&mut self) {
         while let Ok(ToScrollingTimerMsg::ScrollEventProcessedMsg(timestamp)) = self.receiver.recv() {
-            let target = timestamp as i64 + TIMEOUT;
-            let delta_ns = target - (time::precise_time_ns() as i64);
-            sleep_ms((delta_ns / 1000000) as u32);
+            let target = timestamp + TIMEOUT;
+            let delta_ns = target - time::precise_time_ns();
+            thread::sleep(duration_from_nanoseconds(delta_ns));
             self.compositor_proxy.send(Msg::ScrollTimeout(timestamp));
         }
     }

--- a/components/compositing/timer_scheduler.rs
+++ b/components/compositing/timer_scheduler.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use std::sync::atomic::{self, AtomicBool};
 use std::sync::mpsc::{channel, Receiver, Select};
 use std::thread::{self, spawn, Thread};
+use std::time::Duration;
 use util::task::spawn_named;
 
 /// A quick hack to work around the removal of [`std::old_io::timer::Timer`](
@@ -37,7 +38,7 @@ impl CancelableOneshotTimer {
             let mut park_time = duration;
 
             loop {
-                thread::park_timeout_ms(park_time.get() as u32);
+                thread::park_timeout(Duration::from_millis(park_time.get()));
 
                 if canceled_clone.load(atomic::Ordering::Relaxed) {
                     return;

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -16,7 +16,8 @@ use std::cell::RefCell;
 use std::net::TcpStream;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
-use std::thread::sleep_ms;
+use std::thread;
+use std::time::Duration;
 use util::task;
 
 pub struct TimelineActor {
@@ -116,7 +117,7 @@ impl Encodable for HighResolutionStamp {
     }
 }
 
-static DEFAULT_TIMELINE_DATA_PULL_TIMEOUT: u32 = 200; //ms
+static DEFAULT_TIMELINE_DATA_PULL_TIMEOUT: u64 = 200; //ms
 
 impl TimelineActor {
     pub fn new(name: String,
@@ -158,7 +159,7 @@ impl TimelineActor {
                 }
                 emitter.send(markers);
 
-                sleep_ms(DEFAULT_TIMELINE_DATA_PULL_TIMEOUT);
+                thread::sleep(Duration::from_millis(DEFAULT_TIMELINE_DATA_PULL_TIMEOUT));
             }
         });
     }

--- a/components/profile/mem.rs
+++ b/components/profile/mem.rs
@@ -11,8 +11,9 @@ use profile_traits::mem::{ProfilerChan, ProfilerMsg, ReportKind, Reporter, Repor
 use std::borrow::ToOwned;
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::thread::sleep_ms;
+use std::thread;
 use util::task::spawn_named;
+use util::time::duration_from_seconds;
 
 pub struct Profiler {
     /// The port through which messages are received.
@@ -31,11 +32,10 @@ impl Profiler {
 
         // Create the timer thread if a period was provided.
         if let Some(period) = period {
-            let period_ms = (period * 1000.) as u32;
             let chan = chan.clone();
             spawn_named("Memory profiler timer".to_owned(), move || {
                 loop {
-                    sleep_ms(period_ms);
+                    thread::sleep(duration_from_seconds(period));
                     if chan.send(ProfilerMsg::Print).is_err() {
                         break;
                     }

--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -12,10 +12,11 @@ use profile_traits::time::{TimerMetadataReflowType, TimerMetadataFrameType};
 use std::borrow::ToOwned;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use std::f64;
-use std::thread::sleep_ms;
+use std::time::Duration;
+use std::{thread, f64};
 use std_time::precise_time_ns;
 use util::task::spawn_named;
+use util::time::duration_from_seconds;
 
 pub trait Formattable {
     fn format(&self) -> String;
@@ -123,11 +124,10 @@ impl Profiler {
         let (chan, port) = ipc::channel().unwrap();
         match period {
             Some(period) => {
-                let period = (period * 1000.) as u32;
                 let chan = chan.clone();
                 spawn_named("Time profiler timer".to_owned(), move || {
                     loop {
-                        sleep_ms(period);
+                        thread::sleep(duration_from_seconds(period));
                         if chan.send(ProfilerMsg::Print).is_err() {
                             break;
                         }
@@ -173,7 +173,7 @@ impl Profiler {
                 loop {
                     for _ in 0..loop_count {
                         match run_ap_thread() {
-                            true => sleep_ms(SLEEP_MS),
+                            true => thread::sleep(Duration::from_millis(SLEEP_MS as u64)),
                             false => return,
                         }
                     }

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -73,6 +73,7 @@ pub mod task;
 pub mod task_state;
 pub mod taskpool;
 pub mod tid;
+pub mod time;
 pub mod vec;
 pub mod workqueue;
 

--- a/components/util/time.rs
+++ b/components/util/time.rs
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::time::Duration;
+use std::{u32, u64};
+
+pub const NANOS_PER_SEC: u32 = 1_000_000_000;
+
+pub fn duration_from_seconds(secs: f64) -> Duration {
+
+    // Get number of seconds and check that it fits in a u64.
+    let whole_secs = secs.trunc();
+    assert!(whole_secs >= 0.0 && whole_secs <= u64::MAX as f64);
+
+    // Get number of nanoseconds. This should always fit in a u32, but check anyway.
+    let nanos = (secs.fract() * (NANOS_PER_SEC as f64)).trunc();
+    assert!(nanos >= 0.0 && nanos <= u32::MAX as f64);
+
+    Duration::new(whole_secs as u64, nanos as u32)
+}
+
+pub fn duration_from_nanoseconds(nanos: u64) -> Duration {
+    // Get number of seconds.
+    let secs = nanos / NANOS_PER_SEC as u64;
+
+    // Get number of extra nanoseconds. This should always fit in a u32, but check anyway.
+    let subsec_nanos = nanos % NANOS_PER_SEC as u64;
+    assert!(subsec_nanos <= u32::MAX as u64);
+
+    Duration::new(secs, subsec_nanos as u32)
+}

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -38,7 +38,8 @@ use std::borrow::ToOwned;
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::sync::mpsc::Sender;
-use std::thread::{self, sleep_ms};
+use std::thread;
+use std::time::Duration;
 use url::Url;
 use util::prefs::{get_pref, reset_all_prefs, reset_pref, set_pref, PrefValue};
 use util::task::spawn_named;
@@ -228,7 +229,7 @@ impl Handler {
                 return Ok(x)
             };
 
-            sleep_ms(interval);
+            thread::sleep(Duration::from_millis(interval));
         };
 
         Err(WebDriverError::new(ErrorStatus::Timeout,
@@ -319,7 +320,7 @@ impl Handler {
         let timeout = self.load_timeout;
         let timeout_chan = sender;
         thread::spawn(move || {
-            sleep_ms(timeout);
+            thread::sleep(Duration::from_millis(timeout as u64));
             let _ = timeout_chan.send(LoadStatus::LoadTimeout);
         });
 
@@ -653,7 +654,7 @@ impl Handler {
                 break;
             };
 
-            sleep_ms(interval)
+            thread::sleep(Duration::from_millis(interval))
         }
 
         let img = match img {

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -298,7 +298,8 @@ impl Window {
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn handle_next_event(&self) -> bool {
-        use std::thread::sleep_ms;
+        use std::thread;
+        use std::time::Duration;
 
         // TODO(gw): This is an awful hack to work around the
         // broken way we currently call X11 from multiple threads.
@@ -324,7 +325,7 @@ impl Window {
                 self.handle_window_event(event)
             }
             None => {
-                sleep_ms(16);
+                thread::sleep(Duration::from_millis(16));
                 false
             }
         }

--- a/tests/reftest.rs
+++ b/tests/reftest.rs
@@ -25,7 +25,8 @@ use std::io::{self, Read, Result, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::process::{Command};
-use std::thread::sleep_ms;
+use std::thread;
+use std::time::Duration;
 use test::run_tests_console;
 use test::{AutoColor, DynTestName, DynTestFn, TestDesc, TestOpts, TestDescAndFn, ShouldPanic};
 use url::Url;
@@ -124,7 +125,7 @@ fn run(test_opts: TestOpts, all_tests: Vec<TestDescAndFn>,
     };
 
     // Wait for the shell to launch or to fail
-    sleep_ms(1000);
+    thread::sleep(Duration::from_secs(1));
     child.kill().unwrap();
     let output = try!(child.wait_with_output());
 


### PR DESCRIPTION
Similarly, change one instance of `thread::park_timeout_ms`.

Fixes #8694

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8705)

<!-- Reviewable:end -->
