### PR TITLE
Completed implementation of devtools' `getLayout`.

### DIFF
--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -27,5 +27,6 @@ hyper = { version = "0.7", features = [ "serde-serialization" ] }
 log = "0.3"
 rustc-serialize = "0.3"
 serde = "0.6"
+serde_json = "0.6"
 serde_macros = "0.6"
 time = "0.1"

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -11,6 +11,7 @@
 #![crate_type = "rlib"]
 
 #![feature(box_syntax)]
+#![feature(custom_attribute)]
 #![feature(custom_derive)]
 #![feature(plugin)]
 #![plugin(serde_macros)]
@@ -27,6 +28,7 @@ extern crate log;
 extern crate msg;
 extern crate rustc_serialize;
 extern crate serde;
+extern crate serde_json;
 extern crate time;
 extern crate util;
 

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -157,8 +157,37 @@ pub enum TimelineMarkerType {
 /// The properties of a DOM node as computed by layout.
 #[derive(Deserialize, Serialize)]
 pub struct ComputedNodeLayout {
+    pub display: String,
+    pub position: String,
+    pub zIndex: String,
+    pub boxSizing: String,
+
+    pub autoMargins: AutoMargins,
+    pub marginTop: String,
+    pub marginRight: String,
+    pub marginBottom: String,
+    pub marginLeft: String,
+
+    pub borderTopWidth: String,
+    pub borderRightWidth: String,
+    pub borderBottomWidth: String,
+    pub borderLeftWidth: String,
+
+    pub paddingTop: String,
+    pub paddingRight: String,
+    pub paddingBottom: String,
+    pub paddingLeft: String,
+
     pub width: f32,
     pub height: f32,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct AutoMargins {
+    pub top: bool,
+    pub right: bool,
+    pub bottom: bool,
+    pub left: bool,
 }
 
 /// Messages to process in a particular script thread, as instructed by a devtools client.

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -17,7 +17,7 @@ use msg::constellation_msg::ConstellationChan;
 use opaque_node::OpaqueNodeMethods;
 use script::layout_interface::{ContentBoxResponse, ContentBoxesResponse, NodeGeometryResponse};
 use script::layout_interface::{HitTestResponse, LayoutRPC, MouseOverResponse, OffsetParentResponse};
-use script::layout_interface::{ResolvedStyleResponse, ScriptLayoutChan};
+use script::layout_interface::{ResolvedStyleResponse, ScriptLayoutChan, MarginStyleResponse};
 use script_traits::LayoutMsg as ConstellationMsg;
 use sequential;
 use std::ops::Deref;
@@ -130,6 +130,12 @@ impl LayoutRPC for LayoutRPCImpl {
         let &LayoutRPCImpl(ref rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         rw_data.offset_parent_response.clone()
+    }
+
+    fn margin_style(&self) -> MarginStyleResponse {
+        let &LayoutRPCImpl(ref rw_data) = self;
+        let rw_data = rw_data.lock().unwrap();
+        rw_data.margin_style_response.clone()
     }
 }
 
@@ -573,5 +579,19 @@ pub fn process_offset_parent_query<'ln, N: LayoutNode<'ln>>(requested_node: N, l
         None => {
             OffsetParentResponse::empty()
         }
+    }
+}
+
+pub fn process_margin_style_query<'ln, N: LayoutNode<'ln>>(requested_node: N)
+        -> MarginStyleResponse {
+    let layout_node = requested_node.to_threadsafe();
+    let style = &*layout_node.style();
+    let margin = style.get_margin();
+
+    MarginStyleResponse {
+        top: margin.margin_top,
+        right: margin.margin_right,
+        bottom: margin.margin_bottom,
+        left: margin.margin_left,
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -185,7 +185,6 @@ unsafe impl Send for OpaqueStyleAndLayoutData {}
 
 no_jsmanaged_fields!(OpaqueStyleAndLayoutData);
 
-
 impl OpaqueStyleAndLayoutData {
     /// Sends the style and layout data, if any, back to the layout thread to be destroyed.
     pub fn dispose(self, node: &Node) {

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use std::sync::mpsc::{Receiver, Sender, channel};
 use string_cache::Atom;
 use style::context::ReflowGoal;
+use style::properties::longhands::{margin_top, margin_right, margin_bottom, margin_left};
 use style::selector_impl::PseudoElement;
 use style::servo::Stylesheet;
 use url::Url;
@@ -109,8 +110,28 @@ pub trait LayoutRPC {
     /// Query layout for the resolved value of a given CSS property
     fn resolved_style(&self) -> ResolvedStyleResponse;
     fn offset_parent(&self) -> OffsetParentResponse;
+    /// Query layout for the resolve values of the margin properties for an element.
+    fn margin_style(&self) -> MarginStyleResponse;
 }
 
+#[derive(Clone)]
+pub struct MarginStyleResponse {
+    pub top: margin_top::computed_value::T,
+    pub right: margin_right::computed_value::T,
+    pub bottom: margin_bottom::computed_value::T,
+    pub left: margin_left::computed_value::T,
+}
+
+impl MarginStyleResponse {
+    pub fn empty() -> MarginStyleResponse {
+        MarginStyleResponse {
+            top: margin_top::computed_value::T::Auto,
+            right: margin_right::computed_value::T::Auto,
+            bottom: margin_bottom::computed_value::T::Auto,
+            left: margin_left::computed_value::T::Auto,
+        }
+    }
+}
 
 pub struct ContentBoxResponse(pub Rect<Au>);
 pub struct ContentBoxesResponse(pub Vec<Rect<Au>>);
@@ -145,6 +166,7 @@ pub enum ReflowQueryType {
     NodeGeometryQuery(TrustedNodeAddress),
     ResolvedStyleQuery(TrustedNodeAddress, Option<PseudoElement>, Atom),
     OffsetParentQuery(TrustedNodeAddress),
+    MarginStyleQuery(TrustedNodeAddress),
 }
 
 /// Information needed for a reflow.

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "plugins 0.0.1",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "plugins 0.0.1",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
  "plugins 0.0.1",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",


### PR DESCRIPTION
Rebase of #7267. Fixes #3598.

This avoids all of the sketchy issues of trying to read the style data for margins from the script thread. I replaced it with a layout query that fetches the margin style properties for a given element.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9661)

<!-- Reviewable:end -->
