### PR TITLE
Fix build on windows when default python is MSYS64 python

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -80,6 +80,13 @@ def _get_exec(*names):
     return None
 
 
+def _get_virtualenv_script_dir():
+    # Virtualenv calls its scripts folder "bin" on linux/OSX/MSYS64 but "Scripts" on Windows
+    if os.name == "nt" and os.path.sep != "/":
+        return "Scripts"
+    return "bin"
+
+
 # Possible names of executables, sorted from most to least specific
 PYTHON_NAMES = ["python-2.7", "python2.7", "python2", "python"]
 VIRTUALENV_NAMES = ["virtualenv-2.7", "virtualenv2.7", "virtualenv2", "virtualenv"]
@@ -92,8 +99,7 @@ def _activate_virtualenv(topdir):
     if python is None:
         sys.exit("Python is not installed. Please install it prior to running mach.")
 
-    # Virtualenv calls its scripts folder "bin" on linux/OSX but "Scripts" on Windows, detect which one then use that
-    script_dir = "Scripts" if os.name == "nt" else "bin"
+    script_dir = _get_virtualenv_script_dir()
     activate_path = os.path.join(virtualenv_path, script_dir, "activate_this.py")
     if not (os.path.exists(virtualenv_path) and os.path.exists(activate_path)):
         virtualenv = _get_exec(*VIRTUALENV_NAMES)


### PR DESCRIPTION
This removes the need to rename the MSYS64 python binaries for a successful build

See https://github.com/servo/servo/issues/9168#issuecomment-169368989

Tested building on Windows (Where `echo $MSYSTEM` is `MINGW64`) and Ubuntu.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9408)

<!-- Reviewable:end -->
