### PR TITLE
Bug #10128 - Fixed missing rust.png in reftests

### DIFF
--- a/tests/wpt/mozilla/tests/css/inline_margin_multiple_fragments_a.html
+++ b/tests/wpt/mozilla/tests/css/inline_margin_multiple_fragments_a.html
@@ -10,7 +10,6 @@ span {
 </style>
 </head>
 <body>
-<span><img src=rust.png><img src=rust.png><img src=rust.png></span>
+<span><img src=rust-0.png><img src=rust-0.png><img src=rust-0.png></span>
 </body>
 </html>
-

--- a/tests/wpt/mozilla/tests/css/inline_margin_multiple_fragments_ref.html
+++ b/tests/wpt/mozilla/tests/css/inline_margin_multiple_fragments_ref.html
@@ -11,8 +11,6 @@
 </style>
 </head>
 <body>
-<span id=first><img src=rust.png></span><img src=rust.png><span id=last><img src=rust.png></span>
+<span id=first><img src=rust-0.png></span><img src=rust-0.png><span id=last><img src=rust-0.png></span>
 </body>
 </html>
-
-


### PR DESCRIPTION
Changed img tags to point to an existing image

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10139)

<!-- Reviewable:end -->
