### PR TITLE
Remove a stray println in table layout.

### DIFF
--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -828,7 +828,6 @@ fn perform_inline_direction_border_collapse_for_row(
         child_table_cell: &mut TableCellFlow,
         iterator: &mut Peekable<Enumerate<MutFlowListIterator>>,
         preliminary_collapsed_borders: &mut CollapsedBordersForRow) {
-    println!("    perform_inline_direction_border_collapse_for_row");
     let inline_collapsed_border = preliminary_collapsed_borders.inline.push_or_set(
         child_index + 1,
         CollapsedBorder::inline_end(&*child_table_cell.block_flow.fragment.style,


### PR DESCRIPTION
It was introduced in 4dc9d8b1c5a4e68eee09af547ae7069455c9abe9.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9836)

<!-- Reviewable:end -->
