### PR TITLE
Issue #10357: mach run -b now passes additional params to servo

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -132,6 +132,7 @@ class PostBuildCommands(CommandBase):
                 return 1
             args = args + ['-w', '-b', '--pref', 'dom.mozbrowser.enabled',
                            path.join(browserhtml_path, 'out', 'index.html')]
+            args = args + params
         else:
             args = args + params
 


### PR DESCRIPTION
Previously `./mach run` with the `-b` flag set ignored everything passed after the `--`, so for example when running `./mach run -d -b -- --help`, `--help` was not passed to servo - it is now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10363)

<!-- Reviewable:end -->
