### PR TITLE
Test setting response.body and fetching a message on a server

### DIFF
--- a/components/net/fetch/response.rs
+++ b/components/net/fetch/response.rs
@@ -75,8 +75,7 @@ impl ResponseMethods for Response {
                 response.response_type = filter_type;
             },
 
-            ResponseType::Opaque |
-            ResponseType::OpaqueRedirect => {
+            ResponseType::Opaque | ResponseType::OpaqueRedirect => {
                 response.headers = Headers::new();
                 response.status = None;
                 response.body = ResponseBody::Empty;


### PR DESCRIPTION
I've updated http_fetch to now set response.body, as well as written a test to ensure that fetch can retrieve a message on a server. I've also looked into partially implementing some more of http_fetch while trying to figure out where response.body gets written to.

As always I'd like feedback on my logic, I'm confident there are more steps for handling response.body I need but I find the specification difficult to parse on this.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9321)

<!-- Reviewable:end -->
