### PR TITLE
Use <base> in resolving url attributes (like "href").

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1078,7 +1078,7 @@ impl Element {
         }
         let url = self.get_string_attribute(local_name);
         let doc = document_from_node(self);
-        let base = doc.url();
+        let base = doc.base_url();
         // https://html.spec.whatwg.org/multipage/#reflect
         // XXXManishearth this doesn't handle `javascript:` urls properly
         match base.join(&url) {

--- a/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_href_specified.sub.html.ini
+++ b/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_href_specified.sub.html.ini
@@ -3,6 +3,3 @@
   [The href attribute of the base element is specified]
     expected: FAIL
 
-  [The src attribute of the img element must relative to the href attribute of the base element]
-    expected: FAIL
-


### PR DESCRIPTION
Second take of #6303, now that the `base_url` infrastructure is in place.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10247)

<!-- Reviewable:end -->
