### PR TITLE
Remove workaround for Rect::is_empty

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1097,10 +1097,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 }
             }
             SpecificFragmentInfo::Iframe(ref fragment_info) => {
-                // TODO(mrobinson): When https://github.com/servo/euclid/issues/109 is fixed this
-                // check can just become stacking_relative_content_box.is_empty().
-                if stacking_relative_content_box.size.width != Zero::zero() &&
-                   stacking_relative_content_box.size.height != Zero::zero() {
+                if !stacking_relative_content_box.is_empty() {
                     let layer_id = self.layer_id();
                     display_list.content.push_back(DisplayItem::LayeredItemClass(box LayeredItem {
                         item: DisplayItem::NoopClass(


### PR DESCRIPTION
Now that euclid is up-to-date this workaround is no longer necessary.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9041)

<!-- Reviewable:end -->
