### PR TITLE
gfx: Clamp the font size we supply to Core Text to 0.01pt.

### DIFF
--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -38,7 +38,7 @@ fn create_scaled_font(template: &Arc<FontTemplateData>, pt_size: Au) -> ScaledFo
 
 #[cfg(target_os = "macos")]
 fn create_scaled_font(template: &Arc<FontTemplateData>, pt_size: Au) -> ScaledFont {
-    let cgfont = template.ctfont().as_ref().unwrap().copy_to_CGFont();
+    let cgfont = template.ctfont(pt_size.to_f64_px()).as_ref().unwrap().copy_to_CGFont();
     ScaledFont::new(BackendType::Skia, &cgfont, pt_size.to_f32_px())
 }
 

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -72,7 +72,7 @@ impl FontHandleMethods for FontHandle {
             Some(s) => s.to_f64_px(),
             None => 0.0
         };
-        match template.ctfont() {
+        match template.ctfont(size) {
             Some(ref ctfont) => {
                 Ok(FontHandle {
                     font_data: template.clone(),

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2423,6 +2423,18 @@
             "url": "/_mozilla/css/inline_element_border_a.html"
           }
         ],
+        "css/inline_font_size_zero_a.html": [
+          {
+            "path": "css/inline_font_size_zero_a.html",
+            "references": [
+              [
+                "/_mozilla/css/inline_font_size_zero_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/inline_font_size_zero_a.html"
+          }
+        ],
         "css/inline_hypothetical_box_a.html": [
           {
             "path": "css/inline_hypothetical_box_a.html",
@@ -8921,6 +8933,18 @@
             ]
           ],
           "url": "/_mozilla/css/inline_element_border_a.html"
+        }
+      ],
+      "css/inline_font_size_zero_a.html": [
+        {
+          "path": "css/inline_font_size_zero_a.html",
+          "references": [
+            [
+              "/_mozilla/css/inline_font_size_zero_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/inline_font_size_zero_a.html"
         }
       ],
       "css/inline_hypothetical_box_a.html": [

--- a/tests/wpt/mozilla/tests/css/inline_font_size_zero_a.html
+++ b/tests/wpt/mozilla/tests/css/inline_font_size_zero_a.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title></title>
+<link rel="match" href="inline_font_size_zero_ref.html">
+<div style="width: 600px; font-size: 0;">
+    <div style="display: inline-block; width: 200px; background: blue; height: 50px;"></div>
+    <div style="display: inline-block; width: 400px; background: green; height: 50px;"></div>
+</div>
+

--- a/tests/wpt/mozilla/tests/css/inline_font_size_zero_ref.html
+++ b/tests/wpt/mozilla/tests/css/inline_font_size_zero_ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title></title>
+<div style="width: 600px;">
+    <div style="display: inline-block; width: 200px; background: blue; height: 50px;"></div><!--
+    --><div style="display: inline-block; width: 400px; background: green; height: 50px;"></div>
+</div>
+
+


### PR DESCRIPTION
Core Text treats a font size of 0.0 as 12.0, which is obviously not what
we want.

Improves Twitter.
Improves Reddit /r/rust.

Closes #10492.

r? @mbrubeck

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10493)

<!-- Reviewable:end -->
