### PR TITLE
Add build-essential to Debian based Linuxes' requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ On Debian-based Linuxes:
 ``` sh
 sudo apt-get install curl freeglut3-dev autoconf \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
-    gperf g++ cmake virtualenv python-pip \
+    gperf g++ build-essential cmake virtualenv python-pip \
     libssl-dev libbz2-dev libosmesa6-dev libxmu6 libxmu-dev \
     libglu1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev
 ```


### PR DESCRIPTION
This is discovered here: #9262 

Particularly `make` needs to be available.

Usually on developer workstation `build-essential` is already installed. That is why it wasn't there in requirements.

It occurs that if you use minimal ubuntu image for some kind of automated build, it doesn't have `build-essential` by default. So would be nice to still have `build-essential` there in the command.
## 

Kind Regards,
Oleksii
## 

/cc @jdm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9264)

<!-- Reviewable:end -->
