### PR TITLE
Updated WebSocket buffered_amount to match change to html specification

### DIFF
--- a/components/script/dom/webidls/WebSocket.webidl
+++ b/components/script/dom/webidls/WebSocket.webidl
@@ -15,7 +15,7 @@ interface WebSocket : EventTarget {
     const unsigned short CLOSING = 2;
     const unsigned short CLOSED = 3;
     readonly attribute unsigned short readyState;
-    readonly attribute unsigned long bufferedAmount;
+    readonly attribute unsigned long long bufferedAmount;
 
     //networking
     attribute EventHandler onopen;

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -300,10 +300,9 @@ impl WebSocket {
         let address = Trusted::new(self, chan.clone());
 
         match data_byte_len.checked_add(self.buffered_amount.get()) {
-            None => return Ok(false),
+            None => panic!(),
             Some(new_amount) => self.buffered_amount.set(new_amount)
         };
-        // self.buffered_amount.set(self.buffered_amount.get() + data_byte_len);
 
         if return_after_buffer {
             return Ok(false);

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -299,7 +299,11 @@ impl WebSocket {
         let chan = global.r().networking_task_source();
         let address = Trusted::new(self, chan.clone());
 
-        self.buffered_amount.set(self.buffered_amount.get() + data_byte_len);
+        match data_byte_len.checked_add(self.buffered_amount.get()) {
+            None => return Ok(false),
+            Some(new_amount) => self.buffered_amount.set(new_amount)
+        };
+        // self.buffered_amount.set(self.buffered_amount.get() + data_byte_len);
 
         if return_after_buffer {
             return Ok(false);


### PR DESCRIPTION
The size of WebSocket's buffered_amount was changed[1] after an issue I opened, which I found while working on WebSocket previously[2]. @jdm suggested I make a PR updating Servo reflecting this, and so I have! As always, I'd like to hear any feedback on anything I can do to improve this.

[1] https://github.com/whatwg/html/issues/296
[2] https://github.com/servo/servo/pull/8218#issuecomment-152021737 point 5)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9082)

<!-- Reviewable:end -->
