### PR TITLE
Make it possible to use preferences to configure webrender and titlebar

### DIFF
--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -732,7 +732,13 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         (contents, url)
     }).collect();
 
-    let use_webrender = opt_match.opt_present("w") && !opt_match.opt_present("z");
+    let do_not_use_native_titlebar =
+        opt_match.opt_present("b") ||
+        !prefs::get_pref("shell.native-titlebar.enabled").as_boolean().unwrap();
+
+    let use_webrender =
+        (prefs::get_pref("gfx.webrender.enabled").as_boolean().unwrap() || opt_match.opt_present("w")) &&
+        !opt_match.opt_present("z");
 
     let render_api = match opt_match.opt_str("G") {
         Some(ref ga) if ga == "gl" => RenderApi::GL,
@@ -789,7 +795,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         disable_share_style_cache: debug_options.disable_share_style_cache,
         convert_mouse_to_touch: debug_options.convert_mouse_to_touch,
         exit_after_load: opt_match.opt_present("x"),
-        no_native_titlebar: opt_match.opt_present("b"),
+        no_native_titlebar: do_not_use_native_titlebar,
         enable_vsync: !debug_options.disable_vsync,
         use_webrender: use_webrender,
         webrender_stats: debug_options.webrender_stats,

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -1,6 +1,7 @@
 {
   "dom.mouseevent.which.enabled": false,
   "dom.mozbrowser.enabled": false,
+  "gfx.webrender.enabled": false,
   "layout.columns.enabled": false,
   "layout.column-width.enabled": false,
   "layout.column-count.enabled": false,
@@ -11,5 +12,6 @@
   "layout.viewport.enabled": false,
   "layout.writing-mode.enabled": false,
   "net.mime.sniff": false,
+  "shell.native-titlebar.enabled": true,
   "shell.homepage": "http://servo.org"
 }


### PR DESCRIPTION
It's getting tiring for browserhtml to run servo with so many options:

`servo -w -b --pref dom.mozbrowser.enabled --pref dom.forcetouch.enabled http://localhost:6060`.

We want to be able to control all of these with preferences (we have a custom pref file).

Only webrender and titlebar are not controllable via a pref. This PR makes it possible.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10336)

<!-- Reviewable:end -->
