### PR TITLE
Faster display list transfer

### DIFF
--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -17,7 +17,7 @@ use azure::{AzDrawTargetFillGlyphs, struct__AzGlyphBuffer, struct__AzPoint};
 use azure::{AzFloat, struct__AzDrawOptions, struct__AzGlyph};
 use display_list::TextOrientation::{SidewaysLeft, SidewaysRight, Upright};
 use display_list::{BLUR_INFLATION_FACTOR, BorderRadii, BoxShadowClipMode, ClippingRegion};
-use display_list::{TextDisplayItem};
+use display_list::{TextDisplayItem, WebRenderImageInfo};
 use euclid::matrix2d::Matrix2D;
 use euclid::point::Point2D;
 use euclid::rect::{Rect, TypedRect};
@@ -27,10 +27,9 @@ use euclid::size::Size2D;
 use filters;
 use font_context::FontContext;
 use gfx_traits::{color, LayerKind};
-use net_traits::image::base::{Image, PixelFormat};
+use net_traits::image::base::PixelFormat;
 use range::Range;
 use std::default::Default;
-use std::sync::Arc;
 use std::{f32, mem, ptr};
 use style::computed_values::{border_style, filter, image_rendering, mix_blend_mode};
 use text::TextRun;
@@ -181,21 +180,22 @@ impl<'a> PaintContext<'a> {
     pub fn draw_image(&self,
                       bounds: &Rect<Au>,
                       stretch_size: &Size2D<Au>,
-                      image: Arc<Image>,
+                      image_info: &WebRenderImageInfo,
+                      image_data: &[u8],
                       image_rendering: image_rendering::T) {
-        let size = Size2D::new(image.width as i32, image.height as i32);
-        let (pixel_width, source_format) = match image.format {
+        let size = Size2D::new(image_info.width as i32, image_info.height as i32);
+        let (pixel_width, source_format) = match image_info.format {
             PixelFormat::RGBA8 => (4, SurfaceFormat::B8G8R8A8),
             PixelFormat::K8 => (1, SurfaceFormat::A8),
             PixelFormat::RGB8 => panic!("RGB8 color type not supported"),
             PixelFormat::KA8 => panic!("KA8 color type not supported"),
         };
-        let stride = image.width * pixel_width;
+        let stride = image_info.width * pixel_width;
         let scale = self.screen_pixels_per_px();
 
         self.draw_target.make_current();
         let draw_target_ref = &self.draw_target;
-        let azure_surface = match draw_target_ref.create_source_surface_from_data(&image.bytes,
+        let azure_surface = match draw_target_ref.create_source_surface_from_data(image_data,
                                                                                   size,
                                                                                   stride as i32,
                                                                                   source_format) {
@@ -204,7 +204,8 @@ impl<'a> PaintContext<'a> {
         };
 
         let source_rect = Rect::new(Point2D::new(0.0, 0.0),
-                                    Size2D::new(image.width as AzFloat, image.height as AzFloat));
+                                    Size2D::new(image_info.width as AzFloat,
+                                                image_info.height as AzFloat));
         let dest_rect = bounds.to_nearest_azure_rect(scale);
 
         // TODO(pcwalton): According to CSS-IMAGES-3 § 5.3, nearest-neighbor interpolation is a

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -11,11 +11,12 @@ use app_units::Au;
 use canvas_traits::CanvasMsg;
 use euclid::Rect;
 use fnv::FnvHasher;
+use gfx::display_list::WebRenderImageInfo;
 use gfx::font_cache_thread::FontCacheThread;
 use gfx::font_context::FontContext;
 use gfx_traits::LayerId;
 use heapsize::HeapSizeOf;
-use ipc_channel::ipc::{self, IpcSender};
+use ipc_channel::ipc::{self, IpcSender, IpcSharedMemory};
 use net_traits::image::base::Image;
 use net_traits::image_cache_thread::{ImageCacheChan, ImageCacheThread, ImageResponse, ImageState};
 use net_traits::image_cache_thread::{ImageOrMetadataAvailable, UsePlaceholder};
@@ -24,7 +25,7 @@ use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use std::rc::Rc;
 use std::sync::mpsc::Sender;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use style::context::{LocalStyleContext, StyleContext};
 use style::matching::{ApplicableDeclarationsCache, StyleSharingCandidateCache};
 use style::selector_impl::ServoSelectorImpl;
@@ -99,6 +100,11 @@ pub struct SharedLayoutContext {
 
     /// The visible rects for each layer, as reported to us by the compositor.
     pub visible_rects: Arc<HashMap<LayerId, Rect<Au>, BuildHasherDefault<FnvHasher>>>,
+
+    /// A cache of WebRender image info.
+    pub webrender_image_cache: Arc<RwLock<HashMap<(Url, UsePlaceholder),
+                                                  WebRenderImageInfo,
+                                                  BuildHasherDefault<FnvHasher>>>>,
 }
 
 pub struct LayoutContext<'a> {
@@ -132,45 +138,36 @@ impl<'a> LayoutContext<'a> {
         self.cached_local_layout_context.font_context.borrow_mut()
     }
 
-    pub fn get_or_request_image(&self, url: Url, use_placeholder: UsePlaceholder)
-                                -> Option<Arc<Image>> {
+    fn get_or_request_image_synchronously(&self, url: Url, use_placeholder: UsePlaceholder)
+                                          -> Option<Arc<Image>> {
+        debug_assert!(opts::get().output_file.is_some() || opts::get().exit_after_load);
+
         // See if the image is already available
-        let result = self.shared.image_cache_thread.find_image(url.clone(),
-                                                             use_placeholder);
+        let result = self.shared.image_cache_thread.find_image(url.clone(), use_placeholder);
 
         match result {
-            Ok(image) => Some(image),
-            Err(state) => {
-                // If we are emitting an output file, then we need to block on
-                // image load or we risk emitting an output file missing the image.
-                let is_sync = opts::get().output_file.is_some() ||
-                              opts::get().exit_after_load;
+            Ok(image) => return Some(image),
+            Err(ImageState::LoadError) => {
+                // Image failed to load, so just return nothing
+                return None
+            }
+            Err(_) => {}
+        }
 
-                match (state, is_sync) {
-                    // Image failed to load, so just return nothing
-                    (ImageState::LoadError, _) => None,
-                    // Not loaded, test mode - load the image synchronously
-                    (_, true) => {
-                        let (sync_tx, sync_rx) = ipc::channel().unwrap();
-                        self.shared.image_cache_thread.request_image(url,
-                                                                   ImageCacheChan(sync_tx),
-                                                                   None);
-                        match sync_rx.recv().unwrap().image_response {
-                            ImageResponse::Loaded(image) |
-                            ImageResponse::PlaceholderLoaded(image) => Some(image),
-                            ImageResponse::None | ImageResponse::MetadataLoaded(_) => None,
+        // If we are emitting an output file, then we need to block on
+        // image load or we risk emitting an output file missing the image.
+        let (sync_tx, sync_rx) = ipc::channel().unwrap();
+        self.shared.image_cache_thread.request_image(url, ImageCacheChan(sync_tx), None);
+        loop {
+            match sync_rx.recv() {
+                Err(_) => return None,
+                Ok(response) => {
+                    match response.image_response {
+                        ImageResponse::Loaded(image) | ImageResponse::PlaceholderLoaded(image) => {
+                            return Some(image)
                         }
+                        ImageResponse::None | ImageResponse::MetadataLoaded(_) => {}
                     }
-                    // Not yet requested, async mode - request image from the cache
-                    (ImageState::NotRequested, false) => {
-                        let sender = self.shared.image_cache_sender.lock().unwrap().clone();
-                        self.shared.image_cache_thread.request_image(url, sender, None);
-                        None
-                    }
-                    // Image has been requested, is still pending. Return no image
-                    // for this paint loop. When the image loads it will trigger
-                    // a reflow and/or repaint.
-                    (ImageState::Pending, false) => None,
                 }
             }
         }
@@ -180,7 +177,7 @@ impl<'a> LayoutContext<'a> {
                                 -> Option<ImageOrMetadataAvailable> {
         // If we are emitting an output file, load the image synchronously.
         if opts::get().output_file.is_some() || opts::get().exit_after_load {
-            return self.get_or_request_image(url, use_placeholder)
+            return self.get_or_request_image_synchronously(url, use_placeholder)
                        .map(|img| ImageOrMetadataAvailable::ImageAvailable(img));
         }
         // See if the image is already available
@@ -202,4 +199,43 @@ impl<'a> LayoutContext<'a> {
         }
     }
 
+    pub fn get_webrender_image_for_url(&self,
+                                       url: &Url,
+                                       use_placeholder: UsePlaceholder,
+                                       fetch_image_data_as_well: bool)
+                                       -> Option<(WebRenderImageInfo, Option<IpcSharedMemory>)> {
+        if !fetch_image_data_as_well {
+            let webrender_image_cache = self.shared.webrender_image_cache.read().unwrap();
+            if let Some(existing_webrender_image) =
+                    webrender_image_cache.get(&((*url).clone(), use_placeholder)) {
+                return Some(((*existing_webrender_image).clone(), None))
+            }
+        }
+
+        match self.get_or_request_image_or_meta((*url).clone(), use_placeholder) {
+            Some(ImageOrMetadataAvailable::ImageAvailable(image)) => {
+                let image_info = WebRenderImageInfo::from_image(&*image);
+                if image_info.key.is_none() {
+                    let bytes = if !fetch_image_data_as_well {
+                        None
+                    } else {
+                        Some(image.bytes.clone())
+                    };
+                    Some((image_info, bytes))
+                } else if !fetch_image_data_as_well {
+                    let mut webrender_image_cache = self.shared
+                                                        .webrender_image_cache
+                                                        .write()
+                                                        .unwrap();
+                    webrender_image_cache.insert(((*url).clone(), use_placeholder),
+                                                 image_info);
+                    Some((image_info, None))
+                } else {
+                    Some((image_info, Some(image.bytes.clone())))
+                }
+            }
+            None | Some(ImageOrMetadataAvailable::MetadataAvailable(_)) => None,
+        }
+    }
 }
+

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -29,7 +29,7 @@ use gfx::display_list::{GradientDisplayItem};
 use gfx::display_list::{GradientStop, IframeDisplayItem, ImageDisplayItem, WebGLDisplayItem, LayeredItem, LayerInfo};
 use gfx::display_list::{LineDisplayItem, OpaqueNode, SolidColorDisplayItem};
 use gfx::display_list::{StackingContext, StackingContextId, StackingContextType};
-use gfx::display_list::{TextDisplayItem, TextOrientation, DisplayListEntry};
+use gfx::display_list::{TextDisplayItem, TextOrientation, DisplayListEntry, WebRenderImageInfo};
 use gfx::paint_thread::THREAD_TINT_COLORS;
 use gfx::text::glyph::CharIndex;
 use gfx_traits::{color, ScrollPolicy};
@@ -37,7 +37,7 @@ use inline::{FIRST_FRAGMENT_OF_ELEMENT, InlineFlow, LAST_FRAGMENT_OF_ELEMENT};
 use ipc_channel::ipc::{self, IpcSharedMemory};
 use list_item::ListItemFlow;
 use model::{self, MaybeAuto, ToGfxMatrix};
-use net_traits::image::base::{Image, PixelFormat};
+use net_traits::image::base::PixelFormat;
 use net_traits::image_cache_thread::UsePlaceholder;
 use range::Range;
 use std::default::Default;
@@ -136,7 +136,7 @@ pub trait FragmentDisplayListBuilding {
     fn compute_background_image_size(&self,
                                      style: &ComputedValues,
                                      bounds: &Rect<Au>,
-                                     image: &Image)
+                                     image: &WebRenderImageInfo)
                                      -> Size2D<Au>;
 
     /// Adds the display items necessary to paint the background image of this fragment to the
@@ -404,7 +404,7 @@ impl FragmentDisplayListBuilding for Fragment {
     fn compute_background_image_size(&self,
                                      style: &ComputedValues,
                                      bounds: &Rect<Au>,
-                                     image: &Image)
+                                     image: &WebRenderImageInfo)
                                      -> Size2D<Au> {
         // If `image_aspect_ratio` < `bounds_aspect_ratio`, the image is tall; otherwise, it is
         // wide.
@@ -462,14 +462,17 @@ impl FragmentDisplayListBuilding for Fragment {
                                                clip: &ClippingRegion,
                                                image_url: &Url) {
         let background = style.get_background();
-        let image =
-            state.layout_context.get_or_request_image(image_url.clone(), UsePlaceholder::No);
-        if let Some(image) = image {
+        let fetch_image_data_as_well = !opts::get().use_webrender;
+        let webrender_image =
+            state.layout_context.get_webrender_image_for_url(image_url,
+                                                             UsePlaceholder::No,
+                                                             fetch_image_data_as_well);
+        if let Some((webrender_image, image_data)) = webrender_image {
             debug!("(building display list) building background image");
 
             // Use `background-size` to get the size.
             let mut bounds = *absolute_bounds;
-            let image_size = self.compute_background_image_size(style, &bounds, &*image);
+            let image_size = self.compute_background_image_size(style, &bounds, &webrender_image);
 
             // Clip.
             //
@@ -560,7 +563,8 @@ impl FragmentDisplayListBuilding for Fragment {
                                                                     style,
                                                                     Cursor::DefaultCursor),
                                            &clip),
-                image: image.clone(),
+                webrender_image: webrender_image,
+                image_data: image_data.map(Arc::new),
                 stretch_size: Size2D::new(image_size.width, image_size.height),
                 image_rendering: style.get_effects().image_rendering.clone(),
             }), display_list_section);
@@ -1173,7 +1177,8 @@ impl FragmentDisplayListBuilding for Fragment {
                                                                             &*self.style,
                                                                             Cursor::DefaultCursor),
                                                    clip),
-                        image: image.clone(),
+                        webrender_image: WebRenderImageInfo::from_image(image),
+                        image_data: Some(Arc::new(image.bytes.clone())),
                         stretch_size: stacking_relative_content_box.size,
                         image_rendering: self.style.get_effects().image_rendering.clone(),
                     }), DisplayListSection::Content);
@@ -1214,13 +1219,13 @@ impl FragmentDisplayListBuilding for Fragment {
                                                                                     &*self.style,
                                                                                     Cursor::DefaultCursor),
                                                            clip),
-                                image: Arc::new(Image {
+                                image_data: Some(Arc::new(canvas_data.image_data)),
+                                webrender_image: WebRenderImageInfo {
                                     width: width as u32,
                                     height: height as u32,
                                     format: PixelFormat::RGBA8,
-                                    bytes: canvas_data.image_data,
-                                    id: canvas_data.image_key,
-                                }),
+                                    key: canvas_data.image_key,
+                                },
                                 stretch_size: stacking_relative_content_box.size,
                                 image_rendering: image_rendering::T::Auto,
                             })

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -19,26 +19,26 @@ use msg::constellation_msg::ConvertPipelineIdToWebRender;
 use style::computed_values::filter::{self, Filter};
 use style::computed_values::{image_rendering, mix_blend_mode};
 use style::values::computed::BorderStyle;
-use webrender_traits::{self, AuxiliaryListsBuilder};
+use webrender_traits::{self, AuxiliaryListsBuilder, DisplayListId, PipelineId, StackingContextId};
 
 trait WebRenderStackingContextConverter {
     fn convert_to_webrender<'a>(&self,
                                 traversal: &mut DisplayListTraversal<'a>,
-                                api: &webrender_traits::RenderApi,
+                                api: &mut webrender_traits::RenderApi,
                                 pipeline_id: webrender_traits::PipelineId,
                                 epoch: webrender_traits::Epoch,
                                 scroll_layer_id: Option<webrender_traits::ScrollLayerId>,
-                                auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
+                                frame_builder: &mut WebRenderFrameBuilder)
                                 -> webrender_traits::StackingContextId;
 
     fn convert_children_to_webrender<'a>(&self,
                                          traversal: &mut DisplayListTraversal<'a>,
-                                         api: &webrender_traits::RenderApi,
+                                         api: &mut webrender_traits::RenderApi,
                                          pipeline_id: webrender_traits::PipelineId,
                                          epoch: webrender_traits::Epoch,
                                          scroll_layer_id: Option<webrender_traits::ScrollLayerId>,
                                          builder: &mut webrender_traits::DisplayListBuilder,
-                                         auxiliary_lists_builder: &mut AuxiliaryListsBuilder,
+                                         frame_builder: &mut WebRenderFrameBuilder,
                                          force_positioned_stacking_level: bool);
 
     fn web_render_stacking_level(&self) -> webrender_traits::StackingLevel;
@@ -46,11 +46,11 @@ trait WebRenderStackingContextConverter {
 
 pub trait WebRenderDisplayListConverter {
     fn convert_to_webrender(&self,
-                            api: &webrender_traits::RenderApi,
+                            api: &mut webrender_traits::RenderApi,
                             pipeline_id: webrender_traits::PipelineId,
                             epoch: webrender_traits::Epoch,
                             scroll_layer_id: Option<webrender_traits::ScrollLayerId>,
-                            auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
+                            frame_builder: &mut WebRenderFrameBuilder)
                             -> webrender_traits::StackingContextId;
 }
 
@@ -58,7 +58,7 @@ trait WebRenderDisplayItemConverter {
     fn convert_to_webrender(&self,
                             level: webrender_traits::StackingLevel,
                             builder: &mut webrender_traits::DisplayListBuilder,
-                            auxiliary_lists_builder: &mut AuxiliaryListsBuilder);
+                            frame_builder: &mut WebRenderFrameBuilder);
 }
 
 trait WebRenderDisplayListEntryConverter {
@@ -171,12 +171,12 @@ impl ToGradientStop for GradientStop {
 }
 
 trait ToClipRegion {
-    fn to_clip_region(&self, auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
+    fn to_clip_region(&self, frame_builder: &mut WebRenderFrameBuilder)
                       -> webrender_traits::ClipRegion;
 }
 
 impl ToClipRegion for ClippingRegion {
-    fn to_clip_region(&self, auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
+    fn to_clip_region(&self, frame_builder: &mut WebRenderFrameBuilder)
                       -> webrender_traits::ClipRegion {
         webrender_traits::ClipRegion::new(&self.main.to_rectf(),
                                    self.complex.iter().map(|complex_clipping_region| {
@@ -185,7 +185,7 @@ impl ToClipRegion for ClippingRegion {
                                            complex_clipping_region.radii.to_border_radius(),
                                         )
                                    }).collect(),
-                                   auxiliary_lists_builder)
+                                   &mut frame_builder.auxiliary_lists_builder)
     }
 }
 
@@ -272,12 +272,12 @@ impl ToFilterOps for filter::T {
 impl WebRenderStackingContextConverter for StackingContext {
     fn convert_children_to_webrender<'a>(&self,
                                          traversal: &mut DisplayListTraversal<'a>,
-                                         api: &webrender_traits::RenderApi,
+                                         api: &mut webrender_traits::RenderApi,
                                          pipeline_id: webrender_traits::PipelineId,
                                          epoch: webrender_traits::Epoch,
                                          scroll_layer_id: Option<webrender_traits::ScrollLayerId>,
                                          builder: &mut webrender_traits::DisplayListBuilder,
-                                         auxiliary_lists_builder: &mut AuxiliaryListsBuilder,
+                                         frame_builder: &mut WebRenderFrameBuilder,
                                          force_positioned_stacking_level: bool) {
         for child in self.children.iter() {
             while let Some(item) = traversal.advance(self) {
@@ -286,7 +286,7 @@ impl WebRenderStackingContextConverter for StackingContext {
                 } else {
                     item.web_render_stacking_level()
                 };
-                item.item.convert_to_webrender(stacking_level, builder, auxiliary_lists_builder);
+                item.item.convert_to_webrender(stacking_level, builder, frame_builder);
 
             }
             if child.context_type == StackingContextType::Real {
@@ -295,7 +295,7 @@ impl WebRenderStackingContextConverter for StackingContext {
                                                                      pipeline_id,
                                                                      epoch,
                                                                      None,
-                                                                     auxiliary_lists_builder);
+                                                                     frame_builder);
                 builder.push_stacking_context(child.web_render_stacking_level(),
                                               stacking_context_id);
             } else {
@@ -305,7 +305,7 @@ impl WebRenderStackingContextConverter for StackingContext {
                                                     epoch,
                                                     scroll_layer_id,
                                                     builder,
-                                                    auxiliary_lists_builder,
+                                                    frame_builder,
                                                     true);
             }
         }
@@ -313,17 +313,17 @@ impl WebRenderStackingContextConverter for StackingContext {
         while let Some(item) = traversal.advance(self) {
             item.item.convert_to_webrender(webrender_traits::StackingLevel::PositionedContent,
                                            builder,
-                                           auxiliary_lists_builder);
+                                           frame_builder);
         }
     }
 
     fn convert_to_webrender<'a>(&self,
                                 traversal: &mut DisplayListTraversal<'a>,
-                                api: &webrender_traits::RenderApi,
+                                api: &mut webrender_traits::RenderApi,
                                 pipeline_id: webrender_traits::PipelineId,
                                 epoch: webrender_traits::Epoch,
                                 scroll_layer_id: Option<webrender_traits::ScrollLayerId>,
-                                auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
+                                frame_builder: &mut WebRenderFrameBuilder)
                                 -> webrender_traits::StackingContextId {
         let scroll_policy = self.layer_info
                                 .map_or(webrender_traits::ScrollPolicy::Scrollable, |info| {
@@ -333,17 +333,18 @@ impl WebRenderStackingContextConverter for StackingContext {
             }
         });
 
-        let mut sc = webrender_traits::StackingContext::new(scroll_layer_id,
-                                                            scroll_policy,
-                                                            self.bounds.to_rectf(),
-                                                            self.overflow.to_rectf(),
-                                                            self.z_index,
-                                                            &self.transform,
-                                                            &self.perspective,
-                                                            self.establishes_3d_context,
-                                                            self.blend_mode.to_blend_mode(),
-                                                            self.filters.to_filter_ops(),
-                                                            auxiliary_lists_builder);
+        let mut sc =
+            webrender_traits::StackingContext::new(scroll_layer_id,
+                                                   scroll_policy,
+                                                   self.bounds.to_rectf(),
+                                                   self.overflow.to_rectf(),
+                                                   self.z_index,
+                                                   &self.transform,
+                                                   &self.perspective,
+                                                   self.establishes_3d_context,
+                                                   self.blend_mode.to_blend_mode(),
+                                                   self.filters.to_filter_ops(),
+                                                   &mut frame_builder.auxiliary_lists_builder);
         let mut builder = webrender_traits::DisplayListBuilder::new();
         self.convert_children_to_webrender(traversal,
                                            api,
@@ -351,10 +352,10 @@ impl WebRenderStackingContextConverter for StackingContext {
                                            epoch,
                                            scroll_layer_id,
                                            &mut builder,
-                                           auxiliary_lists_builder,
+                                           frame_builder,
                                            false);
-        api.add_display_list(builder.finalize(), &mut sc, pipeline_id, epoch);
-        api.add_stacking_context(sc, pipeline_id, epoch)
+        frame_builder.add_display_list(api, builder.finalize(), &mut sc);
+        frame_builder.add_stacking_context(api, pipeline_id, sc)
     }
 
     fn web_render_stacking_level(&self) -> webrender_traits::StackingLevel {
@@ -368,11 +369,11 @@ impl WebRenderStackingContextConverter for StackingContext {
 
 impl WebRenderDisplayListConverter for DisplayList {
     fn convert_to_webrender(&self,
-                            api: &webrender_traits::RenderApi,
+                            api: &mut webrender_traits::RenderApi,
                             pipeline_id: webrender_traits::PipelineId,
                             epoch: webrender_traits::Epoch,
                             scroll_layer_id: Option<webrender_traits::ScrollLayerId>,
-                            auxiliary_lists_builder: &mut AuxiliaryListsBuilder)
+                            frame_builder: &mut WebRenderFrameBuilder)
                             -> webrender_traits::StackingContextId {
         let mut traversal = DisplayListTraversal {
             display_list: self,
@@ -385,7 +386,7 @@ impl WebRenderDisplayListConverter for DisplayList {
                                                         pipeline_id,
                                                         epoch,
                                                         scroll_layer_id,
-                                                        auxiliary_lists_builder)
+                                                        frame_builder)
     }
 }
 
@@ -393,14 +394,14 @@ impl WebRenderDisplayItemConverter for DisplayItem {
     fn convert_to_webrender(&self,
                             level: webrender_traits::StackingLevel,
                             builder: &mut webrender_traits::DisplayListBuilder,
-                            auxiliary_lists_builder: &mut AuxiliaryListsBuilder) {
+                            frame_builder: &mut WebRenderFrameBuilder) {
         match *self {
             DisplayItem::SolidColorClass(ref item) => {
                 let color = item.color.to_colorf();
                 if color.a > 0.0 {
                     builder.push_rect(level,
                                       item.base.bounds.to_rectf(),
-                                      item.base.clip.to_clip_region(auxiliary_lists_builder),
+                                      item.base.clip.to_clip_region(frame_builder),
                                       color);
                 }
             }
@@ -425,13 +426,13 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                 if glyphs.len() > 0 {
                     builder.push_text(level,
                                       item.base.bounds.to_rectf(),
-                                      item.base.clip.to_clip_region(auxiliary_lists_builder),
+                                      item.base.clip.to_clip_region(frame_builder),
                                       glyphs,
                                       item.text_run.font_key.expect("Font not added to webrender!"),
                                       item.text_color.to_colorf(),
                                       item.text_run.actual_pt_size,
                                       item.blur_radius,
-                                      auxiliary_lists_builder);
+                                      &mut frame_builder.auxiliary_lists_builder);
                 }
             }
             DisplayItem::ImageClass(ref item) => {
@@ -440,7 +441,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                        item.stretch_size.height > Au(0) {
                         builder.push_image(level,
                                            item.base.bounds.to_rectf(),
-                                           item.base.clip.to_clip_region(auxiliary_lists_builder),
+                                           item.base.clip.to_clip_region(frame_builder),
                                            item.stretch_size.to_sizef(),
                                            item.image_rendering.to_image_rendering(),
                                            id);
@@ -450,7 +451,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
             DisplayItem::WebGLClass(ref item) => {
                 builder.push_webgl_canvas(level,
                                           item.base.bounds.to_rectf(),
-                                          item.base.clip.to_clip_region(auxiliary_lists_builder),
+                                          item.base.clip.to_clip_region(frame_builder),
                                           item.context_id);
             }
             DisplayItem::BorderClass(ref item) => {
@@ -478,7 +479,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                 let radius = item.radius.to_border_radius();
                 builder.push_border(level,
                                     rect,
-                                    item.base.clip.to_clip_region(auxiliary_lists_builder),
+                                    item.base.clip.to_clip_region(frame_builder),
                                     left,
                                     top,
                                     right,
@@ -495,11 +496,11 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                 }
                 builder.push_gradient(level,
                                       rect,
-                                      item.base.clip.to_clip_region(auxiliary_lists_builder),
+                                      item.base.clip.to_clip_region(frame_builder),
                                       start_point,
                                       end_point,
                                       stops,
-                                      auxiliary_lists_builder);
+                                      &mut frame_builder.auxiliary_lists_builder);
             }
             DisplayItem::LineClass(..) => {
                 println!("TODO DisplayItem::LineClass");
@@ -512,7 +513,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                 let box_bounds = item.box_bounds.to_rectf();
                 builder.push_box_shadow(level,
                                         rect,
-                                        item.base.clip.to_clip_region(auxiliary_lists_builder),
+                                        item.base.clip.to_clip_region(frame_builder),
                                         box_bounds,
                                         item.offset.to_pointf(),
                                         item.color.to_colorf(),
@@ -526,9 +527,52 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                 let pipeline_id = item.iframe.to_webrender();
                 builder.push_iframe(level,
                                     rect,
-                                    item.base.clip.to_clip_region(auxiliary_lists_builder),
+                                    item.base.clip.to_clip_region(frame_builder),
                                     pipeline_id);
             }
         }
     }
 }
+
+pub struct WebRenderFrameBuilder {
+    pub stacking_contexts: Vec<(StackingContextId, webrender_traits::StackingContext)>,
+    pub display_lists: Vec<(DisplayListId, webrender_traits::BuiltDisplayList)>,
+    pub auxiliary_lists_builder: AuxiliaryListsBuilder,
+    pub root_pipeline_id: PipelineId
+}
+
+impl WebRenderFrameBuilder {
+    pub fn new(root_pipeline_id: PipelineId) -> WebRenderFrameBuilder {
+        WebRenderFrameBuilder {
+            stacking_contexts: vec![],
+            display_lists: vec![],
+            auxiliary_lists_builder: AuxiliaryListsBuilder::new(),
+            root_pipeline_id: root_pipeline_id,
+        }
+    }
+
+    pub fn add_stacking_context(&mut self,
+                                api: &mut webrender_traits::RenderApi,
+                                pipeline_id: PipelineId,
+                                stacking_context: webrender_traits::StackingContext)
+                                -> StackingContextId {
+        assert!(pipeline_id == self.root_pipeline_id);
+        let id = api.next_stacking_context_id();
+        self.stacking_contexts.push((id, stacking_context));
+        id
+    }
+
+    pub fn add_display_list(&mut self,
+                            api: &mut webrender_traits::RenderApi,
+                            display_list: webrender_traits::BuiltDisplayList,
+                            stacking_context: &mut webrender_traits::StackingContext)
+                            -> DisplayListId {
+        let id = api.next_display_list_id();
+        stacking_context.has_stacking_contexts = stacking_context.has_stacking_contexts ||
+                                                 display_list.descriptor().has_stacking_contexts;
+        stacking_context.display_lists.push(id);
+        self.display_lists.push((id, display_list));
+        id
+    }
+}
+

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -436,7 +436,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                 }
             }
             DisplayItem::ImageClass(ref item) => {
-                if let Some(id) = item.image.id {
+                if let Some(id) = item.webrender_image.key {
                     if item.stretch_size.width > Au(0) &&
                        item.stretch_size.height > Au(0) {
                         builder.push_image(level,

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -222,7 +222,7 @@ pub struct ImageMetadata {
     pub height: u32,
 }
 
-#[derive(Deserialize, Serialize, HeapSizeOf)]
+#[derive(Clone, Deserialize, Serialize, HeapSizeOf)]
 pub struct Image {
     pub width: u32,
     pub height: u32,

--- a/components/net_traits/image_cache_thread.rs
+++ b/components/net_traits/image_cache_thread.rs
@@ -96,7 +96,7 @@ pub enum ImageCacheCommand {
     Exit(IpcSender<()>),
 }
 
-#[derive(Copy, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Copy, Clone, PartialEq, Hash, Eq, Deserialize, Serialize)]
 pub enum UsePlaceholder {
     No,
     Yes,

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -2306,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.1.0"
-source = "git+https://github.com/servo/webrender#ab1c795612a5bd560a8adf750b4630cf1d24f706"
+source = "git+https://github.com/servo/webrender#2a71ccb0249601b25ef156f9a585a001c8d606cb"
 dependencies = [
  "app_units 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "webrender_traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/webrender_traits#0bff8081020c0fc0a31258482f4c6e9bfaf597f2"
+source = "git+https://github.com/servo/webrender_traits#2ad5e68f3f49c91ef627848d9561649f3c1be344"
 dependencies = [
  "app_units 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -2182,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.1.0"
-source = "git+https://github.com/servo/webrender#ab1c795612a5bd560a8adf750b4630cf1d24f706"
+source = "git+https://github.com/servo/webrender#2a71ccb0249601b25ef156f9a585a001c8d606cb"
 dependencies = [
  "app_units 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "webrender_traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/webrender_traits#0bff8081020c0fc0a31258482f4c6e9bfaf597f2"
+source = "git+https://github.com/servo/webrender_traits#2ad5e68f3f49c91ef627848d9561649f3c1be344"
 dependencies = [
  "app_units 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.1.0"
-source = "git+https://github.com/servo/webrender#ab1c795612a5bd560a8adf750b4630cf1d24f706"
+source = "git+https://github.com/servo/webrender#2a71ccb0249601b25ef156f9a585a001c8d606cb"
 dependencies = [
  "app_units 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2153,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "webrender_traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/webrender_traits#0bff8081020c0fc0a31258482f4c6e9bfaf597f2"
+source = "git+https://github.com/servo/webrender_traits#2ad5e68f3f49c91ef627848d9561649f3c1be344"
 dependencies = [
  "app_units 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This series of commits improves performance of display list construction in browser.html by about 3x when using WebRender.

It requires https://github.com/servo/webrender_traits/pull/18 and https://github.com/servo/webrender/pull/231.

Anyone should feel free to review if they have time; I'll ask someone in particular once those two upstream commits land.

cc @paulrouget

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9947)

<!-- Reviewable:end -->
