### PR TITLE
Remove activatable element filter within HTMLElement#click()

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4,6 +4,7 @@
 
 use devtools_traits::CSSError;
 use document_loader::{DocumentLoader, LoadType};
+use dom::activation::{ActivationSource, synthetic_click_activation};
 use dom::attr::{Attr, AttrValue};
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
@@ -1077,9 +1078,12 @@ impl Document {
             Key::Space if !prevented && state == KeyState::Released => {
                 let maybe_elem = target.downcast::<Element>();
                 if let Some(el) = maybe_elem {
-                    if let Some(a) = el.as_maybe_activatable() {
-                        a.synthetic_click_activation(ctrl, alt, shift, meta);
-                    }
+                    synthetic_click_activation(el,
+                                               false,
+                                               false,
+                                               false,
+                                               false,
+                                               ActivationSource::NotFromClick)
                 }
             }
             Key::Enter if !prevented && state == KeyState::Released => {

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::activation::Activatable;
+use dom::activation::{Activatable, ActivationSource, synthetic_click_activation};
 use dom::attr::Attr;
 use dom::bindings::codegen::Bindings::HTMLButtonElementBinding;
 use dom::bindings::codegen::Bindings::HTMLButtonElementBinding::HTMLButtonElementMethods;
@@ -256,6 +256,11 @@ impl Activatable for HTMLButtonElement {
         node.query_selector_iter(DOMString::from("button[type=submit]")).unwrap()
             .filter_map(Root::downcast::<HTMLButtonElement>)
             .find(|r| r.form_owner() == owner)
-            .map(|s| s.r().synthetic_click_activation(ctrlKey, shiftKey, altKey, metaKey));
+            .map(|s| synthetic_click_activation(s.r().as_element(),
+                                                ctrlKey,
+                                                shiftKey,
+                                                altKey,
+                                                metaKey,
+                                                ActivationSource::NotFromClick));
     }
 }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::activation::{ActivationSource, synthetic_click_activation};
 use dom::attr::Attr;
 use dom::attr::AttrValue;
 use dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
@@ -9,7 +10,6 @@ use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::OnErrorEventHandlerNonNull;
 use dom::bindings::codegen::Bindings::HTMLElementBinding;
 use dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
-use dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::error::{Error, ErrorResult};
 use dom::bindings::inheritance::Castable;
@@ -182,15 +182,14 @@ impl HTMLElementMethods for HTMLElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-click
     fn Click(&self) {
-        if let Some(i) = self.downcast::<HTMLInputElement>() {
-            if i.Disabled() {
-                return;
-            }
+        if !self.upcast::<Element>().get_disabled_state() {
+            synthetic_click_activation(self.upcast::<Element>(),
+                                       false,
+                                       false,
+                                       false,
+                                       false,
+                                       ActivationSource::FromClick)
         }
-        // https://www.w3.org/Bugs/Public/show_bug.cgi?id=27430 ?
-        self.upcast::<Element>()
-            .as_maybe_activatable()
-            .map(|a| a.synthetic_click_activation(false, false, false, false));
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-focus

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use caseless::compatibility_caseless_match_str;
-use dom::activation::Activatable;
+use dom::activation::{Activatable, ActivationSource, synthetic_click_activation};
 use dom::attr::{Attr, AttrValue};
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
@@ -900,7 +900,12 @@ impl Activatable for HTMLInputElement {
         match submit_button {
             Some(ref button) => {
                 if button.is_instance_activatable() {
-                    button.synthetic_click_activation(ctrlKey, shiftKey, altKey, metaKey)
+                    synthetic_click_activation(button.as_element(),
+                                               ctrlKey,
+                                               shiftKey,
+                                               altKey,
+                                               metaKey,
+                                               ActivationSource::NotFromClick)
                 }
             }
             None => {

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::activation::Activatable;
+use dom::activation::{Activatable, ActivationSource, synthetic_click_activation};
 use dom::attr::AttrValue;
 use dom::bindings::codegen::Bindings::HTMLLabelElementBinding;
 use dom::bindings::codegen::Bindings::HTMLLabelElementBinding::HTMLLabelElementMethods;
@@ -63,9 +63,12 @@ impl Activatable for HTMLLabelElement {
 
     // https://html.spec.whatwg.org/multipage/#run-post-click-activation-steps
     fn activation_behavior(&self, _event: &Event, _target: &EventTarget) {
-        self.upcast::<Element>()
-            .as_maybe_activatable()
-            .map(|a| a.synthetic_click_activation(false, false, false, false));
+        synthetic_click_activation(self.upcast::<Element>(),
+                                   false,
+                                   false,
+                                   false,
+                                   false,
+                                   ActivationSource::NotFromClick);
     }
 
     // https://html.spec.whatwg.org/multipage/#implicit-submission

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -15,6 +15,10 @@ skip: true
   skip: false
 [html]
   skip: false
+  [editing]
+    skip: true
+    [activation]
+      skip: false
 [url]
   skip: false
 [touch-events]

--- a/tests/wpt/metadata/DOMEvents/throwing-in-listener-when-all-have-not-run-yet.html.ini
+++ b/tests/wpt/metadata/DOMEvents/throwing-in-listener-when-all-have-not-run-yet.html.ini
@@ -1,5 +1,0 @@
-[throwing-in-listener-when-all-have-not-run-yet.html]
-  type: testharness
-  [Throwing in event listener]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/editing/__dir__.ini
+++ b/tests/wpt/metadata/html/editing/__dir__.ini
@@ -1,1 +1,0 @@
-disabled: for now


### PR DESCRIPTION
Address https://github.com/servo/servo/issues/6542

Ensure that click() calls are not limited to activatable elements. Also makes the isTrusted attribute false when synthetic click activation are called from a click() method (as per spec).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9930)

<!-- Reviewable:end -->
