### PR TITLE
Removed etc/ci/check_no_unwrap.sh from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
          - ./mach test-compiletest
          - bash etc/ci/lockfile_changed.sh
          - bash etc/ci/manifest_changed.sh
-         - bash etc/ci/check_no_unwrap.sh
       cache:
         directories:
           - .cargo


### PR DESCRIPTION
Temporarily disable #10448 until all the uses of unwrap are removed from the constellation/compositor.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10495)

<!-- Reviewable:end -->
