### PR TITLE
Add origin-clean flag tracking for canvas

### DIFF
--- a/components/script/dom/canvaspattern.rs
+++ b/components/script/dom/canvaspattern.rs
@@ -18,12 +18,14 @@ pub struct CanvasPattern {
     surface_size: Size2D<i32>,
     repeat_x: bool,
     repeat_y: bool,
+    origin_clean: bool,
 }
 
 impl CanvasPattern {
     fn new_inherited(surface_data: Vec<u8>,
                      surface_size: Size2D<i32>,
-                     repeat: RepetitionStyle)
+                     repeat: RepetitionStyle,
+                     origin_clean: bool)
                      -> CanvasPattern {
         let (x, y) = match repeat {
             RepetitionStyle::Repeat => (true, true),
@@ -38,16 +40,22 @@ impl CanvasPattern {
             surface_size: surface_size,
             repeat_x: x,
             repeat_y: y,
+            origin_clean: origin_clean,
         }
     }
     pub fn new(global: GlobalRef,
                surface_data: Vec<u8>,
                surface_size: Size2D<i32>,
-               repeat: RepetitionStyle)
+               repeat: RepetitionStyle,
+               origin_clean: bool)
                -> Root<CanvasPattern> {
-        reflect_dom_object(box CanvasPattern::new_inherited(surface_data, surface_size, repeat),
+        reflect_dom_object(box CanvasPattern::new_inherited(surface_data, surface_size,
+                                                            repeat, origin_clean),
                            global,
                            CanvasPatternBinding::Wrap)
+    }
+    pub fn origin_is_clean(&self) -> bool {
+      self.origin_clean
     }
 }
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.dataURI.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.dataURI.html.ini
@@ -1,0 +1,5 @@
+[security.dataURI.html]
+  type: testharness
+  [data: URIs do not count as different-origin, and do not taint the canvas]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.drawImage.canvas.sub.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.drawImage.canvas.sub.html.ini
@@ -1,5 +1,0 @@
-[security.drawImage.canvas.sub.html]
-  type: testharness
-  [drawImage of unclean canvas makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.drawImage.image.sub.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.drawImage.image.sub.html.ini
@@ -1,5 +1,0 @@
-[security.drawImage.image.sub.html]
-  type: testharness
-  [drawImage of different-origin image makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.fillStyle.sub.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.fillStyle.sub.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.canvas.fillStyle.sub.html]
-  type: testharness
-  [Setting fillStyle to a pattern of an unclean canvas makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.strokeStyle.sub.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.strokeStyle.sub.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.canvas.strokeStyle.sub.html]
-  type: testharness
-  [Setting strokeStyle to a pattern of an unclean canvas makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.cross.sub.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.cross.sub.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.cross.sub.html]
-  type: testharness
-  [Using an unclean pattern makes the target canvas origin-unclean, not the pattern canvas]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.image.fillStyle.sub.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.image.fillStyle.sub.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.image.fillStyle.sub.html]
-  type: testharness
-  [Setting fillStyle to a pattern of a different-origin image makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.image.strokeStyle.sub.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.image.strokeStyle.sub.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.image.strokeStyle.sub.html]
-  type: testharness
-  [Setting strokeStyle to a pattern of a different-origin image makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.reset.sub.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.reset.sub.html.ini
@@ -1,5 +1,0 @@
-[security.reset.sub.html]
-  type: testharness
-  [Resetting the canvas state does not reset the origin-clean flag]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/toDataURL.jpeg.primarycolours.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/toDataURL.jpeg.primarycolours.html.ini
@@ -1,0 +1,5 @@
+[toDataURL.jpeg.primarycolours.html]
+  type: testharness
+  [toDataURL with JPEG handles simple colours correctly]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/toDataURL.png.complexcolours.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/toDataURL.png.complexcolours.html.ini
@@ -1,0 +1,5 @@
+[toDataURL.png.complexcolours.html]
+  type: testharness
+  [toDataURL with PNG handles non-primary and non-solid colours correctly]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/toDataURL.png.primarycolours.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/toDataURL.png.primarycolours.html.ini
@@ -1,0 +1,5 @@
+[toDataURL.png.primarycolours.html]
+  type: testharness
+  [toDataURL with PNG handles simple colours correctly]
+    expected: FAIL
+


### PR DESCRIPTION
The resulting failures are because we aren't doing origin-comparison correctly (I bet the image ends up with an empty hostname or something). We could probably hack around that if we care, but it should just go away when we get the origin checking right.

r? @jdm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8723)

<!-- Reviewable:end -->
