### PR TITLE
Stop using std::slice::bytes::copy_memory.

### DIFF
--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![feature(clone_from_slice)]
 #![feature(nonzero)]
-#![feature(slice_bytes)]
 #![feature(plugin)]
 #![plugin(plugins)]
 

--- a/components/canvas/webgl_paint_task.rs
+++ b/components/canvas/webgl_paint_task.rs
@@ -13,7 +13,6 @@ use ipc_channel::router::ROUTER;
 use layers::platform::surface::NativeSurface;
 use offscreen_gl_context::{ColorAttachmentType, GLContext, GLContextAttributes};
 use std::borrow::ToOwned;
-use std::slice::bytes::copy_memory;
 use std::sync::mpsc::{Sender, channel};
 use util::task::spawn_named;
 use util::vec::byte_swap;
@@ -365,7 +364,7 @@ impl WebGLPaintTask {
             let dst_start = y * stride;
             let src_start = (height - y - 1) * stride;
             let src_slice = &orig_pixels[src_start .. src_start + stride];
-            copy_memory(&src_slice[..stride], &mut pixels[dst_start .. dst_start + stride]);
+            pixels[dst_start .. dst_start + stride].clone_from_slice(&src_slice[..stride]);
         }
 
         // rgba -> bgra

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -44,7 +44,6 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::mem as std_mem;
 use std::rc::Rc;
-use std::slice::bytes::copy_memory;
 use std::sync::mpsc::Sender;
 use style_traits::viewport::ViewportConstraints;
 use surface_map::SurfaceMap;
@@ -1913,8 +1912,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             let dst_start = y * stride;
             let src_start = (height - y - 1) * stride;
             let src_slice = &orig_pixels[src_start .. src_start + stride];
-            copy_memory(&src_slice[..stride],
-                        &mut pixels[dst_start .. dst_start + stride]);
+            pixels[dst_start .. dst_start + stride].clone_from_slice(&src_slice[..stride]);
         }
         RgbImage::from_raw(width as u32, height as u32, pixels).unwrap()
     }

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![feature(box_syntax)]
+#![feature(clone_from_slice)]
 #![feature(custom_derive)]
 #![feature(iter_cmp)]
 #![feature(plugin)]
-#![feature(slice_bytes)]
 #![feature(mpsc_select)]
 #![feature(plugin)]
 #![plugin(plugins)]


### PR DESCRIPTION
Fixes #8929.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8936)

<!-- Reviewable:end -->
