### PR TITLE
Prefer `is_empty` over `len` when option is available.

### DIFF
--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -401,7 +401,7 @@ pub fn line_height_from_style(style: &ComputedValues, metrics: &FontMetrics) -> 
 }
 
 fn split_first_fragment_at_newline_if_necessary(fragments: &mut LinkedList<Fragment>) {
-    if fragments.len() < 1 {
+    if fragments.is_empty() {
         return
     }
 


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9464)

<!-- Reviewable:end -->
