### PR TITLE
Update WebSocket blocked ports to match the Fetch spec

### DIFF
--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -55,8 +55,8 @@ enum WebSocketRequestState {
     Closed = 3,
 }
 
-// list of blacklist ports according to
-// http://mxr.mozilla.org/mozilla-central/source/netwerk/base/nsIOService.cpp#87
+// list of bad ports according to
+// https://fetch.spec.whatwg.org/#port-blocking
 const BLOCKED_PORTS_LIST: &'static [u16] = &[
     1,    // tcpmux
     7,    // echo
@@ -67,7 +67,7 @@ const BLOCKED_PORTS_LIST: &'static [u16] = &[
     17,   // qotd
     19,   // chargen
     20,   // ftp-data
-    21,   // ftp-cntl
+    21,   // ftp
     22,   // ssh
     23,   // telnet
     25,   // smtp
@@ -90,11 +90,11 @@ const BLOCKED_PORTS_LIST: &'static [u16] = &[
     115,  // sftp
     117,  // uucp-path
     119,  // nntp
-    123,  // NTP
+    123,  // ntp
     135,  // loc-srv / epmap
     139,  // netbios
     143,  // imap2
-    179,  // BGP
+    179,  // bgp
     389,  // ldap
     465,  // smtp+ssl
     512,  // print / exec
@@ -103,19 +103,25 @@ const BLOCKED_PORTS_LIST: &'static [u16] = &[
     515,  // printer
     526,  // tempo
     530,  // courier
-    531,  // Chat
+    531,  // chat
     532,  // netnews
     540,  // uucp
     556,  // remotefs
     563,  // nntp+ssl
-    587,  //
-    601,  //
+    587,  // smtp
+    601,  // syslog-conn
     636,  // ldap+ssl
     993,  // imap+ssl
     995,  // pop3+ssl
     2049, // nfs
+    3659, // apple-sasl
     4045, // lockd
     6000, // x11
+    6665, // irc (alternate)
+    6666, // irc (alternate)
+    6667, // irc (default)
+    6668, // irc (alternate)
+    6669, // irc (alternate)
 ];
 
 // Close codes defined in https://tools.ietf.org/html/rfc6455#section-7.4.1

--- a/tests/wpt/web-platform-tests/websockets/Create-Secure-blocked-port.htm
+++ b/tests/wpt/web-platform-tests/websockets/Create-Secure-blocked-port.htm
@@ -10,9 +10,78 @@
     <div id="log"></div>
     <script>
         test(function () {
-            var wsocket;
-            var blockedPort = 25;
-            assert_throws("SECURITY_ERR", function () { wsocket = CreateWebSocketWithBlockedPort(blockedPort) });
+            // list of bad ports according to
+            // https://fetch.spec.whatwg.org/#port-blocking
+            var BLOCKED_PORTS_LIST = [
+                1,    // tcpmux
+                7,    // echo
+                9,    // discard
+                11,   // systat
+                13,   // daytime
+                15,   // netstat
+                17,   // qotd
+                19,   // chargen
+                20,   // ftp-data
+                21,   // ftp
+                22,   // ssh
+                23,   // telnet
+                25,   // smtp
+                37,   // time
+                42,   // name
+                43,   // nicname
+                53,   // domain
+                77,   // priv-rjs
+                79,   // finger
+                87,   // ttylink
+                95,   // supdup
+                101,  // hostriame
+                102,  // iso-tsap
+                103,  // gppitnp
+                104,  // acr-nema
+                109,  // pop2
+                110,  // pop3
+                111,  // sunrpc
+                113,  // auth
+                115,  // sftp
+                117,  // uucp-path
+                119,  // nntp
+                123,  // ntp
+                135,  // loc-srv / epmap
+                139,  // netbios
+                143,  // imap2
+                179,  // bgp
+                389,  // ldap
+                465,  // smtp+ssl
+                512,  // print / exec
+                513,  // login
+                514,  // shell
+                515,  // printer
+                526,  // tempo
+                530,  // courier
+                531,  // chat
+                532,  // netnews
+                540,  // uucp
+                556,  // remotefs
+                563,  // nntp+ssl
+                587,  // smtp
+                601,  // syslog-conn
+                636,  // ldap+ssl
+                993,  // imap+ssl
+                995,  // pop3+ssl
+                2049, // nfs
+                3659, // apple-sasl
+                4045, // lockd
+                6000, // x11
+                6665, // irc (alternate)
+                6666, // irc (alternate)
+                6667, // irc (default)
+                6668, // irc (alternate)
+                6669, // irc (alternate)
+            ];
+            for (var i = 0; i < BLOCKED_PORTS_LIST.length; i++) {
+                var blockedPort = BLOCKED_PORTS_LIST[i];
+                assert_throws("SECURITY_ERR", function () { CreateWebSocketWithBlockedPort(blockedPort) });
+            }
         }, "W3C WebSocket API - Create Secure WebSocket - Pass a URL with a blocked port - SECURITY_ERR should be thrown")
     </script>
 </body>


### PR DESCRIPTION
Adresses #9949.

This adds a function that tests whether a request should be blocked or not based on it's url's scheme and port. It also adds testing for port restriction to the `main_fetch` method. More info in https://github.com/whatwg/fetch/commit/eb07418c8383983a9887498e49a2e2e986d3c9f4.

@Ms2ger In https://github.com/whatwg/html/issues/841, @annevk proposes to remove port restrictions from websockets. Should we go ahead do that, given that the spec hasn't been changed yet?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10014)

<!-- Reviewable:end -->
