### PR TITLE
Follow executable symlink to resolve resources directory

### DIFF
--- a/components/util/resource_files.rs
+++ b/components/util/resource_files.rs
@@ -34,6 +34,8 @@ pub fn resources_dir_path() -> PathBuf {
             // under `<servo source>[/$target_triple]/target/debug`
             // or `<servo source>[/$target_triple]/target/release`.
             let mut path = env::current_exe().expect("can't get exe path");
+            // Follow symlink
+            path = path.canonicalize().expect("path does not exist");
             path.pop();
             path.push("resources");
             if !path.is_dir() {   // resources dir not in same dir as exe?


### PR DESCRIPTION
We need this if we ever want to be able to install Servo, for example: https://github.com/paulrouget/homebrew-servo

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9643)

<!-- Reviewable:end -->
