### PR TITLE
Android build system improvements

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -194,10 +194,7 @@ class PostBuildCommands(CommandBase):
                      help='Package the release build')
     @CommandArgument('--dev', '-d', action='store_true',
                      help='Package the dev build')
-    @CommandArgument(
-        'params', nargs='...',
-        help="Command-line arguments to be passed through to Servo")
-    def package(self, params, release=False, dev=False, debug=False, debugger=None):
+    def package(self, release=False, dev=False, debug=False, debugger=None):
         env = self.build_env()
         binary_path = self.get_binary_path(release, dev, android=True)
 

--- a/support/android/.gitignore
+++ b/support/android/.gitignore
@@ -1,3 +1,0 @@
-openssl-1.0.1k/
-openssl-1.0.1k.tar.gz
-

--- a/support/android/apk/.gitignore
+++ b/support/android/apk/.gitignore
@@ -1,0 +1,6 @@
+/assets/
+/bin/
+/gen/
+/libs/
+/local.properties
+/proguard-project.txt


### PR DESCRIPTION
This PR adds a `mach install` command (a convenient way to run `adb install`), and does some minor code cleanup.

It also fixes parallelism in the OpenSSL build.  For [complicated reasons](http://make.mad-scientist.net/papers/jobserver-implementation/), a sub-Make will not inherit `-j` options from its parent process unless it is invoked directly from another Makefile.  This means we should run make from openssl.makefile rather than openssl.sh.

r? @larsbergstrom

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8891)

<!-- Reviewable:end -->
