### PR TITLE
Implement RootedReference<T> for Option<JS<T>>

### DIFF
--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -444,6 +444,13 @@ impl<T: Reflectable> RootedReference<T> for Option<Root<T>> {
     }
 }
 
+/// Get an `Option<&T> out of an `Option<JS<T>>`
+impl<T: Reflectable> RootedReference<T> for Option<JS<T>> {
+    fn r(&self) -> Option<&T> {
+        self.as_ref().map(|inner| &**inner)
+    }
+}
+
 /// Get an `Option<Option<&T>>` out of an `Option<Option<Root<T>>>`
 pub trait OptionalRootedReference<T> {
     /// Obtain a safe optional optional reference to the wrapped JS owned-value

--- a/components/script/dom/browsingcontext.rs
+++ b/components/script/dom/browsingcontext.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::conversions::{ToJSValConvertible, root_from_handleobject};
-use dom::bindings::js::{JS, Root};
+use dom::bindings::js::{JS, Root, RootedReference};
 use dom::bindings::proxyhandler::{fill_property_descriptor, get_property_descriptor};
 use dom::bindings::reflector::{Reflectable, Reflector};
 use dom::bindings::utils::WindowProxyHandler;
@@ -78,7 +78,7 @@ impl BrowsingContext {
     }
 
     pub fn frame_element(&self) -> Option<&Element> {
-        self.frame_element.as_ref().map(|element| &**element)
+        self.frame_element.r()
     }
 
     pub fn window_proxy(&self) -> *mut JSObject {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -812,7 +812,7 @@ impl Activatable for HTMLInputElement {
                 // We want to restore state only if the element had been changed in the first place
                 if cache.was_mutable {
                     let name = self.get_radio_group_name();
-                    match cache.checked_radio.as_ref().map(|t| &*t) {
+                    match cache.checked_radio.r() {
                         Some(o) => {
                             // Avoiding iterating through the whole tree here, instead
                             // we can check if the conditions for radio group siblings apply


### PR DESCRIPTION
A basic implementation of `RootedReference for Option<JS<T>>` based off of
other implementations of `RootedReference` for `Option` wrapped types.

Really I just wanted an excuse to read more in `bindings` :smile: Let me know
if you have any comments or critiques.

Fixes  #9654

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9664)

<!-- Reviewable:end -->
