### PR TITLE
Treat 'undefined' passed to an optional argument as "missing"

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1172,8 +1172,15 @@ class CGArgumentConverter(CGThing):
                 else:
                     assert not default
                     declType = CGWrapper(declType, pre="Option<", post=">")
+
+                    # Treat `undefined` passed to an optional argument as "missing"
+                    undefined_condition = "args.get({index}).is_undefined()".format(index=index)
+                    template = CGIfElseWrapper(undefined_condition,
+                                               CGGeneric("None"),
+                                               CGGeneric("Some(%s)" % template)).define()
+
                     template = CGIfElseWrapper(condition,
-                                               CGGeneric("Some(%s)" % template),
+                                               CGGeneric(template),
                                                CGGeneric("None")).define()
             else:
                 assert not default

--- a/tests/wpt/metadata/dom/nodes/DOMImplementation-createHTMLDocument.html.ini
+++ b/tests/wpt/metadata/dom/nodes/DOMImplementation-createHTMLDocument.html.ini
@@ -3,9 +3,6 @@
   [createHTMLDocument(): URL parsing]
     expected: FAIL
 
-  [createHTMLDocument test 2: undefined,undefined,""]
-    expected: FAIL
-
   [createHTMLDocument(): characterSet aliases]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/dom/documents/dom-tree-accessors/document.title-07.html.ini
+++ b/tests/wpt/metadata/html/dom/documents/dom-tree-accessors/document.title-07.html.ini
@@ -1,5 +1,0 @@
-[document.title-07.html]
-  type: testharness
-  [createHTMLDocument test 2: undefined,undefined,""]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/Close-undefined.htm.ini
+++ b/tests/wpt/metadata/websockets/Close-undefined.htm.ini
@@ -1,5 +1,0 @@
-[Close-undefined.htm]
-  type: testharness
-  [W3C WebSocket API - Close WebSocket - Code is undefined]
-    expected: FAIL
-

--- a/tests/wpt/metadata/websockets/Secure-Close-undefined.htm.ini
+++ b/tests/wpt/metadata/websockets/Secure-Close-undefined.htm.ini
@@ -1,5 +1,0 @@
-[Secure-Close-undefined.htm]
-  type: testharness
-  [W3C WebSocket API - Close Secure WebSocket - Code is undefined]
-    expected: FAIL
-


### PR DESCRIPTION
Fixes #8813

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8849)

<!-- Reviewable:end -->
