### PR TITLE
Read `rustc-with-gold` setting from env var when no `.servobuild`

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -111,6 +111,12 @@ class CommandBase(object):
     def __init__(self, context):
         self.context = context
 
+        def get_env_bool(var, default):
+            # Contents of env vars are strings by default. This returns the
+            # boolean value of the specified environment variable, or the
+            # speciried default if the var doesn't contain True or False
+            return {'True': True, 'False': False}.get(os.environ.get(var), default)
+
         def resolverelative(category, key):
             # Allow ~
             self.config[category][key] = path.expanduser(self.config[category][key])
@@ -151,7 +157,7 @@ class CommandBase(object):
         if not self.config["tools"]["system-cargo"]:
             self.config["tools"]["cargo-root"] = path.join(
                 context.sharedir, "cargo", self.cargo_build_id())
-        self.config["tools"].setdefault("rustc-with-gold", True)
+        self.config["tools"].setdefault("rustc-with-gold", get_env_bool("SERVO_RUSTC_WITH_GOLD", True))
 
         self.config.setdefault("build", {})
         self.config["build"].setdefault("android", False)


### PR DESCRIPTION
The build system needs to disable gold on arm64 slaves. Other configuration is
done through environment variables, and buildbot hosts currently don't use a
.servobuild file at all.

This change adds the `get_env_bool` function to cast an environment variable's
string contents into a Python boolean, and uses it to retrieve the optional
`SERVO_RUSTC_WITH_GOLD` setting.

I figured it's worth throwing the helper function in now in case we later want to read booleans from other env vars, but there's currently no need to make up a name for and read from an env var for every single setting.

r? @larsbergstrom

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10127)

<!-- Reviewable:end -->
