### PR TITLE
CORS Preflight Logic Fix

### DIFF
--- a/components/script/cors.rs
+++ b/components/script/cors.rs
@@ -77,7 +77,7 @@ impl CORSRequest {
                 let mut req = CORSRequest::new(referer, destination, mode, method, headers);
                 req.preflight_flag = !is_simple_method(&req.method) ||
                                      mode == RequestMode::ForcedPreflight;
-                if req.headers.iter().all(|h| is_simple_header(&h)) {
+                if req.headers.iter().any(|h| !is_simple_header(&h)) {
                     req.preflight_flag = true;
                 }
                 Ok(Some(req))

--- a/tests/wpt/metadata/cors/redirect-origin.htm.ini
+++ b/tests/wpt/metadata/cors/redirect-origin.htm.ini
@@ -108,3 +108,26 @@
   [remote (http://web-platform.test:8000) to remote2 (null), expect origin=null]
     expected: FAIL
 
+  [remote (http://www1.web-platform.test:8000) to remote (*), expect to fail]
+    expected: FAIL
+
+  [remote (null) to remote2 (*), expect to fail]
+    expected: FAIL
+
+  [remote (none) to remote2 (*), expect to fail]
+    expected: FAIL
+
+  [remote (none) to remote2 (*), expect to fail]
+    expected: FAIL
+
+  [remote (null) to remote (*), expect to fail]
+    expected: FAIL
+
+  [remote (none) to remote (*), expect to fail]
+    expected: FAIL
+
+  [remote (none) to local (*), expect to fail]
+    expected: FAIL
+
+  [remote (null) to local (*), expect to fail]
+    expected: FAIL


### PR DESCRIPTION
Fix check to set flag if any header is not a simple header, rather than only if all 
headers are simple headers.
Fix failing tests to allow merge in advance of @nikkibee's changes
as per @jdm's direction via IRC.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9667)

<!-- Reviewable:end -->
