### PR TITLE
Fix ./mach run and ./mach test-unit on Windows

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -261,6 +261,9 @@ class CommandBase(object):
         if not self.config["tools"]["system-rust"] \
                 or self.config["tools"]["rust-root"]:
             env["RUST_ROOT"] = self.config["tools"]["rust-root"]
+            # Add mingw64 binary path before rust paths to avoid conflict with libstdc++-6.dll
+            if sys.platform == "msys":
+                extra_path += [path.join(os.sep, "mingw64", "bin")]
             # These paths are for when rust-root points to an unpacked installer
             extra_path += [path.join(self.config["tools"]["rust-root"], "rustc", "bin")]
             extra_lib += [path.join(self.config["tools"]["rust-root"], "rustc", "lib")]


### PR DESCRIPTION
This small hack fix conflict with mingw and rustc `libstdc++-6.dll`.
This fixes https://github.com/servo/servo/issues/9465 and https://github.com/servo/servo/issues/10048

CC @larsbergstrom @jdm

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10223)

<!-- Reviewable:end -->
