### PR TITLE
Skip printing the backtrace for RecvError/SendError

### DIFF
--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -9,6 +9,7 @@
 #![cfg_attr(feature = "non-geckolib", feature(decode_utf16))]
 #![feature(optin_builtin_traits)]
 #![feature(plugin)]
+#![feature(panic_handler)]
 #![feature(reflect_marker)]
 #![feature(step_by)]
 

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -201,6 +201,9 @@ pub struct Opts {
 
     // Which rendering API to use.
     pub render_api: RenderApi,
+
+    // don't skip any backtraces on panic
+    pub full_backtraces: bool,
 }
 
 fn print_usage(app: &str, opts: &Options) {
@@ -291,6 +294,9 @@ pub struct DebugOptions {
     /// Use multisample antialiasing in WebRender.
     pub use_msaa: bool,
 
+    // don't skip any backtraces on panic
+    pub full_backtraces: bool,
+
 }
 
 
@@ -326,6 +332,7 @@ impl DebugOptions {
                 "disable-vsync" => debug_options.disable_vsync = true,
                 "wr-stats" => debug_options.webrender_stats = true,
                 "msaa" => debug_options.use_msaa = true,
+                "full-backtraces" => debug_options.full_backtraces = true,
                 "" => {},
                 _ => return Err(option)
             };
@@ -373,6 +380,7 @@ pub fn print_debug_usage(app: &str) -> ! {
                  "Disable vsync mode in the compositor to allow profiling at more than monitor refresh rate");
     print_option("wr-stats", "Show WebRender profiler on screen.");
     print_option("msaa", "Use multisample antialiasing in WebRender.");
+    print_option("full-backtraces", "Print full backtraces for all errors");
 
     println!("");
 
@@ -515,6 +523,7 @@ pub fn default_opts() -> Opts {
         use_msaa: false,
         render_api: DEFAULT_RENDER_API,
         profile_dir: None,
+        full_backtraces: false,
     }
 }
 
@@ -795,6 +804,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         webrender_stats: debug_options.webrender_stats,
         use_msaa: debug_options.use_msaa,
         profile_dir: opt_match.opt_str("profile-dir"),
+        full_backtraces: debug_options.full_backtraces,
     };
 
     set_defaults(opts);

--- a/components/util/thread.rs
+++ b/components/util/thread.rs
@@ -11,7 +11,7 @@ use std::sync::mpsc::Sender;
 use std::thread;
 use std::thread::Builder;
 use thread_state;
-#[allow(unused_must_use)]
+
 pub fn spawn_named<F>(name: String, f: F)
     where F: FnOnce() + Send + 'static
 {
@@ -24,11 +24,15 @@ pub fn spawn_named<F>(name: String, f: F)
             let payload = info.payload();
             if let Some(s) = payload.downcast_ref::<String>() {
                 if s.contains("SendError") {
-                    write!(stderr(), "Thread \"{}\" panicked with an unwrap of `SendError` (backtrace skipped)\n",
+                    let err = stderr();
+                    let _ = write!(err.lock(), "Thread \"{}\" panicked with an unwrap of \
+                                                `SendError` (backtrace skipped)\n",
                            thread::current().name().unwrap_or("<unknown thread>"));
                     return;
                 } else if s.contains("RecvError")  {
-                    write!(stderr(), "Thread \"{}\" panicked with an unwrap of `RecvError` (backtrace skipped)\n",
+                    let err = stderr();
+                    let _ = write!(err.lock(), "Thread \"{}\" panicked with an unwrap of \
+                                                `RecvError` (backtrace skipped)\n",
                            thread::current().name().unwrap_or("<unknown thread>"));
                     return;
                 }

--- a/components/util/thread.rs
+++ b/components/util/thread.rs
@@ -5,16 +5,41 @@
 use ipc_channel::ipc::IpcSender;
 use serde::Serialize;
 use std::borrow::ToOwned;
+use std::io::{Write, stderr};
+use std::panic::{PanicInfo, take_handler, set_handler};
 use std::sync::mpsc::Sender;
 use std::thread;
 use std::thread::Builder;
 use thread_state;
-
+#[allow(unused_must_use)]
 pub fn spawn_named<F>(name: String, f: F)
     where F: FnOnce() + Send + 'static
 {
     let builder = thread::Builder::new().name(name);
-    builder.spawn(f).unwrap();
+
+    let f_with_handler = move || {
+        let hook = take_handler();
+
+        let new_handler = move |info: &PanicInfo| {
+            let payload = info.payload();
+            if let Some(s) = payload.downcast_ref::<String>() {
+                if s.contains("SendError") {
+                    write!(stderr(), "Thread \"{}\" panicked with an unwrap of `SendError` (backtrace skipped)\n",
+                           thread::current().name().unwrap_or("<unknown thread>"));
+                    return;
+                } else if s.contains("RecvError")  {
+                    write!(stderr(), "Thread \"{}\" panicked with an unwrap of `RecvError` (backtrace skipped)\n",
+                           thread::current().name().unwrap_or("<unknown thread>"));
+                    return;
+                }
+            }
+            hook(&info);
+        };
+        set_handler(new_handler);
+        f();
+    };
+
+    builder.spawn(f_with_handler).unwrap();
 }
 
 /// An abstraction over `Sender<T>` and `IpcSender<T>`, for use in

--- a/components/util/thread.rs
+++ b/components/util/thread.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use ipc_channel::ipc::IpcSender;
+use opts;
 use serde::Serialize;
 use std::borrow::ToOwned;
 use std::io::{Write, stderr};
@@ -16,6 +17,11 @@ pub fn spawn_named<F>(name: String, f: F)
     where F: FnOnce() + Send + 'static
 {
     let builder = thread::Builder::new().name(name);
+
+    if opts::get().full_backtraces {
+        builder.spawn(f).unwrap();
+        return;
+    }
 
     let f_with_handler = move || {
         let hook = take_handler();


### PR DESCRIPTION
We currently get tons of useless backtraces clogging up the output when we have a panic cascade. This adds a handler that outputs a single line when a thread panics due to a sender or receiver hanging up, since this is almost always due to a panic cascade.

We could add a commandline arg that gets us back the old behavior, though I'm not sure if this is necessary.

r? @asajeffrey

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10329)

<!-- Reviewable:end -->
