### PR TITLE
Update ipc-channel for another intermittent bug fix

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.2.1"
-source = "git+https://github.com/servo/ipc-channel#6ad3885772bc966abd0b6b89d71c218c3f5838cd"
+source = "git+https://github.com/servo/ipc-channel#ba07b349c831ea14ec3dba8c1f7f689044d7462b"
 dependencies = [
  "bincode 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.2.1"
-source = "git+https://github.com/servo/ipc-channel#6ad3885772bc966abd0b6b89d71c218c3f5838cd"
+source = "git+https://github.com/servo/ipc-channel#ba07b349c831ea14ec3dba8c1f7f689044d7462b"
 dependencies = [
  "bincode 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -204,7 +204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ipc-channel"
 version = "0.2.1"
-source = "git+https://github.com/servo/ipc-channel#6ad3885772bc966abd0b6b89d71c218c3f5838cd"
+source = "git+https://github.com/servo/ipc-channel#ba07b349c831ea14ec3dba8c1f7f689044d7462b"
 dependencies = [
  "bincode 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -862,7 +862,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.2.1"
-source = "git+https://github.com/servo/ipc-channel#6ad3885772bc966abd0b6b89d71c218c3f5838cd"
+source = "git+https://github.com/servo/ipc-channel#ba07b349c831ea14ec3dba8c1f7f689044d7462b"
 dependencies = [
  "bincode 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This pulls in https://github.com/servo/ipc-channel/pull/52 , and
especially 8e2357604f7af8869b489b9682a2cf8b58177637, which fixes another
likely cause of intermittent failures on GNU/Linux.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10092)

<!-- Reviewable:end -->
