### PR TITLE
layout: Only take nonnegative margins into account when estimating inline placement of floats.

### DIFF
--- a/components/layout/floats.rs
+++ b/components/layout/floats.rs
@@ -459,8 +459,8 @@ impl SpeculatedFloatPlacement {
         }
     }
 
-    /// Given the speculated inline size of the floats in for this flow, computes the speculated
-    /// inline size of the floats out for this flow.
+    /// Given the speculated inline size of the floats out for this flow's last child, computes the
+    /// speculated inline size of the floats out for this flow.
     pub fn compute_floats_out(&mut self, flow: &mut Flow) {
         if flow.is_block_like() {
             let block_flow = flow.as_block();
@@ -470,10 +470,10 @@ impl SpeculatedFloatPlacement {
                 if self.left > Au(0) || self.right > Au(0) {
                     let speculated_inline_content_edge_offsets =
                         block_flow.fragment.guess_inline_content_edge_offsets();
-                    if self.left > Au(0) {
+                    if self.left > Au(0) && speculated_inline_content_edge_offsets.start > Au(0) {
                         self.left = self.left + speculated_inline_content_edge_offsets.start
                     }
-                    if self.right > Au(0) {
+                    if self.right > Au(0) && speculated_inline_content_edge_offsets.end > Au(0) {
                         self.right = self.right + speculated_inline_content_edge_offsets.end
                     }
                 }
@@ -507,16 +507,20 @@ impl SpeculatedFloatPlacement {
         let speculated_inline_content_edge_offsets =
             parent_block_flow.fragment.guess_inline_content_edge_offsets();
 
-        if placement.left > speculated_inline_content_edge_offsets.start {
-            placement.left = placement.left - speculated_inline_content_edge_offsets.start
-        } else {
-            placement.left = Au(0)
-        };
-        if placement.right > speculated_inline_content_edge_offsets.end {
-            placement.right = placement.right - speculated_inline_content_edge_offsets.end
-        } else {
-            placement.right = Au(0)
-        };
+        if speculated_inline_content_edge_offsets.start > Au(0) {
+            placement.left = if placement.left > speculated_inline_content_edge_offsets.start {
+                placement.left - speculated_inline_content_edge_offsets.start
+            } else {
+                Au(0)
+            }
+        }
+        if speculated_inline_content_edge_offsets.end > Au(0) {
+            placement.right = if placement.right > speculated_inline_content_edge_offsets.end {
+                placement.right - speculated_inline_content_edge_offsets.end
+            } else {
+                Au(0)
+            }
+        }
 
         placement
     }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1484,6 +1484,18 @@
             "url": "/_mozilla/css/float_right_intrinsic_width_a.html"
           }
         ],
+        "css/float_speculation_negative_inline_margins_a.html": [
+          {
+            "path": "css/float_speculation_negative_inline_margins_a.html",
+            "references": [
+              [
+                "/_mozilla/css/float_speculation_negative_inline_margins_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/float_speculation_negative_inline_margins_a.html"
+          }
+        ],
         "css/float_table_a.html": [
           {
             "path": "css/float_table_a.html",
@@ -7820,6 +7832,18 @@
             ]
           ],
           "url": "/_mozilla/css/float_right_intrinsic_width_a.html"
+        }
+      ],
+      "css/float_speculation_negative_inline_margins_a.html": [
+        {
+          "path": "css/float_speculation_negative_inline_margins_a.html",
+          "references": [
+            [
+              "/_mozilla/css/float_speculation_negative_inline_margins_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/float_speculation_negative_inline_margins_a.html"
         }
       ],
       "css/float_table_a.html": [

--- a/tests/wpt/mozilla/tests/css/float_speculation_negative_inline_margins_a.html
+++ b/tests/wpt/mozilla/tests/css/float_speculation_negative_inline_margins_a.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title></title>
+<link rel="match" href="float_speculation_negative_inline_margins_ref.html">
+<style>
+  * {
+    margin: 0;
+    padding: 0;
+    font-size: 0;
+  }
+  .red {
+    left: 50%;
+    position: absolute;
+    top: 40px;
+    width: 480px;
+    margin-left: -240px;
+    background: red;
+  }
+  .green {
+    display: block;
+    width: 410px;
+    height: 34px;
+    line-height: 34px;
+    background: green;
+    border: none
+  }
+</style>
+
+<div class="red"><input class="green"></div>
+

--- a/tests/wpt/mozilla/tests/css/float_speculation_negative_inline_margins_ref.html
+++ b/tests/wpt/mozilla/tests/css/float_speculation_negative_inline_margins_ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title></title>
+<style>
+  * {
+    margin: 0;
+    padding: 0;
+    font-size: 0;
+  }
+  .red {
+    left: 50%;
+    position: absolute;
+    top: 40px;
+    width: 480px;
+    margin-left: -240px;
+    background: red;
+  }
+  .green {
+    display: block;
+    width: 410px;
+    height: 34px;
+    line-height: 34px;
+    background: green;
+    border: none
+  }
+</style>
+
+<div class="red"><div class="green"></div>
+


### PR DESCRIPTION
Otherwise, the heuristics can pass even when there are no floats,
causing block formatting contexts to be speculated to be flowing around
floats that don't exist!

Closes #10237.

r? @mbrubeck

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10248)

<!-- Reviewable:end -->
