### PR TITLE
Make OnErrorEventHandlerNonNull return 'any' instead of 'boolean'.

### DIFF
--- a/components/script/dom/webidls/EventHandler.webidl
+++ b/components/script/dom/webidls/EventHandler.webidl
@@ -16,7 +16,7 @@ callback EventHandlerNonNull = any (Event event);
 typedef EventHandlerNonNull? EventHandler;
 
 [TreatNonObjectAsNull]
-callback OnErrorEventHandlerNonNull = boolean ((Event or DOMString) event, optional DOMString source,
+callback OnErrorEventHandlerNonNull = any ((Event or DOMString) event, optional DOMString source,
                                                optional unsigned long lineno, optional unsigned long column,
                                                optional any error);
 typedef OnErrorEventHandlerNonNull? OnErrorEventHandler;


### PR DESCRIPTION
PR to fix #8710

> I think the specification must have changed since this was first added to Servo: https://html.spec.whatwg.org/multipage/webappapis.html#onerroreventhandler

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8735)

<!-- Reviewable:end -->
