### PR TITLE
Make Fetch Protocol Asynchronous

### DIFF
--- a/components/net/fetch/response.rs
+++ b/components/net/fetch/response.rs
@@ -2,18 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use hyper::header::{AccessControlExposeHeaders, Headers};
+use hyper::header::Headers;
 use hyper::status::StatusCode;
 use net_traits::response::{CacheState, HttpsState, Response, ResponseBody, ResponseType};
 use std::ascii::AsciiExt;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::mpsc::Receiver;
 use url::Url;
 
 pub trait ResponseMethods {
     fn new() -> Response;
-    fn to_filtered(Rc<Response>, ResponseType) -> Response;
 }
 
 impl ResponseMethods for Response {
@@ -28,77 +27,9 @@ impl ResponseMethods for Response {
             body: RefCell::new(ResponseBody::Empty),
             cache_state: CacheState::None,
             https_state: HttpsState::None,
-            internal_response: None
+            internal_response: None,
+            return_internal: Cell::new(true)
         }
-    }
-
-    /// Convert to a filtered response, of type `filter_type`.
-    /// Do not use with type Error or Default
-    fn to_filtered(old_response: Rc<Response>, filter_type: ResponseType) -> Response {
-
-        assert!(filter_type != ResponseType::Error);
-        assert!(filter_type != ResponseType::Default);
-
-        if Response::is_network_error(&old_response) {
-            return Response::network_error();
-        }
-
-        let old_headers = old_response.headers.clone();
-        let mut response = (*old_response).clone();
-        response.internal_response = Some(old_response);
-        response.response_type = filter_type;
-
-        match filter_type {
-
-            ResponseType::Default | ResponseType::Error => unreachable!(),
-
-            ResponseType::Basic => {
-                let headers = old_headers.iter().filter(|header| {
-                    match &*header.name().to_ascii_lowercase() {
-                        "set-cookie" | "set-cookie2" => false,
-                        _ => true
-                    }
-                }).collect();
-                response.headers = headers;
-            },
-
-            ResponseType::CORS => {
-
-                let access = old_headers.get::<AccessControlExposeHeaders>();
-                let allowed_headers = access.as_ref().map(|v| &v[..]).unwrap_or(&[]);
-
-                let headers = old_headers.iter().filter(|header| {
-                    match &*header.name().to_ascii_lowercase() {
-                        "cache-control" | "content-language" | "content-type" |
-                        "expires" | "last-modified" | "pragma" => true,
-                        "set-cookie" | "set-cookie2" => false,
-                        header => {
-                            let result =
-                                allowed_headers.iter().find(|h| *header == *h.to_ascii_lowercase());
-                            result.is_some()
-                        }
-                    }
-                }).collect();
-                response.headers = headers;
-            },
-
-            ResponseType::Opaque => {
-                response.url_list = RefCell::new(vec![]);
-                response.url = None;
-                response.headers = Headers::new();
-                response.status = None;
-                response.body = RefCell::new(ResponseBody::Empty);
-                response.cache_state = CacheState::None;
-            },
-
-            ResponseType::OpaqueRedirect => {
-                response.headers = Headers::new();
-                response.status = None;
-                response.body = RefCell::new(ResponseBody::Empty);
-                response.cache_state = CacheState::None;
-            }
-        }
-
-        response
     }
 }
+

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -111,7 +111,7 @@ pub enum CORSSettings {
 pub struct Request {
     pub method: RefCell<Method>,
     pub local_urls_only: bool,
-    pub sanboxed_storage_area_urls: bool,
+    pub sandboxed_storage_area_urls: bool,
     pub headers: RefCell<Headers>,
     pub unsafe_request: bool,
     pub body: RefCell<Option<Vec<u8>>>,
@@ -155,7 +155,7 @@ impl Request {
          Request {
             method: RefCell::new(Method::Get),
             local_urls_only: false,
-            sanboxed_storage_area_urls: false,
+            sandboxed_storage_area_urls: false,
             headers: RefCell::new(Headers::new()),
             unsafe_request: false,
             body: RefCell::new(None),
@@ -193,7 +193,7 @@ impl Request {
         Request {
             method: RefCell::new(Method::Get),
             local_urls_only: false,
-            sanboxed_storage_area_urls: false,
+            sandboxed_storage_area_urls: false,
             headers: RefCell::new(Headers::new()),
             unsafe_request: false,
             body: RefCell::new(None),


### PR DESCRIPTION
I'm working on making it possible to run Fetch Asynchronously, as required for some steps, such as Main Fetch. It looks like somebody has already laid some groundwork for that, with a AsyncFetchListener trait and two async fetch functions defined, which I'm building on top of.

So far, as a sort of proof of concept, I've written a test to asynchronously retrieve a fetch response, which uses a simple function to check if the fetch response is complete or not. I'd like to be checked if I'm on the right path, to see if I need to rework anything so far, and what my next step can be.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9753)

<!-- Reviewable:end -->
