### PR TITLE
Add test for get action URL planned navigation

### DIFF
--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -34534,6 +34534,12 @@
             "url": "/dom/ranges/Range-stringifier.html"
           }
         ],
+        "html/semantics/forms/form-submission-0/getactionurl.html": [
+          {
+            "path": "html/semantics/forms/form-submission-0/getactionurl.html",
+            "url": "/html/semantics/forms/form-submission-0/getactionurl.html"
+          }
+        ],
         "html/webappapis/scripting/events/event-handler-processing-algorithm.html": [
           {
             "path": "html/webappapis/scripting/events/event-handler-processing-algorithm.html",

--- a/tests/wpt/metadata/html/semantics/forms/form-submission-0/getactionurl.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-0/getactionurl.html.ini
@@ -1,0 +1,5 @@
+[getactionurl.html]
+  type: testharness
+  [Navigating to URL with a data scheme]
+    expected: FAIL
+

--- a/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-0/getactionurl.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-0/getactionurl.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe id=testframe src="/common/blank.html"></iframe>
+<script>
+var tests = [
+  {
+    name: "Navigating to URL with a data scheme",
+    action: "data:,hello%20world",
+    output: "hello world"
+  }
+];
+tests.forEach(function(test_obj) {
+  test_obj.test = async_test(test_obj.name);
+});
+
+function run_test() {
+  if (tests.length == 0) {
+    return;
+  }
+  var test_obj = tests.pop();
+  var t = test_obj.test;
+  var testframe = document.getElementById("testframe");
+  var testdocument = testframe.contentWindow.document;
+  testdocument.body.innerHTML =
+    "<form id=testform method=get action=\"" + test_obj.action +"\"></form>";
+  testframe.onload = function() {
+    t.step(function() {
+      var body_text = testframe.contentWindow.document.textContent;
+      assert_equals(body_text, test_obj.output);
+    });
+    t.done();
+    run_test();
+  };
+  testdocument.getElementById("testform").submit();
+};
+document.getElementById("testframe").onload = run_test;
+</script>


### PR DESCRIPTION
Mutate action URL doesn't need to be tested, since the existing urlencoded.html already tests it.

This new test currently fails, because of the weirdness in calling `testframe.contentWindow`. It returns null for this test, but not for urlencoded.html. Can't figure out why.

Fixes #9690

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9735)

<!-- Reviewable:end -->
