### PR TITLE
Replaced rect_contains_point with Rect.contains()

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -397,7 +397,7 @@ impl DisplayList {
                     // Clipped out.
                     return;
                 }
-                if !geometry::rect_contains_point(item.bounds(), point) {
+                if !item.bounds().contains(&point) {
                     // Can't possibly hit.
                     return;
                 }
@@ -420,7 +420,7 @@ impl DisplayList {
                                         border.base.bounds.size.height -
                                             (border.border_widths.top +
                                              border.border_widths.bottom)));
-                    if geometry::rect_contains_point(interior_rect, point) {
+                    if interior_rect.contains(&point) {
                         return;
                     }
                 }
@@ -1089,8 +1089,8 @@ impl ClippingRegion {
     /// This is a quick, not a precise, test; it can yield false positives.
     #[inline]
     pub fn might_intersect_point(&self, point: &Point2D<Au>) -> bool {
-        geometry::rect_contains_point(self.main, *point) &&
-            self.complex.iter().all(|complex| geometry::rect_contains_point(complex.rect, *point))
+        self.main.contains(point) &&
+            self.complex.iter().all(|complex| complex.rect.contains(point))
     }
 
     /// Returns true if this clipping region might intersect the given rectangle and false

--- a/components/util/geometry.rs
+++ b/components/util/geometry.rs
@@ -86,16 +86,6 @@ pub static MAX_RECT: Rect<Au> = Rect {
     }
 };
 
-/// Returns true if the rect contains the given point. Points on the top or left sides of the rect
-/// are considered inside the rectangle, while points on the right or bottom sides of the rect are
-/// not considered inside the rectangle.
-pub fn rect_contains_point<T>(rect: Rect<T>, point: Point2D<T>) -> bool
-    where T: PartialOrd + Add<T, Output=T>
-{
-    point.x >= rect.origin.x && point.x < rect.origin.x + rect.size.width &&
-        point.y >= rect.origin.y && point.y < rect.origin.y + rect.size.height
-}
-
 /// A helper function to convert a rect of `f32` pixels to a rect of app units.
 pub fn f32_rect_to_au_rect(rect: Rect<f32>) -> Rect<Au> {
     Rect::new(Point2D::new(Au::from_f32_px(rect.origin.x), Au::from_f32_px(rect.origin.y)),


### PR DESCRIPTION
This is a proposed in servo/servo#8791 clean up.

Fixes #8791.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8797)

<!-- Reviewable:end -->
