### PR TITLE
Make Event's isTrusted attribute unforgeable

### DIFF
--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -4,6 +4,7 @@
 
 use dom::bindings::codegen::Bindings::CloseEventBinding;
 use dom::bindings::codegen::Bindings::CloseEventBinding::CloseEventMethods;
+use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::inheritance::Castable;
@@ -89,5 +90,10 @@ impl CloseEventMethods for CloseEvent {
     // https://html.spec.whatwg.org/multipage/#dom-closeevent-reason
     fn Reason(&self) -> DOMString {
         self.reason.clone()
+    }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
     }
 }

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -4,6 +4,7 @@
 
 use dom::bindings::codegen::Bindings::CustomEventBinding;
 use dom::bindings::codegen::Bindings::CustomEventBinding::CustomEventMethods;
+use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::inheritance::Castable;
@@ -88,5 +89,10 @@ impl CustomEventMethods for CustomEvent {
                        cancelable: bool,
                        detail: HandleValue) {
         self.init_custom_event(_cx, Atom::from(&*type_), can_bubble, cancelable, detail)
+    }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
     }
 }

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -5,6 +5,7 @@
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::ErrorEventBinding;
 use dom::bindings::codegen::Bindings::ErrorEventBinding::ErrorEventMethods;
+use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::inheritance::Castable;
@@ -134,4 +135,8 @@ impl ErrorEventMethods for ErrorEvent {
         self.error.get()
     }
 
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
 }

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -841,4 +841,9 @@ impl KeyboardEventMethods for KeyboardEvent {
     fn Which(&self) -> u32 {
         self.char_code.get().unwrap_or(self.KeyCode())
     }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.uievent.IsTrusted()
+    }
 }

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::MessageEventBinding;
 use dom::bindings::codegen::Bindings::MessageEventBinding::MessageEventMethods;
 use dom::bindings::error::Fallible;
@@ -98,5 +99,10 @@ impl MessageEventMethods for MessageEvent {
     // https://html.spec.whatwg.org/multipage/#dom-messageevent-lasteventid
     fn LastEventId(&self) -> DOMString {
         self.lastEventId.clone()
+    }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
     }
 }

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -206,4 +206,9 @@ impl MouseEventMethods for MouseEvent {
         self.button.set(buttonArg);
         self.related_target.set(relatedTargetArg);
     }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.uievent.IsTrusted()
+    }
 }

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::ProgressEventBinding;
 use dom::bindings::codegen::Bindings::ProgressEventBinding::ProgressEventMethods;
 use dom::bindings::error::Fallible;
@@ -69,5 +70,10 @@ impl ProgressEventMethods for ProgressEvent {
     // https://xhr.spec.whatwg.org/#dom-progressevent-total
     fn Total(&self) -> u64 {
         self.total
+    }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
     }
 }

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::StorageEventBinding;
 use dom::bindings::codegen::Bindings::StorageEventBinding::{StorageEventMethods};
 use dom::bindings::error::Fallible;
@@ -107,5 +108,10 @@ impl StorageEventMethods for StorageEvent {
     // https://html.spec.whatwg.org/multipage/#dom-storageevent-storagearea
     fn GetStorageArea(&self) -> Option<Root<Storage>> {
         self.storageArea.get()
+    }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
     }
 }

--- a/components/script/dom/touchevent.rs
+++ b/components/script/dom/touchevent.rs
@@ -114,4 +114,9 @@ impl<'a> TouchEventMethods for &'a TouchEvent {
     fn ChangedTouches(&self) -> Root<TouchList> {
         self.changed_touches.get()
     }
+
+    /// https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.uievent.IsTrusted()
+    }
 }

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::UIEventBinding;
 use dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
 use dom::bindings::error::Fallible;
@@ -94,5 +95,10 @@ impl UIEventMethods for UIEvent {
         event.init_event(Atom::from(&*type_), can_bubble, cancelable);
         self.view.set(view);
         self.detail.set(detail);
+    }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
     }
 }

--- a/components/script/dom/webglcontextevent.rs
+++ b/components/script/dom/webglcontextevent.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::WebGLContextEventBinding;
 use dom::bindings::codegen::Bindings::WebGLContextEventBinding::WebGLContextEventInit;
 use dom::bindings::codegen::Bindings::WebGLContextEventBinding::WebGLContextEventMethods;
@@ -24,6 +25,11 @@ impl WebGLContextEventMethods for WebGLContextEvent {
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15
     fn StatusMessage(&self) -> DOMString {
         self.status_message.clone()
+    }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
     }
 }
 

--- a/components/script/dom/webidls/Event.webidl
+++ b/components/script/dom/webidls/Event.webidl
@@ -34,6 +34,7 @@ interface Event {
   [Pure]
   readonly attribute boolean defaultPrevented;
 
+  [Unforgeable]
   readonly attribute boolean isTrusted;
   [Constant]
   readonly attribute DOMTimeStamp timeStamp;

--- a/tests/wpt/metadata/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/dom/interfaces.html.ini
@@ -1,15 +1,7 @@
 [interfaces.html]
   type: testharness
-  [Event interface: document.createEvent("Event") must have own property "isTrusted"]
-    expected: FAIL
-
-  [Event interface: new Event("foo") must have own property "isTrusted"]
-    expected: FAIL
 
   [CustomEvent interface: existence and properties of interface object]
-    expected: FAIL
-
-  [Event interface: new CustomEvent("foo") must have own property "isTrusted"]
     expected: FAIL
 
   [MutationObserver interface: existence and properties of interface object]


### PR DESCRIPTION
Three failure expectations were able to be removed from `tests/wpt/web-platform-tests/dom/interfaces.html`. This is my first commit to servo and my first time with rust, hopefully I didn't overlook anything.

Fixes #8956.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8963)

<!-- Reviewable:end -->
