### PR TITLE
Refactor gle

### DIFF
--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -26,7 +26,6 @@ use url::{self, Url};
 pub struct Opts {
     pub is_running_problem_test: bool,
 
-   
     /// The initial URL to load.
     pub url: Option<Url>,
 
@@ -190,6 +189,7 @@ pub struct Opts {
     /// Do not use native titlebar
     pub no_native_titlebar: bool,
 
+    //This variable is of the type enum Render API defined below, used for selecting graphic options dynamically
     pub graphics_select: RenderApi,
 }
 
@@ -403,17 +403,6 @@ pub enum RenderApi {
 
 const DEFAULT_GRAPHICS: RenderApi = RenderApi::GL;
 
- fn default_graphics_select_string(goption: RenderApi) -> RenderApi {
-      match goption {
-          RenderApi::GL => {
-                RenderApi::GL
-          },
-          RenderApi::ES2 => {
-              RenderApi::ES2
-          }
-      }.to_owned()
-  }
-
 fn default_user_agent_string(agent: UserAgent) -> String {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     const DESKTOP_UA_STRING: &'static str =
@@ -510,7 +499,7 @@ pub fn default_opts() -> Opts {
         convert_mouse_to_touch: false,
         exit_after_load: false,
         no_native_titlebar: false,
-	graphics_select: default_graphics_select_string(DEFAULT_GRAPHICS),
+	    graphics_select: DEFAULT_GRAPHICS,
     }
 }
 
@@ -649,10 +638,12 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     let nonincremental_layout = opt_match.opt_present("i");
 
     let graphics_select = match opt_match.opt_str("G") {
-         Some(ref ga) if ga == "GL" => default_graphics_select_string(RenderApi::GL),
-         Some(ref ga) if ga == "ES2" => default_graphics_select_string(RenderApi::ES2),
+         Some(ref ga) if ga == "GL" => RenderApi::GL,
+         Some(ref ga) if ga == "ES2" => RenderApi::ES2,
+	     Some(ref ga) if ga == "gl" => RenderApi::GL,
+         Some(ref ga) if ga == "es2" => RenderApi::ES2,
          Some(ga) =>  args_fail(&format!("error: graphics option should be GL or ES2:")),
-         None => default_graphics_select_string(RenderApi::GL),
+         None => RenderApi::GL,
      };
 
     let mut bubble_inline_sizes_separately = debug_options.bubble_widths;
@@ -733,7 +724,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         user_agent: user_agent,
         multiprocess: opt_match.opt_present("M"),
         sandbox: opt_match.opt_present("S"),
-	graphics_select: graphics_select,
+		graphics_select: graphics_select,
         show_debug_borders: debug_options.show_compositor_borders,
         show_debug_fragment_borders: debug_options.show_fragment_borders,
         show_debug_parallel_paint: debug_options.show_parallel_paint,

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -26,6 +26,7 @@ use url::{self, Url};
 pub struct Opts {
     pub is_running_problem_test: bool,
 
+   
     /// The initial URL to load.
     pub url: Option<Url>,
 
@@ -189,7 +190,7 @@ pub struct Opts {
     /// Do not use native titlebar
     pub no_native_titlebar: bool,
 
-    pub graphics_select: String,
+    pub graphics_select: RenderApi,
 }
 
 fn print_usage(app: &str, opts: &Options) {
@@ -395,20 +396,20 @@ enum UserAgent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-enum RenderApi {
+pub enum RenderApi {
     GL,
     ES2
 }
 
 const DEFAULT_GRAPHICS: RenderApi = RenderApi::GL;
 
- fn default_graphics_select_string(goption: RenderApi) -> String {
+ fn default_graphics_select_string(goption: RenderApi) -> RenderApi {
       match goption {
           RenderApi::GL => {
-                "GL"
+                RenderApi::GL
           },
           RenderApi::ES2 => {
-              "ES2"
+              RenderApi::ES2
           }
       }.to_owned()
   }

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -499,7 +499,7 @@ pub fn default_opts() -> Opts {
         convert_mouse_to_touch: false,
         exit_after_load: false,
         no_native_titlebar: false,
-	    graphics_select: DEFAULT_GRAPHICS,
+	graphics_select: DEFAULT_GRAPHICS,
     }
 }
 
@@ -640,7 +640,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     let graphics_select = match opt_match.opt_str("G") {
          Some(ref ga) if ga == "GL" => RenderApi::GL,
          Some(ref ga) if ga == "ES2" => RenderApi::ES2,
-	     Some(ref ga) if ga == "gl" => RenderApi::GL,
+	 Some(ref ga) if ga == "gl" => RenderApi::GL,
          Some(ref ga) if ga == "es2" => RenderApi::ES2,
          Some(ga) =>  args_fail(&format!("error: graphics option should be GL or ES2:")),
          None => RenderApi::GL,
@@ -724,7 +724,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         user_agent: user_agent,
         multiprocess: opt_match.opt_present("M"),
         sandbox: opt_match.opt_present("S"),
-		graphics_select: graphics_select,
+	graphics_select: graphics_select,
         show_debug_borders: debug_options.show_compositor_borders,
         show_debug_fragment_borders: debug_options.show_fragment_borders,
         show_debug_parallel_paint: debug_options.show_parallel_paint,

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -645,7 +645,7 @@ impl WindowMethods for Window {
  			NativeDisplay::new(self.window.platform_display() as *mut xlib::Display)
 		},
 		RenderApi::ES2 => {
- 			NativeDisplay::from_es2(self.window.platform_display() as *mut xlib::Display)
+ 			NativeDisplay::from_es2()
 		}
 	}
 


### PR DESCRIPTION
refactored  opts.rs and windows.rs  to  create command line flag -G  [GL or ES2]    or  --graphics  [GL or ES2],   with error checking on  option. These flags then pass to rust-layers  to  select  GL or ES2 rendering (see servo/rust-layers#219)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8790)

<!-- Reviewable:end -->
