### PR TITLE
remove the "core" feature attribute from canvas

### DIFF
--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(core)]
 #![feature(nonzero)]
 #![feature(slice_bytes)]
 #![feature(vec_push_all)]

--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -4,7 +4,6 @@
 
 #![crate_name = "canvas_traits"]
 #![crate_type = "rlib"]
-#![feature(core)]
 #![feature(custom_derive)]
 #![feature(nonzero)]
 #![feature(plugin)]


### PR DESCRIPTION
The core feature is marked as stable and gives this nice warning:

```
servo/components/canvas_traits/lib.rs:7:12: 7:16 warning: this feature is stable. attribute no longer needed, #[warn(stable_features)] on by default
/servo/components/canvas_traits/lib.rs:7 #![feature(core)]
```

This commit removes the usage of this feature.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8920)

<!-- Reviewable:end -->
