### PR TITLE
Enable xmlhttprequest-timeout-worker-overrides.html (fixes #3887)

### DIFF
--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-overrides.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-worker-overrides.html.ini
@@ -1,3 +1,0 @@
-[xmlhttprequest-timeout-worker-overrides.html]
-  type: testharness
-  disabled: flaky - https://github.com/w3c/web-platform-tests/issues/1362


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9127)

<!-- Reviewable:end -->
