### PR TITLE
update pipeline url after redirections

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -622,6 +622,11 @@ impl<LTF: LayoutTaskFactory, STF: ScriptTaskFactory> Constellation<LTF, STF> {
                 debug!("constellation got activate document message");
                 self.handle_activate_document_msg(pipeline_id);
             }
+            // Update pipeline url after redirections
+            Request::Script(FromScriptMsg::SetFinalUrl(pipeline_id, final_url)) => {
+                debug!("constellation got set final url message");
+                self.mut_pipeline(pipeline_id).url = final_url;
+            }
             Request::Script(FromScriptMsg::MozBrowserEvent(pipeline_id,
                                               subpage_id,
                                               event)) => {

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -1648,6 +1648,10 @@ impl ScriptTask {
             // send the final url to the layout task.
             let LayoutChan(ref chan) = incomplete.layout_chan;
             chan.send(layout_interface::Msg::SetFinalUrl(final_url.clone())).unwrap();
+
+            // update the pipeline url
+            let ConstellationChan(ref chan) = self.constellation_chan;
+            chan.send(ConstellationMsg::SetFinalUrl(incomplete.pipeline_id, final_url.clone())).unwrap();
         }
         debug!("ScriptTask: loading {} on page {:?}", incomplete.url.serialize(), incomplete.pipeline_id);
 

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -79,4 +79,6 @@ pub enum ScriptMsg {
     ActivateDocument(PipelineId),
     /// Set the document state for a pipeline (used by screenshot / reftests)
     SetDocumentState(PipelineId, DocumentState),
+    /// Update the pipeline Url, which can change after redirections.
+    SetFinalUrl(PipelineId, Url),
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5785,6 +5785,12 @@
             "url": "/_mozilla/mozilla/mozbrowser/mozbrowsershowmodalprompt_event.html"
           }
         ],
+        "mozilla/mozbrowser/redirect.html": [
+          {
+            "path": "mozilla/mozbrowser/redirect.html",
+            "url": "/_mozilla/mozilla/mozbrowser/redirect.html"
+          }
+        ],
         "mozilla/mozbrowser/reload.html": [
           {
             "path": "mozilla/mozbrowser/reload.html",

--- a/tests/wpt/mozilla/tests/mozilla/mozbrowser/redirect.html
+++ b/tests/wpt/mozilla/tests/mozilla/mozbrowser/redirect.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>mozbrowserlocationchange with final url after redirect</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body></body>
+<script>
+    async_test(function(t) {
+        var iframe = document.createElement("iframe");
+        iframe.mozbrowser = "true";
+        iframe.src = "redirect_init.html?pipe=status(302)|header(Location,redirect_final.html)";
+        iframe.addEventListener("mozbrowserlocationchange", t.step_func(e => {
+            assert_equals(e.detail, new URL("redirect_final.html", location).href);
+            t.done();
+        }));
+        document.body.appendChild(iframe);
+    });
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/mozbrowser/redirect_final.html
+++ b/tests/wpt/mozilla/tests/mozilla/mozbrowser/redirect_final.html
@@ -1,0 +1,1 @@
+<h1>redirect_final</h1>

--- a/tests/wpt/mozilla/tests/mozilla/mozbrowser/redirect_init.html
+++ b/tests/wpt/mozilla/tests/mozilla/mozbrowser/redirect_init.html
@@ -1,0 +1,1 @@
+<h1>redirect_init</h1>


### PR DESCRIPTION
`pipeline.url` is not updated after a redirection.

Fixes #8902

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9164)

<!-- Reviewable:end -->
