### PR TITLE
Include square brackets for IPv6 addresses in Document::domain.

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1767,12 +1767,6 @@ impl DocumentMethods for Document {
     fn Domain(&self) -> DOMString {
         // TODO: This should use the effective script origin when it exists
         let origin = self.window.get_url();
-
-        if let Some(&Host::Ipv6(ipv6)) = origin.host() {
-            // Omit square brackets for IPv6 addresses.
-            return DOMString::from(ipv6.to_string());
-        }
-
         DOMString::from(origin.serialize_host().unwrap_or_else(|| "".to_owned()))
     }
 


### PR DESCRIPTION
The specification changed out from under us.

It's unfortunately impossible to write a test for this right now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10287)

<!-- Reviewable:end -->
