### PR TITLE
Add a script to CI to check dynamic symbols in Android binary #8351

### DIFF
--- a/etc/ci/check_dynamic_symbols.py
+++ b/etc/ci/check_dynamic_symbols.py
@@ -1,0 +1,34 @@
+# Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import sys
+import re
+import subprocess
+
+symbol_regex = re.compile("D  \*UND\*\t(.*) (.*)$")
+allowed_symbols = frozenset(['unshare', 'malloc_usable_size'])
+actual_symbols = set()
+
+objdump_output = subprocess.check_output([
+    'arm-linux-androideabi-objdump',
+    '-T',
+    'target/arm-linux-androideabi/debug/libservo.so']
+).split('\n')
+
+for line in objdump_output:
+    m = symbol_regex.search(line)
+    if m is not None:
+        actual_symbols.add(m.group(2))
+
+difference = actual_symbols - allowed_symbols
+
+if len(difference) > 0:
+    human_readable_difference = ", ".join(str(s) for s in difference)
+    print("Unexpected dynamic symbols in binary: {0}".format(human_readable_difference))
+    sys.exit(-1)


### PR DESCRIPTION
Tries to fix #8351.

This is meaningful only with the PR to servo/saltfs

Cross PR: https://github.com/servo/saltfs/pull/249

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9981)

<!-- Reviewable:end -->
