### PR TITLE
cargo-update ipc-channel to get important fixes

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.1.0"
-source = "git+https://github.com/servo/ipc-channel#1b95d5490d7b7f49576577315bdb5b4c834d08d0"
+source = "git+https://github.com/servo/ipc-channel#dfd8513d801d16a7e4a5b0b92a68c27b0dd99fe1"
 dependencies = [
  "bincode 0.4.0 (git+https://github.com/TyOverby/bincode)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.1.0"
-source = "git+https://github.com/servo/ipc-channel#1b95d5490d7b7f49576577315bdb5b4c834d08d0"
+source = "git+https://github.com/servo/ipc-channel#dfd8513d801d16a7e4a5b0b92a68c27b0dd99fe1"
 dependencies = [
  "bincode 0.4.0 (git+https://github.com/TyOverby/bincode)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -173,7 +173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ipc-channel"
 version = "0.1.0"
-source = "git+https://github.com/servo/ipc-channel#1b95d5490d7b7f49576577315bdb5b4c834d08d0"
+source = "git+https://github.com/servo/ipc-channel#dfd8513d801d16a7e4a5b0b92a68c27b0dd99fe1"
 dependencies = [
  "bincode 0.4.0 (git+https://github.com/TyOverby/bincode)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.1.0"
-source = "git+https://github.com/servo/ipc-channel#1b95d5490d7b7f49576577315bdb5b4c834d08d0"
+source = "git+https://github.com/servo/ipc-channel#dfd8513d801d16a7e4a5b0b92a68c27b0dd99fe1"
 dependencies = [
  "bincode 0.4.0 (git+https://github.com/TyOverby/bincode)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This pulls in https://github.com/servo/ipc-channel/pull/25 and
https://github.com/servo/ipc-channel/pull/27, thus fixing fallout from
the multiprocess split, and making Servo work on my system again.

(It also pulls in https://github.com/servo/ipc-channel/pull/12 -- I
guess that's fine?)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9299)

<!-- Reviewable:end -->
