### PR TITLE
Remove test-ref command from testing_commands.py. Fixes #10125

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -270,15 +270,6 @@ class MachCommands(CommandBase):
         if result != 0:
             return result
 
-    @Command('test-ref',
-             description='Run the reference tests',
-             category='testing')
-    @CommandArgument('params', default=None, nargs=argparse.REMAINDER)
-    def test_ref(self, params=None):
-        print("Ref tests have been replaced by web-platform-tests under "
-              "tests/wpt/mozilla/.")
-        return 0
-
     @Command('test-content',
              description='Run the content tests',
              category='testing')


### PR DESCRIPTION
Tries to fix #10125

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10148)

<!-- Reviewable:end -->
