### PR TITLE
Disable send-entity-body-document.htm.

### DIFF
--- a/tests/wpt/metadata/XMLHttpRequest/send-entity-body-document.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-entity-body-document.htm.ini
@@ -1,13 +1,4 @@
 [send-entity-body-document.htm]
   type: testharness
-  disabled:
-    if os == "mac": https://github.com/servo/servo/issues/8157
-  [XMLHttpRequest: send() - Document]
-    expected: FAIL
-
-  [XML document, windows-1252]
-    expected: FAIL
-
-  [HTML document, invalid UTF-8]
-    expected: FAIL
+  disabled: https://github.com/servo/servo/issues/8157
 


### PR DESCRIPTION
We don't implement the feature it tests anyway. Filed https://github.com/servo/servo/issues/9490 for that.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9491)

<!-- Reviewable:end -->
