### PR TITLE
Make Cargo share more things between servo and ports

### DIFF
--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -34,7 +34,7 @@ matches = "0.1"
 num = "0.1.24"
 rustc-serialize = "0.3"
 selectors = {version = "0.5", features = ["heap_size", "unstable"]}
-serde = "0.6"
+serde = {version = "0.6", features = ["nightly"]}
 serde_macros = "0.6"
 smallvec = "0.1"
 string_cache = {version = "0.2.10", features = ["heap_size"]}

--- a/ports/cef/Cargo.toml
+++ b/ports/cef/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["dylib"]
 euclid = {version = "0.6.2", features = ["plugins"]}
 gleam = "0.2"
 libc = "0.2"
-log = "0.3"
 url = {version = "0.5.5", features = ["heap_size"]}
 
 [dependencies.servo]
@@ -29,6 +28,10 @@ path = "../../components/compositing"
 
 [dependencies.gfx]
 path = "../../components/gfx"
+
+[dependencies.log]
+version = "0.3"
+features = ["release_max_level_info"]
 
 [dependencies.script]
 path = "../../components/script"

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -509,6 +509,7 @@ name = "url"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -17,12 +17,15 @@ heapsize = "0.3.0"
 heapsize_plugin = "0.1.2"
 lazy_static = "0.1"
 libc = "0.2"
-log = "0.3"
 num_cpus = "0.2.2"
 selectors = {version = "0.5", features = ["heap_size", "unstable"]}
 smallvec = "0.1"
 string_cache = {version = "0.2.10", features = ["heap_size", "unstable"]}
 url = {version = "0.5.5", features = ["heap_size"]}
+
+[dependencies.log]
+version = "0.3"
+features = ["release_max_level_info"]
 
 [dependencies.plugins]
 path = "../../components/plugins"

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -19,9 +19,9 @@ lazy_static = "0.1"
 libc = "0.2"
 log = "0.3"
 num_cpus = "0.2.2"
-selectors = {version = "0.5", features = ["heap_size"]}
+selectors = {version = "0.5", features = ["heap_size", "unstable"]}
 smallvec = "0.1"
-string_cache = {version = "0.2.10", features = ["heap_size"]}
+string_cache = {version = "0.2.10", features = ["heap_size", "unstable"]}
 url = {version = "0.5.5", features = ["heap_size"]}
 
 [dependencies.plugins]

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -21,7 +21,7 @@ num_cpus = "0.2.2"
 selectors = {version = "0.5", features = ["heap_size", "unstable"]}
 smallvec = "0.1"
 string_cache = {version = "0.2.10", features = ["heap_size", "unstable"]}
-url = {version = "0.5.5", features = ["heap_size"]}
+url = {version = "0.5.5", features = ["heap_size", "query_encoding", "serde_serialization"]}
 
 [dependencies.log]
 version = "0.3"


### PR DESCRIPTION
This should enable Cargo to reuse more build artifacts between servo and geckolib.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9886)

<!-- Reviewable:end -->
