### PR TITLE
Simplify the display list slightly

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -744,7 +744,6 @@ pub enum DisplayItem {
     LineClass(Box<LineDisplayItem>),
     BoxShadowClass(Box<BoxShadowDisplayItem>),
     LayeredItemClass(Box<LayeredItem>),
-    NoopClass(Box<BaseDisplayItem>),
     IframeClass(Box<IframeDisplayItem>),
 }
 
@@ -1169,9 +1168,6 @@ pub struct LayeredItem {
     pub item: DisplayItem,
 
     /// The id of the layer this item belongs to.
-    pub layer_id: LayerId,
-
-    /// The id of the layer this item belongs to.
     pub layer_info: LayerInfo,
 }
 
@@ -1251,7 +1247,6 @@ impl DisplayItem {
 
             DisplayItem::LayeredItemClass(ref item) => item.item.draw_into_context(paint_context),
 
-            DisplayItem::NoopClass(_) => { }
             DisplayItem::IframeClass(..) => {}
         }
     }
@@ -1280,7 +1275,6 @@ impl DisplayItem {
             DisplayItem::LineClass(ref line) => &line.base,
             DisplayItem::BoxShadowClass(ref box_shadow) => &box_shadow.base,
             DisplayItem::LayeredItemClass(ref layered_item) => layered_item.item.base(),
-            DisplayItem::NoopClass(ref base_item) => base_item,
             DisplayItem::IframeClass(ref iframe) => &iframe.base,
         }
     }
@@ -1364,7 +1358,6 @@ impl fmt::Debug for DisplayItem {
                 DisplayItem::BoxShadowClass(_) => "BoxShadow".to_owned(),
                 DisplayItem::LayeredItemClass(ref layered_item) =>
                     format!("LayeredItem({:?})", layered_item.item),
-                DisplayItem::NoopClass(_) => "Noop".to_owned(),
                 DisplayItem::IframeClass(_) => "Iframe".to_owned(),
             },
             self.bounds(),

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1141,28 +1141,22 @@ impl FragmentDisplayListBuilding for Fragment {
             }
             SpecificFragmentInfo::Iframe(ref fragment_info) => {
                 if !stacking_relative_content_box.is_empty() {
+                    let item = DisplayItem::IframeClass(box IframeDisplayItem {
+                        base: BaseDisplayItem::new(
+                            &stacking_relative_content_box,
+                            DisplayItemMetadata::new(self.node,
+                                                     &*self.style,
+                                                     Cursor::DefaultCursor),
+                            clip),
+                        iframe: fragment_info.pipeline_id,
+                    });
+
                     if opts::get().use_webrender {
-                        state.add_display_item(DisplayItem::IframeClass(box IframeDisplayItem {
-                            base: BaseDisplayItem::new(
-                                &stacking_relative_content_box,
-                                DisplayItemMetadata::new(self.node,
-                                                         &*self.style,
-                                                         Cursor::DefaultCursor),
-                                clip),
-                            iframe: fragment_info.pipeline_id,
-                        }), DisplayListSection::Content);
+                        state.add_display_item(item, DisplayListSection::Content);
                     } else {
-                        let layer_id = self.layer_id();
                         state.add_display_item(DisplayItem::LayeredItemClass(box LayeredItem {
-                            item: DisplayItem::NoopClass(
-                                box BaseDisplayItem::new(
-                                    &stacking_relative_content_box,
-                                    DisplayItemMetadata::new(self.node,
-                                                             &*self.style,
-                                                             Cursor::DefaultCursor),
-                                    clip)),
-                            layer_id: layer_id,
-                            layer_info: LayerInfo::new(layer_id,
+                            item: item,
+                            layer_info: LayerInfo::new(self.layer_id(),
                                                        ScrollPolicy::Scrollable,
                                                        Some(fragment_info.pipeline_id),
                                                        color::transparent()),
@@ -1248,7 +1242,6 @@ impl FragmentDisplayListBuilding for Fragment {
                     } else {
                         state.add_display_item(DisplayItem::LayeredItemClass(box LayeredItem {
                             item: display_item,
-                            layer_id: layer_id,
                             layer_info: LayerInfo::new(layer_id,
                                                        ScrollPolicy::Scrollable,
                                                        None,

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -504,8 +504,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
             DisplayItem::LineClass(..) => {
                 println!("TODO DisplayItem::LineClass");
             }
-            DisplayItem::LayeredItemClass(..) |
-            DisplayItem::NoopClass(..) => {
+            DisplayItem::LayeredItemClass(..) => {
                 panic!("Unexpected in webrender!");
             }
             DisplayItem::BoxShadowClass(ref item) => {


### PR DESCRIPTION
Now that WebRender uses an Iframe display item, we do not need the Noop
item for the non-WebRender path. We can simply reuse the Iframe display
item. Also remove the layer_id member from the LayeredItem struct, as
it is unused.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9962)

<!-- Reviewable:end -->
