### PR TITLE
webgl: Make a general way to get data from a JS array buffer view

### DIFF
--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::cell::DOMRefCell;
+use dom::bindings::conversions::array_buffer_view_data;
 use dom::bindings::codegen::Bindings::CryptoBinding;
 use dom::bindings::codegen::Bindings::CryptoBinding::CryptoMethods;
 use dom::bindings::error::{Error, Fallible};
@@ -10,9 +11,8 @@ use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
 use js::jsapi::{JSContext, JSObject};
-use js::jsapi::{JS_GetArrayBufferViewType, JS_GetObjectAsArrayBufferView, Type};
+use js::jsapi::{JS_GetArrayBufferViewType, Type};
 use rand::{OsRng, Rng};
-use std::{ptr, slice};
 
 no_jsmanaged_fields!(OsRng);
 
@@ -43,24 +43,23 @@ impl CryptoMethods for Crypto {
                        _cx: *mut JSContext,
                        input: *mut JSObject)
                        -> Fallible<*mut JSObject> {
-        let mut length = 0;
-        let mut data = ptr::null_mut();
-        if unsafe { JS_GetObjectAsArrayBufferView(input, &mut length, &mut data).is_null() } {
-            return Err(Error::Type("Argument to Crypto.getRandomValues is not an ArrayBufferView"
+        let mut data = match unsafe { array_buffer_view_data::<u8>(input) } {
+            Some(data) => data,
+            None => {
+                return Err(Error::Type("Argument to Crypto.getRandomValues is not an ArrayBufferView"
                                        .to_owned()));
-        }
+            }
+        };
+
         if !is_integer_buffer(input) {
             return Err(Error::TypeMismatch);
         }
-        if length > 65536 {
+
+        if data.len() > 65536 {
             return Err(Error::QuotaExceeded);
         }
 
-        let mut buffer = unsafe {
-            slice::from_raw_parts_mut(data, length as usize)
-        };
-
-        self.rng.borrow_mut().fill_bytes(&mut buffer);
+        self.rng.borrow_mut().fill_bytes(&mut data);
 
         Ok(input)
     }

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::cell::DOMRefCell;
-use dom::bindings::conversions::array_buffer_view_data;
 use dom::bindings::codegen::Bindings::CryptoBinding;
 use dom::bindings::codegen::Bindings::CryptoBinding::CryptoMethods;
+use dom::bindings::conversions::array_buffer_view_data;
 use dom::bindings::error::{Error, Fallible};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::Root;

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderi
 use dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::{WebGLRenderingContextMethods};
 use dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::{self, WebGLContextAttributes};
 use dom::bindings::codegen::UnionTypes::ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement;
-use dom::bindings::conversions::{ToJSValConvertible, array_buffer_view_to_vec};
+use dom::bindings::conversions::{ToJSValConvertible, array_buffer_view_to_vec_checked, array_buffer_view_to_vec};
 use dom::bindings::global::{GlobalField, GlobalRef};
 use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{JS, LayoutJS, MutNullableHeap, Root};
@@ -28,7 +28,7 @@ use dom::webgltexture::{TexParameterValue, WebGLTexture};
 use dom::webgluniformlocation::WebGLUniformLocation;
 use euclid::size::Size2D;
 use ipc_channel::ipc::{self, IpcSender};
-use js::jsapi::{JSContext, JSObject, RootedValue};
+use js::jsapi::{JSContext, JSObject, RootedValue, Type};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, JSVal, NullValue, UndefinedValue};
 use net_traits::image::base::PixelFormat;
 use net_traits::image_cache_task::ImageResponse;
@@ -948,7 +948,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             None => return,
         };
 
-        if let Some(data_vec) = array_buffer_view_to_vec::<f32>(data) {
+        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data, Type::Float32) {
             if data_vec.len() < 4 {
                 return self.webgl_error(InvalidOperation);
             }
@@ -976,7 +976,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     fn VertexAttrib1fv(&self, _cx: *mut JSContext, indx: u32, data: *mut JSObject) {
-        if let Some(data_vec) = array_buffer_view_to_vec::<f32>(data) {
+        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data, Type::Float32) {
             if data_vec.len() < 4 {
                 return self.webgl_error(InvalidOperation);
             }
@@ -994,7 +994,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     fn VertexAttrib2fv(&self, _cx: *mut JSContext, indx: u32, data: *mut JSObject) {
-        if let Some(data_vec) = array_buffer_view_to_vec::<f32>(data) {
+        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data, Type::Float32) {
             if data_vec.len() < 2 {
                 return self.webgl_error(InvalidOperation);
             }
@@ -1012,7 +1012,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     fn VertexAttrib3fv(&self, _cx: *mut JSContext, indx: u32, data: *mut JSObject) {
-        if let Some(data_vec) = array_buffer_view_to_vec::<f32>(data) {
+        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data, Type::Float32) {
             if data_vec.len() < 3 {
                 return self.webgl_error(InvalidOperation);
             }
@@ -1027,10 +1027,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         self.vertex_attrib(indx, x, y, z, w)
     }
 
-    #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     fn VertexAttrib4fv(&self, _cx: *mut JSContext, indx: u32, data: *mut JSObject) {
-        if let Some(data_vec) = array_buffer_view_to_vec::<f32>(data) {
+        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data, Type::Float32) {
             if data_vec.len() < 4 {
                 return self.webgl_error(InvalidOperation);
             }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -28,7 +28,7 @@ use dom::webgltexture::{TexParameterValue, WebGLTexture};
 use dom::webgluniformlocation::WebGLUniformLocation;
 use euclid::size::Size2D;
 use ipc_channel::ipc::{self, IpcSender};
-use js::jsapi::{JSContext, JSObject, RootedValue, Type};
+use js::jsapi::{JSContext, JSObject, RootedValue};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, JSVal, NullValue, UndefinedValue};
 use net_traits::image::base::PixelFormat;
 use net_traits::image_cache_task::ImageResponse;
@@ -948,7 +948,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             None => return,
         };
 
-        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data, Type::Float32) {
+        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data) {
             if data_vec.len() < 4 {
                 return self.webgl_error(InvalidOperation);
             }
@@ -976,7 +976,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     fn VertexAttrib1fv(&self, _cx: *mut JSContext, indx: u32, data: *mut JSObject) {
-        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data, Type::Float32) {
+        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data) {
             if data_vec.len() < 4 {
                 return self.webgl_error(InvalidOperation);
             }
@@ -994,7 +994,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     fn VertexAttrib2fv(&self, _cx: *mut JSContext, indx: u32, data: *mut JSObject) {
-        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data, Type::Float32) {
+        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data) {
             if data_vec.len() < 2 {
                 return self.webgl_error(InvalidOperation);
             }
@@ -1012,7 +1012,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     fn VertexAttrib3fv(&self, _cx: *mut JSContext, indx: u32, data: *mut JSObject) {
-        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data, Type::Float32) {
+        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data) {
             if data_vec.len() < 3 {
                 return self.webgl_error(InvalidOperation);
             }
@@ -1029,7 +1029,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     fn VertexAttrib4fv(&self, _cx: *mut JSContext, indx: u32, data: *mut JSObject) {
-        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data, Type::Float32) {
+        if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data) {
             if data_vec.len() < 4 {
                 return self.webgl_error(InvalidOperation);
             }


### PR DESCRIPTION
This fixes an invalid length being reported from
`float32_array_to_slice` (which used the byte length), and also to
generalize getting data from a JS array buffer view, to reduce code
duplication.

The pending type safety issues, like where we could send a `UInt16Array`
where we expect a `Float32` one, should be solved by IDL bindings in
some cases, like `uniform[n]fv` or `vertexAttrib[n]fv`, and with extra
checks in others, like in the pending `texImage2D(..., ArrayBufferView)`.

r? @jdm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8970)

<!-- Reviewable:end -->
