### PR TITLE
Add git to list of packages to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ brew link --force openssl
 On Debian-based Linuxes:
 
 ``` sh
-sudo apt-get install curl freeglut3-dev autoconf \
+sudo apt-get install git curl freeglut3-dev autoconf \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
     gperf g++ build-essential cmake virtualenv python-pip \
     libssl-dev libbz2-dev libosmesa6-dev libxmu6 libxmu-dev \


### PR DESCRIPTION
I tried to get started on Servo development but realised that a clean build of Ubuntu did not come with git out of the box. I had to manually install this before moving on with the next steps (clone and build).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10301)

<!-- Reviewable:end -->
