### PR TITLE
Fix DOMStringMap's stringifier behaviour according to the spec

### DIFF
--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -12,7 +12,7 @@ use dom::bindings::reflector::{Reflector, reflect_dom_object};
 use dom::element::Element;
 use dom::node::window_from_node;
 use string_cache::Atom;
-use util::str::{DOMString, HTML_SPACE_CHARACTERS, str_join};
+use util::str::{DOMString, HTML_SPACE_CHARACTERS};
 
 #[dom_struct]
 pub struct DOMTokenList {
@@ -129,10 +129,9 @@ impl DOMTokenListMethods for DOMTokenList {
         }
     }
 
-    // https://dom.spec.whatwg.org/#stringification-behavior
+    // https://dom.spec.whatwg.org/#concept-dtl-serialize
     fn Stringifier(&self) -> DOMString {
-        let tokenlist = self.element.get_tokenlist_attribute(&self.local_name);
-        DOMString::from(str_join(&tokenlist, "\x20"))
+        self.element.get_string_attribute(&self.local_name)
     }
 
     // check-tidy: no specs after this line

--- a/tests/wpt/web-platform-tests/dom/lists/DOMTokenList-stringifier.html
+++ b/tests/wpt/web-platform-tests/dom/lists/DOMTokenList-stringifier.html
@@ -6,18 +6,20 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<span class="   a  a b"></span>
+<span class="   a  a b "></span>
 <script>
 test(function() {
+  assert_equals(String(document.createElement("span").classList), "",
+                "String(classList) should return the empty list for an undefined class attribute");
   var span = document.querySelector("span");
-  assert_equals(span.getAttribute("class"), "   a  a b",
+  assert_equals(span.getAttribute("class"), "   a  a b ",
                 "getAttribute should return the literal value");
-  assert_equals(span.className, "   a  a b",
+  assert_equals(span.className, "   a  a b ",
                 "className should return the literal value");
-  assert_equals(String(span.classList), "a b",
-                "String(classList) should compress whitespace");
-  assert_equals(span.classList.toString(), "a b",
-                "classList.toString() should compress whitespace");
+  assert_equals(String(span.classList), "   a  a b ",
+                "String(classList) should return the literal value");
+  assert_equals(span.classList.toString(), "   a  a b ",
+                "classList.toString() should return the literal value");
   assert_class_string(span.classList, "DOMTokenList");
 });
 </script>

--- a/tests/wpt/web-platform-tests/dom/nodes/Element-classlist.html
+++ b/tests/wpt/web-platform-tests/dom/nodes/Element-classlist.html
@@ -62,9 +62,9 @@ test(function () {
   assert_equals( elem.className, ' ' );
 }, 'className should contain initial markup whitespace');
 test(function () {
-  assert_equals( elem.classList + '', '', 'implicit' );
-  assert_equals( elem.classList.toString(), '', 'explicit' );
-}, 'empty classList should return the empty string since the ordered set parser skip the whitespaces');
+  assert_equals( elem.classList + '', ' ', 'implicit' );
+  assert_equals( elem.classList.toString(), ' ', 'explicit' );
+}, 'classList should contain initial markup whitespace');
 test(function () {
   assert_throws( 'SYNTAX_ERR', function () { elem.classList.contains(''); } );
 }, '.contains(empty_string) must throw a SYNTAX_ERR');


### PR DESCRIPTION
It should just return its associated attribute's value, if any.

https://github.com/whatwg/dom/issues/105

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8959)

<!-- Reviewable:end -->
