### PR TITLE
mach run --debug: Try using rust-gdb/rust-lldb if available

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -95,8 +95,17 @@ class PostBuildCommands(CommandBase):
                 print("Could not find a suitable debugger in your PATH.")
                 return 1
 
+            command = self.debuggerInfo.path
+            if debugger == 'gdb' or debugger == 'lldb':
+                rustCommand = 'rust-' + debugger
+                try:
+                    subprocess.check_call([rustCommand, '--version'], env=env, stdout=open(os.devnull, 'w'))
+                    command = rustCommand
+                except (OSError, subprocess.CalledProcessError):
+                    pass
+
             # Prepend the debugger args.
-            args = ([self.debuggerInfo.path] + self.debuggerInfo.args +
+            args = ([command] + self.debuggerInfo.args +
                     args + params)
         else:
             args = args + params


### PR DESCRIPTION
If the selected debugger (requested explicitly or detected by mozdebug)
is gdb or lldb, use rust-gdb or rust-lldb instead, if it's available in
the path and appears to be working.

(This should usually be the case when using the default debugger on
GNU/Linux or MacOS, as rust-gdb or rust-lldb is provided by the Rust
snapshot in use.)

Note: I cobbled this together without _any_ previous Python experience -- so if it violates three dozen rules, and only works by luck on my own system during a favourable moon phase, don't hesitate to suggest improvements :-)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9062)

<!-- Reviewable:end -->
