### PR TITLE
Implement flexbox reordering.

### DIFF
--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -310,4 +310,5 @@ partial interface CSSStyleDeclaration {
 
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flexDirection;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flex-direction;
+  [SetterThrows, TreatNullAs=EmptyString] attribute DOMString order;
 };

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -4950,7 +4950,8 @@ pub mod longhands {
     ${new_style_struct("Flex", is_inherited=False)}
 
     // Flex container properties
-    ${single_keyword("flex-direction", "row row-reverse column column-reverse", experimental=True)}
+    ${single_keyword("flex-direction", "row-reverse row column-reverse column",
+                     experimental=True)}
     // Flex item properties
     ${integer_type_or_auto("order",
                            "i32",

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -4951,6 +4951,11 @@ pub mod longhands {
 
     // Flex container properties
     ${single_keyword("flex-direction", "row row-reverse column column-reverse", experimental=True)}
+    // Flex item properties
+    ${integer_type_or_auto("order",
+                           "i32",
+                           "Specified(0)",
+                           experimental=True)}
 }
 
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1315,6 +1315,18 @@
             "url": "/_mozilla/css/flex_column_direction.html"
           }
         ],
+        "css/flex_column_reverse_direction.html": [
+          {
+            "path": "css/flex_column_reverse_direction.html",
+            "references": [
+              [
+                "/_mozilla/css/flex_column_direction_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/flex_column_reverse_direction.html"
+          }
+        ],
         "css/flex_nochild.html": [
           {
             "path": "css/flex_nochild.html",
@@ -1337,6 +1349,18 @@
               ]
             ],
             "url": "/_mozilla/css/flex_row_direction.html"
+          }
+        ],
+        "css/flex_row_reverse_direction.html": [
+          {
+            "path": "css/flex_row_reverse_direction.html",
+            "references": [
+              [
+                "/_mozilla/css/flex_row_direction_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/flex_row_reverse_direction.html"
           }
         ],
         "css/float_clearance_a.html": [

--- a/tests/wpt/mozilla/tests/css/flex_column_direction.html
+++ b/tests/wpt/mozilla/tests/css/flex_column_direction.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>CSS Test: flex container should layout flex items horizontally</title>
+  <title>CSS Test: flex container should layout flex items vertically</title>
   <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
   <link rel="help" href="https://drafts.csswg.org/css-flexbox/">
   <link rel=match href=flex_column_direction_ref.html>

--- a/tests/wpt/mozilla/tests/css/flex_column_reverse_direction.html
+++ b/tests/wpt/mozilla/tests/css/flex_column_reverse_direction.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: flex container with column-reverse should layout flex items
+    vertically in reverse order</title>
+  <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
+  <link rel="help" href="https://drafts.csswg.org/css-flexbox/">
+  <link rel=match href=flex_column_direction_ref.html>
+  <style>
+    body {
+      margin: 0;
+    }
+    .flexbox {
+      display: flex;
+      flex-direction: column;
+      height: 300px;
+    }
+    .first-item {
+      background: blue;
+      height: 150px;
+      width: 100px;
+      flex: 1 0 auto;
+    }
+    .second-item {
+      background: orange;
+      height: 150px;
+      width: 100px;
+      flex: 1 0 auto;
+    }
+  </style>
+</head>
+<body>
+  <div class="flexbox">
+    <div class="first-item"></div>
+    <div class="second-item"></div>
+  </div>
+</body>
+</html>

--- a/tests/wpt/mozilla/tests/css/flex_row_reverse_direction.html
+++ b/tests/wpt/mozilla/tests/css/flex_row_reverse_direction.html
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: flex container with row-reverse direction should layout flex
+    items in reverse order horizontally</title>
+  <link rel="author" title="Kyle Zentner" href="mailto:zentner.kyle@gmail.com">
+  <link rel="help" href="https://drafts.csswg.org/css-flexbox/">
+  <link rel=match href=flex_row_direction_ref.html>
+  <style>
+    body {
+      margin: 0;
+    }
+    .flexbox {
+      display: flex;
+      flex-direction: row-reverse;
+      width: 300px;
+    }
+    .first-item {
+      background: blue;
+      height: 100px;
+      flex: 1 0 auto;
+    }
+    .second-item {
+      background: orange;
+      height: 100px;
+      flex: 1 0 auto;
+    }
+  </style>
+</head>
+<body>
+  <div class="flexbox">
+    <div class="first-item"></div>
+    <div class="second-item"></div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This pull request implements the flex item `order` property and causes the `row-reverse` and `column-reverse` value of `flex-direction` to work.

Note that the reordering in the flexbox algorithm is **purely cosmetic**, and should not result in any reordering in e.g. the selection order, counter calculations, etc.

The way I implemented this is relatively inefficient (items are re-sorted every time they are visited), but I attend to address that in a later pull request.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9117)

<!-- Reviewable:end -->
