### PR TITLE
Fix a broken reftest.

### DIFF
--- a/tests/wpt/mozilla/tests/css/absolute_hypothetical_with_intervening_inline_block_a.html
+++ b/tests/wpt/mozilla/tests/css/absolute_hypothetical_with_intervening_inline_block_a.html
@@ -18,6 +18,7 @@ section {
 }
 strong {
     color: red;
+    font-weight: normal;
 }
 </style>
 There should be no red.<em><main><section></section></main></em><strong>_</strong>


### PR DESCRIPTION
The strong element has a different font weight by default. This means that the line height
is slightly different from the ref test. In normal Servo this doesn't matter due to how the
default snapping works.

However, in both WebRender and Firefox, this results in the reftests being one pixel different.

Setting the font weight to be normal makes the reftest pass in Servo, WebRender and FF.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9665)

<!-- Reviewable:end -->
