### PR TITLE
Reduce size of layout::fragment::Fragment struct

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -578,7 +578,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                 // Add whitespace results. They will be stripped out later on when
                 // between block elements, and retained when between inline elements.
                 let fragment_info = SpecificFragmentInfo::UnscannedText(
-                    UnscannedTextFragmentInfo::new(" ".to_owned(), None));
+                    box UnscannedTextFragmentInfo::new(" ".to_owned(), None));
                 properties::modify_style_for_replaced_content(&mut whitespace_style);
                 properties::modify_style_for_text(&mut whitespace_style);
                 let fragment = Fragment::from_opaque_node_and_style(whitespace_node,
@@ -715,7 +715,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
 
         match text_content {
             TextContent::Text(string) => {
-                let info = UnscannedTextFragmentInfo::new(string, selection);
+                let info = box UnscannedTextFragmentInfo::new(string, selection);
                 let specific_fragment_info = SpecificFragmentInfo::UnscannedText(info);
                 fragments.fragments.push_back(Fragment::from_opaque_node_and_style(
                         node.opaque(),
@@ -728,7 +728,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                 for content_item in content_items.into_iter() {
                     let specific_fragment_info = match content_item {
                         ContentItem::String(string) => {
-                            let info = UnscannedTextFragmentInfo::new(string, None);
+                            let info = box UnscannedTextFragmentInfo::new(string, None);
                             SpecificFragmentInfo::UnscannedText(info)
                         }
                         content_item => {
@@ -859,7 +859,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                         whitespace_damage)) => {
                     // Instantiate the whitespace fragment.
                     let fragment_info = SpecificFragmentInfo::UnscannedText(
-                        UnscannedTextFragmentInfo::new(" ".to_owned(), None));
+                        box UnscannedTextFragmentInfo::new(" ".to_owned(), None));
                     properties::modify_style_for_replaced_content(&mut whitespace_style);
                     properties::modify_style_for_text(&mut whitespace_style);
                     let fragment = Fragment::from_opaque_node_and_style(whitespace_node,
@@ -1241,7 +1241,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                         unscanned_marker_fragments.push_back(Fragment::new(
                             node,
                             SpecificFragmentInfo::UnscannedText(
-                                UnscannedTextFragmentInfo::new(text, None))));
+                                box UnscannedTextFragmentInfo::new(text, None))));
                         let marker_fragments = TextRunScanner::new().scan_for_runs(
                             &mut self.layout_context.font_context(),
                             unscanned_marker_fragments);
@@ -1848,7 +1848,7 @@ fn control_chars_to_fragment(node: &InlineFragmentNodeInfo,
                              restyle_damage: RestyleDamage)
                              -> Fragment {
     let info = SpecificFragmentInfo::UnscannedText(
-        UnscannedTextFragmentInfo::new(String::from(text), None));
+        box UnscannedTextFragmentInfo::new(String::from(text), None));
     let mut style = node.style.clone();
     properties::modify_style_for_text(&mut style);
     Fragment::from_opaque_node_and_style(node.address,

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -297,7 +297,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
         let specific_fragment_info = match node.type_id() {
             Some(NodeTypeId::Element(ElementTypeId::HTMLElement(
                         HTMLElementTypeId::HTMLIFrameElement))) => {
-                SpecificFragmentInfo::Iframe(box IframeFragmentInfo::new(node))
+                SpecificFragmentInfo::Iframe(IframeFragmentInfo::new(node))
             }
             Some(NodeTypeId::Element(ElementTypeId::HTMLElement(
                         HTMLElementTypeId::HTMLImageElement))) => {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -167,7 +167,7 @@ pub enum SpecificFragmentInfo {
     TableWrapper,
     Multicol,
     MulticolColumn,
-    UnscannedText(UnscannedTextFragmentInfo),
+    UnscannedText(Box<UnscannedTextFragmentInfo>),
 }
 
 impl SpecificFragmentInfo {
@@ -896,8 +896,8 @@ impl Fragment {
         let mut unscanned_ellipsis_fragments = LinkedList::new();
         unscanned_ellipsis_fragments.push_back(self.transform(
                 self.border_box.size,
-                SpecificFragmentInfo::UnscannedText(UnscannedTextFragmentInfo::new("…".to_owned(),
-                                                                                   None))));
+                SpecificFragmentInfo::UnscannedText(
+                    box UnscannedTextFragmentInfo::new("…".to_owned(), None))));
         let ellipsis_fragments = TextRunScanner::new().scan_for_runs(&mut layout_context.font_context(),
                                                                      unscanned_ellipsis_fragments);
         debug_assert!(ellipsis_fragments.len() == 1);

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -145,7 +145,7 @@ pub enum SpecificFragmentInfo {
     /// content resolution phase (e.g. an ordered list item marker).
     GeneratedContent(Box<GeneratedContentInfo>),
 
-    Iframe(Box<IframeFragmentInfo>),
+    Iframe(IframeFragmentInfo),
     Image(Box<ImageFragmentInfo>),
     Canvas(Box<CanvasFragmentInfo>),
 

--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -434,7 +434,8 @@ fn render_text(layout_context: &LayoutContext,
                string: String)
                -> Option<SpecificFragmentInfo> {
     let mut fragments = LinkedList::new();
-    let info = SpecificFragmentInfo::UnscannedText(UnscannedTextFragmentInfo::new(string, None));
+    let info = SpecificFragmentInfo::UnscannedText(
+        box UnscannedTextFragmentInfo::new(string, None));
     fragments.push_back(Fragment::from_opaque_node_and_style(node,
                                                              pseudo,
                                                              style,

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -100,3 +100,6 @@ mod text;
 mod traversal;
 mod webrender_helpers;
 mod wrapper;
+
+// For unit tests:
+pub use fragment::Fragment;

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -476,8 +476,8 @@ fn split_first_fragment_at_newline_if_necessary(fragments: &mut LinkedList<Fragm
         }
         first_fragment.transform(first_fragment.border_box.size,
                                  SpecificFragmentInfo::UnscannedText(
-                                     UnscannedTextFragmentInfo::new(string_before,
-                                                                    selection_before)))
+                                     box UnscannedTextFragmentInfo::new(string_before,
+                                                                        selection_before)))
     };
 
     fragments.push_front(new_fragment);

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "ipc-channel 0.2.1 (git+https://github.com/servo/ipc-channel)",
  "layers 0.2.4 (git+https://github.com/servo/rust-layers)",
  "layout 0.0.1",
+ "layout_tests 0.0.1",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -1081,6 +1082,13 @@ dependencies = [
  "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "webrender_traits 0.1.0 (git+https://github.com/servo/webrender_traits)",
+]
+
+[[package]]
+name = "layout_tests"
+version = "0.0.1"
+dependencies = [
+ "layout 0.0.1",
 ]
 
 [[package]]

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -24,6 +24,9 @@ image = "0.7"
 [dev-dependencies.gfx_tests]
 path = "../../tests/unit/gfx"
 
+[dev-dependencies.layout_tests]
+path = "../../tests/unit/layout"
+
 [dev-dependencies.net_tests]
 path = "../../tests/unit/net"
 

--- a/tests/unit/layout/Cargo.toml
+++ b/tests/unit/layout/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "layout_tests"
+version = "0.0.1"
+authors = ["The Servo Project Developers"]
+
+[lib]
+name = "layout_tests"
+path = "lib.rs"
+doctest = false
+
+[dependencies.layout]
+path = "../../../components/layout"

--- a/tests/unit/layout/lib.rs
+++ b/tests/unit/layout/lib.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate layout;
+
+#[cfg(all(test, target_pointer_width = "64"))] mod size_of;

--- a/tests/unit/layout/size_of.rs
+++ b/tests/unit/layout/size_of.rs
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use layout::Fragment;
+use std::mem::size_of;
+
+#[test]
+fn test_size_of_fragment() {
+    let expected = 184;
+    let actual = size_of::<Fragment>();
+
+    if actual < expected {
+        panic!("Your changes have decreased the stack size of layout::fragment::Fragment \
+                from {} to {}. Good work! Please update the size in tests/layout/size_of.rs",
+                expected, actual);
+    }
+
+    if actual > expected {
+        panic!("Your changes have increased the stack size of layout::fragment::Fragment \
+                from {} to {}.  Please consider choosing a design which avoids this increase. \
+                If you feel that the increase is necessary, update the size in \
+                tests/layout/size_of.rs.",
+                expected, actual);
+    }
+}

--- a/tests/unit/layout/size_of.rs
+++ b/tests/unit/layout/size_of.rs
@@ -7,7 +7,7 @@ use std::mem::size_of;
 
 #[test]
 fn test_size_of_fragment() {
-    let expected = 184;
+    let expected = 160;
     let actual = size_of::<Fragment>();
 
     if actual < expected {

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -23,14 +23,14 @@ macro_rules! sizeof_checker (
             let old = $known_size;
             if new < old {
                 panic!("Your changes have decreased the stack size of commonly used DOM struct {} from {} to {}. \
-                        Good work! Please update the size in script/tests.rs",
+                        Good work! Please update the size in tests/unit/script/size_of.rs.",
                         stringify!($t), old, new)
             } else if new > old {
                 panic!("Your changes have increased the stack size of commonly used DOM struct {} from {} to {}. \
                         These structs are present in large quantities in the DOM, and increasing the size \
                         may dramatically affect our memory footprint. Please consider choosing a design which \
                         avoids this increase. If you feel that the increase is necessary, \
-                        update to the new size in script/tests.rs.",
+                        update to the new size in tests/unit/script/size_of.rs.",
                         stringify!($t), old, new)
         }
     });


### PR DESCRIPTION
This reduces the size of the SpecificFragmentInfo enum from 48 to 24.

r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10255)

<!-- Reviewable:end -->
