### PR TITLE
compositing: Fix a couple of bugs that prevented iframes from painting after navigation.

### DIFF
--- a/components/compositing/compositor_layer.rs
+++ b/components/compositing/compositor_layer.rs
@@ -211,6 +211,7 @@ pub enum ScrollEventResult {
 impl CompositorLayer for Layer<CompositorData> {
     fn update_layer_except_bounds(&self, layer_properties: LayerProperties) {
         self.extra_data.borrow_mut().scroll_policy = layer_properties.scroll_policy;
+        self.extra_data.borrow_mut().subpage_info = layer_properties.subpage_pipeline_id;
         *self.transform.borrow_mut() = layer_properties.transform;
         *self.perspective.borrow_mut() = layer_properties.perspective;
 

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -1325,6 +1325,17 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
     fn handle_activate_document_msg(&mut self, pipeline_id: PipelineId) {
         debug!("Document ready to activate {:?}", pipeline_id);
 
+        if let Some(ref child_pipeline) = self.pipelines.get(&pipeline_id) {
+            if let Some(ref parent_info) = child_pipeline.parent_info {
+                if let Some(parent_pipeline) = self.pipelines.get(&parent_info.0) {
+                    let _ = parent_pipeline.script_chan
+                                           .send(ConstellationControlMsg::FramedContentChanged(
+                            parent_info.0,
+                            parent_info.1));
+                }
+            }
+        }
+
         // If this pipeline is already part of the current frame tree,
         // we don't need to do anything.
         if self.pipeline_is_in_current_frame(pipeline_id) {

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -946,6 +946,14 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
                     }
                 }
 
+                if !self.pipeline_is_in_current_frame(source_id) {
+                    // Disregard this load if the navigating pipeline is not actually
+                    // active. This could be caused by a delayed navigation (eg. from
+                    // a timer) or a race between multiple navigations (such as an
+                    // onclick handler on an anchor element).
+                    return None;
+                }
+
                 self.handle_load_start_msg(&source_id);
                 // Being here means either there are no pending frames, or none of the pending
                 // changes would be overridden by changing the subframe associated with source_id.

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -23,9 +23,10 @@ use dom::htmlelement::HTMLElement;
 use dom::node::{Node, UnbindContext, window_from_node};
 use dom::urlhelper::UrlHelper;
 use dom::virtualmethods::VirtualMethods;
-use dom::window::Window;
+use dom::window::{ReflowReason, Window};
 use js::jsapi::{JSAutoCompartment, JSAutoRequest, RootedValue, JSContext, MutableHandleValue};
 use js::jsval::{UndefinedValue, NullValue};
+use layout_interface::ReflowQueryType;
 use msg::constellation_msg::{ConstellationChan};
 use msg::constellation_msg::{NavigationDirection, PipelineId, SubpageId};
 use page::IterablePage;
@@ -34,6 +35,7 @@ use script_traits::{IFrameLoadInfo, MozBrowserEvent, ScriptMsg as ConstellationM
 use std::ascii::AsciiExt;
 use std::cell::Cell;
 use string_cache::Atom;
+use style::context::ReflowGoal;
 use url::Url;
 use util::prefs;
 use util::str::{DOMString, LengthOrPercentageOrAuto};
@@ -211,6 +213,10 @@ impl HTMLIFrameElement {
         let window = window_from_node(self);
         self.upcast::<EventTarget>().fire_simple_event("load", GlobalRef::Window(window.r()));
         // TODO Step 5 - unset child document `mut iframe load` flag
+
+        window.reflow(ReflowGoal::ForDisplay,
+                      ReflowQueryType::NoQuery,
+                      ReflowReason::IFrameLoadEvent);
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -108,6 +108,8 @@ pub enum ReflowReason {
     RequestAnimationFrame,
     WebFontLoaded,
     FramedContentChanged,
+    IFrameLoadEvent,
+    MissingExplicitReflow,
 }
 
 pub type ScrollPoint = Point2D<Au>;
@@ -1427,6 +1429,8 @@ fn debug_reflow_events(goal: &ReflowGoal, query_type: &ReflowQueryType, reason: 
         ReflowReason::RequestAnimationFrame => "\tRequestAnimationFrame",
         ReflowReason::WebFontLoaded => "\tWebFontLoaded",
         ReflowReason::FramedContentChanged => "\tFramedContentChanged",
+        ReflowReason::IFrameLoadEvent => "\tIFrameLoadEvent",
+        ReflowReason::MissingExplicitReflow => "\tMissingExplicitReflow",
     });
 
     println!("{}", debug_msg);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -107,6 +107,7 @@ pub enum ReflowReason {
     ImageLoaded,
     RequestAnimationFrame,
     WebFontLoaded,
+    FramedContentChanged,
 }
 
 pub type ScrollPoint = Point2D<Au>;
@@ -1425,6 +1426,7 @@ fn debug_reflow_events(goal: &ReflowGoal, query_type: &ReflowQueryType, reason: 
         ReflowReason::ImageLoaded => "\tImageLoaded",
         ReflowReason::RequestAnimationFrame => "\tRequestAnimationFrame",
         ReflowReason::WebFontLoaded => "\tWebFontLoaded",
+        ReflowReason::FramedContentChanged => "\tFramedContentChanged",
     });
 
     println!("{}", debug_msg);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1028,6 +1028,14 @@ impl ScriptThread {
                     window.reflow(ReflowGoal::ForDisplay,
                                   ReflowQueryType::NoQuery,
                                   ReflowReason::ImageLoaded);
+                } else {
+                    // Reflow currently happens when explicitly invoked by code that
+                    // knows the document could have been modified. This should really
+                    // be driven by the compositor on an as-needed basis instead, to
+                    // minimize unnecessary work.
+                    window.reflow(ReflowGoal::ForDisplay,
+                                  ReflowQueryType::NoQuery,
+                                  ReflowReason::MissingExplicitReflow);
                 }
             }
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1131,6 +1131,8 @@ impl ScriptThread {
             ConstellationControlMsg::DispatchFrameLoadEvent {
                 target: pipeline_id, parent: containing_id } =>
                 self.handle_frame_load_event(containing_id, pipeline_id),
+            ConstellationControlMsg::FramedContentChanged(containing_pipeline_id, subpage_id) =>
+                self.handle_framed_content_changed(containing_pipeline_id, subpage_id),
             ConstellationControlMsg::ReportCSSError(pipeline_id, filename, line, column, msg) =>
                 self.handle_css_error_reporting(pipeline_id, filename, line, column, msg),
         }
@@ -1484,6 +1486,22 @@ impl ScriptThread {
             doc.begin_focus_transaction();
             doc.request_focus(frame_element.upcast());
             doc.commit_focus_transaction(FocusType::Parent);
+        }
+    }
+
+    fn handle_framed_content_changed(&self,
+                                     parent_pipeline_id: PipelineId,
+                                     subpage_id: SubpageId) {
+        let borrowed_page = self.root_page();
+        let page = borrowed_page.find(parent_pipeline_id).unwrap();
+        let doc = page.document();
+        let frame_element = doc.find_iframe(subpage_id);
+        if let Some(ref frame_element) = frame_element {
+            frame_element.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            let window = page.window();
+            window.reflow(ReflowGoal::ForDisplay,
+                          ReflowQueryType::NoQuery,
+                          ReflowReason::FramedContentChanged);
         }
     }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -143,6 +143,8 @@ pub enum ConstellationControlMsg {
         /// The pipeline that contains a frame loading the target pipeline.
         parent: PipelineId
     },
+    /// Notifies a parent frame that one of its child frames is now active.
+    FramedContentChanged(PipelineId, SubpageId),
     /// Report an error from a CSS parser for the given pipeline
     ReportCSSError(PipelineId, String, u32, u32, String),
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1688,6 +1688,18 @@
             "url": "/_mozilla/css/iframe/multiple_external.html"
           }
         ],
+        "css/iframe/navigation.html": [
+          {
+            "path": "css/iframe/navigation.html",
+            "references": [
+              [
+                "/_mozilla/css/iframe/navigation_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/iframe/navigation.html"
+          }
+        ],
         "css/iframe/overflow.html": [
           {
             "path": "css/iframe/overflow.html",
@@ -7754,6 +7766,18 @@
             ]
           ],
           "url": "/_mozilla/css/iframe/multiple_external.html"
+        }
+      ],
+      "css/iframe/navigation.html": [
+        {
+          "path": "css/iframe/navigation.html",
+          "references": [
+            [
+              "/_mozilla/css/iframe/navigation_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/iframe/navigation.html"
         }
       ],
       "css/iframe/overflow.html": [

--- a/tests/wpt/mozilla/tests/css/iframe/navigation.html
+++ b/tests/wpt/mozilla/tests/css/iframe/navigation.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel=match href=navigation_ref.html>
+<style>
+iframe {
+    display: block;
+    border: 1px solid black;
+    width: 500px;
+    height: 300px;
+    margin-left: 10px;
+    margin-top: 0px;
+}
+</style>
+<body>
+<iframe src="data:text/html,Foo"></iframe>
+<script>
+var iframe = document.getElementsByTagName('iframe')[0];
+iframe.addEventListener('load', function first() {
+    iframe.removeEventListener('load', first);
+    iframe.src = "data:text/html,Hello%20world";
+    iframe.addEventListener('load', function() {
+      document.documentElement.classList.remove("reftest-wait");
+    }, false);
+}, false);
+</script>
+</body>
+</html>
+

--- a/tests/wpt/mozilla/tests/css/iframe/navigation_ref.html
+++ b/tests/wpt/mozilla/tests/css/iframe/navigation_ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<style>
+iframe {
+    display: block;
+    border: 1px solid black;
+    width: 500px;
+    height: 300px;
+    margin-left: 10px;
+    margin-top: 0px;
+}
+</style>
+<body>
+<iframe src="data:text/html,Hello%20world"></iframe>
+</body>
+</html>
+


### PR DESCRIPTION
The first bug was that iframes were not reflowed in their parent DOM when the child page navigated. This is fixed by simply having the constellation notify the appropriate script thread when navigation occurs.

The second bug was that the compositor was unable to adjust the pipeline for existing iframe layers, only new ones. This patch adds logic to do that.

The third bug was that we have ad-hoc reflow calls throughout script/, and we didn't trigger any reflow from the code that dispatches the `load` event for the iframe so the test for the first two issues would always time out. The second commit adds another reflow call to do that, and also bites the bullet and adds a catch-all reflow (which does nothing if there's no dirty nodes in the document) at the return to the event loop.

Closes #8081.

Extension of #9285.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9421)

<!-- Reviewable:end -->
