### PR TITLE
Avoid script execution when not found

### DIFF
--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -40150,6 +40150,14 @@
             "url": "/webvtt/rendering/cues-with-video/processing-model/too_many_cues_wrapped.html"
           }
         ]
+      },
+      "testharness": {
+        "html/semantics/scripting-1/the-script-element/script-not-found-not-executed.html": [
+          {
+            "path": "html/semantics/scripting-1/the-script-element/script-not-found-not-executed.html",
+            "url": "/html/semantics/scripting-1/the-script-element/script-not-found-not-executed.html"
+          }
+        ]
       }
     },
     "reftest_nodes": {

--- a/tests/wpt/web-platform-tests/html/semantics/scripting-1/the-script-element/script-not-found-not-executed-2.py
+++ b/tests/wpt/web-platform-tests/html/semantics/scripting-1/the-script-element/script-not-found-not-executed-2.py
@@ -1,0 +1,4 @@
+def main(request, response):
+    headers = [("Content-Type", "text/javascript")]
+    body = "test2_token = \"script executed\";"
+    return 200, headers, body

--- a/tests/wpt/web-platform-tests/html/semantics/scripting-1/the-script-element/script-not-found-not-executed.html
+++ b/tests/wpt/web-platform-tests/html/semantics/scripting-1/the-script-element/script-not-found-not-executed.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>var test1_token = "script not executed";</script>
+<script src="script-not-found-not-executed.py"></script>
+<script>
+test(function(){
+    assert_equals(test1_token, "script not executed");
+}, "Script that 404");
+</script>
+<script>var test2_token = "script not executed";</script>
+<script src="script-not-found-not-executed-2.py"></script>
+<script>
+test(function(){
+    assert_equals(test2_token, "script executed");
+}, "Script that does not 404");
+</script>

--- a/tests/wpt/web-platform-tests/html/semantics/scripting-1/the-script-element/script-not-found-not-executed.py
+++ b/tests/wpt/web-platform-tests/html/semantics/scripting-1/the-script-element/script-not-found-not-executed.py
@@ -1,0 +1,4 @@
+def main(request, response):
+    headers = [("Content-Type", "text/javascript")]
+    body = "test1_token = \"script executed\";"
+    return 404, headers, body


### PR DESCRIPTION
Fix #8391 

If the status code is an error or has not been received, we discard data and prevent the script from being executed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10203)

<!-- Reviewable:end -->
