### PR TITLE
Fixed compile error in generated code, when webidl constructors have same number of args

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -433,7 +433,7 @@ class CGMethodCall(CGThing):
             # XXXbz Now we're supposed to check for distinguishingArg being
             # an array or a platform object that supports indexed
             # properties... skip that last for now.  It's a bit of a pain.
-            pickFirstSignature("%s.get().isObject() && IsArrayLike(cx, &%s.get().toObject())" %
+            pickFirstSignature("%s.get().is_object() && is_array_like(cx, %s)" %
                                (distinguishingArg, distinguishingArg),
                                lambda s:
                                    (s[1][distinguishingIndex].type.isArray() or
@@ -442,7 +442,7 @@ class CGMethodCall(CGThing):
 
             # Check for Date objects
             # XXXbz Do we need to worry about security wrappers around the Date?
-            pickFirstSignature("%s.get().isObject() && JS_ObjectIsDate(cx, &%s.get().toObject())" %
+            pickFirstSignature("%s.get().is_object() && JS_ObjectIsDate(cx, &%s.get().to_object())" %
                                (distinguishingArg, distinguishingArg),
                                lambda s: (s[1][distinguishingIndex].type.isDate() or
                                           s[1][distinguishingIndex].type.isObject()))
@@ -5391,7 +5391,8 @@ class CGBindingRoot(CGThing):
             'dom::bindings::callback::{CallbackContainer,CallbackInterface,CallbackFunction}',
             'dom::bindings::callback::{CallSetup,ExceptionHandling}',
             'dom::bindings::callback::wrap_call_this_object',
-            'dom::bindings::conversions::{ConversionBehavior, DOM_OBJECT_SLOT, IDLInterface}',
+            'dom::bindings::conversions::{ConversionBehavior, DOM_OBJECT_SLOT}',
+            'dom::bindings::conversions::{IDLInterface, is_array_like}',
             'dom::bindings::conversions::{FromJSValConvertible, StringificationBehavior}',
             'dom::bindings::conversions::{ToJSValConvertible, jsid_to_str, native_from_handlevalue}',
             'dom::bindings::conversions::{native_from_object, private_from_object, root_from_object}',

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -47,7 +47,7 @@ use js::jsapi::{HandleId, HandleObject, HandleValue, JS_GetClass};
 use js::jsapi::{JSClass, JSContext, JSObject, MutableHandleValue};
 use js::jsapi::{JS_GetLatin1StringCharsAndLength, JS_GetReservedSlot};
 use js::jsapi::{JS_GetObjectAsArrayBufferView, JS_GetArrayBufferViewType};
-use js::jsapi::{JS_GetTwoByteStringCharsAndLength, JS_NewStringCopyN};
+use js::jsapi::{JS_GetTwoByteStringCharsAndLength, JS_IsArrayObject, JS_NewStringCopyN};
 use js::jsapi::{JS_StringHasLatin1Chars, JS_WrapValue};
 use js::jsapi::{Type};
 use js::jsval::{ObjectValue, StringValue};
@@ -457,4 +457,11 @@ pub fn array_buffer_view_to_vec_checked<T: ArrayBufferViewContents>(abv: *mut JS
     unsafe {
         array_buffer_view_data_checked(abv).map(|data| data.to_vec())
     }
+}
+
+/// Returns whether `value` is an array-like object.
+/// Note: Currently only Arrays are supported.
+/// TODO: Expand this to support sequences and other array-like objects
+pub unsafe fn is_array_like(cx: *mut JSContext, value: HandleValue) -> bool {
+    JS_IsArrayObject(cx, value)
 }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -51,6 +51,16 @@ impl TestBinding {
     pub fn Constructor(global: GlobalRef) -> Fallible<Root<TestBinding>> {
         Ok(TestBinding::new(global))
     }
+
+    #[allow(unused_variables)]
+    pub fn Constructor_(global: GlobalRef, nums: Vec<f64>) -> Fallible<Root<TestBinding>> {
+        Ok(TestBinding::new(global))
+    }
+
+    #[allow(unused_variables)]
+    pub fn Constructor__(global: GlobalRef, num: f64) -> Fallible<Root<TestBinding>> {
+        Ok(TestBinding::new(global))
+    }
 }
 
 impl TestBindingMethods for TestBinding {

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -69,7 +69,9 @@ dictionary TestDictionaryDefaults {
   object? nullableObjectValue = null;
 };
 
-[Constructor]
+[Constructor,
+ Constructor(sequence<unrestricted double> numberSequence),
+  Constructor(unrestricted double num)]
 interface TestBinding {
            attribute boolean booleanAttribute;
            attribute byte byteAttribute;


### PR DESCRIPTION
One of the ways that generated code differentiates constructors is by comparing if the args are array-like. The generated code was calling a function `IsArrayLike` that no longer exists. I re-implemented it with a more rust-like naming scheme.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9786)

<!-- Reviewable:end -->
