### PR TITLE
Remove dead function Overflow::union_rect

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2602,11 +2602,6 @@ impl Overflow {
         self.paint = self.paint.union(&other.paint);
     }
 
-    pub fn union_rect(&mut self, rect: &Rect<Au>) {
-        self.scroll = self.scroll.union(&rect);
-        self.paint = self.paint.union(&rect);
-    }
-
     pub fn translate(&mut self, point: &Point2D<Au>) {
         self.scroll = self.scroll.translate(point);
         self.paint = self.paint.translate(point);


### PR DESCRIPTION
Fixes #9556.

This makes Servo compile with one warning less.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9565)

<!-- Reviewable:end -->
