### PR TITLE
HTMLFormElement::Elements should honor [SameObject] attribute

### DIFF
--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -35209,6 +35209,12 @@
             "path": "html/semantics/forms/the-button-element/button-activate.html",
             "url": "/html/semantics/forms/the-button-element/button-activate.html"
           }
+        ],
+        "html/semantics/forms/the-form-element/form-elements-sameobject.html": [
+          {
+            "path": "html/semantics/forms/the-form-element/form-elements-sameobject.html",
+            "url": "/html/semantics/forms/the-form-element/form-elements-sameobject.html"
+          }
         ]
       }
     },

--- a/tests/wpt/web-platform-tests/html/semantics/forms/the-form-element/form-elements-sameobject.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/the-form-element/form-elements-sameobject.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Testing [SameObject] on the 'elements' attribute on the 'form' element</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+
+<form>
+  <input>
+</form>
+
+<script>
+test(function() {
+  var form = document.querySelector('form');
+  var elements = form.elements;
+  assert_true(elements === form.elements);
+  form.appendChild(document.createElement('input'));
+  assert_true(elements === form.elements);
+}, "[SameObject] should apply to 'elements' attr on <form>");
+</script>


### PR DESCRIPTION
Ideally, this would get tested by web-platform-tests, but that has yet
to be implemented:

https://github.com/w3c/web-platform-tests/issues/2462

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9242)

<!-- Reviewable:end -->
