### PR TITLE
Implement Document#elementFromPoint

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -60,7 +60,7 @@ use dom::keyboardevent::KeyboardEvent;
 use dom::location::Location;
 use dom::messageevent::MessageEvent;
 use dom::mouseevent::MouseEvent;
-use dom::node::{self, CloneChildrenFlag, Node, NodeDamage};
+use dom::node::{self, CloneChildrenFlag, Node, NodeDamage, window_from_node};
 use dom::nodeiterator::NodeIterator;
 use dom::nodelist::NodeList;
 use dom::processinginstruction::ProcessingInstruction;
@@ -76,6 +76,7 @@ use dom::window::{ReflowReason, Window};
 use euclid::point::Point2D;
 use html5ever::tree_builder::{LimitedQuirks, NoQuirks, Quirks, QuirksMode};
 use ipc_channel::ipc::{self, IpcSender};
+use js::jsapi::JS_GetRuntime;
 use js::jsapi::{JSContext, JSObject, JSRuntime};
 use layout_interface::{HitTestResponse, MouseOverResponse};
 use layout_interface::{LayoutChan, Msg, ReflowQueryType};
@@ -2474,6 +2475,35 @@ impl DocumentMethods for Document {
 
     // https://html.spec.whatwg.org/multipage/#handler-onreadystatechange
     event_handler!(readystatechange, GetOnreadystatechange, SetOnreadystatechange);
+
+    #[allow(unsafe_code)]
+    // https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint
+    fn ElementFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Option<Root<Element>> {
+        let x = *x as f32;
+        let y = *y as f32;
+        let point = &Point2D { x: x, y: y };
+        let window = window_from_node(self);
+        let viewport = window.window_size().unwrap().visible_viewport;
+
+        if x < 0.0 || y < 0.0 || x > viewport.width.get() || y > viewport.height.get() {
+            return None;
+        }
+
+        let js_runtime = unsafe { JS_GetRuntime(window.get_cx()) };
+
+        match self.hit_test(point)  {
+            Some(untrusted_node_address) => {
+                let node = node::from_untrusted_node_address(js_runtime, untrusted_node_address);
+                let parent_node = node.GetParentNode().unwrap();
+                let element_ref = node.downcast::<Element>().unwrap_or_else(|| {
+                    parent_node.downcast::<Element>().unwrap()
+                });
+
+                Some(Root::from_ref(element_ref))
+            },
+            None => self.GetDocumentElement()
+        }
+    }
 }
 
 fn is_scheme_host_port_tuple(url: &Url) -> bool {

--- a/components/script/dom/webidls/Document.webidl
+++ b/components/script/dom/webidls/Document.webidl
@@ -180,3 +180,8 @@ partial interface Document {
 
       TouchList createTouchList(Touch... touches);
 };
+
+// https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint
+partial interface Document {
+  Element? elementFromPoint(double x, double y);
+};

--- a/tests/wpt/metadata-css/cssom-view-1_dev/html/CaretPosition-001.htm.ini
+++ b/tests/wpt/metadata-css/cssom-view-1_dev/html/CaretPosition-001.htm.ini
@@ -1,5 +1,4 @@
 [CaretPosition-001.htm]
   type: testharness
   [getBox]
-    expected: FAIL
-
+    disabled: https://github.com/servo/servo/issues/9805

--- a/tests/wpt/metadata-css/cssom-view-1_dev/html/elementFromPoint-001.htm.ini
+++ b/tests/wpt/metadata-css/cssom-view-1_dev/html/elementFromPoint-001.htm.ini
@@ -1,3 +1,5 @@
 [elementFromPoint-001.htm]
   type: testharness
-  expected: TIMEOUT
+  [CSSOM View - 5 - extensions to the Document interface]
+    expected: FAIL
+

--- a/tests/wpt/metadata-css/cssom-view-1_dev/html/elementFromPosition.htm.ini
+++ b/tests/wpt/metadata-css/cssom-view-1_dev/html/elementFromPosition.htm.ini
@@ -1,11 +1,5 @@
 [elementFromPosition.htm]
   type: testharness
-  [document.elementFromPoint]
-    expected: FAIL
-
-  [document.elementFromPoint is a Function]
-    expected: FAIL
-
   [test some point of the element: top left corner]
     expected: FAIL
 
@@ -31,20 +25,5 @@
     expected: FAIL
 
   [test some point of the element: botom right corner]
-    expected: FAIL
-
-  [Point (0, 0), return root element(HTML)]
-    expected: FAIL
-
-  [ test negative x ]
-    expected: FAIL
-
-  [ test nagetive y ]
-    expected: FAIL
-
-  [test outside of viewport]
-    expected: FAIL
-
-  [test the top of layer]
     expected: FAIL
 

--- a/tests/wpt/metadata/cssom-view/elementFromPoint.html.ini
+++ b/tests/wpt/metadata/cssom-view/elementFromPoint.html.ini
@@ -1,0 +1,20 @@
+[elementFromPoint.html]
+  type: testharness
+  [co-ordinates larger than the viewport from in iframe]
+    expected: FAIL
+
+  [SVG element at x,y]
+    expected: FAIL
+
+  [transformed element at x,y]
+    expected: FAIL
+
+  [no hit target at x,y]
+    expected: FAIL
+
+  [No viewport available]
+    expected: FAIL
+
+  [Image Maps]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-area-element/area-coords.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-area-element/area-coords.html.ini
@@ -21,15 +21,6 @@
   [CARRIGAGE RETURN: "2\\r2\\r10\\r10" (rect)]
     expected: FAIL
 
-  [LINE TABULATION: "2\\v2\\v10\\v10" (rect)]
-    expected: FAIL
-
-  [LINE NEXT: "221010" (rect)]
-    expected: FAIL
-
-  [EN QUAD: "2 2 10 10" (rect)]
-    expected: FAIL
-
   [abc between numbers: "2a2b20c20,2,10,10" (rect)]
     expected: FAIL
 
@@ -46,15 +37,6 @@
     expected: FAIL
 
   [leading SEMICOLON: ";2,2,10,10" (rect)]
-    expected: FAIL
-
-  [trailing COMMA: "2,2,10," (rect)]
-    expected: FAIL
-
-  [trailing SPACE: "2,2,10 " (rect)]
-    expected: FAIL
-
-  [trailing SEMICOLON: "2,2,10;" (rect)]
     expected: FAIL
 
   [PERCENT: "2%,2%,10%,10%" (rect)]
@@ -76,18 +58,6 @@
     expected: FAIL
 
   [non-ascii garbage: "“2,2,10,10\\"" (rect)]
-    expected: FAIL
-
-  [URL garbage with number: "2,2,10ls/spain/holidays/regions/10/Canary+Islands/Canary+Islands.html" (rect)]
-    expected: FAIL
-
-  [consecutive COMMAs: "2,,10,10" (rect)]
-    expected: FAIL
-
-  [consecutive SPACEs: "2  10,10" (rect)]
-    expected: FAIL
-
-  [consecutive SEMICOLONs: "2;;10,10" (rect)]
     expected: FAIL
 
   [several consecutive separators: ",,2;,;2,;,10 \\t\\r\\n10;;" (rect)]

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-area-element/area-processing.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-area-element/area-processing.html.ini
@@ -1,15 +1,6 @@
 [area-processing.html]
   type: testharness
-  [too few numbers: "2,2,10" (rect)]
-    expected: FAIL
-
   [negative: "-10,-10,10,10" (rect)]
-    expected: FAIL
-
-  [empty string: "" (rect)]
-    expected: FAIL
-
-  [omitted coords: null (rect)]
     expected: FAIL
 
   [first > third: "10,2,2,10" (rect)]
@@ -22,18 +13,6 @@
     expected: FAIL
 
   [negative: "-10,-10,-10,-10" (default)]
-    expected: FAIL
-
-  [too few numbers: "20,40" (circle)]
-    expected: FAIL
-
-  [negative radius: "20,40,-10" (circle)]
-    expected: FAIL
-
-  [zero radius: "20,40,0" (circle)]
-    expected: FAIL
-
-  [too few numbers: "100,100,120,100,100" (poly)]
     expected: FAIL
 
   [one too many numbers: "100,100,120,100,100,120,300" (poly)]

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-area-element/area-shape.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-area-element/area-shape.html.ini
@@ -3,12 +3,6 @@
   [missing value default: "2,2,10,10" (null)]
     expected: FAIL
 
-  [missing value default: "20,40,10" (null)]
-    expected: FAIL
-
-  [missing value default: null (null)]
-    expected: FAIL
-
   [invalid value default: "2,2,10,10" (foobar invalid)]
     expected: FAIL
 
@@ -31,12 +25,6 @@
     expected: FAIL
 
   [simple: "20,40,10" (CIRC)]
-    expected: FAIL
-
-  [LATIN CAPITAL LETTER I WITH DOT ABOVE: "20,40,10" (CİRCLE)]
-    expected: FAIL
-
-  [LATIN SMALL LETTER DOTLESS I: "20,40,10" (cırcle)]
     expected: FAIL
 
   [simple: "100,100,120,100,100,120" (poly)]


### PR DESCRIPTION
Related to #8666. I haven't implemented elementsFromPoint, because from my past discussion with jdm, [it's not good yet](https://github.com/rilut/servo/commit/dbfa25214b2888dda7527d62b5df1bb61f1ab047#commitcomment-14668959) to implement elementsFromPoint because it may cause GC hazards.

By the way, I also have to include the test for this, right? I've found this [1]. So, is all I have to do is just to put this into `tests/wpt/web-platform-tests/cssom-view/elementFromPoint.html`?

[1] http://test.csswg.org/suites/cssom-view-1_dev/nightly-unstable/html/elementFromPosition.htm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8932)

<!-- Reviewable:end -->
