### PR TITLE
Some minor layout cleanups

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1921,8 +1921,7 @@ impl Flow for BlockFlow {
                                               CoordinateSystem::Own);
         self.fragment.adjust_clipping_region_for_children(
             &mut clip,
-            &stacking_relative_border_box,
-            self.base.flags.contains(IS_ABSOLUTELY_POSITIONED));
+            &stacking_relative_border_box);
 
         // Process children.
         for kid in self.base.child_iter() {

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -229,8 +229,7 @@ pub trait FragmentDisplayListBuilding {
     /// Adjusts the clipping region for descendants of this fragment as appropriate.
     fn adjust_clipping_region_for_children(&self,
                                            current_clip: &mut ClippingRegion,
-                                           stacking_relative_border_box: &Rect<Au>,
-                                           is_absolutely_positioned: bool);
+                                           stacking_relative_border_box: &Rect<Au>);
 
     /// Adjusts the clipping rectangle for a fragment to take the `clip` property into account
     /// per CSS 2.1 § 11.1.2.
@@ -1439,8 +1438,7 @@ impl FragmentDisplayListBuilding for Fragment {
 
     fn adjust_clipping_region_for_children(&self,
                                            current_clip: &mut ClippingRegion,
-                                           stacking_relative_border_box: &Rect<Au>,
-                                           is_absolutely_positioned: bool) {
+                                           stacking_relative_border_box: &Rect<Au>) {
         // Don't clip if we're text.
         if self.is_scanned_text_fragment() {
             return

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2344,7 +2344,10 @@ impl Fragment {
                         modified = true;
                         continue
                     }
-                    new_text_string.push_str(&unscanned_text_fragment_info.text[i..]);
+                    // Finished processing leading control chars and whitespace.
+                    if modified {
+                        new_text_string.push_str(&unscanned_text_fragment_info.text[i..]);
+                    }
                     break
                 }
                 if modified {

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1682,8 +1682,7 @@ impl Flow for InlineFlow {
                 fragment.stacking_relative_content_box(&stacking_relative_border_box);
             let mut clip = self.base.clip.clone();
             fragment.adjust_clipping_region_for_children(&mut clip,
-                                                         &stacking_relative_border_box,
-                                                         false);
+                                                         &stacking_relative_border_box);
             let is_positioned = fragment.is_positioned();
             match fragment.specific {
                 SpecificFragmentInfo::InlineBlock(ref mut info) => {


### PR DESCRIPTION
- Prevent unnecessary copying in `strip_leading_whitespace_if_necessary`
- Remove unused argument to `adjust_clipping_region_for_children` (silences a compiler warning)

r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10469)

<!-- Reviewable:end -->
