### PR TITLE
Changes on comments in servo/lib.rs

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -2,20 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/// Servo, the mighty web browser engine from the future.
-///
-/// This is a very simple library that wires all of Servo's components
-/// together as type `Browser`, along with a generic client
-/// implementing the `WindowMethods` trait, to create a working web
-/// browser.
-///
-/// The `Browser` type is responsible for configuring a
-/// `Constellation`, which does the heavy lifting of coordinating all
-/// of Servo's internal subsystems, including the `ScriptTask` and the
-/// `LayoutTask`, as well maintains the navigation context.
-///
-/// The `Browser` is fed events from a generic type that implements the
-/// `WindowMethods` trait.
+//! Servo, the mighty web browser engine from the future.
+//!
+//! This is a very simple library that wires all of Servo's components
+//! together as type `Browser`, along with a generic client
+//! implementing the `WindowMethods` trait, to create a working web
+//! browser.
+//!
+//! The `Browser` type is responsible for configuring a
+//! `Constellation`, which does the heavy lifting of coordinating all
+//! of Servo's internal subsystems, including the `ScriptTask` and the
+//! `LayoutTask`, as well maintains the navigation context.
+//!
+//! The `Browser` is fed events from a generic type that implements the
+//! `WindowMethods` trait.
 
 extern crate gaol;
 extern crate libc;

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -2,20 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Servo, the mighty web browser engine from the future.
-//
-// This is a very simple library that wires all of Servo's components
-// together as type `Browser`, along with a generic client
-// implementing the `WindowMethods` trait, to create a working web
-// browser.
-//
-// The `Browser` type is responsible for configuring a
-// `Constellation`, which does the heavy lifting of coordinating all
-// of Servo's internal subsystems, including the `ScriptTask` and the
-// `LayoutTask`, as well maintains the navigation context.
-//
-// The `Browser` is fed events from a generic type that implements the
-// `WindowMethods` trait.
+/// Servo, the mighty web browser engine from the future.
+///
+/// This is a very simple library that wires all of Servo's components
+/// together as type `Browser`, along with a generic client
+/// implementing the `WindowMethods` trait, to create a working web
+/// browser.
+///
+/// The `Browser` type is responsible for configuring a
+/// `Constellation`, which does the heavy lifting of coordinating all
+/// of Servo's internal subsystems, including the `ScriptTask` and the
+/// `LayoutTask`, as well maintains the navigation context.
+///
+/// The `Browser` is fed events from a generic type that implements the
+/// `WindowMethods` trait.
 
 extern crate gaol;
 extern crate libc;
@@ -103,10 +103,6 @@ pub use export::script_traits;
 pub use export::style;
 pub use export::url;
 
-pub struct Browser {
-    compositor: Box<CompositorEventListener + 'static>,
-}
-
 /// The in-process interface to Servo.
 ///
 /// It does everything necessary to render the web, primarily
@@ -118,6 +114,11 @@ pub struct Browser {
 /// application Servo is embedded in. Clients then create an event
 /// loop to pump messages between the embedding application and
 /// various browser components.
+
+pub struct Browser {
+    compositor: Box<CompositorEventListener + 'static>,
+}
+
 impl Browser {
     pub fn new<Window>(window: Option<Rc<Window>>) -> Browser
                        where Window: WindowMethods + 'static {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -114,7 +114,6 @@ pub use export::url;
 /// application Servo is embedded in. Clients then create an event
 /// loop to pump messages between the embedding application and
 /// various browser components.
-
 pub struct Browser {
     compositor: Box<CompositorEventListener + 'static>,
 }


### PR DESCRIPTION
1. converted the first comments in servo/lib.rs into doc comments.
2. moved doc comment of impl Browser to pub struct Browser.
   resolves #8872

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8901)

<!-- Reviewable:end -->
