### PR TITLE
Correct x and y input for origin_rect

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -442,7 +442,7 @@ impl FragmentBorderBoxIterator for UnioningFragmentScrollAreaIterator {
                 self.level = Some(level);
                 self.is_child = true;
                 self.overflow_direction = overflow_direction(&fragment.style.writing_mode);
-                self.origin_rect = Rect::new(Point2D::new(top_padding, left_padding),
+                self.origin_rect = Rect::new(Point2D::new(left_padding, top_padding),
                                              Size2D::new(right_padding, bottom_padding));
             },
         };


### PR DESCRIPTION
Fix error in construction of the `origin_rect` for `UnioningFragmentBorderBoxIterator`.

r? @asajeffrey

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10444)

<!-- Reviewable:end -->
