### PR TITLE
Refactor FormData code to match updated spec

### DIFF
--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -51,6 +51,7 @@ impl FormData {
     }
 
     pub fn Constructor(global: GlobalRef, form: Option<&HTMLFormElement>) -> Fallible<Root<FormData>> {
+        // TODO: Construct form data set for form if it is supplied
         Ok(FormData::new(form, global))
     }
 }
@@ -91,6 +92,18 @@ impl FormDataMethods for FormData {
                      FormDatum::StringData(ref s) => eString(s.clone()),
                      FormDatum::FileData(ref f) => eFile(Root::from_ref(&*f)),
                  })
+    }
+
+    // https://xhr.spec.whatwg.org/#dom-formdata-getall
+    fn GetAll(&self, name: DOMString) -> Vec<FileOrString> {
+        self.data.borrow()
+                 .get(&name)
+                 .map_or(vec![], |data|
+                    data.iter().map(|item| match *item {
+                        FormDatum::StringData(ref s) => eString(s.clone()),
+                        FormDatum::FileData(ref f) => eFile(Root::from_ref(&*f)),
+                    }).collect()
+                 )
     }
 
     // https://xhr.spec.whatwg.org/#dom-formdata-has

--- a/components/script/dom/webidls/FormData.webidl
+++ b/components/script/dom/webidls/FormData.webidl
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 /*
  * The origin of this IDL file is
- * https://xhr.spec.whatwg.org
+ * https://xhr.spec.whatwg.org/#interface-formdata
  */
 
 typedef (File or DOMString) FormDataEntryValue;
@@ -15,7 +15,7 @@ interface FormData {
   void append(DOMString name, DOMString value);
   void delete(DOMString name);
   FormDataEntryValue? get(DOMString name);
-  // sequence<FormDataEntryValue> getAll(DOMString name);
+  sequence<FormDataEntryValue> getAll(DOMString name);
   boolean has(DOMString name);
   void set(DOMString name, Blob value, optional DOMString filename);
   void set(DOMString name, DOMString value);

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -30149,7 +30149,28 @@
   },
   "local_changes": {
     "deleted": [],
-    "items": {},
+    "items": {
+      "testharness": {
+        "XMLHttpRequest/formdata-delete.htm": [
+          {
+            "path": "XMLHttpRequest/formdata-delete.htm",
+            "url": "/XMLHttpRequest/formdata-delete.htm"
+          }
+        ],
+        "XMLHttpRequest/formdata-get.htm": [
+          {
+            "path": "XMLHttpRequest/formdata-get.htm",
+            "url": "/XMLHttpRequest/formdata-get.htm"
+          }
+        ],
+        "XMLHttpRequest/formdata-has.htm": [
+          {
+            "path": "XMLHttpRequest/formdata-has.htm",
+            "url": "/XMLHttpRequest/formdata-has.htm"
+          }
+        ]
+      }
+    },
     "reftest_nodes": {}
   },
   "reftest_nodes": {

--- a/tests/wpt/metadata/XMLHttpRequest/FormData-append.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/FormData-append.html.ini
@@ -2,4 +2,6 @@
   type: testharness
   [Passing a String object to FormData.append should work.]
     expected: FAIL
+  [testFormDataAppendEmptyBlob]
+    expected: FAIL
 

--- a/tests/wpt/metadata/XMLHttpRequest/formdata-delete.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/formdata-delete.htm.ini
@@ -1,0 +1,7 @@
+[formdata-delete.htm]
+  type:testharness
+  [testFormDataDeleteFromFormNonExistentKey]
+    expected: FAIL
+  [testFormDataDeleteFromFormOtherKey]
+    expected: FAIL
+

--- a/tests/wpt/metadata/XMLHttpRequest/formdata-get.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/formdata-get.htm.ini
@@ -1,0 +1,6 @@
+[formdata-get.htm]
+  type: testharness
+  [testFormDataGetFromForm]
+    expected: FAIL
+  [testFormDataGetAllFromForm]
+    expected: FAIL

--- a/tests/wpt/metadata/XMLHttpRequest/interfaces.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/interfaces.html.ini
@@ -1,20 +1,5 @@
 [interfaces.html]
   type: testharness
-  [FormData interface: new FormData() must inherit property "getAll" with the proper type (4)]
-    expected: FAIL
-
-  [FormData interface: new FormData(form) must inherit property "getAll" with the proper type (4)]
-    expected: FAIL
-
-  [FormData interface: operation getAll(USVString)]
-    expected: FAIL
-
-  [FormData interface: calling getAll(USVString) on new FormData() with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [FormData interface: calling getAll(USVString) on new FormData(form) with too few arguments must throw TypeError]
-    expected: FAIL
-
   [ProgressEvent interface: existence and properties of interface object]
     expected: FAIL
 

--- a/tests/wpt/web-platform-tests/XMLHttpRequest/FormData-append.html
+++ b/tests/wpt/web-platform-tests/XMLHttpRequest/FormData-append.html
@@ -1,28 +1,94 @@
 <!doctype html>
-<meta charset=utf-8>
+<meta charset="utf-8">
 <title>FormData.append</title>
-<link rel=help href=https://xhr.spec.whatwg.org/#dom-formdata-append>
-<script src=/resources/testharness.js></script>
-<script src=/resources/testharnessreport.js></script>
-<div id=log></div>
+<link rel="help" href="https://xhr.spec.whatwg.org/#dom-formdata-append">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<form id="form" />
 <script>
-function test_formdata(creator, verifier, description) {
-  async_test(description).step(function() {
-    var fd = creator();
-    var xhr = new XMLHttpRequest();
-    xhr.onload = this.step_func(function() {
-      verifier(xhr.responseText);
-      this.done();
-    });
-    xhr.open("POST", "resources/upload.py");
-    xhr.send(fd);
-  })
-}
-test_formdata(function() {
-  var fd = new FormData();
-  fd.append("name", new String("value"));
-  return fd;
-}, function(data) {
-  assert_equals(data, "name=value,\n");
-}, "Passing a String object to FormData.append should work.");
+    function test_formdata(creator, verifier, description) {
+        async_test(description).step(function() {
+            var fd = creator();
+            var xhr = new XMLHttpRequest();
+            xhr.onload = this.step_func(function() {
+                verifier(xhr.responseText);
+                this.done();
+            });
+            xhr.open("POST", "resources/upload.py");
+            xhr.send(fd);
+        });
+    }
+
+    test_formdata(function() {
+        var fd = new FormData();
+        fd.append("name", new String("value"));
+        return fd;
+    }, function(data) {
+        assert_equals(data, "name=value,\n");
+    }, "Passing a String object to FormData.append should work.");
+
+    test(function() {
+        assert_equals(create_formdata(['key', 'value1']).get('key'), "value1");
+    }, 'testFormDataAppend1');
+    test(function() {
+        assert_equals(create_formdata(['key', 'value2'], ['key', 'value1']).get('key'), "value2");
+    }, 'testFormDataAppend2');
+    test(function() {
+        assert_equals(create_formdata(['key', undefined]).get('key'), "undefined");
+    }, 'testFormDataAppendUndefined1');
+    test(function() {
+        assert_equals(create_formdata(['key', undefined], ['key', 'value1']).get('key'), "undefined");
+    }, 'testFormDataAppendUndefined2');
+    test(function() {
+        assert_equals(create_formdata(['key', null]).get('key'), "null");
+    }, 'testFormDataAppendNull1');
+    test(function() {
+        assert_equals(create_formdata(['key', null], ['key', 'value1']).get('key'), "null");
+    }, 'testFormDataAppendNull2');
+    test(function() {
+        var fd = new FormData(document.getElementById("form"));
+        fd.append('key', 'value1');
+        assert_equals(fd.get('key'), "value1");
+    }, 'testFormDataAppendToForm1');
+    test(function() {
+        var fd = new FormData(document.getElementById("form"));
+        fd.append('key', 'value2');
+        fd.append('key', 'value1');
+        assert_equals(fd.get('key'), "value2");
+    }, 'testFormDataAppendToForm2');
+    test(function() {
+        var fd = new FormData(document.getElementById("form"));
+        fd.append('key', undefined);
+        assert_equals(fd.get('key'), "undefined");
+    }, 'testFormDataAppendToFormUndefined1');
+    test(function() {
+        var fd = new FormData(document.getElementById("form"));
+        fd.append('key', undefined);
+        fd.append('key', 'value1');
+        assert_equals(fd.get('key'), "undefined");
+    }, 'testFormDataAppendToFormUndefined2');
+    test(function() {
+        var fd = new FormData(document.getElementById("form"));
+        fd.append('key', null);
+        assert_equals(fd.get('key'), "null");
+    }, 'testFormDataAppendToFormNull1');
+    test(function() {
+        var fd = new FormData(document.getElementById("form"));
+        fd.append('key', null);
+        fd.append('key', 'value1');
+        assert_equals(fd.get('key'), "null");
+    }, 'testFormDataAppendToFormNull2');
+    test(function() {
+        assert_object_equals(create_formdata(['key', new Blob(), 'blank.txt']).get('key'),
+                             new File(new Blob(), 'blank.txt'));
+    }, 'testFormDataAppendEmptyBlob');
+
+    function create_formdata() {
+        var fd = new FormData();
+        for (var i = 0; i < arguments.length; i++) {
+            fd.append.apply(fd, arguments[i]);
+        };
+        return fd;
+    }
 </script>

--- a/tests/wpt/web-platform-tests/XMLHttpRequest/formdata-delete.htm
+++ b/tests/wpt/web-platform-tests/XMLHttpRequest/formdata-delete.htm
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang=en>
+<meta charset=utf-8>
+<title>FormData: delete</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#dom-formdata-get" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#dom-formdata-getall" />
+<div id="log"></div>
+<form id="form1">
+    <input type="hidden" name="key" value="value1">
+    <input type="hidden" name="key" value="value2">
+</form>
+<form id="form2">
+    <input type="hidden" name="key1" value="value1">
+    <input type="hidden" name="key2" value="value2">
+</form>
+<form id="empty-form" />
+<script>
+    test(function() {
+        var fd = create_formdata(['key', 'value1'], ['key', 'value2']);
+        fd.delete('key');
+        assert_equals(fd.get('key'), null);
+    }, 'testFormDataDelete');
+    test(function() {
+        var fd = new FormData(document.getElementById('form1'));
+        fd.delete('key');
+        assert_equals(fd.get('key'), null);
+    }, 'testFormDataDeleteFromForm');
+    test(function() {
+        var fd = new FormData(document.getElementById('form1'));
+        fd.delete('nil');
+        assert_equals(fd.get('key'), 'value1');
+    }, 'testFormDataDeleteFromFormNonExistentKey');
+    test(function() {
+        var fd = new FormData(document.getElementById('form2'));
+        fd.delete('key1');
+        assert_equals(fd.get('key1'), null);
+        assert_equals(fd.get('key2'), 'value2');
+    }, 'testFormDataDeleteFromFormOtherKey');
+    test(function() {
+        var fd = new FormData(document.getElementById('empty-form'));
+        fd.delete('key');
+        assert_equals(fd.get('key'), null);
+    }, 'testFormDataDeleteFromEmptyForm');
+    test(function() {
+        var fd = create_formdata(['key', 'value1'], ['key', 'value2']);
+        fd.delete('nil');
+        assert_equals(fd.get('key'), 'value1');
+    }, 'testFormDataDeleteNonExistentKey');
+    test(function() {
+        var fd = create_formdata(['key1', 'value1'], ['key2', 'value2']);
+        fd.delete('key1');
+        assert_equals(fd.get('key1'), null);
+        assert_equals(fd.get('key2'), 'value2');
+    }, 'testFormDataDeleteOtherKey');
+
+    function create_formdata() {
+        var fd = new FormData();
+        for (var i = 0; i < arguments.length; i++) {
+            fd.append.apply(fd, arguments[i]);
+        };
+        return fd;
+    }
+</script>

--- a/tests/wpt/web-platform-tests/XMLHttpRequest/formdata-get.htm
+++ b/tests/wpt/web-platform-tests/XMLHttpRequest/formdata-get.htm
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang=en>
+<meta charset=utf-8>
+<title>FormData: get and getAll</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#dom-formdata-get" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#dom-formdata-getall" />
+<div id="log"></div>
+<form id="form">
+    <input type="hidden" name="key" value="value1">
+    <input type="hidden" name="key" value="value2">
+</form>
+<form id="empty-form" />
+<script>
+    test(function() {
+        assert_equals(create_formdata(['key', 'value1'], ['key', 'value2']).get('key'), "value1");
+    }, 'testFormDataGet');
+    test(function() {
+        assert_equals(new FormData(document.getElementById('form')).get('key'), "value1");
+    }, 'testFormDataGetFromForm');
+    test(function() {
+        assert_equals(new FormData(document.getElementById('form')).get('nil'), null);
+    }, 'testFormDataGetFromFormNull');
+    test(function() {
+        assert_equals(new FormData(document.getElementById('empty-form')).get('key'), null);
+    }, 'testFormDataGetFromEmptyForm');
+    test(function() {
+        assert_equals(create_formdata(['key', 'value1'], ['key', 'value2']).get('nil'), null);
+    }, 'testFormDataGetNull1');
+    test(function() {
+        assert_equals(create_formdata().get('key'), null);
+    }, 'testFormDataGetNull2');
+    test(function() {
+        assert_array_equals(create_formdata(['key', 'value1'], ['key', 'value2']).getAll('key'), ["value1", "value2"]);
+    }, 'testFormDataGetAll');
+    test(function() {
+        assert_array_equals(create_formdata(['key', 'value1'], ['key', 'value2']).getAll('nil'), []);
+    }, 'testFormDataGetAllEmpty1');
+    test(function() {
+        assert_array_equals(create_formdata().getAll('key'), []);
+    }, 'testFormDataGetAllEmpty2');
+    test(function() {
+        assert_array_equals(new FormData(document.getElementById('form')).getAll('key'), ["value1", "value2"]);
+    }, 'testFormDataGetAllFromForm');
+    test(function() {
+        assert_array_equals(new FormData(document.getElementById('form')).getAll('nil'), []);
+    }, 'testFormDataGetAllFromFormNull');
+    test(function() {
+        assert_array_equals(new FormData(document.getElementById('empty-form')).getAll('key'), []);
+    }, 'testFormDataGetAllFromEmptyForm');
+
+    function create_formdata() {
+        var fd = new FormData();
+        for (var i = 0; i < arguments.length; i++) {
+            fd.append.apply(fd, arguments[i]);
+        };
+        return fd;
+    }
+</script>

--- a/tests/wpt/web-platform-tests/XMLHttpRequest/formdata-has.htm
+++ b/tests/wpt/web-platform-tests/XMLHttpRequest/formdata-has.htm
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang=en>
+<meta charset=utf-8>
+<title>FormData: has</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#dom-formdata-get" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#dom-formdata-getall" />
+<div id="log"></div>
+<form id="form">
+    <input type="hidden" name="key" value="value1">
+    <input type="hidden" name="key" value="value2">
+</form>
+<form id="empty-form" />
+<script>
+    test(function() {
+        assert_equals(create_formdata(['key', 'value1'], ['key', 'value2']).has('key'), true);
+    }, 'testFormDataHas');
+    test(function() {
+        assert_equals(new FormData(document.getElementById('form')).has('key'), true);
+    }, 'testFormDataHasFromForm');
+    test(function() {
+        assert_equals(new FormData(document.getElementById('form')).has('nil'), false);
+    }, 'testFormDataHasFromFormNull');
+    test(function() {
+        assert_equals(new FormData(document.getElementById('empty-form')).has('key'), false);
+    }, 'testFormDataHasFromEmptyForm');
+    test(function() {
+        assert_equals(create_formdata(['key', 'value1'], ['key', 'value2']).has('nil'), false);
+    }, 'testFormDataHasEmpty1');
+    test(function() {
+        assert_equals(create_formdata().has('key'), false);
+    }, 'testFormDataHasEmpty2');
+
+    function create_formdata() {
+        var fd = new FormData();
+        for (var i = 0; i < arguments.length; i++) {
+            fd.append.apply(fd, arguments[i]);
+        };
+        return fd;
+    }
+</script>


### PR DESCRIPTION
I don't think there's an issue filed for this. I just happen to come across an incomplete implementation of FormData while I was "patrolling".

Kinda feel a bit guilty about this since it could've been an E-easy issue.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9031)

<!-- Reviewable:end -->
