### PR TITLE
script: Fix MouseOver handling

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -16,7 +16,7 @@ use layout_thread::LayoutThreadData;
 use msg::constellation_msg::ConstellationChan;
 use opaque_node::OpaqueNodeMethods;
 use script::layout_interface::{ContentBoxResponse, ContentBoxesResponse, NodeGeometryResponse};
-use script::layout_interface::{HitTestResponse, LayoutRPC, MouseOverResponse, OffsetParentResponse};
+use script::layout_interface::{HitTestResponse, LayoutRPC, OffsetParentResponse};
 use script::layout_interface::{ResolvedStyleResponse, ScriptLayoutChan, MarginStyleResponse};
 use script_traits::LayoutMsg as ConstellationMsg;
 use sequential;
@@ -67,48 +67,29 @@ impl LayoutRPC for LayoutRPCImpl {
     }
 
     /// Requests the node containing the point of interest.
-    fn hit_test(&self, point: Point2D<f32>) -> Result<HitTestResponse, ()> {
+    fn hit_test(&self, point: Point2D<f32>, update_cursor: bool) -> Result<HitTestResponse, ()> {
         let point = Point2D::new(Au::from_f32_px(point.x), Au::from_f32_px(point.y));
         let &LayoutRPCImpl(ref rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
-        let result = match rw_data.display_list {
-            None => panic!("Tried to hit test without a DisplayList"),
-            Some(ref display_list) => display_list.hit_test(point),
-        };
+        let display_list = rw_data.display_list.as_ref().expect("Tried to hit test without a DisplayList!");
 
-        if result.is_empty() {
-            return Err(());
-        }
+        let result = display_list.hit_test(point);
 
-        Ok(HitTestResponse(result[0].node.to_untrusted_node_address()))
-    }
-
-    fn mouse_over(&self, point: Point2D<f32>) -> Result<MouseOverResponse, ()> {
-        let point = Point2D::new(Au::from_f32_px(point.x), Au::from_f32_px(point.y));
-        let mouse_over_list = {
-            let &LayoutRPCImpl(ref rw_data) = self;
-            let rw_data = rw_data.lock().unwrap();
-            let result = match rw_data.display_list {
-                None => panic!("Tried to hit test without a DisplayList"),
-                Some(ref display_list) => display_list.hit_test(point),
-            };
-
-            // Compute the new cursor.
+        if update_cursor {
             let cursor = if !result.is_empty() {
                 result[0].pointing.unwrap()
             } else {
                 Cursor::DefaultCursor
             };
+
             let ConstellationChan(ref constellation_chan) = rw_data.constellation_chan;
             constellation_chan.send(ConstellationMsg::SetCursor(cursor)).unwrap();
-            result
         };
 
-        if mouse_over_list.is_empty() {
-            Err(())
+        if !result.is_empty() {
+            Ok(HitTestResponse(result[0].node.to_untrusted_node_address()))
         } else {
-            let response = mouse_over_list[0].node.to_untrusted_node_address();
-            Ok(MouseOverResponse(response))
+            Err(())
         }
     }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -107,11 +107,8 @@ impl LayoutRPC for LayoutRPCImpl {
         if mouse_over_list.is_empty() {
             Err(())
         } else {
-            let response_list =
-                mouse_over_list.iter()
-                               .map(|metadata| metadata.node.to_untrusted_node_address())
-                               .collect();
-            Ok(MouseOverResponse(response_list))
+            let response = mouse_over_list[0].node.to_untrusted_node_address();
+            Ok(MouseOverResponse(response))
         }
     }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -824,21 +824,28 @@ impl Document {
             }
         }
 
+        // Werther the topmost element we are hovering now is diffrent than the previous
+        let is_different_topmost_target = mouse_over_targets.is_empty() ||
+                                          prev_mouse_over_targets.is_empty() ||
+                                          prev_mouse_over_targets[0].upcast::<Node>().to_trusted_node_address() !=
+                                              mouse_over_targets[0].upcast::<Node>().to_trusted_node_address();
+
         // Remove hover from any elements in the previous list that are no longer
         // under the mouse.
-        for target in prev_mouse_over_targets.iter() {
-            if !mouse_over_targets.contains(target) {
-                let target_ref = &**target;
-                if target_ref.get_hover_state() {
-                    target_ref.set_hover_state(false);
+        for (index, target) in prev_mouse_over_targets.iter().enumerate() {
+            // Hover state is reset as appropiate later
+            target.set_hover_state(false);
 
-                    let target = target_ref.upcast();
+            // https://www.w3.org/TR/uievents/#event-type-mouseout
+            //
+            // mouseout must be dispatched when the mouse moves off an element or when pointer
+            // mouse moves from an element onto the boundaries of one of its descendent elements.
+            let has_to_dispatch_mouse_out = index == 0 && is_different_topmost_target;
 
-                    // FIXME: we should be dispatching this event but we lack an actual
-                    //        point to pass to it.
-                    if let Some(client_point) = client_point {
-                        self.fire_mouse_event(client_point, &target, "mouseout".to_owned());
-                    }
+            if has_to_dispatch_mouse_out {
+                let target = target.upcast();
+                if let Some(client_point) = client_point {
+                    self.fire_mouse_event(client_point, &target, "mouseout".to_owned());
                 }
             }
         }
@@ -846,12 +853,20 @@ impl Document {
         // Set hover state for any elements in the current mouse over list.
         // Check if any of them changed state to determine whether to
         // force a reflow below.
-        for target in mouse_over_targets.r() {
-            if !target.get_hover_state() {
-                target.set_hover_state(true);
+        for (index, target) in mouse_over_targets.r().iter().enumerate() {
+            target.set_hover_state(true);
 
+            // https://www.w3.org/TR/uievents/#event-type-mouseover
+            //
+            // Mouseover must be fired when a pointing device is moved onto the boundaries of an
+            // element (we only fire it in the first because it bubbles), or when the pointer has
+            // moved from our children to ours.
+            //
+            // The below condition adresses both situations.
+            let has_to_dispatch_mouse_over = index == 0 && is_different_topmost_target;
+
+            if has_to_dispatch_mouse_over {
                 let target = target.upcast();
-
                 if let Some(client_point) = client_point {
                     self.fire_mouse_event(client_point, target, "mouseover".to_owned());
                 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -798,81 +798,33 @@ impl Document {
     pub fn handle_mouse_move_event(&self,
                                    js_runtime: *mut JSRuntime,
                                    client_point: Option<Point2D<f32>>,
-                                   prev_mouse_over_targets: &mut RootedVec<JS<Element>>) {
-        // Build a list of elements that are currently under the mouse.
-        let mouse_over_address = client_point.as_ref().map(|client_point| {
-            let page_point = Point2D::new(client_point.x + self.window.PageXOffset() as f32,
-                                          client_point.y + self.window.PageYOffset() as f32);
-            self.hit_test(&page_point, true)
-        }).unwrap_or(None);
+                                   prev_mouse_over_target: &MutNullableHeap<JS<Element>>) {
+        let page_point = match client_point {
+            None => {
+                // If there's no point, there's no target under the mouse
+                // FIXME: dispatch mouseout here. We have no point.
+                prev_mouse_over_target.set(None);
+                return;
+            }
+            Some(ref client_point) => {
+                Point2D::new(client_point.x + self.window.PageXOffset() as f32,
+                             client_point.y + self.window.PageYOffset() as f32)
+            }
+        };
 
-        let mut mouse_over_targets = RootedVec::<JS<Element>>::new();
+        let client_point = client_point.unwrap();
 
-        if let Some(address) = mouse_over_address {
+        let maybe_new_target = self.hit_test(&page_point, true).and_then(|address| {
             let node = node::from_untrusted_node_address(js_runtime, address);
-            for node in node.inclusive_ancestors()
-                            .filter_map(Root::downcast::<Element>) {
-                mouse_over_targets.push(JS::from_rooted(&node));
-            }
-        }
+            node.inclusive_ancestors()
+                .filter_map(Root::downcast::<Element>)
+                .next()
+        });
 
-        // Werther the topmost element we are hovering now is diffrent than the previous
-        let is_different_topmost_target = mouse_over_targets.is_empty() ||
-                                          prev_mouse_over_targets.is_empty() ||
-                                          prev_mouse_over_targets[0].upcast::<Node>().to_trusted_node_address() !=
-                                              mouse_over_targets[0].upcast::<Node>().to_trusted_node_address();
-
-        // Remove hover from any elements in the previous list that are no longer
-        // under the mouse.
-        for (index, target) in prev_mouse_over_targets.iter().enumerate() {
-            // Hover state is reset as appropiate later
-            target.set_hover_state(false);
-
-            // https://www.w3.org/TR/uievents/#event-type-mouseout
-            //
-            // mouseout must be dispatched when the mouse moves off an element or when pointer
-            // mouse moves from an element onto the boundaries of one of its descendent elements.
-            let has_to_dispatch_mouse_out = index == 0 && is_different_topmost_target;
-
-            if has_to_dispatch_mouse_out {
-                let target = target.upcast();
-                if let Some(client_point) = client_point {
-                    self.fire_mouse_event(client_point, &target, "mouseout".to_owned());
-                }
-            }
-        }
-
-        // Set hover state for any elements in the current mouse over list.
-        // Check if any of them changed state to determine whether to
-        // force a reflow below.
-        for (index, target) in mouse_over_targets.r().iter().enumerate() {
-            target.set_hover_state(true);
-
-            // https://www.w3.org/TR/uievents/#event-type-mouseover
-            //
-            // Mouseover must be fired when a pointing device is moved onto the boundaries of an
-            // element (we only fire it in the first because it bubbles), or when the pointer has
-            // moved from our children to ours.
-            //
-            // The below condition adresses both situations.
-            let has_to_dispatch_mouse_over = index == 0 && is_different_topmost_target;
-
-            if has_to_dispatch_mouse_over {
-                let target = target.upcast();
-                if let Some(client_point) = client_point {
-                    self.fire_mouse_event(client_point, target, "mouseover".to_owned());
-                }
-            }
-        }
-
-        // Send mousemove event to topmost target
-        if let Some(address) = mouse_over_address {
-            let top_most_node = node::from_untrusted_node_address(js_runtime,
-                                                                  address);
-            let client_point = client_point.unwrap(); // Must succeed because hit test succeeded.
-
+        // Send mousemove event to topmost target, and forward it if it's an iframe
+        if let Some(ref new_target) = maybe_new_target {
             // If the target is an iframe, forward the event to the child document.
-            if let Some(iframe) = top_most_node.downcast::<HTMLIFrameElement>() {
+            if let Some(iframe) = new_target.downcast::<HTMLIFrameElement>() {
                 if let Some(pipeline_id) = iframe.pipeline_id() {
                     let rect = iframe.upcast::<Element>().GetBoundingClientRect();
                     let child_origin = Point2D::new(rect.X() as f32, rect.Y() as f32);
@@ -884,13 +836,59 @@ impl Document {
                 return;
             }
 
-            let target = top_most_node.upcast();
-            self.fire_mouse_event(client_point, target, "mousemove".to_owned());
+            self.fire_mouse_event(client_point, new_target.upcast(), "mousemove".to_owned());
         }
 
-        // Store the current mouse over targets for next frame
-        prev_mouse_over_targets.clear();
-        prev_mouse_over_targets.append(&mut *mouse_over_targets);
+        // Nothing more to do here, mousemove is sent,
+        // and the element under the mouse hasn't changed.
+        if maybe_new_target == prev_mouse_over_target.get() {
+            return;
+        }
+
+        let old_target_is_ancestor_of_new_target = match (prev_mouse_over_target.get(), maybe_new_target.as_ref()) {
+            (Some(old_target), Some(new_target))
+                => old_target.upcast::<Node>().is_ancestor_of(new_target.upcast::<Node>()),
+            _   => false,
+        };
+
+        // Here we know the target has changed, so we must update the state,
+        // dispatch mouseout to the previous one, mouseover to the new one,
+        if let Some(old_target) = prev_mouse_over_target.get() {
+            // If the old target is an ancestor of the new target, this can be skipped
+            // completely, since the node's hover state will be reseted below.
+            if !old_target_is_ancestor_of_new_target {
+                for element in old_target.upcast::<Node>()
+                                         .inclusive_ancestors()
+                                         .filter_map(Root::downcast::<Element>) {
+                    element.set_hover_state(false);
+                }
+            }
+
+            // Remove hover state to old target and its parents
+            self.fire_mouse_event(client_point, old_target.upcast(), "mouseout".to_owned());
+
+            // TODO: Fire mouseleave here only if the old target is
+            // not an ancestor of the new target.
+        }
+
+        if let Some(ref new_target) = maybe_new_target {
+            for element in new_target.upcast::<Node>()
+                                     .inclusive_ancestors()
+                                     .filter_map(Root::downcast::<Element>) {
+                if element.get_hover_state() {
+                    break;
+                }
+
+                element.set_hover_state(true);
+            }
+
+            self.fire_mouse_event(client_point, &new_target.upcast(), "mouseover".to_owned());
+
+            // TODO: Fire mouseenter here.
+        }
+
+        // Store the current mouse over target for next frame.
+        prev_mouse_over_target.set(maybe_new_target.as_ref().map(|target| target.r()));
 
         self.window.reflow(ReflowGoal::ForDisplay,
                            ReflowQueryType::NoQuery,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -574,11 +574,11 @@ impl Document {
         }
     }
 
-    pub fn get_nodes_under_mouse(&self, page_point: &Point2D<f32>) -> Vec<UntrustedNodeAddress> {
+    pub fn get_node_under_mouse(&self, page_point: &Point2D<f32>) -> Option<UntrustedNodeAddress> {
         assert!(self.GetDocumentElement().is_some());
         match self.window.layout().mouse_over(*page_point) {
-            Ok(MouseOverResponse(node_address)) => node_address,
-            Err(()) => vec![],
+            Ok(MouseOverResponse(node_address)) => Some(node_address),
+            Err(()) => None,
         }
     }
 
@@ -808,18 +808,21 @@ impl Document {
                                    client_point: Option<Point2D<f32>>,
                                    prev_mouse_over_targets: &mut RootedVec<JS<Element>>) {
         // Build a list of elements that are currently under the mouse.
-        let mouse_over_addresses = client_point.as_ref().map(|client_point| {
+        let mouse_over_address = client_point.as_ref().map(|client_point| {
             let page_point = Point2D::new(client_point.x + self.window.PageXOffset() as f32,
                                           client_point.y + self.window.PageYOffset() as f32);
-            self.get_nodes_under_mouse(&page_point)
-        }).unwrap_or(vec![]);
-        let mut mouse_over_targets = mouse_over_addresses.iter().map(|node_address| {
-            node::from_untrusted_node_address(js_runtime, *node_address)
-                .inclusive_ancestors()
-                .filter_map(Root::downcast::<Element>)
-                .next()
-                .unwrap()
-        }).collect::<RootedVec<JS<Element>>>();
+            self.get_node_under_mouse(&page_point)
+        }).unwrap_or(None);
+
+        let mut mouse_over_targets = RootedVec::<JS<Element>>::new();
+
+        if let Some(address) = mouse_over_address {
+            let node = node::from_untrusted_node_address(js_runtime, address);
+            for node in node.inclusive_ancestors()
+                            .filter_map(Root::downcast::<Element>) {
+                mouse_over_targets.push(JS::from_rooted(&node));
+            }
+        }
 
         // Remove hover from any elements in the previous list that are no longer
         // under the mouse.
@@ -856,9 +859,9 @@ impl Document {
         }
 
         // Send mousemove event to topmost target
-        if mouse_over_addresses.len() > 0 {
+        if let Some(address) = mouse_over_address {
             let top_most_node = node::from_untrusted_node_address(js_runtime,
-                                                                  mouse_over_addresses[0]);
+                                                                  address);
             let client_point = client_point.unwrap(); // Must succeed because hit test succeeded.
 
             // If the target is an iframe, forward the event to the child document.

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -80,7 +80,7 @@ use html5ever::tree_builder::{LimitedQuirks, NoQuirks, Quirks, QuirksMode};
 use ipc_channel::ipc::{self, IpcSender};
 use js::jsapi::JS_GetRuntime;
 use js::jsapi::{JSContext, JSObject, JSRuntime};
-use layout_interface::{HitTestResponse, MouseOverResponse};
+use layout_interface::HitTestResponse;
 use layout_interface::{LayoutChan, Msg, ReflowQueryType};
 use msg::constellation_msg::{ALT, CONTROL, SHIFT, SUPER};
 use msg::constellation_msg::{ConstellationChan, Key, KeyModifiers, KeyState};
@@ -563,22 +563,14 @@ impl Document {
                 .map(Root::upcast)
     }
 
-    pub fn hit_test(&self, page_point: &Point2D<f32>) -> Option<UntrustedNodeAddress> {
+    pub fn hit_test(&self, page_point: &Point2D<f32>, update_cursor: bool) -> Option<UntrustedNodeAddress> {
         assert!(self.GetDocumentElement().is_some());
-        match self.window.layout().hit_test(*page_point) {
+        match self.window.layout().hit_test(*page_point, update_cursor) {
             Ok(HitTestResponse(node_address)) => Some(node_address),
             Err(()) => {
                 debug!("layout query error");
                 None
             }
-        }
-    }
-
-    pub fn get_node_under_mouse(&self, page_point: &Point2D<f32>) -> Option<UntrustedNodeAddress> {
-        assert!(self.GetDocumentElement().is_some());
-        match self.window.layout().mouse_over(*page_point) {
-            Ok(MouseOverResponse(node_address)) => Some(node_address),
-            Err(()) => None,
         }
     }
 
@@ -693,7 +685,7 @@ impl Document {
 
         let page_point = Point2D::new(client_point.x + self.window.PageXOffset() as f32,
                                       client_point.y + self.window.PageYOffset() as f32);
-        let node = match self.hit_test(&page_point) {
+        let node = match self.hit_test(&page_point, false) {
             Some(node_address) => {
                 debug!("node address is {:?}", node_address);
                 node::from_untrusted_node_address(js_runtime, node_address)
@@ -811,7 +803,7 @@ impl Document {
         let mouse_over_address = client_point.as_ref().map(|client_point| {
             let page_point = Point2D::new(client_point.x + self.window.PageXOffset() as f32,
                                           client_point.y + self.window.PageYOffset() as f32);
-            self.get_node_under_mouse(&page_point)
+            self.hit_test(&page_point, true)
         }).unwrap_or(None);
 
         let mut mouse_over_targets = RootedVec::<JS<Element>>::new();
@@ -918,7 +910,7 @@ impl Document {
             TouchEventType::Cancel => "touchcancel",
         };
 
-        let node = match self.hit_test(&point) {
+        let node = match self.hit_test(&point, false) {
             Some(node_address) => node::from_untrusted_node_address(js_runtime, node_address),
             None => return false,
         };
@@ -2585,7 +2577,7 @@ impl DocumentMethods for Document {
 
         let js_runtime = unsafe { JS_GetRuntime(window.get_cx()) };
 
-        match self.hit_test(point)  {
+        match self.hit_test(point, false)  {
             Some(untrusted_node_address) => {
                 let node = node::from_untrusted_node_address(js_runtime, untrusted_node_address);
                 let parent_node = node.GetParentNode().unwrap();

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -518,7 +518,11 @@ impl Node {
     }
 
     pub fn is_inclusive_ancestor_of(&self, parent: &Node) -> bool {
-        self == parent || parent.ancestors().any(|ancestor| ancestor.r() == self)
+        self == parent || self.is_ancestor_of(parent)
+    }
+
+    pub fn is_ancestor_of(&self, parent: &Node) -> bool {
+        parent.ancestors().any(|ancestor| ancestor.r() == self)
     }
 
     pub fn following_siblings(&self) -> NodeSiblingIterator {

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -105,9 +105,7 @@ pub trait LayoutRPC {
     /// Requests the geometry of this node. Used by APIs such as `clientTop`.
     fn node_geometry(&self) -> NodeGeometryResponse;
     /// Requests the node containing the point of interest
-    fn hit_test(&self, point: Point2D<f32>) -> Result<HitTestResponse, ()>;
-    /// Query layout for the topmost node under the mouse.
-    fn mouse_over(&self, point: Point2D<f32>) -> Result<MouseOverResponse, ()>;
+    fn hit_test(&self, point: Point2D<f32>, update_cursor: bool) -> Result<HitTestResponse, ()>;
     /// Query layout for the resolved value of a given CSS property
     fn resolved_style(&self) -> ResolvedStyleResponse;
     fn offset_parent(&self) -> OffsetParentResponse;
@@ -140,7 +138,6 @@ pub struct NodeGeometryResponse {
     pub client_rect: Rect<i32>,
 }
 pub struct HitTestResponse(pub UntrustedNodeAddress);
-pub struct MouseOverResponse(pub UntrustedNodeAddress);
 pub struct ResolvedStyleResponse(pub Option<String>);
 
 #[derive(Clone)]

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -106,6 +106,7 @@ pub trait LayoutRPC {
     fn node_geometry(&self) -> NodeGeometryResponse;
     /// Requests the node containing the point of interest
     fn hit_test(&self, point: Point2D<f32>) -> Result<HitTestResponse, ()>;
+    /// Query layout for the topmost node under the mouse.
     fn mouse_over(&self, point: Point2D<f32>) -> Result<MouseOverResponse, ()>;
     /// Query layout for the resolved value of a given CSS property
     fn resolved_style(&self) -> ResolvedStyleResponse;
@@ -139,7 +140,7 @@ pub struct NodeGeometryResponse {
     pub client_rect: Rect<i32>,
 }
 pub struct HitTestResponse(pub UntrustedNodeAddress);
-pub struct MouseOverResponse(pub Vec<UntrustedNodeAddress>);
+pub struct MouseOverResponse(pub UntrustedNodeAddress);
 pub struct ResolvedStyleResponse(pub Option<String>);
 
 #[derive(Clone)]

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -34513,6 +34513,14 @@
   "local_changes": {
     "deleted": [],
     "items": {
+      "manual": {
+        "uievents/order-of-events/mouse-events/mouseover-out-manual.html": [
+          {
+            "path": "uievents/order-of-events/mouse-events/mouseover-out-manual.html",
+            "url": "/uievents/order-of-events/mouse-events/mouseover-out-manual.html"
+          }
+        ]
+      },
       "testharness": {
         "dom/lists/DOMTokenList-value.html": [
           {

--- a/tests/wpt/web-platform-tests/uievents/order-of-events/mouse-events/mouseover-out-manual.html
+++ b/tests/wpt/web-platform-tests/uievents/order-of-events/mouse-events/mouseover-out-manual.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Mouseover/mouseout handling</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#outer,
+#inner,
+#released {
+  padding: 10px;
+  margin: 10px;
+  height: 15px;
+}
+
+#outer:hover,
+#inner:hover,
+#released:hover {
+  background: red;
+}
+
+#outer {
+  background: blue;
+}
+
+#inner {
+  background: green;
+}
+
+#released {
+  background: yellow;
+}
+</style>
+<p>
+  Steps:
+
+  <ol>
+    <li>Move your mouse over the blue <code>&lt;div&gt;</code> element, later
+      over the green one, later over the yellow one.
+    <li>Move the mouse from the yellow element to the green one, later to the
+      blue one, and later over this paragraph.
+  </ol>
+</p>
+
+
+<div id="outer">
+  <div id="inner"></div>
+</div>
+<div id="released"></div>
+
+<div id="log"></div>
+
+<script>
+var t = async_test("Mouseover/out events");
+var outer = document.getElementById("outer");
+var inner = document.getElementById("inner");
+
+var inner_over = 0;
+var inner_out = 0;
+
+var outer_own_over = 0;
+var outer_own_out = 0;
+var outer_over = 0;
+var outer_out = 0;
+
+
+inner.addEventListener("mouseover", t.step_func(function(e) {
+  assert_true(inner_over == inner_out, "mouseover is received before mouseout");
+
+  switch (inner_over) {
+    case 0:
+      assert_true(outer_own_over == 1, "should have triggered a mouseover in the outer before");
+      break;
+    case 1:
+      assert_true(outer_own_over == 1, "should have not triggered a mouseover in the outer before");
+      break;
+    default:
+      assert_true(false, "should not get more than two mouseovers");
+  }
+
+  inner_over++;
+}), false);
+
+inner.addEventListener("mouseout", t.step_func(function(e) {
+  assert_true(inner_over == inner_out + 1, "mouseout is received after mouseover");
+
+  switch (inner_out) {
+    case 0:
+      assert_true(outer_own_out == 1, "mouseout should have been received in the parent when hovering over this element");
+      break;
+    case 1:
+      break;
+    default:
+      assert_true(false, "should not get more than two mouseouts");
+  }
+
+  inner_out++;
+}), false);
+
+outer.addEventListener("mouseover", t.step_func(function(e) {
+  if (e.target == outer) {
+    assert_true(outer_own_over == outer_own_out, "outer: mouseover is received before mouseout");
+    outer_own_over++;
+  } else {
+    assert_true(outer_over - outer_own_over == inner_over - 1, "mouseover: should only receive this via bubbling");
+  }
+
+  outer_over++;
+}), false);
+
+outer.addEventListener('mouseout', t.step_func(function(e) {
+  if (e.target == outer) {
+    assert_true(outer_own_over == outer_own_out + 1, "outer: mouseout is received after mouseover");
+    if (outer_own_out == 1) {
+      assert_true(inner_out == 2, "inner should be done now");
+      t.done();
+    }
+
+    outer_own_out++;
+  } else {
+    assert_true(outer_out - outer_own_out == inner_out - 1, "mouseout: should only receive this via bubbling");
+  }
+
+  outer_out++;
+}), false);
+</script>


### PR DESCRIPTION
Now we only query for the topmost node, and apply the hover state to all
of the parent elements.

This fixes things like #9705, where the hover state was applied only to
the children.

This also makes us more conformant with other browsers in the case of
taking in account margins and paddings.

For example, prior to this PR, when your mouse was over the inner
element, in the bottom part, `hover` styles didn't apply to the parent.

``` html
<style>
div {
  padding: 10px;
  margin: 10px;
  height: 15px;
  background: blue;
}

div:hover {
  background: red;
}
</style>

<div>
  <div></div>
</div>
```

Fixes #9705

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9715)

<!-- Reviewable:end -->
