### PR TITLE
Refactor WebGLPaintTask to prevent creating extra IPC channels #9228

### DIFF
--- a/components/canvas/webgl_paint_thread.rs
+++ b/components/canvas/webgl_paint_thread.rs
@@ -228,15 +228,11 @@ impl WebGLPaintThread {
             }
         });
 
-        match result_port.recv() {
-            Ok(_) => {
-                let (out_of_process_chan, out_of_process_port) = ipc::channel::<CanvasMsg>().unwrap();
-                ROUTER.route_ipc_receiver_to_mpsc_sender(out_of_process_port, in_process_chan.clone());
-
-                Ok((out_of_process_chan, in_process_chan))
-            },
-            Err(_) => Err("Could not create WebGLPaintThread.")
-        }
+        result_port.recv().unwrap().map(|_| {
+             let (out_of_process_chan, out_of_process_port) = ipc::channel::<CanvasMsg>().unwrap();
+             ROUTER.route_ipc_receiver_to_mpsc_sender(out_of_process_port, in_process_chan.clone());
+             (out_of_process_chan, in_process_chan)
+        })
     }
 
     #[inline]


### PR DESCRIPTION
Closes #9228 

I think this code will actually do what is desired now. I had to rebase off of master since WebGLPaintTask was renamed to WebGLPaintThread in a commit since last night.

I'm sorry this has been so much trouble so far. I'm still learning how things are done around here. I didn't even think about trailing whitespace, but now I know about the test-tidy tool.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9240)

<!-- Reviewable:end -->
