### PR TITLE
Fix #9511. Export webidl enums using "pub use".

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -5349,8 +5349,8 @@ class CGBindingRoot(CGThing):
         # Do codegen for all the typdefs
         for t in typedefs:
             if t.innerType.isUnion():
-                cgthings.extend([CGGeneric("\npub type %s = %s;\n\n" % (t.identifier.name,
-                                                                        "UnionTypes::" + str(t.innerType)))])
+                cgthings.extend([CGGeneric("\npub use dom::bindings::codegen::UnionTypes::%s as %s;\n\n" %
+                                           (t.innerType, t.identifier.name))])
             else:
                 assert not typeNeedsRooting(t.innerType, config.getDescriptorProvider)
                 cgthings.extend([CGGeneric("\npub type %s = " % (t.identifier.name)),


### PR DESCRIPTION
Change typedef codegen to export the underlying enum itself, rather
than an alias. Works around https://github.com/rust-lang/rust/issues/31355

Rebase of #9691.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10152)

<!-- Reviewable:end -->
