### PR TITLE
Fix incorrect return code for 'update-wpt' mach command

### DIFF
--- a/tests/wpt/update.py
+++ b/tests/wpt/update.py
@@ -23,7 +23,7 @@ def update_tests(**kwargs):
     logger = update.setup_logging(kwargs, {"mach": sys.stdout})
 
     rv = update.run_update(logger, **kwargs)
-    return 0 if rv is update.exit_unclean else 1
+    return 1 if rv is update.exit_unclean else 0
 
 
 def set_defaults(kwargs):


### PR DESCRIPTION
`mach update-wpt` should return 1 if it exits in an unclean state

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9129)

<!-- Reviewable:end -->
