### PR TITLE
compositing: Fix a couple of bugs that prevented iframes from painting after navigation.

### DIFF
--- a/components/compositing/compositor_layer.rs
+++ b/components/compositing/compositor_layer.rs
@@ -211,6 +211,7 @@ pub enum ScrollEventResult {
 impl CompositorLayer for Layer<CompositorData> {
     fn update_layer_except_bounds(&self, layer_properties: LayerProperties) {
         self.extra_data.borrow_mut().scroll_policy = layer_properties.scroll_policy;
+        self.extra_data.borrow_mut().subpage_info = layer_properties.subpage_pipeline_id;
         *self.transform.borrow_mut() = layer_properties.transform;
         *self.perspective.borrow_mut() = layer_properties.perspective;
 

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -1311,6 +1311,17 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
     fn handle_activate_document_msg(&mut self, pipeline_id: PipelineId) {
         debug!("Document ready to activate {:?}", pipeline_id);
 
+        if let Some(ref child_pipeline) = self.pipelines.get(&pipeline_id) {
+            if let Some(ref parent_info) = child_pipeline.parent_info {
+                if let Some(parent_pipeline) = self.pipelines.get(&parent_info.0) {
+                    let _ = parent_pipeline.script_chan
+                                           .send(ConstellationControlMsg::FramedContentChanged(
+                            parent_info.0,
+                            parent_info.1));
+                }
+            }
+        }
+
         // If this pipeline is already part of the current frame tree,
         // we don't need to do anything.
         if self.pipeline_is_in_current_frame(pipeline_id) {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -107,6 +107,7 @@ pub enum ReflowReason {
     ImageLoaded,
     RequestAnimationFrame,
     WebFontLoaded,
+    FramedContentChanged,
 }
 
 pub type ScrollPoint = Point2D<Au>;
@@ -1425,6 +1426,7 @@ fn debug_reflow_events(goal: &ReflowGoal, query_type: &ReflowQueryType, reason: 
         ReflowReason::ImageLoaded => "\tImageLoaded",
         ReflowReason::RequestAnimationFrame => "\tRequestAnimationFrame",
         ReflowReason::WebFontLoaded => "\tWebFontLoaded",
+        ReflowReason::FramedContentChanged => "\tFramedContentChanged",
     });
 
     println!("{}", debug_msg);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1127,6 +1127,8 @@ impl ScriptThread {
             ConstellationControlMsg::DispatchFrameLoadEvent {
                 target: pipeline_id, parent: containing_id } =>
                 self.handle_frame_load_event(containing_id, pipeline_id),
+            ConstellationControlMsg::FramedContentChanged(containing_pipeline_id, subpage_id) =>
+                self.handle_framed_content_changed(containing_pipeline_id, subpage_id),
             ConstellationControlMsg::ReportCSSError(pipeline_id, filename, line, column, msg) =>
                 self.handle_css_error_reporting(pipeline_id, filename, line, column, msg),
         }
@@ -1480,6 +1482,22 @@ impl ScriptThread {
             doc.begin_focus_transaction();
             doc.request_focus(frame_element.upcast());
             doc.commit_focus_transaction(FocusType::Parent);
+        }
+    }
+
+    fn handle_framed_content_changed(&self,
+                                     parent_pipeline_id: PipelineId,
+                                     subpage_id: SubpageId) {
+        let borrowed_page = self.root_page();
+        let page = borrowed_page.find(parent_pipeline_id).unwrap();
+        let doc = page.document();
+        let frame_element = doc.find_iframe(subpage_id);
+        if let Some(ref frame_element) = frame_element {
+            frame_element.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            let window = page.window();
+            window.reflow(ReflowGoal::ForDisplay,
+                          ReflowQueryType::NoQuery,
+                          ReflowReason::FramedContentChanged);
         }
     }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -143,6 +143,8 @@ pub enum ConstellationControlMsg {
         /// The pipeline that contains a frame loading the target pipeline.
         parent: PipelineId
     },
+    /// Notifies a parent frame that one of its child frames is now active.
+    FramedContentChanged(PipelineId, SubpageId),
     /// Report an error from a CSS parser for the given pipeline
     ReportCSSError(PipelineId, String, u32, u32, String),
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1688,6 +1688,18 @@
             "url": "/_mozilla/css/iframe/multiple_external.html"
           }
         ],
+        "css/iframe/navigation.html": [
+          {
+            "path": "css/iframe/navigation.html",
+            "references": [
+              [
+                "/_mozilla/css/iframe/navigation_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/iframe/navigation.html"
+          }
+        ],
         "css/iframe/overflow.html": [
           {
             "path": "css/iframe/overflow.html",

--- a/tests/wpt/mozilla/tests/css/iframe/navigation.html
+++ b/tests/wpt/mozilla/tests/css/iframe/navigation.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<style>
+iframe {
+    display: block;
+    border: 1px solid black;
+    width: 500px;
+    height: 300px;
+    margin-left: 10px;
+    margin-top: 0px;
+}
+</style>
+<body>
+<iframe src="data:text/html,Foo"></iframe>
+<script>
+setTimeout(function() {
+    var iframe = document.getElementsByTagName('iframe')[0];
+    var navigated = false;
+    iframe.addEventListener('load', function() {
+        if (navigated) {
+            // Uncomment the following lines to observe that the navigation happens.
+            // If the lines are commented out, the test times out.
+            /*console.log("about to remove reftest-wait: document class is now: " +
+                        document.documentElement.getAttribute('class'));*/
+            document.documentElement.classList.remove("reftest-wait");
+            /*console.log("navigated: document class is now: " +
+                        document.documentElement.getAttribute('class'));*/
+        }
+    }, false);
+    iframe.src = "data:text/html,Hello%20world";
+    navigated = true;
+}, 16);
+</script>
+</body>
+</html>
+

--- a/tests/wpt/mozilla/tests/css/iframe/navigation_ref.html
+++ b/tests/wpt/mozilla/tests/css/iframe/navigation_ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<style>
+iframe {
+    display: block;
+    border: 1px solid black;
+    width: 500px;
+    height: 300px;
+    margin-left: 10px;
+    margin-top: 0px;
+}
+</style>
+<body>
+<iframe src="data:text/html,Hello%20world"></iframe>
+</body>
+</html>
+


### PR DESCRIPTION
The first bug was that iframes were not reflowed in their parent DOM when the child page navigated. This is fixed by simply having the constellation notify the appropriate script thread when navigation occurs.

The second bug was that the compositor was unable to adjust the pipeline for existing iframe layers, only new ones. This patch adds logic to do that.

Closes #8081.

r? @jdm 
cc @metajack

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9285)

<!-- Reviewable:end -->
