### PR TITLE
style: Compute damage for text nodes.

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -655,6 +655,7 @@ pub trait MatchMethods : TNode {
             }
         };
 
+        let damage;
         if self.is_text_node() {
             // Text nodes get a copy of the parent style. This ensures
             // that during fragment construction any non-inherited
@@ -663,9 +664,11 @@ pub trait MatchMethods : TNode {
             let mut data_ref = self.mutate_data().unwrap();
             let mut data = &mut *data_ref;
             let cloned_parent_style = parent_style.unwrap().clone();
+            damage = Self::ConcreteRestyleDamage::compute(data.style.as_ref(),
+                                                          &*cloned_parent_style);
             data.style = Some(cloned_parent_style);
         } else {
-            let damage = {
+            damage = {
                 let mut data_ref = self.mutate_data().unwrap();
                 let mut data = &mut *data_ref;
                 let (mut damage, final_style) = self.cascade_node_pseudo_element(
@@ -706,13 +709,15 @@ pub trait MatchMethods : TNode {
 
             // This method needs to borrow the data as mutable, so make sure data_ref goes out of
             // scope first.
-            self.set_restyle_damage(damage);
-
             self.set_can_be_fragmented(parent.map_or(false, |p| {
                 p.can_be_fragmented() ||
                 parent_style.as_ref().unwrap().is_multicol()
             }));
         }
+
+        // This method needs to borrow the data as mutable, so make sure data_ref goes out of
+        // scope first.
+        self.set_restyle_damage(damage);
     }
 }
 

--- a/tests/wpt/metadata-css/css21_dev/html4/run-in-display-none-between-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/run-in-display-none-between-003.htm.ini
@@ -1,3 +1,0 @@
-[run-in-display-none-between-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -4560,6 +4560,18 @@
             "url": "/_mozilla/css/text_align_start_end.html"
           }
         ],
+        "css/text_damage_a.html": [
+          {
+            "path": "css/text_damage_a.html",
+            "references": [
+              [
+                "/_mozilla/css/text_damage_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/text_damage_a.html"
+          }
+        ],
         "css/text_decoration_cached.html": [
           {
             "path": "css/text_decoration_cached.html",
@@ -10758,6 +10770,18 @@
             ]
           ],
           "url": "/_mozilla/css/text_align_start_end.html"
+        }
+      ],
+      "css/text_damage_a.html": [
+        {
+          "path": "css/text_damage_a.html",
+          "references": [
+            [
+              "/_mozilla/css/text_damage_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/text_damage_a.html"
         }
       ],
       "css/text_decoration_cached.html": [

--- a/tests/wpt/mozilla/tests/css/text_damage_a.html
+++ b/tests/wpt/mozilla/tests/css/text_damage_a.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title></title>
+<link rel="match" href="text_damage_ref.html">
+<span class="lock" style="display: none">foo</span><span>bar</span>
+<script>
+window.onload = function() {
+    document.querySelector(".lock").style.display = "inline";
+    document.documentElement.classList.remove("reftest-wait");
+};
+</script>
+
+

--- a/tests/wpt/mozilla/tests/css/text_damage_ref.html
+++ b/tests/wpt/mozilla/tests/css/text_damage_ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<title></title>
+<span class="lock" style="display: inline">foo</span><span>bar</span>
+


### PR DESCRIPTION
They have styles just like elements do.

Allows a dynamic change of `display: none` to `display: inline` to work.

Closes #9868.

r? @mbrubeck

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/9997)

<!-- Reviewable:end -->
