### PR TITLE
Fix delete_char when selection range is empty

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -20,7 +20,7 @@ pub enum Selection {
     NotSelected
 }
 
-#[derive(JSTraceable, Copy, Clone, HeapSizeOf)]
+#[derive(JSTraceable, Copy, Clone, HeapSizeOf, PartialEq)]
 pub struct TextPoint {
     /// 0-based line number
     pub line: usize,
@@ -123,7 +123,7 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     /// Remove a character at the current editing point
     pub fn delete_char(&mut self, dir: Direction) {
-        if self.selection_begin.is_none() {
+        if self.selection_begin.is_none() || self.selection_begin == Some(self.edit_point) {
             self.adjust_horizontal_by_one(dir, Selection::Selected);
         }
         self.replace_selection(DOMString::new());

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -150,6 +150,13 @@ fn test_textinput_delete_char() {
     textinput.delete_char(Direction::Forward);
     // Not splitting surrogate pairs.
     assert_eq!(textinput.get_content(), "ab");
+
+    let mut textinput = text_input(Lines::Single, "abcdefg");
+    textinput.adjust_horizontal(2, Selection::NotSelected);
+    // Set an empty selection range.
+    textinput.selection_begin = Some(textinput.edit_point);
+    textinput.delete_char(Direction::Backward);
+    assert_eq!(textinput.get_content(), "acdefg");
 }
 
 #[test]


### PR DESCRIPTION
An empty selection range should be treated the same as no selection.  Fixes browserhtml/browserhtml#930.

r? @jdm

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10182)

<!-- Reviewable:end -->
