### PR TITLE
Support navigation keys

### DIFF
--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -186,6 +186,9 @@ pub enum Key {
     RightAlt,
     RightSuper,
     Menu,
+
+    NavigateBackward,
+    NavigateForward,
 }
 
 bitflags! {

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -617,7 +617,7 @@ fn code_value(key: Key) -> &'static str {
         Key::LeftControl | Key::RightControl => "Control",
         Key::LeftAlt | Key::RightAlt => "Alt",
         Key::LeftSuper | Key::RightSuper => "Super",
-        Key::Menu => "Menu",
+        Key::Menu => "ContextMenu",
 
         Key::NavigateForward => "BrowserForward",
         Key::NavigateBackward => "BrowserBackward",

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -148,7 +148,7 @@ impl KeyboardEvent {
 }
 
 
-// https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3Events-key.html
+// https://w3c.github.io/uievents-key/#key-value-tables
 pub fn key_value(key: Key, mods: KeyModifiers) -> &'static str {
     let shift = mods.contains(constellation_msg::SHIFT);
     match key {
@@ -497,7 +497,7 @@ fn key_from_string(key_string: &str, location: u32) -> Option<Key> {
     }
 }
 
-// https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3Events-code.html
+// https://w3c.github.io/uievents-code/#code-value-tables
 fn code_value(key: Key) -> &'static str {
     match key {
         Key::Space => "Space",

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -319,6 +319,8 @@ pub fn key_value(key: Key, mods: KeyModifiers) -> &'static str {
         Key::RightAlt => "Alt",
         Key::RightSuper => "Super",
         Key::Menu => "ContextMenu",
+        Key::NavigateForward => "BrowserForward",
+        Key::NavigateBackward => "BrowserBack",
     }
 }
 
@@ -489,6 +491,8 @@ fn key_from_string(key_string: &str, location: u32) -> Option<Key> {
         "Alt" if location == KeyboardEventConstants::DOM_KEY_LOCATION_RIGHT => Some(Key::RightAlt),
         "Super" if location == KeyboardEventConstants::DOM_KEY_LOCATION_RIGHT => Some(Key::RightSuper),
         "ContextMenu" => Some(Key::Menu),
+        "BrowserForward" => Some(Key::NavigateForward),
+        "BrowserBack" => Some(Key::NavigateBackward),
         _ => None
     }
 }
@@ -614,6 +618,9 @@ fn code_value(key: Key) -> &'static str {
         Key::LeftAlt | Key::RightAlt => "Alt",
         Key::LeftSuper | Key::RightSuper => "Super",
         Key::Menu => "Menu",
+
+        Key::NavigateForward => "BrowserForward",
+        Key::NavigateBackward => "BrowserBackward",
     }
 }
 

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -498,6 +498,8 @@ impl Window {
             VirtualKeyCode::Tab => Ok(Key::Tab),
             VirtualKeyCode::Subtract => Ok(Key::Minus),
 
+            VirtualKeyCode::NavigateBackward => Ok(Key::NavigateBackward),
+            VirtualKeyCode::NavigateForward => Ok(Key::NavigateForward),
             _ => Err(()),
         }
     }
@@ -729,6 +731,12 @@ impl WindowMethods for Window {
                 self.event_queue.borrow_mut().push(WindowEvent::Navigation(WindowNavigateMsg::Forward));
             }
             (NONE, Key::Backspace) => {
+                self.event_queue.borrow_mut().push(WindowEvent::Navigation(WindowNavigateMsg::Back));
+            }
+            (SHIFT, Key::NavigateForward) => {
+                self.event_queue.borrow_mut().push(WindowEvent::Navigation(WindowNavigateMsg::Forward));
+            }
+            (NONE, Key::NavigateBackward) => {
                 self.event_queue.borrow_mut().push(WindowEvent::Navigation(WindowNavigateMsg::Back));
             }
 


### PR DESCRIPTION
Rather useful.

If most people have these keys on their keyboard, I'd prefer to remove the backspace navigation handler. I've never used it on purpose, but it gets hit often by accident when an input widget isn't focused (either due to a misclick or debug build lag).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10122)

<!-- Reviewable:end -->
