### PR TITLE
Add CI script to retry builds

### DIFF
--- a/etc/ci/retry.sh
+++ b/etc/ci/retry.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Retries a given command until it passes
+# Run as `retry.sh N command args...`
+# where `N` is the maximum  number of tries, and `command args...` is the
+# command to run, with arguments
+
+n=$1
+shift; # this removes the first argument from $@
+for i in `seq $n`; do
+        echo "====== RUN NUMBER: $i ======";
+        if $@ # run command, check if exit code is zero
+        then
+                exit 0 # command passed, all is well
+        fi
+done
+exit 1


### PR DESCRIPTION
We can then run test-ref as `retry.sh 2 ./mach test-ref ....`

We could also have this curl to some server with information on the
intermittent; so that we can keep track of these separately. It would also be
nice to have crowbot report them in chat (@jdm, is this possible?) and have
something comment on GH with a cross-reference.

This isn't too different from what we do already, we mostly just file or link to
an intermittent hit retry, and move on.

r? @larsbergstrom

cc @jack @edunham

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9572)

<!-- Reviewable:end -->
