### PR TITLE
Slightly reduce the output of codegen

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2576,7 +2576,7 @@ class CGGetProtoObjectMethod(CGGetPerInterfaceObject):
     """
     def __init__(self, descriptor):
         CGGetPerInterfaceObject.__init__(self, descriptor, "GetProtoObject",
-                                         "PrototypeList::", pub=True)
+                                         "PrototypeList::", pub=descriptor.hasDescendants())
 
     def definition_body(self):
         return CGList([
@@ -2593,7 +2593,7 @@ class CGGetConstructorObjectMethod(CGGetPerInterfaceObject):
     """
     def __init__(self, descriptor):
         CGGetPerInterfaceObject.__init__(self, descriptor, "GetConstructorObject",
-                                         "constructors::")
+                                         "constructors::", pub=descriptor.hasDescendants())
 
     def definition_body(self):
         return CGList([

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -4986,7 +4986,8 @@ class CGDescriptor(CGThing):
             cgThings.append(CGWrapMethod(descriptor))
 
         if not descriptor.interface.isCallback():
-            cgThings.append(CGIDLInterface(descriptor))
+            if descriptor.concrete or descriptor.hasDescendants():
+                cgThings.append(CGIDLInterface(descriptor))
             cgThings.append(CGInterfaceTrait(descriptor))
             if descriptor.weakReferenceable:
                 cgThings.append(CGWeakReferenceableTrait(descriptor))

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -180,7 +180,7 @@ class Descriptor(DescriptorProvider):
         # If we're concrete, we need to crawl our ancestor interfaces and mark
         # them as having a concrete descendant.
         self.concrete = (not self.interface.isCallback() and
-                         desc.get('concrete', True))
+                         not self.interface.getExtendedAttribute("Abstract"))
         self.hasUnforgeableMembers = (self.concrete and
                                       any(MemberIsUnforgeable(m, self) for m in
                                           self.interface.members))

--- a/components/script/dom/webidls/CSS.webidl
+++ b/components/script/dom/webidls/CSS.webidl
@@ -6,6 +6,7 @@
  * http://dev.w3.org/csswg/cssom/#the-css-interface
  */
 
+[Abstract]
 interface CSS {
   [Throws]
   static DOMString escape(DOMString ident);


### PR DESCRIPTION
Interfaces which we know are never instantiated can generate less code.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/8993)

<!-- Reviewable:end -->
