### PR TITLE
Replace deprecated fs::walk_dir call with walkdir crate

### DIFF
--- a/support/android/build-apk/Cargo.lock
+++ b/support/android/build-apk/Cargo.lock
@@ -1,4 +1,35 @@
 [root]
 name = "build-apk"
 version = "0.0.1"
+dependencies = [
+ "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "walkdir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/support/android/build-apk/Cargo.toml
+++ b/support/android/build-apk/Cargo.toml
@@ -11,3 +11,5 @@ test = false
 doc = false
 bench = false
 
+[dependencies]
+walkdir = "0.1.5"


### PR DESCRIPTION
While working on #8351 I discovered that deprecated fs::walk_dir is used in android support files.

This is my first PR to any Rust project, so any constructive feedback is more than welcome!

Thanks

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9891)

<!-- Reviewable:end -->
