### PR TITLE
Fix redraw of WPT UI output, and slightly improve line counting

### DIFF
--- a/tests/wpt/grouping_formatter.py
+++ b/tests/wpt/grouping_formatter.py
@@ -57,7 +57,7 @@ class GroupingFormatter(base.BaseFormatter):
 
         try:
             self.terminal = blessings.Terminal()
-            return self.terminal.clear_eol, self.terminal.move_up
+            return self.terminal.move_up, self.terminal.clear_eol
         except Exception as exception:
             sys.stderr.write("GroupingFormatter: Could not get terminal "
                              "control characters: %s\n" % exception)

--- a/tests/wpt/grouping_formatter.py
+++ b/tests/wpt/grouping_formatter.py
@@ -67,7 +67,7 @@ class GroupingFormatter(base.BaseFormatter):
         if not self.interactive or not self.current_display:
             return ""
         return ((self.move_up + self.clear_eol) *
-                len(self.current_display.splitlines()))
+                self.current_display.count('\n'))
 
     def generate_output(self, text=None, new_display=None):
         if not self.interactive:


### PR DESCRIPTION
See discussion in PR #8551.

Redraw of the first test name was broken due to a mix-up between two ANSI escape codes.
I also took the opportunity to change the way line count is calculated. It's a bit cleaner that way (the new operation is ~%20 faster, but that's unnoticeable).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8861)

<!-- Reviewable:end -->
