### PR TITLE
Load prefs.json from profile-dir if --profile-dir is specified at launch

### DIFF
--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -799,8 +799,12 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
 
     set_defaults(opts);
 
-    // This must happen after setting the default options, since the prefs rely on
+    // These must happen after setting the default options, since the prefs rely on
     // on the resource path.
+    // Note that command line preferences have the highest precedent
+    if get().profile_dir.is_some() {
+        prefs::add_user_prefs();
+    }
     for pref in opt_match.opt_strs("pref").iter() {
         let split: Vec<&str> = pref.splitn(2, '=').collect();
         let pref_name = split[0];

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -801,7 +801,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
 
     // These must happen after setting the default options, since the prefs rely on
     // on the resource path.
-    // Note that command line preferences have the highest precedent
+    // Note that command line preferences have the highest precedence
     if get().profile_dir.is_some() {
         prefs::add_user_prefs();
     }

--- a/components/util/prefs.rs
+++ b/components/util/prefs.rs
@@ -8,7 +8,7 @@ use rustc_serialize::json::{Json, ToJson};
 use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::Read;
+use std::io::{Read, Write, stderr};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -156,7 +156,8 @@ pub fn add_user_prefs() {
                 extend_prefs(prefs);
             }
         } else {
-            println!("Error opening prefs.json from profile_dir");
+            writeln!(&mut stderr(), "Error opening prefs.json from profile_dir")
+                .expect("failed printing to stderr");
         }
     }
 }
@@ -166,7 +167,8 @@ fn read_prefs() -> Result<HashMap<String, Pref>, ()> {
     path.push("prefs.json");
 
     let file = try!(File::open(path).or_else(|e| {
-        println!("Error opening preferences: {:?}.", e);
+        writeln!(&mut stderr(), "Error opening preferences: {:?}.", e)
+            .expect("failed printing to stderr");
         Err(())
     }));
 

--- a/components/util/prefs.rs
+++ b/components/util/prefs.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use opts;
 use resource_files::resources_dir_path;
 use rustc_serialize::json::{Json, ToJson};
-use opts;
 use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::fs::File;

--- a/tests/unit/util/lib.rs
+++ b/tests/unit/util/lib.rs
@@ -16,3 +16,4 @@ extern crate util;
 #[cfg(test)] mod opts;
 #[cfg(test)] mod str;
 #[cfg(test)] mod thread;
+#[cfg(test)] mod prefs;

--- a/tests/unit/util/prefs.rs
+++ b/tests/unit/util/prefs.rs
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use util::prefs::{PrefValue, extend_prefs, read_prefs_from_file, get_pref, set_pref, reset_pref, reset_all_prefs};
+
+#[test]
+fn test_create_pref() {
+    let json_str = "{\
+  \"layout.writing-mode.enabled\": true,\
+  \"net.mime.sniff\": false,\
+  \"shell.homepage\": \"http://servo.org\"\
+}";
+
+    let prefs = read_prefs_from_file(json_str.as_bytes());
+    assert!(prefs.is_ok());
+    let prefs = prefs.unwrap();
+
+    assert_eq!(prefs.len(), 3);
+}
+
+#[test]
+fn test_get_set_reset_extend() {
+    let json_str = "{\
+  \"layout.writing-mode.enabled\": true,\
+  \"extra.stuff\": false,\
+  \"shell.homepage\": \"https://google.com\"\
+}";
+
+    assert_eq!(*get_pref("test"), PrefValue::Missing);
+    set_pref("test", PrefValue::String("hi".to_owned()));
+    assert_eq!(*get_pref("test"), PrefValue::String("hi".to_owned()));
+    assert_eq!(*get_pref("shell.homepage"), PrefValue::String("http://servo.org".to_owned()));
+    set_pref("shell.homepage", PrefValue::Boolean(true));
+    assert_eq!(*get_pref("shell.homepage"), PrefValue::Boolean(true));
+    reset_pref("shell.homepage");
+    assert_eq!(*get_pref("shell.homepage"), PrefValue::String("http://servo.org".to_owned()));
+
+    let extension = read_prefs_from_file(json_str.as_bytes()).unwrap();
+    extend_prefs(extension);
+    assert_eq!(*get_pref("shell.homepage"), PrefValue::String("https://google.com".to_owned()));
+    assert_eq!(*get_pref("layout.writing-mode.enabled"), PrefValue::Boolean(true));
+    assert_eq!(*get_pref("extra.stuff"), PrefValue::Boolean(false));
+}


### PR DESCRIPTION
In response to #10098 
Tries to load `prefs.json` from the profile-dir and merge them into the preferences if `--profile-dir` is specified at launch.  The profile-dir preferences take precedence over the default preferences, but command line preferences still take precedence over everything.

Also adds some tests for `prefs.rs`.  These rely on the contents of `resources/prefs.json` (at least `test_get_set_reset_extend()` does), so they may need to be re-worked a bit.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10114)

<!-- Reviewable:end -->
