### PR TITLE
layout: Remove some bogus code that tried to handle absolutely-positioned flows separately when storing overflow.

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -251,13 +251,6 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
                                                                       container_size);
                     overflow = overflow.union(&kid_overflow.translate(&kid_position.origin))
                 }
-
-                for kid in mut_base(self).abs_descendants.iter() {
-                    let kid_overflow = base(kid).overflow;
-                    let kid_position = base(kid).position.to_physical(base(kid).writing_mode,
-                                                                      container_size);
-                    overflow = overflow.union(&kid_overflow.translate(&kid_position.origin))
-                }
             }
             _ => {}
         }

--- a/tests/html/overflow-bug-0.html
+++ b/tests/html/overflow-bug-0.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!-- https://github.com/servo/servo/issues/9306 -->
+<style>
+  body {
+    margin: 0;
+  }
+
+  .green {
+    background: #0F0;
+    height: 40px;
+    width: 600px;
+    margin-left: -300px;
+  }
+</style>
+
+<div class="green">
+</div>
+

--- a/tests/html/overflow-bug-1.html
+++ b/tests/html/overflow-bug-1.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!-- https://github.com/servo/servo/issues/9306 -->
+<style>
+  body {
+    margin: 0;
+  }
+
+  .green {
+    background: #0F0;
+    height: 40px;
+    width: 400px;
+    top: 40px;
+    left: 50%;
+    margin-left: -300px;
+    position: absolute;
+    padding: 0px 100px;
+  }
+
+  .red {
+    background: #F00;
+    position: absolute;
+    right: 0;
+  }
+
+</style>
+
+<div class="green">
+  <span class="red">x</span>
+</div>

--- a/tests/html/overflow-bug-2.html
+++ b/tests/html/overflow-bug-2.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<!-- https://github.com/servo/servo/issues/9309 -->
+<style>
+  body {
+    margin: 0;
+  }
+
+  .a {
+    background: red;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    overflow: hidden;
+  }
+
+  .b {
+    background: green;
+    width: 40px;
+    height: 40px;
+    position: absolute;
+    right: -40px;
+  }
+
+</style>
+
+<div class="a">
+  <div class="b"></div>
+</div>

--- a/tests/wpt/metadata-css/css21_dev/html4/numbers-units-018.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/numbers-units-018.htm.ini
@@ -1,3 +1,0 @@
-[numbers-units-018.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
This code dates back to the time when absolutely positioned flows were
ignored by all of their ancestors up to the containing block. This
hasn't been true for at least a year.

Closes #9306.
Closes #9309.
Is a partial fix for #9308.

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9405)

<!-- Reviewable:end -->
