### PR TITLE
Download extra stdlib only when required: #9557

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -193,18 +193,21 @@ class MachCommands(CommandBase):
             print("Please specify either --dev or --release.")
             sys.exit(1)
 
-        self.ensure_bootstrapped()
-
+        targets = []
         if release:
             opts += ["--release"]
         if target:
             opts += ["--target", target]
+            targets.append(target)
         if jobs is not None:
             opts += ["-j", jobs]
         if verbose:
             opts += ["-v"]
         if android:
             opts += ["--target", self.config["android"]["target"]]
+            targets.append("arm-linux-androideabi")
+
+        self.ensure_bootstrapped(targets=targets)
 
         if debug_mozjs or self.config["build"]["debug-mozjs"]:
             features += ["script/debugmozjs"]

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -394,18 +394,21 @@ class CommandBase(object):
     def android_build_dir(self, dev):
         return path.join(self.get_target_dir(), "arm-linux-androideabi", "debug" if dev else "release")
 
-    def ensure_bootstrapped(self):
+    def ensure_bootstrapped(self, targets=[]):
         if self.context.bootstrapped:
             return
 
         Registrar.dispatch("update-submodules", context=self.context)
 
         if not self.config["tools"]["system-rust"] and \
-           not path.exists(path.join(
-                self.config["tools"]["rust-root"], "rustc", "bin", "rustc" + BIN_SUFFIX)):
+           (not path.exists(path.join(
+                            self.config["tools"]["rust-root"], "rustc", "bin", "rustc" + BIN_SUFFIX)) or
+                not all([path.exists(path.join(
+                        self.config["tools"]["rust-root"], "rustc", "lib", "rustlib", x
+                        )) for x in targets])):
             print("looking for rustc at %s" % path.join(
                 self.config["tools"]["rust-root"], "rustc", "bin", "rustc" + BIN_SUFFIX))
-            Registrar.dispatch("bootstrap-rust", context=self.context)
+            Registrar.dispatch("bootstrap-rust", context=self.context, target=targets)
         if not self.config["tools"]["system-cargo"] and \
            not path.exists(path.join(
                 self.config["tools"]["cargo-root"], "cargo", "bin", "cargo" + BIN_SUFFIX)):


### PR DESCRIPTION
Split [`ensure_bootstrap`](https://github.com/danlrobertson/servo/blob/i9557/python/servo/command_base.py#L397-L422) into two phases including a phase checking the compiler, and a phase checking for target libraries. E.g.

```
    # should download the stdlib for "i686-unknown-linux-gnu", "arm-linux-androideabi"
    # and the hosts target
    ./mach build -d --target i686-unknown-linux-gnu --android
    # should only download the stdlib for the hosts target
    ./mach build -d
```

Let me know if I missed anything! There are a few parts of this patch in its current state that I'm not a huge fan of, but I couldn't think of a better way in the moment.

Still new to working on servo, so any comments or critiques are welcome!

Fix #9557 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9611)

<!-- Reviewable:end -->
