### PR TITLE
Remove unused import from tests/unit/net/data_loader.rs

### DIFF
--- a/tests/unit/net/data_loader.rs
+++ b/tests/unit/net/data_loader.rs
@@ -20,7 +20,6 @@ fn assert_parse(url:          &'static str,
     use net::mime_classifier::MIMEClassifier;
     use net::resource_thread::CancellationListener;
     use std::sync::Arc;
-    use std::sync::mpsc::channel;
     use url::Url;
 
     let (start_chan, start_port) = ipc::channel().unwrap();


### PR DESCRIPTION
I noticed the following output at https://travis-ci.org/servo/servo/jobs/104733377#L1146:

<pre>
/home/travis/build/servo/servo/tests/unit/net/data_loader.rs:23:9: 23:33 warning: unused import, #[warn(unused_imports)] on by default
/home/travis/build/servo/servo/tests/unit/net/data_loader.rs:23     use std::sync::mpsc::channel;`
</pre>


Manual inspection also tells me that this import is not used. It seems to have become obsolete by https://github.com/servo/servo/commit/2aa51742460a351abfb746aec4352dd6d27a3c52#diff-46fd738c30b50dc2950348f1563f99b9R7.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9426)

<!-- Reviewable:end -->
