### PR TITLE
Update Cargo.{lock,toml} to reference servo-egl instead of egl

### DIFF
--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -4,7 +4,6 @@ version = "0.0.1"
 dependencies = [
  "compositing 0.0.1",
  "devtools 0.0.1",
- "egl 0.2.0 (git+https://github.com/servo/rust-egl)",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -18,6 +17,7 @@ dependencies = [
  "profile 0.0.1",
  "script 0.0.1",
  "servo 0.0.1",
+ "servo-egl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -384,14 +384,6 @@ dependencies = [
 name = "dylib"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "egl"
-version = "0.2.0"
-source = "git+https://github.com/servo/rust-egl#c59c59f6dc252e2ab17103b045d7ab1e452f32da"
 dependencies = [
  "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/ports/gonk/Cargo.toml
+++ b/ports/gonk/Cargo.toml
@@ -40,9 +40,6 @@ path = "../../components/profile"
 [dependencies.util]
 path = "../../components/util"
 
-[dependencies.egl]
-git = "https://github.com/servo/rust-egl"
-
 [dependencies]
 env_logger = "0.3"
 url = "0.5"
@@ -51,3 +48,4 @@ errno = "0.1"
 libc = "0.2"
 euclid = {version = "0.4", features = ["plugins"]}
 gleam = "0.2"
+servo-egl = "0.2"


### PR DESCRIPTION
The crate name was changed in this commit:

https://github.com/servo/rust-egl/commit/ebbd1cff89c640ac5581fef7e3f14e3ef0d35d4a

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9005)

<!-- Reviewable:end -->
