### PR TITLE
Rename net/fetch/request.rs to net/fetch/methods.rs and move Request …

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -15,158 +15,17 @@ use hyper::header::{QualityItem, q, qitem, Referer as RefererHeader, UserAgent};
 use hyper::method::Method;
 use hyper::mime::{Attr, Mime, SubLevel, TopLevel, Value};
 use hyper::status::StatusCode;
+use net_traits::request::{CacheMode, Context, ContextFrameType, CredentialsMode};
+use net_traits::request::{RedirectMode, Referer, Request, RequestMode, ResponseTainting};
 use net_traits::response::{CacheState, HttpsState, Response, ResponseType, TerminationReason};
 use net_traits::{AsyncFetchListener, Metadata};
 use resource_thread::CancellationListener;
 use std::ascii::AsciiExt;
-use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::str::FromStr;
 use std::thread;
 use url::{Origin, Url, UrlParser};
 use util::thread::spawn_named;
-
-/// A [request context](https://fetch.spec.whatwg.org/#concept-request-context)
-#[derive(Copy, Clone, PartialEq)]
-pub enum Context {
-    Audio, Beacon, CSPreport, Download, Embed, Eventsource,
-    Favicon, Fetch, Font, Form, Frame, Hyperlink, IFrame, Image,
-    ImageSet, Import, Internal, Location, Manifest, MetaRefresh, Object,
-    Ping, Plugin, Prefetch, PreRender, Script, ServiceWorker, SharedWorker,
-    Subresource, Style, Track, Video, Worker, XMLHttpRequest, XSLT
-}
-
-/// A [request context frame type](https://fetch.spec.whatwg.org/#concept-request-context-frame-type)
-#[derive(Copy, Clone, PartialEq)]
-pub enum ContextFrameType {
-    Auxiliary,
-    TopLevel,
-    Nested,
-    ContextNone
-}
-
-/// A [referer](https://fetch.spec.whatwg.org/#concept-request-referrer)
-#[derive(Clone, PartialEq)]
-pub enum Referer {
-    NoReferer,
-    Client,
-    RefererUrl(Url)
-}
-
-/// A [request mode](https://fetch.spec.whatwg.org/#concept-request-mode)
-#[derive(Copy, Clone, PartialEq)]
-pub enum RequestMode {
-    SameOrigin,
-    NoCORS,
-    CORSMode,
-    ForcedPreflightMode
-}
-
-/// Request [credentials mode](https://fetch.spec.whatwg.org/#concept-request-credentials-mode)
-#[derive(Copy, Clone, PartialEq)]
-pub enum CredentialsMode {
-    Omit,
-    CredentialsSameOrigin,
-    Include
-}
-
-/// [Cache mode](https://fetch.spec.whatwg.org/#concept-request-cache-mode)
-#[derive(Copy, Clone, PartialEq)]
-pub enum CacheMode {
-    Default,
-    NoStore,
-    Reload,
-    NoCache,
-    ForceCache,
-    OnlyIfCached
-}
-
-/// [Redirect mode](https://fetch.spec.whatwg.org/#concept-request-redirect-mode)
-#[derive(Copy, Clone, PartialEq)]
-pub enum RedirectMode {
-    Follow,
-    Error,
-    Manual
-}
-
-/// [Response tainting](https://fetch.spec.whatwg.org/#concept-request-response-tainting)
-#[derive(Copy, Clone, PartialEq)]
-pub enum ResponseTainting {
-    Basic,
-    CORSTainting,
-    Opaque
-}
-
-/// A [Request](https://fetch.spec.whatwg.org/#requests) as defined by the Fetch spec
-#[derive(Clone)]
-pub struct Request {
-    pub method: RefCell<Method>,
-    // Use the last method on url_list to act as spec url field
-    pub url_list: RefCell<Vec<Url>>,
-    pub headers: RefCell<Headers>,
-    pub unsafe_request: bool,
-    pub body: Option<Vec<u8>>,
-    pub preserve_content_codings: bool,
-    // pub client: GlobalRef, // XXXManishearth copy over only the relevant fields of the global scope,
-                              // not the entire scope to avoid the libscript dependency
-    pub is_service_worker_global_scope: bool,
-    pub skip_service_worker: Cell<bool>,
-    pub context: Context,
-    pub context_frame_type: ContextFrameType,
-    pub origin: Option<Url>, // FIXME: Use Url::Origin
-    pub force_origin_header: bool,
-    pub omit_origin_header: bool,
-    pub same_origin_data: Cell<bool>,
-    pub referer: Referer,
-    pub authentication: bool,
-    pub sync: bool,
-    pub mode: RequestMode,
-    pub credentials_mode: CredentialsMode,
-    pub use_url_credentials: bool,
-    pub cache_mode: Cell<CacheMode>,
-    pub redirect_mode: RedirectMode,
-    pub redirect_count: Cell<u32>,
-    pub response_tainting: ResponseTainting
-}
-
-impl Request {
-    pub fn new(url: Url, context: Context, is_service_worker_global_scope: bool) -> Request {
-         Request {
-            method: RefCell::new(Method::Get),
-            url_list: RefCell::new(vec![url]),
-            headers: RefCell::new(Headers::new()),
-            unsafe_request: false,
-            body: None,
-            preserve_content_codings: false,
-            is_service_worker_global_scope: is_service_worker_global_scope,
-            skip_service_worker: Cell::new(false),
-            context: context,
-            context_frame_type: ContextFrameType::ContextNone,
-            origin: None,
-            force_origin_header: false,
-            omit_origin_header: false,
-            same_origin_data: Cell::new(false),
-            referer: Referer::Client,
-            authentication: false,
-            sync: false,
-            mode: RequestMode::NoCORS,
-            credentials_mode: CredentialsMode::Omit,
-            use_url_credentials: false,
-            cache_mode: Cell::new(CacheMode::Default),
-            redirect_mode: RedirectMode::Follow,
-            redirect_count: Cell::new(0),
-            response_tainting: ResponseTainting::Basic,
-        }
-    }
-
-    fn get_last_url_string(&self) -> String {
-        self.url_list.borrow().last().unwrap().serialize()
-    }
-
-    fn current_url(&self) -> Url {
-        self.url_list.borrow().last().unwrap().clone()
-    }
-}
 
 pub fn fetch_async(request: Request, cors_flag: bool, listener: Box<AsyncFetchListener + Send>) {
     spawn_named(format!("fetch for {:?}", request.get_last_url_string()), move || {

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -46,6 +46,6 @@ pub mod websocket_loader;
 pub mod fetch {
     #![allow(dead_code, unused)] // XXXManishearth this is only temporary until the Fetch mod starts being used
     pub mod cors_cache;
-    pub mod request;
+    pub mod methods;
     pub mod response;
 }

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -38,6 +38,7 @@ use websocket::header;
 pub mod hosts;
 pub mod image_cache_thread;
 pub mod net_error_list;
+pub mod request;
 pub mod response;
 pub mod storage_thread;
 

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use hyper::header::Headers;
+use hyper::method::Method;
+use std::cell::{Cell, RefCell};
+use url::Url;
+
+/// A [request context](https://fetch.spec.whatwg.org/#concept-request-context)
+#[derive(Copy, Clone, PartialEq)]
+pub enum Context {
+    Audio, Beacon, CSPreport, Download, Embed, Eventsource,
+    Favicon, Fetch, Font, Form, Frame, Hyperlink, IFrame, Image,
+    ImageSet, Import, Internal, Location, Manifest, MetaRefresh, Object,
+    Ping, Plugin, Prefetch, PreRender, Script, ServiceWorker, SharedWorker,
+    Subresource, Style, Track, Video, Worker, XMLHttpRequest, XSLT
+}
+
+/// A [request context frame type](https://fetch.spec.whatwg.org/#concept-request-context-frame-type)
+#[derive(Copy, Clone, PartialEq)]
+pub enum ContextFrameType {
+    Auxiliary,
+    TopLevel,
+    Nested,
+    ContextNone
+}
+
+/// A [referer](https://fetch.spec.whatwg.org/#concept-request-referrer)
+#[derive(Clone, PartialEq)]
+pub enum Referer {
+    NoReferer,
+    Client,
+    RefererUrl(Url)
+}
+
+/// A [request mode](https://fetch.spec.whatwg.org/#concept-request-mode)
+#[derive(Copy, Clone, PartialEq)]
+pub enum RequestMode {
+    SameOrigin,
+    NoCORS,
+    CORSMode,
+    ForcedPreflightMode
+}
+
+/// Request [credentials mode](https://fetch.spec.whatwg.org/#concept-request-credentials-mode)
+#[derive(Copy, Clone, PartialEq)]
+pub enum CredentialsMode {
+    Omit,
+    CredentialsSameOrigin,
+    Include
+}
+
+/// [Cache mode](https://fetch.spec.whatwg.org/#concept-request-cache-mode)
+#[derive(Copy, Clone, PartialEq)]
+pub enum CacheMode {
+    Default,
+    NoStore,
+    Reload,
+    NoCache,
+    ForceCache,
+    OnlyIfCached
+}
+
+/// [Redirect mode](https://fetch.spec.whatwg.org/#concept-request-redirect-mode)
+#[derive(Copy, Clone, PartialEq)]
+pub enum RedirectMode {
+    Follow,
+    Error,
+    Manual
+}
+
+/// [Response tainting](https://fetch.spec.whatwg.org/#concept-request-response-tainting)
+#[derive(Copy, Clone, PartialEq)]
+pub enum ResponseTainting {
+    Basic,
+    CORSTainting,
+    Opaque
+}
+
+/// A [Request](https://fetch.spec.whatwg.org/#requests) as defined by the Fetch spec
+#[derive(Clone)]
+pub struct Request {
+    pub method: RefCell<Method>,
+    // Use the last method on url_list to act as spec url field
+    pub url_list: RefCell<Vec<Url>>,
+    pub headers: RefCell<Headers>,
+    pub unsafe_request: bool,
+    pub body: Option<Vec<u8>>,
+    pub preserve_content_codings: bool,
+    // pub client: GlobalRef, // XXXManishearth copy over only the relevant fields of the global scope,
+                              // not the entire scope to avoid the libscript dependency
+    pub is_service_worker_global_scope: bool,
+    pub skip_service_worker: Cell<bool>,
+    pub context: Context,
+    pub context_frame_type: ContextFrameType,
+    pub origin: Option<Url>, // FIXME: Use Url::Origin
+    pub force_origin_header: bool,
+    pub omit_origin_header: bool,
+    pub same_origin_data: Cell<bool>,
+    pub referer: Referer,
+    pub authentication: bool,
+    pub sync: bool,
+    pub mode: RequestMode,
+    pub credentials_mode: CredentialsMode,
+    pub use_url_credentials: bool,
+    pub cache_mode: Cell<CacheMode>,
+    pub redirect_mode: RedirectMode,
+    pub redirect_count: Cell<u32>,
+    pub response_tainting: ResponseTainting
+}
+
+impl Request {
+    pub fn new(url: Url, context: Context, is_service_worker_global_scope: bool) -> Request {
+         Request {
+            method: RefCell::new(Method::Get),
+            url_list: RefCell::new(vec![url]),
+            headers: RefCell::new(Headers::new()),
+            unsafe_request: false,
+            body: None,
+            preserve_content_codings: false,
+            is_service_worker_global_scope: is_service_worker_global_scope,
+            skip_service_worker: Cell::new(false),
+            context: context,
+            context_frame_type: ContextFrameType::ContextNone,
+            origin: None,
+            force_origin_header: false,
+            omit_origin_header: false,
+            same_origin_data: Cell::new(false),
+            referer: Referer::Client,
+            authentication: false,
+            sync: false,
+            mode: RequestMode::NoCORS,
+            credentials_mode: CredentialsMode::Omit,
+            use_url_credentials: false,
+            cache_mode: Cell::new(CacheMode::Default),
+            redirect_mode: RedirectMode::Follow,
+            redirect_count: Cell::new(0),
+            response_tainting: ResponseTainting::Basic,
+        }
+    }
+
+    pub fn get_last_url_string(&self) -> String {
+        self.url_list.borrow().last().unwrap().serialize()
+    }
+
+    pub fn current_url(&self) -> Url {
+        self.url_list.borrow().last().unwrap().clone()
+    }
+}

--- a/tests/unit/net/fetch.rs
+++ b/tests/unit/net/fetch.rs
@@ -4,8 +4,9 @@
 
 use hyper::server::{Listening, Server};
 use hyper::server::{Request as HyperRequest, Response as HyperResponse};
-use net::fetch::request::{Context, fetch, Referer, Request};
-use net_traits::response::{Response};
+use net::fetch::methods::fetch;
+use net_traits::request::{Context, Referer, Request};
+use net_traits::response::Response;
 use std::rc::Rc;
 use url::Url;
 
@@ -23,7 +24,6 @@ fn make_server(message: &'static [u8]) -> (Listening, Url) {
     let url = Url::parse(&url_string).unwrap();
     (server, url)
 }
-
 
 #[test]
 fn test_fetch_response_is_not_network_error() {


### PR DESCRIPTION
…to net_traits.

Also updated unit tests to correctly reference and use Request and Fetch methods.

This is in preparation for XHR and EventSource (possibly WebSocket as well), which rely on using Request, but we cannot make the script crate depend upon the net crate.

cc @nikkisquared @jdm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9362)

<!-- Reviewable:end -->
