### PR TITLE
Redesign ScriptMsg to be more specific to DOMManipulationTaskSource

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -19,6 +19,7 @@ use dom::bindings::trace::JSTraceable;
 use dom::document::Document;
 use dom::element::{AttributeMutation, Element, ElementCreator};
 use dom::event::{Event, EventBubbles, EventCancelable};
+use dom::eventtarget::EventTarget;
 use dom::htmlelement::HTMLElement;
 use dom::node::{ChildrenMutation, CloneChildrenFlag, Node};
 use dom::node::{document_from_node, window_from_node};
@@ -34,13 +35,13 @@ use js::jsapi::RootedValue;
 use js::jsval::UndefinedValue;
 use net_traits::{AsyncResponseListener, AsyncResponseTarget, Metadata};
 use network_listener::{NetworkListener, PreInvoke};
-use script_thread::ScriptThreadEventCategory::ScriptEvent;
-use script_thread::{CommonScriptMsg, Runnable, ScriptChan};
+use script_thread::{MainThreadScriptChan, ScriptChan};
 use std::ascii::AsciiExt;
 use std::cell::Cell;
 use std::mem;
 use std::sync::{Arc, Mutex};
 use string_cache::Atom;
+use task_source::dom_manipulation::DOMManipulationTask;
 use url::Url;
 use util::str::{DOMString, HTML_SPACE_CHARACTERS, StaticStringVec};
 
@@ -442,26 +443,20 @@ impl HTMLScriptElement {
         if external {
             self.dispatch_load_event();
         } else {
-            let chan = window.dom_manipulation_task_source();
-            let handler = Trusted::new(self, chan.clone());
-            let dispatcher = box EventDispatcher {
-                element: handler,
-                is_error: false,
-            };
-            chan.send(CommonScriptMsg::RunnableMsg(ScriptEvent, dispatcher)).unwrap();
+            let chan = MainThreadScriptChan(window.main_thread_script_chan().clone()).clone();
+            let script_element = Trusted::new(self.upcast::<EventTarget>(), chan);
+            let task_source = window.dom_manipulation_task_source();
+            task_source.queue(DOMManipulationTask::FireSimpleEvent(atom!("load"), script_element)).unwrap();
         }
     }
 
     pub fn queue_error_event(&self) {
         let window = window_from_node(self);
         let window = window.r();
-        let chan = window.dom_manipulation_task_source();
-        let handler = Trusted::new(self, chan.clone());
-        let dispatcher = box EventDispatcher {
-            element: handler,
-            is_error: true,
-        };
-        chan.send(CommonScriptMsg::RunnableMsg(ScriptEvent, dispatcher)).unwrap();
+        let chan = MainThreadScriptChan(window.main_thread_script_chan().clone()).clone();
+        let task_source = window.dom_manipulation_task_source();
+        let script_element = Trusted::new(self.upcast::<EventTarget>(), chan);
+        task_source.queue(DOMManipulationTask::FireSimpleEvent(atom!("error"), script_element)).unwrap();
     }
 
     pub fn dispatch_before_script_execute_event(&self) -> bool {
@@ -608,21 +603,5 @@ impl HTMLScriptElementMethods for HTMLScriptElement {
     // https://html.spec.whatwg.org/multipage/#dom-script-text
     fn SetText(&self, value: DOMString) {
         self.upcast::<Node>().SetTextContent(Some(value))
-    }
-}
-
-struct EventDispatcher {
-    element: Trusted<HTMLScriptElement>,
-    is_error: bool,
-}
-
-impl Runnable for EventDispatcher {
-    fn handler(self: Box<EventDispatcher>) {
-        let target = self.element.root();
-        if self.is_error {
-            target.dispatch_error_event();
-        } else {
-            target.dispatch_load_event();
-        }
     }
 }

--- a/components/script/dom/webidls/Worker.webidl
+++ b/components/script/dom/webidls/Worker.webidl
@@ -14,8 +14,8 @@ interface AbstractWorker {
 interface Worker : EventTarget {
   //void terminate();
 
-  [Throws]
-  void postMessage(any message/*, optional sequence<Transferable> transfer*/);
+[Throws]
+void postMessage(any message/*, optional sequence<Transferable> transfer*/);
            attribute EventHandler onmessage;
 };
 Worker implements AbstractWorker;

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -91,6 +91,7 @@ pub mod parse;
 pub mod reporter;
 #[allow(unsafe_code)]
 pub mod script_thread;
+mod task_source;
 pub mod textinput;
 mod timers;
 mod unpremultiplytable;

--- a/components/script/task_source/dom_manipulation.rs
+++ b/components/script/task_source/dom_manipulation.rs
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::refcounted::Trusted;
+use dom::event::{EventBubbles, EventCancelable};
+use dom::eventtarget::EventTarget;
+use script_thread::{MainThreadRunnable, MainThreadScriptMsg, Runnable, ScriptThread};
+use std::result::Result;
+use std::sync::mpsc::Sender;
+use string_cache::Atom;
+use task_source::TaskSource;
+
+#[derive(JSTraceable)]
+pub struct DOMManipulationTaskSource(pub Sender<MainThreadScriptMsg>);
+
+impl TaskSource<DOMManipulationTask> for DOMManipulationTaskSource {
+    fn queue(&self, msg: DOMManipulationTask) -> Result<(), ()> {
+        let DOMManipulationTaskSource(ref chan) = *self;
+        chan.send(MainThreadScriptMsg::DOMManipulation(msg)).map_err(|_| ())
+    }
+
+    fn clone(&self) -> Box<TaskSource<DOMManipulationTask> + Send> {
+        let DOMManipulationTaskSource(ref chan) = *self;
+        box DOMManipulationTaskSource((*chan).clone())
+    }
+}
+
+pub enum DOMManipulationTask {
+    // https://html.spec.whatwg.org/multipage/#the-end step 7
+    DocumentProgress(Box<Runnable + Send>),
+    // https://dom.spec.whatwg.org/#concept-event-fire
+    FireEvent(Atom, Trusted<EventTarget>, EventBubbles, EventCancelable),
+    // https://html.spec.whatwg.org/multipage/#fire-a-simple-event
+    FireSimpleEvent(Atom, Trusted<EventTarget>),
+    // https://html.spec.whatwg.org/multipage/#details-notification-task-steps
+    FireToggleEvent(Box<Runnable + Send>),
+    // https://html.spec.whatwg.org/multipage/#planned-navigation
+    PlannedNavigation(Box<Runnable + Send>),
+    // https://html.spec.whatwg.org/multipage/#send-a-storage-notification
+    SendStorageNotification(Box<MainThreadRunnable + Send>)
+}
+
+impl DOMManipulationTask {
+    pub fn handle_msg(self, script_thread: &ScriptThread) {
+        use self::DOMManipulationTask::*;
+
+        match self {
+            DocumentProgress(runnable) => runnable.handler(),
+            FireEvent(name, element, bubbles, cancelable) => {
+                let target = element.root();
+                target.fire_event(&*name, bubbles, cancelable);
+            }
+            FireSimpleEvent(name, element) => {
+                let target = element.root();
+                target.fire_simple_event(&*name);
+            }
+            FireToggleEvent(runnable) => runnable.handler(),
+            PlannedNavigation(runnable) => runnable.handler(),
+            SendStorageNotification(runnable) => runnable.handler(script_thread)
+        }
+    }
+}

--- a/components/script/task_source/file_reading.rs
+++ b/components/script/task_source/file_reading.rs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use script_thread::{CommonScriptMsg, MainThreadScriptMsg, ScriptChan};
+use std::sync::mpsc::Sender;
+
+#[derive(JSTraceable)]
+pub struct FileReadingTaskSource(pub Sender<MainThreadScriptMsg>);
+
+impl ScriptChan for FileReadingTaskSource {
+    fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
+        let FileReadingTaskSource(ref chan) = *self;
+        chan.send(MainThreadScriptMsg::Common(msg)).map_err(|_| ())
+    }
+
+    fn clone(&self) -> Box<ScriptChan + Send> {
+        let FileReadingTaskSource(ref chan) = *self;
+        box FileReadingTaskSource((*chan).clone())
+    }
+}

--- a/components/script/task_source/history_traversal.rs
+++ b/components/script/task_source/history_traversal.rs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use script_thread::{CommonScriptMsg, MainThreadScriptMsg, ScriptChan};
+use std::sync::mpsc::Sender;
+
+#[derive(JSTraceable)]
+pub struct HistoryTraversalTaskSource(pub Sender<MainThreadScriptMsg>);
+
+impl ScriptChan for HistoryTraversalTaskSource {
+    fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
+        let HistoryTraversalTaskSource(ref chan) = *self;
+        chan.send(MainThreadScriptMsg::Common(msg)).map_err(|_| ())
+    }
+
+    fn clone(&self) -> Box<ScriptChan + Send> {
+        let HistoryTraversalTaskSource(ref chan) = *self;
+        box HistoryTraversalTaskSource((*chan).clone())
+    }
+}

--- a/components/script/task_source/mod.rs
+++ b/components/script/task_source/mod.rs
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub mod dom_manipulation;
+pub mod file_reading;
+pub mod history_traversal;
+pub mod networking;
+pub mod user_interaction;
+
+use std::result::Result;
+
+pub trait TaskSource<T> {
+    fn queue(&self, msg: T) -> Result<(), ()>;
+    fn clone(&self) -> Box<TaskSource<T> + Send>;
+}

--- a/components/script/task_source/networking.rs
+++ b/components/script/task_source/networking.rs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use script_thread::{CommonScriptMsg, MainThreadScriptMsg, ScriptChan};
+use std::sync::mpsc::Sender;
+
+#[derive(JSTraceable)]
+pub struct NetworkingTaskSource(pub Sender<MainThreadScriptMsg>);
+
+impl ScriptChan for NetworkingTaskSource {
+    fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
+        let NetworkingTaskSource(ref chan) = *self;
+        chan.send(MainThreadScriptMsg::Common(msg)).map_err(|_| ())
+    }
+
+    fn clone(&self) -> Box<ScriptChan + Send> {
+        let NetworkingTaskSource(ref chan) = *self;
+        box NetworkingTaskSource((*chan).clone())
+    }
+}

--- a/components/script/task_source/user_interaction.rs
+++ b/components/script/task_source/user_interaction.rs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use script_thread::{CommonScriptMsg, MainThreadScriptMsg, ScriptChan};
+use std::sync::mpsc::Sender;
+
+#[derive(JSTraceable)]
+pub struct UserInteractionTaskSource(pub Sender<MainThreadScriptMsg>);
+
+impl ScriptChan for UserInteractionTaskSource {
+    fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
+        let UserInteractionTaskSource(ref chan) = *self;
+        chan.send(MainThreadScriptMsg::Common(msg)).map_err(|_| ())
+    }
+
+    fn clone(&self) -> Box<ScriptChan + Send> {
+        let UserInteractionTaskSource(ref chan) = *self;
+        box UserInteractionTaskSource((*chan).clone())
+    }
+}


### PR DESCRIPTION
This is a large-ish PR that contains the following:
- A new directory is created under `components/script/` called `task_source`, which houses all the stuff for different task sources. Note that the ones that I have now aren't exhaustive - there are more task sources than just the generic ones.
- A `DOMManipulationTaskMsg` which eliminates some usage of `Runnable`s to fire events. Instead, they send event information to the `DOMManipulationTaskSource` and lets the `ScriptTask` handle all the event firing.
- Re-added `fn script_chan`, since I can't think of any other way to give `Trusted` values an appropriate sender.
- Rewrote step 7 of [the end](https://html.spec.whatwg.org/multipage/syntax.html#the-end) to make use of the `DOMManipulationTaskSource`

Partial #7959

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9217)

<!-- Reviewable:end -->
