### PR TITLE
Issue #9561 Renamed *_thread_source to *_task_source window.rs

### DIFF
--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -144,7 +144,7 @@ impl<'a> GlobalRef<'a> {
     /// thread.
     pub fn dom_manipulation_thread_source(&self) -> Box<ScriptChan + Send> {
         match *self {
-            GlobalRef::Window(ref window) => window.dom_manipulation_thread_source(),
+            GlobalRef::Window(ref window) => window.dom_manipulation_task_source(),
             GlobalRef::Worker(ref worker) => worker.script_chan(),
         }
     }
@@ -153,7 +153,7 @@ impl<'a> GlobalRef<'a> {
     /// thread.
     pub fn user_interaction_thread_source(&self) -> Box<ScriptChan + Send> {
         match *self {
-            GlobalRef::Window(ref window) => window.user_interaction_thread_source(),
+            GlobalRef::Window(ref window) => window.user_interaction_task_source(),
             GlobalRef::Worker(ref worker) => worker.script_chan(),
         }
     }
@@ -162,7 +162,7 @@ impl<'a> GlobalRef<'a> {
     /// thread.
     pub fn networking_thread_source(&self) -> Box<ScriptChan + Send> {
         match *self {
-            GlobalRef::Window(ref window) => window.networking_thread_source(),
+            GlobalRef::Window(ref window) => window.networking_task_source(),
             GlobalRef::Worker(ref worker) => worker.script_chan(),
         }
     }
@@ -171,7 +171,7 @@ impl<'a> GlobalRef<'a> {
     /// thread.
     pub fn history_traversal_thread_source(&self) -> Box<ScriptChan + Send> {
         match *self {
-            GlobalRef::Window(ref window) => window.history_traversal_thread_source(),
+            GlobalRef::Window(ref window) => window.history_traversal_task_source(),
             GlobalRef::Worker(ref worker) => worker.script_chan(),
         }
     }
@@ -180,7 +180,7 @@ impl<'a> GlobalRef<'a> {
     /// thread.
     pub fn file_reading_thread_source(&self) -> Box<ScriptChan + Send> {
         match *self {
-            GlobalRef::Window(ref window) => window.file_reading_thread_source(),
+            GlobalRef::Window(ref window) => window.file_reading_task_source(),
             GlobalRef::Worker(ref worker) => worker.script_chan(),
         }
     }

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -83,7 +83,7 @@ impl ToggleEventRunnable {
     pub fn send(node: &HTMLDetailsElement, toggle_number: u32) {
         let window = window_from_node(node);
         let window = window.r();
-        let chan = window.dom_manipulation_thread_source();
+        let chan = window.dom_manipulation_task_source();
         let handler = Trusted::new(node, chan.clone());
         let dispatcher = ToggleEventRunnable {
             element: handler,

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -110,9 +110,9 @@ impl HTMLImageElement {
                 let img_url = img_url.unwrap();
                 *self.url.borrow_mut() = Some(img_url.clone());
 
-                let trusted_node = Trusted::new(self, window.networking_thread_source());
+                let trusted_node = Trusted::new(self, window.networking_task_source());
                 let (responder_sender, responder_receiver) = ipc::channel().unwrap();
-                let script_chan = window.networking_thread_source();
+                let script_chan = window.networking_task_source();
                 let wrapper = window.get_runnable_wrapper();
                 ROUTER.add_route(responder_receiver.to_opaque(), box move |message| {
                     // Return the image via a message to the script thread, which marks the element

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -936,7 +936,7 @@ impl ChangeEventRunnable {
     pub fn send(node: &Node) {
         let window = window_from_node(node);
         let window = window.r();
-        let chan = window.user_interaction_thread_source();
+        let chan = window.user_interaction_task_source();
         let handler = Trusted::new(node, chan.clone());
         let dispatcher = ChangeEventRunnable {
             element: handler,

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -198,7 +198,7 @@ impl HTMLLinkElement {
 
                 // TODO: #8085 - Don't load external stylesheets if the node's mq doesn't match.
                 let doc = window.Document();
-                let script_chan = window.networking_thread_source();
+                let script_chan = window.networking_task_source();
                 let elem = Trusted::new(self, script_chan.clone());
 
                 let context = Arc::new(Mutex::new(StylesheetContext {

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -283,7 +283,7 @@ impl HTMLScriptElement {
 
                 // Step 16.6.
                 // TODO(#9186): use the fetch infrastructure.
-                let script_chan = window.networking_thread_source();
+                let script_chan = window.networking_task_source();
                 let elem = Trusted::new(self, script_chan.clone());
 
                 let context = Arc::new(Mutex::new(ScriptContext {
@@ -442,7 +442,7 @@ impl HTMLScriptElement {
         if external {
             self.dispatch_load_event();
         } else {
-            let chan = window.dom_manipulation_thread_source();
+            let chan = window.dom_manipulation_task_source();
             let handler = Trusted::new(self, chan.clone());
             let dispatcher = box EventDispatcher {
                 element: handler,
@@ -455,7 +455,7 @@ impl HTMLScriptElement {
     pub fn queue_error_event(&self) {
         let window = window_from_node(self);
         let window = window.r();
-        let chan = window.dom_manipulation_thread_source();
+        let chan = window.dom_manipulation_task_source();
         let handler = Trusted::new(self, chan.clone());
         let dispatcher = box EventDispatcher {
             element: handler,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -53,8 +53,8 @@ use page::Page;
 use profile_traits::mem;
 use reporter::CSSErrorReporter;
 use rustc_serialize::base64::{FromBase64, STANDARD, ToBase64};
-use script_thread::{DOMManipulationThreadSource, UserInteractionThreadSource, NetworkingThreadSource};
-use script_thread::{HistoryTraversalThreadSource, FileReadingThreadSource, SendableMainThreadScriptChan};
+use script_thread::{DOMManipulationTaskSource, UserInteractionTaskSource, NetworkingTaskSource};
+use script_thread::{HistoryTraversalTaskSource, FileReadingTaskSource, SendableMainThreadScriptChan};
 use script_thread::{ScriptChan, ScriptPort, MainThreadScriptChan, MainThreadScriptMsg, RunnableWrapper};
 use script_traits::ConstellationControlMsg;
 use script_traits::{DocumentState, MsDuration, ScriptToCompositorMsg, TimerEvent, TimerEventId};
@@ -120,16 +120,16 @@ pub struct Window {
     eventtarget: EventTarget,
     #[ignore_heap_size_of = "trait objects are hard"]
     script_chan: MainThreadScriptChan,
-    #[ignore_heap_size_of = "thread sources are hard"]
-    dom_manipulation_thread_source: DOMManipulationThreadSource,
-    #[ignore_heap_size_of = "thread sources are hard"]
-    user_interaction_thread_source: UserInteractionThreadSource,
-    #[ignore_heap_size_of = "thread sources are hard"]
-    networking_thread_source: NetworkingThreadSource,
-    #[ignore_heap_size_of = "thread sources are hard"]
-    history_traversal_thread_source: HistoryTraversalThreadSource,
-    #[ignore_heap_size_of = "thread sources are hard"]
-    file_reading_thread_source: FileReadingThreadSource,
+    #[ignore_heap_size_of = "task sources are hard"]
+    dom_manipulation_task_source: DOMManipulationTaskSource,
+    #[ignore_heap_size_of = "task sources are hard"]
+    user_interaction_task_source: UserInteractionTaskSource,
+    #[ignore_heap_size_of = "task sources are hard"]
+    networking_task_source: NetworkingTaskSource,
+    #[ignore_heap_size_of = "task sources are hard"]
+    history_traversal_task_source: HistoryTraversalTaskSource,
+    #[ignore_heap_size_of = "task sources are hard"]
+    file_reading_task_source: FileReadingTaskSource,
     console: MutNullableHeap<JS<Console>>,
     crypto: MutNullableHeap<JS<Crypto>>,
     navigator: MutNullableHeap<JS<Navigator>>,
@@ -253,24 +253,24 @@ impl Window {
         self.js_runtime.borrow().as_ref().unwrap().cx()
     }
 
-    pub fn dom_manipulation_thread_source(&self) -> Box<ScriptChan + Send> {
-        self.dom_manipulation_thread_source.clone()
+    pub fn dom_manipulation_task_source(&self) -> Box<ScriptChan + Send> {
+        self.dom_manipulation_task_source.clone()
     }
 
-    pub fn user_interaction_thread_source(&self) -> Box<ScriptChan + Send> {
-        self.user_interaction_thread_source.clone()
+    pub fn user_interaction_task_source(&self) -> Box<ScriptChan + Send> {
+        self.user_interaction_task_source.clone()
     }
 
-    pub fn networking_thread_source(&self) -> Box<ScriptChan + Send> {
-        self.networking_thread_source.clone()
+    pub fn networking_task_source(&self) -> Box<ScriptChan + Send> {
+        self.networking_task_source.clone()
     }
 
-    pub fn history_traversal_thread_source(&self) -> Box<ScriptChan + Send> {
-        self.history_traversal_thread_source.clone()
+    pub fn history_traversal_task_source(&self) -> Box<ScriptChan + Send> {
+        self.history_traversal_task_source.clone()
     }
 
-    pub fn file_reading_thread_source(&self) -> Box<ScriptChan + Send> {
-        self.file_reading_thread_source.clone()
+    pub fn file_reading_task_source(&self) -> Box<ScriptChan + Send> {
+        self.file_reading_task_source.clone()
     }
 
     pub fn main_thread_script_chan(&self) -> &Sender<MainThreadScriptMsg> {
@@ -1292,11 +1292,11 @@ impl Window {
     pub fn new(runtime: Rc<Runtime>,
                page: Rc<Page>,
                script_chan: MainThreadScriptChan,
-               dom_thread_source: DOMManipulationThreadSource,
-               user_thread_source: UserInteractionThreadSource,
-               network_thread_source: NetworkingThreadSource,
-               history_thread_source: HistoryTraversalThreadSource,
-               file_thread_source: FileReadingThreadSource,
+               dom_task_source: DOMManipulationTaskSource,
+               user_task_source: UserInteractionTaskSource,
+               network_task_source: NetworkingTaskSource,
+               history_task_source: HistoryTraversalTaskSource,
+               file_task_source: FileReadingTaskSource,
                image_cache_chan: ImageCacheChan,
                compositor: IpcSender<ScriptToCompositorMsg>,
                image_cache_thread: ImageCacheThread,
@@ -1326,11 +1326,11 @@ impl Window {
         let win = box Window {
             eventtarget: EventTarget::new_inherited(),
             script_chan: script_chan,
-            dom_manipulation_thread_source: dom_thread_source,
-            user_interaction_thread_source: user_thread_source,
-            networking_thread_source: network_thread_source,
-            history_traversal_thread_source: history_thread_source,
-            file_reading_thread_source: file_thread_source,
+            dom_manipulation_task_source: dom_task_source,
+            user_interaction_task_source: user_task_source,
+            networking_task_source: network_task_source,
+            history_traversal_task_source: history_task_source,
+            file_reading_task_source: file_task_source,
             image_cache_chan: image_cache_chan,
             console: Default::default(),
             crypto: Default::default(),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -356,87 +356,87 @@ impl MainThreadScriptChan {
     }
 }
 
-// FIXME: Use a thread source specific message instead of MainThreadScriptMsg
+// FIXME: Use a task source specific message instead of MainThreadScriptMsg
 #[derive(JSTraceable)]
-pub struct DOMManipulationThreadSource(pub Sender<MainThreadScriptMsg>);
+pub struct DOMManipulationTaskSource(pub Sender<MainThreadScriptMsg>);
 
-impl ScriptChan for DOMManipulationThreadSource {
+impl ScriptChan for DOMManipulationTaskSource {
     fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
-        let DOMManipulationThreadSource(ref chan) = *self;
+        let DOMManipulationTaskSource(ref chan) = *self;
         chan.send(MainThreadScriptMsg::Common(msg)).map_err(|_| ())
     }
 
     fn clone(&self) -> Box<ScriptChan + Send> {
-        let DOMManipulationThreadSource(ref chan) = *self;
-        box DOMManipulationThreadSource((*chan).clone())
+        let DOMManipulationTaskSource(ref chan) = *self;
+        box DOMManipulationTaskSource((*chan).clone())
     }
 }
 
-// FIXME: Use a thread source specific message instead of MainThreadScriptMsg
+// FIXME: Use a task source specific message instead of MainThreadScriptMsg
 #[derive(JSTraceable)]
-pub struct UserInteractionThreadSource(pub Sender<MainThreadScriptMsg>);
+pub struct UserInteractionTaskSource(pub Sender<MainThreadScriptMsg>);
 
-impl ScriptChan for UserInteractionThreadSource {
+impl ScriptChan for UserInteractionTaskSource {
     fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
-        let UserInteractionThreadSource(ref chan) = *self;
+        let UserInteractionTaskSource(ref chan) = *self;
         chan.send(MainThreadScriptMsg::Common(msg)).map_err(|_| ())
     }
 
     fn clone(&self) -> Box<ScriptChan + Send> {
-        let UserInteractionThreadSource(ref chan) = *self;
-        box UserInteractionThreadSource((*chan).clone())
+        let UserInteractionTaskSource(ref chan) = *self;
+        box UserInteractionTaskSource((*chan).clone())
     }
 }
 
-// FIXME: Use a thread source specific message instead of MainThreadScriptMsg
+// FIXME: Use a task source specific message instead of MainThreadScriptMsg
 #[derive(JSTraceable)]
-pub struct NetworkingThreadSource(pub Sender<MainThreadScriptMsg>);
+pub struct NetworkingTaskSource(pub Sender<MainThreadScriptMsg>);
 
-impl ScriptChan for NetworkingThreadSource {
+impl ScriptChan for NetworkingTaskSource {
     fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
-        let NetworkingThreadSource(ref chan) = *self;
+        let NetworkingTaskSource(ref chan) = *self;
         chan.send(MainThreadScriptMsg::Common(msg)).map_err(|_| ())
     }
 
     fn clone(&self) -> Box<ScriptChan + Send> {
-        let NetworkingThreadSource(ref chan) = *self;
-        box NetworkingThreadSource((*chan).clone())
+        let NetworkingTaskSource(ref chan) = *self;
+        box NetworkingTaskSource((*chan).clone())
     }
 }
 
-// FIXME: Use a thread source specific message instead of MainThreadScriptMsg
+// FIXME: Use a task source specific message instead of MainThreadScriptMsg
 #[derive(JSTraceable)]
-pub struct HistoryTraversalThreadSource(pub Sender<MainThreadScriptMsg>);
+pub struct HistoryTraversalTaskSource(pub Sender<MainThreadScriptMsg>);
 
-impl ScriptChan for HistoryTraversalThreadSource {
+impl ScriptChan for HistoryTraversalTaskSource {
     fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
-        let HistoryTraversalThreadSource(ref chan) = *self;
+        let HistoryTraversalTaskSource(ref chan) = *self;
         chan.send(MainThreadScriptMsg::Common(msg)).map_err(|_| ())
     }
 
     fn clone(&self) -> Box<ScriptChan + Send> {
-        let HistoryTraversalThreadSource(ref chan) = *self;
-        box HistoryTraversalThreadSource((*chan).clone())
+        let HistoryTraversalTaskSource(ref chan) = *self;
+        box HistoryTraversalTaskSource((*chan).clone())
     }
 }
 
-// FIXME: Use a thread source specific message instead of MainThreadScriptMsg
+// FIXME: Use a task source specific message instead of MainThreadScriptMsg
 #[derive(JSTraceable)]
-pub struct FileReadingThreadSource(pub Sender<MainThreadScriptMsg>);
+pub struct FileReadingTaskSource(pub Sender<MainThreadScriptMsg>);
 
-impl ScriptChan for FileReadingThreadSource {
+impl ScriptChan for FileReadingTaskSource {
     fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
-        let FileReadingThreadSource(ref chan) = *self;
+        let FileReadingTaskSource(ref chan) = *self;
         chan.send(MainThreadScriptMsg::Common(msg)).map_err(|_| ())
     }
 
     fn clone(&self) -> Box<ScriptChan + Send> {
-        let FileReadingThreadSource(ref chan) = *self;
-        box FileReadingThreadSource((*chan).clone())
+        let FileReadingTaskSource(ref chan) = *self;
+        box FileReadingTaskSource((*chan).clone())
     }
 }
 
-// FIXME: Use a thread source specific message instead of MainThreadScriptMsg
+// FIXME: Use a task source specific message instead of MainThreadScriptMsg
 #[derive(JSTraceable)]
 pub struct ProfilerThreadSource(pub Sender<MainThreadScriptMsg>);
 
@@ -493,15 +493,15 @@ pub struct ScriptThread {
     /// A channel to hand out to script thread-based entities that need to be able to enqueue
     /// events in the event queue.
     chan: MainThreadScriptChan,
-    dom_manipulation_thread_source: DOMManipulationThreadSource,
+    dom_manipulation_task_source: DOMManipulationTaskSource,
 
-    user_interaction_thread_source: UserInteractionThreadSource,
+    user_interaction_task_source: UserInteractionTaskSource,
 
-    networking_thread_source: NetworkingThreadSource,
+    networking_task_source: NetworkingTaskSource,
 
-    history_traversal_thread_source: HistoryTraversalThreadSource,
+    history_traversal_task_source: HistoryTraversalTaskSource,
 
-    file_reading_thread_source: FileReadingThreadSource,
+    file_reading_task_source: FileReadingTaskSource,
 
     /// A channel to hand out to threads that need to respond to a message from the script thread.
     control_chan: IpcSender<ConstellationControlMsg>,
@@ -768,11 +768,11 @@ impl ScriptThread {
 
             port: port,
             chan: MainThreadScriptChan(chan.clone()),
-            dom_manipulation_thread_source: DOMManipulationThreadSource(chan.clone()),
-            user_interaction_thread_source: UserInteractionThreadSource(chan.clone()),
-            networking_thread_source: NetworkingThreadSource(chan.clone()),
-            history_traversal_thread_source: HistoryTraversalThreadSource(chan.clone()),
-            file_reading_thread_source: FileReadingThreadSource(chan),
+            dom_manipulation_task_source: DOMManipulationTaskSource(chan.clone()),
+            user_interaction_task_source: UserInteractionTaskSource(chan.clone()),
+            networking_task_source: NetworkingTaskSource(chan.clone()),
+            history_traversal_task_source: HistoryTraversalTaskSource(chan.clone()),
+            file_reading_task_source: FileReadingTaskSource(chan),
 
             control_chan: state.control_chan,
             control_port: control_port,
@@ -1758,11 +1758,11 @@ impl ScriptThread {
         };
         let mut page_remover = AutoPageRemover::new(self, page_to_remove);
         let MainThreadScriptChan(ref sender) = self.chan;
-        let DOMManipulationThreadSource(ref dom_sender) = self.dom_manipulation_thread_source;
-        let UserInteractionThreadSource(ref user_sender) = self.user_interaction_thread_source;
-        let NetworkingThreadSource(ref network_sender) = self.networking_thread_source;
-        let HistoryTraversalThreadSource(ref history_sender) = self.history_traversal_thread_source;
-        let FileReadingThreadSource(ref file_sender) = self.file_reading_thread_source;
+        let DOMManipulationTaskSource(ref dom_sender) = self.dom_manipulation_task_source;
+        let UserInteractionTaskSource(ref user_sender) = self.user_interaction_task_source;
+        let NetworkingTaskSource(ref network_sender) = self.networking_task_source;
+        let HistoryTraversalTaskSource(ref history_sender) = self.history_traversal_task_source;
+        let FileReadingTaskSource(ref file_sender) = self.file_reading_task_source;
 
         let (ipc_timer_event_chan, ipc_timer_event_port) = ipc::channel().unwrap();
         ROUTER.route_ipc_receiver_to_mpsc_sender(ipc_timer_event_port,
@@ -1772,11 +1772,11 @@ impl ScriptThread {
         let window = Window::new(self.js_runtime.clone(),
                                  page.clone(),
                                  MainThreadScriptChan(sender.clone()),
-                                 DOMManipulationThreadSource(dom_sender.clone()),
-                                 UserInteractionThreadSource(user_sender.clone()),
-                                 NetworkingThreadSource(network_sender.clone()),
-                                 HistoryTraversalThreadSource(history_sender.clone()),
-                                 FileReadingThreadSource(file_sender.clone()),
+                                 DOMManipulationTaskSource(dom_sender.clone()),
+                                 UserInteractionTaskSource(user_sender.clone()),
+                                 NetworkingTaskSource(network_sender.clone()),
+                                 HistoryTraversalTaskSource(history_sender.clone()),
+                                 FileReadingTaskSource(file_sender.clone()),
                                  self.image_cache_channel.clone(),
                                  self.compositor.borrow_mut().clone(),
                                  self.image_cache_thread.clone(),


### PR DESCRIPTION
Related to: https://github.com/servo/servo/issues/9561

Renamed *thread_source to *_task_source in components/script/dom/window.rs and files that use window methods.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9576)

<!-- Reviewable:end -->
