### PR TITLE
Renamed the style structs

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -16,7 +16,7 @@ use std::str;
 use std::sync::Arc;
 use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 use style::computed_values::{font_stretch, font_variant, font_weight};
-use style::properties::style_structs::Font as FontStyle;
+use style::properties::style_structs::ServoFont;
 use text::Shaper;
 use text::glyph::{GlyphId, GlyphStore};
 use text::shaping::ShaperMethods;
@@ -88,7 +88,7 @@ pub struct FontMetrics {
     pub line_gap:         Au,
 }
 
-pub type SpecifiedFontStyle = FontStyle;
+pub type SpecifiedFontStyle = ServoFont;
 
 #[derive(Debug)]
 pub struct Font {
@@ -266,4 +266,3 @@ pub fn get_and_reset_text_shaping_performance_counter() -> usize {
     TEXT_SHAPING_PERFORMANCE_COUNTER.store(0, Ordering::SeqCst);
     value
 }
-

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -50,7 +50,7 @@ use style::computed_values::{background_repeat, background_size};
 use style::computed_values::{border_style, image_rendering, overflow_x, position};
 use style::computed_values::{transform, transform_style, visibility};
 use style::logical_geometry::{LogicalPoint, LogicalRect, LogicalSize, WritingMode};
-use style::properties::style_structs::Border;
+use style::properties::style_structs::ServoBorder;
 use style::properties::{self, ComputedValues, ServoComputedValues};
 use style::values::RGBA;
 use style::values::computed;
@@ -306,7 +306,7 @@ fn handle_overlapping_radii(size: &Size2D<Au>, radii: &BorderRadii<Au>) -> Borde
     }
 }
 
-fn build_border_radius(abs_bounds: &Rect<Au>, border_style: &Border) -> BorderRadii<Au> {
+fn build_border_radius(abs_bounds: &Rect<Au>, border_style: &ServoBorder) -> BorderRadii<Au> {
     // TODO(cgaebel): Support border radii even in the case of multiple border widths.
     // This is an extension of supporting elliptical radii. For now, all percentage
     // radii will be relative to the width.

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -388,7 +388,7 @@ impl ParentOffsetBorderBoxIterator {
 
 impl FragmentBorderBoxIterator for FragmentLocatingFragmentIterator {
     fn process(&mut self, fragment: &Fragment, _: i32, border_box: &Rect<Au>) {
-        let style_structs::Border {
+        let style_structs::ServoBorder {
             border_top_width: top_width,
             border_right_width: right_width,
             border_bottom_width: bottom_width,
@@ -414,7 +414,7 @@ impl FragmentBorderBoxIterator for UnioningFragmentScrollAreaIterator {
         // increase in size. To work around this, we store the original elements padding
         // rectangle as `origin_rect` and the union of all child elements padding and
         // margin rectangles as `union_rect`.
-        let style_structs::Border {
+        let style_structs::ServoBorder {
             border_top_width: top_border,
             border_right_width: right_border,
             border_bottom_width: bottom_border,

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use style::computed_values::{line_height, text_orientation, text_rendering, text_transform};
 use style::computed_values::{white_space};
 use style::logical_geometry::{LogicalSize, WritingMode};
-use style::properties::style_structs::Font as FontStyle;
+use style::properties::style_structs::ServoFont;
 use style::properties::{ComputedValues, ServoComputedValues};
 use unicode_bidi::{is_rtl, process_text};
 use unicode_script::{get_script, Script};
@@ -409,11 +409,11 @@ fn bounding_box_for_run_metrics(metrics: &RunMetrics, writing_mode: WritingMode)
 
 }
 
-/// Returns the metrics of the font represented by the given `FontStyle`, respectively.
+/// Returns the metrics of the font represented by the given `ServoFont`, respectively.
 ///
 /// `#[inline]` because often the caller only needs a few fields from the font metrics.
 #[inline]
-pub fn font_metrics_for_style(font_context: &mut FontContext, font_style: Arc<FontStyle>)
+pub fn font_metrics_for_style(font_context: &mut FontContext, font_style: Arc<ServoFont>)
                               -> FontMetrics {
     let fontgroup = font_context.layout_font_group_for_style(font_style);
     // FIXME(https://github.com/rust-lang/rust/issues/23338)

--- a/ports/geckolib/build.rs
+++ b/ports/geckolib/build.rs
@@ -62,8 +62,7 @@ try:
     style_template.render(PRODUCT='gecko')
 
     geckolib_template = Template(filename=os.environ['GECKOLIB_TEMPLATE'], input_encoding='utf8')
-    output = geckolib_template.render(STYLE_STRUCTS = style_template.module.STYLE_STRUCTS,
-                                      LONGHANDS = style_template.module.LONGHANDS)
+    output = geckolib_template.render(STYLE_STRUCTS = style_template.module.STYLE_STRUCTS)
     print(output.encode('utf8'))
 except:
     sys.stderr.write(exceptions.text_error_template().render().encode('utf8'))


### PR DESCRIPTION
Renamed style structs.

The idea is to rename all style structs from Foo to ServoFoo, as described out in #10185.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10324)

<!-- Reviewable:end -->
