### PR TITLE
Use piston_image instead of stb_image for decoding JPEGs

### DIFF
--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -91,7 +91,7 @@ git = "https://github.com/servo/webrender"
 app_units = {version = "0.2.1", features = ["plugins"]}
 euclid = {version = "0.6.2", features = ["plugins"]}
 gleam = "0.2"
-image = "0.5.0"
+image = "0.7"
 log = "0.3"
 num = "0.1.24"
 serde = "0.6"

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -23,10 +23,9 @@ path = "../plugins"
 heapsize = "0.3.0"
 heapsize_plugin = "0.1.2"
 hyper = { version = "0.7", features = [ "serde-serialization" ] }
-image = "0.5.0"
+image = "0.7"
 log = "0.3"
 serde = "0.6"
 serde_macros = "0.6"
-stb_image = "0.2"
 url = {version = "0.5.5", features = ["heap_size"]}
 websocket = "0.15.0"

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -19,7 +19,6 @@ extern crate ipc_channel;
 extern crate log;
 extern crate msg;
 extern crate serde;
-extern crate stb_image;
 extern crate url;
 extern crate util;
 extern crate websocket;

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -74,7 +74,7 @@ heapsize = "0.3.0"
 heapsize_plugin = "0.1.2"
 html5ever = {version = "0.5.1", features = ["heap_size", "unstable"]}
 hyper = { version = "0.7", features = [ "serde-serialization" ] }
-image = "0.5.0"
+image = "0.7"
 libc = "0.2"
 log = "0.3"
 num = "0.1.24"

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "gfx_tests 0.0.1",
  "gleam 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin_app 0.0.1",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "layers 0.2.2 (git+https://github.com/servo/rust-layers)",
  "layout 0.0.1",
@@ -278,7 +278,7 @@ dependencies = [
  "gfx 0.0.1",
  "gfx_traits 0.0.1",
  "gleam 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "layers 0.2.2 (git+https://github.com/servo/rust-layers)",
  "layout_traits 0.0.1",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "color_quant 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -887,13 +887,14 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.5.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gif 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gif 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jpeg-decoder 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -938,6 +939,17 @@ dependencies = [
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1280,14 +1292,13 @@ dependencies = [
  "heapsize 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "plugins 0.0.1",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "stb_image 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "websocket 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1575,6 +1586,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ref_slice"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,7 +1657,7 @@ dependencies = [
  "heapsize_plugin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "js 0.1.2 (git+https://github.com/servo/rust-mozjs)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1876,14 +1897,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "stb_image"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2225,7 +2238,7 @@ version = "0.0.1"
 dependencies = [
  "compositing 0.0.1",
  "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -18,7 +18,7 @@ doc = false
 bench = false
 
 [dev-dependencies]
-image = "0.5.0"
+image = "0.7"
 
 [dev-dependencies.gfx_tests]
 path = "../../tests/unit/gfx"

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -26,7 +26,7 @@ git = "https://github.com/jgraham/webdriver-rust.git"
 git = "https://github.com/servo/ipc-channel"
 
 [dependencies]
-image = "0.5.0"
+image = "0.7"
 log = "0.3"
 hyper = "0.7"
 rustc-serialize = "0.3.4"

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -25,7 +25,6 @@ dependencies = [
  "script 0.0.1",
  "script_traits 0.0.1",
  "servo 0.0.1",
- "stb_image 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "url 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -250,7 +249,7 @@ dependencies = [
  "gfx 0.0.1",
  "gfx_traits 0.0.1",
  "gleam 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "layers 0.2.2 (git+https://github.com/servo/rust-layers)",
  "layout_traits 0.0.1",
@@ -651,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "color_quant 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -817,13 +816,14 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.5.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gif 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gif 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jpeg-decoder 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -868,6 +868,17 @@ dependencies = [
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1191,14 +1202,13 @@ dependencies = [
  "heapsize 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "plugins 0.0.1",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "stb_image 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "websocket 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1461,6 +1471,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ref_slice"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,7 +1542,7 @@ dependencies = [
  "heapsize_plugin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "js 0.1.2 (git+https://github.com/servo/rust-mozjs)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1790,14 +1810,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "stb_image"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2111,7 +2123,7 @@ version = "0.0.1"
 dependencies = [
  "compositing 0.0.1",
  "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",

--- a/ports/cef/Cargo.toml
+++ b/ports/cef/Cargo.toml
@@ -13,7 +13,6 @@ euclid = {version = "0.6.2", features = ["plugins"]}
 gleam = "0.2"
 libc = "0.2"
 log = "0.3"
-stb_image = "0.2"
 url = {version = "0.5.5", features = ["heap_size"]}
 
 [dependencies.servo]

--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -40,7 +40,6 @@ extern crate msg;
 extern crate util;
 extern crate style;
 extern crate style_traits;
-extern crate stb_image;
 
 extern crate libc;
 extern crate url as std_url;

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
  "gfx 0.0.1",
  "gfx_traits 0.0.1",
  "gleam 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "layers 0.2.2 (git+https://github.com/servo/rust-layers)",
  "layout_traits 0.0.1",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "color_quant 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -798,13 +798,14 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.5.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gif 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gif 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jpeg-decoder 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -849,6 +850,17 @@ dependencies = [
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1172,14 +1184,13 @@ dependencies = [
  "heapsize 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "plugins 0.0.1",
  "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "stb_image 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "websocket 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1442,6 +1453,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ref_slice"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,7 +1524,7 @@ dependencies = [
  "heapsize_plugin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.0 (git+https://github.com/servo/ipc-channel)",
  "js 0.1.2 (git+https://github.com/servo/rust-mozjs)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1769,14 +1790,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "stb_image"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]


### PR DESCRIPTION
The main reason stb_image was used for decoding JPEGs was the lack of progressive support in piston_image.
With version 0.7, piston_image gained support for decoding progressive JPEGs through use of the [jpeg-decoder](https://crates.io/crates/jpeg-decoder) crate.

This PR removes the dependency on stb_image and instead uses piston_image 0.7 for decoding JPEGs.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9790)

<!-- Reviewable:end -->
