### PR TITLE
Implement input.setSelectionRange

### DIFF
--- a/components/script/dom/webidls/HTMLInputElement.webidl
+++ b/components/script/dom/webidls/HTMLInputElement.webidl
@@ -62,13 +62,13 @@ interface HTMLInputElement : HTMLElement {
   readonly attribute NodeList labels;
 
   //void select();
-  //         attribute unsigned long selectionStart;
-  //         attribute unsigned long selectionEnd;
-  //         attribute DOMString selectionDirection;
+           attribute unsigned long selectionStart;
+           attribute unsigned long selectionEnd;
+           attribute DOMString selectionDirection;
   //void setRangeText(DOMString replacement);
   //void setRangeText(DOMString replacement, unsigned long start, unsigned long end,
   //                  optional SelectionMode selectionMode = "preserve");
-  //void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
+  void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 
   // also has obsolete members
 };

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -4644,22 +4644,10 @@
   [HTMLInputElement interface: operation select()]
     expected: FAIL
 
-  [HTMLInputElement interface: attribute selectionStart]
-    expected: FAIL
-
-  [HTMLInputElement interface: attribute selectionEnd]
-    expected: FAIL
-
-  [HTMLInputElement interface: attribute selectionDirection]
-    expected: FAIL
-
   [HTMLInputElement interface: operation setRangeText(DOMString)]
     expected: FAIL
 
   [HTMLInputElement interface: operation setRangeText(DOMString,unsigned long,unsigned long,SelectionMode)]
-    expected: FAIL
-
-  [HTMLInputElement interface: operation setSelectionRange(unsigned long,unsigned long,DOMString)]
     expected: FAIL
 
   [HTMLInputElement interface: attribute align]
@@ -4770,15 +4758,6 @@
   [HTMLInputElement interface: document.createElement("input") must inherit property "select" with the proper type (49)]
     expected: FAIL
 
-  [HTMLInputElement interface: document.createElement("input") must inherit property "selectionStart" with the proper type (50)]
-    expected: FAIL
-
-  [HTMLInputElement interface: document.createElement("input") must inherit property "selectionEnd" with the proper type (51)]
-    expected: FAIL
-
-  [HTMLInputElement interface: document.createElement("input") must inherit property "selectionDirection" with the proper type (52)]
-    expected: FAIL
-
   [HTMLInputElement interface: document.createElement("input") must inherit property "setRangeText" with the proper type (53)]
     expected: FAIL
 
@@ -4789,12 +4768,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: calling setRangeText(DOMString,unsigned long,unsigned long,SelectionMode) on document.createElement("input") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [HTMLInputElement interface: document.createElement("input") must inherit property "setSelectionRange" with the proper type (55)]
-    expected: FAIL
-
-  [HTMLInputElement interface: calling setSelectionRange(unsigned long,unsigned long,DOMString) on document.createElement("input") with too few arguments must throw TypeError]
     expected: FAIL
 
   [HTMLInputElement interface: document.createElement("input") must inherit property "align" with the proper type (56)]

--- a/tests/wpt/metadata/html/semantics/forms/textfieldselection/textfieldselection-setSelectionRange.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/textfieldselection/textfieldselection-setSelectionRange.html.ini
@@ -1,62 +1,6 @@
 [textfieldselection-setSelectionRange.html]
   type: testharness
-  [input typeof(input.setSelectionRange)']
-    expected: FAIL
-
-  [input setSelectionRange return void]
-    expected: FAIL
-
-  [input setSelectionRange(0,1)]
-    expected: FAIL
-
-  [input setSelectionRange(0,input.value.length+1)]
-    expected: FAIL
-
-  [input setSelectionRange(2,2)]
-    expected: FAIL
-
-  [input setSelectionRange(2,1)]
-    expected: FAIL
-
-  [input direction of setSelectionRange(0,1,"backward")]
-    expected: FAIL
-
-  [input direction of setSelectionRange(0,1,"forward")]
-    expected: FAIL
-
-  [input direction of setSelectionRange(0,1,"none")]
-    expected: FAIL
-
-  [input direction of setSelectionRange(0,1,"hoge")]
-    expected: FAIL
-
-  [input direction of setSelectionRange(0,1,"BACKWARD")]
-    expected: FAIL
-
-  [input direction of setSelectionRange(0,1)]
-    expected: FAIL
-
-  [input setSelectionRange("string",1)]
-    expected: FAIL
-
-  [input setSelectionRange(true,1)]
-    expected: FAIL
-
-  [input setSelectionRange([\],1)]
-    expected: FAIL
-
-  [input setSelectionRange({},1)]
-    expected: FAIL
-
-  [input setSelectionRange(NaN,1)]
-    expected: FAIL
-
-  [input setSelectionRange(null,1)]
-    expected: FAIL
-
-  [input setSelectionRange(undefined,1)]
-    expected: FAIL
-
+  
   [textarea typeof(input.setSelectionRange)']
     expected: FAIL
 


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/9862.

Passes all tests for `input` in `tests/wpt/web-platform-tests/html/semantics/forms/textfieldselection/textfieldselection-setSelectionRange.html`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9905)

<!-- Reviewable:end -->
