### PR TITLE
Test PutForwards attribute on document and window

### DIFF
--- a/components/script/dom/webidls/Document.webidl
+++ b/components/script/dom/webidls/Document.webidl
@@ -80,7 +80,7 @@ enum DocumentReadyState { "loading", "interactive", "complete" };
 // [OverrideBuiltins]
 partial /*sealed*/ interface Document {
   // resource metadata management
-  [/*PutForwards=href, */Unforgeable]
+  [PutForwards=href, Unforgeable]
   readonly attribute Location/*?*/ location;
   readonly attribute DOMString domain;
   // readonly attribute DOMString referrer;

--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -13,7 +13,7 @@
   [BinaryName="Self_"] readonly attribute Window self;
   [Unforgeable] readonly attribute Document document;
   //         attribute DOMString name;
-  [/*PutForwards=href, */Unforgeable] readonly attribute Location location;
+  [PutForwards=href, Unforgeable] readonly attribute Location location;
   //readonly attribute History history;
   //[Replaceable] readonly attribute BarProp locationbar;
   //[Replaceable] readonly attribute BarProp menubar;

--- a/tests/wpt/metadata/html/browsers/the-window-object/window-properties.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/window-properties.html.ini
@@ -300,9 +300,6 @@
   [Window unforgeable attribute: window]
     expected: FAIL
 
-  [Window unforgeable attribute: location]
-    expected: FAIL
-
   [Window unforgeable attribute: top]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -999,9 +999,6 @@
   [Document interface: calling enableStyleSheetsForSet(DOMString) on document.implementation.createDocument(null, "", null) with too few arguments must throw TypeError]
     expected: FAIL
 
-  [Document interface: document.implementation.createDocument(null, "", null) must have own property "location"]
-    expected: FAIL
-
   [Document interface: document.implementation.createDocument(null, "", null) must inherit property "domain" with the proper type (34)]
     expected: FAIL
 
@@ -6442,9 +6439,6 @@
     expected: FAIL
 
   [Window interface: window must inherit property "name" with the proper type (3)]
-    expected: FAIL
-
-  [Window interface: window must have own property "location"]
     expected: FAIL
 
   [Window interface: window must inherit property "history" with the proper type (5)]

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/079.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/079.html.ini
@@ -1,5 +1,4 @@
 [079.html]
   type: testharness
-  [ setting location to javascript URL from event handler ]
-    expected: FAIL
+  expected: TIMEOUT
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5598,6 +5598,12 @@
             "url": "/_mozilla/mozilla/MouseEvent.html"
           }
         ],
+        "mozilla/PutForwards.html": [
+          {
+            "path": "mozilla/PutForwards.html",
+            "url": "/_mozilla/mozilla/PutForwards.html"
+          }
+        ],
         "mozilla/bad_cert_detected.html": [
           {
             "path": "mozilla/bad_cert_detected.html",

--- a/tests/wpt/mozilla/tests/mozilla/PutForwards.html
+++ b/tests/wpt/mozilla/tests/mozilla/PutForwards.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  assert_equals(window.location.href, window.location.toString());
+  assert_equals(document.location.href, document.location.toString());
+}, "Forwarded attributes are handled correctly");
+</script>


### PR DESCRIPTION
`.toString` is necessary on the forwarded attributes to evaluate to strings instead of objects.

Fixes #9990.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10157)

<!-- Reviewable:end -->
