### PR TITLE
Partial implementation of HTTP-network Fetch step

### DIFF
--- a/components/net/fetch/response.rs
+++ b/components/net/fetch/response.rs
@@ -4,7 +4,7 @@
 
 use hyper::header::Headers;
 use hyper::status::StatusCode;
-use net_traits::{CacheState, Response, ResponseBody, ResponseType};
+use net_traits::{CacheState, HttpsState, Response, ResponseBody, ResponseType};
 use std::ascii::AsciiExt;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -27,6 +27,7 @@ impl ResponseMethods for Response {
             headers: Headers::new(),
             body: ResponseBody::Empty,
             cache_state: CacheState::None,
+            https_state: HttpsState::None,
             internal_response: None
         }
     }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -198,8 +198,8 @@ pub trait HttpResponse: Read {
 }
 
 
-struct WrappedHttpResponse {
-    response: Response
+pub struct WrappedHttpResponse {
+    pub response: Response
 }
 
 impl Read for WrappedHttpResponse {
@@ -235,8 +235,8 @@ pub trait HttpRequestFactory {
     fn create(&self, url: Url, method: Method) -> Result<Self::R, LoadError>;
 }
 
-struct NetworkHttpRequestFactory {
-    connector: Arc<Pool<Connector>>,
+pub struct NetworkHttpRequestFactory {
+    pub connector: Arc<Pool<Connector>>,
 }
 
 impl HttpRequestFactory for NetworkHttpRequestFactory {
@@ -276,7 +276,7 @@ pub trait HttpRequest {
     fn send(self, body: &Option<Vec<u8>>) -> Result<Self::R, LoadError>;
 }
 
-struct WrappedHttpRequest {
+pub struct WrappedHttpRequest {
     request: Request<Fresh>
 }
 
@@ -556,7 +556,9 @@ pub fn obtain_response<A>(request_factory: &HttpRequestFactory<R=A>,
                           method: &Method,
                           request_headers: &mut Headers,
                           cancel_listener: &CancellationListener,
-                          load_data: &LoadData,
+                          data: &Option<Vec<u8>>,
+                          load_data_method: &Method,
+                          pipeline_id: &Option<PipelineId>,
                           iters: u32,
                           devtools_chan: &Option<Sender<DevtoolsControlMsg>>,
                           request_id: &str)
@@ -581,7 +583,7 @@ pub fn obtain_response<A>(request_factory: &HttpRequestFactory<R=A>,
             for header in req.headers_mut().iter() {
                 info!(" - {}", header);
             }
-            info!("{:?}", load_data.data);
+            info!("{:?}", data);
         }
 
         // Avoid automatically sending request body if a redirect has occurred.
@@ -592,21 +594,21 @@ pub fn obtain_response<A>(request_factory: &HttpRequestFactory<R=A>,
         // https://tools.ietf.org/html/rfc7231#section-6.4
         let is_redirected_request = iters != 1;
         let cloned_data;
-        let maybe_response = match load_data.data {
-            Some(ref data) if !is_redirected_request => {
-                req.headers_mut().set(ContentLength(data.len() as u64));
-                cloned_data = load_data.data.clone();
-                req.send(&load_data.data)
-            }
+        let maybe_response = match data {
+            &Some(ref d) if !is_redirected_request => {
+                req.headers_mut().set(ContentLength(d.len() as u64));
+                cloned_data = data.clone();
+                req.send(data)
+            },
             _ => {
-                if load_data.method != Method::Get && load_data.method != Method::Head {
+                if *load_data_method != Method::Get && *load_data_method != Method::Head {
                     req.headers_mut().set(ContentLength(0))
                 }
                 cloned_data = None;
                 req.send(&None)
             }
         };
-        if let Some(pipeline_id) = load_data.pipeline_id {
+        if let Some(pipeline_id) = *pipeline_id {
             send_request_to_devtools(
                 devtools_chan.clone(), request_id.clone().into(),
                 url.clone(), method.clone(), request_headers.clone(),
@@ -705,7 +707,8 @@ pub fn load<A>(load_data: LoadData,
         modify_request_headers(&mut request_headers, &doc_url, &user_agent, &cookie_jar, &load_data);
 
         let response = try!(obtain_response(request_factory, &url, &method, &mut request_headers,
-                                            &cancel_listener, &load_data, iters, &devtools_chan, &request_id));
+                                            &cancel_listener, &load_data.data, &load_data.method,
+                                            &load_data.pipeline_id, iters, &devtools_chan, &request_id));
 
         process_response_headers(&response, &url, &doc_url, &cookie_jar, &hsts_list, &load_data);
 

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -72,13 +72,21 @@ pub enum ResponseBody {
     Done(Vec<u8>),
 }
 
-// [Cache state](https://fetch.spec.whatwg.org/#concept-response-cache-state)
+/// [Cache state](https://fetch.spec.whatwg.org/#concept-response-cache-state)
 #[derive(Clone)]
 pub enum CacheState {
     None,
     Local,
     Validated,
     Partial
+}
+
+/// [Https state](https://fetch.spec.whatwg.org/#concept-response-https-state)
+#[derive(Clone)]
+pub enum HttpsState {
+    None,
+    Deprecated,
+    Modern
 }
 
 pub enum ResponseMsg {
@@ -99,6 +107,7 @@ pub struct Response {
     pub headers: Headers,
     pub body: ResponseBody,
     pub cache_state: CacheState,
+    pub https_state: HttpsState,
     /// [Internal response](https://fetch.spec.whatwg.org/#concept-internal-response), only used if the Response
     /// is a filtered response
     pub internal_response: Option<Rc<RefCell<Response>>>,
@@ -115,6 +124,7 @@ impl Response {
             headers: Headers::new(),
             body: ResponseBody::Empty,
             cache_state: CacheState::None,
+            https_state: HttpsState::None,
             internal_response: None
         }
     }


### PR DESCRIPTION
I've been working on making a partial implementation of HTTP-network Fetch[1] so that I can begin testing the entire Fetch protocol as implemented in Servo. The empty steps are intentionally so, including the incomplete Step 5, which I started without realizing I don't need to do basic testing.

[1] https://fetch.spec.whatwg.org/#http-network-fetch

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9153)

<!-- Reviewable:end -->
