### PR TITLE
Fix sandboxing on OS X

### DIFF
--- a/components/compositing/sandboxing.rs
+++ b/components/compositing/sandboxing.rs
@@ -16,7 +16,9 @@ pub fn content_process_sandbox_profile() -> Profile {
         Operation::FileReadAll(PathPattern::Subpath(PathBuf::from("/Library/Fonts"))),
         Operation::FileReadAll(PathPattern::Subpath(PathBuf::from("/System/Library/Fonts"))),
         Operation::FileReadAll(PathPattern::Subpath(PathBuf::from(
-                    "/System/Library/Frameworks/ApplicationServices.framework/"))),
+                    "/System/Library/Frameworks/ApplicationServices.framework"))),
+        Operation::FileReadAll(PathPattern::Subpath(PathBuf::from(
+                    "/System/Library/Frameworks/CoreGraphics.framework"))),
         Operation::FileReadMetadata(PathPattern::Literal(PathBuf::from("/"))),
         Operation::FileReadMetadata(PathPattern::Literal(PathBuf::from("/Library"))),
         Operation::FileReadMetadata(PathPattern::Literal(PathBuf::from("/System"))),

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -275,7 +275,8 @@ pub unsafe extern fn __errno_location() -> *mut i32 {
 
 #[cfg(not(target_os = "windows"))]
 fn create_sandbox() {
-    ChildSandbox::new(sandboxing::content_process_sandbox_profile()).activate().unwrap();
+    ChildSandbox::new(sandboxing::content_process_sandbox_profile()).activate()
+        .expect("Failed to activate sandbox!");
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
The main issue was resources_dir_path. Every time it was called it would start from the executable's path and walk up the hierarchy to find a directory named "resources". The sandbox was granted permission to read from the found resources dir, but after the sandbox had been activated resources_dir_path would again start from the executable's path and try to find the resources dir. It would then fail with "Operation not permitted" when trying to canonicalize the path because it didn't have permissions to read metadata under ./target.

To fix this the resources dir path is now cached between resources_dir_path calls.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10496)

<!-- Reviewable:end -->
