### PR TITLE
Derive Debug for FontGroup and its components

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -85,6 +85,7 @@ pub struct FontMetrics {
 
 pub type SpecifiedFontStyle = FontStyle;
 
+#[derive(Debug)]
 pub struct Font {
     pub handle: FontHandle,
     pub metrics: FontMetrics,
@@ -111,7 +112,7 @@ bitflags! {
 }
 
 /// Various options that control text shaping.
-#[derive(Clone, Eq, PartialEq, Hash, Copy)]
+#[derive(Clone, Eq, PartialEq, Hash, Copy, Debug)]
 pub struct ShapingOptions {
     /// Spacing to add between each letter. Corresponds to the CSS 2.1 `letter-spacing` property.
     /// NB: You will probably want to set the `IGNORE_LIGATURES_SHAPING_FLAG` if this is non-null.
@@ -125,7 +126,7 @@ pub struct ShapingOptions {
 }
 
 /// An entry in the shape cache.
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct ShapeCacheEntry {
     text: String,
     options: ShapingOptions,
@@ -206,6 +207,7 @@ impl Font {
     }
 }
 
+#[derive(Debug)]
 pub struct FontGroup {
     pub fonts: SmallVec<[Rc<RefCell<Font>>; 8]>,
 }

--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -14,7 +14,7 @@ use style::computed_values::{font_stretch, font_weight};
 /// to be expanded or refactored when we support more of the font styling parameters.
 ///
 /// NB: If you change this, you will need to update `style::properties::compute_font_hash()`.
-#[derive(Clone, Copy, Eq, Hash, Deserialize, Serialize)]
+#[derive(Clone, Copy, Eq, Hash, Deserialize, Serialize, Debug)]
 pub struct FontTemplateDescriptor {
     pub weight: font_weight::T,
     pub stretch: font_stretch::T,

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -45,6 +45,7 @@ impl FontTableMethods for FontTable {
     }
 }
 
+#[derive(Debug)]
 pub struct FontHandle {
     // The font binary. This must stay valid for the lifetime of the font,
     // if the font is created using FT_Memory_Face.

--- a/components/gfx/platform/freetype/font_context.rs
+++ b/components/gfx/platform/freetype/font_context.rs
@@ -70,7 +70,7 @@ pub type UserPtr = *mut User;
 
 // WARNING: We need to be careful how we use this struct. See the comment about Rc<> in
 // FontContextHandle.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FreeTypeLibraryHandle {
     pub ctx: FT_Library,
     mem: FT_Memory,
@@ -98,7 +98,7 @@ impl HeapSizeOf for FreeTypeLibraryHandle {
     }
 }
 
-#[derive(Clone, HeapSizeOf)]
+#[derive(Clone, HeapSizeOf, Debug)]
 pub struct FontContextHandle {
     // WARNING: FreeTypeLibraryHandle contains raw pointers, is clonable, and also implements
     // `Drop`. This field needs to be Rc<> to make sure that the `drop` function is only called

--- a/components/gfx/platform/freetype/font_template.rs
+++ b/components/gfx/platform/freetype/font_template.rs
@@ -10,7 +10,7 @@ use string_cache::Atom;
 /// The identifier is an absolute path, and the bytes
 /// field is the loaded data that can be passed to
 /// freetype and azure directly.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct FontTemplateData {
     pub bytes: Vec<u8>,
     pub identifier: Atom,

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -57,6 +57,7 @@ impl FontTableMethods for FontTable {
     }
 }
 
+#[derive(Debug)]
 pub struct FontHandle {
     pub font_data: Arc<FontTemplateData>,
     pub ctfont: CTFont,

--- a/components/gfx/platform/macos/font_context.rs
+++ b/components/gfx/platform/macos/font_context.rs
@@ -4,7 +4,7 @@
 
 use util::mem::HeapSizeOf;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FontContextHandle {
     ctx: ()
 }

--- a/components/gfx/platform/macos/font_template.rs
+++ b/components/gfx/platform/macos/font_template.rs
@@ -17,7 +17,7 @@ use string_cache::Atom;
 /// The identifier is a PostScript font name. The
 /// CTFont object is cached here for use by the
 /// paint functions that create CGFont references.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct FontTemplateData {
     /// The `CTFont` object, if present. This is cached here so that we don't have to keep creating
     /// `CTFont` instances over and over. It can always be recreated from the `identifier` and/or
@@ -64,6 +64,7 @@ impl FontTemplateData {
     }
 }
 
+#[derive(Debug)]
 pub struct CachedCTFont(Mutex<Option<CTFont>>);
 
 impl Deref for CachedCTFont {

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -134,11 +134,13 @@ impl ShapedGlyphData {
     }
 }
 
+#[derive(Debug)]
 struct FontAndShapingOptions {
     font: *mut Font,
     options: ShapingOptions,
 }
 
+#[derive(Debug)]
 pub struct Shaper {
     hb_face: *mut hb_face_t,
     hb_font: *mut hb_font_t,

--- a/components/util/cache.rs
+++ b/components/util/cache.rs
@@ -12,7 +12,10 @@ use std::hash::{Hash, Hasher, SipHasher};
 use std::slice::Iter;
 
 
-pub struct HashCache<K, V> {
+pub struct HashCache<K, V>
+    where K: Clone + PartialEq + Eq + Hash,
+          V: Clone,
+{
     entries: HashMap<K, V, DefaultState<SipHasher>>,
 }
 

--- a/components/util/cache.rs
+++ b/components/util/cache.rs
@@ -12,6 +12,7 @@ use std::hash::{Hash, Hasher, SipHasher};
 use std::slice::Iter;
 
 
+#[derive(Debug)]
 pub struct HashCache<K, V>
     where K: Clone + PartialEq + Eq + Hash,
           V: Clone,


### PR DESCRIPTION
In order to enable `#[derive(Debug)]` on HashMap (used by Font), this also requires applying trait bounds to HashMap itself (rather than just the impl) -- which is probably better anyway.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8908)

<!-- Reviewable:end -->
