### PR TITLE
Add 'test-tidy-faster' command to ./mach

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -256,8 +256,10 @@ class MachCommands(CommandBase):
     @Command('test-tidy',
              description='Run the source code tidiness check',
              category='testing')
-    def test_tidy(self):
-        return tidy.scan()
+    @CommandArgument('--faster', default=False, action="store_true",
+                     help="Only check changed files and skip the WPT lint")
+    def test_tidy(self, faster):
+        return tidy.scan(faster)
 
     @Command('test-wpt-failure',
              description='Run the web platform tests',


### PR DESCRIPTION
For issue #9088, this adds a `--changes` option to `./mach test-tidy`. If this option is set, `tidy.py` will only check files that have been modified since `FETCH_HEAD`.

Mention: @Wafflespeanut

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9118)

<!-- Reviewable:end -->
