### PR TITLE
Generate html and json of supported css properties.

### DIFF
--- a/components/style/list_properties.py
+++ b/components/style/list_properties.py
@@ -21,4 +21,17 @@ properties = dict(
     })
     for p in template.module.LONGHANDS + template.module.SHORTHANDS
 )
-print(json.dumps(properties, indent=4))
+
+json_dump = json.dumps(properties, indent=4)
+
+#
+# Resolve path to doc directory and write CSS properties and JSON.
+#
+servo_doc_path = os.path.abspath(os.path.join(style, '../', '../', 'target', 'doc', 'servo'))
+
+with open(os.path.join(servo_doc_path, 'css-properties.json'), "w") as out_file:
+    out_file.write(json_dump)
+
+html_template = Template(filename=os.path.join(style, "properties.html.mako"), input_encoding='utf8')
+with open(os.path.join(servo_doc_path, 'css-properties.html'), "w") as out_file:
+    out_file.write(html_template.render(properties=properties))

--- a/components/style/list_properties.py
+++ b/components/style/list_properties.py
@@ -23,7 +23,6 @@ properties = dict(
 )
 
 json_dump = json.dumps(properties, indent=4)
-print(json_dump)
 
 #
 # Resolve path to doc directory and write CSS properties and JSON.

--- a/components/style/list_properties.py
+++ b/components/style/list_properties.py
@@ -23,11 +23,16 @@ properties = dict(
 )
 
 json_dump = json.dumps(properties, indent=4)
+print(json_dump)
 
 #
 # Resolve path to doc directory and write CSS properties and JSON.
 #
 servo_doc_path = os.path.abspath(os.path.join(style, '../', '../', 'target', 'doc', 'servo'))
+
+# Ensure ./target/doc/servo exists
+if not os.path.exists(servo_doc_path):
+    os.makedirs(servo_doc_path)
 
 with open(os.path.join(servo_doc_path, 'css-properties.json'), "w") as out_file:
     out_file.write(json_dump)

--- a/components/style/properties.html.mako
+++ b/components/style/properties.html.mako
@@ -20,48 +20,21 @@
     <section id='main' class="content mod">
       <h1 class='fqn'><span class='in-band'>CSS properties currently supported in <a class='mod' href=''>Servo</a></span></h1>
       <div id='properties' class='docblock'>
-        <em>Loading</em>
+        <table>
+          <tr>
+            <th>Property</th>
+            <th>Flag</th>
+            <th>Shorthand</th>
+          </tr>
+          % for prop in properties:
+            <tr>
+              <td>${prop}</td>
+              <td>${properties[prop]['flag']}</td>
+              <td>${properties[prop]['shorthand']}</td>
+            </tr>
+          % endfor
+        </table>
       </div>
     </section>
-
-    <script src="../jquery.js"></script>
-    <script>
-    (function() {
-      "use strict";
-      //
-      // Renders list of properties into a table.
-      //
-      function updatePropertyList (properties) {
-        var compiledTable = $('<table></table>');
-        
-        var header = $('<tr></tr>');
-        header.append('<th>Property</th>');
-        header.append('<th>Flag</td>');
-        header.append('<th>Shorthand</th>');
-        compiledTable.append(header);
-
-        for (var property in properties) {
-          if (properties.hasOwnProperty(property)) {
-            var tr = $('<tr></tr>');
-            tr.append('<td>' + property + '</td>');
-            if (!properties[property].flag) {
-              tr.append('<td>-</td>');
-            } else {
-              tr.append('<td>' + properties[property].flag + '</td>');
-            }
-            tr.append('<td>' + properties[property].shorthand + '</td>');
-            compiledTable.append(tr);
-          }
-        }
-
-
-        $('#properties').html(compiledTable);
-      }
-
-      $.get('./css-properties.json').success(updatePropertyList).error(function () {
-        $('#properties').html("<p>Unable to load json.</p>");
-      });
-    }());
-    </script>
 </body>
 </html>

--- a/components/style/properties.html.mako
+++ b/components/style/properties.html.mako
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="generator" content="rustdoc">
+    <meta name="description" content="API documentation for the Rust `servo` crate.">
+    <meta name="keywords" content="rust, rustlang, rust-lang, servo">
+    <title>Supported CSS properties - servo - Rust</title>
+    <link rel="stylesheet" type="text/css" href="../rustdoc.css">
+    <link rel="stylesheet" type="text/css" href="../main.css">
+</head>
+<body class="rustdoc">
+    <!--[if lte IE 8]>
+    <div class="warning">
+        This old browser is unsupported and will most likely display funky
+        things.
+    </div>
+    <![endif]-->
+    <section id='main' class="content mod">
+      <h1 class='fqn'><span class='in-band'>CSS properties currently supported in <a class='mod' href=''>Servo</a></span></h1>
+      <div id='properties' class='docblock'>
+        <em>Loading</em>
+      </div>
+    </section>
+
+    <script src="../jquery.js"></script>
+    <script>
+    (function() {
+      "use strict";
+      //
+      // Renders list of properties into a table.
+      //
+      function updatePropertyList (properties) {
+        var compiledTable = $('<table></table>');
+        
+        var header = $('<tr></tr>');
+        header.append('<th>Property</th>');
+        header.append('<th>Flag</td>');
+        header.append('<th>Shorthand</th>');
+        compiledTable.append(header);
+
+        for (var property in properties) {
+          if (properties.hasOwnProperty(property)) {
+            var tr = $('<tr></tr>');
+            tr.append('<td>' + property + '</td>');
+            if (!properties[property].flag) {
+              tr.append('<td>-</td>');
+            } else {
+              tr.append('<td>' + properties[property].flag + '</td>');
+            }
+            tr.append('<td>' + properties[property].shorthand + '</td>');
+            compiledTable.append(tr);
+          }
+        }
+
+
+        $('#properties').html(compiledTable);
+      }
+
+      $.get('./css-properties.json').success(updatePropertyList).error(function () {
+        $('#properties').html("<p>Unable to load json.</p>");
+      });
+    }());
+    </script>
+</body>
+</html>

--- a/etc/ci/upload_docs.sh
+++ b/etc/ci/upload_docs.sh
@@ -12,5 +12,7 @@ cd "$(dirname $0)/../.."
 # etc/doc.servo.org/index.html overwrites $(mach rust-root)/doc/index.html
 cp etc/doc.servo.org/* target/doc/
 
+python components/style/list_properties.py
+
 ghp-import -n target/doc
 git push -qf https://${TOKEN}@github.com/servo/doc.servo.org.git gh-pages

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -163,10 +163,17 @@ class MachCommands(CommandBase):
     @CommandArgument('test_name', nargs=argparse.REMAINDER,
                      help="Only run tests that match this pattern or file path")
     def test_unit(self, test_name=None, package=None):
-        properties = json.loads(subprocess.check_output([
+        subprocess.check_output([
             sys.executable,
             path.join(self.context.topdir, "components", "style", "list_properties.py")
-        ]))
+        ])
+
+        this_file = style = os.path.dirname(__file__)
+        servo_doc_path = os.path.abspath(os.path.join(this_file, '../', '../', 'target', 'doc', 'servo'))
+
+        with open(os.path.join(servo_doc_path, 'css-properties.json'), 'r') as property_file:
+            properties = json.loads(property_file.read())
+
         assert len(properties) >= 100
         assert "margin-top" in properties
         assert "margin" in properties

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -168,7 +168,7 @@ class MachCommands(CommandBase):
             path.join(self.context.topdir, "components", "style", "list_properties.py")
         ])
 
-        this_file = style = os.path.dirname(__file__)
+        this_file = os.path.dirname(__file__)
         servo_doc_path = os.path.abspath(os.path.join(this_file, '../', '../', 'target', 'doc', 'servo'))
 
         with open(os.path.join(servo_doc_path, 'css-properties.json'), 'r') as property_file:


### PR DESCRIPTION
Fixes #10196. Outputs html and json of supported css properties to `target/doc/` directory when deploying github-pages.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10208)

<!-- Reviewable:end -->
