### PR TITLE
Removed references of android-rs-glue from comments and documentation

### DIFF
--- a/ORGANIZATION.md
+++ b/ORGANIZATION.md
@@ -69,8 +69,6 @@
 * support
 	* android
 		* Libraries that require special handling for building for Android platforms
-	* android-rs-glue
-		* Library to integrate better with Android platforms
 	* rust-task_info
 		* Library for obtaining information about memory usage for a process
 * target

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -362,10 +362,10 @@ class CommandBase(object):
             env["OPENSSL_LIB_DIR"] = openssl_dir
             env['OPENSSL_INCLUDE_DIR'] = path.join(env["GONKDIR"], "external/openssl/include")
 
-        # FIXME: These are set because they are the variable names that
-        # android-rs-glue expects. However, other submodules have makefiles that
-        # reference the env var names above. Once glutin is enabled and set as
-        # the default, we could modify the subproject makefiles to use the names
+        # These are set because they are the variable names that build-apk
+        # expects. However, other submodules have makefiles that reference
+        # the env var names above. Once glutin is enabled and set as the
+        # default, we could modify the subproject makefiles to use the names
         # below and remove the vars above, to avoid duplication.
         if "ANDROID_SDK" in env:
             env["ANDROID_HOME"] = env["ANDROID_SDK"]


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/9507.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9549)

<!-- Reviewable:end -->
