### PR TITLE
Implement EventSource and update test expectations

### DIFF
--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::cell::DOMRefCell;
+use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
+use dom::bindings::codegen::Bindings::EventSourceBinding::{EventSourceInit, EventSourceMethods, Wrap};
+use dom::bindings::error::{Error, Fallible};
+use dom::bindings::global::GlobalRef;
+use dom::bindings::js::Root;
+use dom::bindings::reflector::reflect_dom_object;
+use dom::eventtarget::EventTarget;
+use std::cell::Cell;
+use url::Url;
+use util::str::DOMString;
+
+#[derive(JSTraceable, PartialEq, Copy, Clone, Debug, HeapSizeOf)]
+enum EventSourceReadyState {
+    Connecting = 0,
+    Open = 1,
+    Closed = 2
+}
+
+#[dom_struct]
+pub struct EventSource {
+    eventtarget: EventTarget,
+    url: Url,
+    ready_state: Cell<EventSourceReadyState>,
+    with_credentials: bool,
+    last_event_id: DOMRefCell<DOMString>
+}
+
+impl EventSource {
+    fn new_inherited(url: Url, with_credentials: bool) -> EventSource {
+        EventSource {
+            eventtarget: EventTarget::new_inherited(),
+            url: url,
+            ready_state: Cell::new(EventSourceReadyState::Connecting),
+            with_credentials: with_credentials,
+            last_event_id: DOMRefCell::new(DOMString::from(""))
+        }
+    }
+
+    fn new(global: GlobalRef, url: Url, with_credentials: bool) -> Root<EventSource> {
+        reflect_dom_object(box EventSource::new_inherited(url, with_credentials), global, Wrap)
+    }
+
+    pub fn Constructor(global: GlobalRef,
+                       url_str: DOMString,
+                       event_source_init: &EventSourceInit) -> Fallible<Root<EventSource>> {
+        // Steps 1-2
+        let base_url = global.get_url();
+        let url = match base_url.join(&*url_str) {
+            Ok(u) => u,
+            Err(_) => return Err(Error::Syntax)
+        };
+        // Step 3
+        let event_source = EventSource::new(global, url, event_source_init.withCredentials);
+        // Step 4
+        // Step 5
+        // Step 6
+        // Step 7
+        // Step 8
+        // Step 9
+        // Step 10
+        // Step 11
+        Ok(event_source)
+        // Step 12
+    }
+}
+
+impl EventSourceMethods for EventSource {
+    // https://html.spec.whatwg.org/multipage/#handler-eventsource-onopen
+    event_handler!(open, GetOnopen, SetOnopen);
+
+    // https://html.spec.whatwg.org/multipage/#handler-eventsource-onmessage
+    event_handler!(message, GetOnmessage, SetOnmessage);
+
+    // https://html.spec.whatwg.org/multipage/#handler-eventsource-onerror
+    event_handler!(error, GetOnerror, SetOnerror);
+
+    // https://html.spec.whatwg.org/multipage/#dom-eventsource-url
+    fn Url(&self) -> DOMString {
+        DOMString::from(self.url.serialize())
+    }
+
+    // https://html.spec.whatwg.org/multipage/#dom-eventsource-withcredentials
+    fn WithCredentials(&self) -> bool {
+        self.with_credentials
+    }
+
+    // https://html.spec.whatwg.org/multipage/#dom-eventsource-readystate
+    fn ReadyState(&self) -> u16 {
+        self.ready_state.get() as u16
+    }
+
+    // https://html.spec.whatwg.org/multipage/#dom-eventsource-close
+    fn Close(&self) {
+        self.ready_state.set(EventSourceReadyState::Closed);
+        // TODO: Terminate ongoing fetch
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -246,6 +246,7 @@ pub mod element;
 pub mod errorevent;
 pub mod event;
 pub mod eventdispatcher;
+pub mod eventsource;
 pub mod eventtarget;
 pub mod file;
 pub mod filelist;

--- a/components/script/dom/webidls/EventSource.webidl
+++ b/components/script/dom/webidls/EventSource.webidl
@@ -1,0 +1,31 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/*
+ * The origin of this IDL file is:
+ * https://html.spec.whatwg.org/multipage/#eventsource
+ */
+
+[Constructor(DOMString url, optional EventSourceInit eventSourceInitDict),
+/*Exposed=(Window,Worker)*/]
+interface EventSource : EventTarget {
+  readonly attribute DOMString url;
+  readonly attribute boolean withCredentials;
+
+  // ready state
+  const unsigned short CONNECTING = 0;
+  const unsigned short OPEN = 1;
+  const unsigned short CLOSED = 2;
+  readonly attribute unsigned short readyState;
+
+  // networking
+  attribute EventHandler onopen;
+  attribute EventHandler onmessage;
+  attribute EventHandler onerror;
+  void close();
+};
+
+dictionary EventSourceInit {
+  boolean withCredentials = false;
+};

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -9,6 +9,8 @@ skip: true
   skip: false
 [DOMEvents]
   skip: false
+[eventsource]
+  skip: false
 [FileAPI]
   skip: false
 [html]

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-close.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-close.htm.ini
@@ -1,0 +1,6 @@
+[eventsource-close.htm]
+  type: testharness
+  expected: TIMEOUT
+  [dedicated worker - EventSource: close()]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-constructor-non-same-origin.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-constructor-non-same-origin.htm.ini
@@ -1,0 +1,20 @@
+[eventsource-constructor-non-same-origin.htm]
+  type: testharness
+  [dedicated worker - EventSource: constructor (act as if there is a network error) (http://example.not/)]
+    expected: TIMEOUT
+
+  [dedicated worker - EventSource: constructor (act as if there is a network error) (https://example.not/test)]
+    expected: TIMEOUT
+
+  [dedicated worker - EventSource: constructor (act as if there is a network error) (ftp://example.not/)]
+    expected: TIMEOUT
+
+  [dedicated worker - EventSource: constructor (act as if there is a network error) (about:blank)]
+    expected: TIMEOUT
+
+  [dedicated worker - EventSource: constructor (act as if there is a network error) (mailto:whatwg@awesome.example)]
+    expected: TIMEOUT
+
+  [dedicated worker - EventSource: constructor (act as if there is a network error) (javascript:alert('FAIL'))]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-eventtarget.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-eventtarget.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-eventtarget.htm]
+  type: testharness
+  [dedicated worker - EventSource: addEventListener()]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-onmesage.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-onmesage.htm.ini
@@ -1,0 +1,6 @@
+[eventsource-onmesage.htm]
+  type: testharness
+  expected: TIMEOUT
+  [dedicated worker - EventSource: onmessage]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-onopen.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-onopen.htm.ini
@@ -1,0 +1,6 @@
+[eventsource-onopen.htm]
+  type: testharness
+  expected: TIMEOUT
+  [dedicated worker - EventSource: onopen (announcing the connection)]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/event-data.html.ini
+++ b/tests/wpt/metadata/eventsource/event-data.html.ini
@@ -1,0 +1,6 @@
+[event-data.html]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: lines and data parsing]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/eventsource-close.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-close.htm.ini
@@ -1,0 +1,9 @@
+[eventsource-close.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: close()]
+    expected: TIMEOUT
+
+  [EventSource: close(), test events]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/eventsource-constructor-document-domain.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-constructor-document-domain.htm.ini
@@ -1,0 +1,6 @@
+[eventsource-constructor-document-domain.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: document.domain]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/eventsource-constructor-non-same-origin.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-constructor-non-same-origin.htm.ini
@@ -1,0 +1,20 @@
+[eventsource-constructor-non-same-origin.htm]
+  type: testharness
+  [EventSource: constructor (act as if there is a network error) (http://example.not/)]
+    expected: TIMEOUT
+
+  [EventSource: constructor (act as if there is a network error) (https://example.not/test)]
+    expected: TIMEOUT
+
+  [EventSource: constructor (act as if there is a network error) (ftp://example.not/)]
+    expected: TIMEOUT
+
+  [EventSource: constructor (act as if there is a network error) (about:blank)]
+    expected: TIMEOUT
+
+  [EventSource: constructor (act as if there is a network error) (mailto:whatwg@awesome.example)]
+    expected: TIMEOUT
+
+  [EventSource: constructor (act as if there is a network error) (javascript:alert('FAIL'))]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/eventsource-constructor-stringify.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-constructor-stringify.htm.ini
@@ -1,0 +1,6 @@
+[eventsource-constructor-stringify.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: stringify argument, object]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/eventsource-constructor-url-multi-window.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-constructor-url-multi-window.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-constructor-url-multi-window.htm]
+  type: testharness
+  [EventSource: resolving URLs]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/eventsource-cross-origin.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-cross-origin.htm.ini
@@ -1,0 +1,21 @@
+[eventsource-cross-origin.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: cross-origin basic use]
+    expected: TIMEOUT
+
+  [EventSource: cross-origin redirect use]
+    expected: TIMEOUT
+
+  [EventSource: cross-origin redirect use recon]
+    expected: TIMEOUT
+
+  [EventSource: cross-origin allow-origin: http://example.org should fail]
+    expected: TIMEOUT
+
+  [EventSource: cross-origin allow-origin:'' should fail]
+    expected: TIMEOUT
+
+  [EventSource: cross-origin No allow-origin should fail]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/eventsource-eventtarget.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-eventtarget.htm.ini
@@ -1,0 +1,6 @@
+[eventsource-eventtarget.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: addEventListener()]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/eventsource-onmessage.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-onmessage.htm.ini
@@ -1,0 +1,6 @@
+[eventsource-onmessage.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: onmessage]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/eventsource-onopen.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-onopen.htm.ini
@@ -1,0 +1,6 @@
+[eventsource-onopen.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: onopen (announcing the connection)]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/eventsource-reconnect.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-reconnect.htm.ini
@@ -1,0 +1,9 @@
+[eventsource-reconnect.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: reconnection 200]
+    expected: TIMEOUT
+
+  [EventSource: reconnection, test reconnection events]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/eventsource-request-cancellation.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-request-cancellation.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-request-cancellation.htm]
+  type: testharness
+  [EventSource: request cancellation]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/format-bom-2.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-bom-2.htm.ini
@@ -1,0 +1,6 @@
+[format-bom-2.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: Double BOM]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-bom.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-bom.htm.ini
@@ -1,0 +1,6 @@
+[format-bom.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: BOM]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-comments.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-comments.htm.ini
@@ -1,0 +1,6 @@
+[format-comments.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: comment fest]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-data-before-final-empty-line.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-data-before-final-empty-line.htm.ini
@@ -1,0 +1,6 @@
+[format-data-before-final-empty-line.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: a data before final empty line]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-field-data.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-data.htm.ini
@@ -1,0 +1,6 @@
+[format-field-data.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: data field parsing]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-field-event-empty.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-event-empty.htm.ini
@@ -1,0 +1,6 @@
+[format-field-event-empty.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: empty "event" field]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-field-event.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-event.htm.ini
@@ -1,0 +1,6 @@
+[format-field-event.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: custom event name]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-field-id-2.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-id-2.htm.ini
@@ -1,0 +1,6 @@
+[format-field-id-2.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: Last-Event-ID (2)]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-field-id.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-id.htm.ini
@@ -1,0 +1,6 @@
+[format-field-id.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: Last-Event-ID]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-field-parsing.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-parsing.htm.ini
@@ -1,0 +1,6 @@
+[format-field-parsing.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: field parsing]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-field-retry-bogus.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-retry-bogus.htm.ini
@@ -1,0 +1,6 @@
+[format-field-retry-bogus.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: "retry" field (bogus)]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-field-retry-empty.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-retry-empty.htm.ini
@@ -1,0 +1,6 @@
+[format-field-retry-empty.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: empty retry field]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-field-retry.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-retry.htm.ini
@@ -1,0 +1,6 @@
+[format-field-retry.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: "retry" field]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-field-unknown.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-unknown.htm.ini
@@ -1,0 +1,6 @@
+[format-field-unknown.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: unknown fields and parsing fun]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-leading-space.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-leading-space.htm.ini
@@ -1,0 +1,6 @@
+[format-leading-space.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: leading space]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-mime-bogus.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-mime-bogus.htm.ini
@@ -1,0 +1,6 @@
+[format-mime-bogus.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: bogus MIME type]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-mime-trailing-semicolon.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-mime-trailing-semicolon.htm.ini
@@ -1,0 +1,6 @@
+[format-mime-trailing-semicolon.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: MIME type with trailing ;]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-mime-valid-bogus.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-mime-valid-bogus.htm.ini
@@ -1,0 +1,6 @@
+[format-mime-valid-bogus.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: incorrect valid MIME type]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-newlines.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-newlines.htm.ini
@@ -1,0 +1,6 @@
+[format-newlines.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: newline fest]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-null-character.html.ini
+++ b/tests/wpt/metadata/eventsource/format-null-character.html.ini
@@ -1,0 +1,6 @@
+[format-null-character.html]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: null character in response]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/format-utf-8.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-utf-8.htm.ini
@@ -1,0 +1,6 @@
+[format-utf-8.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: always UTF-8]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/interfaces.html.ini
+++ b/tests/wpt/metadata/eventsource/interfaces.html.ini
@@ -1,0 +1,11 @@
+[interfaces.html]
+  type: testharness
+  [EventSource interface: existence and properties of interface object]
+    expected: FAIL
+
+  [EventSource interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Stringification of new EventSource("http://foo")]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/request-accept.htm.ini
+++ b/tests/wpt/metadata/eventsource/request-accept.htm.ini
@@ -1,0 +1,6 @@
+[request-accept.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: Accept header]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/request-cache-control.htm.ini
+++ b/tests/wpt/metadata/eventsource/request-cache-control.htm.ini
@@ -1,0 +1,9 @@
+[request-cache-control.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: Cache-Control]
+    expected: TIMEOUT
+
+  [EventSource: Cache-Control 1]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/request-credentials.htm.ini
+++ b/tests/wpt/metadata/eventsource/request-credentials.htm.ini
@@ -1,0 +1,12 @@
+[request-credentials.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: credentials: credentials enabled]
+    expected: TIMEOUT
+
+  [EventSource: credentials: credentials disabled]
+    expected: TIMEOUT
+
+  [EventSource: credentials: credentials default]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/request-redirect.htm.ini
+++ b/tests/wpt/metadata/eventsource/request-redirect.htm.ini
@@ -1,0 +1,15 @@
+[request-redirect.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: redirect (301)]
+    expected: TIMEOUT
+
+  [EventSource: redirect (302)]
+    expected: TIMEOUT
+
+  [EventSource: redirect (303)]
+    expected: TIMEOUT
+
+  [EventSource: redirect (307)]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/request-status-error.htm.ini
+++ b/tests/wpt/metadata/eventsource/request-status-error.htm.ini
@@ -1,0 +1,24 @@
+[request-status-error.htm]
+  type: testharness
+  expected: TIMEOUT
+  [EventSource: incorrect HTTP status code (204)]
+    expected: TIMEOUT
+
+  [EventSource: incorrect HTTP status code (205)]
+    expected: TIMEOUT
+
+  [EventSource: incorrect HTTP status code (210)]
+    expected: TIMEOUT
+
+  [EventSource: incorrect HTTP status code (299)]
+    expected: TIMEOUT
+
+  [EventSource: incorrect HTTP status code (404)]
+    expected: TIMEOUT
+
+  [EventSource: incorrect HTTP status code (410)]
+    expected: TIMEOUT
+
+  [EventSource: incorrect HTTP status code (503)]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/eventsource/shared-worker/eventsource-close.htm.ini
+++ b/tests/wpt/metadata/eventsource/shared-worker/eventsource-close.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-close.htm]
+  type: testharness
+  [shared worker - EventSource: close()]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/shared-worker/eventsource-constructor-non-same-origin.htm.ini
+++ b/tests/wpt/metadata/eventsource/shared-worker/eventsource-constructor-non-same-origin.htm.ini
@@ -1,0 +1,20 @@
+[eventsource-constructor-non-same-origin.htm]
+  type: testharness
+  [shared worker - EventSource: constructor (act as if there is a network error) (http://example.not)]
+    expected: FAIL
+
+  [shared worker - EventSource: constructor (act as if there is a network error) (https://example.not/test)]
+    expected: FAIL
+
+  [shared worker - EventSource: constructor (act as if there is a network error) (ftp://example.not)]
+    expected: FAIL
+
+  [shared worker - EventSource: constructor (act as if there is a network error) (about:blank)]
+    expected: FAIL
+
+  [shared worker - EventSource: constructor (act as if there is a network error) (mailto:whatwg@awesome.example)]
+    expected: FAIL
+
+  [shared worker - EventSource: constructor (act as if there is a network error) (javascript:alert('FAIL'))]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/shared-worker/eventsource-constructor-url-bogus.htm.ini
+++ b/tests/wpt/metadata/eventsource/shared-worker/eventsource-constructor-url-bogus.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-constructor-url-bogus.htm]
+  type: testharness
+  [shared worker - EventSource: constructor (invalid URL)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/shared-worker/eventsource-eventtarget.htm.ini
+++ b/tests/wpt/metadata/eventsource/shared-worker/eventsource-eventtarget.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-eventtarget.htm]
+  type: testharness
+  [shared worker - EventSource: addEventListener()]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/shared-worker/eventsource-onmesage.htm.ini
+++ b/tests/wpt/metadata/eventsource/shared-worker/eventsource-onmesage.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-onmesage.htm]
+  type: testharness
+  [shared worker - EventSource: onmessage]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/shared-worker/eventsource-onopen.htm.ini
+++ b/tests/wpt/metadata/eventsource/shared-worker/eventsource-onopen.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-onopen.htm]
+  type: testharness
+  [shared worker - EventSource: onopen (announcing the connection)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/shared-worker/eventsource-prototype.htm.ini
+++ b/tests/wpt/metadata/eventsource/shared-worker/eventsource-prototype.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-prototype.htm]
+  type: testharness
+  [shared worker - EventSource: prototype et al]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/shared-worker/eventsource-url.htm.ini
+++ b/tests/wpt/metadata/eventsource/shared-worker/eventsource-url.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-url.htm]
+  type: testharness
+  [shared worker - EventSource: url]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -7755,54 +7755,6 @@
   [EventSource interface: existence and properties of interface object]
     expected: FAIL
 
-  [EventSource interface object length]
-    expected: FAIL
-
-  [EventSource interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [EventSource interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [EventSource interface: attribute url]
-    expected: FAIL
-
-  [EventSource interface: attribute withCredentials]
-    expected: FAIL
-
-  [EventSource interface: constant CONNECTING on interface object]
-    expected: FAIL
-
-  [EventSource interface: constant CONNECTING on interface prototype object]
-    expected: FAIL
-
-  [EventSource interface: constant OPEN on interface object]
-    expected: FAIL
-
-  [EventSource interface: constant OPEN on interface prototype object]
-    expected: FAIL
-
-  [EventSource interface: constant CLOSED on interface object]
-    expected: FAIL
-
-  [EventSource interface: constant CLOSED on interface prototype object]
-    expected: FAIL
-
-  [EventSource interface: attribute readyState]
-    expected: FAIL
-
-  [EventSource interface: attribute onopen]
-    expected: FAIL
-
-  [EventSource interface: attribute onmessage]
-    expected: FAIL
-
-  [EventSource interface: attribute onerror]
-    expected: FAIL
-
-  [EventSource interface: operation close()]
-    expected: FAIL
-
   [WebSocket interface: existence and properties of interface object]
     expected: FAIL
 
@@ -9427,9 +9379,6 @@
     expected: FAIL
 
   [ImageBitmap interface object name]
-    expected: FAIL
-
-  [EventSource interface object name]
     expected: FAIL
 
   [MessageChannel interface object name]

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.html
@@ -99,6 +99,7 @@ var interfaceNamesInGlobalScope = [
   "Element",
   "ErrorEvent",
   "Event",
+  "EventSource",
   "EventTarget",
   "File",
   "FileList",


### PR DESCRIPTION
Partial #8925.

Most of the processing model for `EventSource` are unimplemented because we currently don't have a fetch implementation.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9029)

<!-- Reviewable:end -->
