### PR TITLE
Fix animation smoothness when using requestAnimationFrame.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use AnimationTickType;
 use CompositorMsg as ConstellationMsg;
 use app_units::Au;
 use compositor_layer::{CompositorData, CompositorLayer, RcCompositorLayer, WantsScrollEventsFlag};
@@ -1550,7 +1551,13 @@ impl<Window: WindowMethods> IOCompositor<Window> {
 
     fn tick_animations_for_pipeline(&mut self, pipeline_id: PipelineId) {
         self.schedule_delayed_composite_if_necessary();
-        self.constellation_chan.send(ConstellationMsg::TickAnimation(pipeline_id)).unwrap()
+        let animation_callbacks_running = self.pipeline_details(pipeline_id).animation_callbacks_running;
+        let animation_type = if animation_callbacks_running {
+            AnimationTickType::Script
+        } else {
+            AnimationTickType::Layout
+        };
+        self.constellation_chan.send(ConstellationMsg::TickAnimation(pipeline_id, animation_type)).unwrap()
     }
 
     fn constrain_viewport(&mut self, pipeline_id: PipelineId, constraints: ViewportConstraints) {

--- a/components/compositing/headless.rs
+++ b/components/compositing/headless.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use AnimationTickType;
 use CompositorMsg as ConstellationMsg;
 use compositor_thread::{CompositorEventListener, CompositorReceiver};
 use compositor_thread::{InitialCompositorState, Msg};
@@ -98,7 +99,7 @@ impl CompositorEventListener for NullCompositor {
                     AnimationState::NoAnimationsPresent |
                     AnimationState::NoAnimationCallbacksPresent => {}
                     AnimationState::AnimationCallbacksPresent => {
-                        let msg = ConstellationMsg::TickAnimation(pipeline_id);
+                        let msg = ConstellationMsg::TickAnimation(pipeline_id, AnimationTickType::Script);
                         self.constellation_chan.send(msg).unwrap()
                     }
                 }

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -76,6 +76,13 @@ mod timer_scheduler;
 mod touch;
 pub mod windowing;
 
+/// Specifies whether the script or layout thread needs to be ticked for animation.
+#[derive(Deserialize, Serialize)]
+pub enum AnimationTickType {
+    Script,
+    Layout,
+}
+
 /// Messages from the compositor to the constellation.
 #[derive(Deserialize, Serialize)]
 pub enum CompositorMsg {
@@ -98,7 +105,7 @@ pub enum CompositorMsg {
     Navigate(Option<(PipelineId, SubpageId)>, NavigationDirection),
     ResizedWindow(WindowSizeData),
     /// Requests that the constellation instruct layout to begin a new tick of the animation.
-    TickAnimation(PipelineId),
+    TickAnimation(PipelineId, AnimationTickType),
     /// Dispatch a webdriver command
     WebDriverCommand(WebDriverCommandMsg),
 }

--- a/components/layout/layout_thread.rs
+++ b/components/layout/layout_thread.rs
@@ -1202,10 +1202,6 @@ impl LayoutThread {
     fn tick_all_animations<'a, 'b>(&mut self, possibly_locked_rw_data: &mut RwData<'a, 'b>) {
         let mut rw_data = possibly_locked_rw_data.lock();
         self.tick_animations(&mut rw_data);
-
-        self.script_chan
-            .send(ConstellationControlMsg::TickAllAnimations(self.id))
-            .unwrap();
     }
 
     pub fn tick_animations(&mut self, rw_data: &mut LayoutThreadData) {


### PR DESCRIPTION
Previously, the flow for ticking animations was:

Compositor -> Constellation -> Layout -> Script

However, this means that the compositor <-> layout messages can thrash, meaning layout thread is very rarely idle.

This means that the script thread (which joins on the layout thread during reflow) was unable to execute and run rAF callbacks.

With this change, the flow is now:

Compositor -> Constellation -> Script (when rAF is active).
Compositor -> Constellation -> Layout (when transitions / animations are active and no rAF is present).

This makes rAF based animation _much_ smoother.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9858)

<!-- Reviewable:end -->
