### PR TITLE
Added dependency for Fedora, mesa-libEGL-devel. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ On Fedora:
 
 ``` sh
 sudo dnf install curl freeglut-devel libtool gcc-c++ libXi-devel \
-    freetype-devel mesa-libGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
+    freetype-devel mesa-libGL-devel mesa-libEGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
     fontconfig-devel cabextract ttmkfdir python python-virtualenv python-pip expat-devel \
     rpm-build openssl-devel cmake bzip2-devel libXcursor-devel libXmu-devel mesa-libOSMesa-devel
 ```


### PR DESCRIPTION
mesa-libEGL-devel was necessary on Centos 7 and likely on Fedora distos as well.

Fixes #6483

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9545)

<!-- Reviewable:end -->
