### PR TITLE
#10141 : Document::location set null for documents without a browsing context

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2423,8 +2423,8 @@ impl DocumentMethods for Document {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-document-location
-    fn Location(&self) -> Root<Location> {
-        self.location.or_init(|| Location::new(&self.window))
+    fn GetLocation(&self) -> Option<Root<Location>> {
+        self.browsing_context().map(|_| self.location.or_init(|| Location::new(&self.window)))
     }
 
     // https://dom.spec.whatwg.org/#dom-parentnode-children
@@ -2777,4 +2777,3 @@ pub enum FocusEventType {
     Focus,      // Element gained focus. Doesn't bubble.
     Blur,       // Element lost focus. Doesn't bubble.
 }
-

--- a/components/script/dom/webidls/Document.webidl
+++ b/components/script/dom/webidls/Document.webidl
@@ -81,7 +81,7 @@ enum DocumentReadyState { "loading", "interactive", "complete" };
 partial /*sealed*/ interface Document {
   // resource metadata management
   [/*PutForwards=href, */Unforgeable]
-  readonly attribute Location/*?*/ location;
+  readonly attribute Location? location;
   readonly attribute DOMString domain;
   // readonly attribute DOMString referrer;
   [Throws]

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -441,7 +441,7 @@ impl WindowMethods for Window {
 
     // https://html.spec.whatwg.org/multipage/#dom-location
     fn Location(&self) -> Root<Location> {
-        self.Document().Location()
+        self.Document().GetLocation().unwrap()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-sessionstorage

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -76,8 +76,8 @@ impl XMLDocument {
 
 impl XMLDocumentMethods for XMLDocument {
     // https://html.spec.whatwg.org/multipage/#dom-document-location
-    fn Location(&self) -> Root<Location> {
-        self.document.Location()
+    fn GetLocation(&self) -> Option<Root<Location>> {
+        self.document.GetLocation()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tree-accessors:supported-property-names

--- a/tests/wpt/metadata/XMLHttpRequest/responsexml-document-properties.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/responsexml-document-properties.htm.ini
@@ -9,9 +9,6 @@
   [readyState]
     expected: FAIL
 
-  [location]
-    expected: FAIL
-
   [defaultView]
     expected: FAIL
 

--- a/tests/wpt/metadata/domparsing/DOMParser-parseFromString-html.html.ini
+++ b/tests/wpt/metadata/domparsing/DOMParser-parseFromString-html.html.ini
@@ -1,5 +1,1 @@
-[DOMParser-parseFromString-html.html]
-  type: testharness
-  [Location value]
-    expected: FAIL
 

--- a/tests/wpt/metadata/domparsing/DOMParser-parseFromString-xml.html.ini
+++ b/tests/wpt/metadata/domparsing/DOMParser-parseFromString-xml.html.ini
@@ -1,9 +1,6 @@
 [DOMParser-parseFromString-xml.html]
   type: testharness
   expected: TIMEOUT
-  [Should parse correctly in type text/xml]
-    expected: FAIL
-
   [Should return an error document for XML wellformedness errors in type text/xml]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/browsers/history/the-location-interface/document_location.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-location-interface/document_location.html.ini
@@ -1,5 +1,0 @@
-[document_location.html]
-  type: testharness
-  [document not in a browsing context]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/windowproxy.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/windowproxy.html.ini
@@ -1,5 +1,0 @@
-[windowproxy.html]
-  type: testharness
-  [document.location is the right thing on non-rendered document]
-    expected: FAIL
-


### PR DESCRIPTION
Fixes #10141.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10257)

<!-- Reviewable:end -->
