### PR TITLE
Reset canvas state when changing bitmap dimensions

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -143,10 +143,18 @@ impl CanvasRenderingContext2D {
                            CanvasRenderingContext2DBinding::Wrap)
     }
 
-    pub fn recreate(&self, size: Size2D<i32>) {
+    // https://html.spec.whatwg.org/multipage/#concept-canvas-set-bitmap-dimensions
+    pub fn set_bitmap_dimensions(&self, size: Size2D<i32>) {
+        self.reset_to_initial_state();
         self.ipc_renderer
             .send(CanvasMsg::Common(CanvasCommonMsg::Recreate(size)))
             .unwrap();
+    }
+
+    // https://html.spec.whatwg.org/multipage/#reset-the-rendering-context-to-its-default-state
+    fn reset_to_initial_state(&self) {
+        self.saved_states.borrow_mut().clear();
+        *self.state.borrow_mut() = CanvasContextState::new();
     }
 
     pub fn ipc_renderer(&self) -> IpcSender<CanvasMsg> {

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -81,7 +81,7 @@ impl HTMLCanvasElement {
         let size = self.get_size();
         if let Some(ref context) = *self.context.borrow() {
             match *context {
-                CanvasContext::Context2d(ref context) => context.recreate(size),
+                CanvasContext::Context2d(ref context) => context.set_bitmap_dimensions(size),
                 CanvasContext::WebGL(ref context) => context.recreate(size),
             }
         }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5187,6 +5187,12 @@
             "url": "/_mozilla/mozilla/calc.html"
           }
         ],
+        "mozilla/canvas.initial.reset.2dstate.html": [
+          {
+            "path": "mozilla/canvas.initial.reset.2dstate.html",
+            "url": "/_mozilla/mozilla/canvas.initial.reset.2dstate.html"
+          }
+        ],
         "mozilla/caption.html": [
           {
             "path": "mozilla/caption.html",

--- a/tests/wpt/mozilla/tests/mozilla/canvas.initial.reset.2dstate.html
+++ b/tests/wpt/mozilla/tests/mozilla/canvas.initial.reset.2dstate.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<!-- THIS IS COPIED FROM
+tests/wpt/web-platform-tests/html/semantics/embedded-content/the-canvas-element/initial.reset.2dstate.html - delete when that test passes -->
+<title>Canvas test: initial.reset.2dstate</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/canvas-tests.js"></script>
+<link rel="stylesheet" href="/common/canvas-tests.css">
+<body class="show_output">
+
+<h1>initial.reset.2dstate</h1>
+<p class="desc">Resetting the canvas state resets 2D state variables</p>
+
+
+<p class="output">Actual output:</p>
+<canvas id="c" class="output" width="100" height="50"><p class="fallback">FAIL (fallback content)</p></canvas>
+
+<ul id="d"></ul>
+<script>
+var t = async_test("Resetting the canvas state resets 2D state variables");
+_addTest(function(canvas, ctx) {
+
+canvas.width = 100;
+var default_val;
+
+default_val = ctx.strokeStyle;
+ctx.strokeStyle = "#ff0000";
+canvas.width = 100;
+_assertSame(ctx.strokeStyle, default_val, "ctx.strokeStyle", "default_val");
+
+default_val = ctx.fillStyle;
+ctx.fillStyle = "#ff0000";
+canvas.width = 100;
+_assertSame(ctx.fillStyle, default_val, "ctx.fillStyle", "default_val");
+
+default_val = ctx.globalAlpha;
+ctx.globalAlpha = 0.5;
+canvas.width = 100;
+_assertSame(ctx.globalAlpha, default_val, "ctx.globalAlpha", "default_val");
+
+default_val = ctx.lineWidth;
+ctx.lineWidth = 0.5;
+canvas.width = 100;
+_assertSame(ctx.lineWidth, default_val, "ctx.lineWidth", "default_val");
+
+default_val = ctx.lineCap;
+ctx.lineCap = "round";
+canvas.width = 100;
+_assertSame(ctx.lineCap, default_val, "ctx.lineCap", "default_val");
+
+default_val = ctx.lineJoin;
+ctx.lineJoin = "round";
+canvas.width = 100;
+_assertSame(ctx.lineJoin, default_val, "ctx.lineJoin", "default_val");
+
+default_val = ctx.miterLimit;
+ctx.miterLimit = 0.5;
+canvas.width = 100;
+_assertSame(ctx.miterLimit, default_val, "ctx.miterLimit", "default_val");
+
+default_val = ctx.shadowOffsetX;
+ctx.shadowOffsetX = 5;
+canvas.width = 100;
+_assertSame(ctx.shadowOffsetX, default_val, "ctx.shadowOffsetX", "default_val");
+
+default_val = ctx.shadowOffsetY;
+ctx.shadowOffsetY = 5;
+canvas.width = 100;
+_assertSame(ctx.shadowOffsetY, default_val, "ctx.shadowOffsetY", "default_val");
+
+default_val = ctx.shadowBlur;
+ctx.shadowBlur = 5;
+canvas.width = 100;
+_assertSame(ctx.shadowBlur, default_val, "ctx.shadowBlur", "default_val");
+
+default_val = ctx.shadowColor;
+ctx.shadowColor = "#ff0000";
+canvas.width = 100;
+_assertSame(ctx.shadowColor, default_val, "ctx.shadowColor", "default_val");
+
+default_val = ctx.globalCompositeOperation;
+ctx.globalCompositeOperation = "copy";
+canvas.width = 100;
+_assertSame(ctx.globalCompositeOperation, default_val, "ctx.globalCompositeOperation", "default_val");
+});
+</script>
+


### PR DESCRIPTION
Ran http://mxr.mozilla.org/servo/source/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-canvas-element/initial.reset.2dstate.html?force=1#88 to confirm that this code is being executed, but the test still fails because the font isn't implemented and the expando doesn't get reset.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8728)

<!-- Reviewable:end -->
