### PR TITLE
Implement Worker#terminate() (fixes #4427).

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -38,6 +38,7 @@ use dom::bindings::js::{JS, Root};
 use dom::bindings::refcounted::Trusted;
 use dom::bindings::reflector::{Reflectable, Reflector};
 use dom::bindings::utils::WindowProxyHandler;
+use dom::worker::SharedRt;
 use encoding::types::EncodingRef;
 use euclid::length::Length as EuclidLength;
 use euclid::matrix2d::Matrix2D;
@@ -319,6 +320,7 @@ no_jsmanaged_fields!(AttrIdentifier);
 no_jsmanaged_fields!(AttrValue);
 no_jsmanaged_fields!(ElementSnapshot);
 no_jsmanaged_fields!(HttpsState);
+no_jsmanaged_fields!(SharedRt);
 no_jsmanaged_fields!(TouchpadPressurePhase);
 
 impl JSTraceable for ConstellationChan<ScriptMsg> {

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -9,20 +9,21 @@ use dom::bindings::codegen::Bindings::DedicatedWorkerGlobalScopeBinding;
 use dom::bindings::codegen::Bindings::DedicatedWorkerGlobalScopeBinding::DedicatedWorkerGlobalScopeMethods;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::error::ErrorResult;
-use dom::bindings::global::GlobalRef;
+use dom::bindings::global::{GlobalRef, global_root_from_context};
 use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{Root, RootCollection};
 use dom::bindings::refcounted::LiveDOMReferences;
 use dom::bindings::reflector::Reflectable;
 use dom::bindings::structuredclone::StructuredCloneData;
+use dom::bindings::trace::JSTraceable;
 use dom::messageevent::MessageEvent;
-use dom::worker::{SimpleWorkerErrorHandler, TrustedWorkerAddress, WorkerMessageHandler};
+use dom::worker::{SimpleWorkerErrorHandler, SharedRt, TrustedWorkerAddress, WorkerMessageHandler};
 use dom::workerglobalscope::WorkerGlobalScope;
 use dom::workerglobalscope::WorkerGlobalScopeInit;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
-use js::jsapi::{HandleValue, JSContext, RootedValue};
-use js::jsapi::{JSAutoCompartment, JSAutoRequest};
+use js::jsapi::{HandleValue, JS_SetInterruptCallback};
+use js::jsapi::{JSAutoCompartment, JSAutoRequest, JSContext, RootedValue};
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use msg::constellation_msg::PipelineId;
@@ -33,6 +34,7 @@ use script_runtime::{CommonScriptMsg, ScriptChan, ScriptPort, StackRootTLS, get_
 use script_traits::{TimerEvent, TimerSource};
 use std::mem::replace;
 use std::sync::mpsc::{Receiver, RecvError, Select, Sender, channel};
+use std::sync::{Arc, Mutex};
 use url::Url;
 use util::str::DOMString;
 use util::thread::spawn_named;
@@ -206,10 +208,12 @@ impl DedicatedWorkerGlobalScope {
         DedicatedWorkerGlobalScopeBinding::Wrap(cx, scope)
     }
 
+    #[allow(unsafe_code)]
     pub fn run_worker_scope(init: WorkerGlobalScopeInit,
                             worker_url: Url,
                             id: PipelineId,
                             from_devtools_receiver: IpcReceiver<DevtoolScriptControlMsg>,
+                            main_thread_rt: Arc<Mutex<Option<SharedRt>>>,
                             worker: TrustedWorkerAddress,
                             parent_sender: Box<ScriptChan + Send>,
                             own_sender: Sender<(TrustedWorkerAddress, WorkerScriptMsg)>,
@@ -237,6 +241,7 @@ impl DedicatedWorkerGlobalScope {
             };
 
             let runtime = new_rt_and_cx();
+            *main_thread_rt.lock().unwrap() = Some(SharedRt::new(&runtime));
 
             let (devtools_mpsc_chan, devtools_mpsc_port) = channel();
             ROUTER.route_ipc_receiver_to_mpsc_sender(from_devtools_receiver, devtools_mpsc_chan);
@@ -257,6 +262,15 @@ impl DedicatedWorkerGlobalScope {
             // registration (#6631), so we instead use a random number and cross our fingers.
             let scope = global.upcast::<WorkerGlobalScope>();
 
+            unsafe {
+                // Handle interrupt requests
+                JS_SetInterruptCallback(scope.runtime(), Some(interrupt_callback));
+            }
+
+            if scope.is_closing() {
+                return;
+            }
+
             {
                 let _ar = AutoWorkerReset::new(global.r(), worker);
                 scope.execute_script(DOMString::from(source));
@@ -265,6 +279,9 @@ impl DedicatedWorkerGlobalScope {
             let reporter_name = format!("worker-reporter-{}", random::<u64>());
             scope.mem_profiler_chan().run_with_memory_reporting(|| {
                 while let Ok(event) = global.receive_event() {
+                    if scope.is_closing() {
+                        break;
+                    }
                     global.handle_event(event);
                 }
             }, reporter_name, parent_sender, CommonScriptMsg::CollectReports);
@@ -385,6 +402,19 @@ impl DedicatedWorkerGlobalScope {
             },
         }
     }
+}
+
+#[allow(unsafe_code)]
+unsafe extern "C" fn interrupt_callback(cx: *mut JSContext) -> bool {
+    let global = global_root_from_context(cx);
+    let worker = match global.r() {
+        GlobalRef::Worker(w) => w,
+        _ => panic!("global for worker is not a worker scope")
+    };
+    assert!(worker.is::<DedicatedWorkerGlobalScope>());
+
+    // A false response causes the script to terminate
+    !worker.is_closing()
 }
 
 impl DedicatedWorkerGlobalScopeMethods for DedicatedWorkerGlobalScope {

--- a/components/script/dom/webidls/Worker.webidl
+++ b/components/script/dom/webidls/Worker.webidl
@@ -12,7 +12,7 @@ interface AbstractWorker {
 // https://html.spec.whatwg.org/multipage/#worker
 [Constructor(DOMString scriptURL)/*, Exposed=Window,Worker*/]
 interface Worker : EventTarget {
-  //void terminate();
+  void terminate();
 
 [Throws]
 void postMessage(any message/*, optional sequence<Transferable> transfer*/);

--- a/tests/html/worker/worker_post_block.js
+++ b/tests/html/worker/worker_post_block.js
@@ -1,0 +1,9 @@
+var prev = Date.now()
+for (var i=0; true; i++) {
+
+  if (i % 100000000 == 0) {
+    var now = Date.now();
+    postMessage(now - prev);
+    prev = now;
+  }
+}

--- a/tests/html/worker/worker_post_interval.js
+++ b/tests/html/worker/worker_post_interval.js
@@ -1,0 +1,6 @@
+var prev = Date.now()
+setInterval(function () {
+  var now = Date.now();
+  postMessage(now - prev);
+  prev = now;
+}, 500);

--- a/tests/html/worker/worker_terminate.html
+++ b/tests/html/worker/worker_terminate.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Worker Test</title>
+</head>
+<body>
+<script>
+var workerPath = (function () {
+  var workerType;
+  switch (window.location.search.match(/worker=(\w+)/)[1]) {
+    case 'block':
+      workerType = 'block';
+      break;
+    default:
+      workerType = 'interval';
+      break;
+  }
+
+  return './worker_post_' + workerType + '.js';
+})();
+
+function startWorker() {
+  window.w = new Worker(workerPath);
+  w.onmessage = function(m) {
+    var p = document.createElement('p');
+    p.innerHTML = JSON.stringify(m.data);
+    document.body.appendChild(p);
+  };
+
+  var ps = document.getElementsByTagName('p');
+  while (ps.length) {
+    document.body.removeChild(ps[0]);
+  }
+}
+
+function stopWorker() {
+  if (w) {
+    w.terminate();
+  }
+
+  window.w = null;
+}
+</script>
+  <button onclick="startWorker()">Start Worker</button>
+  <button onclick="stopWorker()">Stop Worker</button>
+</body>
+</html>

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -7458,9 +7458,6 @@
   [SharedWorkerGlobalScope interface: attribute onconnect]
     expected: FAIL
 
-  [Worker interface: operation terminate()]
-    expected: FAIL
-
   [SharedWorker interface: existence and properties of interface object]
     expected: FAIL
 

--- a/tests/wpt/metadata/workers/Worker_terminate_event_queue.htm.ini
+++ b/tests/wpt/metadata/workers/Worker_terminate_event_queue.htm.ini
@@ -1,3 +1,0 @@
-[Worker_terminate_event_queue.htm]
-  type: testharness
-  disabled: too much output

--- a/tests/wpt/metadata/workers/constructors/Worker/terminate.html.ini
+++ b/tests/wpt/metadata/workers/constructors/Worker/terminate.html.ini
@@ -1,5 +1,0 @@
-[terminate.html]
-  type: testharness
-  [terminate()]
-    expected: FAIL
-

--- a/tests/wpt/metadata/workers/nested_worker.worker.js.ini
+++ b/tests/wpt/metadata/workers/nested_worker.worker.js.ini
@@ -1,9 +1,0 @@
-[nested_worker.worker]
-  type: testharness
-  expected: TIMEOUT
-  [Nested worker]
-    expected: FAIL
-
-  [Checking contents for text file]
-    expected: FAIL
-


### PR DESCRIPTION
Adds support for terminating DOM workers. A closing flag was added to
WorkerGlobalScope per the spec.

Rebased #6652, with some comments addressed.
Fixes #4427.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9688)

<!-- Reviewable:end -->
