### PR TITLE
Remove lifetimes from Style/Layout traits

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -209,8 +209,8 @@ impl InlineFragmentsAccumulator {
         }
     }
 
-    fn from_inline_node<'ln, N>(node: &N) -> InlineFragmentsAccumulator
-            where N: ThreadSafeLayoutNode<'ln> {
+    fn from_inline_node<N>(node: &N) -> InlineFragmentsAccumulator
+            where N: ThreadSafeLayoutNode {
         InlineFragmentsAccumulator {
             fragments: IntermediateInlineFragments::new(),
             enclosing_node: Some(InlineFragmentNodeInfo {
@@ -267,22 +267,20 @@ impl InlineFragmentsAccumulator {
 }
 
 /// An object that knows how to create flows.
-pub struct FlowConstructor<'a, 'ln, N: ThreadSafeLayoutNode<'ln>> {
+pub struct FlowConstructor<'a, N: ThreadSafeLayoutNode> {
     /// The layout context.
     pub layout_context: &'a LayoutContext<'a>,
     /// Satisfy the compiler about the unused parameters, which we use to improve the ergonomics of
     /// the ensuing impl {} by removing the need to parameterize all the methods individually.
-    phantom1: PhantomData<&'ln ()>,
     phantom2: PhantomData<N>,
 }
 
-impl<'a, 'ln, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<'ln>>
-  FlowConstructor<'a, 'ln, ConcreteThreadSafeLayoutNode> {
+impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
+  FlowConstructor<'a, ConcreteThreadSafeLayoutNode> {
     /// Creates a new flow constructor.
     pub fn new(layout_context: &'a LayoutContext<'a>) -> Self {
         FlowConstructor {
             layout_context: layout_context,
-            phantom1: PhantomData,
             phantom2: PhantomData,
         }
     }
@@ -1444,9 +1442,9 @@ impl<'a, 'ln, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<'ln>>
     }
 }
 
-impl<'a, 'ln, ConcreteThreadSafeLayoutNode> PostorderNodeMutTraversal<'ln, ConcreteThreadSafeLayoutNode>
-                                            for FlowConstructor<'a, 'ln, ConcreteThreadSafeLayoutNode>
-                                            where ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<'ln> {
+impl<'a, ConcreteThreadSafeLayoutNode> PostorderNodeMutTraversal<ConcreteThreadSafeLayoutNode>
+                                       for FlowConstructor<'a, ConcreteThreadSafeLayoutNode>
+                                       where ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode {
     // Construct Flow based on 'display', 'position', and 'float' values.
     //
     // CSS 2.1 Section 9.7
@@ -1623,8 +1621,8 @@ trait NodeUtils {
     fn swap_out_construction_result(self) -> ConstructionResult;
 }
 
-impl<'ln, ConcreteThreadSafeLayoutNode> NodeUtils for ConcreteThreadSafeLayoutNode
-                                                  where ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<'ln> {
+impl<ConcreteThreadSafeLayoutNode> NodeUtils for ConcreteThreadSafeLayoutNode
+                                             where ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode {
     fn is_replaced_content(&self) -> bool {
         match self.type_id() {
             None |
@@ -1682,7 +1680,7 @@ trait ObjectElement {
     fn object_data(&self) -> Option<Url>;
 }
 
-impl<'ln, N> ObjectElement for N  where N: ThreadSafeLayoutNode<'ln> {
+impl<N> ObjectElement for N  where N: ThreadSafeLayoutNode {
     fn has_object_data(&self) -> bool {
         let elem = self.as_element();
         let type_and_data = (elem.get_attr(&ns!(), &atom!("type")), elem.get_attr(&ns!(), &atom!("data")));

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1674,10 +1674,7 @@ impl<'ln, ConcreteThreadSafeLayoutNode> NodeUtils for ConcreteThreadSafeLayoutNo
 }
 
 /// Methods for interacting with HTMLObjectElement nodes
-trait ObjectElement<'a> {
-    /// Returns None if this node is not matching attributes.
-    fn get_type_and_data(&self) -> (Option<&'a str>, Option<&'a str>);
-
+trait ObjectElement {
     /// Returns true if this node has object data that is correct uri.
     fn has_object_data(&self) -> bool;
 
@@ -1685,21 +1682,20 @@ trait ObjectElement<'a> {
     fn object_data(&self) -> Option<Url>;
 }
 
-impl<'ln, N> ObjectElement<'ln> for N  where N: ThreadSafeLayoutNode<'ln> {
-    fn get_type_and_data(&self) -> (Option<&'ln str>, Option<&'ln str>) {
-        let elem = self.as_element();
-        (elem.get_attr(&ns!(), &atom!("type")), elem.get_attr(&ns!(), &atom!("data")))
-    }
-
+impl<'ln, N> ObjectElement for N  where N: ThreadSafeLayoutNode<'ln> {
     fn has_object_data(&self) -> bool {
-        match self.get_type_and_data() {
+        let elem = self.as_element();
+        let type_and_data = (elem.get_attr(&ns!(), &atom!("type")), elem.get_attr(&ns!(), &atom!("data")));
+        match type_and_data {
             (None, Some(uri)) => is_image_data(uri),
             _ => false
         }
     }
 
     fn object_data(&self) -> Option<Url> {
-        match self.get_type_and_data() {
+        let elem = self.as_element();
+        let type_and_data = (elem.get_attr(&ns!(), &atom!("type")), elem.get_attr(&ns!(), &atom!("data")));
+        match type_and_data {
             (None, Some(uri)) if is_image_data(uri) => Url::parse(uri).ok(),
             _ => None
         }

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -483,7 +483,7 @@ pub trait ImmutableFlowUtils {
     fn need_anonymous_flow(self, child: &Flow) -> bool;
 
     /// Generates missing child flow of this flow.
-    fn generate_missing_child_flow<'ln, N: ThreadSafeLayoutNode<'ln>>(self, node: &N) -> FlowRef;
+    fn generate_missing_child_flow<N: ThreadSafeLayoutNode>(self, node: &N) -> FlowRef;
 
     /// Returns true if this flow contains fragments that are roots of an absolute flow tree.
     fn contains_roots_of_absolute_flow_tree(&self) -> bool;
@@ -1272,7 +1272,7 @@ impl<'a> ImmutableFlowUtils for &'a Flow {
     /// FIXME(pcwalton): This duplicates some logic in
     /// `generate_anonymous_table_flows_if_necessary()`. We should remove this function eventually,
     /// as it's harder to understand.
-    fn generate_missing_child_flow<'ln, N: ThreadSafeLayoutNode<'ln>>(self, node: &N) -> FlowRef {
+    fn generate_missing_child_flow<N: ThreadSafeLayoutNode>(self, node: &N) -> FlowRef {
         let mut style = node.style().clone();
         match self.class() {
             FlowClass::Table | FlowClass::TableRowGroup => {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -323,7 +323,7 @@ pub struct CanvasFragmentInfo {
 }
 
 impl CanvasFragmentInfo {
-    pub fn new<'ln, N: ThreadSafeLayoutNode<'ln>>(node: &N, data: HTMLCanvasData) -> CanvasFragmentInfo {
+    pub fn new<N: ThreadSafeLayoutNode>(node: &N, data: HTMLCanvasData) -> CanvasFragmentInfo {
         CanvasFragmentInfo {
             replaced_image_fragment_info: ReplacedImageFragmentInfo::new(node),
             renderer_id: data.renderer_id,
@@ -368,8 +368,8 @@ impl ImageFragmentInfo {
     ///
     /// FIXME(pcwalton): The fact that image fragments store the cache in the fragment makes little
     /// sense to me.
-    pub fn new<'ln, N: ThreadSafeLayoutNode<'ln>>(node: &N, url: Option<Url>,
-                                                  layout_context: &LayoutContext) -> ImageFragmentInfo {
+    pub fn new<N: ThreadSafeLayoutNode>(node: &N, url: Option<Url>,
+                                        layout_context: &LayoutContext) -> ImageFragmentInfo {
         let image_or_metadata = url.and_then(|url| {
             layout_context.get_or_request_image_or_meta(url, UsePlaceholder::Yes)
         });
@@ -446,8 +446,8 @@ pub struct ReplacedImageFragmentInfo {
 }
 
 impl ReplacedImageFragmentInfo {
-    pub fn new<'ln, N>(node: &N) -> ReplacedImageFragmentInfo
-            where N: ThreadSafeLayoutNode<'ln> {
+    pub fn new<N>(node: &N) -> ReplacedImageFragmentInfo
+            where N: ThreadSafeLayoutNode {
         let is_vertical = node.style().writing_mode.is_vertical();
         ReplacedImageFragmentInfo {
             computed_inline_size: None,
@@ -590,7 +590,7 @@ pub struct IframeFragmentInfo {
 
 impl IframeFragmentInfo {
     /// Creates the information specific to an iframe fragment.
-    pub fn new<'ln, N: ThreadSafeLayoutNode<'ln>>(node: &N) -> IframeFragmentInfo {
+    pub fn new<N: ThreadSafeLayoutNode>(node: &N) -> IframeFragmentInfo {
         let pipeline_id = node.iframe_pipeline_id();
         IframeFragmentInfo {
             pipeline_id: pipeline_id,
@@ -765,7 +765,7 @@ pub struct TableColumnFragmentInfo {
 
 impl TableColumnFragmentInfo {
     /// Create the information specific to an table column fragment.
-    pub fn new<'ln, N: ThreadSafeLayoutNode<'ln>>(node: &N) -> TableColumnFragmentInfo {
+    pub fn new<N: ThreadSafeLayoutNode>(node: &N) -> TableColumnFragmentInfo {
         let element = node.as_element();
         let span = element.get_attr(&ns!(), &atom!("span"))
                           .and_then(|string| string.parse().ok())
@@ -778,7 +778,7 @@ impl TableColumnFragmentInfo {
 
 impl Fragment {
     /// Constructs a new `Fragment` instance.
-    pub fn new<'ln, N: ThreadSafeLayoutNode<'ln>>(node: &N, specific: SpecificFragmentInfo) -> Fragment {
+    pub fn new<N: ThreadSafeLayoutNode>(node: &N, specific: SpecificFragmentInfo) -> Fragment {
         let style = node.style().clone();
         let writing_mode = style.writing_mode;
 

--- a/components/layout/layout_thread.rs
+++ b/components/layout/layout_thread.rs
@@ -794,7 +794,7 @@ impl LayoutThread {
         possibly_locked_rw_data.block(rw_data);
     }
 
-    fn try_get_layout_root<'ln, N: LayoutNode<'ln>>(&self, node: N) -> Option<FlowRef> {
+    fn try_get_layout_root<N: LayoutNode>(&self, node: N) -> Option<FlowRef> {
         let mut data = match node.mutate_layout_data() {
             Some(x) => x,
             None => return None,
@@ -1372,7 +1372,7 @@ impl LayoutThread {
         }
     }
 
-    unsafe fn dirty_all_nodes<'ln, N: LayoutNode<'ln>>(node: N) {
+    unsafe fn dirty_all_nodes<N: LayoutNode>(node: N) {
         for node in node.traverse_preorder() {
             // TODO(cgaebel): mark nodes which are sensitive to media queries as
             // "changed":

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -284,7 +284,7 @@ impl FragmentBorderBoxIterator for MarginRetrievingFragmentBorderBoxIterator {
     }
 }
 
-pub fn process_content_box_request<'ln, N: LayoutNode<'ln>>(
+pub fn process_content_box_request<N: LayoutNode>(
         requested_node: N, layout_root: &mut FlowRef) -> Rect<Au> {
     // FIXME(pcwalton): This has not been updated to handle the stacking context relative
     // stuff. So the position is wrong in most cases.
@@ -296,7 +296,7 @@ pub fn process_content_box_request<'ln, N: LayoutNode<'ln>>(
     }
 }
 
-pub fn process_content_boxes_request<'ln, N: LayoutNode<'ln>>(requested_node: N, layout_root: &mut FlowRef)
+pub fn process_content_boxes_request<N: LayoutNode>(requested_node: N, layout_root: &mut FlowRef)
         -> Vec<Rect<Au>> {
     // FIXME(pcwalton): This has not been updated to handle the stacking context relative
     // stuff. So the position is wrong in most cases.
@@ -490,14 +490,14 @@ impl FragmentBorderBoxIterator for ParentOffsetBorderBoxIterator {
     }
 }
 
-pub fn process_node_geometry_request<'ln, N: LayoutNode<'ln>>(requested_node: N, layout_root: &mut FlowRef)
+pub fn process_node_geometry_request<N: LayoutNode>(requested_node: N, layout_root: &mut FlowRef)
         -> Rect<i32> {
     let mut iterator = FragmentLocatingFragmentIterator::new(requested_node.opaque());
     sequential::iterate_through_flow_tree_fragment_border_boxes(layout_root, &mut iterator);
     iterator.client_rect
 }
 
-pub fn process_node_scroll_area_request<'ln, N: LayoutNode<'ln>>(requested_node: N, layout_root: &mut FlowRef)
+pub fn process_node_scroll_area_request< N: LayoutNode>(requested_node: N, layout_root: &mut FlowRef)
         -> Rect<i32> {
     let mut iterator = UnioningFragmentScrollAreaIterator::new(requested_node.opaque());
     sequential::iterate_through_flow_tree_fragment_border_boxes(layout_root, &mut iterator);
@@ -529,7 +529,7 @@ pub fn process_node_scroll_area_request<'ln, N: LayoutNode<'ln>>(requested_node:
 
 /// Return the resolved value of property for a given (pseudo)element.
 /// https://drafts.csswg.org/cssom/#resolved-value
-pub fn process_resolved_style_request<'ln, N: LayoutNode<'ln>>(
+pub fn process_resolved_style_request<N: LayoutNode>(
             requested_node: N, pseudo: &Option<PseudoElement>,
             property: &Atom, layout_root: &mut FlowRef) -> Option<String> {
     let layout_node = requested_node.to_threadsafe();
@@ -566,7 +566,7 @@ pub fn process_resolved_style_request<'ln, N: LayoutNode<'ln>>(
     // There are probably other quirks.
     let applies = true;
 
-    fn used_value_for_position_property<'ln, N: LayoutNode<'ln>>(
+    fn used_value_for_position_property<N: LayoutNode>(
             layout_node: N::ConcreteThreadSafeLayoutNode,
             layout_root: &mut FlowRef,
             requested_node: N,
@@ -647,7 +647,7 @@ pub fn process_resolved_style_request<'ln, N: LayoutNode<'ln>>(
     }
 }
 
-pub fn process_offset_parent_query<'ln, N: LayoutNode<'ln>>(requested_node: N, layout_root: &mut FlowRef)
+pub fn process_offset_parent_query<N: LayoutNode>(requested_node: N, layout_root: &mut FlowRef)
         -> OffsetParentResponse {
     let mut iterator = ParentOffsetBorderBoxIterator::new(requested_node.opaque());
     sequential::iterate_through_flow_tree_fragment_border_boxes(layout_root, &mut iterator);
@@ -668,7 +668,7 @@ pub fn process_offset_parent_query<'ln, N: LayoutNode<'ln>>(requested_node: N, l
     }
 }
 
-pub fn process_margin_style_query<'ln, N: LayoutNode<'ln>>(requested_node: N)
+pub fn process_margin_style_query<N: LayoutNode>(requested_node: N)
         -> MarginStyleResponse {
     let layout_node = requested_node.to_threadsafe();
     let style = &*layout_node.style();

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -45,7 +45,7 @@ pub struct TableCellFlow {
 }
 
 impl TableCellFlow {
-    pub fn from_node_fragment_and_visibility_flag<'ln, N: ThreadSafeLayoutNode<'ln>>(
+    pub fn from_node_fragment_and_visibility_flag<N: ThreadSafeLayoutNode>(
             node: &N, fragment: Fragment, visible: bool) -> TableCellFlow {
         TableCellFlow {
             block_flow: BlockFlow::from_fragment(fragment, None),

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -28,7 +28,7 @@ pub struct RecalcStyleAndConstructFlows<'lc> {
     root: OpaqueNode,
 }
 
-impl<'lc, 'ln> DomTraversalContext<'ln, ServoLayoutNode<'ln>> for RecalcStyleAndConstructFlows<'lc> {
+impl<'lc, 'ln> DomTraversalContext<ServoLayoutNode<'ln>> for RecalcStyleAndConstructFlows<'lc> {
     type SharedContext = SharedLayoutContext;
     #[allow(unsafe_code)]
     fn new<'a>(shared: &'a Self::SharedContext, root: OpaqueNode) -> Self {

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -73,7 +73,7 @@ impl<'lc, 'ln> DomTraversalContext<ServoLayoutNode<'ln>> for RecalcStyleAndConst
 }
 
 /// A bottom-up, parallelizable traversal.
-pub trait PostorderNodeMutTraversal<'ln, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<'ln>> {
+pub trait PostorderNodeMutTraversal<ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode> {
     /// The operation to perform. Return true to continue or false to stop.
     fn process(&mut self, node: &ConcreteThreadSafeLayoutNode) -> bool;
 }
@@ -81,7 +81,7 @@ pub trait PostorderNodeMutTraversal<'ln, ConcreteThreadSafeLayoutNode: ThreadSaf
 /// The flow construction traversal, which builds flows for styled nodes.
 #[inline]
 #[allow(unsafe_code)]
-fn construct_flows_at<'a, 'ln, N: LayoutNode<'ln>>(context: &'a LayoutContext<'a>, root: OpaqueNode, node: N) {
+fn construct_flows_at<'a, N: LayoutNode>(context: &'a LayoutContext<'a>, root: OpaqueNode, node: N) {
     // Construct flows for this node.
     {
         let tnode = node.to_threadsafe();

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -79,8 +79,8 @@ pub type NonOpaqueStyleAndLayoutData = *mut RefCell<PrivateLayoutData>;
 /// A wrapper so that layout can access only the methods that it should have access to. Layout must
 /// only ever see these and must never see instances of `LayoutJS`.
 
-pub trait LayoutNode<'ln> : TNode {
-    type ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<'ln>;
+pub trait LayoutNode : TNode {
+    type ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode;
     fn to_threadsafe(&self) -> Self::ConcreteThreadSafeLayoutNode;
 
     /// Returns the type ID of this node.
@@ -286,7 +286,7 @@ impl<'ln> TNode for ServoLayoutNode<'ln> {
     }
 }
 
-impl<'ln> LayoutNode<'ln> for ServoLayoutNode<'ln> {
+impl<'ln> LayoutNode for ServoLayoutNode<'ln> {
     type ConcreteThreadSafeLayoutNode = ServoThreadSafeLayoutNode<'ln>;
 
     fn to_threadsafe(&self) -> Self::ConcreteThreadSafeLayoutNode {
@@ -637,8 +637,8 @@ impl<T> PseudoElementType<T> {
 /// A thread-safe version of `LayoutNode`, used during flow construction. This type of layout
 /// node does not allow any parents or siblings of nodes to be accessed, to avoid races.
 
-pub trait ThreadSafeLayoutNode<'ln> : Clone + Copy + Sized {
-    type ConcreteThreadSafeLayoutElement: ThreadSafeLayoutElement<'ln, ConcreteThreadSafeLayoutNode = Self>;
+pub trait ThreadSafeLayoutNode : Clone + Copy + Sized {
+    type ConcreteThreadSafeLayoutElement: ThreadSafeLayoutElement<ConcreteThreadSafeLayoutNode = Self>;
     type ChildrenIterator: Iterator<Item = Self> + Sized;
 
     /// Creates a new `ThreadSafeLayoutNode` for the same `LayoutNode`
@@ -788,16 +788,16 @@ pub trait ThreadSafeLayoutNode<'ln> : Clone + Copy + Sized {
 
 // This trait is only public so that it can be implemented by the gecko wrapper.
 // It can be used to violate thread-safety, so don't use it elsewhere in layout!
-pub trait DangerousThreadSafeLayoutNode<'ln> : ThreadSafeLayoutNode<'ln> {
+pub trait DangerousThreadSafeLayoutNode : ThreadSafeLayoutNode {
     unsafe fn dangerous_first_child(&self) -> Option<Self>;
     unsafe fn dangerous_next_sibling(&self) -> Option<Self>;
 }
 
-pub trait ThreadSafeLayoutElement<'le>: Clone + Copy + Sized {
-    type ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<'le, ConcreteThreadSafeLayoutElement = Self>;
+pub trait ThreadSafeLayoutElement: Clone + Copy + Sized {
+    type ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<ConcreteThreadSafeLayoutElement = Self>;
 
     #[inline]
-    fn get_attr(&self, namespace: &Namespace, name: &Atom) -> Option<&'le str>;
+    fn get_attr<'a>(&'a self, namespace: &Namespace, name: &Atom) -> Option<&'a str>;
 }
 
 #[derive(Copy, Clone)]
@@ -808,7 +808,7 @@ pub struct ServoThreadSafeLayoutNode<'ln> {
     pseudo: PseudoElementType<display::T>,
 }
 
-impl<'ln> DangerousThreadSafeLayoutNode<'ln> for ServoThreadSafeLayoutNode<'ln> {
+impl<'ln> DangerousThreadSafeLayoutNode for ServoThreadSafeLayoutNode<'ln> {
     unsafe fn dangerous_first_child(&self) -> Option<Self> {
             self.get_jsmanaged().first_child_ref()
                 .map(|node| self.new_with_this_lifetime(&node))
@@ -843,9 +843,9 @@ impl<'ln> ServoThreadSafeLayoutNode<'ln> {
     }
 }
 
-impl<'ln> ThreadSafeLayoutNode<'ln> for ServoThreadSafeLayoutNode<'ln> {
+impl<'ln> ThreadSafeLayoutNode for ServoThreadSafeLayoutNode<'ln> {
     type ConcreteThreadSafeLayoutElement = ServoThreadSafeLayoutElement<'ln>;
-    type ChildrenIterator = ThreadSafeLayoutNodeChildrenIterator<'ln, Self>;
+    type ChildrenIterator = ThreadSafeLayoutNodeChildrenIterator<Self>;
 
     fn with_pseudo(&self, pseudo: PseudoElementType<display::T>) -> ServoThreadSafeLayoutNode<'ln> {
         ServoThreadSafeLayoutNode {
@@ -1031,15 +1031,13 @@ impl<'ln> ThreadSafeLayoutNode<'ln> for ServoThreadSafeLayoutNode<'ln> {
     }
 }
 
-pub struct ThreadSafeLayoutNodeChildrenIterator<'ln, ConcreteNode: ThreadSafeLayoutNode<'ln>> {
+pub struct ThreadSafeLayoutNodeChildrenIterator<ConcreteNode: ThreadSafeLayoutNode> {
     current_node: Option<ConcreteNode>,
     parent_node: ConcreteNode,
-    // Satisfy the compiler about the unused lifetime.
-    phantom: PhantomData<&'ln ()>,
 }
 
-impl<'ln, ConcreteNode> ThreadSafeLayoutNodeChildrenIterator<'ln, ConcreteNode>
-                        where ConcreteNode: DangerousThreadSafeLayoutNode<'ln> {
+impl<ConcreteNode> ThreadSafeLayoutNodeChildrenIterator<ConcreteNode>
+                   where ConcreteNode: DangerousThreadSafeLayoutNode {
     pub fn new(parent: ConcreteNode) -> Self {
         let first_child: Option<ConcreteNode> = match parent.get_pseudo_element_type() {
             PseudoElementType::Normal => {
@@ -1052,13 +1050,12 @@ impl<'ln, ConcreteNode> ThreadSafeLayoutNodeChildrenIterator<'ln, ConcreteNode>
         ThreadSafeLayoutNodeChildrenIterator {
             current_node: first_child,
             parent_node: parent,
-            phantom: PhantomData,
         }
     }
 }
 
-impl<'ln, ConcreteNode> Iterator for ThreadSafeLayoutNodeChildrenIterator<'ln, ConcreteNode>
-                                 where ConcreteNode: DangerousThreadSafeLayoutNode<'ln> {
+impl<ConcreteNode> Iterator for ThreadSafeLayoutNodeChildrenIterator<ConcreteNode>
+                            where ConcreteNode: DangerousThreadSafeLayoutNode {
     type Item = ConcreteNode;
     fn next(&mut self) -> Option<ConcreteNode> {
         let node = self.current_node.clone();
@@ -1094,10 +1091,10 @@ pub struct ServoThreadSafeLayoutElement<'le> {
     element: &'le Element,
 }
 
-impl<'le> ThreadSafeLayoutElement<'le> for ServoThreadSafeLayoutElement<'le> {
+impl<'le> ThreadSafeLayoutElement for ServoThreadSafeLayoutElement<'le> {
     type ConcreteThreadSafeLayoutNode = ServoThreadSafeLayoutNode<'le>;
 
-    fn get_attr(&self, namespace: &Namespace, name: &Atom) -> Option<&'le str> {
+    fn get_attr<'a>(&'a self, namespace: &Namespace, name: &Atom) -> Option<&'a str> {
         unsafe {
             self.element.get_attr_val_for_layout(namespace, name)
         }

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -79,7 +79,7 @@ pub type NonOpaqueStyleAndLayoutData = *mut RefCell<PrivateLayoutData>;
 /// A wrapper so that layout can access only the methods that it should have access to. Layout must
 /// only ever see these and must never see instances of `LayoutJS`.
 
-pub trait LayoutNode<'ln> : TNode<'ln> {
+pub trait LayoutNode<'ln> : TNode {
     type ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<'ln>;
     fn to_threadsafe(&self) -> Self::ConcreteThreadSafeLayoutNode;
 
@@ -130,7 +130,7 @@ impl<'ln> ServoLayoutNode<'ln> {
     }
 }
 
-impl<'ln> TNode<'ln> for ServoLayoutNode<'ln> {
+impl<'ln> TNode for ServoLayoutNode<'ln> {
     type ConcreteElement = ServoLayoutElement<'ln>;
     type ConcreteDocument = ServoLayoutDocument<'ln>;
     type ConcreteRestyleDamage = RestyleDamage;
@@ -364,7 +364,7 @@ pub struct ServoLayoutDocument<'ld> {
     chain: PhantomData<&'ld ()>,
 }
 
-impl<'ld> TDocument<'ld> for ServoLayoutDocument<'ld> {
+impl<'ld> TDocument for ServoLayoutDocument<'ld> {
     type ConcreteNode = ServoLayoutNode<'ld>;
     type ConcreteElement = ServoLayoutElement<'ld>;
 
@@ -398,7 +398,7 @@ pub struct ServoLayoutElement<'le> {
     chain: PhantomData<&'le ()>,
 }
 
-impl<'le> TElement<'le> for ServoLayoutElement<'le> {
+impl<'le> TElement for ServoLayoutElement<'le> {
     type ConcreteNode = ServoLayoutNode<'le>;
     type ConcreteDocument = ServoLayoutDocument<'le>;
 
@@ -406,7 +406,7 @@ impl<'le> TElement<'le> for ServoLayoutElement<'le> {
         ServoLayoutNode::from_layout_js(self.element.upcast())
     }
 
-    fn style_attribute(&self) -> &'le Option<PropertyDeclarationBlock> {
+    fn style_attribute(&self) -> &Option<PropertyDeclarationBlock> {
         unsafe {
             &*self.element.style_attribute()
         }

--- a/components/style/parallel.rs
+++ b/components/style/parallel.rs
@@ -39,10 +39,10 @@ pub fn run_queue_with_custom_work_data_type<To, F, SharedContext: Sync>(
     queue.run(shared);
 }
 
-pub fn traverse_dom<'ln, N, C>(root: N,
-                               queue_data: &C::SharedContext,
-                               queue: &mut WorkQueue<C::SharedContext, WorkQueueData>)
-                               where N: TNode<'ln>, C: DomTraversalContext<'ln, N> {
+pub fn traverse_dom<N, C>(root: N,
+                          queue_data: &C::SharedContext,
+                          queue: &mut WorkQueue<C::SharedContext, WorkQueueData>)
+                          where N: TNode, C: DomTraversalContext<N> {
     run_queue_with_custom_work_data_type(queue, |queue| {
         queue.push(WorkUnit {
             fun:  top_down_dom::<N, C>,
@@ -53,9 +53,9 @@ pub fn traverse_dom<'ln, N, C>(root: N,
 
 /// A parallel top-down DOM traversal.
 #[inline(always)]
-fn top_down_dom<'ln, N, C>(unsafe_nodes: UnsafeNodeList,
-                           proxy: &mut WorkerProxy<C::SharedContext, UnsafeNodeList>)
-                           where N: TNode<'ln>, C: DomTraversalContext<'ln, N> {
+fn top_down_dom<N, C>(unsafe_nodes: UnsafeNodeList,
+                      proxy: &mut WorkerProxy<C::SharedContext, UnsafeNodeList>)
+                      where N: TNode, C: DomTraversalContext<N> {
     let context = C::new(proxy.user_data(), unsafe_nodes.1);
 
     let mut discovered_child_nodes = Vec::new();
@@ -105,10 +105,10 @@ fn top_down_dom<'ln, N, C>(unsafe_nodes: UnsafeNodeList,
 ///
 /// The only communication between siblings is that they both
 /// fetch-and-subtract the parent's children count.
-fn bottom_up_dom<'ln, N, C>(root: OpaqueNode,
-                            unsafe_node: UnsafeNode,
-                            proxy: &mut WorkerProxy<C::SharedContext, UnsafeNodeList>)
-                            where N: TNode<'ln>, C: DomTraversalContext<'ln, N> {
+fn bottom_up_dom<N, C>(root: OpaqueNode,
+                       unsafe_node: UnsafeNode,
+                       proxy: &mut WorkerProxy<C::SharedContext, UnsafeNodeList>)
+                       where N: TNode, C: DomTraversalContext<N> {
     let context = C::new(proxy.user_data(), root);
 
     // Get a real layout node.

--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -248,7 +248,7 @@ impl<Impl: SelectorImplExt> Stylist<Impl> {
     /// The returned boolean indicates whether the style is *shareable*; that is, whether the
     /// matched selectors are simple enough to allow the matching logic to be reduced to the logic
     /// in `css::matching::PrivateMatchMethods::candidate_element_allows_for_style_sharing`.
-    pub fn push_applicable_declarations<'le, E, V>(
+    pub fn push_applicable_declarations<E, V>(
                                         &self,
                                         element: &E,
                                         parent_bf: Option<&BloomFilter>,
@@ -256,7 +256,7 @@ impl<Impl: SelectorImplExt> Stylist<Impl> {
                                         pseudo_element: Option<Impl::PseudoElement>,
                                         applicable_declarations: &mut V)
                                         -> bool
-                                        where E: Element<Impl=Impl> + TElement<'le>,
+                                        where E: Element<Impl=Impl> + TElement,
                                               V: VecLike<DeclarationBlock> {
         assert!(!self.is_device_dirty);
         assert!(style_attribute.is_none() || pseudo_element.is_none(),

--- a/components/style/sequential.rs
+++ b/components/style/sequential.rs
@@ -7,12 +7,12 @@
 use dom::TNode;
 use traversal::DomTraversalContext;
 
-pub fn traverse_dom<'ln, N, C>(root: N,
-                               shared: &C::SharedContext)
-                               where N: TNode<'ln>,
-                                     C: DomTraversalContext<'ln, N> {
-    fn doit<'a, 'ln, N, C>(context: &'a C, node: N)
-                           where N: TNode<'ln>, C: DomTraversalContext<'ln, N> {
+pub fn traverse_dom<N, C>(root: N,
+                          shared: &C::SharedContext)
+                          where N: TNode,
+                                C: DomTraversalContext<N> {
+    fn doit<'a, N, C>(context: &'a C, node: N)
+                      where N: TNode, C: DomTraversalContext<N> {
         context.process_preorder(node);
 
         for kid in node.children() {

--- a/ports/geckolib/traversal.rs
+++ b/ports/geckolib/traversal.rs
@@ -64,7 +64,7 @@ pub struct RecalcStyleOnly<'lc> {
     root: OpaqueNode,
 }
 
-impl<'lc, 'ln, N: TNode<'ln>> DomTraversalContext<'ln, N> for RecalcStyleOnly<'lc>
+impl<'lc, N: TNode> DomTraversalContext<N> for RecalcStyleOnly<'lc>
     where N::ConcreteElement: ::selectors::Element<Impl=GeckoSelectorImpl> {
     type SharedContext = SharedStyleContext;
     #[allow(unsafe_code)]

--- a/ports/geckolib/wrapper.rs
+++ b/ports/geckolib/wrapper.rs
@@ -88,7 +88,7 @@ impl BitOr for DummyRestyleDamage {
 
 
 
-impl<'ln> TNode<'ln> for GeckoNode<'ln> {
+impl<'ln> TNode for GeckoNode<'ln> {
     type ConcreteDocument = GeckoDocument<'ln>;
     type ConcreteElement = GeckoElement<'ln>;
     type ConcreteRestyleDamage = DummyRestyleDamage;
@@ -268,7 +268,7 @@ impl<'ld> GeckoDocument<'ld> {
     }
 }
 
-impl<'ld> TDocument<'ld> for GeckoDocument<'ld> {
+impl<'ld> TDocument for GeckoDocument<'ld> {
     type ConcreteNode = GeckoNode<'ld>;
     type ConcreteElement = GeckoElement<'ld>;
 
@@ -309,7 +309,7 @@ impl<'le> GeckoElement<'le> {
     }
 }
 
-impl<'le> TElement<'le> for GeckoElement<'le> {
+impl<'le> TElement for GeckoElement<'le> {
     type ConcreteNode = GeckoNode<'le>;
     type ConcreteDocument = GeckoDocument<'le>;
 
@@ -317,7 +317,7 @@ impl<'le> TElement<'le> for GeckoElement<'le> {
         unsafe { GeckoNode::from_raw(self.element as *mut RawGeckoNode) }
     }
 
-    fn style_attribute(&self) -> &'le Option<PropertyDeclarationBlock> {
+    fn style_attribute(&self) -> &Option<PropertyDeclarationBlock> {
         panic!("Requires signature modification - only implemented in stylo branch");
         /*
         // FIXME(bholley): We should do what Servo does here. Gecko needs to


### PR DESCRIPTION
Right now, there's a huge amount of complexity in T{Node,Element,Document} and friends because of the lifetime parameter.

Before I started generalizing this code for use by Gecko, these wrappers were plain structs. They had (and still have) a phantom lifetime associated with them to prevent references to DOM nodes from leaking past the end of restyle, when they might be invalidated by a GC.

When I generalized them, I decided to put the lifetime on the trait as well, since there are some situations where the lifetime is, in fact, necessary. Specifically, they are necessary for the compiler to understand that all the things borrowed from all the nodes and elements and so on have the same lifetime (the lifetime of the restyle), rather than the lifetime of whichever particular element or node pointer the value was borrowed from. This come up in situations where we do |let el = node.as_element()| or |let n = el.as_node()| and then borrow something from the result. The compiler thinks the borrow lifetime is that of |el| or |n|, when it's actually longer.

In practice though, I think the style and layout algorithms we use don't run into this issue much, and we can hack around it where it comes up. So I think we should remove the lifetimes from the traits, which will let us aggregate the embedding-provided traits together onto a single meta-trait and significantly simplify the code.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9976)

<!-- Reviewable:end -->
