### PR TITLE
Fixed jump tag issue

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1144,7 +1144,8 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                                 layer_id: LayerId,
                                 point: Point2D<f32>) {
         if self.move_layer(pipeline_id, layer_id, Point2D::from_untyped(&point)) {
-            self.perform_updates_after_scroll()
+            self.perform_updates_after_scroll();
+            self.send_viewport_rects_for_all_layers()
         } else {
             self.fragment_point = Some(point)
         }


### PR DESCRIPTION
Fixes the issue where once a jump tag is clicked, the viewport rects are not updated. #9671

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10112)

<!-- Reviewable:end -->
