### PR TITLE
WebGL nits

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -417,7 +417,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         }
         let data = match data {
             Some(data) => data,
-            None => return,
+            None => return self.webgl_error(InvalidValue),
         };
         if offset < 0 {
             return self.webgl_error(InvalidValue);

--- a/tests/html/test_webgl_triangle.html
+++ b/tests/html/test_webgl_triangle.html
@@ -19,9 +19,7 @@
    }
 </script>
 <script id="fragmentshader" type="x-shader">
-   #ifdef GL_ES
-   precision highp float;
-   #endif
+   precision mediump float;
 
    varying vec4 aVertexColor;
 


### PR DESCRIPTION
This improves support for running our triangle test (see: https://github.com/servo/servo/pull/8831), and adds missing error in `BufferSubData`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8876)

<!-- Reviewable:end -->
