### PR TITLE
Fix broken env_logger documentation link in HACKING_QUICKSTART

### DIFF
--- a/HACKING_QUICKSTART.md
+++ b/HACKING_QUICKSTART.md
@@ -159,7 +159,7 @@ Using `RUST_LOG="debug"` is usually the very first thing you might want to do if
 RUST_LOG="debug" ./mach run -d -- -i -y 1 -t 1  /tmp/a.html 2>&1 | ts -s "%.S: " | tee /tmp/log.txt
 ```
 
-You can filter by crate or module, for example `RUST_LOG="layout::inline=debug" ./mach run …`. This is documented at https://rust-lang.github.io/log/env_logger/.
+You can filter by crate or module, for example `RUST_LOG="layout::inline=debug" ./mach run …`. Check the [env_logger](http://doc.rust-lang.org/log/env_logger/index.html) documentation for more details.
 
 Use `RUST_BACKTRACE=1` to dump the backtrace when Servo panics.
 


### PR DESCRIPTION
Rebase of #8775

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8794)

<!-- Reviewable:end -->
