### PR TITLE
Remove JS_SaveFrameChain and JS_RestoreFrameChain calls.

### DIFF
--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -13,7 +13,6 @@ use js::jsapi::{Heap, MutableHandleObject, RootedObject, RootedValue};
 use js::jsapi::{IsCallable, JSContext, JSObject, JS_WrapObject};
 use js::jsapi::{JSCompartment, JS_EnterCompartment, JS_LeaveCompartment};
 use js::jsapi::{JS_GetProperty, JS_IsExceptionPending, JS_ReportPendingException};
-use js::jsapi::{JS_RestoreFrameChain, JS_SaveFrameChain};
 use js::jsval::{JSVal, UndefinedValue};
 use std::default::Default;
 use std::ffi::CString;
@@ -197,14 +196,8 @@ impl Drop for CallSetup {
         if need_to_deal_with_exception {
             unsafe {
                 let old_global = RootedObject::new(self.cx, self.exception_compartment.ptr);
-                let saved = JS_SaveFrameChain(self.cx);
-                {
-                    let _ac = JSAutoCompartment::new(self.cx, old_global.ptr);
-                    JS_ReportPendingException(self.cx);
-                }
-                if saved {
-                    JS_RestoreFrameChain(self.cx);
-                }
+                let _ac = JSAutoCompartment::new(self.cx, old_global.ptr);
+                JS_ReportPendingException(self.cx);
             }
         }
     }

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -195,8 +195,7 @@ impl Drop for CallSetup {
                                           unsafe { JS_IsExceptionPending(self.cx) };
         if need_to_deal_with_exception {
             unsafe {
-                let old_global = RootedObject::new(self.cx, self.exception_compartment.ptr);
-                let _ac = JSAutoCompartment::new(self.cx, old_global.ptr);
+                let _ac = JSAutoCompartment::new(self.cx, self.exception_compartment.ptr);
                 JS_ReportPendingException(self.cx);
             }
         }

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -12,7 +12,6 @@ use js::error::{throw_range_error, throw_type_error};
 use js::jsapi::JSAutoCompartment;
 use js::jsapi::{JSContext, JSObject, RootedValue};
 use js::jsapi::{JS_IsExceptionPending, JS_ReportPendingException, JS_SetPendingException};
-use js::jsapi::{JS_RestoreFrameChain, JS_SaveFrameChain};
 use js::jsval::UndefinedValue;
 
 /// DOM exceptions that can be thrown by a native DOM method.
@@ -125,14 +124,8 @@ pub unsafe fn throw_dom_exception(cx: *mut JSContext, global: GlobalRef, result:
 pub fn report_pending_exception(cx: *mut JSContext, obj: *mut JSObject) {
     unsafe {
         if JS_IsExceptionPending(cx) {
-            let saved = JS_SaveFrameChain(cx);
-            {
-                let _ac = JSAutoCompartment::new(cx, obj);
-                JS_ReportPendingException(cx);
-            }
-            if saved {
-                JS_RestoreFrameChain(cx);
-            }
+            let _ac = JSAutoCompartment::new(cx, obj);
+            JS_ReportPendingException(cx);
         }
     }
 }


### PR DESCRIPTION
They were cargo-culted from Gecko, where they haven't been necessary for a
while either.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10190)

<!-- Reviewable:end -->
