### PR TITLE
HACKING_QUICKSTART.md: Don't recommend creating .cargo/config in pare…

### DIFF
--- a/HACKING_QUICKSTART.md
+++ b/HACKING_QUICKSTART.md
@@ -111,11 +111,11 @@ This is how my projects are laid out:
 
 These are all git repositories.
 
-To make it so that servo uses `~/my-projects/cocoa-rs/` and `~/my-projects/glutin/` , create a `~/my-projects/.cargo/config` file:
+To make it so that servo uses `~/my-projects/cocoa-rs/` and `~/my-projects/glutin/` , create a `~/my-projects/servo/.cargo/config` file:
 
 ``` shell
-$ cat ~/my-projects/.cargo/config
-paths = ['glutin', 'cocoa-rs']
+$ cat ~/my-projects/servo/.cargo/config
+paths = ['../glutin', '../cocoa-rs']
 ```
 
 This will tell any cargo project to not use the online version of the dependency, but your local clone.


### PR DESCRIPTION
…nt directory

Recommend putting crate overrides directly in the servo/.cargo/config,
rather than in Servo's parent directory.

Overrides in the parent directory are unnecessary and confusing for
typical use cases.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9069)

<!-- Reviewable:end -->
