### PR TITLE
Fix AArch64 target triplets

### DIFF
--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -78,7 +78,7 @@ git = "https://github.com/pcwalton/gaol"
 [target.arm-unknown-linux-gnueabihf.dependencies.gaol]
 git = "https://github.com/pcwalton/gaol"
 
-[target.aarch64-unknown-linux-gnueabihf.dependencies.gaol]
+[target.aarch64-unknown-linux-gnu.dependencies.gaol]
 git = "https://github.com/pcwalton/gaol"
 
 [dependencies]

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -140,7 +140,7 @@ git = "https://github.com/pcwalton/gaol"
 [target.arm-unknown-linux-gnueabihf.dependencies.gaol]
 git = "https://github.com/pcwalton/gaol"
 
-[target.aarch64-unknown-linux-gnueabihf.dependencies.gaol]
+[target.aarch64-unknown-linux-gnu.dependencies.gaol]
 git = "https://github.com/pcwalton/gaol"
 
 [dependencies.ipc-channel]


### PR DESCRIPTION
The AArch64 platform uses the `aarch64-linux-gnu` triplet.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9447)

<!-- Reviewable:end -->
