### PR TITLE
Add methods to move ByteStrings underlying bytes

### DIFF
--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -25,8 +25,7 @@ impl ByteString {
     /// Returns `self` as a string, if it encodes valid UTF-8, and `None`
     /// otherwise.
     pub fn as_str(&self) -> Option<&str> {
-        let ByteString(ref vec) = *self;
-        str::from_utf8(&vec).ok()
+        str::from_utf8(&self.0).ok()
     }
 
     /// Returns ownership of the underlying Vec<u8> and copies an empty
@@ -37,8 +36,7 @@ impl ByteString {
 
     /// Returns the length.
     pub fn len(&self) -> usize {
-        let ByteString(ref vector) = *self;
-        vector.len()
+        self.0.len()
     }
 
     /// Compare `self` to `other`, matching A–Z and a–z as equal.
@@ -54,8 +52,7 @@ impl ByteString {
     /// Returns whether `self` is a `token`, as defined by
     /// [RFC 2616](http://tools.ietf.org/html/rfc2616#page-17).
     pub fn is_token(&self) -> bool {
-        let ByteString(ref vec) = *self;
-        is_token(vec)
+        is_token(&self.0)
     }
 
     /// Returns whether `self` is a `field-value`, as defined by
@@ -69,9 +66,8 @@ impl ByteString {
             LF,
             SPHT, // SP or HT
         }
-        let ByteString(ref vec) = *self;
         let mut prev = PreviousCharacter::Other; // The previous character
-        vec.iter().all(|&x| {
+        self.0.iter().all(|&x| {
             // http://tools.ietf.org/html/rfc2616#section-2.2
             match x {
                 13  => { // CR

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -7,6 +7,7 @@
 use std::ascii::AsciiExt;
 use std::borrow::ToOwned;
 use std::hash::{Hash, Hasher};
+use std::mem;
 use std::ops;
 use std::str;
 use std::str::FromStr;
@@ -26,6 +27,12 @@ impl ByteString {
     pub fn as_str(&self) -> Option<&str> {
         let ByteString(ref vec) = *self;
         str::from_utf8(&vec).ok()
+    }
+
+    /// Returns ownership of the underlying Vec<u8> and copies an empty
+    /// vec in its place
+    pub fn bytes(&mut self) -> Vec<u8> {
+        mem::replace(&mut self.0, Vec::new())
     }
 
     /// Returns the length.
@@ -114,6 +121,12 @@ impl ByteString {
                 _ => false // Previous character was a CR/LF but not part of the [CRLF] (SP|HT) rule
             }
         })
+    }
+}
+
+impl Into<Vec<u8>> for ByteString {
+    fn into(self) -> Vec<u8> {
+        self.0
     }
 }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -435,7 +435,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
             None => {}
         }
 
-        headers.set_raw(name_str.to_owned(), vec![value.to_vec()]);
+        headers.set_raw(name_str.to_owned(), vec![value.into()]);
         Ok(())
     }
 

--- a/tests/unit/script/dom/bindings.rs
+++ b/tests/unit/script/dom/bindings.rs
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use script::dom::bindings::str::ByteString;
+
+#[test]
+fn test_byte_string_move() {
+    let mut byte_str = ByteString::new(vec![0x73, 0x65, 0x72, 0x76, 0x6f]);
+    let mut byte_vec = byte_str.bytes();
+
+    assert_eq!(byte_vec, "servo".as_bytes());
+    assert_eq!(*byte_str, []);
+
+    byte_vec = byte_str.into();
+    assert_eq!(byte_vec, Vec::new());
+}

--- a/tests/unit/script/lib.rs
+++ b/tests/unit/script/lib.rs
@@ -9,5 +9,6 @@ extern crate util;
 #[cfg(all(test, target_pointer_width = "64"))] mod size_of;
 #[cfg(test)] mod textinput;
 #[cfg(test)] mod dom {
+    mod bindings;
     mod blob;
 }


### PR DESCRIPTION
Add methods to move the underlying `Vec<u8>` for `ByteString`.

I saw this as at least two methods. One to "move and replace with and empty Vec<u8> (`bytes`), and one to take ownership of the whole object (`own_bytes`). I typically also don't like adding methods with out unit tests. If you think they're unnecessary, just let me know.

As always, please let me know if you have any comments, critiques, or nits!

Fixes #9655

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9684)

<!-- Reviewable:end -->
