### PR TITLE
compositing: Send only one mouse move event if WebRender is in use.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1346,6 +1346,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                          .send(ConstellationControlMsg::SendEvent(root_pipeline_id,
                                                                   event_to_send))
                          .unwrap();
+            return
         }
 
         match self.find_topmost_layer_at_point(cursor / self.scene.scale) {


### PR DESCRIPTION
In WebRender mode, we were sending two mouse move events: one with the
proper coordinates and one with the wrong coordinates, because of
incorrect fall-through. The script task would usually (but not always,
depending on timing) ignore the first event in favor of the second
event, resulting in incorrect mouse move event coordinates in most
cases.

Closes servo/webrender#238.
Closes #10298.

r? @metajack

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10321)

<!-- Reviewable:end -->
