### PR TITLE
Detect Cygwin environment on Windows

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -41,7 +41,7 @@ def host_triple():
         os_type = "apple-darwin"
     elif os_type == "android":
         os_type = "linux-androideabi"
-    elif os_type == "windows" or os_type.startswith("mingw64_nt-"):
+    elif os_type == "windows" or os_type.startswith("mingw64_nt-") or os_type.startswith("cygwin_nt-"):
         os_type = "pc-windows-gnu"
     else:
         os_type = "unknown"


### PR DESCRIPTION
Currently if Servo is built using Cygwin, it is incorrectly classified as "unknown" host, which makes downloading Rust and Cargo fail. This pull request fixes that.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9937)

<!-- Reviewable:end -->
