### PR TITLE
Integrate compiletest_rs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
       script:
          - ./mach build -d --verbose
          - ./mach test-unit
+         - ./mach test-compiletest
          - bash etc/ci/lockfile_changed.sh
          - bash etc/ci/manifest_changed.sh
       cache:

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -6,6 +6,7 @@ dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
+ "compiletest_helper 0.0.1",
  "compositing 0.0.1",
  "devtools 0.0.1",
  "devtools_traits 0.0.1",
@@ -28,6 +29,7 @@ dependencies = [
  "net_traits 0.0.1",
  "net_traits_tests 0.0.1",
  "offscreen_gl_context 0.1.0 (git+https://github.com/ecoal95/rust-offscreen-rendering-context)",
+ "plugin_compiletest 0.0.1",
  "plugin_tests 0.0.1",
  "profile 0.0.1",
  "profile_traits 0.0.1",
@@ -235,6 +237,21 @@ dependencies = [
 name = "color_quant"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "compiletest_helper"
+version = "0.0.1"
+dependencies = [
+ "compiletest_rs 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "compiletest_rs"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "compositing"
@@ -1372,6 +1389,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pkg-config"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "plugin_compiletest"
+version = "0.0.1"
+dependencies = [
+ "compiletest_helper 0.0.1",
+ "plugins 0.0.1",
+]
 
 [[package]]
 name = "plugin_tests"

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -41,6 +41,12 @@ path = "../../tests/unit/style"
 [dev-dependencies.util_tests]
 path = "../../tests/unit/util"
 
+[dev-dependencies.compiletest_helper]
+path = "../../tests/compiletest/helper"
+
+[dev-dependencies.plugin_compiletest]
+path = "../../tests/compiletest/plugin"
+
 [[test]]
 name = "reftest"
 path = "../../tests/reftest.rs"

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -109,7 +109,10 @@ class MachCommands(CommandBase):
                      "include_arg": "include"}),
             ("unit", {"kwargs": {},
                       "paths": [path.abspath(path.join("tests", "unit"))],
-                      "include_arg": "test_name"})
+                      "include_arg": "test_name"}),
+            ("compiletest", {"kwargs": {"release": release},
+                             "paths": [path.abspath(path.join("tests", "compiletest"))],
+                             "include_arg": "test_name"})
         ])
 
         suites_by_prefix = {path: k for k, v in suites.iteritems() if "paths" in v for path in v["paths"]}
@@ -204,6 +207,65 @@ class MachCommands(CommandBase):
             args += ["-p", "%s_tests" % crate]
         args += test_patterns
         result = call(args, env=self.build_env(), cwd=self.servo_crate())
+        if result != 0:
+            return result
+
+    @Command('test-compiletest',
+             description='Run compiletests',
+             category='testing')
+    @CommandArgument('--package', '-p', default=None, help="Specific package to test")
+    @CommandArgument('test_name', nargs=argparse.REMAINDER,
+                     help="Only run tests that match this pattern or file path")
+    @CommandArgument('--release', default=False, action="store_true",
+                     help="Run with a release build of servo")
+    def test_compiletest(self, test_name=None, package=None, release=False):
+        if test_name is None:
+            test_name = []
+
+        self.ensure_bootstrapped()
+
+        if package:
+            packages = {package}
+        else:
+            packages = set()
+
+        test_patterns = []
+        for test in test_name:
+            # add package if 'tests/compiletest/<package>'
+            match = re.search("tests/compiletest/(\\w+)/?$", test)
+            if match:
+                packages.add(match.group(1))
+            # add package & test if '<package>/<test>', 'tests/compiletest/<package>/<test>.rs', or similar
+            elif re.search("\\w/\\w", test):
+                tokens = test.split("/")
+                packages.add(tokens[-2])
+                test_prefix = tokens[-1]
+                if test_prefix.endswith(".rs"):
+                    test_prefix = test_prefix[:-3]
+                test_prefix += "::"
+                test_patterns.append(test_prefix)
+            # add test as-is otherwise
+            else:
+                test_patterns.append(test)
+
+        if not packages:
+            packages = set(os.listdir(path.join(self.context.topdir, "tests", "compiletest")))
+
+        packages.remove("helper")
+
+        args = ["cargo", "test"]
+        for crate in packages:
+            args += ["-p", "%s_compiletest" % crate]
+        args += test_patterns
+
+        env = self.build_env()
+        if release:
+            env["BUILD_MODE"] = "release"
+            args += ["--release"]
+        else:
+            env["BUILD_MODE"] = "debug"
+
+        result = call(args, env=env, cwd=self.servo_crate())
         if result != 0:
             return result
 

--- a/tests/compiletest/helper/Cargo.toml
+++ b/tests/compiletest/helper/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "compiletest_helper"
+version = "0.0.1"
+authors = ["The Servo Project Developers"]
+
+[lib]
+name = "compiletest_helper"
+path = "lib.rs"
+doctest = false
+
+[dependencies.compiletest_rs]
+compiletest_rs = "0.11"

--- a/tests/compiletest/helper/lib.rs
+++ b/tests/compiletest/helper/lib.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate compiletest_rs as compiletest;
+
+use std::env;
+use std::path::PathBuf;
+
+pub fn run_mode(mode: &'static str) {
+
+    let mut config = compiletest::default_config();
+    let cfg_mode = mode.parse().ok().expect("Invalid mode");
+
+    config.mode = cfg_mode;
+    config.src_base = PathBuf::from(format!("{}", mode));
+
+    let mut base_path = env::current_dir().expect("Current directory is invalid");
+    base_path.pop();
+    base_path.pop();
+    base_path.pop();
+
+    let mode = env::var("BUILD_MODE").expect("BUILD_MODE environment variable must be set");
+    let debug_path = base_path.join(PathBuf::from(format!("target/{}", mode)));
+    let deps_path = base_path.join(PathBuf::from(format!("target/{}/deps", mode)));
+
+    config.target_rustcflags = Some(format!("-L {} -L {}",  debug_path.display(), deps_path.display()));
+    compiletest::run_tests(&config);
+}

--- a/tests/compiletest/plugin/Cargo.toml
+++ b/tests/compiletest/plugin/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "plugin_compiletest"
+version = "0.0.1"
+authors = ["The Servo Project Developers"]
+
+[lib]
+name = "plugin_compiletest"
+path = "lib.rs"
+doctest = false
+
+[dependencies.compiletest_helper]
+path = "../helper"
+
+[dependencies.plugins]
+path = "../../../components/plugins"

--- a/tests/compiletest/plugin/compile-fail/ban.rs
+++ b/tests/compiletest/plugin/compile-fail/ban.rs
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![feature(plugin)]
+#![plugin(plugins)]
+
+extern crate js;
+
+use js::jsval::JSVal;
+use std::cell::Cell;
+
+struct Foo {
+    bar: Cell<JSVal>
+    //~^ ERROR Banned type Cell<JSVal> detected. Use MutHeap<JSVal> instead,
+}
+
+fn main() {}

--- a/tests/compiletest/plugin/compile-fail/privatize.rs
+++ b/tests/compiletest/plugin/compile-fail/privatize.rs
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![feature(plugin, custom_attribute)]
+#![plugin(plugins)]
+#![allow(dead_code)]
+
+#[privatize]
+struct Foo {
+    pub v1: i32,
+    //~^ ERROR Field v1 is public where only private fields are allowed
+    v2: i32
+}
+
+fn main() {}

--- a/tests/compiletest/plugin/compile-fail/str_to_string.rs
+++ b/tests/compiletest/plugin/compile-fail/str_to_string.rs
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![feature(plugin)]
+#![plugin(plugins)]
+
+
+fn main() {
+    let x = "foo".to_string();
+    //~^ ERROR str.to_owned() is more efficient than str.to_string()
+
+    let x = &x[..];
+    x.to_string();
+    //~^ ERROR str.to_owned() is more efficient than str.to_string()
+}

--- a/tests/compiletest/plugin/compile-fail/transmute_type.rs
+++ b/tests/compiletest/plugin/compile-fail/transmute_type.rs
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![feature(plugin)]
+#![plugin(plugins)]
+#![allow(dead_code)]
+#![deny(transmute_type_lint)]
+
+use std::mem::{self, transmute};
+
+
+fn main() {
+    let _: &[u8] = unsafe { transmute("Rust") };
+    //~^ ERROR Transmute to &[u8] from &'static str detected
+
+    let _: &[u8] = unsafe { mem::transmute("Rust") };
+    //~^ ERROR Transmute to &[u8] from &'static str detected
+}

--- a/tests/compiletest/plugin/compile-fail/unrooted_must_root.rs
+++ b/tests/compiletest/plugin/compile-fail/unrooted_must_root.rs
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![feature(plugin)]
+#![plugin(plugins)]
+#![allow(dead_code)]
+
+#[must_root]
+struct Foo {
+    v: i32
+}
+
+struct Bar {
+    f: Foo
+    //~^ ERROR Type must be rooted, use #[must_root] on the struct definition to propagate
+}
+
+fn foo1(_: Foo) {} //~ ERROR Type must be rooted
+
+
+fn foo2() -> Foo { //~ ERROR Type must be rooted
+    Foo { v: 10 }
+}
+
+
+fn main() {}

--- a/tests/compiletest/plugin/lib.rs
+++ b/tests/compiletest/plugin/lib.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate compiletest_helper;
+
+#[test]
+fn compile_test() {
+    compiletest_helper::run_mode("compile-fail");
+}


### PR DESCRIPTION
This PR integrates `compiletest_rs` as suggested in #5646. I created a new  `tests/compiletest` directory which contains separate crates for the tests.

Currently this PR includes `compile-fail` tests for some lints (acutally all except  inheritance_integrity, beacuse I'm not sure how to include the dom stuff in a way the `#[dom_struct]` works).

I gathered that there should be more crates for which compiletests make sense and would appreciate any pointers to relevant crates.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9469)

<!-- Reviewable:end -->
