### PR TITLE
Comment explaining constellation panic for recv

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -517,6 +517,17 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
             Paint(FromPaintMsg)
         }
 
+        // Get one incoming request.
+        // This is one of the few places where the compositor is
+        // allowed to panic. If one of the receiver.recv() calls
+        // fails, it is because the matching sender has been
+        // reclaimed, but this can't happen in normal execution
+        // because the constellation keeps a pointer to the sender,
+        // so it should never be reclaimed. A possible scenario in
+        // which receiver.recv() fails is if some unsafe code
+        // produces undefined behaviour, resulting in the destructor
+        // being called. If this happens, there's not much we can do
+        // other than panic.
         let request = {
             let receiver_from_script = &self.script_receiver;
             let receiver_from_compositor = &self.compositor_receiver;
@@ -524,16 +535,17 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
             let receiver_from_paint = &self.painter_receiver;
             select! {
                 msg = receiver_from_script.recv() =>
-                    Request::Script(msg.unwrap()),
+                    Request::Script(msg.expect("Unexpected script failure in constellation")),
                 msg = receiver_from_compositor.recv() =>
-                    Request::Compositor(msg.unwrap()),
+                    Request::Compositor(msg.expect("Unexpected compositor failure in constellation")),
                 msg = receiver_from_layout.recv() =>
-                    Request::Layout(msg.unwrap()),
+                    Request::Layout(msg.expect("Unexpected layout failure in constellation")),
                 msg = receiver_from_paint.recv() =>
-                    Request::Paint(msg.unwrap())
+                    Request::Paint(msg.expect("Unexpected paint failure in constellation"))
             }
         };
 
+        // Process the request.
         match request {
             // Messages from compositor
 


### PR DESCRIPTION
Added comment explaining why the constellation still panics in the case of recv failure. Also changed `.unwrap()` to `.expect("reason")` so we can track down panics more easily.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10294)

<!-- Reviewable:end -->
