### PR TITLE
Change all DOMStrings to USV strings for XHR

### DIFF
--- a/components/script/dom/webidls/XMLHttpRequest.webidl
+++ b/components/script/dom/webidls/XMLHttpRequest.webidl
@@ -37,16 +37,15 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
   const unsigned short HEADERS_RECEIVED = 2;
   const unsigned short LOADING = 3;
   const unsigned short DONE = 4;
-
   readonly attribute unsigned short readyState;
 
   // request
   [Throws]
-  void open(ByteString method, /* [EnsureUTF16] */ DOMString url);
+  void open(ByteString method, USVString url);
   [Throws]
-  void open(ByteString method, /* [EnsureUTF16] */ DOMString url, boolean async,
-            optional /* [EnsureUTF16] */ DOMString? username = null,
-            optional /* [EnsureUTF16] */ DOMString? password = null);
+  void open(ByteString method, USVString url, boolean async,
+            optional USVString? username = null,
+            optional USVString? password = null);
 
   [Throws]
   void setRequestHeader(ByteString name, ByteString value);
@@ -60,7 +59,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
   void abort();
 
   // response
-  readonly attribute DOMString responseURL;
+  readonly attribute USVString responseURL;
   readonly attribute unsigned short status;
   readonly attribute ByteString statusText;
   ByteString? getResponseHeader(ByteString name);
@@ -71,7 +70,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
            attribute XMLHttpRequestResponseType responseType;
   readonly attribute any response;
   [Throws]
-  readonly attribute DOMString responseText;
+  readonly attribute USVString responseText;
   [Throws]
   /*[Exposed=Window]*/ readonly attribute Document? responseXML;
 };

--- a/tests/wpt/metadata/XMLHttpRequest/open-url-encoding.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/open-url-encoding.htm.ini
@@ -1,5 +1,0 @@
-[open-url-encoding.htm]
-  type: testharness
-  [XMLHttpRequest: open() - URL encoding]
-    expected: FAIL
-

--- a/tests/wpt/web-platform-tests/XMLHttpRequest/open-url-encoding.htm
+++ b/tests/wpt/web-platform-tests/XMLHttpRequest/open-url-encoding.htm
@@ -12,10 +12,16 @@
     <script>
       test(function() {
         var client = new XMLHttpRequest()
-        client.open("GET", "resources/content.py?ß", false)
-        client.send(null)
+        client.open("GET", "resources/content.py?\u00DF", false) // This is the German "eszett" character
+        client.send()
         assert_equals(client.getResponseHeader("x-request-query"), "%C3%9F")
-      })
+      }, "percent encode characters");
+      test(function() {
+        var client = new XMLHttpRequest()
+        client.open("GET", "resources/content.py?\uD83D", false)
+        client.send()
+        assert_equals(client.getResponseHeader("x-request-query"), "%EF%BF%BD")
+      }, "lone surrogate should return U+FFFD");
     </script>
   </body>
 </html>


### PR DESCRIPTION
This is in compliance with the new spec [here](https://xhr.spec.whatwg.org/#xmlhttprequest).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9294)

<!-- Reviewable:end -->
