### PR TITLE
Appveyor: Cancel unnecessary builds on 'auto' branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,11 @@ cache:
   - .cargo
 
 install:
+    # Check if commit in auto branch exists in master, if exists build will be canceled.
+  - cmd: >-
+      for /f %%i in ('git branch -r origin/master --contain %APPVEYOR_REPO_COMMIT%') do set git_status=%%i
+
+      IF %APPVEYOR_REPO_BRANCH%==auto (IF [%git_status%]==[origin/master] EXIT -1)
   - bash -lc "echo $MSYSTEM; pacman --needed --noconfirm -Sy pacman-mirrors"
   - bash -lc "pacman --noconfirm -Sy"
   - bash -lc "pacman -Sy --needed --noconfirm git mingw-w64-x86_64-toolchain mingw-w64-x86_64-freetype mingw-w64-x86_64-icu mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates mingw-w64-x86_64-expat mingw-w64-x86_64-cmake tar diffutils patch patchutils make python2-setuptools"
@@ -35,8 +40,6 @@ install:
 build_script:
   - cmd: >-
       set MSYSTEM=MINGW64
-
-      PATH C:\msys64\mingw64\bin;C:\msys64\usr\bin\;%PATH%
 
       bash -lc "cd $APPVEYOR_BUILD_FOLDER; ./mach build -d -v && ./mach test-unit"
 


### PR DESCRIPTION
This simple script will cancel build on `auto` branch if same commit already exist in `master`. 
As a part of solution mentioned in https://github.com/servo/servo/issues/9953

Tested:
Commit on master: [Appveyor/1.0.300](https://ci.appveyor.com/project/UK992/servo-hga0y/build/1.0.300)
Same commit on auto: [Appveyor/1.0.302](https://ci.appveyor.com/project/UK992/servo-hga0y/build/1.0.301)
Different commit on auto:  [Appveyor/1.0.302](https://ci.appveyor.com/project/UK992/servo-hga0y/build/1.0.302)

r? @larsbergstrom

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10340)

<!-- Reviewable:end -->
