### PR TITLE
Remove remaining reference to the long-disappeared JSRef type.

### DIFF
--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -431,7 +431,7 @@ impl<T: Reflectable> LayoutJS<T> {
     }
 }
 
-/// Get an `Option<JSRef<T>>` out of an `Option<Root<T>>`
+/// Get an `Option<&T>` out of an `Option<Root<T>>`
 pub trait RootedReference<T> {
     /// Obtain a safe optional reference to the wrapped JS owned-value that
     /// cannot outlive the lifetime of this root.

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -33,7 +33,8 @@
 //!
 //! The instance methods for an interface `Foo` are defined on a
 //! `dom::bindings::codegen::Bindings::FooBindings::FooMethods` trait. This
-//! trait is then implemented for `JSRef<'a, Foo>`.
+//! trait is then implemented for `Foo`. (All methods take an `&self`
+//! parameter, as pointers to DOM objects can be freely aliased.)
 //!
 //! The return type and argument types are determined [as described below]
 //! (#rust-reflections-of-webidl-types).


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9366)

<!-- Reviewable:end -->
