### PR TITLE
Websocket errors

### DIFF
--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -241,6 +241,7 @@ pub enum WebSocketDomAction {
 pub enum WebSocketNetworkEvent {
     ConnectionEstablished,
     MessageReceived(MessageData),
+    Fail,
     Close,
 }
 

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/015.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/015.html.ini
@@ -1,6 +1,0 @@
-[015.html]
-  type: testharness
-  expected: TIMEOUT
-  [WebSockets: instanceof on events]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/017.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/017.html.ini
@@ -1,6 +1,0 @@
-[017.html]
-  type: testharness
-  expected: TIMEOUT
-  [WebSockets: this, e.target, e.currentTarget, e.eventPhase]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/018.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/018.html.ini
@@ -1,9 +1,0 @@
-[018.html]
-  type: testharness
-  expected: TIMEOUT
-  [error event]
-    expected: TIMEOUT
-
-  [close event]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/020.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/020.html.ini
@@ -1,6 +1,0 @@
-[020.html]
-  type: testharness
-  expected: TIMEOUT
-  [WebSockets: error events]
-    expected: TIMEOUT
-


### PR DESCRIPTION
Fixes #7861. Errors should be triggered on failed connections (e.g. invalid DNS resolution, invalid port, etc) and on invalid message data (e.g. improperly encoded UTF-8 messages).

Errors are simple errors and should not reveal to the script any details about the failure that could lead to probing.

The spec recommends a message to the console as an indication to developers what went wrong, but I've not implemented that. I believe another issue should be opened for this.

Relevant:

https://html.spec.whatwg.org/multipage/comms.html#handler-eventsource-onerror
https://tools.ietf.org/html/rfc6455#section-8
http://www.w3.org/TR/websockets/#concept-websocket-close-fail

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8868)

<!-- Reviewable:end -->
