### PR TITLE
add check for win32 or msys before running rustc-with-gold fixes #9499

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -379,7 +379,8 @@ class CommandBase(object):
 
         env['RUSTDOC'] = path.join(self.context.topdir, 'etc', 'rustdoc-with-private')
 
-        if self.config["tools"]["rustc-with-gold"]:
+        # Don't run the gold linker if on Windows https://github.com/servo/servo/issues/9499
+        if self.config["tools"]["rustc-with-gold"] and sys.platform not in ("win32", "msys"):
             if subprocess.call(['which', 'ld.gold'], stdout=PIPE, stderr=PIPE) == 0:
                 env['RUSTC'] = path.join(self.context.topdir, 'etc', 'rustc-with-gold')
 


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9588)

<!-- Reviewable:end -->
