### PR TITLE
Added --soft-fail option.

### DIFF
--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -532,6 +532,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
                   "A user stylesheet to be added to every document", "file.css");
     opts.optflag("z", "headless", "Headless mode");
     opts.optflag("f", "hard-fail", "Exit on thread failure instead of displaying about:failure");
+    opts.optflag("F", "soft-fail", "Display about:failure on thread failure instead of exiting");
     opts.optflagopt("", "devtools", "Start remote devtools server on port", "6000");
     opts.optflagopt("", "webdriver", "Start remote WebDriver server on port", "7000");
     opts.optopt("", "resolution", "Set window resolution.", "800x600");
@@ -756,7 +757,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         gc_profile: debug_options.gc_profile,
         load_webfonts_synchronously: debug_options.load_webfonts_synchronously,
         headless: opt_match.opt_present("z"),
-        hard_fail: opt_match.opt_present("f"),
+        hard_fail: opt_match.opt_present("f") && !opt_match.opt_present("F"),
         bubble_inline_sizes_separately: bubble_inline_sizes_separately,
         profile_script_events: debug_options.profile_script_events,
         profile_heartbeats: debug_options.profile_heartbeats,


### PR DESCRIPTION
At the moment, wptrunner always runs the WPT tests with `servo --hard-fail`. To test hardening, we need to switch off `--hard-fail`. This PR introduces a `--soft-fail` option to do that.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10420)

<!-- Reviewable:end -->
