### PR TITLE
Implement flexbox reordering

### DIFF
--- a/components/layout/flow_list.rs
+++ b/components/layout/flow_list.rs
@@ -64,6 +64,12 @@ impl FlowList {
         }
     }
 
+    /// Provide a forward iterator with FlowRef items
+    #[inline]
+    pub fn iter_flow_ref_mut<'a>(&'a mut self) -> linked_list::IterMut<'a, FlowRef> {
+        self.flows.iter_mut()
+    }
+
     /// O(1)
     #[inline]
     pub fn is_empty(&self) -> bool {

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -310,4 +310,5 @@ partial interface CSSStyleDeclaration {
 
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flexDirection;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flex-direction;
+  [SetterThrows, TreatNullAs=EmptyString] attribute DOMString order;
 };

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -4906,6 +4906,28 @@ pub mod longhands {
 
     // Flex container properties
     ${single_keyword("flex-direction", "row row-reverse column column-reverse", experimental=True)}
+
+    // https://drafts.csswg.org/css-flexbox/#propdef-order
+    <%self:longhand name="order">
+        use values::computed::ComputedValueAsSpecified;
+
+        impl ComputedValueAsSpecified for SpecifiedValue {}
+
+        pub type SpecifiedValue = computed_value::T;
+
+        pub mod computed_value {
+            pub type T = i32;
+        }
+
+        #[inline]
+        pub fn get_initial_value() -> computed_value::T {
+            0
+        }
+
+        fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
+            specified::parse_integer(input)
+        }
+    </%self:longhand>
 }
 
 

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_order-inherit.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_order-inherit.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_order-inherit.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_order-integer.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_order-integer.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_order-integer.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_order-invalid.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_order-invalid.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_order-invalid.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_order-negative.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_order-negative.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_order-negative.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_order.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_order.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_order.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/order_value.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/order_value.htm.ini
@@ -1,5 +1,0 @@
-[order_value.htm]
-  type: testharness
-  [CSS Flexible Box Test: order_check]
-    expected: FAIL
-


### PR DESCRIPTION
Add style property for `order` and implement reordering by this property
in flex flow. Based on previous work by @zentner-kyle.

Fixes: #9957

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10178)

<!-- Reviewable:end -->
