### PR TITLE
Upgrade to harfbuzz-sys 0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sudo port install python27 py27-virtualenv cmake
 On Debian-based Linuxes:
 
 ``` sh
-sudo apt-get install curl freeglut3-dev autoconf \
+sudo apt-get install curl freeglut3-dev \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
     gperf g++ build-essential cmake virtualenv python-pip \
     libssl-dev libbz2-dev libosmesa6-dev libxmu6 libxmu-dev \

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -652,7 +652,7 @@ dependencies = [
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "gfx_traits 0.0.1",
- "harfbuzz-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "harfbuzz-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "harfbuzz-sys"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1985,7 +1985,7 @@ name = "unicode-script"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "harfbuzz-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "harfbuzz-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "gfx_traits 0.0.1",
- "harfbuzz-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "harfbuzz-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "harfbuzz-sys"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1882,7 +1882,7 @@ name = "unicode-script"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "harfbuzz-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "harfbuzz-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -594,7 +594,7 @@ dependencies = [
  "fnv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "gfx_traits 0.0.1",
- "harfbuzz-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "harfbuzz-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "harfbuzz-sys"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1862,7 +1862,7 @@ name = "unicode-script"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "harfbuzz-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "harfbuzz-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]


### PR DESCRIPTION
This includes the fix for servo/rust-harfbuzz#54, and reverts #9128 which was a temporary workaround for that issue.

r? @metajack

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9559)

<!-- Reviewable:end -->
