### PR TITLE
Dirty elements whose selectors are affected by sibling changes

### DIFF
--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -70,7 +70,7 @@ heapsize_plugin = "0.1.2"
 libc = "0.2"
 log = "0.3"
 rustc-serialize = "0.3"
-selectors = {version = "0.5", features = ["heap_size"]}
+selectors = {version = "0.5.1", features = ["heap_size"]}
 serde = "0.6"
 serde_json = "0.6"
 serde_macros = "0.6"

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -53,7 +53,7 @@ use script::dom::node::{CAN_BE_FRAGMENTED, HAS_CHANGED, HAS_DIRTY_DESCENDANTS, I
 use script::dom::node::{LayoutNodeHelpers, Node, OpaqueStyleAndLayoutData};
 use script::dom::text::Text;
 use script::layout_interface::TrustedNodeAddress;
-use selectors::matching::DeclarationBlock;
+use selectors::matching::{DeclarationBlock, ElementFlags};
 use selectors::parser::{AttrSelector, NamespaceConstraint};
 use smallvec::VecLike;
 use std::borrow::ToOwned;
@@ -603,6 +603,10 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
         unsafe {
             self.element.html_element_in_html_document_for_layout()
         }
+    }
+
+    fn insert_flags(&self, flags: ElementFlags) {
+        self.element.insert_atomic_flags(flags);
     }
 }
 

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -79,7 +79,7 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::mpsc::{Receiver, Sender};
 use string_cache::{Atom, Namespace, QualName};
 use style::attr::{AttrIdentifier, AttrValue};
@@ -265,7 +265,7 @@ impl<A: JSTraceable, B: JSTraceable, C: JSTraceable> JSTraceable for (A, B, C) {
     }
 }
 
-no_jsmanaged_fields!(bool, f32, f64, String, Url, AtomicBool, Uuid);
+no_jsmanaged_fields!(bool, f32, f64, String, Url, AtomicBool, AtomicUsize, Uuid);
 no_jsmanaged_fields!(usize, u8, u16, u32, u64);
 no_jsmanaged_fields!(isize, i8, i16, i32, i64);
 no_jsmanaged_fields!(Sender<T>);

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "script 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1619,7 +1619,7 @@ dependencies = [
  "ref_slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1884,7 +1884,7 @@ dependencies = [
  "num 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1904,7 +1904,7 @@ dependencies = [
  "euclid 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "plugins 0.0.1",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
@@ -1925,7 +1925,7 @@ dependencies = [
  "num 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2088,7 +2088,7 @@ dependencies = [
  "plugins 0.0.1",
  "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -941,7 +941,7 @@ dependencies = [
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "script 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1505,7 +1505,7 @@ dependencies = [
  "ref_slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1798,7 +1798,7 @@ dependencies = [
  "num 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1822,7 +1822,7 @@ dependencies = [
  "num 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1985,7 +1985,7 @@ dependencies = [
  "plugins 0.0.1",
  "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
@@ -352,7 +352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "selectors"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -429,7 +429,7 @@ dependencies = [
  "num 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,7 +453,7 @@ dependencies = [
  "num 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -537,7 +537,7 @@ dependencies = [
  "plugins 0.0.1",
  "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "script 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1486,7 +1486,7 @@ dependencies = [
  "ref_slice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1777,7 +1777,7 @@ dependencies = [
  "num 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1801,7 +1801,7 @@ dependencies = [
  "num 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1964,7 +1964,7 @@ dependencies = [
  "plugins 0.0.1",
  "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -39,9 +39,9 @@ macro_rules! sizeof_checker (
 // Update the sizes here
 sizeof_checker!(size_event_target, EventTarget, 40);
 sizeof_checker!(size_node, Node, 160);
-sizeof_checker!(size_element, Element, 304);
-sizeof_checker!(size_htmlelement, HTMLElement, 320);
-sizeof_checker!(size_div, HTMLDivElement, 320);
-sizeof_checker!(size_span, HTMLSpanElement, 320);
+sizeof_checker!(size_element, Element, 312);
+sizeof_checker!(size_htmlelement, HTMLElement, 328);
+sizeof_checker!(size_div, HTMLDivElement, 328);
+sizeof_checker!(size_span, HTMLSpanElement, 328);
 sizeof_checker!(size_text, Text, 192);
 sizeof_checker!(size_characterdata, CharacterData, 192);

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-stacking-003.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-stacking-003.htm.ini
@@ -1,3 +1,0 @@
-[transform-stacking-003.htm]
-  type: reftest
-  disabled: https://github.com/servo/servo/issues/9303

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-stacking-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-stacking-004.htm.ini
@@ -1,3 +1,0 @@
-[transform-stacking-004.htm]
-  type: reftest
-  disabled: https://github.com/servo/servo/issues/9448

--- a/tests/wpt/mozilla/meta/css/last_of_type_pseudo_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/last_of_type_pseudo_a.html.ini
@@ -1,3 +1,0 @@
-[last_of_type_pseudo_a.html]
-  type: reftest
-  disabled: https://github.com/servo/servo/issues/8191

--- a/tests/wpt/mozilla/meta/css/nth_last_of_type_pseudo_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/nth_last_of_type_pseudo_a.html.ini
@@ -1,3 +1,0 @@
-[nth_last_of_type_pseudo_a.html]
-  type: reftest
-  disabled: https://github.com/servo/servo/issues/9063


### PR DESCRIPTION
This fixes incremental layout of nodes that match pseudo-class selectors such as :first-child, :nth-child, :last-child, :first-of-type, etc.  Fixes #8191 and other intermittent layout bugs.

This code is based on the following flags from Gecko:
https://hg.mozilla.org/mozilla-central/file/e1cf617a1f28/dom/base/nsINode.h#l134

Depends on servo/rust-selectors#71. r? @SimonSapin

There are a couple of TODO items in this commit, but I'd appreciate feedback on the general approach before I finish it up.  (Also, if someone who knows more than I do could give some advice about atomic orderings...)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9722)

<!-- Reviewable:end -->
