### PR TITLE
Refactor 'listed element' logic for HTMLFieldSetElement::Elements

### DIFF
--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -354,6 +354,30 @@ impl HTMLElement {
         }
     }
 
+    // https://html.spec.whatwg.org/multipage/#category-listed
+    pub fn is_listed_element(&self) -> bool {
+        // Servo does not implement HTMLKeygenElement
+        // https://github.com/servo/servo/issues/2782
+        if self.upcast::<Element>().local_name() == &atom!("keygen") {
+            return true;
+        }
+
+        match self.upcast::<Node>().type_id() {
+            NodeTypeId::Element(ElementTypeId::HTMLElement(type_id)) =>
+                match type_id {
+                    HTMLElementTypeId::HTMLButtonElement |
+                        HTMLElementTypeId::HTMLFieldSetElement |
+                        HTMLElementTypeId::HTMLInputElement |
+                        HTMLElementTypeId::HTMLObjectElement |
+                        HTMLElementTypeId::HTMLOutputElement |
+                        HTMLElementTypeId::HTMLSelectElement |
+                        HTMLElementTypeId::HTMLTextAreaElement => true,
+                    _ => false,
+                },
+            _ => false,
+        }
+    }
+
     pub fn supported_prop_names_custom_attr(&self) -> Vec<DOMString> {
         let element = self.upcast::<Element>();
         element.attrs().iter().filter_map(|attr| {

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -18,7 +18,7 @@ use dom::validitystate::ValidityState;
 use dom::virtualmethods::VirtualMethods;
 use selectors::states::*;
 use string_cache::Atom;
-use util::str::{DOMString, StaticStringVec};
+use util::str::DOMString;
 
 #[dom_struct]
 pub struct HTMLFieldSetElement {
@@ -52,9 +52,8 @@ impl HTMLFieldSetElementMethods for HTMLFieldSetElement {
         struct ElementsFilter;
         impl CollectionFilter for ElementsFilter {
             fn filter<'a>(&self, elem: &'a Element, _root: &'a Node) -> bool {
-                static TAG_NAMES: StaticStringVec = &["button", "fieldset", "input",
-                    "keygen", "object", "output", "select", "textarea"];
-                TAG_NAMES.iter().any(|&tag_name| tag_name == &**elem.local_name())
+                elem.downcast::<HTMLElement>()
+                    .map_or(false, HTMLElement::is_listed_element)
             }
         }
         let filter = box ElementsFilter;


### PR DESCRIPTION
`HTMLElement::is_listed_element` method was added, which matches the
`HTMLElement::is_labelable_element` method directly above

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9214)

<!-- Reviewable:end -->
