### PR TITLE
Added a mapping between nodes and stylesheets

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -996,7 +996,7 @@ impl Window {
                 page_clip_rect: self.page_clip_rect.get(),
             },
             document: self.Document().upcast::<Node>().to_trusted_node_address(),
-            document_stylesheets: document.stylesheets().clone(),
+            document_stylesheets: document.stylesheets(),
             stylesheets_changed: stylesheets_changed,
             window_size: window_size,
             script_join_chan: join_chan,


### PR DESCRIPTION
Currently a work in progress solution for #10143.

I am not sure how to make the stylesheets() func return a `Ref<Vec<Arc<Stylesheet>>>` or if this way work just as well.

If anyone has any feedback, that would be great.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10202)

<!-- Reviewable:end -->
