### PR TITLE
gfx: handle the ResponseAction::ResponseComplete error case in font_cache_task

### DIFF
--- a/components/gfx/font_cache_task.rs
+++ b/components/gfx/font_cache_task.rs
@@ -185,14 +185,13 @@ impl FontCache {
                                               metadata.content_type);
                                         *response_valid.lock().unwrap() = is_response_valid;
                                     }
-                                    ResponseAction::ResponseComplete(Err(_)) => {}
                                     ResponseAction::DataAvailable(new_bytes) => {
                                         if *response_valid.lock().unwrap() {
                                             bytes.lock().unwrap().extend(new_bytes.into_iter())
                                         }
                                     }
-                                    ResponseAction::ResponseComplete(Ok(_)) => {
-                                        if !*response_valid.lock().unwrap() {
+                                    ResponseAction::ResponseComplete(response) => {
+                                        if response.is_err() || !*response_valid.lock().unwrap() {
                                             drop(result.send(()));
                                             return;
                                         }


### PR DESCRIPTION
Fix #9158

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9159)

<!-- Reviewable:end -->
