### PR TITLE
Restore stripped whitespace before reflowing text fragments

### DIFF
--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -527,6 +527,9 @@ impl LineBreaker {
                        mut fragment: Fragment,
                        flow: &InlineFlow,
                        layout_context: &LayoutContext) {
+        // Undo any whitespace stripping from previous reflows.
+        fragment.reset_text_range_and_inline_size();
+
         // Determine initial placement for the fragment if we need to.
         //
         // Also, determine whether we can legally break the line before, or inside, this fragment.

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2084,6 +2084,30 @@
             "url": "/_mozilla/css/incremental_text_color_a.html"
           }
         ],
+        "css/incremental_trailing_whitespace_a.html": [
+          {
+            "path": "css/incremental_trailing_whitespace_a.html",
+            "references": [
+              [
+                "/_mozilla/css/incremental_trailing_whitespace_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/incremental_trailing_whitespace_a.html"
+          }
+        ],
+        "css/incremental_trailing_whitespace_ref.html": [
+          {
+            "path": "css/incremental_trailing_whitespace_ref.html",
+            "references": [
+              [
+                "/_mozilla/css/incremental_trailing_whitespace_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/incremental_trailing_whitespace_ref.html"
+          }
+        ],
         "css/incremental_visibility_a.html": [
           {
             "path": "css/incremental_visibility_a.html",
@@ -8420,6 +8444,30 @@
             ]
           ],
           "url": "/_mozilla/css/incremental_text_color_a.html"
+        }
+      ],
+      "css/incremental_trailing_whitespace_a.html": [
+        {
+          "path": "css/incremental_trailing_whitespace_a.html",
+          "references": [
+            [
+              "/_mozilla/css/incremental_trailing_whitespace_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/incremental_trailing_whitespace_a.html"
+        }
+      ],
+      "css/incremental_trailing_whitespace_ref.html": [
+        {
+          "path": "css/incremental_trailing_whitespace_ref.html",
+          "references": [
+            [
+              "/_mozilla/css/incremental_trailing_whitespace_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/incremental_trailing_whitespace_ref.html"
         }
       ],
       "css/incremental_visibility_a.html": [

--- a/tests/wpt/mozilla/tests/css/incremental_trailing_whitespace_a.html
+++ b/tests/wpt/mozilla/tests/css/incremental_trailing_whitespace_a.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>incremental trailing whitespace test</title>
+    <link rel="match" href="incremental_trailing_whitespace_ref.html">
+    <style>
+      #a {
+        border: 0 solid;
+      }
+      #a.go {
+        border-bottom-width: 4px !important;
+      }
+    </style>
+  </head>
+  <body>
+    <div style="display: inline-block; width: 33.3333%;"></div>
+    <div style="display: inline-block; width: 66.66%;">
+      <div id="a" style="transition: all .1s ease-out;">Hello</div>
+    </div>
+    <script>
+      document.body.offsetWidth; // force layout
+      document.querySelector('#a').classList.add('go');
+      // FIXME (#10245): Wait for the "transitionend" event.
+    </script>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/incremental_trailing_whitespace_ref.html
+++ b/tests/wpt/mozilla/tests/css/incremental_trailing_whitespace_ref.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>incremental trailing whitespace reference</title>
+    <link rel="match" href="incremental_trailing_whitespace_ref.html">
+    <style>
+      #a {
+        border: 0 solid;
+        border-bottom-width: 4px !important;
+      }
+    </style>
+  </head>
+  <body>
+    <div style="display: inline-block; width: 33.3333%;"></div>
+    <div style="display: inline-block; width: 66.66%;">
+      <div id="a">Hello</div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #10200. r? @pcwalton

Note: The reftest uses a transition of non-zero duration, because I couldn't find any other way to reproduce the bug.  Unfortunately this makes it unreliable in debug builds. I tried to fix this using reftest-wait with setTimeout and requestAnimationFrame, but it still wouldn't complete the animation consistently.  To make the test work in debug builds we may need `transitionend` events (#10245) or a different way to reproduce the bug.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10246)

<!-- Reviewable:end -->
