### PR TITLE
Whitespace stripping should not result in a dangling, open border.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1782,20 +1782,20 @@ pub fn strip_ignorable_whitespace_from_start(this: &mut LinkedList<Fragment>) {
                             remaining_fragment.inline_context {
                         if let Some(ref inline_context_of_removed_fragment) =
                                 removed_fragment.inline_context {
-                            for (i, inline_context_node_from_removed_fragment) in
-                                    inline_context_of_removed_fragment.nodes.iter().enumerate() {
-                                if i >= inline_context_of_remaining_fragment.nodes.len() {
-                                    break
-                                }
+                            for (inline_context_node_from_removed_fragment,
+                                 inline_context_node_from_remaining_fragment) in
+                                    inline_context_of_removed_fragment.nodes.iter().rev().zip(
+                                        inline_context_of_remaining_fragment.nodes.iter_mut().rev()
+                                    ) {
                                 if !inline_context_node_from_removed_fragment.flags.contains(
                                         FIRST_FRAGMENT_OF_ELEMENT) {
                                     continue
                                 }
                                 if inline_context_node_from_removed_fragment.address !=
-                                        inline_context_of_remaining_fragment.nodes[i].address {
+                                        inline_context_node_from_remaining_fragment.address {
                                     continue
                                 }
-                                inline_context_of_remaining_fragment.nodes[i].flags.insert(
+                                inline_context_node_from_remaining_fragment.flags.insert(
                                     FIRST_FRAGMENT_OF_ELEMENT);
                             }
                         }

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1874,6 +1874,8 @@ impl fmt::Debug for InlineFragmentNodeInfo {
 
 #[derive(Clone)]
 pub struct InlineFragmentContext {
+    /// The list of nodes that this fragment will be inheriting styles from,
+    /// from the most deeply-nested node out.
     pub nodes: Vec<InlineFragmentNodeInfo>,
 }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5323,6 +5323,18 @@
             "url": "/_mozilla/css/white_space_intrinsic_sizes_a.html"
           }
         ],
+        "css/whitespace_no_affect_border.html": [
+          {
+            "path": "css/whitespace_no_affect_border.html",
+            "references": [
+              [
+                "/_mozilla/css/whitespace_no_affect_border_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/whitespace_no_affect_border.html"
+          }
+        ],
         "css/whitespace_nowrap_a.html": [
           {
             "path": "css/whitespace_nowrap_a.html",
@@ -11779,6 +11791,18 @@
             ]
           ],
           "url": "/_mozilla/css/white_space_intrinsic_sizes_a.html"
+        }
+      ],
+      "css/whitespace_no_affect_border.html": [
+        {
+          "path": "css/whitespace_no_affect_border.html",
+          "references": [
+            [
+              "/_mozilla/css/whitespace_no_affect_border_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/whitespace_no_affect_border.html"
         }
       ],
       "css/whitespace_nowrap_a.html": [

--- a/tests/wpt/mozilla/tests/css/whitespace_no_affect_border.html
+++ b/tests/wpt/mozilla/tests/css/whitespace_no_affect_border.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Whitespace stripping should not affect the border</title>
+<link rel="match" href="whitespace_no_affect_border_ref.html">
+<span style="border: solid 1px #000"> <span>text</span> next</span>

--- a/tests/wpt/mozilla/tests/css/whitespace_no_affect_border_ref.html
+++ b/tests/wpt/mozilla/tests/css/whitespace_no_affect_border_ref.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Whitespace stripping should not affect the border</title>
+<span style="border: solid 1px #000"><span>text</span> next</span>


### PR DESCRIPTION
No open issue (found it while working on #7681).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10419)

<!-- Reviewable:end -->
