### PR TITLE
Give WindowProxy objects an innerObject hook.

### DIFF
--- a/components/script/dom/browsingcontext.rs
+++ b/components/script/dom/browsingcontext.rs
@@ -12,7 +12,7 @@ use dom::document::Document;
 use dom::element::Element;
 use dom::window::Window;
 use js::JSCLASS_IS_GLOBAL;
-use js::glue::{CreateWrapperProxyHandler, ProxyTraps, WrapperNew};
+use js::glue::{CreateWrapperProxyHandler, ProxyTraps, NewWindowProxy};
 use js::glue::{GetProxyPrivate, SetProxyExtra};
 use js::jsapi::{Handle, JS_ForwardSetPropertyTo, ObjectOpResult, RootedObject, RootedValue};
 use js::jsapi::{HandleId, HandleObject, MutableHandle, MutableHandleValue};
@@ -56,11 +56,7 @@ impl BrowsingContext {
             assert!(((*JS_GetClass(parent.get())).flags & JSCLASS_IS_GLOBAL) != 0);
             let _ac = JSAutoCompartment::new(cx, parent.get());
             let window_proxy = RootedObject::new(cx,
-                                                 WrapperNew(cx,
-                                                            parent,
-                                                            handler,
-                                                            ptr::null(),
-                                                            true));
+                NewWindowProxy(cx, parent, handler));
             assert!(!window_proxy.ptr.is_null());
 
             let object = box BrowsingContext::new_inherited(document, frame_element);

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.1"
-source = "git+https://github.com/servo/rust-mozjs#b96675b217534c7742cbfda8150ea0536aedbdfb"
+source = "git+https://github.com/servo/rust-mozjs#6b53c4937b67dc71414d37dd3f4ad5cf407b2c2b"
 dependencies = [
  "heapsize 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.1"
-source = "git+https://github.com/servo/rust-mozjs#b96675b217534c7742cbfda8150ea0536aedbdfb"
+source = "git+https://github.com/servo/rust-mozjs#6b53c4937b67dc71414d37dd3f4ad5cf407b2c2b"
 dependencies = [
  "heapsize 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.1"
-source = "git+https://github.com/servo/rust-mozjs#b96675b217534c7742cbfda8150ea0536aedbdfb"
+source = "git+https://github.com/servo/rust-mozjs#6b53c4937b67dc71414d37dd3f4ad5cf407b2c2b"
 dependencies = [
  "heapsize 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This ensures that UncheckedUnwrap(obj, /\* stopAtOuter = */ true) will indeed
stop at the WindowProxy ("outer window", in older SpiderMonkey jargon), which
is necessary to prevent raw Window ("inner window") objects becoming visible
to JavaScript code, or tripping assertions that we don't do that.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9584)

<!-- Reviewable:end -->
