### PR TITLE
Adding sync method to update atrr from inline style updates

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -174,11 +174,16 @@ impl Attr {
     pub fn set_value(&self, mut value: AttrValue, owner: &Element) {
         assert!(Some(owner) == self.owner().r());
         owner.will_mutate_attr();
-        mem::swap(&mut *self.value.borrow_mut(), &mut value);
+        self.swap_value(&mut value);
         if self.identifier.namespace == ns!() {
             vtable_for(owner.upcast())
                 .attribute_mutated(self, AttributeMutation::Set(Some(&value)));
         }
+    }
+
+    /// Used to swap the attribute's value without triggering mutation events
+    pub fn swap_value(&self, value: &mut AttrValue) {
+        mem::swap(&mut *self.value.borrow_mut(), value);
     }
 
     pub fn identifier(&self) -> &AttrIdentifier {

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -156,7 +156,9 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
                     self.0.next().map(|r| &**r)
                 }
             }
-            let serialized_value = shorthand.serialize_shorthand_to_string(Map(list.iter()));
+
+            // TODO: important is hardcoded to false because method does not implement it yet
+            let serialized_value = shorthand.serialize_shorthand_value_to_string(Map(list.iter()), false);
             return DOMString::from(serialized_value);
         }
 
@@ -238,10 +240,8 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
         let element = self.owner.upcast::<Element>();
 
         // Step 8
-        for decl in declarations {
-            // Step 9
-            element.update_inline_style(decl, priority);
-        }
+        // Step 9
+        element.update_inline_style(declarations, priority);
 
         Ok(())
     }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -145,8 +145,8 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
             }
 
             // Step 2.3
-            let list = list.iter().map(|x| &*x).collect::<Vec<_>>();
-            let serialized_value = shorthand.serialize_shorthand_to_string(&list);
+            let mut list = list.iter().map(|x| &*x);
+            let serialized_value = shorthand.serialize_shorthand_to_string(&mut list);
             return DOMString::from(serialized_value);
         }
 

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -12,6 +12,8 @@ use dom::element::{Element, StylePriority};
 use dom::node::{Node, window_from_node};
 use dom::window::Window;
 use std::ascii::AsciiExt;
+use std::cell::Ref;
+use std::slice;
 use string_cache::Atom;
 use style::properties::{PropertyDeclaration, Shorthand};
 use style::properties::{is_supported_property, parse_one_declaration};
@@ -139,14 +141,22 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
 
                 // Step 2.2.2 & 2.2.3
                 match declaration {
-                    Some(declaration) => list.push(declaration.clone()),
+                    Some(declaration) => list.push(declaration),
                     None => return DOMString::new(),
                 }
             }
 
             // Step 2.3
-            let mut list = list.iter().map(|x| &*x);
-            let serialized_value = shorthand.serialize_shorthand_to_string(&mut list);
+            // Work around closures not being Clone
+            #[derive(Clone)]
+            struct Map<'a, 'b: 'a>(slice::Iter<'a, Ref<'b, PropertyDeclaration>>);
+            impl<'a, 'b> Iterator for Map<'a, 'b> {
+                type Item = &'a PropertyDeclaration;
+                fn next(&mut self) -> Option<Self::Item> {
+                    self.0.next().map(|r| &**r)
+                }
+            }
+            let serialized_value = shorthand.serialize_shorthand_to_string(Map(list.iter()));
             return DOMString::from(serialized_value);
         }
 

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -9,7 +9,7 @@ use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{JS, Root};
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
 use dom::element::{Element, StylePriority};
-use dom::node::{Node, window_from_node};
+use dom::node::{Node, NodeDamage, window_from_node};
 use dom::window::Window;
 use std::ascii::AsciiExt;
 use std::cell::Ref;
@@ -243,6 +243,8 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
         // Step 9
         element.update_inline_style(declarations, priority);
 
+        let node = element.upcast::<Node>();
+        node.dirty(NodeDamage::NodeStyleDamaged);
         Ok(())
     }
 
@@ -275,6 +277,8 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
             None => element.set_inline_style_property_priority(&[&*property], priority),
         }
 
+        let node = element.upcast::<Node>();
+        node.dirty(NodeDamage::NodeStyleDamaged);
         Ok(())
     }
 
@@ -296,18 +300,21 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
         // Step 3
         let value = self.GetPropertyValue(property.clone());
 
-        let elem = self.owner.upcast::<Element>();
+        let element = self.owner.upcast::<Element>();
 
         match Shorthand::from_name(&property) {
             // Step 4
             Some(shorthand) => {
                 for longhand in shorthand.longhands() {
-                    elem.remove_inline_style_property(longhand)
+                    element.remove_inline_style_property(longhand)
                 }
             }
             // Step 5
-            None => elem.remove_inline_style_property(&property),
+            None => element.remove_inline_style_property(&property),
         }
+
+        let node = element.upcast::<Node>();
+        node.dirty(NodeDamage::NodeStyleDamaged);
 
         // Step 6
         Ok(value)

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -9,7 +9,7 @@ use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{JS, Root};
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
 use dom::element::{Element, StylePriority};
-use dom::node::{Node, NodeDamage, window_from_node};
+use dom::node::{Node, window_from_node};
 use dom::window::Window;
 use std::ascii::AsciiExt;
 use string_cache::Atom;
@@ -146,7 +146,8 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
 
             // Step 2.3
             let list = list.iter().map(|x| &*x).collect::<Vec<_>>();
-            return DOMString::from(shorthand.serialize_shorthand(&list));
+            let serialized_value = shorthand.serialize_shorthand_to_string(&list);
+            return DOMString::from(serialized_value);
         }
 
         // Step 3 & 4

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -12,13 +12,11 @@ use dom::element::{Element, StylePriority};
 use dom::node::{Node, NodeDamage, window_from_node};
 use dom::window::Window;
 use std::ascii::AsciiExt;
-use std::borrow::ToOwned;
-use std::cell::Ref;
 use string_cache::Atom;
 use style::properties::{PropertyDeclaration, Shorthand};
 use style::properties::{is_supported_property, parse_one_declaration};
 use style::selector_impl::PseudoElement;
-use util::str::{DOMString, str_join};
+use util::str::DOMString;
 
 // http://dev.w3.org/csswg/cssom/#the-cssstyledeclaration-interface
 #[dom_struct]
@@ -47,29 +45,6 @@ macro_rules! css_properties(
         )*
     );
 );
-
-fn serialize_shorthand(shorthand: Shorthand, declarations: &[Ref<PropertyDeclaration>]) -> String {
-    // https://drafts.csswg.org/css-variables/#variables-in-shorthands
-    if let Some(css) = declarations[0].with_variables_from_shorthand(shorthand) {
-        if declarations[1..]
-               .iter()
-               .all(|d| d.with_variables_from_shorthand(shorthand) == Some(css)) {
-            css.to_owned()
-        } else {
-            String::new()
-        }
-    } else {
-        if declarations.iter().any(|d| d.with_variables()) {
-            String::new()
-        } else {
-            let str_iter = declarations.iter().map(|d| d.value());
-            // FIXME: this needs property-specific code, which probably should be in style/
-            // "as appropriate according to the grammar of shorthand "
-            // https://drafts.csswg.org/cssom/#serialize-a-css-value
-            str_join(str_iter, " ")
-        }
-    }
-}
 
 impl CSSStyleDeclaration {
     pub fn new_inherited(owner: &Element,
@@ -164,13 +139,14 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
 
                 // Step 2.2.2 & 2.2.3
                 match declaration {
-                    Some(declaration) => list.push(declaration),
+                    Some(declaration) => list.push(declaration.clone()),
                     None => return DOMString::new(),
                 }
             }
 
             // Step 2.3
-            return DOMString::from(serialize_shorthand(shorthand, &list));
+            let list = list.iter().map(|x| &*x).collect::<Vec<_>>();
+            return DOMString::from(shorthand.serialize_shorthand(&list));
         }
 
         // Step 3 & 4
@@ -256,8 +232,6 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
             element.update_inline_style(decl, priority);
         }
 
-        let node = element.upcast::<Node>();
-        node.dirty(NodeDamage::NodeStyleDamaged);
         Ok(())
     }
 
@@ -290,8 +264,6 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
             None => element.set_inline_style_property_priority(&[&*property], priority),
         }
 
-        let node = element.upcast::<Node>();
-        node.dirty(NodeDamage::NodeStyleDamaged);
         Ok(())
     }
 
@@ -325,9 +297,6 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
             // Step 5
             None => elem.remove_inline_style_property(&property),
         }
-
-        let node = elem.upcast::<Node>();
-        node.dirty(NodeDamage::NodeStyleDamaged);
 
         // Step 6
         Ok(value)

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -746,37 +746,45 @@ impl Element {
     }
 
     pub fn update_inline_style(&self,
-                               property_decl: PropertyDeclaration,
+                               declarations: Vec<PropertyDeclaration>,
                                style_priority: StylePriority) {
 
-        fn update(element: &Element, property_decl: PropertyDeclaration, style_priority: StylePriority) {
+        fn update(element: &Element, mut declarations: Vec<PropertyDeclaration>, style_priority: StylePriority) {
             let mut inline_declarations = element.style_attribute().borrow_mut();
-            if let &mut Some(ref mut declarations) = &mut *inline_declarations {
+            if let &mut Some(ref mut existing_declarations) = &mut *inline_declarations {
                 let existing_declarations = if style_priority == StylePriority::Important {
-                    &mut declarations.important
+                    &mut existing_declarations.important
                 } else {
-                    &mut declarations.normal
+                    &mut existing_declarations.normal
                 };
 
                 // Usually, the reference count will be 1 here. But transitions could make it greater
                 // than that.
                 let existing_declarations = Arc::make_mut(existing_declarations);
-                for declaration in &mut *existing_declarations {
-                    if declaration.name() == property_decl.name() {
-                        *declaration = property_decl;
-                        return;
+
+                while let Some(mut incoming_declaration) = declarations.pop() {
+                    let mut replaced = false;
+                    for existing_declaration in &mut *existing_declarations {
+                        if existing_declaration.name() == incoming_declaration.name() {
+                            mem::swap(existing_declaration, &mut incoming_declaration);
+                            replaced = true;
+                            break;
+                        }
+                    }
+
+                    if !replaced {
+                        // inserting instead of pushing since the declarations are in reverse order
+                        existing_declarations.insert(0, incoming_declaration);
                     }
                 }
 
-                // inserting instead of pushing since the declarations are in reverse order
-                existing_declarations.insert(0, property_decl);
                 return;
             }
 
             let (important, normal) = if style_priority == StylePriority::Important {
-                (vec![property_decl], vec![])
+                (declarations, vec![])
             } else {
-                (vec![], vec![property_decl])
+                (vec![], declarations)
             };
 
             *inline_declarations = Some(PropertyDeclarationBlock {
@@ -785,7 +793,7 @@ impl Element {
             });
         }
 
-        update(self, property_decl, style_priority);
+        update(self, declarations, style_priority);
         self.sync_property_with_attrs_style();
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -696,6 +696,8 @@ impl Element {
         }
     }
 
+    // this sync method is called upon modification of the style_attribute property,
+    // therefore, it should not trigger subsequent mutation events
     fn sync_property_with_attrs_style(&self) {
         let style_str = if let &Some(ref declarations) = &*self.style_attribute().borrow() {
             declarations.to_css_string()
@@ -703,20 +705,26 @@ impl Element {
             String::new()
         };
 
-        let new_style = AttrValue::String(DOMString::from_string(style_str));
+        let mut new_style = AttrValue::String(DOMString::from_string(style_str));
 
         if let Some(style_attr) = self.attrs.borrow().iter().find(|a| a.name() == &atom!("style")) {
-            style_attr.set_value(new_style, self);
+            style_attr.swap_value(&mut new_style);
             return;
         }
 
-        self.push_new_attribute(
-            atom!("style"),
-            new_style,
-            atom!("style"),
-            ns!(),
-            Some(atom!("style"))
-        );
+        // explicitly not calling the push_new_attribute convenience method
+        // in order to avoid triggering mutation events
+        let window = window_from_node(self);
+        let attr = Attr::new(&window,
+                             atom!("style"),
+                             new_style,
+                             atom!("style"),
+                             ns!(),
+                             Some(atom!("style")),
+                             Some(self));
+
+         assert!(attr.GetOwnerElement().r() == Some(self));
+         self.attrs.borrow_mut().push(JS::from_ref(&attr));
     }
 
     pub fn remove_inline_style_property(&self, property: &str) {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -697,10 +697,11 @@ impl Element {
     }
 
     fn sync_property_with_attrs_style(&self) {
-        let mut style_str = String::new();
-        if let &Some(ref declarations) = &*self.style_attribute().borrow() {
-            declarations.to_css(&mut style_str).unwrap();
-        }
+        let style_str = if let &Some(ref declarations) = &*self.style_attribute().borrow() {
+            declarations.to_css_string()
+        } else {
+            String::new()
+        };
 
         let new_style = AttrValue::String(DOMString::from_string(style_str));
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -697,11 +697,12 @@ impl Element {
     }
 
     fn sync_property_with_attrs_style(&self) {
-        let mut style_str = String::new();
-
-        if let &Some(ref declarations) = &*self.style_attribute().borrow() {
-            style_str.push_str(&declarations.serialize());
+        let style_str = if let &Some(ref declarations) = &*self.style_attribute().borrow() {
+            declarations.serialize()
         }
+        else {
+            String::new()
+        };
 
         let new_style = AttrValue::String(DOMString::from_string(style_str));
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -696,89 +696,129 @@ impl Element {
         }
     }
 
-    pub fn remove_inline_style_property(&self, property: &str) {
-        let mut inline_declarations = self.style_attribute.borrow_mut();
-        if let &mut Some(ref mut declarations) = &mut *inline_declarations {
-            let index = declarations.normal
-                                    .iter()
-                                    .position(|decl| decl.matches(property));
-            if let Some(index) = index {
-                Arc::make_mut(&mut declarations.normal).remove(index);
-                return;
-            }
+    fn sync_property_with_attrs_style(&self) {
+        let mut style_str = String::new();
 
-            let index = declarations.important
-                                    .iter()
-                                    .position(|decl| decl.matches(property));
-            if let Some(index) = index {
-                Arc::make_mut(&mut declarations.important).remove(index);
-                return;
+        if let &Some(ref declarations) = &*self.style_attribute().borrow() {
+            style_str.push_str(&declarations.serialize());
+        }
+
+        let new_style = AttrValue::String(DOMString::from_string(style_str));
+
+        if let Some(style_attr) = self.attrs.borrow().iter().find(|a| a.name() == &atom!("style")) {
+            style_attr.set_value(new_style, self);
+            return;
+        }
+
+        self.push_new_attribute(
+            atom!("style"),
+            new_style,
+            atom!("style"),
+            ns!(),
+            Some(atom!("style"))
+        );
+    }
+
+    pub fn remove_inline_style_property(&self, property: &str) {
+        fn remove(element: &Element, property: &str) {
+            let mut inline_declarations = element.style_attribute.borrow_mut();
+            if let &mut Some(ref mut declarations) = &mut *inline_declarations {
+                let index = declarations.normal
+                                        .iter()
+                                        .position(|decl| decl.matches(property));
+                if let Some(index) = index {
+                    Arc::make_mut(&mut declarations.normal).remove(index);
+                    return;
+                }
+
+                let index = declarations.important
+                                        .iter()
+                                        .position(|decl| decl.matches(property));
+                if let Some(index) = index {
+                    Arc::make_mut(&mut declarations.important).remove(index);
+                    return;
+                }
             }
         }
+
+        remove(self, property);
+        self.sync_property_with_attrs_style();
     }
 
     pub fn update_inline_style(&self,
                                property_decl: PropertyDeclaration,
                                style_priority: StylePriority) {
-        let mut inline_declarations = self.style_attribute().borrow_mut();
-        if let &mut Some(ref mut declarations) = &mut *inline_declarations {
-            let existing_declarations = if style_priority == StylePriority::Important {
-                &mut declarations.important
+
+        fn update(element: &Element, property_decl: PropertyDeclaration, style_priority: StylePriority) {
+            let mut inline_declarations = element.style_attribute().borrow_mut();
+            if let &mut Some(ref mut declarations) = &mut *inline_declarations {
+                let existing_declarations = if style_priority == StylePriority::Important {
+                    &mut declarations.important
+                } else {
+                    &mut declarations.normal
+                };
+
+                // Usually, the reference count will be 1 here. But transitions could make it greater
+                // than that.
+                let existing_declarations = Arc::make_mut(existing_declarations);
+                for declaration in &mut *existing_declarations {
+                    if declaration.name() == property_decl.name() {
+                        *declaration = property_decl;
+                        return;
+                    }
+                }
+
+                // inserting instead of pushing since the declarations are in reverse order
+                existing_declarations.insert(0, property_decl);
+                return;
+            }
+
+            let (important, normal) = if style_priority == StylePriority::Important {
+                (vec![property_decl], vec![])
             } else {
-                &mut declarations.normal
+                (vec![], vec![property_decl])
             };
 
-            // Usually, the reference count will be 1 here. But transitions could make it greater
-            // than that.
-            let existing_declarations = Arc::make_mut(existing_declarations);
-            for declaration in &mut *existing_declarations {
-                if declaration.name() == property_decl.name() {
-                    *declaration = property_decl;
-                    return;
-                }
-            }
-            existing_declarations.push(property_decl);
-            return;
+            *inline_declarations = Some(PropertyDeclarationBlock {
+                important: Arc::new(important),
+                normal: Arc::new(normal),
+            });
         }
 
-        let (important, normal) = if style_priority == StylePriority::Important {
-            (vec![property_decl], vec![])
-        } else {
-            (vec![], vec![property_decl])
-        };
-
-        *inline_declarations = Some(PropertyDeclarationBlock {
-            important: Arc::new(important),
-            normal: Arc::new(normal),
-        });
+        update(self, property_decl, style_priority);
+        self.sync_property_with_attrs_style();
     }
 
     pub fn set_inline_style_property_priority(&self,
                                               properties: &[&str],
                                               style_priority: StylePriority) {
-        let mut inline_declarations = self.style_attribute().borrow_mut();
-        if let &mut Some(ref mut declarations) = &mut *inline_declarations {
-            let (from, to) = if style_priority == StylePriority::Important {
-                (&mut declarations.normal, &mut declarations.important)
-            } else {
-                (&mut declarations.important, &mut declarations.normal)
-            };
+        {
+            let mut inline_declarations = self.style_attribute().borrow_mut();
+            if let &mut Some(ref mut declarations) = &mut *inline_declarations {
+              let (from, to) = if style_priority == StylePriority::Important {
+                  (&mut declarations.normal, &mut declarations.important)
+              } else {
+                  (&mut declarations.important, &mut declarations.normal)
+              };
 
-            // Usually, the reference counts of `from` and `to` will be 1 here. But transitions
-            // could make them greater than that.
-            let from = Arc::make_mut(from);
-            let to = Arc::make_mut(to);
-            let mut new_from = Vec::new();
-            for declaration in from.drain(..) {
-                let name = declaration.name();
-                if properties.iter().any(|p| name == **p) {
-                    to.push(declaration)
-                } else {
-                    new_from.push(declaration)
-                }
+              // Usually, the reference counts of `from` and `to` will be 1 here. But transitions
+              // could make them greater than that.
+              let from = Arc::make_mut(from);
+              let to = Arc::make_mut(to);
+              let mut new_from = Vec::new();
+              for declaration in from.drain(..) {
+                  let name = declaration.name();
+                  if properties.iter().any(|p| name == **p) {
+                      to.push(declaration)
+                  } else {
+                      new_from.push(declaration)
+                  }
+              }
+              mem::replace(from, new_from);
             }
-            mem::replace(from, new_from);
         }
+
+        self.sync_property_with_attrs_style();
     }
 
     pub fn get_inline_style_declaration(&self,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -5,7 +5,7 @@
 //! Element nodes.
 
 use app_units::Au;
-use cssparser::Color;
+use cssparser::{Color, ToCss};
 use devtools_traits::AttrInfo;
 use dom::activation::Activatable;
 use dom::attr::AttrValue;
@@ -697,12 +697,10 @@ impl Element {
     }
 
     fn sync_property_with_attrs_style(&self) {
-        let style_str = if let &Some(ref declarations) = &*self.style_attribute().borrow() {
-            declarations.serialize()
+        let mut style_str = String::new();
+        if let &Some(ref declarations) = &*self.style_attribute().borrow() {
+            declarations.to_css(&mut style_str).unwrap();
         }
-        else {
-            String::new()
-        };
 
         let new_style = AttrValue::String(DOMString::from_string(style_str));
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -248,10 +248,9 @@ mod property_bit_field {
 
 /// Declarations are stored in reverse order.
 /// Overridden declarations are skipped.
-// TODO: Because normal & important are stored in seperate lists, it is impossible to know their
-// exact declaration order. They should be changed into one list, adding an important/normal
-// flag to PropertyDeclaration
 
+
+// FIXME (https://github.com/servo/servo/issues/3426)
 #[derive(Debug, PartialEq, HeapSizeOf)]
 pub struct PropertyDeclarationBlock {
     #[ignore_heap_size_of = "#7038"]
@@ -267,16 +266,13 @@ impl PropertyDeclarationBlock {
         let mut result_list = String::new();
 
         // Step 2
-        let mut already_serialized = HashSet::new();
+        let mut already_serialized = Vec::new();
 
         // Step 3
         // restore order of declarations since PropertyDeclarationBlock is stored in reverse order
-        let declarations = self.normal.iter().rev().chain(self.important.iter().rev()).collect::<Vec<_>>();
-
-
-        for declaration in &declarations {
+        for declaration in self.important.iter().chain(self.normal.iter()).rev() {
             // Step 3.1
-            let property = declaration.name().to_string();
+            let property = declaration.name();
 
             // Step 3.2
             if already_serialized.contains(&property) {
@@ -284,13 +280,12 @@ impl PropertyDeclarationBlock {
             }
 
             // Step 3.3
-            let mut shorthands = Vec::from(declaration.shorthands());
-            if shorthands.len() > 0 {
-                shorthands.sort_by(|a,b| a.longhands().len().cmp(&b.longhands().len()));
+            let shorthands = declaration.shorthands();
+            if !shorthands.is_empty() {
 
                 // Step 3.3.1
-                let mut longhands = declarations.iter().cloned()
-                .filter(|d| !already_serialized.contains(&d.name().to_string()))
+                let mut longhands = self.important.iter().chain(self.normal.iter()).rev()
+                    .filter(|d| !already_serialized.contains(&d.name()))
                     .collect::<Vec<_>>();
 
                 // Step 3.3.2
@@ -299,22 +294,16 @@ impl PropertyDeclarationBlock {
 
                     // Substep 2 & 3
                     let mut current_longhands = Vec::new();
-                    let mut missing_properties: HashSet<_> = HashSet::from_iter(
-                        properties.iter().map(|&s| s.to_owned())
-                    );
 
-                    for longhand in longhands.iter().cloned() {
-                        let longhand_string = longhand.name().to_string();
-                        if !properties.contains(&&*longhand_string) {
-                            continue;
+                    for longhand in longhands.iter() {
+                        let longhand_name = longhand.name();
+                        if properties.iter().any(|p| &longhand_name == *p) {
+                            current_longhands.push(*longhand);
                         }
-
-                        missing_properties.remove(&longhand_string);
-                        current_longhands.push(longhand);
                     }
 
                     // Substep 1
-                    if current_longhands.len() == 0 || missing_properties.len() > 0 {
+                    if current_longhands.is_empty() || current_longhands.len() != properties.len() {
                         continue;
                     }
 
@@ -338,11 +327,11 @@ impl PropertyDeclarationBlock {
                     }
 
                     // Substep 7 & 8
-                    result_list.push_str(&format!("{}: {}; ", &shorthand.to_name(), value));
+                    result_list.push_str(&format!("{}: {}; ", &shorthand.name(), value));
 
                     for current_longhand in current_longhands {
                         // Substep 9
-                        already_serialized.insert(current_longhand.name().to_string());
+                        already_serialized.push(current_longhand.name());
                         let index_to_remove = longhands.iter().position(|l| l == &current_longhand);
                         if let Some(index) = index_to_remove {
                             // Substep 10
@@ -360,13 +349,13 @@ impl PropertyDeclarationBlock {
             // Step 3.3.5
             let mut value = declaration.value();
             if self.important.contains(declaration) {
-                value.push_str(" ! important");
+                value.push_str(" !important");
             }
             // Steps 3.3.6 & 3.3.7
             result_list.push_str(&format!("{}: {}; ", &property, value));
 
             // Step 3.3.8
-            already_serialized.insert(property);
+            already_serialized.push(property);
         }
 
         result_list.pop(); // remove trailling whitespace
@@ -512,8 +501,6 @@ pub enum Shorthand {
     % endfor
 }
 
-use std::borrow::ToOwned;
-use std::iter::FromIterator;
 use util::str::str_join;
 
 impl Shorthand {
@@ -526,7 +513,7 @@ impl Shorthand {
         }
     }
 
-    pub fn to_name(&self) -> &str {
+    pub fn name(&self) -> &'static str {
         match *self {
             % for property in SHORTHANDS:
                 Shorthand::${property.camel_case} => "${property.name}",
@@ -827,7 +814,7 @@ impl PropertyDeclaration {
         }
     }
 
-    pub fn shorthands(&self) -> &[Shorthand] {
+    pub fn shorthands(&self) -> &'static [Shorthand] {
         // first generate longhand to shorthands lookup map
         <%
             longhand_to_shorthand_map = {}
@@ -855,7 +842,7 @@ impl PropertyDeclaration {
             % for property in LONGHANDS:
                 PropertyDeclaration::${property.camel_case}(_) => ${property.ident.upper()},
             % endfor
-            _ => &[] // include outlet for Custom enum value
+            PropertyDeclaration::Custom(_, _) => &[]
         }
     }
 }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -591,7 +591,7 @@ impl Shorthand {
 
     pub fn name(&self) -> &'static str {
         match *self {
-            % for property in SHORTHANDS:
+            % for property in data.shorthands:
                 Shorthand::${property.camel_case} => "${property.name}",
             % endfor
         }
@@ -755,8 +755,8 @@ impl fmt::Display for PropertyDeclarationName {
 impl ToCss for PropertyDeclaration {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         match *self {
-            % for property in LONGHANDS:
-                % if property.derived_from is None:
+            % for property in data.longhands:
+                % if not property.derived_from:
                     PropertyDeclaration::${property.camel_case}(ref value) =>
                         value.to_css(dest),
                 % endif
@@ -833,7 +833,7 @@ impl PropertyDeclaration {
     /// This is the case of custom properties and values that contain unsubstituted variables.
     pub fn value_is_unparsed(&self) -> bool {
       match *self {
-          % for property in LONGHANDS:
+          % for property in data.longhands:
               PropertyDeclaration::${property.camel_case}(ref value) => {
                   matches!(*value, DeclaredValue::WithVariables { .. })
               },
@@ -954,7 +954,7 @@ impl PropertyDeclaration {
         // first generate longhand to shorthands lookup map
         <%
             longhand_to_shorthand_map = {}
-            for shorthand in SHORTHANDS:
+            for shorthand in data.shorthands:
                 for sub_property in shorthand.sub_properties:
                     if sub_property.ident not in longhand_to_shorthand_map:
                         longhand_to_shorthand_map[sub_property.ident] = []
@@ -966,7 +966,7 @@ impl PropertyDeclaration {
         %>
 
         // based on lookup results for each longhand, create result arrays
-        % for property in LONGHANDS:
+        % for property in data.longhands:
             static ${property.ident.upper()}: &'static [Shorthand] = &[
                 % for shorthand in longhand_to_shorthand_map.get(property.ident, []):
                     Shorthand::${shorthand},
@@ -975,7 +975,7 @@ impl PropertyDeclaration {
         % endfor
 
         match *self {
-            % for property in LONGHANDS:
+            % for property in data.longhands:
                 PropertyDeclaration::${property.camel_case}(_) => ${property.ident.upper()},
             % endfor
             PropertyDeclaration::Custom(_, _) => &[]

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -804,7 +804,9 @@ impl ToCss for PropertyDeclaration {
                 % endif
             % endfor
             PropertyDeclaration::Custom(_, ref value) => value.to_css(dest),
-            _ => Err(fmt::Error),
+            % if any(property.derived_from for property in data.longhands):
+                _ => Err(fmt::Error),
+            % endif
         }
     }
 }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -397,7 +397,55 @@ enum AppendableValue<'a, I>
 where I: Iterator<Item=&'a PropertyDeclaration> {
     Declaration(&'a PropertyDeclaration),
     DeclarationsForShorthand(I),
-    Css(&'a str)
+    Css(&'a str, bool)
+}
+
+fn append_property_name<W>(dest: &mut W,
+                           property_name: &str,
+                           is_first_serialization: &mut bool)
+                           -> fmt::Result where W: fmt::Write {
+
+    // after first serialization(key: value;) add whitespace between the pairs
+    if !*is_first_serialization {
+        try!(write!(dest, " "));
+    }
+    else {
+        *is_first_serialization = false;
+    }
+
+    write!(dest, "{}", property_name)
+}
+
+fn append_declaration_value<'a, W, I>
+                           (dest: &mut W,
+                            appendable_value: AppendableValue<'a, I>,
+                            is_important: bool)
+                            -> fmt::Result
+                            where W: fmt::Write, I: Iterator<Item=&'a PropertyDeclaration> {
+  match appendable_value {
+      AppendableValue::Css(css, _) => {
+          try!(write!(dest, "{}", css))
+      },
+      AppendableValue::Declaration(decl) => {
+          try!(decl.to_css(dest));
+       },
+       AppendableValue::DeclarationsForShorthand(decls) => {
+           let mut decls = decls.peekable();
+           while let Some(decl) = decls.next() {
+               try!(decl.to_css(dest));
+
+               if decls.peek().is_some() {
+                   try!(write!(dest, " "));
+               }
+           }
+       }
+  }
+
+  if is_important {
+      try!(write!(dest, " !important"));
+  }
+
+  Ok(())
 }
 
 fn append_serialization<'a, W, I>(dest: &mut W,
@@ -408,38 +456,26 @@ fn append_serialization<'a, W, I>(dest: &mut W,
                                   -> fmt::Result
                                   where W: fmt::Write, I: Iterator<Item=&'a PropertyDeclaration> {
 
-    // after first serialization(key: value;) add whitespace between the pairs
-    if !*is_first_serialization {
-        try!(write!(dest, " "));
-    }
-    else {
-        *is_first_serialization = false;
-    }
+    try!(append_property_name(dest, property_name, is_first_serialization));
+    try!(write!(dest, ":"));
 
-    try!(write!(dest, "{}:", property_name));
-
-    match appendable_value {
-        AppendableValue::Css(css) => try!(write!(dest, " {}", css)),
-        AppendableValue::Declaration(decl) => {
+    // for normal parsed values, add a space between key: and value
+    match &appendable_value {
+        &AppendableValue::Css(_, is_unparsed) => {
+            if !is_unparsed {
+                try!(write!(dest, " "))
+            }
+        },
+        &AppendableValue::Declaration(decl) => {
             if !decl.value_is_unparsed() {
                 // for normal parsed values, add a space between key: and value
                 try!(write!(dest, " "));
             }
-
-            try!(decl.to_css(dest));
          },
-         AppendableValue::DeclarationsForShorthand(decls) => {
-             for decl in decls {
-                 try!(write!(dest, " "));
-                 try!(decl.to_css(dest));
-             }
-         }
+         &AppendableValue::DeclarationsForShorthand(_) => try!(write!(dest, " "))
     }
 
-    if is_important {
-        try!(write!(dest, " !important"));
-    }
-
+    try!(append_declaration_value(dest, appendable_value, is_important));
     write!(dest, ";")
 }
 
@@ -613,15 +649,15 @@ impl Shorthand {
     }
 
     /// Serializes possible shorthand value to String.
-    pub fn serialize_shorthand_to_string<'a, I>(self, declarations: I) -> String
+    pub fn serialize_shorthand_value_to_string<'a, I>(self, declarations: I, is_important: bool) -> String
     where I: Iterator<Item=&'a PropertyDeclaration> + Clone {
+        let appendable_value = self.get_shorthand_appendable_value(declarations).unwrap();
         let mut result = String::new();
-        self.serialize_shorthand_to_buffer(&mut result, declarations, &mut true).unwrap();
+        append_declaration_value(&mut result, appendable_value, is_important).unwrap();
         result
     }
 
-
-    /// Serializes possible shorthand value to input buffer given a list of longhand declarations.
+    /// Serializes possible shorthand name with value to input buffer given a list of longhand declarations.
     /// On success, returns true if shorthand value is written and false if no shorthand value is present.
     pub fn serialize_shorthand_to_buffer<'a, W, I>(self,
                                                    dest: &mut W,
@@ -629,47 +665,53 @@ impl Shorthand {
                                                    is_first_serialization: &mut bool)
                                                    -> Result<bool, fmt::Error>
     where W: Write, I: Iterator<Item=&'a PropertyDeclaration> + Clone {
+        match self.get_shorthand_appendable_value(declarations) {
+            None => Ok(false),
+            Some(appendable_value) => {
+                let property_name = self.name();
 
-        // Only cloning iterators (a few pointers each) not declarations.
-        let mut declarations2 = declarations.clone();
-        let mut declarations3 = declarations.clone();
-
-        let first_declaration = match declarations2.next() {
-            Some(declaration) => declaration,
-            None => return Ok(false)
-        };
-
-        let property_name = self.name();
-
-        // https://drafts.csswg.org/css-variables/#variables-in-shorthands
-        if let Some(css) = first_declaration.with_variables_from_shorthand(self) {
-            if declarations2.all(|d| d.with_variables_from_shorthand(self) == Some(css)) {
-               return append_serialization::<W, I>(
-                   dest, property_name, AppendableValue::Css(css), false, is_first_serialization
-               ).and_then(|_| Ok(true));
-           }
-           else {
-               return Ok(false);
-           }
-        }
-
-        if !declarations3.any(|d| d.with_variables()) {
-            try!(
                 append_serialization(
                     dest,
                     property_name,
-                    AppendableValue::DeclarationsForShorthand(declarations),
+                    appendable_value,
                     false,
                     is_first_serialization
-                )
-            );
-            // FIXME: this needs property-specific code, which probably should be in style/
-            // "as appropriate according to the grammar of shorthand "
-            // https://drafts.csswg.org/cssom/#serialize-a-css-value
-            return Ok(true);
+                ).and_then(|_| Ok(true))
+            }
         }
+    }
 
-        Ok(false)
+    fn get_shorthand_appendable_value<'a, I>(self, declarations: I) -> Option<AppendableValue<'a, I>>
+        where I: Iterator<Item=&'a PropertyDeclaration> + Clone {
+
+            // Only cloning iterators (a few pointers each) not declarations.
+            let mut declarations2 = declarations.clone();
+            let mut declarations3 = declarations.clone();
+
+            let first_declaration = match declarations2.next() {
+                Some(declaration) => declaration,
+                None => return None
+            };
+
+            // https://drafts.csswg.org/css-variables/#variables-in-shorthands
+            if let Some(css) = first_declaration.with_variables_from_shorthand(self) {
+                if declarations2.all(|d| d.with_variables_from_shorthand(self) == Some(css)) {
+                   let is_unparsed = first_declaration.value_is_unparsed();
+                   return Some(AppendableValue::Css(css, is_unparsed));
+               }
+               else {
+                   return None;
+               }
+            }
+
+            if !declarations3.any(|d| d.with_variables()) {
+                return Some(AppendableValue::DeclarationsForShorthand(declarations));
+                // FIXME: this needs property-specific code, which probably should be in style/
+                // "as appropriate according to the grammar of shorthand "
+                // https://drafts.csswg.org/cssom/#serialize-a-css-value
+            }
+
+            None
     }
 }
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -397,7 +397,7 @@ enum AppendableValue<'a, I>
 where I: Iterator<Item=&'a PropertyDeclaration> {
     Declaration(&'a PropertyDeclaration),
     DeclarationsForShorthand(I),
-    Css(&'a str, bool)
+    Css(&'a str)
 }
 
 fn append_property_name<W>(dest: &mut W,
@@ -423,7 +423,7 @@ fn append_declaration_value<'a, W, I>
                             -> fmt::Result
                             where W: fmt::Write, I: Iterator<Item=&'a PropertyDeclaration> {
   match appendable_value {
-      AppendableValue::Css(css, _) => {
+      AppendableValue::Css(css) => {
           try!(write!(dest, "{}", css))
       },
       AppendableValue::Declaration(decl) => {
@@ -461,10 +461,8 @@ fn append_serialization<'a, W, I>(dest: &mut W,
 
     // for normal parsed values, add a space between key: and value
     match &appendable_value {
-        &AppendableValue::Css(_, is_unparsed) => {
-            if !is_unparsed {
-                try!(write!(dest, " "))
-            }
+        &AppendableValue::Css(_) => {
+            try!(write!(dest, " "))
         },
         &AppendableValue::Declaration(decl) => {
             if !decl.value_is_unparsed() {
@@ -696,8 +694,7 @@ impl Shorthand {
             // https://drafts.csswg.org/css-variables/#variables-in-shorthands
             if let Some(css) = first_declaration.with_variables_from_shorthand(self) {
                 if declarations2.all(|d| d.with_variables_from_shorthand(self) == Some(css)) {
-                   let is_unparsed = first_declaration.value_is_unparsed();
-                   return Some(AppendableValue::Css(css, is_unparsed));
+                   return Some(AppendableValue::Css(css));
                }
                else {
                    return None;

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -338,7 +338,13 @@ impl ToCss for PropertyDeclarationBlock {
                     // TODO: serialize shorthand does not take is_important into account currently
                     // Substep 5
                     let was_serialized =
-                        try!(shorthand.serialize_shorthand_to_buffer(dest, &current_longhands[..], &mut is_first_serialization));
+                        try!(
+                            shorthand.serialize_shorthand_to_buffer(
+                                dest,
+                                &mut current_longhands.iter().cloned(),
+                                &mut is_first_serialization
+                            )
+                        );
                     // If serialization occured, Substep 7 & 8 will have been completed
 
                     // Substep 6
@@ -365,10 +371,10 @@ impl ToCss for PropertyDeclarationBlock {
 
             // Steps 3.3.5, 3.3.6 & 3.3.7
             try!(append_serialization(dest,
-                                 &property.to_string(),
-                                 AppendableValue::Declaration(declaration),
-                                 important,
-                                 &mut is_first_serialization));
+                                      &property.to_string(),
+                                      AppendableValue::Declaration(declaration),
+                                      important,
+                                      &mut is_first_serialization));
 
             // Step 3.3.8
             already_serialized.push(property);
@@ -381,6 +387,7 @@ impl ToCss for PropertyDeclarationBlock {
 
 enum AppendableValue<'a> {
     Declaration(&'a PropertyDeclaration),
+    DeclarationsForShorthand(&'a mut Iterator<Item=&'a PropertyDeclaration>),
     Css(&'a str)
 }
 
@@ -401,6 +408,7 @@ fn append_serialization<W>(dest: &mut W,
     try!(write!(dest, "{}:", property_name));
 
     match appendable_value {
+        AppendableValue::Css(css) => try!(write!(dest, " {}", css)),
         AppendableValue::Declaration(decl) => {
             if !decl.value_is_unparsed() {
                 // for normal parsed values, add a space between key: and value
@@ -409,8 +417,13 @@ fn append_serialization<W>(dest: &mut W,
 
             try!(decl.to_css(dest));
          },
-        AppendableValue::Css(css) =>  try!(write!(dest, "{}", css))
-    };
+         AppendableValue::DeclarationsForShorthand(decls) => {
+             for decl in decls {
+                 try!(write!(dest, " "));
+                 try!(decl.to_css(dest));
+             }
+         }
+    }
 
     if is_important {
         try!(write!(dest, " !important"));
@@ -589,49 +602,62 @@ impl Shorthand {
     }
 
     /// Serializes possible shorthand value to String.
-    pub fn serialize_shorthand_to_string(self, declarations: &[&PropertyDeclaration]) -> String {
+    pub fn serialize_shorthand_to_string(self, declarations: &mut Iterator<Item=&PropertyDeclaration>) -> String {
         let mut result = String::new();
         self.serialize_shorthand_to_buffer(&mut result, declarations, &mut true).unwrap();
         result
     }
 
+
     /// Serializes possible shorthand value to input buffer given a list of longhand declarations.
     /// On success, returns true if shorthand value is written and false if no shorthand value is present.
     pub fn serialize_shorthand_to_buffer<W>(self,
                                             dest: &mut W,
-                                            declarations: &[&PropertyDeclaration],
+                                            declarations: &mut Iterator<Item=&PropertyDeclaration>,
                                             is_first_serialization: &mut bool)
          -> Result<bool, fmt::Error> where W: Write {
 
-        let property_name = self.name();
+        // FIXME: I know that creating this list here is wrong, but I couldn't get it to compile otherwise
+        // using plain iterators, need advice!
+        let declaration_list: Vec<_> = declarations.cloned().collect();
+        let mut declarations = declaration_list.iter();
+
+        let first_declaration = match declarations.next() {
+            Some(declaration) => declaration,
+            None => return Ok(false)
+        };
+
+        let property_name = &self.name();
 
         // https://drafts.csswg.org/css-variables/#variables-in-shorthands
-        if let Some(css) = declarations[0].with_variables_from_shorthand(self) {
-            if declarations[1..]
-                   .iter()
-                   .all(|d| d.with_variables_from_shorthand(self) == Some(css)) {
-
-                       append_serialization(
-                           dest, property_name, AppendableValue::Css(css), false, is_first_serialization
-                       ).and_then(|_| Ok(true))
-            } else {
-                Ok(false)
-            }
-        } else {
-            if declarations.iter().any(|d| d.with_variables()) {
-                Ok(false)
-            } else {
-                for declaration in declarations.iter() {
-                    try!(append_serialization(
-                        dest, property_name, AppendableValue::Declaration(declaration), false, is_first_serialization
-                    ));
-                }
-                // FIXME: this needs property-specific code, which probably should be in style/
-                // "as appropriate according to the grammar of shorthand "
-                // https://drafts.csswg.org/cssom/#serialize-a-css-value
-                Ok(true)
-            }
+        if let Some(css) = first_declaration.with_variables_from_shorthand(self) {
+            if declarations.all(|d| d.with_variables_from_shorthand(self) == Some(css)) {
+               return append_serialization(
+                   dest, property_name, AppendableValue::Css(css), false, is_first_serialization
+               ).and_then(|_| Ok(true));
+           }
+           else {
+               return Ok(false);
+           }
         }
+
+        if !declaration_list.iter().any(|d| d.with_variables()) {
+            try!(
+                append_serialization(
+                    dest,
+                    property_name,
+                    AppendableValue::DeclarationsForShorthand(&mut declaration_list.iter()),
+                    false,
+                    is_first_serialization
+                )
+            );
+            // FIXME: this needs property-specific code, which probably should be in style/
+            // "as appropriate according to the grammar of shorthand "
+            // https://drafts.csswg.org/cssom/#serialize-a-css-value
+            return Ok(true);
+        }
+
+        Ok(false)
     }
 }
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -247,9 +247,10 @@ mod property_bit_field {
     % endif
 % endfor
 
-/// Declarations are stored in reverse order.
-/// Overridden declarations are skipped.
 
+use std::iter::{Iterator, Chain, Zip, Rev, Repeat, repeat};
+use std::slice;
+/// Overridden declarations are skipped.
 
 // FIXME (https://github.com/servo/servo/issues/3426)
 #[derive(Debug, PartialEq, HeapSizeOf)]
@@ -258,6 +259,19 @@ pub struct PropertyDeclarationBlock {
     pub important: Arc<Vec<PropertyDeclaration>>,
     #[ignore_heap_size_of = "#7038"]
     pub normal: Arc<Vec<PropertyDeclaration>>,
+}
+
+impl PropertyDeclarationBlock {
+    /// Provides an iterator of all declarations, with indication of !important value
+    pub fn declarations(&self) -> Chain<
+        Zip<Rev<slice::Iter<PropertyDeclaration>>, Repeat<bool>>,
+        Zip<Rev<slice::Iter<PropertyDeclaration>>, Repeat<bool>>
+    > {
+        // Declarations are stored in reverse order.
+        let normal = self.normal.iter().rev().zip(repeat(false));
+        let important = self.important.iter().rev().zip(repeat(true));
+        normal.chain(important)
+    }
 }
 
 impl ToCss for PropertyDeclarationBlock {
@@ -271,8 +285,7 @@ impl ToCss for PropertyDeclarationBlock {
         let mut already_serialized = Vec::new();
 
         // Step 3
-        // restore order of declarations since PropertyDeclarationBlock is stored in reverse order
-        for declaration in self.important.iter().chain(self.normal.iter()).rev() {
+        for (declaration, important) in self.declarations() {
             // Step 3.1
             let property = declaration.name();
 
@@ -286,8 +299,8 @@ impl ToCss for PropertyDeclarationBlock {
             if !shorthands.is_empty() {
 
                 // Step 3.3.1
-                let mut longhands = self.important.iter().chain(self.normal.iter()).rev()
-                    .filter(|d| !already_serialized.contains(&d.name()))
+                let mut longhands = self.declarations()
+                    .filter(|d| !already_serialized.contains(&d.0.name()))
                     .collect::<Vec<_>>();
 
                 // Step 3.3.2
@@ -296,24 +309,27 @@ impl ToCss for PropertyDeclarationBlock {
 
                     // Substep 2 & 3
                     let mut current_longhands = Vec::new();
+                    let mut important_count = 0;
 
                     for longhand in longhands.iter() {
-                        let longhand_name = longhand.name();
+                        let longhand_name = longhand.0.name();
                         if properties.iter().any(|p| &longhand_name == *p) {
-                            current_longhands.push(*longhand);
+                            current_longhands.push(longhand.0);
+                            if longhand.1 == true {
+                                important_count += 1;
+                            }
                         }
                     }
 
                     // Substep 1
+                    /* Assuming that the PropertyDeclarationBlock contains no duplicate entries,
+                    if the current_longhands length is equal to the properties length, it means
+                    that the properties that map to shorthand are present in longhands */
                     if current_longhands.is_empty() || current_longhands.len() != properties.len() {
                         continue;
                     }
 
                     // Substep 4
-                    let important_count = current_longhands.iter()
-                        .filter(|l| self.important.contains(l))
-                        .count();
-
                     let is_important = important_count > 0;
                     if is_important && important_count != current_longhands.len() {
                         continue;
@@ -333,7 +349,7 @@ impl ToCss for PropertyDeclarationBlock {
                     for current_longhand in current_longhands {
                         // Substep 9
                         already_serialized.push(current_longhand.name());
-                        let index_to_remove = longhands.iter().position(|l| l == &current_longhand);
+                        let index_to_remove = longhands.iter().position(|l| l.0 == current_longhand);
                         if let Some(index) = index_to_remove {
                             // Substep 10
                             longhands.remove(index);
@@ -348,11 +364,10 @@ impl ToCss for PropertyDeclarationBlock {
             }
 
             // Steps 3.3.5, 3.3.6 & 3.3.7
-            let append_important = self.important.contains(declaration);
             try!(append_serialization(dest,
                                  &property.to_string(),
                                  AppendableValue::Declaration(declaration),
-                                 append_important,
+                                 important,
                                  &mut is_first_serialization));
 
             // Step 3.3.8
@@ -373,7 +388,7 @@ fn append_serialization<W>(dest: &mut W,
                            property_name: &str,
                            appendable_value: AppendableValue,
                            is_important: bool,
-                           is_first_serialization: &mut bool) -> fmt::Result where W: fmt::Write
+                           is_first_serialization: &mut bool) -> fmt::Result where W: fmt::Write {
 
     // after first serialization(key: value;) add whitespace between the pairs
     if !*is_first_serialization {

--- a/tests/unit/style/properties.rs
+++ b/tests/unit/style/properties.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use cssparser::ToCss;
 use rustc_serialize::json::Json;
 use std::env;
 use std::fs::{File, remove_file};
@@ -83,10 +84,10 @@ fn property_declaration_block_should_serialize_correctly() {
         important: Arc::new(important)
     };
 
-    let css_string = block.serialize();
+    let css_string = block.to_css_string();
 
     assert_eq!(
         css_string,
-        "width: 70px; min-height: 20px; display: inline-block; height: 20px ! important;"
+        "width: 70px; min-height: 20px; display: inline-block; height: 20px !important;"
     );
 }

--- a/tests/unit/style/properties.rs
+++ b/tests/unit/style/properties.rs
@@ -7,6 +7,10 @@ use std::env;
 use std::fs::{File, remove_file};
 use std::path::Path;
 use std::process::Command;
+use std::sync::Arc;
+use style::computed_values::display::T::inline_block;
+use style::properties::{PropertyDeclaration, PropertyDeclarationBlock, DeclaredValue};
+use style::values::specified::{Length, LengthOrPercentageOrAuto, LengthOrPercentage};
 
 #[test]
 fn properties_list_json() {
@@ -50,4 +54,39 @@ fn find_python() -> String {
     } else {
         "python"
     }.to_owned()
+}
+
+#[test]
+fn property_declaration_block_should_serialize_correctly() {
+    let mut normal = Vec::new();
+    let mut important = Vec::new();
+
+    let length = LengthOrPercentageOrAuto::Length(Length::from_px(70f32));
+    let value = DeclaredValue::Value(length);
+    normal.push(PropertyDeclaration::Width(value));
+
+    let min_height = LengthOrPercentage::Length(Length::from_px(20f32));
+    let value = DeclaredValue::Value(min_height);
+    normal.push(PropertyDeclaration::MinHeight(value));
+
+    let value = DeclaredValue::Value(inline_block);
+    normal.push(PropertyDeclaration::Display(value));
+
+    let height = LengthOrPercentageOrAuto::Length(Length::from_px(20f32));
+    let value = DeclaredValue::Value(height);
+    important.push(PropertyDeclaration::Height(value));
+
+    normal.reverse();
+    important.reverse();
+    let block = PropertyDeclarationBlock {
+        normal: Arc::new(normal),
+        important: Arc::new(important)
+    };
+
+    let css_string = block.serialize();
+
+    assert_eq!(
+        css_string,
+        "width: 70px; min-height: 20px; display: inline-block; height: 20px ! important;"
+    );
 }


### PR DESCRIPTION
https://github.com/servo/servo/issues/9307

I am not terribly confident in this PR, but `getAttribute("style")` does update correctly now. If the implementation here is more or less "correct", I will add unit tests to confirm that the attr for style is updated correctly. If it is completely off, I will gladly keep trying, but I also understand if someone else with more experience with Rust and this area of the application wants to do it.

There are a few things I do not like here, such as:
- Manually forming the string `new_style` in `sync_property_with_attrs_style` 
- In the `fn update_inline_style`, I needed to coerce the value to a string slice, so I did `&format!("{}", &property_decl.name()`, but I am sure there is a better way to do this.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9410)

<!-- Reviewable:end -->
