### PR TITLE
Add Python 3 compatibility to Android symbol checker

### DIFF
--- a/etc/ci/check_dynamic_symbols.py
+++ b/etc/ci/check_dynamic_symbols.py
@@ -11,15 +11,15 @@ import sys
 import re
 import subprocess
 
-symbol_regex = re.compile("D  \*UND\*\t(.*) (.*)$")
-allowed_symbols = frozenset(['unshare', 'malloc_usable_size'])
+symbol_regex = re.compile(b"D  \*UND\*\t(.*) (.*)$")
+allowed_symbols = frozenset([b'unshare', b'malloc_usable_size'])
 actual_symbols = set()
 
 objdump_output = subprocess.check_output([
     'arm-linux-androideabi-objdump',
     '-T',
     'target/arm-linux-androideabi/debug/libservo.so']
-).split('\n')
+).split(b'\n')
 
 for line in objdump_output:
     m = symbol_regex.search(line)


### PR DESCRIPTION
Make the script that checks for undefined Android symbols compatible
with both Python 2 and Python 3, to allow for future updates to the
default system Python on our build machines.

I'd like to land this before https://github.com/servo/saltfs/pull/249.

We currently use Ubuntu 14.04 (an LTS release); Ubuntu is aiming for Python 3 as the default Python in the next LTS release, 16.04, and I'd like to have any scripts be ready for the transition.

Do we have a Python 2/3 compatibility policy?

cc @cengizIO @larsbergstrom

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10097)

<!-- Reviewable:end -->
