### PR TITLE
Change OS X 10.11 to El Capitan

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ On OS X (MacPorts):
 sudo port install python27 py27-virtualenv cmake
 ```
 
-On El Capitan, you also have to install openssl:
+On OS X 10.11 (El Capitan), you also have to install openssl:
 
 ``` sh
 brew install openssl

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ On OS X (MacPorts):
 sudo port install python27 py27-virtualenv cmake
 ```
 
-On OS X 10.11, you also have to install openssl:
+On El Capitan, you also have to install openssl:
 
 ``` sh
 brew install openssl


### PR DESCRIPTION
I think "El Capitan" is a lot clearer than 10.11 – I had to look up which version that was. Thoughts?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10332)

<!-- Reviewable:end -->
