### PR TITLE
stub out gluCheckExtension in embedding

### DIFF
--- a/ports/cef/stubs.rs
+++ b/ports/cef/stubs.rs
@@ -51,3 +51,5 @@ stub!(cef_string_wide_to_utf16);
 stub!(cef_unregister_internal_web_plugin);
 stub!(cef_visit_web_plugin_info);
 
+//from skia
+stub!(gluCheckExtension);


### PR DESCRIPTION
this is called from src/gpu/gl/unix/SkNativeGLContext_unix.cpp which
is not something that is used in servo

ref #8883

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8888)

<!-- Reviewable:end -->
