### PR TITLE
Making create attribute lowercase

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1847,12 +1847,14 @@ impl DocumentMethods for Document {
     }
 
     // https://dom.spec.whatwg.org/#dom-document-createattribute
-    fn CreateAttribute(&self, local_name: DOMString) -> Fallible<Root<Attr>> {
+    fn CreateAttribute(&self, mut local_name: DOMString) -> Fallible<Root<Attr>> {
         if xml_name_type(&local_name) == InvalidXMLName {
             debug!("Not a valid element name");
             return Err(Error::InvalidCharacter);
         }
-
+        if self.is_html_document {
+            local_name.make_ascii_lowercase();
+        }
         let name = Atom::from(&*local_name);
         // repetition used because string_cache::atom::Atom is non-copyable
         let l_name = Atom::from(&*local_name);

--- a/tests/wpt/metadata/dom/nodes/Document-createAttribute.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-createAttribute.html.ini
@@ -1,5 +1,0 @@
-[Document-createAttribute.html]
-  type: testharness
-  [HTML document.createAttribute("TITLE")]
-    expected: FAIL
-


### PR DESCRIPTION
This should fix #9252. I need some help getting the test case to work correctly. I get output that "TITLE" should FAIL, but it PASS. How do I make it to where it should PASS?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9282)

<!-- Reviewable:end -->
