### PR TITLE
Test using 4 parallel codegen units on release builds

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -66,12 +66,11 @@ headless = ["glutin_app/headless"]
 webdriver = ["webdriver_server"]
 energy-profiling = ["profile_traits/energy-profiling"]
 
+[profile.release]
+opt-level = 3
+codegen-units = 4
 # Uncomment to profile on Linux:
-#
-# [profile.release]
-# opt-level = 3
 # debug = true
-# rpath = false
 # lto = false
 
 [dependencies.compositing]

--- a/ports/cef/Cargo.toml
+++ b/ports/cef/Cargo.toml
@@ -8,6 +8,13 @@ name = "embedding"
 path = "lib.rs"
 crate-type = ["dylib"]
 
+[profile.release]
+opt-level = 3
+codegen-units = 4
+# Uncomment to profile on Linux:
+# debug = true
+# lto = false
+
 [dependencies]
 euclid = {version = "0.6.4", features = ["plugins"]}
 gleam = "0.2.8"


### PR DESCRIPTION
Do not merge yet! Doing a test run first.

Note that `codegen-units` had very little effect on our dev builds (saved ~12 seconds http://logs.glob.uno/?c=mozilla%23servo&s=6+Aug+2015&e=6+Aug+2015#c252485).

@bors-servo try

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/servo/9987)

<!-- Reviewable:end -->
