### PR TITLE
Fix build error on AArch64

### DIFF
--- a/components/servo/.cargo/config
+++ b/components/servo/.cargo/config
@@ -5,3 +5,7 @@ ar = "arm-linux-androideabi-ar"
 [target.arm-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
 ar = "arm-linux-gnueabihf-ar"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+ar = "aarch64-linux-gnu-ar"


### PR DESCRIPTION
When cross compiling to AArch64, the native `cc` is used in the final linking step, instead of `aarch64-linux-gnu-gcc`. This patch fixes the issue.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9492)

<!-- Reviewable:end -->
