### PR TITLE
Mach update-wpt should default to "--no-patch"

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -360,9 +360,12 @@ class MachCommands(CommandBase):
              description='Update the web platform tests',
              category='testing',
              parser=updatecommandline.create_parser())
-    def update_wpt(self, **kwargs):
+    @CommandArgument('--patch', action='store_true', default=False,
+                     help='Create an mq patch or git commit containing the changes')
+    def update_wpt(self, patch, **kwargs):
         self.ensure_bootstrapped()
         run_file = path.abspath(path.join("tests", "wpt", "update.py"))
+        kwargs["no_patch"] = not patch
         run_globals = {"__file__": run_file}
         execfile(run_file, run_globals)
         return run_globals["update_tests"](**kwargs)


### PR DESCRIPTION
Change mach default behavior for `update-wpt` to use the "--no-patch" option and provide an alternate option "--patch" for anyone who does in fact want `update-wpt` to automatically create a commit.

Fixes #9666

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9685)

<!-- Reviewable:end -->
