### PR TITLE
Disable tests that fail unless non-free Microsoft fonts are installed.

### DIFF
--- a/tests/wpt/metadata-css/css21_dev/html4/font-family-013.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/font-family-013.htm.ini
@@ -1,0 +1,3 @@
+[font-family-013.htm]
+  type: reftest
+  disabled: https://github.com/servo/servo/issues/7625#issuecomment-168109518

--- a/tests/wpt/metadata-css/css21_dev/html4/fonts-013.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/fonts-013.htm.ini
@@ -1,0 +1,3 @@
+[fonts-013.htm]
+  type: reftest
+  disabled: https://github.com/servo/servo/issues/7625#issuecomment-168109518


### PR DESCRIPTION
This is a bug, font fallback should be more flexible than this.

https://github.com/servo/servo/issues/7625

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9235)

<!-- Reviewable:end -->
