### PR TITLE
Ensure when calculating font metrics that the total line height matches requested line height.

### DIFF
--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1928,9 +1928,14 @@ impl InlineMetrics {
     #[inline]
     pub fn from_font_metrics(font_metrics: &FontMetrics, line_height: Au) -> InlineMetrics {
         let leading = line_height - (font_metrics.ascent + font_metrics.descent);
+        // Calculating the half leading here and then using leading - half_leading
+        // below ensure that we don't introduce any rounding accuracy issues here.
+        // The invariant is that the resulting total line height must exactly
+        // equal the requested line_height.
+        let half_leading = leading.scale_by(0.5);
         InlineMetrics {
-            block_size_above_baseline: font_metrics.ascent + leading.scale_by(0.5),
-            depth_below_baseline: font_metrics.descent + leading.scale_by(0.5),
+            block_size_above_baseline: font_metrics.ascent + half_leading,
+            depth_below_baseline: font_metrics.descent + leading - half_leading,
             ascent: font_metrics.ascent,
         }
     }

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-017.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-017.htm.ini
@@ -1,5 +1,0 @@
-[transform-input-017.htm]
-  type: reftest
-  expected:
-    if os == "linux": PASS
-    FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-018.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-018.htm.ini
@@ -1,3 +1,5 @@
 [transform-input-018.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": PASS
+    FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/position-relative-035.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/position-relative-035.htm.ini
@@ -1,3 +1,5 @@
 [position-relative-035.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": PASS
+    FAIL


### PR DESCRIPTION
This fixes rounding accuracy issues that could result in layout producing results off by a small number of Au.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9668)

<!-- Reviewable:end -->
