### PR TITLE
Fixes for compute_damage

### DIFF
--- a/components/layout/incremental.rs
+++ b/components/layout/incremental.rs
@@ -182,8 +182,15 @@ pub fn compute_damage(old: Option<&Arc<ComputedValues>>, new: &ComputedValues) -
         // text shaping is re-run.
         get_inheritedtext.letter_spacing, get_inheritedtext.text_rendering,
         get_inheritedtext.text_transform, get_inheritedtext.word_spacing,
+        get_inheritedtext.overflow_wrap, get_inheritedtext.text_justify,
+        get_inheritedtext.white_space, get_inheritedtext.word_break, get_inheritedtext.text_overflow,
         get_font.font_family, get_font.font_style, get_font.font_variant, get_font.font_weight,
-        get_font.font_size, get_font.font_stretch
+        get_font.font_size, get_font.font_stretch,
+        get_inheritedbox.direction, get_inheritedbox.writing_mode,
+        get_inheritedbox.text_orientation,
+        get_text.text_decoration, get_text.unicode_bidi,
+        get_inheritedtable.empty_cells, get_inheritedtable.caption_side,
+        get_column.column_width, get_column.column_count
     ]) || add_if_not_equal!(old, new, damage,
                             [ REPAINT, STORE_OVERFLOW, BUBBLE_ISIZES, REFLOW_OUT_OF_FLOW, REFLOW ],
         [get_border.border_top_width, get_border.border_right_width,
@@ -193,7 +200,13 @@ pub fn compute_damage(old: Option<&Arc<ComputedValues>>, new: &ComputedValues) -
         get_padding.padding_top, get_padding.padding_right,
         get_padding.padding_bottom, get_padding.padding_left,
         get_box.width, get_box.height,
-        get_inheritedtext.text_align, get_text.text_decoration, get_inheritedbox.line_height
+        get_inheritedbox.line_height,
+        get_inheritedtext.text_align, get_inheritedtext.text_indent,
+        get_table.table_layout,
+        get_inheritedtable.border_collapse,
+        get_inheritedtable.border_spacing,
+        get_column.column_gap,
+        get_flex.flex_direction
     ]) || add_if_not_equal!(old, new, damage,
                             [ REPAINT, STORE_OVERFLOW, REFLOW_OUT_OF_FLOW ], [
         get_positionoffsets.top, get_positionoffsets.left,
@@ -201,8 +214,26 @@ pub fn compute_damage(old: Option<&Arc<ComputedValues>>, new: &ComputedValues) -
     ]) || add_if_not_equal!(old, new, damage,
                             [ REPAINT ], [
         get_color.color, get_background.background_color,
+        get_background.background_image, get_background.background_position,
+        get_background.background_repeat, get_background.background_attachment,
+        get_background.background_clip, get_background.background_origin,
+        get_background.background_size,
         get_border.border_top_color, get_border.border_right_color,
-        get_border.border_bottom_color, get_border.border_left_color
+        get_border.border_bottom_color, get_border.border_left_color,
+        get_border.border_top_style, get_border.border_right_style,
+        get_border.border_bottom_style, get_border.border_left_style,
+        get_border.border_top_left_radius, get_border.border_top_right_radius,
+        get_border.border_bottom_left_radius, get_border.border_bottom_right_radius,
+        get_box.z_index, get_box._servo_overflow_clip_box,
+        get_inheritedtext._servo_text_decorations_in_effect,
+        get_pointing.cursor, get_pointing.pointer_events,
+        get_effects.box_shadow, get_effects.clip, get_effects.text_shadow, get_effects.filter,
+        get_effects.transform, get_effects.backface_visibility, get_effects.transform_style,
+        get_effects.transform_origin, get_effects.perspective, get_effects.perspective_origin,
+        get_effects.mix_blend_mode, get_effects.image_rendering,
+
+        // Note: May require REFLOW et al. if `visibility: collapse` is implemented.
+        get_inheritedbox.visibility
     ]);
 
     // If the layer requirements of this flow have changed due to the value

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2072,6 +2072,30 @@
             "url": "/_mozilla/css/incremental_text_color_a.html"
           }
         ],
+        "css/incremental_visibility_a.html": [
+          {
+            "path": "css/incremental_visibility_a.html",
+            "references": [
+              [
+                "/_mozilla/css/incremental_visibility_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/incremental_visibility_a.html"
+          }
+        ],
+        "css/incremental_visibility_ref.html": [
+          {
+            "path": "css/incremental_visibility_ref.html",
+            "references": [
+              [
+                "/_mozilla/css/incremental_visibility_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/incremental_visibility_ref.html"
+          }
+        ],
         "css/inline_absolute_hypothetical_clip_a.html": [
           {
             "path": "css/inline_absolute_hypothetical_clip_a.html",
@@ -8330,6 +8354,30 @@
             ]
           ],
           "url": "/_mozilla/css/incremental_text_color_a.html"
+        }
+      ],
+      "css/incremental_visibility_a.html": [
+        {
+          "path": "css/incremental_visibility_a.html",
+          "references": [
+            [
+              "/_mozilla/css/incremental_visibility_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/incremental_visibility_a.html"
+        }
+      ],
+      "css/incremental_visibility_ref.html": [
+        {
+          "path": "css/incremental_visibility_ref.html",
+          "references": [
+            [
+              "/_mozilla/css/incremental_visibility_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/incremental_visibility_ref.html"
         }
       ],
       "css/inline_absolute_hypothetical_clip_a.html": [

--- a/tests/wpt/mozilla/tests/css/incremental_visibility_a.html
+++ b/tests/wpt/mozilla/tests/css/incremental_visibility_a.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <meta charset="UTF-8">
+    <title>Incremental visibility test</title>
+    <link rel="match" href="incremental_visibility_ref.html">
+    <style>
+      div {
+        background: green;
+        height: 100px;
+        width: 100px;
+        visibility: hidden;
+      }
+      div.show {
+        visibility: visible;
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+    <script>
+      window.onload = function() {
+        document.body.offsetWidth; // force layout
+        document.querySelector('div').classList.add('show');
+        document.documentElement.classList.remove('reftest-wait');
+      }
+    </script>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/incremental_visibility_ref.html
+++ b/tests/wpt/mozilla/tests/css/incremental_visibility_ref.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Incremental visibility reference</title>
+    <link rel="match" href="incremental_visibility_ref.html">
+    <style>
+      div {
+        background: green;
+        height: 100px;
+        width: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>


### PR DESCRIPTION
A few changes:
- Make `compute_damage` short-circuit more, by skipping comparisons if they will only set flags that are already set.
- Update some obsolete comments.
- Add a bunch of missing properties to `compute_damage`.
- Set `RECONSTRUCT_FLOW` when `text-decoration` changes, because it can affect text fragment splitting/merging.

I believe this is all of the computed properties except for the animation properties. (I wasn't sure what to do with those.)  After this lands I'd like to work on moving this information into `properties.mako.rs` so that this function can be auto-generated, and so that newly-added properties can default to setting all flags instead of none.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10109)

<!-- Reviewable:end -->
