### PR TITLE
Fix work list order after split_line_at_last_known_good_position

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2732,6 +2732,18 @@
             "url": "/_mozilla/css/li_absolute_containing_block_a.html"
           }
         ],
+        "css/line_break_nowrap.html": [
+          {
+            "path": "css/line_break_nowrap.html",
+            "references": [
+              [
+                "/_mozilla/css/line_break_nowrap_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/line_break_nowrap.html"
+          }
+        ],
         "css/line_breaking_whitespace_collapse_a.html": [
           {
             "path": "css/line_breaking_whitespace_collapse_a.html",
@@ -8918,6 +8930,18 @@
             ]
           ],
           "url": "/_mozilla/css/li_absolute_containing_block_a.html"
+        }
+      ],
+      "css/line_break_nowrap.html": [
+        {
+          "path": "css/line_break_nowrap.html",
+          "references": [
+            [
+              "/_mozilla/css/line_break_nowrap_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/line_break_nowrap.html"
         }
       ],
       "css/line_breaking_whitespace_collapse_a.html": [

--- a/tests/wpt/mozilla/tests/css/line_break_nowrap.html
+++ b/tests/wpt/mozilla/tests/css/line_break_nowrap.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>nowrap line-breaking test</title>
+    <link rel="match" href="line_break_nowrap_ref.html">
+    <style>
+      body {
+        font-family: 'ahem';
+        width: 25em;
+      }
+      span {
+        white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <span>hello world</span>
+    <span>hello world</span>
+    <span>hello world</span>
+    <span>hello world</span>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/line_break_nowrap_ref.html
+++ b/tests/wpt/mozilla/tests/css/line_break_nowrap_ref.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>nowrap line-breaking reference</title>
+    <style>
+      body { font-family: 'ahem'; }
+    </style>
+  </head>
+  <body>
+    <div>
+      hello world hello world<br>
+      hello world hello world
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This fixes a bug in line splitting caused by the following actions when `LineBreaker::split_line_at_last_known_good_position` is called:
1. Push some number of previous fragments onto the front of the work list.
2. Push the current fragment back onto the front of the work list.

This resulted in the work list being out of order.  The correct order is action 2 followed by action 1.  Fixes #9830. r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9961)

<!-- Reviewable:end -->
