### PR TITLE
Make selection blue instead of orange

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -105,10 +105,7 @@ impl<'a> DisplayListBuildState<'a> {
 const INSERTION_POINT_LOGICAL_WIDTH: Au = Au(1 * AU_PER_PX);
 
 // Colors for selected text.  TODO (#8077): Use the ::selection pseudo-element to set these.
-const SELECTION_FOREGROUND_COLOR: RGBA = RGBA { red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0 };
-#[cfg(target_os="linux")]
-const SELECTION_BACKGROUND_COLOR: RGBA = RGBA { red: 1.0, green: 0.5, blue: 0.0, alpha: 1.0 };
-#[cfg(not(target_os="linux"))]
+const SELECTION_FOREGROUND_COLOR: RGBA = RGBA { red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0 };
 const SELECTION_BACKGROUND_COLOR: RGBA = RGBA { red: 0.69, green: 0.84, blue: 1.0, alpha: 1.0 };
 
 // TODO(gw): The transforms spec says that perspective length must

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -106,7 +106,10 @@ const INSERTION_POINT_LOGICAL_WIDTH: Au = Au(1 * AU_PER_PX);
 
 // Colors for selected text.  TODO (#8077): Use the ::selection pseudo-element to set these.
 const SELECTION_FOREGROUND_COLOR: RGBA = RGBA { red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0 };
+#[cfg(target_os="linux")]
 const SELECTION_BACKGROUND_COLOR: RGBA = RGBA { red: 1.0, green: 0.5, blue: 0.0, alpha: 1.0 };
+#[cfg(not(target_os="linux"))]
+const SELECTION_BACKGROUND_COLOR: RGBA = RGBA { red: 0.69, green: 0.84, blue: 1.0, alpha: 1.0 };
 
 // TODO(gw): The transforms spec says that perspective length must
 // be positive. However, there is some confusion between the spec

--- a/tests/wpt/mozilla/tests/css/input_selection_a.html
+++ b/tests/wpt/mozilla/tests/css/input_selection_a.html
@@ -12,8 +12,8 @@
         padding: 0;
       }
       ::selection {
-        color: white;
-        background: rgba(255, 127, 0, 1.0);
+        color: black;
+        background: rgba(176, 214, 255, 1.0);
       }
     </style>
   </head>

--- a/tests/wpt/mozilla/tests/css/input_selection_ref.html
+++ b/tests/wpt/mozilla/tests/css/input_selection_ref.html
@@ -7,8 +7,8 @@
     <style>
       span {
         font: 16px sans-serif;
-        color: white;
-        background: rgba(255, 128, 0, 1.0);
+        color: black;
+        background: rgba(176, 214, 255, 1.0);
       }
     </style>
   </head>


### PR DESCRIPTION
PR https://github.com/servo/servo/pull/10176 add a background color for selected text. It uses a builtin color until `::selection` is supported. ~~Orange makes sense for Linux. Let's make it blue for windows and mac.~~ See https://github.com/servo/servo/pull/10231#issuecomment-202335065

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10231)

<!-- Reviewable:end -->
