### PR TITLE
compositing: In borderless mode, don't show the window until the page has loaded.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -592,7 +592,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 self.window.load_start(back, forward);
             }
 
-            (Msg::LoadComplete(back, forward), ShutdownState::NotShuttingDown) => {
+            (Msg::LoadComplete(back, forward, root), ShutdownState::NotShuttingDown) => {
                 self.got_load_complete_message = true;
 
                 // If we're painting in headless mode, schedule a recomposite.
@@ -603,7 +603,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 // Inform the embedder that the load has finished.
                 //
                 // TODO(pcwalton): Specify which frame's load completed.
-                self.window.load_end(back, forward);
+                self.window.load_end(back, forward, root);
             }
 
             (Msg::DelayedCompositionTimeout(timestamp), ShutdownState::NotShuttingDown) => {

--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -195,8 +195,8 @@ pub enum Msg {
     SetFrameTree(SendableFrameTree, IpcSender<()>, Sender<ConstellationMsg>),
     /// The load of a page has begun: (can go back, can go forward).
     LoadStart(bool, bool),
-    /// The load of a page has completed: (can go back, can go forward).
-    LoadComplete(bool, bool),
+    /// The load of a page has completed: (can go back, can go forward, is root frame).
+    LoadComplete(bool, bool, bool),
     /// We hit the delayed composition timeout. (See `delayed_composition.rs`.)
     DelayedCompositionTimeout(u64),
     /// Composite.

--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -1005,11 +1005,11 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
 
         let forward = !self.frame(frame_id).next.is_empty();
         let back = !self.frame(frame_id).prev.is_empty();
-        self.compositor_proxy.send(ToCompositorMsg::LoadComplete(back, forward));
+        let root = self.root_frame_id.is_none() || self.root_frame_id == Some(frame_id);
+        self.compositor_proxy.send(ToCompositorMsg::LoadComplete(back, forward, root));
     }
 
-    fn handle_dom_load(&mut self,
-                       pipeline_id: PipelineId) {
+    fn handle_dom_load(&mut self, pipeline_id: PipelineId) {
         let mut webdriver_reset = false;
         if let Some((expected_pipeline_id, ref reply_chan)) = self.webdriver.load_channel {
             debug!("Sending load to WebDriver");

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -125,7 +125,7 @@ pub trait WindowMethods {
     /// Called when the browser has started loading a frame.
     fn load_start(&self, back: bool, forward: bool);
     /// Called when the browser is done loading a frame.
-    fn load_end(&self, back: bool, forward: bool);
+    fn load_end(&self, back: bool, forward: bool, root: bool);
     /// Called when the browser encounters an error while loading a URL
     fn load_error(&self, code: NetError, url: String);
     /// Called when the <head> tag has finished parsing

--- a/ports/cef/window.rs
+++ b/ports/cef/window.rs
@@ -374,7 +374,7 @@ impl WindowMethods for Window {
         }
     }
 
-    fn load_end(&self, back: bool, forward: bool) {
+    fn load_end(&self, back: bool, forward: bool, _: bool) {
         // FIXME(pcwalton): The status code 200 is a lie.
         let browser = self.cef_browser.borrow();
         let browser = match *browser {

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -93,13 +93,20 @@ impl Window {
                parent: Option<glutin::WindowID>) -> Rc<Window> {
         let width = window_size.to_untyped().width;
         let height = window_size.to_untyped().height;
+
+        // If there's no chrome, start off with the window invisible. It will be set to visible in
+        // `load_end()`. This avoids an ugly flash of unstyled content (especially important since
+        // unstyled content is white and chrome often has a transparent background). See issue
+        // #9996.
+        let visible = is_foreground && !opts::get().no_native_titlebar;
+
         let mut builder =
             glutin::WindowBuilder::new().with_title("Servo".to_string())
                                         .with_decorations(!opts::get().no_native_titlebar)
                                         .with_transparency(opts::get().no_native_titlebar)
                                         .with_dimensions(width, height)
                                         .with_gl(Window::gl_version())
-                                        .with_visibility(is_foreground)
+                                        .with_visibility(visible)
                                         .with_parent(parent)
                                         .with_multitouch();
 
@@ -613,7 +620,10 @@ impl WindowMethods for Window {
     fn load_start(&self, _: bool, _: bool) {
     }
 
-    fn load_end(&self, _: bool, _: bool) {
+    fn load_end(&self, _: bool, _: bool, root: bool) {
+        if root && opts::get().no_native_titlebar {
+            self.window.show()
+        }
     }
 
     fn load_error(&self, _: NetError, _: String) {
@@ -869,7 +879,7 @@ impl WindowMethods for Window {
 
     fn load_start(&self, _: bool, _: bool) {
     }
-    fn load_end(&self, _: bool, _: bool) {
+    fn load_end(&self, _: bool, _: bool, _: bool) {
     }
     fn load_error(&self, _: NetError, _: String) {
     }

--- a/ports/gonk/src/window.rs
+++ b/ports/gonk/src/window.rs
@@ -820,7 +820,7 @@ impl WindowMethods for Window {
     fn load_start(&self, _: bool, _: bool) {
     }
 
-    fn load_end(&self, _: bool, _: bool) {
+    fn load_end(&self, _: bool, _: bool, _: bool) {
     }
 
     fn load_error(&self, _: NetError, _: String) {


### PR DESCRIPTION
This avoids a flash of unstyled content, which looks especially bad in
browser.html since unstyled content is white and browser.html has a
transparent background.

Closes #9996.

r? @metajack
cc @jdm since you had some concerns

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10026)

<!-- Reviewable:end -->
