### PR TITLE
Pass around event types as Atoms instead of Strings

### DIFF
--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -12,6 +12,7 @@ use dom::bindings::js::Root;
 use dom::bindings::reflector::reflect_dom_object;
 use dom::event::{Event, EventBubbles, EventCancelable};
 use script_task::ScriptChan;
+use string_cache::Atom;
 use util::str::DOMString;
 
 #[dom_struct]
@@ -33,7 +34,7 @@ impl CloseEvent {
     }
 
     pub fn new(global: GlobalRef,
-               type_: DOMString,
+               type_: Atom,
                bubbles: EventBubbles,
                cancelable: EventCancelable,
                wasClean: bool,
@@ -44,9 +45,9 @@ impl CloseEvent {
         let ev = reflect_dom_object(event, global, CloseEventBinding::Wrap);
         {
             let event = ev.upcast::<Event>();
-            event.InitEvent(type_,
-                            bubbles == EventBubbles::Bubbles,
-                            cancelable == EventCancelable::Cancelable);
+            event.init_event(type_,
+                             bubbles == EventBubbles::Bubbles,
+                             cancelable == EventCancelable::Cancelable);
         }
         ev
     }
@@ -66,7 +67,7 @@ impl CloseEvent {
             EventCancelable::NotCancelable
         };
         Ok(CloseEvent::new(global,
-                           type_,
+                           Atom::from(&*type_),
                            bubbles,
                            cancelable,
                            init.wasClean,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -524,7 +524,7 @@ impl Document {
         self.ready_state.set(state);
 
         let event = Event::new(GlobalRef::Window(&self.window),
-                               DOMString::from("readystatechange"),
+                               atom!("readystatechange"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         let target = self.upcast::<EventTarget>();
@@ -1326,7 +1326,7 @@ impl Document {
         update_with_current_time(&self.dom_content_loaded_event_start);
 
         let event = Event::new(GlobalRef::Window(self.window()),
-                               DOMString::from("DOMContentLoaded"),
+                               atom!("DOMContentLoaded"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         let doctarget = self.upcast::<EventTarget>();
@@ -2464,7 +2464,7 @@ impl DocumentProgressHandler {
         let document = self.addr.root();
         let window = document.window();
         let event = Event::new(GlobalRef::Window(window),
-                               DOMString::from("load"),
+                               atom!("load"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         let wintarget = window.upcast::<EventTarget>();

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -16,6 +16,7 @@ use dom::event::{Event, EventBubbles, EventCancelable};
 use js::jsapi::{RootedValue, HandleValue, JSContext};
 use js::jsval::JSVal;
 use std::cell::Cell;
+use string_cache::Atom;
 use util::str::DOMString;
 
 #[dom_struct]
@@ -48,7 +49,7 @@ impl ErrorEvent {
     }
 
     pub fn new(global: GlobalRef,
-               type_: DOMString,
+               type_: Atom,
                bubbles: EventBubbles,
                cancelable: EventCancelable,
                message: DOMString,
@@ -59,8 +60,8 @@ impl ErrorEvent {
         let ev = ErrorEvent::new_uninitialized(global);
         {
             let event = ev.upcast::<Event>();
-            event.InitEvent(type_, bubbles == EventBubbles::Bubbles,
-                            cancelable == EventCancelable::Cancelable);
+            event.init_event(type_, bubbles == EventBubbles::Bubbles,
+                             cancelable == EventCancelable::Cancelable);
             *ev.message.borrow_mut() = message;
             *ev.filename.borrow_mut() = filename;
             ev.lineno.set(lineno);
@@ -98,7 +99,7 @@ impl ErrorEvent {
         // Dictionaries need to be rooted
         // https://github.com/servo/servo/issues/6381
         let error = RootedValue::new(global.get_cx(), init.error);
-        let event = ErrorEvent::new(global, type_,
+        let event = ErrorEvent::new(global, Atom::from(&*type_),
                                 bubbles, cancelable,
                                 msg, file_name,
                                 line_num, col_num,

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -162,7 +162,7 @@ impl HTMLFormElement {
         // TODO: Handle browsing contexts
         // TODO: Handle validation
         let event = Event::new(GlobalRef::Window(win.r()),
-                               DOMString::from("submit"),
+                               atom!("submit"),
                                EventBubbles::Bubbles,
                                EventCancelable::Cancelable);
         event.fire(self.upcast());
@@ -315,7 +315,7 @@ impl HTMLFormElement {
 
         let win = window_from_node(self);
         let event = Event::new(GlobalRef::Window(win.r()),
-                               DOMString::from("reset"),
+                               atom!("reset"),
                                EventBubbles::Bubbles,
                                EventCancelable::Cancelable);
         event.fire(self.upcast());

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -144,7 +144,7 @@ impl HTMLIFrameElement {
                 let _ar = JSAutoRequest::new(cx);
                 let _ac = JSAutoCompartment::new(cx, window.reflector().get_jsobject().get());
                 let mut detail = RootedValue::new(cx, UndefinedValue());
-                let event_name = DOMString::from(event.name().to_owned());
+                let event_name = Atom::from(event.name());
                 self.build_mozbrowser_event_detail(event, cx, detail.handle_mut());
                 CustomEvent::new(GlobalRef::Window(window.r()),
                                  event_name,
@@ -210,7 +210,7 @@ impl HTMLIFrameElement {
         // Step 4
         let window = window_from_node(self);
         let event = Event::new(GlobalRef::Window(window.r()),
-                               DOMString::from("load".to_owned()),
+                               atom!("load"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         event.fire(self.upcast());

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -78,7 +78,7 @@ impl Runnable for ImageResponseHandlerRunnable {
         // Fire image.onload
         let window = window_from_node(document.r());
         let event = Event::new(GlobalRef::Window(window.r()),
-                               DOMString::from("load"),
+                               atom!("load"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         event.fire(element.upcast());

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -850,13 +850,13 @@ impl Activatable for HTMLInputElement {
                     let target = self.upcast();
 
                     let event = Event::new(GlobalRef::Window(win.r()),
-                                           DOMString::from("input"),
+                                           atom!("input"),
                                            EventBubbles::Bubbles,
                                            EventCancelable::NotCancelable);
                     event.fire(target);
 
                     let event = Event::new(GlobalRef::Window(win.r()),
-                                           DOMString::from("change"),
+                                           atom!("change"),
                                            EventBubbles::Bubbles,
                                            EventCancelable::NotCancelable);
                     event.fire(target);

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -478,25 +478,25 @@ impl HTMLScriptElement {
     }
 
     pub fn dispatch_before_script_execute_event(&self) -> bool {
-        self.dispatch_event("beforescriptexecute".to_owned(),
+        self.dispatch_event(atom!("beforescriptexecute"),
                             EventBubbles::Bubbles,
                             EventCancelable::Cancelable)
     }
 
     pub fn dispatch_after_script_execute_event(&self) {
-        self.dispatch_event("afterscriptexecute".to_owned(),
+        self.dispatch_event(atom!("afterscriptexecute"),
                             EventBubbles::Bubbles,
                             EventCancelable::NotCancelable);
     }
 
     pub fn dispatch_load_event(&self) {
-        self.dispatch_event("load".to_owned(),
+        self.dispatch_event(atom!("load"),
                             EventBubbles::DoesNotBubble,
                             EventCancelable::NotCancelable);
     }
 
     pub fn dispatch_error_event(&self) {
-        self.dispatch_event("error".to_owned(),
+        self.dispatch_event(atom!("error"),
                             EventBubbles::DoesNotBubble,
                             EventCancelable::NotCancelable);
     }
@@ -546,15 +546,12 @@ impl HTMLScriptElement {
     }
 
     fn dispatch_event(&self,
-                      type_: String,
+                      type_: Atom,
                       bubbles: EventBubbles,
                       cancelable: EventCancelable) -> bool {
         let window = window_from_node(self);
         let window = window.r();
-        let event = Event::new(GlobalRef::Window(window),
-                               DOMString::from(type_),
-                               bubbles,
-                               cancelable);
+        let event = Event::new(GlobalRef::Window(window), type_, bubbles, cancelable);
         event.fire(self.upcast())
     }
 }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -238,7 +238,7 @@ impl HTMLTextAreaElement {
         let window = window_from_node(self);
         let window = window.r();
         let event = Event::new(GlobalRef::Window(window),
-                               DOMString::from("input"),
+                               atom!("input"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
 

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -15,6 +15,7 @@ use dom::eventtarget::EventTarget;
 use js::jsapi::{RootedValue, HandleValue, Heap, JSContext};
 use js::jsval::JSVal;
 use std::default::Default;
+use string_cache::Atom;
 use util::str::DOMString;
 
 #[dom_struct]
@@ -47,14 +48,14 @@ impl MessageEvent {
         reflect_dom_object(ev, global, MessageEventBinding::Wrap)
     }
 
-    pub fn new(global: GlobalRef, type_: DOMString,
+    pub fn new(global: GlobalRef, type_: Atom,
                bubbles: bool, cancelable: bool,
                data: HandleValue, origin: DOMString, lastEventId: DOMString)
                -> Root<MessageEvent> {
         let ev = MessageEvent::new_initialized(global, data, origin, lastEventId);
         {
             let event = ev.upcast::<Event>();
-            event.InitEvent(type_, bubbles, cancelable);
+            event.init_event(type_, bubbles, cancelable);
         }
         ev
     }
@@ -66,7 +67,7 @@ impl MessageEvent {
         // Dictionaries need to be rooted
         // https://github.com/servo/servo/issues/6381
         let data = RootedValue::new(global.get_cx(), init.data);
-        let ev = MessageEvent::new(global, type_, init.parent.bubbles, init.parent.cancelable,
+        let ev = MessageEvent::new(global, Atom::from(&*type_), init.parent.bubbles, init.parent.cancelable,
                                    data.handle(),
                                    init.origin.clone(), init.lastEventId.clone());
         Ok(ev)
@@ -78,7 +79,7 @@ impl MessageEvent {
                           scope: GlobalRef,
                           message: HandleValue) {
         let messageevent = MessageEvent::new(
-            scope, DOMString::from("message"), false, false, message,
+            scope, atom!("message"), false, false, message,
             DOMString::new(), DOMString::new());
         messageevent.upcast::<Event>().fire(target);
     }

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -11,6 +11,7 @@ use dom::bindings::inheritance::Castable;
 use dom::bindings::js::Root;
 use dom::bindings::reflector::reflect_dom_object;
 use dom::event::{Event, EventBubbles, EventCancelable};
+use string_cache::Atom;
 use util::str::DOMString;
 
 #[dom_struct]
@@ -30,7 +31,7 @@ impl ProgressEvent {
             total: total
         }
     }
-    pub fn new(global: GlobalRef, type_: DOMString,
+    pub fn new(global: GlobalRef, type_: Atom,
                can_bubble: EventBubbles, cancelable: EventCancelable,
                length_computable: bool, loaded: u64, total: u64) -> Root<ProgressEvent> {
         let ev = reflect_dom_object(box ProgressEvent::new_inherited(length_computable, loaded, total),
@@ -38,7 +39,7 @@ impl ProgressEvent {
                                     ProgressEventBinding::Wrap);
         {
             let event = ev.upcast::<Event>();
-            event.InitEvent(type_, can_bubble == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
+            event.init_event(type_, can_bubble == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
         }
         ev
     }
@@ -49,7 +50,7 @@ impl ProgressEvent {
         let bubbles = if init.parent.bubbles { EventBubbles::Bubbles } else { EventBubbles::DoesNotBubble };
         let cancelable = if init.parent.cancelable { EventCancelable::Cancelable }
                          else { EventCancelable::NotCancelable };
-        let ev = ProgressEvent::new(global, type_, bubbles, cancelable,
+        let ev = ProgressEvent::new(global, Atom::from(&*type_), bubbles, cancelable,
                                     init.lengthComputable, init.loaded, init.total);
         Ok(ev)
     }

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -189,7 +189,7 @@ impl MainThreadRunnable for StorageEventRunnable {
 
         let storage_event = StorageEvent::new(
             global_ref,
-            DOMString::from("storage"),
+            atom!("storage"),
             EventBubbles::DoesNotBubble, EventCancelable::NotCancelable,
             this.key.map(DOMString::from), this.old_value.map(DOMString::from), this.new_value.map(DOMString::from),
             DOMString::from(ev_url.to_string()),

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -12,6 +12,7 @@ use dom::bindings::js::{JS, MutNullableHeap, Root, RootedReference};
 use dom::bindings::reflector::reflect_dom_object;
 use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::storage::Storage;
+use string_cache::Atom;
 use util::str::DOMString;
 
 #[dom_struct]
@@ -42,7 +43,7 @@ impl StorageEvent {
     }
 
     pub fn new(global: GlobalRef,
-               type_: DOMString,
+               type_: Atom,
                bubbles: EventBubbles,
                cancelable: EventCancelable,
                key: Option<DOMString>,
@@ -56,7 +57,7 @@ impl StorageEvent {
                                     StorageEventBinding::Wrap);
         {
             let event = ev.upcast::<Event>();
-            event.InitEvent(type_, bubbles == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
+            event.init_event(type_, bubbles == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
         }
         ev
     }
@@ -75,7 +76,7 @@ impl StorageEvent {
         } else {
             EventCancelable::NotCancelable
         };
-        let event = StorageEvent::new(global, type_,
+        let event = StorageEvent::new(global, Atom::from(&*type_),
                                       bubbles, cancelable,
                                       key, oldValue, newValue,
                                       url, storageArea);

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -15,6 +15,7 @@ use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::window::Window;
 use std::cell::Cell;
 use std::default::Default;
+use string_cache::Atom;
 use util::str::DOMString;
 
 // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#interface-UIEvent
@@ -91,7 +92,7 @@ impl UIEventMethods for UIEvent {
             return;
         }
 
-        event.InitEvent(type_, can_bubble, cancelable);
+        event.init_event(Atom::from(&*type_), can_bubble, cancelable);
         self.view.set(view);
         self.detail.set(detail);
     }

--- a/components/script/dom/webglcontextevent.rs
+++ b/components/script/dom/webglcontextevent.rs
@@ -12,6 +12,7 @@ use dom::bindings::inheritance::Castable;
 use dom::bindings::js::Root;
 use dom::bindings::reflector::reflect_dom_object;
 use dom::event::{Event, EventBubbles, EventCancelable};
+use string_cache::Atom;
 use util::str::DOMString;
 
 #[dom_struct]
@@ -36,7 +37,7 @@ impl WebGLContextEvent {
     }
 
     pub fn new(global: GlobalRef,
-               type_: DOMString,
+               type_: Atom,
                bubbles: EventBubbles,
                cancelable: EventCancelable,
                status_message: DOMString) -> Root<WebGLContextEvent> {
@@ -47,7 +48,7 @@ impl WebGLContextEvent {
 
         {
             let parent = event.upcast::<Event>();
-            parent.InitEvent(type_, bubbles == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
+            parent.init_event(type_, bubbles == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
         }
 
         event
@@ -73,7 +74,7 @@ impl WebGLContextEvent {
             EventCancelable::NotCancelable
         };
 
-        Ok(WebGLContextEvent::new(global, type_,
+        Ok(WebGLContextEvent::new(global, Atom::from(&*type_),
                                   bubbles,
                                   cancelable,
                                   status_message))

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -119,7 +119,7 @@ impl WebGLRenderingContext {
             Err(msg) => {
                 error!("Couldn't create WebGLRenderingContext: {}", msg);
                 let event = WebGLContextEvent::new(global,
-                                                   DOMString::from("webglcontextcreationerror"),
+                                                   atom!("webglcontextcreationerror"),
                                                    EventBubbles::DoesNotBubble,
                                                    EventCancelable::Cancelable,
                                                    DOMString::from(msg));

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -464,7 +464,7 @@ impl Runnable for ConnectionEstablishedTask {
 
         // Step 6.
         let global = ws.global.root();
-        let event = Event::new(global.r(), DOMString::from("open"),
+        let event = Event::new(global.r(), atom!("open"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         event.fire(ws.upcast());
@@ -506,7 +506,7 @@ impl Runnable for CloseTask {
             //A Bad close
             ws.clean_close.set(false);
             let event = Event::new(global.r(),
-                                   DOMString::from("error"),
+                                   atom!("error"),
                                    EventBubbles::DoesNotBubble,
                                    EventCancelable::Cancelable);
             event.fire(ws.upcast());
@@ -516,7 +516,7 @@ impl Runnable for CloseTask {
          https://html.spec.whatwg.org/multipage/#closeWebSocket
         */
         let close_event = CloseEvent::new(global.r(),
-                                          DOMString::from("close"),
+                                          atom!("close"),
                                           EventBubbles::DoesNotBubble,
                                           EventCancelable::NotCancelable,
                                           ws.clean_close.get(),

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -128,7 +128,7 @@ impl Worker {
         let worker = address.root();
         let global = worker.r().global.root();
         let event = Event::new(global.r(),
-                               DOMString::from("error"),
+                               atom!("error"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::NotCancelable);
         event.fire(worker.upcast());
@@ -139,7 +139,7 @@ impl Worker {
         let worker = address.root();
         let global = worker.r().global.root();
         let error = RootedValue::new(global.r().get_cx(), UndefinedValue());
-        let errorevent = ErrorEvent::new(global.r(), DOMString::from("error"),
+        let errorevent = ErrorEvent::new(global.r(), atom!("error"),
                                          EventBubbles::Bubbles, EventCancelable::Cancelable,
                                          message, filename, lineno, colno, error.handle());
         errorevent.upcast::<Event>().fire(worker.upcast());

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -57,6 +57,7 @@ use std::cell::{Cell, RefCell};
 use std::default::Default;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
+use string_cache::Atom;
 use time;
 use timers::{ScheduledCallback, TimerHandle};
 use url::{Url, UrlParser};
@@ -505,12 +506,12 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
             // If one of the event handlers below aborts the fetch by calling
             // abort or open we will need the current generation id to detect it.
             let gen_id = self.generation_id.get();
-            self.dispatch_response_progress_event("loadstart".to_owned());
+            self.dispatch_response_progress_event(atom!("loadstart"));
             if self.generation_id.get() != gen_id {
                 return Ok(());
             }
             if !self.upload_complete.get() {
-                self.dispatch_upload_progress_event("loadstart".to_owned(), Some(0));
+                self.dispatch_upload_progress_event(atom!("loadstart"), Some(0));
                 if self.generation_id.get() != gen_id {
                     return Ok(());
                 }
@@ -775,11 +776,12 @@ pub type TrustedXHRAddress = Trusted<XMLHttpRequest>;
 
 impl XMLHttpRequest {
     fn change_ready_state(&self, rs: XMLHttpRequestState) {
+        use string_cache::Atom;
         assert!(self.ready_state.get() != rs);
         self.ready_state.set(rs);
         let global = self.global.root();
         let event = Event::new(global.r(),
-                               DOMString::from("readystatechange"),
+                               atom!("readystatechange"),
                                EventBubbles::DoesNotBubble,
                                EventCancelable::Cancelable);
         event.fire(self.upcast());
@@ -855,11 +857,11 @@ impl XMLHttpRequest {
                 self.upload_complete.set(true);
                 // Substeps 2-4
                 if !self.sync.get() {
-                    self.dispatch_upload_progress_event("progress".to_owned(), None);
+                    self.dispatch_upload_progress_event(atom!("progress"), None);
                     return_if_fetch_was_terminated!();
-                    self.dispatch_upload_progress_event("load".to_owned(), None);
+                    self.dispatch_upload_progress_event(atom!("load"), None);
                     return_if_fetch_was_terminated!();
-                    self.dispatch_upload_progress_event("loadend".to_owned(), None);
+                    self.dispatch_upload_progress_event(atom!("loadend"), None);
                     return_if_fetch_was_terminated!();
                 }
                 // Part of step 13, send() (processing response)
@@ -887,7 +889,7 @@ impl XMLHttpRequest {
                         self.change_ready_state(XMLHttpRequestState::Loading);
                         return_if_fetch_was_terminated!();
                     }
-                    self.dispatch_response_progress_event("progress".to_owned());
+                    self.dispatch_response_progress_event(atom!("progress"));
                 }
             },
             XHRProgress::Done(_) => {
@@ -905,11 +907,11 @@ impl XMLHttpRequest {
                 self.change_ready_state(XMLHttpRequestState::Done);
                 return_if_fetch_was_terminated!();
                 // Subsubsteps 10-12
-                self.dispatch_response_progress_event("progress".to_owned());
+                self.dispatch_response_progress_event(atom!("progress"));
                 return_if_fetch_was_terminated!();
-                self.dispatch_response_progress_event("load".to_owned());
+                self.dispatch_response_progress_event(atom!("load"));
                 return_if_fetch_was_terminated!();
-                self.dispatch_response_progress_event("loadend".to_owned());
+                self.dispatch_response_progress_event(atom!("loadend"));
             },
             XHRProgress::Errored(_, e) => {
                 self.cancel_timeout();
@@ -929,18 +931,18 @@ impl XMLHttpRequest {
                 let upload_complete = &self.upload_complete;
                 if !upload_complete.get() {
                     upload_complete.set(true);
-                    self.dispatch_upload_progress_event("progress".to_owned(), None);
+                    self.dispatch_upload_progress_event(atom!("progress"), None);
                     return_if_fetch_was_terminated!();
-                    self.dispatch_upload_progress_event(errormsg.to_owned(), None);
+                    self.dispatch_upload_progress_event(Atom::from(errormsg), None);
                     return_if_fetch_was_terminated!();
-                    self.dispatch_upload_progress_event("loadend".to_owned(), None);
+                    self.dispatch_upload_progress_event(atom!("loadend"), None);
                     return_if_fetch_was_terminated!();
                 }
-                self.dispatch_response_progress_event("progress".to_owned());
+                self.dispatch_response_progress_event(atom!("progress"));
                 return_if_fetch_was_terminated!();
-                self.dispatch_response_progress_event(errormsg.to_owned());
+                self.dispatch_response_progress_event(Atom::from(errormsg));
                 return_if_fetch_was_terminated!();
-                self.dispatch_response_progress_event("loadend".to_owned());
+                self.dispatch_response_progress_event(atom!("loadend"));
             }
         }
     }
@@ -957,10 +959,10 @@ impl XMLHttpRequest {
         self.request_headers.borrow_mut().set_raw(name, vec![value.into_bytes()]);
     }
 
-    fn dispatch_progress_event(&self, upload: bool, type_: String, loaded: u64, total: Option<u64>) {
+    fn dispatch_progress_event(&self, upload: bool, type_: Atom, loaded: u64, total: Option<u64>) {
         let global = self.global.root();
         let progressevent = ProgressEvent::new(global.r(),
-                                               DOMString::from(type_),
+                                               type_,
                                                EventBubbles::DoesNotBubble,
                                                EventCancelable::NotCancelable,
                                                total.is_some(), loaded,
@@ -973,14 +975,14 @@ impl XMLHttpRequest {
         progressevent.upcast::<Event>().fire(target);
     }
 
-    fn dispatch_upload_progress_event(&self, type_: String, partial_load: Option<u64>) {
+    fn dispatch_upload_progress_event(&self, type_: Atom, partial_load: Option<u64>) {
         // If partial_load is None, loading has completed and we can just use the value from the request body
 
         let total = self.request_body_len.get() as u64;
         self.dispatch_progress_event(true, type_, partial_load.unwrap_or(total), Some(total));
     }
 
-    fn dispatch_response_progress_event(&self, type_: String) {
+    fn dispatch_response_progress_event(&self, type_: Atom) {
         let len = self.response.borrow().len() as u64;
         let total = self.response_headers.borrow().get::<ContentLength>().map(|x| { **x as u64 });
         self.dispatch_progress_event(false, type_, len, total);

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
  "servo-skia 0.20130412.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "simd 0.1.0 (git+https://github.com/huonw/simd)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -798,7 +798,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -958,7 +958,7 @@ dependencies = [
  "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1521,7 +1521,7 @@ dependencies = [
  "selectors 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1577,7 +1577,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "debug_unreachable 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1777,7 +1777,7 @@ dependencies = [
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
  "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1792,7 +1792,7 @@ dependencies = [
  "euclid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "selectors 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1960,7 +1960,7 @@ dependencies = [
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2125,7 +2125,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
  "servo-skia 0.20130412.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "simd 0.1.0 (git+https://github.com/huonw/simd)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -758,7 +758,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -918,7 +918,7 @@ dependencies = [
  "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1446,7 +1446,7 @@ dependencies = [
  "selectors 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1493,7 +1493,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "debug_unreachable 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1729,7 +1729,7 @@ dependencies = [
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
  "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1896,7 +1896,7 @@ dependencies = [
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2050,7 +2050,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
  "servo-skia 0.20130412.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "simd 0.1.0 (git+https://github.com/huonw/simd)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -734,7 +734,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -894,7 +894,7 @@ dependencies = [
  "serde_json 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1422,7 +1422,7 @@ dependencies = [
  "selectors 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1469,7 +1469,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "debug_unreachable 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1703,7 +1703,7 @@ dependencies = [
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
  "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1870,7 +1870,7 @@ dependencies = [
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1994,7 +1994,7 @@ dependencies = [
  "phf_codegen 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]


### PR DESCRIPTION
`Event` internally stores the `type` as an `Atom`, and we're `String`s
everywhere, which can cause unnecessary allocations to occur since
they'll end up as `Atom`s anyways.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8930)

<!-- Reviewable:end -->
