### PR TITLE
Ask for reset when option is removed.

### DIFF
--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -210,6 +210,12 @@ impl VirtualMethods for HTMLOptionElement {
     fn unbind_from_tree(&self, context: &UnbindContext) {
         self.super_type().unwrap().unbind_from_tree(context);
 
+        if let Some(select) = context.parent.inclusive_ancestors()
+                .filter_map(Root::downcast::<HTMLSelectElement>)
+                .next() {
+            select.ask_for_reset();
+        }
+
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();
         if node.GetParentNode().is_some() {

--- a/tests/wpt/metadata/html/semantics/forms/the-select-element/select-ask-for-reset.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-select-element/select-ask-for-reset.html.ini
@@ -1,5 +1,0 @@
-[select-ask-for-reset.html]
-  type: testharness
-  [ask for reset on node remove, non multiple.]
-    expected: FAIL
-


### PR DESCRIPTION
Now that `UnbindContext` is available, asking the `select` element for a reset when an option is removed is now possible.

Link to the spec: https://html.spec.whatwg.org/multipage/#ask-for-a-reset

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9074)

<!-- Reviewable:end -->
