### PR TITLE
script: Make iframes know their pipeline IDs at all times, even after navigation.

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -1256,7 +1256,10 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
                     Some((_, new_subpage_id)) => new_subpage_id,
                 },
             };
-            let msg = ConstellationControlMsg::UpdateSubpageId(parent_pipeline_id, subpage_id, new_subpage_id);
+            let msg = ConstellationControlMsg::UpdateSubpageId(parent_pipeline_id,
+                                                               subpage_id,
+                                                               new_subpage_id,
+                                                               next_pipeline_id);
             let result = match self.pipelines.get(&parent_pipeline_id) {
                 None => return warn!("Pipeline {:?} child navigated after closure.", parent_pipeline_id),
                 Some(pipeline) => pipeline.script_chan.send(msg),

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -24,7 +24,7 @@ use dom::element::{AttributeMutation, Element, RawLayoutElementHelpers};
 use dom::event::Event;
 use dom::eventtarget::EventTarget;
 use dom::htmlelement::HTMLElement;
-use dom::node::{Node, UnbindContext, window_from_node, document_from_node};
+use dom::node::{Node, NodeDamage, UnbindContext, window_from_node, document_from_node};
 use dom::urlhelper::UrlHelper;
 use dom::virtualmethods::VirtualMethods;
 use dom::window::{ReflowReason, Window};
@@ -177,8 +177,14 @@ impl HTMLIFrameElement {
         }
     }
 
-    pub fn update_subpage_id(&self, new_subpage_id: SubpageId) {
+    pub fn update_subpage_id(&self, new_subpage_id: SubpageId, new_pipeline_id: PipelineId) {
         self.subpage_id.set(Some(new_subpage_id));
+        self.pipeline_id.set(Some(new_pipeline_id));
+
+        let mut blocker = self.load_blocker.borrow_mut();
+        LoadBlocker::terminate(&mut blocker);
+
+        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
     }
 
     fn new_inherited(localName: Atom,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -883,8 +883,12 @@ impl ScriptThread {
                                                  event),
             ConstellationControlMsg::UpdateSubpageId(containing_pipeline_id,
                                                      old_subpage_id,
-                                                     new_subpage_id) =>
-                self.handle_update_subpage_id(containing_pipeline_id, old_subpage_id, new_subpage_id),
+                                                     new_subpage_id,
+                                                     new_pipeline_id) =>
+                self.handle_update_subpage_id(containing_pipeline_id,
+                                              old_subpage_id,
+                                              new_subpage_id,
+                                              new_pipeline_id),
             ConstellationControlMsg::FocusIFrame(containing_pipeline_id, subpage_id) =>
                 self.handle_focus_iframe_msg(containing_pipeline_id, subpage_id),
             ConstellationControlMsg::WebDriverScriptCommand(pipeline_id, msg) =>
@@ -1243,7 +1247,8 @@ impl ScriptThread {
     fn handle_update_subpage_id(&self,
                                 containing_pipeline_id: PipelineId,
                                 old_subpage_id: SubpageId,
-                                new_subpage_id: SubpageId) {
+                                new_subpage_id: SubpageId,
+                                new_pipeline_id: PipelineId) {
         let borrowed_page = self.root_page();
 
         let frame_element = borrowed_page.find(containing_pipeline_id).and_then(|page| {
@@ -1251,7 +1256,7 @@ impl ScriptThread {
             doc.find_iframe(old_subpage_id)
         });
 
-        frame_element.unwrap().update_subpage_id(new_subpage_id);
+        frame_element.unwrap().update_subpage_id(new_subpage_id, new_pipeline_id);
     }
 
     /// Window was resized, but this script was not active, so don't reflow yet

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -128,8 +128,8 @@ pub enum ConstellationControlMsg {
     Navigate(PipelineId, SubpageId, LoadData),
     /// Requests the script thread forward a mozbrowser event to an iframe it owns
     MozBrowserEvent(PipelineId, SubpageId, MozBrowserEvent),
-    /// Updates the current subpage id of a given iframe
-    UpdateSubpageId(PipelineId, SubpageId, SubpageId),
+    /// Updates the current subpage and pipeline IDs of a given iframe
+    UpdateSubpageId(PipelineId, SubpageId, SubpageId, PipelineId),
     /// Set an iframe to be focused. Used when an element in an iframe gains focus.
     FocusIFrame(PipelineId, SubpageId),
     /// Passes a webdriver command to the script thread for execution

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1788,6 +1788,18 @@
             "url": "/_mozilla/css/iframe/hide_layers2.html"
           }
         ],
+        "css/iframe/mozbrowser_navigation.html": [
+          {
+            "path": "css/iframe/mozbrowser_navigation.html",
+            "references": [
+              [
+                "/_mozilla/css/iframe/mozbrowser_navigation_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/iframe/mozbrowser_navigation.html"
+          }
+        ],
         "css/iframe/multiple_external.html": [
           {
             "path": "css/iframe/multiple_external.html",
@@ -8514,6 +8526,18 @@
             ]
           ],
           "url": "/_mozilla/css/iframe/hide_layers2.html"
+        }
+      ],
+      "css/iframe/mozbrowser_navigation.html": [
+        {
+          "path": "css/iframe/mozbrowser_navigation.html",
+          "references": [
+            [
+              "/_mozilla/css/iframe/mozbrowser_navigation_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/iframe/mozbrowser_navigation.html"
         }
       ],
       "css/iframe/multiple_external.html": [

--- a/tests/wpt/mozilla/meta/css/iframe/mozbrowser_navigation.html.ini
+++ b/tests/wpt/mozilla/meta/css/iframe/mozbrowser_navigation.html.ini
@@ -1,0 +1,3 @@
+[mozbrowser_navigation.html]
+  type: reftest
+  prefs: [dom.mozbrowser.enabled:true]

--- a/tests/wpt/mozilla/tests/css/iframe/mozbrowser_navigation.html
+++ b/tests/wpt/mozilla/tests/css/iframe/mozbrowser_navigation.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<style>
+iframe {
+    display: block;
+    border: 1px solid black;
+    width: 500px;
+    height: 300px;
+    margin-left: 10px;
+    margin-top: 0px;
+}
+</style>
+<link rel="match" href="mozbrowser_navigation_ref.html">
+</head>
+<body>
+<iframe mozbrowser="true" src="data:text/html,Hello%20world"></iframe>
+<script>
+var iframe = document.getElementsByTagName('iframe')[0];
+iframe.addEventListener('load', function first() {
+    iframe.removeEventListener('load', first);
+    iframe.src = "data:text/html,Foo";
+    iframe.addEventListener('load', function() {
+        iframe.goBack();
+        iframe.offsetHeight;    // flush layout
+        document.documentElement.classList.remove("reftest-wait");
+    }, false);
+}, false);
+</script>
+</body>
+</html>
+

--- a/tests/wpt/mozilla/tests/css/iframe/mozbrowser_navigation_ref.html
+++ b/tests/wpt/mozilla/tests/css/iframe/mozbrowser_navigation_ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<style>
+iframe {
+    display: block;
+    border: 1px solid black;
+    width: 500px;
+    height: 300px;
+    margin-left: 10px;
+    margin-top: 0px;
+}
+</style>
+<body>
+<iframe src="data:text/html,Hello%20world"></iframe>
+</body>
+</html>
+
+


### PR DESCRIPTION
Since WebRender uses the pipeline ID stored in the iframe element to
determine which pipeline to display, it had better be kept up to date!

Closes #9919.

r? @jdm

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10159)

<!-- Reviewable:end -->
