### PR TITLE
Add an `Unserializable` type to utils

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -196,7 +196,7 @@ impl<'a> CanvasPaintThread<'a> {
                         }
                     }
                     CanvasMsg::FromPaint(message) => {
-                        match message {
+                        match message.get() {
                             FromPaintMsg::SendNativeSurface(chan) => {
                                 painter.send_native_surface(chan)
                             }

--- a/components/canvas/webgl_paint_thread.rs
+++ b/components/canvas/webgl_paint_thread.rs
@@ -222,7 +222,7 @@ impl WebGLPaintThread {
                         }
                     }
                     CanvasMsg::FromPaint(message) => {
-                        match message {
+                        match message.get() {
                             FromPaintMsg::SendNativeSurface(chan) =>
                                 painter.send_native_surface(chan),
                         }

--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -35,11 +35,11 @@ use gfx_traits::color;
 use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
 use layers::platform::surface::NativeSurface;
 use offscreen_gl_context::GLContextAttributes;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::default::Default;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::mpsc::Sender;
+use util::ipc::Unserializable;
 use util::mem::HeapSizeOf;
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -53,7 +53,7 @@ pub enum CanvasMsg {
     Canvas2d(Canvas2dMsg),
     Common(CanvasCommonMsg),
     FromLayout(FromLayoutMsg),
-    FromPaint(FromPaintMsg),
+    FromPaint(Unserializable<FromPaintMsg>),
     WebGL(CanvasWebGLMsg),
 }
 
@@ -71,18 +71,6 @@ pub enum FromLayoutMsg {
 #[derive(Clone)]
 pub enum FromPaintMsg {
     SendNativeSurface(Sender<NativeSurface>),
-}
-
-impl Serialize for FromPaintMsg {
-    fn serialize<S>(&self, _: &mut S) -> Result<(), S::Error> where S: Serializer {
-        panic!("can't serialize a `FromPaintMsg`!")
-    }
-}
-
-impl Deserialize for FromPaintMsg {
-    fn deserialize<D>(_: &mut D) -> Result<FromPaintMsg, D::Error> where D: Deserializer {
-        panic!("can't deserialize a `FromPaintMsg`!")
-    }
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1985,8 +1985,11 @@ version = "0.0.1"
 dependencies = [
  "app_units 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.1.0 (git+https://github.com/servo/ipc-channel)",
  "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
+ "serde 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_macros 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
 ]
 

--- a/components/util/ipc.rs
+++ b/components/util/ipc.rs
@@ -8,9 +8,11 @@ use opts;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
+use std::fmt;
 use std::io::{Error, ErrorKind};
 use std::marker::Reflect;
 use std::mem;
+use std::ops::{Deref, DerefMut};
 use std::sync::Mutex;
 use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -177,3 +179,54 @@ pub fn optional_ipc_channel<T>() -> (OptionalIpcSender<T>, Receiver<T>)
     }
 }
 
+pub struct Unserializable<T>(T);
+
+impl<T> Unserializable<T> {
+    pub fn new(inner: T) -> Unserializable<T> {
+        Unserializable(inner)
+    }
+
+    pub fn get(self) -> T {
+        self.0
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Unserializable<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Unserializable({:?})", self.0)
+    }
+}
+
+impl<T: Clone> Clone for Unserializable<T> {
+    fn clone(&self) -> Self {
+        Unserializable(self.0.clone())
+    }
+}
+
+impl<T: Copy> Copy for Unserializable<T> {}
+
+impl<T> Serialize for Unserializable<T> {
+    fn serialize<S>(&self, _: &mut S) -> Result<(), S::Error> where S: Serializer {
+        panic!("Can't serialize a `Unserializable` struct");
+    }
+}
+
+impl<T> Deserialize for Unserializable<T> {
+    fn deserialize<D>(_: &mut D) -> Result<Unserializable<T>, D::Error> where D: Deserializer {
+        panic!("Can't deserialize a `Unserializable` struct");
+    }
+}
+
+impl<T> Deref for Unserializable<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Unserializable<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}

--- a/components/util/ipc.rs
+++ b/components/util/ipc.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::fmt;
+use std::intrinsics::type_name;
 use std::io::{Error, ErrorKind};
 use std::marker::Reflect;
 use std::mem;
@@ -205,15 +206,23 @@ impl<T: Clone> Clone for Unserializable<T> {
 
 impl<T: Copy> Copy for Unserializable<T> {}
 
+impl<T: PartialEq> PartialEq for Unserializable<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<T: Eq> Eq for Unserializable<T> {}
+
 impl<T> Serialize for Unserializable<T> {
     fn serialize<S>(&self, _: &mut S) -> Result<(), S::Error> where S: Serializer {
-        panic!("Can't serialize a `Unserializable` struct");
+        panic!("Can't serialize a `Unserializable({})` struct", unsafe { type_name::<T>() });
     }
 }
 
 impl<T> Deserialize for Unserializable<T> {
     fn deserialize<D>(_: &mut D) -> Result<Unserializable<T>, D::Error> where D: Deserializer {
-        panic!("Can't deserialize a `Unserializable` struct");
+        panic!("Can't deserialize a `Unserializable({})` struct", unsafe { type_name::<T>() });
     }
 }
 

--- a/tests/unit/util/Cargo.toml
+++ b/tests/unit/util/Cargo.toml
@@ -17,6 +17,11 @@ path = "../../../components/plugins"
 
 [dependencies]
 app_units = {version = "0.1", features = ["plugins"]}
-libc = "0.2"
 euclid = {version = "0.4", features = ["plugins"]}
+libc = "0.2"
+serde = "0.6"
+serde_macros = "0.6"
+
+[dependencies.ipc-channel]
+git = "https://github.com/servo/ipc-channel"
 

--- a/tests/unit/util/ipc.rs
+++ b/tests/unit/util/ipc.rs
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use ipc_channel::ipc;
+use std::sync::mpsc::channel;
+use util::ipc::Unserializable;
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+enum Dummy {
+    Serializable(i32),
+    Unserializable(Unserializable<i32>),
+}
+
+#[test]
+fn test_serializable() {
+    let (tx, rx) = ipc::channel().unwrap();
+    tx.send(Dummy::Serializable(4)).unwrap();
+    assert_eq!(rx.recv().unwrap(), Dummy::Serializable(4));
+}
+
+#[test]
+fn test_unserializable_in_process() {
+    let (tx, rx) = channel();
+    tx.send(Dummy::Unserializable(Unserializable::new(4))).unwrap();
+    assert_eq!(rx.recv().unwrap(), Dummy::Unserializable(Unserializable::new(4)));
+}
+
+#[test]
+#[should_panic]
+fn test_unserializable_over_ipc() {
+    let (tx, _rx) = ipc::channel().unwrap();
+    tx.send(Dummy::Unserializable(Unserializable::new(4))).unwrap();
+}

--- a/tests/unit/util/lib.rs
+++ b/tests/unit/util/lib.rs
@@ -5,11 +5,15 @@
 #![cfg_attr(test, feature(plugin, custom_derive, heap_api))]
 #![cfg_attr(test, plugin(plugins))]
 #![feature(alloc)]
+#![feature(plugin)]
+#![plugin(serde_macros)]
 
 extern crate alloc;
 extern crate app_units;
 extern crate euclid;
+extern crate ipc_channel;
 extern crate libc;
+extern crate serde;
 extern crate util;
 
 #[cfg(test)] mod cache;
@@ -19,3 +23,4 @@ extern crate util;
 #[cfg(test)] mod mem;
 #[cfg(test)] mod str;
 #[cfg(test)] mod opts;
+#[cfg(test)] mod ipc;


### PR DESCRIPTION
This allows unifying the way we prevent the serialisation of things that
can't be sent over IPC for their in-process nature.

This is a proposed solution to things like #9373

Where something like the following can be used:

``` rust
    Exit(Unserializable<Sender<()>>),
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9379)

<!-- Reviewable:end -->
