### PR TITLE
Stop returning an Option from Window::browsing_context.

### DIFF
--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -395,7 +395,7 @@ pub unsafe extern "C" fn outerize_global(_cx: *mut JSContext, obj: HandleObject)
     debug!("outerizing");
     let win = root_from_handleobject::<window::Window>(obj).unwrap();
     let context = win.browsing_context();
-    context.as_ref().unwrap().window_proxy()
+    context.window_proxy()
 }
 
 /// Deletes the property `id` from `object`.

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -314,8 +314,8 @@ impl Window {
         &self.compositor
     }
 
-    pub fn browsing_context(&self) -> Option<Root<BrowsingContext>> {
-        self.browsing_context.get()
+    pub fn browsing_context(&self) -> Root<BrowsingContext> {
+        self.browsing_context.get().unwrap()
     }
 
     pub fn page(&self) -> &Page {
@@ -426,7 +426,7 @@ impl WindowMethods for Window {
 
     // https://html.spec.whatwg.org/multipage/#dom-document-2
     fn Document(&self) -> Root<Document> {
-        self.browsing_context().as_ref().unwrap().active_document()
+        self.browsing_context().active_document()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-location
@@ -456,7 +456,7 @@ impl WindowMethods for Window {
 
     // https://html.spec.whatwg.org/multipage/#dom-frameelement
     fn GetFrameElement(&self) -> Option<Root<Element>> {
-        self.browsing_context().as_ref().unwrap().frame_element().map(Root::from_ref)
+        self.browsing_context().frame_element().map(Root::from_ref)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator
@@ -1283,12 +1283,12 @@ impl Window {
     }
 
     pub fn parent(&self) -> Option<Root<Window>> {
-        let browsing_context = self.browsing_context().unwrap();
+        let browsing_context = self.browsing_context();
 
         browsing_context.frame_element().map(|frame_element| {
             let window = window_from_node(frame_element);
             let context = window.browsing_context();
-            context.unwrap().active_window()
+            context.active_window()
         })
     }
 }


### PR DESCRIPTION
A Window always has a WindowProxy; the only reason it's wrapped in a nullable
field is the order in which those objects are created.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9729)

<!-- Reviewable:end -->
