### PR TITLE
With WebRender, only send resize events when window size is valid.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -353,10 +353,11 @@ impl webrender_traits::RenderNotifier for RenderNotifier {
                              pipeline_id: webrender_traits::PipelineId,
                              size: Option<Size2D<f32>>) {
         let pipeline_id = pipeline_id.from_webrender();
-        let size = size.unwrap_or(Size2D::zero());
 
-        self.constellation_chan.send(ConstellationMsg::FrameSize(pipeline_id,
-                                                                 size)).unwrap();
+        if let Some(size) = size {
+            self.constellation_chan.send(ConstellationMsg::FrameSize(pipeline_id,
+                                                                     size)).unwrap();
+        }
     }
 }
 


### PR DESCRIPTION
Fixes WR 112.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9813)

<!-- Reviewable:end -->
