### PR TITLE
Calculate correct mp4 header length.

### DIFF
--- a/components/net/mime_classifier.rs
+++ b/components/net/mime_classifier.rs
@@ -325,8 +325,8 @@ impl Mp4Matcher {
             return false;
         }
 
-        let box_size = ((data[0] as u32) << 3 | (data[1] as u32) << 2 |
-                        (data[2] as u32) << 1 | (data[3] as u32)) as usize;
+        let box_size = ((data[0] as u32) << 24 | (data[1] as u32) << 16 |
+                        (data[2] as u32) << 8 | (data[3] as u32)) as usize;
         if (data.len() < box_size) || (box_size % 4 != 0) {
             return false;
         }

--- a/tests/unit/net/mime_classifier.rs
+++ b/tests/unit/net/mime_classifier.rs
@@ -37,6 +37,19 @@ fn test_sniff_mp4_matcher() {
     }
 }
 
+#[test]
+fn test_sniff_mp4_matcher_long() {
+    // Check that a multi-byte length is calculated correctly
+    let matcher = Mp4Matcher;
+
+    let mut data: [u8; 260] = [0; 260];
+    &data[.. 11].clone_from_slice(
+        &[0x00, 0x00, 0x01, 0x04, 0x66, 0x74, 0x79, 0x70, 0x6D, 0x70, 0x34]
+    );
+
+    assert!(matcher.matches(&data));
+}
+
 #[cfg(test)]
 fn test_sniff_with_flags(filename_orig: &path::Path,
                                  type_string: &str,


### PR DESCRIPTION
The calculation of MP4 frame length is incorrect, shifting values by 1 bit instead of 8 bits.  It works for the test MP4 file because the length of the frame is less than 256 bytes, so the shifted values are all zero.

This PR changes the code to calculate the length correctly. It adds a test to check a fake long stream. Still not long enough to test completely, but at least detects the problem with the original code.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9618)

<!-- Reviewable:end -->
