### PR TITLE
use return value of invoking event handlers to cancel the event

### DIFF
--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -30149,7 +30149,16 @@
   },
   "local_changes": {
     "deleted": [],
-    "items": {},
+    "items": {
+      "testharness": {
+        "html/webappapis/scripting/events/event-handler-processing-algorithm.html": [
+          {
+            "path": "html/webappapis/scripting/events/event-handler-processing-algorithm.html",
+            "url": "/html/webappapis/scripting/events/event-handler-processing-algorithm.html"
+          }
+        ]
+      }
+    },
     "reftest_nodes": {}
   },
   "reftest_nodes": {

--- a/tests/wpt/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm.html
+++ b/tests/wpt/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<title>Event handlers processing algorithm</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script
+ <body>
+ <div id="foo" style="width: 100px; height: 100px; background-color: black"></div>
+ <script>
+ async_test(function(t){
+     document.getElementById("foo").onmouseover = t.step_func(function() { return true; });
+     document.getElementById("foo").addEventListener("mouseover", t.step_func(function(ev) { assert_equals(ev.defaultPrevented, true)}), false);
+     document.getElementById("foo").dispatchEvent(new Event('mouseover', {cancelable: true}));
+     t.done();
+ }, "test Mouseover listener returning true cancels event");
+ async_test(function(t){
+     document.getElementById("foo").onmouseover = t.step_func(function() { return false; });
+     document.getElementById("foo").addEventListener("mouseover", t.step_func(function(ev) { assert_equals(ev.defaultPrevented, false) }), false);
+     document.getElementById("foo").dispatchEvent(new Event('mouseover', {cancelable: true}));
+     t.done();
+ }, "test Mouseover listener returning false doesn't cancel event");
+ async_test(function(t){
+     window.onbeforeunload = t.step_func(function() {return null});
+     window.addEventListener("beforeunload", t.step_func(function(ev) { assert_equals(ev.defaultPrevented, true)}));
+     window.dispatchEvent(new Event('beforeunload', {cancelable: true}));
+     t.done();
+ }, "test beforeunload listener returning null cancels event");
+ test(function(t){
+     window.onbeforeunload = t.step_func(function() {return true});
+     window.addEventListener("beforeunload", t.step_func(function(ev) { assert_equals(ev.defaultPrevented, false)}));
+     window.dispatchEvent(new Event('beforeunload', {cancelable: true}));
+     t.done();
+ }, "test beforeunload listener returning non null doesn't cancel event");
+ test(function(t){
+     document.getElementById("foo").onclick = t.step_func(function() { return false; });
+     document.getElementById("foo").addEventListener("click", t.step_func(function(ev) { assert_equals(ev.defaultPrevented, true) }), false);
+     document.getElementById("foo").dispatchEvent(new Event("click", {cancelable: true}));
+     t.done();
+ }, "click listener returning false cancels event");
+ test(function(t){
+     document.getElementById("foo").onblur = t.step_func(function() { return false; });
+     document.getElementById("foo").addEventListener("blur", t.step_func(function(ev) { assert_equals(ev.defaultPrevented, true) }), false);
+     document.getElementById("foo").dispatchEvent(new Event("blur", {cancelable: true}));
+     t.done();
+ }, "blur listener returning false cancels event");
+ test(function(t){
+     document.getElementById("foo").ondblkclick = t.step_func(function() { return false; });
+     document.getElementById("foo").addEventListener("dblclick", t.step_func(function(ev) { assert_equals(ev.defaultPrevented, true) }), false);
+     document.getElementById("foo").dispatchEvent(new Event("dblclick", {cancelable: true}));
+     t.done();
+ }, "dblclick listener returning false cancels event");
+</script>


### PR DESCRIPTION
Fixes #8490.

@jdm having some questions on the beforeunload event: how can i check if return_value is null?
shoud i also check if "If the Event object E is a BeforeUnloadEvent object, and the Event object E's returnValue attribute's value is the empty string, then set the returnValue attribute's value to return value." ?

thanks!

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8707)

<!-- Reviewable:end -->
