### PR TITLE
gfx: Simplify complex clipping regions as we construct them.

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -836,6 +836,18 @@
             "url": "/_mozilla/css/border_radius_elliptical_a.html"
           }
         ],
+        "css/border_radius_in_border_radius_a.html": [
+          {
+            "path": "css/border_radius_in_border_radius_a.html",
+            "references": [
+              [
+                "/_mozilla/css/border_radius_in_border_radius_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/border_radius_in_border_radius_a.html"
+          }
+        ],
         "css/border_radius_overlapping_a.html": [
           {
             "path": "css/border_radius_overlapping_a.html",
@@ -7244,6 +7256,18 @@
             ]
           ],
           "url": "/_mozilla/css/border_radius_elliptical_a.html"
+        }
+      ],
+      "css/border_radius_in_border_radius_a.html": [
+        {
+          "path": "css/border_radius_in_border_radius_a.html",
+          "references": [
+            [
+              "/_mozilla/css/border_radius_in_border_radius_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/border_radius_in_border_radius_a.html"
         }
       ],
       "css/border_radius_overlapping_a.html": [

--- a/tests/wpt/mozilla/tests/css/border_radius_in_border_radius_a.html
+++ b/tests/wpt/mozilla/tests/css/border_radius_in_border_radius_a.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="border_radius_in_border_radius_ref.html">
+<style>
+html, body {
+    margin: 0;
+    padding: 0;
+}
+
+.green {
+    overflow: hidden;
+    border-radius: 50px;
+    background: green;
+    padding: 50px;
+    width: 100px;
+}
+
+.red {
+    background: red;
+    border-radius: 50%;
+    width: 100px;
+    height: 100px
+}
+</style>
+<div class="green"><div class="red"></div></div>
+

--- a/tests/wpt/mozilla/tests/css/border_radius_in_border_radius_ref.html
+++ b/tests/wpt/mozilla/tests/css/border_radius_in_border_radius_ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+html, body {
+    margin: 0;
+    padding: 0;
+}
+
+.green {
+    position: absolute;
+    border-radius: 50px;
+    background: green;
+    padding: 50px;
+    width: 100px;
+    height: 100px;
+}
+
+.red {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+    width: 100px;
+    height: 100px;
+    background: red;
+    border-radius: 50%;
+}
+</style>
+<div class="green"></div><div class="red"></div>
+


### PR DESCRIPTION
This allows WebRender to correctly render complex clipping regions that
can be reduced to single rounded rectangles. WebRender still can't
render rounded rectangles with arbitrary intersections yet, but this
allows it to handle many more cases.

Closes servo/webrender#241.

r? @glennw

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10331)

<!-- Reviewable:end -->
