### PR TITLE
Update virtualenv package name for Debian systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ On Debian-based Linuxes:
 ``` sh
 sudo apt-get install curl freeglut3-dev \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
-    gperf g++ cmake python-virtualenv python-pip \
+    gperf g++ cmake virtualenv python-pip \
     libssl-dev libbz2-dev libosmesa6-dev libxmu6 libxmu-dev \
     libglu1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev
 ```
 If you are on **Ubuntu 14.04** and encountered errors on installing these dependencies involving `libcheese`, see [#6158](https://github.com/servo/servo/issues/6158) for a workaround.
+
+If `virtualenv` does not exist, try `python-virtualenv`.
 
 On Fedora:
 


### PR DESCRIPTION
Since Debian Jessie (current stable), the executable is in a `virtualenv` package.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9116)

<!-- Reviewable:end -->
