### PR TITLE
Refactor EventBubbles, EventCancelable to be bool tuple structs

### DIFF
--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -52,8 +52,8 @@ pub trait Activatable {
         let target = element.upcast();
         let mouse = MouseEvent::new(win.r(),
                                     DOMString::from("click"),
-                                    EventBubbles::DoesNotBubble,
-                                    EventCancelable::NotCancelable,
+                                    EventBubbles(false),
+                                    EventCancelable(false),
                                     Some(win.r()),
                                     1,
                                     0,

--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -45,9 +45,7 @@ impl CloseEvent {
         let ev = reflect_dom_object(event, global, CloseEventBinding::Wrap);
         {
             let event = ev.upcast::<Event>();
-            event.init_event(type_,
-                             bubbles == EventBubbles::Bubbles,
-                             cancelable == EventCancelable::Cancelable);
+            event.init_event(type_, bubbles.0, cancelable.0);
         }
         ev
     }
@@ -56,20 +54,10 @@ impl CloseEvent {
                        type_: DOMString,
                        init: &CloseEventBinding::CloseEventInit)
                        -> Fallible<Root<CloseEvent>> {
-        let bubbles = if init.parent.bubbles {
-            EventBubbles::Bubbles
-        } else {
-            EventBubbles::DoesNotBubble
-        };
-        let cancelable = if init.parent.cancelable {
-            EventCancelable::Cancelable
-        } else {
-            EventCancelable::NotCancelable
-        };
         Ok(CloseEvent::new(global,
                            Atom::from(&*type_),
-                           bubbles,
-                           cancelable,
+                           EventBubbles(init.parent.bubbles),
+                           EventCancelable(init.parent.cancelable),
                            init.wasClean,
                            init.code,
                            init.reason.clone()))

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -693,8 +693,8 @@ impl Document {
         let clickCount = 1;
         let event = MouseEvent::new(&self.window,
                                     DOMString::from(mouse_event_type_string),
-                                    EventBubbles::Bubbles,
-                                    EventCancelable::Cancelable,
+                                    EventBubbles(true),
+                                    EventCancelable(true),
                                     Some(&self.window),
                                     clickCount,
                                     client_x,
@@ -734,8 +734,8 @@ impl Document {
 
         let mouse_event = MouseEvent::new(&self.window,
                                           DOMString::from(event_name),
-                                          EventBubbles::Bubbles,
-                                          EventCancelable::Cancelable,
+                                          EventBubbles(true),
+                                          EventCancelable(true),
                                           Some(&self.window),
                                           0i32,
                                           client_x,
@@ -922,8 +922,8 @@ impl Document {
 
         let event = TouchEvent::new(window,
                                     DOMString::from(event_name),
-                                    EventBubbles::Bubbles,
-                                    EventCancelable::Cancelable,
+                                    EventBubbles(true),
+                                    EventCancelable(true),
                                     Some(window),
                                     0i32,
                                     &TouchList::new(window, touches.r()),
@@ -1352,8 +1352,8 @@ impl Document {
 
         let event = Event::new(GlobalRef::Window(self.window()),
                                atom!("DOMContentLoaded"),
-                               EventBubbles::DoesNotBubble,
-                               EventCancelable::NotCancelable);
+                               EventBubbles(false),
+                               EventCancelable(false));
         let doctarget = self.upcast::<EventTarget>();
         let _ = doctarget.DispatchEvent(event.r());
         self.window().reflow(ReflowGoal::ForDisplay,
@@ -2502,8 +2502,8 @@ impl DocumentProgressHandler {
         let window = document.window();
         let event = Event::new(GlobalRef::Window(window),
                                atom!("load"),
-                               EventBubbles::DoesNotBubble,
-                               EventCancelable::NotCancelable);
+                               EventBubbles(false),
+                               EventCancelable(false));
         let wintarget = window.upcast::<EventTarget>();
         event.set_trusted(true);
         let _ = wintarget.dispatch_event_with_target(document.upcast(), &event);

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -60,8 +60,7 @@ impl ErrorEvent {
         let ev = ErrorEvent::new_uninitialized(global);
         {
             let event = ev.upcast::<Event>();
-            event.init_event(type_, bubbles == EventBubbles::Bubbles,
-                             cancelable == EventCancelable::Cancelable);
+            event.init_event(type_, bubbles.0, cancelable.0);
             *ev.message.borrow_mut() = message;
             *ev.filename.borrow_mut() = filename;
             ev.lineno.set(lineno);
@@ -88,19 +87,12 @@ impl ErrorEvent {
 
         let col_num = init.colno.unwrap_or(0);
 
-        let bubbles = if init.parent.bubbles { EventBubbles::Bubbles } else { EventBubbles::DoesNotBubble };
-
-        let cancelable = if init.parent.cancelable {
-            EventCancelable::Cancelable
-        } else {
-            EventCancelable::NotCancelable
-        };
-
         // Dictionaries need to be rooted
         // https://github.com/servo/servo/issues/6381
         let error = RootedValue::new(global.get_cx(), init.error);
         let event = ErrorEvent::new(global, Atom::from(&*type_),
-                                bubbles, cancelable,
+                                EventBubbles(init.parent.bubbles),
+                                EventCancelable(init.parent.cancelable),
                                 msg, file_name,
                                 line_num, col_num,
                                 error.handle());

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -27,16 +27,10 @@ pub enum EventPhase {
 }
 
 #[derive(PartialEq, HeapSizeOf)]
-pub enum EventBubbles {
-    Bubbles,
-    DoesNotBubble
-}
+pub struct EventBubbles(pub bool);
 
 #[derive(PartialEq, HeapSizeOf)]
-pub enum EventCancelable {
-    Cancelable,
-    NotCancelable
-}
+pub struct EventCancelable(pub bool);
 
 #[dom_struct]
 pub struct Event {
@@ -87,16 +81,14 @@ impl Event {
                bubbles: EventBubbles,
                cancelable: EventCancelable) -> Root<Event> {
         let event = Event::new_uninitialized(global);
-        event.init_event(type_, bubbles == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
+        event.init_event(type_, bubbles.0, cancelable.0);
         event
     }
 
     pub fn Constructor(global: GlobalRef,
                        type_: DOMString,
                        init: &EventBinding::EventInit) -> Fallible<Root<Event>> {
-        let bubbles = if init.bubbles { EventBubbles::Bubbles } else { EventBubbles::DoesNotBubble };
-        let cancelable = if init.cancelable { EventCancelable::Cancelable } else { EventCancelable::NotCancelable };
-        Ok(Event::new(global, Atom::from(&*type_), bubbles, cancelable))
+        Ok(Event::new(global, Atom::from(&*type_), EventBubbles(init.bubbles), EventCancelable(init.cancelable)))
     }
 
     pub fn init_event(&self, type_: Atom, bubbles: bool, cancelable: bool) {

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -332,8 +332,8 @@ impl EventTarget {
 
     /// Implements https://html.spec.whatwg.org/multipage/#fire-a-simple-event
     pub fn fire_simple_event(&self, name: &str, win: GlobalRef) -> Root<Event> {
-        self.fire_simple_event_params(name, EventBubbles::DoesNotBubble,
-                                      EventCancelable::NotCancelable, win)
+        self.fire_simple_event_params(name, EventBubbles(false),
+                                      EventCancelable(false), win)
     }
 
     /// Implements more customizable variant of EventTarget::fire_simple_event.

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -324,7 +324,7 @@ impl FileReader {
 
         let global = self.global.root();
         let progressevent = ProgressEvent::new(global.r(),
-            type_, EventBubbles::DoesNotBubble, EventCancelable::NotCancelable,
+            type_, EventBubbles(false), EventCancelable(false),
             total.is_some(), loaded, total.unwrap_or(0));
         progressevent.upcast::<Event>().fire(self.upcast());
     }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -173,8 +173,8 @@ impl HTMLFormElement {
         if submit_method_flag == SubmittedFrom::NotFromFormSubmitMethod {
             let event = self.upcast::<EventTarget>()
                 .fire_simple_event_params("submit",
-                                          EventBubbles::Bubbles,
-                                          EventCancelable::Cancelable,
+                                          EventBubbles(true),
+                                          EventCancelable(true),
                                           GlobalRef::Window(win.r()));
             if event.DefaultPrevented() {
                 return;
@@ -272,8 +272,8 @@ impl HTMLFormElement {
         let unhandled_invalid_controls = invalid_controls.into_iter().filter_map(|field| {
             let event = field.as_event_target()
                 .fire_simple_event_params("invalid",
-                                          EventBubbles::DoesNotBubble,
-                                          EventCancelable::Cancelable,
+                                          EventBubbles(false),
+                                          EventCancelable(true),
                                           GlobalRef::Window(win.r()));
             if !event.DefaultPrevented() { return Some(field); }
             None
@@ -399,8 +399,8 @@ impl HTMLFormElement {
         let win = window_from_node(self);
         let event = self.upcast::<EventTarget>()
             .fire_simple_event_params("reset",
-                                      EventBubbles::Bubbles,
-                                      EventCancelable::Cancelable,
+                                      EventBubbles(true),
+                                      EventCancelable(true),
                                       GlobalRef::Window(win.r()));
         if event.DefaultPrevented() {
             return;

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -867,12 +867,12 @@ impl Activatable for HTMLInputElement {
                     let target = self.upcast::<EventTarget>();
 
                     target.fire_simple_event_params("input",
-                                                    EventBubbles::Bubbles,
-                                                    EventCancelable::NotCancelable,
+                                                    EventBubbles(true),
+                                                    EventCancelable(false),
                                                     GlobalRef::Window(win.r()));
                     target.fire_simple_event_params("change",
-                                                    EventBubbles::Bubbles,
-                                                    EventCancelable::NotCancelable,
+                                                    EventBubbles(true),
+                                                    EventCancelable(false),
                                                     GlobalRef::Window(win.r()));
                 }
             },
@@ -953,8 +953,8 @@ impl Runnable for ChangeEventRunnable {
         let window = window.r();
         let event = Event::new(GlobalRef::Window(window),
                                atom!("input"),
-                               EventBubbles::DoesNotBubble,
-                               EventCancelable::NotCancelable);
+                               EventBubbles(false),
+                               EventCancelable(false));
         target.upcast::<EventTarget>().dispatch_event(&event);
     }
 }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -479,26 +479,26 @@ impl HTMLScriptElement {
 
     pub fn dispatch_before_script_execute_event(&self) -> bool {
         self.dispatch_event(atom!("beforescriptexecute"),
-                            EventBubbles::Bubbles,
-                            EventCancelable::Cancelable)
+                            EventBubbles(true),
+                            EventCancelable(true))
     }
 
     pub fn dispatch_after_script_execute_event(&self) {
         self.dispatch_event(atom!("afterscriptexecute"),
-                            EventBubbles::Bubbles,
-                            EventCancelable::NotCancelable);
+                            EventBubbles(true),
+                            EventCancelable(false));
     }
 
     pub fn dispatch_load_event(&self) {
         self.dispatch_event(atom!("load"),
-                            EventBubbles::DoesNotBubble,
-                            EventCancelable::NotCancelable);
+                            EventBubbles(false),
+                            EventCancelable(false));
     }
 
     pub fn dispatch_error_event(&self) {
         self.dispatch_event(atom!("error"),
-                            EventBubbles::DoesNotBubble,
-                            EventCancelable::NotCancelable);
+                            EventBubbles(false),
+                            EventCancelable(false));
     }
 
     pub fn is_javascript(&self) -> bool {

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -74,7 +74,7 @@ impl MouseEvent {
                button: i16,
                relatedTarget: Option<&EventTarget>) -> Root<MouseEvent> {
         let ev = MouseEvent::new_uninitialized(window);
-        ev.InitMouseEvent(type_, canBubble == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable,
+        ev.InitMouseEvent(type_, canBubble.0, cancelable.0,
                           view, detail,
                           screenX, screenY, clientX, clientY,
                           ctrlKey, altKey, shiftKey, metaKey,
@@ -85,19 +85,9 @@ impl MouseEvent {
     pub fn Constructor(global: GlobalRef,
                        type_: DOMString,
                        init: &MouseEventBinding::MouseEventInit) -> Fallible<Root<MouseEvent>> {
-        let bubbles = if init.parent.parent.parent.bubbles {
-            EventBubbles::Bubbles
-        } else {
-            EventBubbles::DoesNotBubble
-        };
-        let cancelable = if init.parent.parent.parent.cancelable {
-            EventCancelable::Cancelable
-        } else {
-        EventCancelable::NotCancelable
-        };
         let event = MouseEvent::new(global.as_window(), type_,
-                                    bubbles,
-                                    cancelable,
+                                    EventBubbles(init.parent.parent.parent.bubbles),
+                                    EventCancelable(init.parent.parent.parent.cancelable),
                                     init.parent.parent.view.r(),
                                     init.parent.parent.detail,
                                     init.screenX, init.screenY,

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -39,7 +39,7 @@ impl ProgressEvent {
                                     ProgressEventBinding::Wrap);
         {
             let event = ev.upcast::<Event>();
-            event.init_event(type_, can_bubble == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
+            event.init_event(type_, can_bubble.0, cancelable.0);
         }
         ev
     }
@@ -47,10 +47,8 @@ impl ProgressEvent {
                        type_: DOMString,
                        init: &ProgressEventBinding::ProgressEventInit)
                        -> Fallible<Root<ProgressEvent>> {
-        let bubbles = if init.parent.bubbles { EventBubbles::Bubbles } else { EventBubbles::DoesNotBubble };
-        let cancelable = if init.parent.cancelable { EventCancelable::Cancelable }
-                         else { EventCancelable::NotCancelable };
-        let ev = ProgressEvent::new(global, Atom::from(&*type_), bubbles, cancelable,
+        let ev = ProgressEvent::new(global, Atom::from(&*type_), EventBubbles(init.parent.bubbles),
+                                    EventCancelable(init.parent.cancelable),
                                     init.lengthComputable, init.loaded, init.total);
         Ok(ev)
     }

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -189,7 +189,7 @@ impl MainThreadRunnable for StorageEventRunnable {
         let storage_event = StorageEvent::new(
             global_ref,
             atom!("storage"),
-            EventBubbles::DoesNotBubble, EventCancelable::NotCancelable,
+            EventBubbles(false), EventCancelable(false),
             this.key.map(DOMString::from), this.old_value.map(DOMString::from), this.new_value.map(DOMString::from),
             DOMString::from(ev_url.to_string()),
             Some(storage)

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -57,7 +57,7 @@ impl StorageEvent {
                                     StorageEventBinding::Wrap);
         {
             let event = ev.upcast::<Event>();
-            event.init_event(type_, bubbles == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
+            event.init_event(type_, bubbles.0, cancelable.0);
         }
         ev
     }
@@ -70,14 +70,8 @@ impl StorageEvent {
         let newValue = init.newValue.clone();
         let url = init.url.clone();
         let storageArea = init.storageArea.r();
-        let bubbles = if init.parent.bubbles { EventBubbles::Bubbles } else { EventBubbles::DoesNotBubble };
-        let cancelable = if init.parent.cancelable {
-            EventCancelable::Cancelable
-        } else {
-            EventCancelable::NotCancelable
-        };
         let event = StorageEvent::new(global, Atom::from(&*type_),
-                                      bubbles, cancelable,
+                                      EventBubbles(init.parent.bubbles), EventCancelable(init.parent.cancelable),
                                       key, oldValue, newValue,
                                       url, storageArea);
         Ok(event)

--- a/components/script/dom/touchevent.rs
+++ b/components/script/dom/touchevent.rs
@@ -67,10 +67,7 @@ impl TouchEvent {
                shiftKey: bool,
                metaKey: bool) -> Root<TouchEvent> {
         let ev = TouchEvent::new_uninitialized(window, touches, changed_touches, target_touches);
-        ev.upcast::<UIEvent>().InitUIEvent(type_,
-                                           canBubble == EventBubbles::Bubbles,
-                                           cancelable == EventCancelable::Cancelable,
-                                           view, detail);
+        ev.upcast::<UIEvent>().InitUIEvent(type_, canBubble.0, cancelable.0, view, detail);
         ev.ctrl_key.set(ctrlKey);
         ev.alt_key.set(altKey);
         ev.shift_key.set(shiftKey);

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -48,22 +48,15 @@ impl UIEvent {
                view: Option<&Window>,
                detail: i32) -> Root<UIEvent> {
         let ev = UIEvent::new_uninitialized(window);
-        ev.InitUIEvent(type_, can_bubble == EventBubbles::Bubbles,
-                       cancelable == EventCancelable::Cancelable, view, detail);
+        ev.InitUIEvent(type_, can_bubble.0, cancelable.0, view, detail);
         ev
     }
 
     pub fn Constructor(global: GlobalRef,
                        type_: DOMString,
                        init: &UIEventBinding::UIEventInit) -> Fallible<Root<UIEvent>> {
-        let bubbles = if init.parent.bubbles { EventBubbles::Bubbles } else { EventBubbles::DoesNotBubble };
-        let cancelable = if init.parent.cancelable {
-            EventCancelable::Cancelable
-        } else {
-            EventCancelable::NotCancelable
-        };
         let event = UIEvent::new(global.as_window(), type_,
-                                 bubbles, cancelable,
+                                 EventBubbles(init.parent.bubbles), EventCancelable(init.parent.cancelable),
                                  init.view.r(), init.detail);
         Ok(event)
     }

--- a/components/script/dom/webglcontextevent.rs
+++ b/components/script/dom/webglcontextevent.rs
@@ -53,7 +53,7 @@ impl WebGLContextEvent {
 
         {
             let parent = event.upcast::<Event>();
-            parent.init_event(type_, bubbles == EventBubbles::Bubbles, cancelable == EventCancelable::Cancelable);
+            parent.init_event(type_, bubbles.0, cancelable.0);
         }
 
         event
@@ -67,21 +67,9 @@ impl WebGLContextEvent {
             None => DOMString::new(),
         };
 
-        let bubbles = if init.parent.bubbles {
-            EventBubbles::Bubbles
-        } else {
-            EventBubbles::DoesNotBubble
-        };
-
-        let cancelable = if init.parent.cancelable {
-            EventCancelable::Cancelable
-        } else {
-            EventCancelable::NotCancelable
-        };
-
         Ok(WebGLContextEvent::new(global, Atom::from(&*type_),
-                                  bubbles,
-                                  cancelable,
+                                  EventBubbles(init.parent.bubbles),
+                                  EventCancelable(init.parent.cancelable),
                                   status_message))
     }
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -122,8 +122,8 @@ impl WebGLRenderingContext {
                 error!("Couldn't create WebGLRenderingContext: {}", msg);
                 let event = WebGLContextEvent::new(global,
                                                    atom!("webglcontextcreationerror"),
-                                                   EventBubbles::DoesNotBubble,
-                                                   EventCancelable::Cancelable,
+                                                   EventBubbles(false),
+                                                   EventCancelable(true),
                                                    DOMString::from(msg));
                 event.upcast::<Event>().fire(canvas.upcast());
                 None

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -530,8 +530,8 @@ impl Runnable for CloseTask {
             //A Bad close
             ws.clean_close.set(false);
             ws.upcast().fire_simple_event_params("error",
-                                                 EventBubbles::DoesNotBubble,
-                                                 EventCancelable::Cancelable,
+                                                 EventBubbles(false),
+                                                 EventCancelable(true),
                                                  global.r());
         }
         let reason = ws.reason.borrow().clone();
@@ -540,8 +540,8 @@ impl Runnable for CloseTask {
         */
         let close_event = CloseEvent::new(global.r(),
                                           atom!("close"),
-                                          EventBubbles::DoesNotBubble,
-                                          EventCancelable::NotCancelable,
+                                          EventBubbles(false),
+                                          EventCancelable(false),
                                           ws.clean_close.get(),
                                           ws.code.get(),
                                           DOMString::from(reason));

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -135,7 +135,7 @@ impl Worker {
         let global = worker.r().global.root();
         let error = RootedValue::new(global.r().get_cx(), UndefinedValue());
         let errorevent = ErrorEvent::new(global.r(), atom!("error"),
-                                         EventBubbles::Bubbles, EventCancelable::Cancelable,
+                                         EventBubbles(true), EventCancelable(true),
                                          message, filename, lineno, colno, error.handle());
         errorevent.upcast::<Event>().fire(worker.upcast());
     }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -792,8 +792,8 @@ impl XMLHttpRequest {
         let global = self.global.root();
         let event = Event::new(global.r(),
                                atom!("readystatechange"),
-                               EventBubbles::DoesNotBubble,
-                               EventCancelable::Cancelable);
+                               EventBubbles(false),
+                               EventCancelable(true));
         event.fire(self.upcast());
     }
 
@@ -973,8 +973,8 @@ impl XMLHttpRequest {
         let global = self.global.root();
         let progressevent = ProgressEvent::new(global.r(),
                                                type_,
-                                               EventBubbles::DoesNotBubble,
-                                               EventCancelable::NotCancelable,
+                                               EventBubbles(false),
+                                               EventCancelable(false),
                                                total.is_some(), loaded,
                                                total.unwrap_or(0));
         let target = if upload {

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -2088,8 +2088,8 @@ impl ScriptTask {
         // http://dev.w3.org/csswg/cssom-view/#resizing-viewports
         // https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#event-type-resize
         let uievent = UIEvent::new(window.r(),
-                                   DOMString::from("resize"), EventBubbles::DoesNotBubble,
-                                   EventCancelable::NotCancelable, Some(window.r()),
+                                   DOMString::from("resize"), EventBubbles(false),
+                                   EventCancelable(false), Some(window.r()),
                                    0i32);
         uievent.upcast::<Event>().fire(window.upcast());
     }


### PR DESCRIPTION
Prior to this commit, both `EventBubbles` and `EventCancelable` were
essentially enum booleans (with two enum variants each). These are
useful (in comparison to just booleans) to prevent accidental
parameter mismatching between both `EventBubbles` and
`EventCancelable` since they often appear right next to each other.

This commit changes them from two-variant enums into a tuple struct with
a single boolean field. It is common in our code to take these two
structures and convert them to/from boolean equivalents. Changing the
structures to tuple structs makes this become easier and more ergonomic.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9162)

<!-- Reviewable:end -->
