### PR TITLE
Correctly handle local sources for CSS3 fonts

### DIFF
--- a/components/gfx/font_cache_task.rs
+++ b/components/gfx/font_cache_task.rs
@@ -152,7 +152,7 @@ impl FontCache {
                     let family_name = LowercaseString::new(family.name());
                     if !self.web_families.contains_key(&family_name) {
                         let templates = FontTemplates::new();
-                        self.web_families.insert(family_name, templates);
+                        self.web_families.insert(family_name.clone(), templates);
                     }
 
                     match src {
@@ -208,10 +208,10 @@ impl FontCache {
                                 }
                             });
                         }
-                        Source::Local(ref family) => {
-                            let family_name = LowercaseString::new(family.name());
+                        Source::Local(ref font) => {
+                            let font_face_name = LowercaseString::new(font.name());
                             let templates = &mut self.web_families.get_mut(&family_name).unwrap();
-                            for_each_variation(&family_name, |path| {
+                            for_each_variation(&font_face_name, |path| {
                                 templates.add_template(Atom::from(&*path), None);
                             });
                             result.send(()).unwrap();

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -650,6 +650,8 @@ name = "gfx_tests"
 version = "0.0.1"
 dependencies = [
  "gfx 0.0.1",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
+ "style 0.0.1",
 ]
 
 [[package]]

--- a/tests/unit/gfx/Cargo.toml
+++ b/tests/unit/gfx/Cargo.toml
@@ -10,3 +10,9 @@ doctest = false
 
 [dependencies.gfx]
 path = "../../../components/gfx"
+
+[dependencies.ipc-channel]
+git = "https://github.com/servo/ipc-channel"
+
+[dependencies.style]
+path = "../../../components/style"

--- a/tests/unit/gfx/font_cache_task.rs
+++ b/tests/unit/gfx/font_cache_task.rs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use gfx::font_cache_task::FontCacheTask;
+use ipc_channel::ipc;
+use style::computed_values::font_family::FontFamily;
+use style::font_face::Source;
+
+#[test]
+fn test_local_web_font() {
+  let (inp_chan, _) = ipc::channel().unwrap();
+  let (out_chan, out_receiver) = ipc::channel().unwrap();
+  let font_cache_task = FontCacheTask::new(inp_chan);
+  let family_name = FontFamily::FamilyName(From::from("test family"));
+  let variant_name = FontFamily::FamilyName(From::from("test font face"));
+
+  font_cache_task.add_web_font(family_name, Source::Local(variant_name), out_chan);
+
+  assert_eq!(out_receiver.recv().unwrap(), ());
+}

--- a/tests/unit/gfx/lib.rs
+++ b/tests/unit/gfx/lib.rs
@@ -3,5 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate gfx;
+extern crate ipc_channel;
+extern crate style;
 
+#[cfg(test)] mod font_cache_task;
 #[cfg(test)] mod text_util;


### PR DESCRIPTION
Currently, servo panics for me when loading something like this:

```
@font-face {
  font-family: "test family";
  src: local(test font face);
}
```

That's due to a bug in `FontCacheTask`. `FontCacheTask` tries to get the value for the key
"test font face" from `self.web_families`, but previously initialized a value for the key "test family".

These two commits add an awkward test and fix the bug by not shadowing the variable `family_name`. Since the argument to `local()` should explicitly not be the name of a font family, the previous variable name was wrong and misleading anyways.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9149)

<!-- Reviewable:end -->
