### PR TITLE
Suppress reflows before RefreshTick or FirstLoad

### DIFF
--- a/components/layout/layout_thread.rs
+++ b/components/layout/layout_thread.rs
@@ -22,7 +22,7 @@ use euclid::size::Size2D;
 use flow::{self, Flow, ImmutableFlowUtils, MutableFlowUtils, MutableOwnedFlowUtils};
 use flow_ref::{self, FlowRef};
 use fnv::FnvHasher;
-use gfx::display_list::{ClippingRegion, DisplayList, LayerInfo};
+use gfx::display_list::{ClippingRegion, DisplayItemMetadata, DisplayList, LayerInfo};
 use gfx::display_list::{OpaqueNode, StackingContext, StackingContextId, StackingContextType};
 use gfx::font;
 use gfx::font_cache_thread::FontCacheThread;
@@ -113,6 +113,9 @@ pub struct LayoutThreadData {
 
     /// A queued response for the client {top, left, width, height} of a node in pixels.
     pub client_rect_response: Rect<i32>,
+
+    /// A queued response for the node at a given point
+    pub hit_test_response: (Option<DisplayItemMetadata>, bool),
 
     /// A queued response for the resolved style property of an element.
     pub resolved_style_response: Option<String>,
@@ -458,6 +461,7 @@ impl LayoutThread {
                     content_box_response: Rect::zero(),
                     content_boxes_response: Vec::new(),
                     client_rect_response: Rect::zero(),
+                    hit_test_response: (None, false),
                     resolved_style_response: None,
                     offset_parent_response: OffsetParentResponse::empty(),
                     margin_style_response: MarginStyleResponse::empty(),
@@ -978,6 +982,9 @@ impl LayoutThread {
                     ReflowQueryType::ContentBoxesQuery(_) => {
                         rw_data.content_boxes_response = Vec::new();
                     },
+                    ReflowQueryType::HitTestQuery(_, _) => {
+                        rw_data.hit_test_response = (None, false);
+                    },
                     ReflowQueryType::NodeGeometryQuery(_) => {
                         rw_data.client_rect_response = Rect::zero();
                     },
@@ -1119,6 +1126,18 @@ impl LayoutThread {
                 ReflowQueryType::ContentBoxesQuery(node) => {
                     let node = unsafe { ServoLayoutNode::new(&node) };
                     rw_data.content_boxes_response = process_content_boxes_request(node, &mut root_flow);
+                },
+                ReflowQueryType::HitTestQuery(point, update_cursor) => {
+                    let point = Point2D::new(Au::from_f32_px(point.x), Au::from_f32_px(point.y));
+                    let result = match rw_data.display_list {
+                        None => panic!("Tried to hit test with no display list"),
+                        Some(ref dl) => dl.hit_test(point),
+                    };
+                    rw_data.hit_test_response = if result.len() > 0 {
+                        (Some(result[0]), update_cursor)
+                    } else {
+                        (None, update_cursor)
+                    };
                 },
                 ReflowQueryType::NodeGeometryQuery(node) => {
                     let node = unsafe { ServoLayoutNode::new(&node) };

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -6,7 +6,6 @@ use document_loader::DocumentLoader;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::codegen::Bindings::XMLDocumentBinding::{self, XMLDocumentMethods};
-use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{Root, RootedReference};

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -105,7 +105,7 @@ pub trait LayoutRPC {
     /// Requests the geometry of this node. Used by APIs such as `clientTop`.
     fn node_geometry(&self) -> NodeGeometryResponse;
     /// Requests the node containing the point of interest
-    fn hit_test(&self, point: Point2D<f32>, update_cursor: bool) -> Result<HitTestResponse, ()>;
+    fn hit_test(&self) -> HitTestResponse;
     /// Query layout for the resolved value of a given CSS property
     fn resolved_style(&self) -> ResolvedStyleResponse;
     fn offset_parent(&self) -> OffsetParentResponse;
@@ -134,10 +134,12 @@ impl MarginStyleResponse {
 
 pub struct ContentBoxResponse(pub Rect<Au>);
 pub struct ContentBoxesResponse(pub Vec<Rect<Au>>);
+pub struct HitTestResponse {
+    pub node_address: Option<UntrustedNodeAddress>,
+}
 pub struct NodeGeometryResponse {
     pub client_rect: Rect<i32>,
 }
-pub struct HitTestResponse(pub UntrustedNodeAddress);
 pub struct ResolvedStyleResponse(pub Option<String>);
 
 #[derive(Clone)]
@@ -161,6 +163,7 @@ pub enum ReflowQueryType {
     NoQuery,
     ContentBoxQuery(TrustedNodeAddress),
     ContentBoxesQuery(TrustedNodeAddress),
+    HitTestQuery(Point2D<f32>, bool),
     NodeGeometryQuery(TrustedNodeAddress),
     ResolvedStyleQuery(TrustedNodeAddress, Option<PseudoElement>, Atom),
     OffsetParentQuery(TrustedNodeAddress),

--- a/tests/wpt/metadata-css/cssom-view-1_dev/html/CaretPosition-001.htm.ini
+++ b/tests/wpt/metadata-css/cssom-view-1_dev/html/CaretPosition-001.htm.ini
@@ -1,5 +1,0 @@
-[CaretPosition-001.htm]
-  type: testharness
-  [Element at (400, 100)]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/cssom-view-1_dev/html/elementFromPoint-001.htm.ini
+++ b/tests/wpt/metadata-css/cssom-view-1_dev/html/elementFromPoint-001.htm.ini
@@ -1,5 +1,0 @@
-[elementFromPoint-001.htm]
-  type: testharness
-  [CSSOM View - 5 - extensions to the Document interface]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/cssom-view-1_dev/html/elementFromPosition.htm.ini
+++ b/tests/wpt/metadata-css/cssom-view-1_dev/html/elementFromPosition.htm.ini
@@ -1,18 +1,6 @@
 [elementFromPosition.htm]
   type: testharness
-  [test some point of the element: top left corner]
-    expected: FAIL
-
-  [test some point of the element: top line]
-    expected: FAIL
-
   [test some point of the element: top right corner]
-    expected: FAIL
-
-  [test some point of the element: left line]
-    expected: FAIL
-
-  [test some point of the element: inside]
     expected: FAIL
 
   [test some point of the element: right line]


### PR DESCRIPTION
This fixes a bug where partially loaded content is displayed to the user
before it should be, usually before stylesheets have loaded. This commit
supresses reflows until either FirstLoad or RefreshTick, whichever comes
first.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9832)

<!-- Reviewable:end -->
