### PR TITLE
Don't re-resolve already-resolved generated content

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -256,6 +256,8 @@ fn clamp_size(size: Au,
 pub enum GeneratedContentInfo {
     ListItem,
     ContentItem(ContentItem),
+    /// Placeholder for elements with generated content that did not generate any fragments.
+    Empty,
 }
 
 /// A hypothetical box (see CSS 2.1 § 10.3.7) for an absolutely-positioned block that was declared
@@ -1291,8 +1293,9 @@ impl Fragment {
     }
 
     /// Returns true if and only if this fragment is a generated content fragment.
-    pub fn is_generated_content(&self) -> bool {
+    pub fn is_unscanned_generated_content(&self) -> bool {
         match self.specific {
+            SpecificFragmentInfo::GeneratedContent(box GeneratedContentInfo::Empty) => false,
             SpecificFragmentInfo::GeneratedContent(..) => true,
             _ => false,
         }

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -846,10 +846,8 @@ impl InlineFlow {
             first_line_indentation: Au(0),
         };
 
-        for fragment in &flow.fragments.fragments {
-            if fragment.is_generated_content() {
-                flow.base.restyle_damage.insert(RESOLVE_GENERATED_CONTENT)
-            }
+        if flow.fragments.fragments.iter().any(Fragment::is_unscanned_generated_content) {
+            flow.base.restyle_damage.insert(RESOLVE_GENERATED_CONTENT);
         }
 
         flow

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![feature(as_unsafe_cell)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(custom_derive)]
 #![feature(mpsc_select)]

--- a/tests/wpt/metadata-css/css21_dev/html4/quotes-036.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/quotes-036.htm.ini
@@ -1,3 +1,0 @@
-[quotes-036.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
This fixes #7846, a failure in the "quotes-036.htm" test. Servo lays out this test correctly in its initial layout, but then messes it up in any relayout (whether it's an incremental or full layout).

The problem is that the ResolveGeneratedContent traversal is not safe to run more than once on the same flow. It mutates some GeneratedContent fragments into ScannedText fragments, but leaves others unmodified (in particular, those that generate empty content). The next time layout runs, these remaining GeneratedContent fragments are processed _again_ but with an incorrect correct quote nesting level (because some of the surrounding GeneratedContent fragments are gone).

This patch ensures that each GeneratedContent fragment is resolved only once.

r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9969)

<!-- Reviewable:end -->
