### PR TITLE
geckolib: All bindings aligning properly!

### DIFF
--- a/ports/geckolib/gecko_style_structs.rs
+++ b/ports/geckolib/gecko_style_structs.rs
@@ -4672,9 +4672,8 @@ pub struct nsStyleSVG {
     pub mStrokeLinejoin: u8,
     pub mTextAnchor: u8,
     pub mTextRendering: u8,
-    pub _bitfield_1: nsStyleSVGOpacitySource,
-    pub _bitfield_2: nsStyleSVGOpacitySource,
-    pub _bitfield_3: u8,
+    pub _bitfield_1: u8,
+    pub _bitfield_2: u8,
 }
 #[test]
 fn bindgen_test_layout_nsStyleSVG() {

--- a/ports/geckolib/gecko_style_structs.rs
+++ b/ports/geckolib/gecko_style_structs.rs
@@ -2541,8 +2541,12 @@ fn bindgen_test_layout_nsRect() {
 #[repr(i8)]
 #[derive(Debug, Copy, Clone)]
 pub enum StyleBoxSizing { Content = 0, Padding = 1, Border = 2, }
-pub enum PlaybackDirection { }
-pub enum FillMode { }
+#[repr(i32)]
+#[derive(Debug, Copy, Clone)]
+pub enum PlaybackDirection { _BindgenOpaqueEnum = 0, }
+#[repr(i32)]
+#[derive(Debug, Copy, Clone)]
+pub enum FillMode { _BindgenOpaqueEnum = 0, }
 pub enum WritingMode { }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone)]

--- a/ports/geckolib/tools/regen_style_structs.sh
+++ b/ports/geckolib/tools/regen_style_structs.sh
@@ -65,6 +65,7 @@ fi
   -no-type-renaming                                                 \
   -DMOZILLA_INTERNAL_API                                            \
   -DMOZ_STYLO_BINDINGS=1                                            \
+  -DJS_DEBUG=1                                                      \
   -DDEBUG=1 -DTRACING=1 -DOS_POSIX=1                                \
   -DIMPL_LIBXUL                                                     \
   -match "RefCountType.h"                                           \
@@ -130,7 +131,7 @@ fi
   "$DIST_INCLUDE/nsStyleStruct.h"
 
 if [ $? -ne 0 ]; then
-  echo -e "\e[91warning:\e[0m bindgen exited with nonzero exit status"
+  echo -e "\e[91mwarning:\e[0m bindgen exited with nonzero exit status"
 else
   echo -e "\e[34minfo:\e[0m bindgen exited successfully, running tests"
   TESTS_FILE=$(mktemp)


### PR DESCRIPTION
So the following PR includes bitfield support and correct `#[repr(..)]` for enum declarations (even though I was forced to add a dummy variant in order for `rustc` to be happy).

So... **That makes all of our style structs align correctly**!

The only failing test is `nsDataHashTable`, but you know, that test is ill-formed because of it being an opaque type with type parameters.

BTW, just landed on bindgen https://github.com/emilio/rust-bindgen/commit/7ee7bae7887899642f9c07f9c02ee841e9f06556, so you can add `-raw-line "use gecko_style_structs::*;"` in `regen_bindings.sh` and stop relying on manual hacks.

r? @bholley

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10377)

<!-- Reviewable:end -->
