### PR TITLE
layout: Move overflow calculation to be a separate, sequential, bottom-up pass.

### DIFF
--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -210,7 +210,6 @@ impl<'a> PreorderFlowTraversal for ComputeAbsolutePositions<'a> {
     #[inline]
     fn process(&self, flow: &mut Flow) {
         flow.compute_absolute_position(self.layout_context);
-        flow.store_overflow(self.layout_context);
     }
 }
 

--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -60,6 +60,7 @@ impl Formattable for ProfilerCategory {
             ProfilerCategory::LayoutGeneratedContent |
             ProfilerCategory::LayoutDisplayListSorting |
             ProfilerCategory::LayoutMain |
+            ProfilerCategory::LayoutStoreOverflow |
             ProfilerCategory::LayoutDispListBuild |
             ProfilerCategory::LayoutDamagePropagate |
             ProfilerCategory::PaintingPerTile |
@@ -83,6 +84,7 @@ impl Formattable for ProfilerCategory {
             ProfilerCategory::LayoutDisplayListSorting => "Sorting Display List",
             ProfilerCategory::LayoutGeneratedContent => "Generated Content Resolution",
             ProfilerCategory::LayoutMain => "Primary Layout Pass",
+            ProfilerCategory::LayoutStoreOverflow => "Store Overflow",
             ProfilerCategory::LayoutParallelWarmup => "Parallel Warmup",
             ProfilerCategory::LayoutDispListBuild => "Display List Construction",
             ProfilerCategory::PaintingPerTile => "Painting Per Tile",

--- a/components/profile_traits/time.rs
+++ b/components/profile_traits/time.rs
@@ -50,6 +50,7 @@ pub enum ProfilerCategory {
     LayoutGeneratedContent,
     LayoutDisplayListSorting,
     LayoutMain,
+    LayoutStoreOverflow,
     LayoutParallelWarmup,
     LayoutDispListBuild,
     PaintingPerTile,

--- a/tests/wpt/metadata-css/css21_dev/html4/numbers-units-018.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/numbers-units-018.htm.ini
@@ -1,0 +1,3 @@
+[numbers-units-018.htm]
+  type: reftest
+  expected: FAIL


### PR DESCRIPTION
Right now, the only reason that overflow calculation works is that we
rely on script inducing extra reflows that are sent for display. This
was preventing #10021 from landing.

This change regresses layout performance by about 1% in my tests.

Fixes #7797 properly.

r? @mbrubeck 
cc @glennw

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10064)

<!-- Reviewable:end -->
