### PR TITLE
Snap scrolling to major axis of movement

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -260,7 +260,14 @@ impl Window {
     }
 
     /// Helper function to send a scroll event.
-    fn scroll_window(&self, dx: f32, dy: f32, phase: TouchEventType) {
+    fn scroll_window(&self, mut dx: f32, mut dy: f32, phase: TouchEventType) {
+        // Scroll events snap to the major axis of movement, with vertical
+        // preferred over horizontal.
+        if dy.abs() >= dx.abs() {
+            dx = 0.0;
+        } else {
+            dy = 0.0;
+        }
         let mouse_pos = self.mouse_pos.get();
         let event = WindowEvent::Scroll(Point2D::typed(dx as f32, dy as f32),
                                         Point2D::typed(mouse_pos.x as i32, mouse_pos.y as i32),


### PR DESCRIPTION
This is what Safari does, and it leads to much better behavior, in particular wrt overscrolling. It does cause a staircase effect when scrolling diagonally, which again Safari has, too. I don't think that bad, because it should occur very rarely in practice.

Fixes #10341

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10387)

<!-- Reviewable:end -->
