### PR TITLE
Enable Pattern variant of CanvasFillOrStrokeStyle

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -50,10 +50,11 @@ use util::vec::byte_swap;
 
 #[must_root]
 #[derive(JSTraceable, Clone, HeapSizeOf)]
+#[allow(dead_code)]
 enum CanvasFillOrStrokeStyle {
     Color(RGBA),
     Gradient(JS<CanvasGradient>),
-    // Pattern(JS<CanvasPattern>),  // https://github.com/servo/servo/pull/6157
+    Pattern(JS<CanvasPattern>),
 }
 
 // https://html.spec.whatwg.org/multipage/#canvasrenderingcontext2d
@@ -922,6 +923,9 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
             CanvasFillOrStrokeStyle::Gradient(ref gradient) => {
                 StringOrCanvasGradientOrCanvasPattern::eCanvasGradient(Root::from_ref(&*gradient))
             },
+            CanvasFillOrStrokeStyle::Pattern(ref pattern) => {
+                StringOrCanvasGradientOrCanvasPattern::eCanvasPattern(Root::from_ref(&*pattern))
+            }
         }
     }
 
@@ -966,6 +970,9 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
             CanvasFillOrStrokeStyle::Gradient(ref gradient) => {
                 StringOrCanvasGradientOrCanvasPattern::eCanvasGradient(Root::from_ref(&*gradient))
             },
+            CanvasFillOrStrokeStyle::Pattern(ref pattern) => {
+                StringOrCanvasGradientOrCanvasPattern::eCanvasPattern(Root::from_ref(&*pattern))
+            }
         }
     }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5313,6 +5313,12 @@
             "url": "/_mozilla/mozilla/canvas.initial.reset.2dstate.html"
           }
         ],
+        "mozilla/canvas/fill_and_stroke_getters_setters.html": [
+          {
+            "path": "mozilla/canvas/fill_and_stroke_getters_setters.html",
+            "url": "/_mozilla/mozilla/canvas/fill_and_stroke_getters_setters.html"
+          }
+        ],
         "mozilla/caption.html": [
           {
             "path": "mozilla/caption.html",

--- a/tests/wpt/mozilla/meta/mozilla/canvas/fill_and_stroke_getters_setters.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/canvas/fill_and_stroke_getters_setters.html.ini
@@ -1,0 +1,6 @@
+[fill_and_stroke_getters_setters.html]
+  type: testharness
+  [strokeStyle roundtrips with \[object CanvasPattern\]]
+    expected: FAIL
+  [fillStyle roundtrips with \[object CanvasPattern\]]
+    expected: FAIL

--- a/tests/wpt/mozilla/tests/mozilla/canvas/fill_and_stroke_getters_setters.html
+++ b/tests/wpt/mozilla/tests/mozilla/canvas/fill_and_stroke_getters_setters.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>fillStyle/strokeStyle setters store the value for retrieval by getters</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<canvas id="c">
+<script>
+var ctx = document.getElementById('c').getContext('2d');
+
+function roundtrip(property, vals) {
+  for (var i = 0; i < vals.length; i++) {
+    test(function() {
+      ctx[property] = vals[i];
+      assert_equals(ctx[property], vals[i]);
+    }, property + ' roundtrips with ' + vals[i]);
+  }
+}
+
+var img = document.createElement('img');
+img.src = '../2x2.png';
+var pattern = ctx.createPattern(img, 'repeat');
+
+var gradient = ctx.createLinearGradient(0.0, 0.0, 1.0, 1.0);
+
+roundtrip('strokeStyle', ['#ff0000', gradient, pattern]);
+roundtrip('fillStyle', ['#ff0000', gradient, pattern]);
+</script>


### PR DESCRIPTION
This is a rebase of #8104, with a test added that exposes pre-existing problems in the canvas code for dealing with patterns.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9080)

<!-- Reviewable:end -->
