### PR TITLE
Fix forced repaint on image load

### DIFF
--- a/components/layout/layout_thread.rs
+++ b/components/layout/layout_thread.rs
@@ -593,6 +593,11 @@ impl LayoutThread {
     fn repaint<'a, 'b>(&mut self, possibly_locked_rw_data: &mut RwData<'a, 'b>) -> bool {
         let mut rw_data = possibly_locked_rw_data.lock();
 
+        if let Some(mut root_flow) = self.root_flow.clone() {
+            let flow = flow::mut_base(flow_ref::deref_mut(&mut root_flow));
+            flow.restyle_damage.insert(REPAINT);
+        }
+
         let reflow_info = Reflow {
             goal: ReflowGoal::ForDisplay,
             page_clip_rect: MAX_RECT,


### PR DESCRIPTION
After #10021, `LayoutThread::repaint` no longer forced a repaint because of the `restyle_damage` check.  This patch adds the correct restyle damage and fixes #10163.

r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10197)

<!-- Reviewable:end -->
