### PR TITLE
Enable canvas_complexshapes_*_001.htm (fixes #6748, #6780)

### DIFF
--- a/tests/wpt/metadata/2dcontext/building-paths/canvas_complexshapes_arcto_001.htm.ini
+++ b/tests/wpt/metadata/2dcontext/building-paths/canvas_complexshapes_arcto_001.htm.ini
@@ -1,5 +1,3 @@
 [canvas_complexshapes_arcto_001.htm]
   type: reftest
-  reftype: ==
-  refurl: /2dcontext/building-paths/canvas_complexshapes_arcto_001-ref.htm
-  disabled: https://github.com/servo/servo/issues/6780
+  expected: FAIL

--- a/tests/wpt/metadata/2dcontext/building-paths/canvas_complexshapes_beziercurveto_001.htm.ini
+++ b/tests/wpt/metadata/2dcontext/building-paths/canvas_complexshapes_beziercurveto_001.htm.ini
@@ -1,5 +1,3 @@
 [canvas_complexshapes_beziercurveto_001.htm]
   type: reftest
-  reftype: ==
-  refurl: /2dcontext/building-paths/canvas_complexshapes_beziercurveto_001-ref.htm
-  disabled: https://github.com/servo/servo/issues/6748
+  expected: FAIL


### PR DESCRIPTION
Serde landed bincode support, so we can probably enable these again.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9141)

<!-- Reviewable:end -->
