### PR TITLE
forcetouch events

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -13,7 +13,7 @@ use layers::geometry::DevicePixel;
 use layers::platform::surface::NativeDisplay;
 use msg::constellation_msg::{Key, KeyModifiers, KeyState};
 use net_traits::net_error_list::NetError;
-use script_traits::{MouseButton, TouchEventType, TouchId};
+use script_traits::{MouseButton, TouchpadPressurePhase, TouchEventType, TouchId};
 use std::fmt::{Debug, Error, Formatter};
 use style_traits::cursor::Cursor;
 use url::Url;
@@ -50,6 +50,8 @@ pub enum WindowEvent {
     InitializeCompositing,
     /// Sent when the window is resized.
     Resize(TypedSize2D<DevicePixel, u32>),
+    /// Touchpad Pressure
+    TouchpadPressure(TypedPoint2D<DevicePixel, f32>, f32, TouchpadPressurePhase),
     /// Sent when you want to override the viewport.
     Viewport(TypedPoint2D<DevicePixel, u32>, TypedSize2D<DevicePixel, u32>),
     /// Sent when a new URL is to be loaded.
@@ -84,6 +86,7 @@ impl Debug for WindowEvent {
             WindowEvent::Refresh => write!(f, "Refresh"),
             WindowEvent::InitializeCompositing => write!(f, "InitializeCompositing"),
             WindowEvent::Resize(..) => write!(f, "Resize"),
+            WindowEvent::TouchpadPressure(..) => write!(f, "TouchpadPressure"),
             WindowEvent::Viewport(..) => write!(f, "Viewport"),
             WindowEvent::KeyEvent(..) => write!(f, "Key"),
             WindowEvent::LoadUrl(..) => write!(f, "LoadUrl"),

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -64,7 +64,7 @@ use net_traits::storage_thread::StorageType;
 use profile_traits::mem::ProfilerChan as MemProfilerChan;
 use profile_traits::time::ProfilerChan as TimeProfilerChan;
 use script_thread::ScriptChan;
-use script_traits::{LayoutMsg, ScriptMsg, TimerEventId, TimerSource, UntrustedNodeAddress};
+use script_traits::{LayoutMsg, ScriptMsg, TimerEventId, TimerSource, TouchpadPressurePhase, UntrustedNodeAddress};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::boxed::FnBox;
@@ -319,6 +319,7 @@ no_jsmanaged_fields!(AttrIdentifier);
 no_jsmanaged_fields!(AttrValue);
 no_jsmanaged_fields!(ElementSnapshot);
 no_jsmanaged_fields!(HttpsState);
+no_jsmanaged_fields!(TouchpadPressurePhase);
 
 impl JSTraceable for ConstellationChan<ScriptMsg> {
     #[inline]

--- a/components/script/dom/forcetouchevent.rs
+++ b/components/script/dom/forcetouchevent.rs
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::codegen::Bindings::ForceTouchEventBinding;
+use dom::bindings::codegen::Bindings::ForceTouchEventBinding::ForceTouchEventMethods;
+use dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
+use dom::bindings::global::GlobalRef;
+use dom::bindings::inheritance::Castable;
+use dom::bindings::js::{Root};
+use dom::bindings::num::Finite;
+use dom::bindings::reflector::reflect_dom_object;
+use dom::uievent::UIEvent;
+use dom::window::Window;
+use util::str::DOMString;
+
+#[dom_struct]
+pub struct ForceTouchEvent {
+    uievent: UIEvent,
+    force: f32,
+}
+
+impl ForceTouchEvent {
+    fn new_inherited(force: f32) -> ForceTouchEvent {
+        ForceTouchEvent {
+            uievent: UIEvent::new_inherited(),
+            force: force,
+        }
+    }
+
+    pub fn new(window: &Window,
+               type_: DOMString,
+               force: f32) -> Root<ForceTouchEvent> {
+        let event = box ForceTouchEvent::new_inherited(force);
+        let ev = reflect_dom_object(event, GlobalRef::Window(window), ForceTouchEventBinding::Wrap);
+        ev.upcast::<UIEvent>().InitUIEvent(type_, true, true, Some(window), 0);
+        ev
+    }
+}
+
+impl<'a> ForceTouchEventMethods for &'a ForceTouchEvent {
+
+    fn ServoForce(&self) -> Finite<f32> {
+        Finite::wrap(self.force)
+    }
+
+    fn SERVO_FORCE_AT_MOUSE_DOWN(&self) -> Finite<f32> {
+        Finite::wrap(1.0)
+    }
+
+    fn SERVO_FORCE_AT_FORCE_MOUSE_DOWN(&self) -> Finite<f32> {
+        Finite::wrap(2.0)
+    }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.uievent.IsTrusted()
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -264,6 +264,7 @@ pub mod file;
 pub mod filelist;
 pub mod filereader;
 pub mod focusevent;
+pub mod forcetouchevent;
 pub mod formdata;
 pub mod htmlanchorelement;
 pub mod htmlappletelement;

--- a/components/script/dom/webidls/ForceTouchEvent.webidl
+++ b/components/script/dom/webidls/ForceTouchEvent.webidl
@@ -1,0 +1,35 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// https://developer.apple.com/library/mac/documentation/AppleApplications/Conceptual/SafariJSProgTopics/RespondingtoForceTouchEventsfromJavaScript.html
+
+/**
+ * Events: (copy/paste from apple.com)
+ *
+ *  webkitmouseforcewillbegin: This event occurs immediately before the mousedown event. It allows you to
+ *   prevent the default system behavior, such as displaying a dictionary window when force clicking on a
+ *   word, in order to perform a custom action instead. To prevent the default system behavior, call the
+ *   preventDefault() method on the event.
+ *  webkitmouseforcedown: This event occurs after the mousedown event, once enough force has been applied
+ *   to register as a force click. The user receives haptic feedback representing the force click when this
+ *   event occurs.
+ *  webkitmouseforceup: This event occurs after a webkitmouseforcedown event, once enough force has been
+ *   released to exit the force click operation. The user receives haptic feedback representing the exit
+ *   from force click when this event occurs.
+ *  webkitmouseforcechanged: This event occurs whenever a change in trackpad force is detected between the
+ *   mousedown and mouseup events.
+ *
+ */
+
+
+[Pref="dom.forcetouch.enabled"]
+interface ForceTouchEvent : UIEvent {
+    // Represents the amount of force required to perform a regular click.
+    readonly attribute float SERVO_FORCE_AT_MOUSE_DOWN;
+    // Represents the force required to perform a force click.
+    readonly attribute float SERVO_FORCE_AT_FORCE_MOUSE_DOWN;
+    // force level
+    readonly attribute float servoForce;
+};

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -79,7 +79,7 @@ use parse::xml::{self, parse_xml};
 use profile_traits::mem::{self, OpaqueSender, Report, ReportKind, ReportsChan};
 use profile_traits::time::{self, ProfilerCategory, profile};
 use script_traits::CompositorEvent::{KeyEvent, MouseButtonEvent, MouseMoveEvent, ResizeEvent};
-use script_traits::CompositorEvent::{TouchEvent};
+use script_traits::CompositorEvent::{TouchEvent, TouchpadPressureEvent};
 use script_traits::{CompositorEvent, ConstellationControlMsg, EventResult};
 use script_traits::{InitialScriptState, MouseButton, MouseEventType, MozBrowserEvent, NewLayoutInfo};
 use script_traits::{LayoutMsg, OpaqueScriptLayoutChannel, ScriptMsg as ConstellationMsg};
@@ -1967,6 +1967,12 @@ impl ScriptThread {
                         // TODO: Calling preventDefault on a touchup event should prevent clicks.
                     }
                 }
+            }
+
+            TouchpadPressureEvent(point, pressure, phase) => {
+                let page = get_page(&self.root_page(), pipeline_id);
+                let document = page.document();
+                document.r().handle_touchpad_pressure_event(self.js_runtime.rt(), point, pressure, phase);
             }
 
             KeyEvent(key, state, modifiers) => {

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -227,8 +227,21 @@ pub enum CompositorEvent {
     MouseMoveEvent(Option<Point2D<f32>>),
     /// A touch event was generated with a touch ID and location.
     TouchEvent(TouchEventType, TouchId, Point2D<f32>),
+    /// Touchpad pressure event
+    TouchpadPressureEvent(Point2D<f32>, f32, TouchpadPressurePhase),
     /// A key was pressed.
     KeyEvent(Key, KeyState, KeyModifiers),
+}
+
+/// Touchpad pressure phase for TouchpadPressureEvent.
+#[derive(Copy, Clone, HeapSizeOf, PartialEq, Deserialize, Serialize)]
+pub enum TouchpadPressurePhase {
+    /// Pressure before a regular click.
+    BeforeClick,
+    /// Pressure after a regular click.
+    AfterFirstClick,
+    /// Pressure after a "forceTouch" click
+    AfterSecondClick,
 }
 
 /// An opaque wrapper around script<->layout channels to avoid leaking message types into

--- a/python/tidy.py
+++ b/python/tidy.py
@@ -39,6 +39,7 @@ ignored_files = [
     os.path.join(".", "resources", "hsts_preload.json"),
     os.path.join(".", "tests", "wpt", "metadata", "MANIFEST.json"),
     os.path.join(".", "tests", "wpt", "metadata-css", "MANIFEST.json"),
+    os.path.join(".", "components", "script", "dom", "webidls", "ForceTouchEvent.webidl"),
     # Hidden files
     os.path.join(".", "."),
 ]

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -1,4 +1,5 @@
 {
+  "dom.forcetouch.enabled": false,
   "dom.mouseevent.which.enabled": false,
   "dom.mozbrowser.enabled": false,
   "gfx.webrender.enabled": false,

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.html
@@ -23,6 +23,7 @@ var ecmaGlobals = [
   "Float32Array",
   "Float64Array",
   "FocusEvent",
+  "ForceTouchEvent",
   "Function",
   "Infinity",
   "Int16Array",


### PR DESCRIPTION
https://developer.apple.com/library/mac/documentation/AppleApplications/Conceptual/SafariJSProgTopics/RespondingtoForceTouchEventsfromJavaScript.html

Not sure how we want to land that yet. Maybe reproduce the webkit events (as in this PR), or as touch/mousemouse events.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9811)

<!-- Reviewable:end -->
