### PR TITLE
test websocket origin set in worker

### DIFF
--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -32070,6 +32070,10 @@
         "url": "/websockets/opening-handshake/001.html"
       },
       {
+        "path": "websockets/opening-handshake/003-sets-origin.worker.js",
+        "url": "/websockets/opening-handshake/003-sets-origin.worker"
+      },
+      {
         "path": "websockets/opening-handshake/003.html",
         "url": "/websockets/opening-handshake/003.html"
       },

--- a/tests/wpt/web-platform-tests/websockets/opening-handshake/003-sets-origin.worker.js
+++ b/tests/wpt/web-platform-tests/websockets/opening-handshake/003-sets-origin.worker.js
@@ -1,0 +1,19 @@
+importScripts("/resources/testharness.js");
+importScripts('../constants.js?pipe=sub');
+importScripts('../websocket.js?pipe=sub');
+
+async_test(function(t) {
+  var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/origin');
+  ws.onmessage = t.step_func(function(e) {
+    assert_equals(e.data, location.protocol+'//'+location.host);
+    ws.onclose = t.step_func(function(e) {
+      assert_equals(e.wasClean, true);
+      ws.onclose = t.step_func(function() {assert_unreached()});
+      setTimeout(t.step_func_done(), 50)
+    })
+    ws.close();
+  })
+  ws.onerror = ws.onclose = t.step_func(function() {assert_unreached()});
+}, "W3C WebSocket API - origin set in a Worker");
+
+done();


### PR DESCRIPTION
Fixes #9535

This crashes and I'm not sure how to debug it (and whether it's a problem with the browser or more likely a problem with the test):

```
./mach test-wpt /websockets/opening-handshake/003-sets-origin.worker --log-raw wpt.log                         Running 1 tests in web-platform-tests

  ▶ CRASH [expected OK] /websockets/opening-handshake/003-sets-origin.worker

Ran 1 tests finished in 2.0 seconds.
  • 0 ran as expected. 0 tests skipped.
  • 1 tests crashed unexpectedly
```

Also, should the test file be in `/websockets/` or `/websockets/opening-handshake/`?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9737)

<!-- Reviewable:end -->
