### PR TITLE
Support empty strings as the repeat argument (CreatePattern)

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -1147,7 +1147,7 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createpattern
     fn CreatePattern(&self,
                      image: HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2D,
-                     repetition: DOMString)
+                     mut repetition: DOMString)
                      -> Fallible<Root<CanvasPattern>> {
         let (image_data, image_size) = match image {
             HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2D::eHTMLImageElement(ref image) => {
@@ -1168,6 +1168,10 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
                 try!(canvas.fetch_all_data().ok_or(Error::InvalidState))
             }
         };
+
+        if repetition.is_empty() {
+            repetition.push_str("repeat");
+        }
 
         if let Ok(rep) = RepetitionStyle::from_str(&repetition) {
             Ok(CanvasPattern::new(self.global.root().r(),

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.repeat.empty.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.repeat.empty.html.ini
@@ -1,5 +1,0 @@
-[2d.pattern.repeat.empty.html]
-  type: testharness
-  [Canvas test: 2d.pattern.repeat.empty]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.repeat.null.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.repeat.null.html.ini
@@ -1,5 +1,0 @@
-[2d.pattern.repeat.null.html]
-  type: testharness
-  [Canvas test: 2d.pattern.repeat.null]
-    expected: FAIL
-


### PR DESCRIPTION
According to the third step in the specification [1], createPattern
should let the repetition argument be "repeat" when it is the empty
string.

The code in CanvasRenderingContext2D::CreatePattern did not implement
this step and instead threw a SyntaxError exception when an empty
string was supplied as the repetition argument.

Fixes #9079.

[1] https://html.spec.whatwg.org/multipage/#dom-context-2d-createpattern

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9109)

<!-- Reviewable:end -->
