### PR TITLE
webgl: Fix texturing

### DIFF
--- a/components/canvas/webgl_paint_task.rs
+++ b/components/canvas/webgl_paint_task.rs
@@ -169,6 +169,9 @@ impl WebGLPaintTask {
             CanvasWebGLMsg::DrawingBufferHeight(sender) =>
                 self.send_drawing_buffer_height(sender),
         }
+
+        // FIXME: Convert to `debug_assert!` once tests are run with debug assertions
+        assert!(gl::get_error() == gl::NO_ERROR);
     }
 
     /// Creates a new `WebGLPaintTask` and returns the out-of-process sender and the in-process

--- a/components/canvas/webgl_paint_task.rs
+++ b/components/canvas/webgl_paint_task.rs
@@ -257,7 +257,7 @@ impl WebGLPaintTask {
     }
 
     fn create_texture(&self, chan: IpcSender<Option<NonZero<u32>>>) {
-        let texture = gl::gen_framebuffers(1)[0];
+        let texture = gl::gen_textures(1)[0];
         let texture = if texture == 0 {
             None
         } else {

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -70,7 +70,7 @@ impl WebGLTexture {
             self.target.set(Some(target));
         }
 
-        self.renderer.send(CanvasMsg::WebGL(CanvasWebGLMsg::BindTexture(self.id, target))).unwrap();
+        self.renderer.send(CanvasMsg::WebGL(CanvasWebGLMsg::BindTexture(target, self.id))).unwrap();
 
         Ok(())
     }


### PR DESCRIPTION
These two tiny changes were making WebGL textures not work.

It was not seen in our texturing test since it only used one texture, 
we render to a texture by default, and that texture was bound to
`gl::TEXTURE_2D`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8788)

<!-- Reviewable:end -->
