### PR TITLE
Trigger WebSocket error event

### DIFF
--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -107,7 +107,11 @@ pub fn init(connect: WebSocketCommunicate, connect_data: WebSocketConnectData, c
             for message in receiver.incoming_messages() {
                 let message: Message = match message {
                     Ok(m) => m,
-                    Err(_) => break,
+                    Err(e) => {
+                        debug!("Error receiving incoming WebSocket message: {:?}", e);
+                        let _ = resource_event_sender.send(WebSocketNetworkEvent::Fail);
+                        break;
+                    }
                 };
                 let message = match message.opcode {
                     Type::Text => MessageData::Text(String::from_utf8_lossy(&message.payload).into_owned()),

--- a/tests/wpt/metadata/websockets/constructor/010.html.ini
+++ b/tests/wpt/metadata/websockets/constructor/010.html.ini
@@ -1,6 +1,5 @@
 [010.html]
   type: testharness
-  expected: TIMEOUT
   [WebSockets: protocol in response but no requested protocol]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/websockets/constructor/011.html.ini
+++ b/tests/wpt/metadata/websockets/constructor/011.html.ini
@@ -1,6 +1,0 @@
-[011.html]
-  type: testharness
-  expected: TIMEOUT
-  [WebSockets: protocol mismatch]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/websockets/cookies/005.html.ini
+++ b/tests/wpt/metadata/websockets/cookies/005.html.ini
@@ -1,0 +1,4 @@
+[005.html]
+  type: testharness
+  [WebSockets: setting HttpOnly cookies in ws response, checking ws request]
+    expected: FAIL

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/015.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/015.html.ini
@@ -1,6 +1,0 @@
-[015.html]
-  type: testharness
-  expected: TIMEOUT
-  [WebSockets: instanceof on events]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/017.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/017.html.ini
@@ -1,6 +1,0 @@
-[017.html]
-  type: testharness
-  expected: TIMEOUT
-  [WebSockets: this, e.target, e.currentTarget, e.eventPhase]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/websockets/interfaces/WebSocket/events/018.html.ini
+++ b/tests/wpt/metadata/websockets/interfaces/WebSocket/events/018.html.ini
@@ -1,9 +1,0 @@
-[018.html]
-  type: testharness
-  expected: TIMEOUT
-  [error event]
-    expected: TIMEOUT
-
-  [close event]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/websockets/opening-handshake/005.html.ini
+++ b/tests/wpt/metadata/websockets/opening-handshake/005.html.ini
@@ -1,6 +1,5 @@
 [005.html]
   type: testharness
-  expected: TIMEOUT
   [WebSockets: proper first line]
-    expected: TIMEOUT
+    expected: FAIL
 


### PR DESCRIPTION
Trigger a WebSocket error after receiving an invalid message from the server. Rebased from #8868. Fixes #7861.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9757)

<!-- Reviewable:end -->
