### PR TITLE
Upgrade to latest stb_image 0.2.1 from crates.io

### DIFF
--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -13,9 +13,6 @@ path = "../util"
 [dependencies.msg]
 path = "../msg"
 
-[dependencies.stb_image]
-git = "https://github.com/servo/rust-stb-image"
-
 [dependencies.ipc-channel]
 git = "https://github.com/servo/ipc-channel"
 
@@ -29,5 +26,6 @@ hyper = { version = "0.7", features = [ "serde-serialization" ] }
 image = "0.5.0"
 serde = "0.6"
 serde_macros = "0.6"
+stb_image = "0.2"
 url = "0.5.2"
 websocket = "0.14.0"

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1206,7 +1206,7 @@ dependencies = [
  "plugins 0.0.1",
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "stb_image 0.2.0 (git+https://github.com/servo/rust-stb-image)",
+ "stb_image 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "websocket 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1751,8 +1751,8 @@ dependencies = [
 
 [[package]]
 name = "stb_image"
-version = "0.2.0"
-source = "git+https://github.com/servo/rust-stb-image#bf1edc24753962e474cae3a2ad376a6d423cd91d"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
  "script 0.0.1",
  "script_traits 0.0.1",
  "servo 0.0.1",
- "stb_image 0.2.0 (git+https://github.com/servo/rust-stb-image)",
+ "stb_image 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1146,7 +1146,7 @@ dependencies = [
  "plugins 0.0.1",
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "stb_image 0.2.0 (git+https://github.com/servo/rust-stb-image)",
+ "stb_image 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "websocket 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1701,8 +1701,8 @@ dependencies = [
 
 [[package]]
 name = "stb_image"
-version = "0.2.0"
-source = "git+https://github.com/servo/rust-stb-image#bf1edc24753962e474cae3a2ad376a6d423cd91d"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/ports/cef/Cargo.toml
+++ b/ports/cef/Cargo.toml
@@ -9,11 +9,12 @@ path = "lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-log = "0.3"
-url = "0.5.2"
-libc = "0.2"
 euclid = {version = "0.4", features = ["plugins"]}
 gleam = "0.2"
+libc = "0.2"
+log = "0.3"
+stb_image = "0.2"
+url = "0.5.2"
 
 [dependencies.servo]
 path = "../../components/servo"
@@ -61,9 +62,6 @@ git = "https://github.com/servo/rust-mozjs"
 [dependencies.layers]
 git = "https://github.com/servo/rust-layers"
 features = ["plugins"]
-
-[dependencies.stb_image]
-git = "https://github.com/servo/rust-stb-image"
 
 [target.x86_64-apple-darwin.dependencies]
 objc = "0.1"

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -1114,7 +1114,7 @@ dependencies = [
  "plugins 0.0.1",
  "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "stb_image 0.2.0 (git+https://github.com/servo/rust-stb-image)",
+ "stb_image 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "websocket 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1667,8 +1667,8 @@ dependencies = [
 
 [[package]]
 name = "stb_image"
-version = "0.2.0"
-source = "git+https://github.com/servo/rust-stb-image#bf1edc24753962e474cae3a2ad376a6d423cd91d"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]


### PR DESCRIPTION
Includes servo/rust-stb-image#84.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9258)

<!-- Reviewable:end -->
