### PR TITLE
Patch handles exception with errormessage on topdir with Unicode characters.

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -149,6 +149,15 @@ def _activate_virtualenv(topdir):
 def bootstrap(topdir):
     topdir = os.path.abspath(topdir)
 
+    # We don't support paths with Unicode characters for now
+    # https://github.com/servo/servo/issues/10002
+    try:
+        topdir.decode('ascii')
+    except UnicodeDecodeError:
+        print('Cannot run mach in a path with Unicode characters.')
+        print('Current path:', topdir)
+        sys.exit(1)
+
     # We don't support paths with spaces for now
     # https://github.com/servo/servo/issues/9442
     if ' ' in topdir:


### PR DESCRIPTION
https://github.com/servo/servo/issues/10002
./mach does not support paths with Unicode characters for now

it fail on original line 154 with exception UnicodeDecodeError
This patch handles the exception

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10003)

<!-- Reviewable:end -->
