### PR TITLE
M1504: Implement final charset support for text_response method

### DIFF
--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -995,20 +995,9 @@ impl XMLHttpRequest {
         }
     }
 
-    //FIXME: add support for override_mime_type and override_charset
+    //FIXME: add support for XML encoding guess stuff using XML spec
     fn text_response(&self) -> String {
-        let mut encoding = UTF_8 as EncodingRef;
-        match self.response_headers.borrow().get() {
-            Some(&ContentType(mime::Mime(_, _, ref params))) => {
-                for &(ref name, ref value) in params {
-                    if name == &mime::Attr::Charset {
-                        encoding = encoding_from_whatwg_label(&value.to_string()).unwrap_or(encoding);
-                    }
-                }
-            },
-            None => {}
-        }
-
+        let encoding = self.final_charset().unwrap_or(UTF_8);
 
         // According to Simon, decode() should never return an error, so unwrap()ing
         // the result should be fine. XXXManishearth have a closer look at this later
@@ -1101,6 +1090,34 @@ impl XMLHttpRequest {
             }
         }
         Ok(())
+    }
+
+    fn final_charset(&self) -> Option<EncodingRef> {
+        if self.override_charset.borrow().is_some() {
+            self.override_charset.borrow().clone()
+        } else {
+            match self.response_headers.borrow().get() {
+                Some(&ContentType(ref mime)) => {
+                    let value = mime.get_param(mime::Attr::Charset);
+                    value.and_then(|value|{
+                        encoding_from_whatwg_label(value)
+                    })
+                }
+                None => { None }
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn final_mime_type(&self) -> Option<Mime> {
+        if self.override_mime_type.borrow().is_some() {
+            self.override_mime_type.borrow().clone()
+        } else {
+            match self.response_headers.borrow().get() {
+                Some(&ContentType(ref mime)) => { Some(mime.clone()) },
+                None => { None }
+            }
+        }
     }
 }
 

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-headers-received-state-force-shiftjis.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-headers-received-state-force-shiftjis.htm.ini
@@ -1,5 +1,0 @@
-[overridemimetype-headers-received-state-force-shiftjis.htm]
-  type: testharness
-  [XMLHttpRequest: overrideMimeType() in HEADERS RECEIVED state, enforcing Shift-JIS encoding]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-open-state-force-utf-8.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-open-state-force-utf-8.htm.ini
@@ -1,6 +1,0 @@
-[overridemimetype-open-state-force-utf-8.htm]
-  type: testharness
-  expected: TIMEOUT
-  [XMLHttpRequest: overrideMimeType() in open state, enforcing UTF-8 encoding]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/XMLHttpRequest/overridemimetype-unsent-state-force-shiftjis.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/overridemimetype-unsent-state-force-shiftjis.htm.ini
@@ -1,6 +1,0 @@
-[overridemimetype-unsent-state-force-shiftjis.htm]
-  type: testharness
-  expected: TIMEOUT
-  [XMLHttpRequest: overrideMimeType() in unsent state, enforcing Shift-JIS encoding]
-    expected: TIMEOUT
-


### PR DESCRIPTION
Following changes have been made:
- Added final_mime_type and final_charset helper methods to return the appropriate final mime/charset values
- Modified the text_response method to use the final_charset instead of directly using the response charset

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8739)

<!-- Reviewable:end -->
