### PR TITLE
Don't re-add stylesheets to recompute vw/vh lengths

### DIFF
--- a/components/layout/layout_thread.rs
+++ b/components/layout/layout_thread.rs
@@ -1040,6 +1040,8 @@ impl LayoutThread {
         };
 
         // Handle conditions where the entire flow tree is invalid.
+        let mut needs_dirtying = false;
+
         let viewport_size_changed = self.viewport_size != old_viewport_size;
         if viewport_size_changed {
             if let Some(constraints) = constraints {
@@ -1048,11 +1050,15 @@ impl LayoutThread {
                 constellation_chan.send(ConstellationMsg::ViewportConstrained(
                         self.id, constraints)).unwrap();
             }
+            // FIXME (#10104): Only dirty nodes affected by vh/vw/vmin/vmax styles.
+            if data.document_stylesheets.iter().any(|sheet| sheet.dirty_on_viewport_size_change) {
+                needs_dirtying = true;
+            }
         }
 
         // If the entire flow tree is invalid, then it will be reflowed anyhow.
-        let needs_dirtying = rw_data.stylist.update(&data.document_stylesheets,
-                                                    data.stylesheets_changed);
+        needs_dirtying |= rw_data.stylist.update(&data.document_stylesheets,
+                                                 data.stylesheets_changed);
         let needs_reflow = viewport_size_changed && !needs_dirtying;
         unsafe {
             if needs_dirtying {

--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -226,10 +226,7 @@ impl<Impl: SelectorImplExt> Stylist<Impl> {
             device = Device::new(MediaType::Screen, constraints.size);
         }
 
-        let size_changed = device.viewport_size != self.device.viewport_size;
-
         self.is_device_dirty |= stylesheets.iter().any(|stylesheet| {
-                (size_changed && stylesheet.dirty_on_viewport_size_change) ||
                 stylesheet.rules().media().any(|media_rule|
                     media_rule.evaluate(&self.device) != media_rule.evaluate(&device))
         });


### PR DESCRIPTION
This is a follow-up to #9876.  It avoids clearing and rebuilding SelectorMaps
when vh and vw units need to be recomputed. Instead it just dirties all nodes,
to force elements to be re-cascaded.

Filed #10104 for later follow-up work to dirty only affected nodes.

r? @SimonSapin

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10105)

<!-- Reviewable:end -->
