### PR TITLE
Remove parallel display list construction

### DIFF
--- a/components/layout/layout_thread.rs
+++ b/components/layout/layout_thread.rs
@@ -855,19 +855,7 @@ impl LayoutThread {
             flow::mut_base(flow_ref::deref_mut(layout_root)).clip =
                 ClippingRegion::from_rect(&data.page_clip_rect);
 
-            match (&mut self.parallel_traversal, opts::get().parallel_display_list_building) {
-                (&mut Some(ref mut traversal), true) => {
-                    parallel::build_display_list_for_subtree(layout_root,
-                                                             metadata,
-                                                             sender,
-                                                             shared_layout_context,
-                                                             traversal);
-                }
-                _ => {
-                    sequential::build_display_list_for_subtree(layout_root,
-                                                               shared_layout_context);
-                }
-            }
+            sequential::build_display_list_for_subtree(layout_root, shared_layout_context);
 
             if data.goal == ReflowGoal::ForDisplay {
                 debug!("Done building display list.");

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -169,9 +169,6 @@ pub struct Opts {
     /// Whether Style Sharing Cache is used
     pub disable_share_style_cache: bool,
 
-    /// Whether to run absolute position calculation and display list construction in parallel.
-    pub parallel_display_list_building: bool,
-
     /// Translate mouse input into touch events.
     pub convert_mouse_to_touch: bool,
 
@@ -263,9 +260,6 @@ pub struct DebugOptions {
     /// Disable the style sharing cache.
     pub disable_share_style_cache: bool,
 
-    /// Build display lists in parallel.
-    pub parallel_display_list_building: bool,
-
     /// Translate mouse input into touch events.
     pub convert_mouse_to_touch: bool,
 
@@ -316,7 +310,6 @@ impl DebugOptions {
                 "trace-layout" => debug_options.trace_layout = true,
                 "validate-display-list-geometry" => debug_options.validate_display_list_geometry = true,
                 "disable-share-style-cache" => debug_options.disable_share_style_cache = true,
-                "parallel-display-list-building" => debug_options.parallel_display_list_building = true,
                 "convert-mouse-to-touch" => debug_options.convert_mouse_to_touch = true,
                 "replace-surrogates" => debug_options.replace_surrogates = true,
                 "gc-profile" => debug_options.gc_profile = true,
@@ -497,7 +490,6 @@ pub fn default_opts() -> Opts {
         profile_script_events: false,
         profile_heartbeats: false,
         disable_share_style_cache: false,
-        parallel_display_list_building: false,
         convert_mouse_to_touch: false,
         exit_after_load: false,
         no_native_titlebar: false,
@@ -737,7 +729,6 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         relayout_event: debug_options.relayout_event,
         validate_display_list_geometry: debug_options.validate_display_list_geometry,
         disable_share_style_cache: debug_options.disable_share_style_cache,
-        parallel_display_list_building: debug_options.parallel_display_list_building,
         convert_mouse_to_touch: debug_options.convert_mouse_to_touch,
         exit_after_load: opt_match.opt_present("x"),
         no_native_titlebar: opt_match.opt_present("b"),


### PR DESCRIPTION
Parallel display list construction hasn't been shown to give any
performance gains. It is also incompatible with the current flat display
list implementation. Once flat display lists have landed, we can explore
possible benefits of parallel construction once again.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9706)

<!-- Reviewable:end -->
