### PR TITLE
Add autoconf to build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sudo port install python27 py27-virtualenv cmake
 On Debian-based Linuxes:
 
 ``` sh
-sudo apt-get install curl freeglut3-dev \
+sudo apt-get install curl freeglut3-dev autoconf \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
     gperf g++ cmake virtualenv python-pip \
     libssl-dev libbz2-dev libosmesa6-dev libxmu6 libxmu-dev \


### PR DESCRIPTION
`autoheader` from `autoconf` was necessary for the build on my system.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9128)

<!-- Reviewable:end -->
