### PR TITLE
Fix the Node.replaceChild tests

### DIFF
--- a/tests/wpt/metadata/dom/nodes/Node-replaceChild.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Node-replaceChild.html.ini
@@ -1,5 +1,0 @@
-[Node-replaceChild.html]
-  type: testharness
-  [If child's parent is not the context node, a NotFoundError exception should be thrown]
-    expected: FAIL
-

--- a/tests/wpt/web-platform-tests/dom/nodes/Node-replaceChild.html
+++ b/tests/wpt/web-platform-tests/dom/nodes/Node-replaceChild.html
@@ -37,13 +37,7 @@ test(function() {
     a.replaceChild(b, c);
   });
   assert_throws("NotFoundError", function() {
-    a.replaceChild(a, c);
-  });
-  assert_throws("NotFoundError", function() {
     a.replaceChild(b, a);
-  });
-  assert_throws("NotFoundError", function() {
-    a.replaceChild(a, a);
   });
 }, "If child's parent is not the context node, a NotFoundError exception should be thrown")
 test(function() {
@@ -67,6 +61,11 @@ test(function() {
 test(function() {
   var a = document.createElement("div");
   var b = document.createElement("div");
+
+  assert_throws("HierarchyRequestError", function() {
+    a.replaceChild(a, a);
+  });
+
   a.appendChild(b);
   assert_throws("HierarchyRequestError", function() {
     a.replaceChild(a, b);


### PR DESCRIPTION
That method first does "if node is a host-including inclusive ancestor of parent,
throw a HierarchyRequestError" and only then "if child’s parent is not parent,
throw a NotFoundError exception".

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9816)

<!-- Reviewable:end -->
