### PR TITLE
Handle escaped strings in rust linting, tidy.py

### DIFF
--- a/python/tidy.py
+++ b/python/tidy.py
@@ -290,7 +290,7 @@ def check_rust(file_name, lines):
 
         # get rid of strings and chars because cases like regex expression, keep attributes
         if not line_is_attribute(line):
-            line = re.sub('".*?"|\'.*?\'', '', line)
+            line = re.sub(r'"(\\.|[^\\"])*?"|' + r"'(\\.|[^\\'])*?'", '', line)
 
         # get rid of comments
         line = re.sub('//.*?$|/\*.*?$|^\*.*?$', '', line)
@@ -346,6 +346,7 @@ def check_rust(file_name, lines):
             for match in re.finditer(pattern, line):
                 if not filter_func(match, line):
                     continue
+
                 yield (idx + 1, message.format(*match.groups(), **match.groupdict()))
 
         # check alphabetical order of extern crates


### PR DESCRIPTION
A little annoying to read since we have to escape for python (\) and
then escape for re (\\) and then even at times escape for single
quotes immediately after, (\\), but tidy.py now strips strings even
if they have escapes before linting.

Fixes #9806 -- basically the problem is that the PR which first revealed this had an escape in one of its strings which included an = sign. The escape meant the string wasn't escaped before it looked for spaces around spaces.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9889)

<!-- Reviewable:end -->
