### PR TITLE
Update ORGANIZATION.md to remove the legacy reftest harness item

### DIFF
--- a/ORGANIZATION.md
+++ b/ORGANIZATION.md
@@ -91,8 +91,6 @@
 		* Harness for automatically running the jQuery testsuite.
 	* power
 		* Tools for measurement of power consumption.
-	* ref, reftest.rs
-		* Legacy reftest harness and reference tests. In the process of being removed (<https://github.com/servo/servo/issues/5618>).
 	* unit
 		* Unit tests using rustc’s built-in test harness.
 	* wpt


### PR DESCRIPTION
The mentioned directory and file do not exist anymore. The linked issue, #5618, has been closed after PR #9293, so this item should be removed from the overview.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9422)

<!-- Reviewable:end -->
