### PR TITLE
Make input elements not inherit parent containers alignment

### DIFF
--- a/resources/servo.css
+++ b/resources/servo.css
@@ -1,4 +1,4 @@
-input                   { background: white; min-height: 1.0em; padding: 0em; padding-left: 0.25em; padding-right: 0.25em; border: solid lightgrey 1px; color: black; white-space: nowrap; }
+input                   { background: white; min-height: 1.0em; padding: 0em; padding-left: 0.25em; padding-right: 0.25em; border: solid lightgrey 1px; color: black; white-space: nowrap; text-align: left; }
 textarea                { background: white; min-height: 1.0em; padding: 0em; padding-left: 0.25em; padding-right: 0.25em; border: solid lightgrey 1px; color: black; white-space: pre; }
 button,
 input[type="button"],

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2480,6 +2480,18 @@
             "url": "/_mozilla/css/inline_whitespace_b.html"
           }
         ],
+        "css/input_alignment_a.html": [
+          {
+            "path": "css/input_alignment_a.html",
+            "references": [
+              [
+                "/_mozilla/css/input_alignment_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/input_alignment_a.html"
+          }
+        ],
         "css/input_button_margins_a.html": [
           {
             "path": "css/input_button_margins_a.html",
@@ -8816,6 +8828,18 @@
             ]
           ],
           "url": "/_mozilla/css/inline_whitespace_b.html"
+        }
+      ],
+      "css/input_alignment_a.html": [
+        {
+          "path": "css/input_alignment_a.html",
+          "references": [
+            [
+              "/_mozilla/css/input_alignment_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/input_alignment_a.html"
         }
       ],
       "css/input_button_margins_a.html": [

--- a/tests/wpt/mozilla/tests/css/input_alignment_a.html
+++ b/tests/wpt/mozilla/tests/css/input_alignment_a.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+    <title>Input elements shouldn't inherit parent containers alignment</title>
+    <link rel="match" href="input_alignment_ref.html">
+    <style>
+        div { 
+            text-align: center; 
+            float: left; 
+        }
+    </style>
+</head>
+<body>
+    <div><input value="test" /></div>
+</body>
+</html>

--- a/tests/wpt/mozilla/tests/css/input_alignment_ref.html
+++ b/tests/wpt/mozilla/tests/css/input_alignment_ref.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+    <title>Input elements shouldn't inherit parent containers alignment</title>
+    <style>
+        div { float: left; }
+    </style>
+</head>
+<body>
+    <div><input value="test" /></div>
+</body>
+</html>


### PR DESCRIPTION
Fixes  #10234 .

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10249)

<!-- Reviewable:end -->
