### PR TITLE
Lint json files

### DIFF
--- a/python/tidy.py
+++ b/python/tidy.py
@@ -15,14 +15,18 @@ import StringIO
 import site
 import subprocess
 import sys
+import json
 from licenseck import licenses
 
-filetypes_to_check = [".rs", ".rc", ".cpp", ".c", ".h", ".lock", ".py", ".toml", ".webidl"]
+filetypes_to_check = [".rs", ".rc", ".cpp", ".c", ".h", ".lock", ".py", ".toml", ".webidl", ".json"]
 
 ignored_files = [
     # Generated and upstream code combined with our own. Could use cleanup
     os.path.join(".", "ports", "gonk", "src", "native_window_glue.cpp"),
     os.path.join(".", "ports", "geckolib", "bindings.rs"),
+    os.path.join(".", "resources", "hsts_preload.json"),
+    os.path.join(".", "tests", "wpt", "metadata", "MANIFEST.json"),
+    os.path.join(".", "tests", "wpt", "metadata-css", "MANIFEST.json"),
     # MIT license
     os.path.join(".", "components", "util", "deque", "mod.rs"),
     # Hidden files
@@ -81,7 +85,7 @@ MAX_LICENSE_LINESPAN = max(len(license.splitlines()) for license in licenses)
 
 
 def check_license(file_name, lines):
-    if file_name.endswith(".toml") or file_name.endswith(".lock"):
+    if any(file_name.endswith(ext) for ext in (".toml", ".lock", ".json")):
         raise StopIteration
     while lines and (lines[0].startswith(EMACS_HEADER) or lines[0].startswith(VIM_HEADER)):
         lines = lines[1:]
@@ -93,7 +97,7 @@ def check_license(file_name, lines):
 
 
 def check_length(file_name, idx, line):
-    if file_name.endswith(".lock"):
+    if file_name.endswith(".lock") or file_name.endswith(".json"):
         raise StopIteration
     max_length = 120
     if len(line.rstrip('\n')) > max_length:
@@ -469,6 +473,18 @@ def check_webidl_spec(file_name, contents):
     yield 0, "No specification link found."
 
 
+def check_json(filename, contents):
+    if not filename.endswith(".json"):
+        raise StopIteration
+
+    try:
+        json.loads(contents)
+    except ValueError as e:
+        match = re.search(r"line (\d+) ", e.message)
+        line_no = match and match.group(1)
+        yield (line_no, e.message)
+
+
 def check_spec(file_name, lines):
     base_path = "components/script/dom/"
     if base_path not in file_name:
@@ -573,7 +589,7 @@ def get_file_list(directory, only_changed_files=False, exclude_dirs=[]):
 def scan(faster=False, progress=True):
     # standard checks
     files_to_check = filter_files('.', faster, progress)
-    checking_functions = (check_flake8, check_lock, check_webidl_spec)
+    checking_functions = (check_flake8, check_lock, check_webidl_spec, check_json)
     line_checking_functions = (check_license, check_by_line, check_toml, check_rust, check_spec)
     errors = collect_errors_for_files(files_to_check, checking_functions, line_checking_functions)
 


### PR DESCRIPTION
Fixes #9745 

This is a very simple solution: try to load all json files, and catch any `ValueErrors` that pop up. Do we need something more complex?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9750)

<!-- Reviewable:end -->
