### PR TITLE
Fix the "get the parent" loop when dispatching event (fixes #6733)

### DIFF
--- a/tests/wpt/metadata-css/css-transitions-1_dev/html/before-load-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transitions-1_dev/html/before-load-001.htm.ini
@@ -1,3 +1,5 @@
 [before-load-001.htm]
   type: testharness
-  expected: TIMEOUT
+  [transition height from 10px to 100px / events]
+    expected: FAIL
+

--- a/tests/wpt/metadata/DOMEvents/tests/approved/DOM.event.flow.html.ini
+++ b/tests/wpt/metadata/DOMEvents/tests/approved/DOM.event.flow.html.ini
@@ -1,5 +1,0 @@
-[DOM.event.flow.html]
-  type: testharness
-  [Test Description: Dispatch an event in a DOM tree using the DOM event flow.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/DOMEvents/tests/approved/stopImmediatePropagation.effect.html.ini
+++ b/tests/wpt/metadata/DOMEvents/tests/approved/stopImmediatePropagation.effect.html.ini
@@ -1,5 +1,0 @@
-[stopImmediatePropagation.effect.html]
-  type: testharness
-  [Test Description: stopImmediatePropagation() prevents other event listeners from being triggered and, unlike Event.stopPropagation(), its effect must be immediate. Once it has been called, further calls to this method have no additional effect.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/DOMEvents/tests/approved/stopPropagation.deferred.effect.html.ini
+++ b/tests/wpt/metadata/DOMEvents/tests/approved/stopPropagation.deferred.effect.html.ini
@@ -1,5 +1,0 @@
-[stopPropagation.deferred.effect.html]
-  type: testharness
-  [Test Description: stopPropagation() prevents other event listeners from being triggered but its effect must be deferred until all event listeners attached on the Event.currentTarget have been triggered.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/DOMEvents/tests/submissions/Microsoft/converted/DOM.event.flow.html.ini
+++ b/tests/wpt/metadata/DOMEvents/tests/submissions/Microsoft/converted/DOM.event.flow.html.ini
@@ -1,5 +1,0 @@
-[DOM.event.flow.html]
-  type: testharness
-  [Test Description: Dispatch an event in a DOM tree using the DOM event flow.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/DOMEvents/tests/submissions/Microsoft/converted/EventListener.dispatch.new.event.html.ini
+++ b/tests/wpt/metadata/DOMEvents/tests/submissions/Microsoft/converted/EventListener.dispatch.new.event.html.ini
@@ -1,5 +1,0 @@
-[EventListener.dispatch.new.event.html]
-  type: testharness
-  [Test Description: Implementations of the DOM event model must be reentrant. Event listeners may perform actions that cause additional events to be dispatched. Such events are handled in a synchronous manner, the event propagation that causes the event listener to be triggered must resume only after the event dispatch of the new event is completed.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/DOMEvents/tests/submissions/Microsoft/converted/stopImmediatePropagation.effect.html.ini
+++ b/tests/wpt/metadata/DOMEvents/tests/submissions/Microsoft/converted/stopImmediatePropagation.effect.html.ini
@@ -1,5 +1,0 @@
-[stopImmediatePropagation.effect.html]
-  type: testharness
-  [Test Description: stopImmediatePropagation() prevents other event listeners from being triggered and, unlike Event.stopPropagation(), its effect must be immediate. Once it has been called, further calls to this method have no additional effect.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/DOMEvents/tests/submissions/Microsoft/converted/stopPropagation.deferred.effect.html.ini
+++ b/tests/wpt/metadata/DOMEvents/tests/submissions/Microsoft/converted/stopPropagation.deferred.effect.html.ini
@@ -1,5 +1,0 @@
-[stopPropagation.deferred.effect.html]
-  type: testharness
-  [Test Description: stopPropagation() prevents other event listeners from being triggered but its effect must be deferred until all event listeners attached on the Event.currentTarget have been triggered.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/events/Event-dispatch-bubbles-false.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-dispatch-bubbles-false.html.ini
@@ -1,5 +1,0 @@
-[Event-dispatch-bubbles-false.html]
-  type: testharness
-  [In document with a browsing context: Event.dispatchEvent with Event.bubbles set to false.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/events/Event-dispatch-bubbles-false.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-dispatch-bubbles-false.html.ini
@@ -1,5 +1,5 @@
 [Event-dispatch-bubbles-false.html]
   type: testharness
-  [Event.dispatchEvent with Event.bubbles set to false.]
+  [In document with a browsing context: Event.dispatchEvent with Event.bubbles set to false.]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/events/Event-dispatch-handlers-changed.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-dispatch-handlers-changed.html.ini
@@ -1,5 +1,0 @@
-[Event-dispatch-handlers-changed.html]
-  type: testharness
-  [ Dispatch additional events inside an event listener ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/events/Event-dispatch-omitted-capture.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-dispatch-omitted-capture.html.ini
@@ -1,5 +1,0 @@
-[Event-dispatch-omitted-capture.html]
-  type: testharness
-  [EventTarget.addEventListener with the capture argument omitted]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/events/Event-dispatch-reenter.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-dispatch-reenter.html.ini
@@ -1,5 +1,0 @@
-[Event-dispatch-reenter.html]
-  type: testharness
-  [ Dispatch additional events inside an event listener ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/events/Event-dispatch-target-moved.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-dispatch-target-moved.html.ini
@@ -1,5 +1,0 @@
-[Event-dispatch-target-moved.html]
-  type: testharness
-  [Event propagation path when an element in it is moved within the DOM]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/events/Event-dispatch-target-removed.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-dispatch-target-removed.html.ini
@@ -1,5 +1,0 @@
-[Event-dispatch-target-removed.html]
-  type: testharness
-  [Event propagation path when an element in it is removed from the DOM]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/112.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/112.html.ini
@@ -1,0 +1,5 @@
+[112.html]
+  type: testharness
+  [ scheduler: removing async attribute at runtime, script also has defer attribute]
+    expected: FAIL
+

--- a/tests/wpt/web-platform-tests/dom/events/Event-dispatch-bubbles-false.html
+++ b/tests/wpt/web-platform-tests/dom/events/Event-dispatch-bubbles-false.html
@@ -19,50 +19,63 @@
     </tbody>
 </table>
 <script>
-test(function() {
-    var event_type = "click";
-    var target = document.getElementById("target");
-    var targets = [
-        window,
+function targetsForDocumentChain(document) {
+    return [
         document,
         document.documentElement,
         document.body,
         document.getElementById("table"),
         document.getElementById("table-body"),
-        document.getElementById("parent"),
-        target,
+        document.getElementById("parent")
     ];
-    var expected_targets = targets.concat(target);
-    var phases = [
-        Event.CAPTURING_PHASE,
-        Event.CAPTURING_PHASE,
-        Event.CAPTURING_PHASE,
-        Event.CAPTURING_PHASE,
-        Event.CAPTURING_PHASE,
-        Event.CAPTURING_PHASE,
-        Event.CAPTURING_PHASE,
-        Event.AT_TARGET,
-        Event.AT_TARGET,
-    ];
+}
 
+function testChain(document, targetParents, phases, label) {
+    test(function() {
+        var event_type = "click";
+        var target = document.getElementById("target");
+        var targets = targetParents.concat(target);
+        var expected_targets = targets.concat(target);
 
-    var actual_targets = [], actual_phases = [];
-    var test_event = function(evt) {
-        actual_targets.push(evt.currentTarget);
-        actual_phases.push(evt.eventPhase);
-    }
+        var actual_targets = [], actual_phases = [];
+        var test_event = function(evt) {
+            actual_targets.push(evt.currentTarget);
+            actual_phases.push(evt.eventPhase);
+        }
 
-    for (var i = 0; i < targets.length; i++) {
-        targets[i].addEventListener(event_type, test_event, true);
-        targets[i].addEventListener(event_type, test_event, false);
-    }
+        for (var i = 0; i < targets.length; i++) {
+            targets[i].addEventListener(event_type, test_event, true);
+            targets[i].addEventListener(event_type, test_event, false);
+        }
 
-    var evt = document.createEvent("Event");
-    evt.initEvent(event_type, false, true);
+        var evt = document.createEvent("Event");
+        evt.initEvent(event_type, false, true);
 
-    target.dispatchEvent(evt);
+        target.dispatchEvent(evt);
 
-    assert_array_equals(actual_targets, expected_targets, "targets");
-    assert_array_equals(actual_phases, phases, "phases");
-}, "Event.dispatchEvent with Event.bubbles set to false.");
+        assert_array_equals(actual_targets, expected_targets, "targets");
+        assert_array_equals(actual_phases, phases, "phases");
+    }, label + ": Event.dispatchEvent with Event.bubbles set to false.");
+}
+
+var phasesForDocumentChain = [
+    Event.CAPTURING_PHASE,
+    Event.CAPTURING_PHASE,
+    Event.CAPTURING_PHASE,
+    Event.CAPTURING_PHASE,
+    Event.CAPTURING_PHASE,
+    Event.CAPTURING_PHASE,
+    Event.AT_TARGET,
+    Event.AT_TARGET,
+];
+
+chainWithWindow = [window].concat(targetsForDocumentChain(document));
+testChain(
+    document, chainWithWindow, [Event.CAPTURING_PHASE].concat(phasesForDocumentChain),
+    "In document with a browsing context");
+
+var documentClone = document.cloneNode(true);
+testChain(
+    documentClone, targetsForDocumentChain(documentClone), phasesForDocumentChain,
+    "In document without a browsing context");
 </script>

--- a/tests/wpt/web-platform-tests/dom/events/Event-dispatch-bubbles-false.html
+++ b/tests/wpt/web-platform-tests/dom/events/Event-dispatch-bubbles-false.html
@@ -30,32 +30,29 @@ function targetsForDocumentChain(document) {
     ];
 }
 
-function testChain(document, targetParents, phases, label) {
-    test(function() {
-        var event_type = "click";
-        var target = document.getElementById("target");
-        var targets = targetParents.concat(target);
-        var expected_targets = targets.concat(target);
+function testChain(document, targetParents, phases, event_type) {
+    var target = document.getElementById("target");
+    var targets = targetParents.concat(target);
+    var expected_targets = targets.concat(target);
 
-        var actual_targets = [], actual_phases = [];
-        var test_event = function(evt) {
-            actual_targets.push(evt.currentTarget);
-            actual_phases.push(evt.eventPhase);
-        }
+    var actual_targets = [], actual_phases = [];
+    var test_event = function(evt) {
+        actual_targets.push(evt.currentTarget);
+        actual_phases.push(evt.eventPhase);
+    }
 
-        for (var i = 0; i < targets.length; i++) {
-            targets[i].addEventListener(event_type, test_event, true);
-            targets[i].addEventListener(event_type, test_event, false);
-        }
+    for (var i = 0; i < targets.length; i++) {
+        targets[i].addEventListener(event_type, test_event, true);
+        targets[i].addEventListener(event_type, test_event, false);
+    }
 
-        var evt = document.createEvent("Event");
-        evt.initEvent(event_type, false, true);
+    var evt = document.createEvent("Event");
+    evt.initEvent(event_type, false, true);
 
-        target.dispatchEvent(evt);
+    target.dispatchEvent(evt);
 
-        assert_array_equals(actual_targets, expected_targets, "targets");
-        assert_array_equals(actual_phases, phases, "phases");
-    }, label + ": Event.dispatchEvent with Event.bubbles set to false.");
+    assert_array_equals(actual_targets, expected_targets, "targets");
+    assert_array_equals(actual_phases, phases, "phases");
 }
 
 var phasesForDocumentChain = [
@@ -69,13 +66,33 @@ var phasesForDocumentChain = [
     Event.AT_TARGET,
 ];
 
-chainWithWindow = [window].concat(targetsForDocumentChain(document));
-testChain(
-    document, chainWithWindow, [Event.CAPTURING_PHASE].concat(phasesForDocumentChain),
-    "In document with a browsing context");
+test(function () {
+    var chainWithWindow = [window].concat(targetsForDocumentChain(document));
+    testChain(
+        document, chainWithWindow, [Event.CAPTURING_PHASE].concat(phasesForDocumentChain), "click");
+}, "In window.document with click event");
 
-var documentClone = document.cloneNode(true);
-testChain(
-    documentClone, targetsForDocumentChain(documentClone), phasesForDocumentChain,
-    "In document without a browsing context");
+test(function () {
+    testChain(document, targetsForDocumentChain(document), phasesForDocumentChain, "load");
+}, "In window.document with load event")
+
+test(function () {
+    var documentClone = document.cloneNode(true);
+    testChain(
+        documentClone, targetsForDocumentChain(documentClone), phasesForDocumentChain, "click");
+}, "In window.document.cloneNode(true)");
+
+test(function () {
+    var newDocument = new Document();
+    newDocument.appendChild(document.documentElement.cloneNode(true));
+    testChain(
+        newDocument, targetsForDocumentChain(newDocument), phasesForDocumentChain, "click");
+}, "In new Document()");
+
+test(function () {
+    var HTMLDocument = document.implementation.createHTMLDocument();
+    HTMLDocument.body.appendChild(document.getElementById("table").cloneNode(true));
+    testChain(
+        HTMLDocument, targetsForDocumentChain(HTMLDocument), phasesForDocumentChain, "click");
+}, "In DOMImplementation.createHTMLDocument()");
 </script>


### PR DESCRIPTION
The DOM specification says:

> A document's get the parent algorithm, given an event, returns null
> if event's type attribute value is "load" or document does not have
> a browsing context, and the document's associated Window object
> otherwise.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9734)

<!-- Reviewable:end -->
