### PR TITLE
DOMContentLoaded should bubble.

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1352,7 +1352,7 @@ impl Document {
 
         let event = Event::new(GlobalRef::Window(self.window()),
                                atom!("DOMContentLoaded"),
-                               EventBubbles::DoesNotBubble,
+                               EventBubbles::Bubbles,
                                EventCancelable::NotCancelable);
         let doctarget = self.upcast::<EventTarget>();
         let _ = doctarget.DispatchEvent(event.r());


### PR DESCRIPTION
DOMContentLoaded event is currently set as non bubbling event.
Test : 
./tests/wpt/web-platform-tests/html/syntax/parsing/the-end.html

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9317)

<!-- Reviewable:end -->
