### PR TITLE
Implement setAttributeNode and setAttributeNodeNS

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -31,6 +31,12 @@ pub struct Attr {
     owner: MutNullableHeap<JS<Element>>,
 }
 
+impl PartialEq for Attr {
+    fn eq(&self, other: &Attr) -> bool {
+        self as *const Attr == &*other
+    }
+}
+
 impl Attr {
     fn new_inherited(local_name: Atom,
                      value: AttrValue,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -850,15 +850,22 @@ impl Element {
 
 
 impl Element {
+    fn push_new_attr(&self, attr: Root<Attr>) {
+        self.will_mutate_attr();
+        let in_empty_ns = *attr.namespace() == ns!();
+        self.attrs.borrow_mut().push(JS::from_rooted(&attr));
+        if in_empty_ns {
+            vtable_for(self.upcast()).attribute_mutated(&attr, AttributeMutation::Set(None));
+        }
+    }
+
     pub fn push_new_attribute(&self,
                               local_name: Atom,
                               value: AttrValue,
                               name: Atom,
                               namespace: Namespace,
                               prefix: Option<Atom>) {
-        self.will_mutate_attr();
         let window = window_from_node(self);
-        let in_empty_ns = namespace == ns!();
         let attr = Attr::new(&window,
                              local_name,
                              value,
@@ -866,10 +873,7 @@ impl Element {
                              namespace,
                              prefix,
                              Some(self));
-        self.attrs.borrow_mut().push(JS::from_rooted(&attr));
-        if in_empty_ns {
-            vtable_for(self.upcast()).attribute_mutated(&attr, AttributeMutation::Set(None));
-        }
+        self.push_new_attr(attr);
     }
 
     pub fn get_attribute(&self, namespace: &Namespace, local_name: &Atom) -> Option<Root<Attr>> {
@@ -941,6 +945,16 @@ impl Element {
                                               *attr.name() == name && *attr.namespace() == ns!()
                                           });
         Ok(())
+    }
+
+    fn get_first_matching_attribute<F>(&self, find: F) -> Option<Root<Attr>>
+        where F: Fn(&Attr) -> bool
+    {
+        self.attrs
+            .borrow()
+            .iter()
+            .find(|attr| find(&attr))
+            .map(|js| Root::from_ref(&**js))
     }
 
     fn set_first_matching_attribute<F>(&self,
@@ -1238,6 +1252,49 @@ impl ElementMethods for Element {
             local_name.clone(), value, qualified_name, namespace.clone(), prefix,
             |attr| *attr.local_name() == local_name && *attr.namespace() == namespace);
         Ok(())
+    }
+
+    // https://dom.spec.whatwg.org/#dom-element-setattributenode
+    fn SetAttributeNode(&self, new_attr: &Attr) -> Fallible<Option<Root<Attr>>> {
+        // Step 1.
+        if let Some(elem) = new_attr.owner() {
+            if *elem != *self {
+                return Err(Error::InUseAttribute);
+            }
+        }
+
+        // Step 2.
+        let old_attr = self.get_first_matching_attribute(
+            |attr| attr.namespace() == new_attr.namespace()
+                && attr.local_name() == new_attr.local_name());
+
+        let old_attr = if let Some(old_attr) = old_attr {
+            debug_assert!(*old_attr.owner().unwrap() == *self);
+
+            // Step 3.
+            if *old_attr == *new_attr {
+                return Ok(Some(old_attr));
+            }
+
+            // Step 4.
+            self.remove_first_matching_attribute(|attr| *attr == *old_attr);
+
+            Some(old_attr)
+        } else {
+            old_attr
+        };
+
+        // Step 5.
+        self.push_new_attr(Root::from_ref(new_attr));
+        new_attr.set_owner(Some(self));
+
+        // Step 6.
+        Ok(old_attr)
+    }
+
+    // https://dom.spec.whatwg.org/#dom-element-setattributenodens
+    fn SetAttributeNodeNS(&self, new_attr: &Attr) -> Fallible<Option<Root<Attr>>> {
+        self.SetAttributeNode(new_attr)
     }
 
     // https://dom.spec.whatwg.org/#dom-element-removeattribute

--- a/components/script/dom/webidls/Element.webidl
+++ b/components/script/dom/webidls/Element.webidl
@@ -45,6 +45,10 @@ interface Element : Node {
   void setAttribute(DOMString name, DOMString value);
   [Throws]
   void setAttributeNS(DOMString? namespace, DOMString name, DOMString value);
+  [Throws]
+  Attr? setAttributeNode(Attr newAttr);
+  [Throws]
+  Attr? setAttributeNodeNS(Attr newAttr);
   void removeAttribute(DOMString name);
   void removeAttributeNS(DOMString? namespace, DOMString localName);
   boolean hasAttribute(DOMString name);

--- a/tests/wpt/metadata/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/dom/interfaces.html.ini
@@ -135,12 +135,6 @@
   [Element interface: operation hasAttributes()]
     expected: FAIL
 
-  [Element interface: operation setAttributeNode(Attr)]
-    expected: FAIL
-
-  [Element interface: operation setAttributeNodeNS(Attr)]
-    expected: FAIL
-
   [Element interface: operation removeAttributeNode(Attr)]
     expected: FAIL
 
@@ -151,18 +145,6 @@
     expected: FAIL
 
   [Element interface: element must inherit property "hasAttributes" with the proper type (7)]
-    expected: FAIL
-
-  [Element interface: element must inherit property "setAttributeNode" with the proper type (19)]
-    expected: FAIL
-
-  [Element interface: calling setAttributeNode(Attr) on element with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Element interface: element must inherit property "setAttributeNodeNS" with the proper type (20)]
-    expected: FAIL
-
-  [Element interface: calling setAttributeNodeNS(Attr) on element with too few arguments must throw TypeError]
     expected: FAIL
 
   [Element interface: element must inherit property "removeAttributeNode" with the proper type (21)]
@@ -233,4 +215,3 @@
 
   [DOMSettableTokenList interface object length]
     expected: FAIL
-

--- a/tests/wpt/metadata/dom/nodes/attributes.html.ini
+++ b/tests/wpt/metadata/dom/nodes/attributes.html.ini
@@ -1,14 +1,4 @@
 [attributes.html]
   type: testharness
-  [Basic functionality of setAttributeNode]
-    expected: FAIL
-
   [Basic functionality of removeAttributeNode]
     expected: FAIL
-
-  [setAttributeNode on bound attribute should throw InUseAttributeError]
-    expected: FAIL
-
-  [Basic functionality of setAttributeNodeNS]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -2049,18 +2049,6 @@
   [Element interface: document.createElement("noscript") must inherit property "hasAttributes" with the proper type (7)]
     expected: FAIL
 
-  [Element interface: document.createElement("noscript") must inherit property "setAttributeNode" with the proper type (19)]
-    expected: FAIL
-
-  [Element interface: calling setAttributeNode(Attr) on document.createElement("noscript") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Element interface: document.createElement("noscript") must inherit property "setAttributeNodeNS" with the proper type (20)]
-    expected: FAIL
-
-  [Element interface: calling setAttributeNodeNS(Attr) on document.createElement("noscript") with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Element interface: document.createElement("noscript") must inherit property "removeAttributeNode" with the proper type (21)]
     expected: FAIL
 
@@ -9401,4 +9389,3 @@
 
   [WorkerLocation interface: attribute origin]
     expected: FAIL
-

--- a/tests/wpt/web-platform-tests/dom/nodes/attributes.html
+++ b/tests/wpt/web-platform-tests/dom/nodes/attributes.html
@@ -423,11 +423,11 @@ test(function() {
   assert_equals(attrNode.ownerElement, el2);
   assert_equals(attrNode.value, "bar");
 
-   var el3 = document.createElement("div");
-   el2.removeAttribute("foo");
-   el3.setAttribute("foo", "baz");
-   el3.setAttributeNode(attrNode);
-   assert_equals(el3.getAttribute("foo"), "bar");
+  var el3 = document.createElement("div");
+  el2.removeAttribute("foo");
+  el3.setAttribute("foo", "baz");
+  el3.setAttributeNode(attrNode);
+  assert_equals(el3.getAttribute("foo"), "bar");
 }, "Basic functionality of setAttributeNode")
 
 test(function() {


### PR DESCRIPTION
This commit implements setAttributeNode and setAttributeNodeNS, as described
here: https://dom.spec.whatwg.org/#dom-element-setattributenode.

See also #8068.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8724)

<!-- Reviewable:end -->
