### PR TITLE
Fix ./mach run on Windows

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -80,6 +80,13 @@ def _get_exec(*names):
     return None
 
 
+def _get_virtualenv_script_dir():
+    # Virtualenv calls its scripts folder "bin" on linux/OSX/MSYS64 but "Scripts" on Windows
+    if os.name == "nt" and os.path.sep != "/":
+        return "Scripts"
+    return "bin"
+
+
 # Possible names of executables, sorted from most to least specific
 PYTHON_NAMES = ["python-2.7", "python2.7", "python2", "python"]
 VIRTUALENV_NAMES = ["virtualenv-2.7", "virtualenv2.7", "virtualenv2", "virtualenv"]
@@ -92,8 +99,7 @@ def _activate_virtualenv(topdir):
     if python is None:
         sys.exit("Python is not installed. Please install it prior to running mach.")
 
-    # Virtualenv calls its scripts folder "bin" on linux/OSX but "Scripts" on Windows, detect which one then use that
-    script_dir = "Scripts" if os.name == "nt" else "bin"
+    script_dir = _get_virtualenv_script_dir()
     activate_path = os.path.join(virtualenv_path, script_dir, "activate_this.py")
     if not (os.path.exists(virtualenv_path) and os.path.exists(activate_path)):
         virtualenv = _get_exec(*VIRTUALENV_NAMES)


### PR DESCRIPTION
This branch also includes the commit being reviewed in https://github.com/servo/servo/pull/9408 . Is it OK to just wait for that one to merge, or should I separate them?

This patch adds the BIN_SUFFIX to the servo executable name when doing ./mach run. 

However just doing this caused subprocess to error due to some unicode symbols in PATH.

To fix this, I pulled a peice of code from mozilla-central which fixes this problem there. Source: https://dxr.mozilla.org/mozilla-central/source/python/mach/mach/mixin/process.py#108

Revisiting this now (originally developed this a few weeks ago), perhaps we should be using https://github.com/servo/servo/blob/master/python/mach/mach/mixin/process.py instead of subprocess to give us all of this crossplatform process execution support. I think that should be a nice to have though - this patch at least gets a necessary development command working on windows.

Tested on Windows and Ubuntu.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9415)

<!-- Reviewable:end -->
