### PR TITLE
Compute damage even when incremental layout is disabled

### DIFF
--- a/components/layout/layout_thread.rs
+++ b/components/layout/layout_thread.rs
@@ -1291,9 +1291,11 @@ impl LayoutThread {
                     self.profiler_metadata(),
                     self.time_profiler_chan.clone(),
                     || {
-                if opts::get().nonincremental_layout ||
-                        flow_ref::deref_mut(&mut root_flow).compute_layout_damage()
-                                                           .contains(REFLOW_ENTIRE_DOCUMENT) {
+                // Call `compute_layout_damage` even in non-incremental mode, because it sets flags
+                // that are needed in both incremental and non-incremental traversals.
+                let damage = flow_ref::deref_mut(&mut root_flow).compute_layout_damage();
+
+                if opts::get().nonincremental_layout || damage.contains(REFLOW_ENTIRE_DOCUMENT) {
                     flow_ref::deref_mut(&mut root_flow).reflow_entire_document()
                 }
             });


### PR DESCRIPTION
This fixes traversals that use the damage flags to decide which nodes to process, such as `resolve_generated_content`, which was broken in non-incremental mode. r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9964)

<!-- Reviewable:end -->
