### PR TITLE
Share prefs to content processes

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -468,6 +468,11 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
         let child_process = if opts::get().sandbox {
             let mut command = sandbox::Command::me().expect("Failed to get current sandbox.");
             command.arg("--content-process").arg(token);
+
+            if let Ok(value) = env::var("RUST_BACKTRACE") {
+                command.env("RUST_BACKTRACE", value);
+            }
+
             let profile = sandboxing::content_process_sandbox_profile();
             ChildProcess::Sandboxed(Sandbox::new(profile).start(&mut command)
                                     .expect("Failed to start sandboxed child process!"))
@@ -477,6 +482,11 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
             let mut child_process = process::Command::new(path_to_self);
             child_process.arg("--content-process");
             child_process.arg(token);
+
+            if let Ok(value) = env::var("RUST_BACKTRACE") {
+                child_process.env("RUST_BACKTRACE", value);
+            }
+
             ChildProcess::Unsandboxed(child_process.spawn()
                                       .expect("Failed to start unsandboxed child process!"))
         };

--- a/components/compositing/pipeline.rs
+++ b/components/compositing/pipeline.rs
@@ -26,6 +26,7 @@ use profile_traits::time;
 use script_traits::{ConstellationControlMsg, InitialScriptState, MozBrowserEvent};
 use script_traits::{LayoutControlMsg, LayoutMsg, NewLayoutInfo, ScriptMsg};
 use script_traits::{ScriptToCompositorMsg, ScriptThreadFactory, TimerEventRequest};
+use std::collections::HashMap;
 use std::mem;
 use std::sync::mpsc::{Receiver, Sender, channel};
 use url::Url;
@@ -33,7 +34,7 @@ use util;
 use util::geometry::{PagePx, ViewportPx};
 use util::ipc::OptionalIpcSender;
 use util::opts::{self, Opts};
-use util::prefs;
+use util::prefs::{self, Pref};
 use util::thread;
 use webrender_traits;
 
@@ -232,6 +233,7 @@ impl Pipeline {
             failure: failure,
             script_port: script_port,
             opts: (*opts::get()).clone(),
+            prefs: prefs::get_cloned(),
             layout_to_paint_chan: layout_to_paint_chan,
             pipeline_port: pipeline_port,
             layout_shutdown_chan: layout_shutdown_chan,
@@ -408,6 +410,7 @@ pub struct UnprivilegedPipelineContent {
     script_port: Option<IpcReceiver<ConstellationControlMsg>>,
     layout_to_paint_chan: OptionalIpcSender<LayoutToPaintMsg>,
     opts: Opts,
+    prefs: HashMap<String, Pref>,
     paint_shutdown_chan: IpcSender<()>,
     pipeline_port: Option<IpcReceiver<LayoutControlMsg>>,
     pipeline_namespace_id: PipelineNamespaceId,
@@ -471,6 +474,10 @@ impl UnprivilegedPipelineContent {
 
     pub fn opts(&self) -> Opts {
         self.opts.clone()
+    }
+
+    pub fn prefs(&self) -> HashMap<String, Pref> {
+        self.prefs.clone()
     }
 }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -81,8 +81,8 @@ use profile_traits::mem;
 use profile_traits::time;
 use std::rc::Rc;
 use std::sync::mpsc::Sender;
-use util::opts;
 use util::resource_files::resources_dir_path;
+use util::{opts, prefs};
 
 pub use gleam::gl;
 
@@ -251,6 +251,7 @@ pub fn run_content_process(token: String) {
 
     let unprivileged_content = unprivileged_content_receiver.recv().unwrap();
     opts::set_defaults(unprivileged_content.opts());
+    prefs::extend_prefs(unprivileged_content.prefs());
 
     // Enter the sandbox if necessary.
     if opts::get().sandbox {

--- a/components/util/prefs.rs
+++ b/components/util/prefs.rs
@@ -19,7 +19,7 @@ lazy_static! {
     };
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub enum PrefValue {
     Boolean(bool),
     String(String),
@@ -83,7 +83,7 @@ impl ToJson for PrefValue {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Pref {
     NoDefault(Arc<PrefValue>),
     WithDefault(Arc<PrefValue>, Option<Arc<PrefValue>>)
@@ -155,6 +155,10 @@ pub fn read_prefs_from_file<T>(mut file: T)
         }
     }
     Ok(prefs)
+}
+
+pub fn get_cloned() -> HashMap<String, Pref> {
+    PREFS.lock().unwrap().clone()
 }
 
 pub fn extend_prefs(extension: HashMap<String, Pref>) {


### PR DESCRIPTION
Without this `./mach run -b -- -M` would start fine but navigating to a site would fail with:

`thread 'ScriptThread PipelineId { namespace_id: PipelineNamespaceId(0), index: PipelineIndex(0) }' panicked at 'assertion failed: mozbrowser_enabled()', /Users/ulf/Documents/Code/servo/components/script/dom/htmliframeelement.rs:163`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10497)

<!-- Reviewable:end -->
