### PR TITLE
Add API base url method to global objects

### DIFF
--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -143,6 +143,17 @@ impl<'a> GlobalRef<'a> {
         }
     }
 
+    /// Get the [base url](https://html.spec.whatwg.org/multipage/#api-base-url)
+    /// for this global scope.
+    pub fn api_base_url(&self) -> Url {
+        match *self {
+            // https://html.spec.whatwg.org/multipage/#script-settings-for-browsing-contexts:api-base-url
+            GlobalRef::Window(ref window) => window.Document().base_url(),
+            // https://html.spec.whatwg.org/multipage/#script-settings-for-workers:api-base-url
+            GlobalRef::Worker(ref worker) => worker.get_url().clone(),
+        }
+    }
+
     /// `ScriptChan` used to send messages to the event loop of this global's
     /// thread.
     pub fn script_chan(&self) -> Box<ScriptChan + Send> {

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -352,7 +352,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
                 }
 
                 // Step 2
-                let base = self.global().r().get_url();
+                let base = self.global().r().api_base_url();
                 // Step 6
                 let mut parsed_url = match base.join(&url.0) {
                     Ok(parsed) => parsed,

--- a/tests/wpt/metadata/XMLHttpRequest/open-url-base.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/open-url-base.htm.ini
@@ -1,5 +1,0 @@
-[open-url-base.htm]
-  type: testharness
-  [XMLHttpRequest: open() resolving URLs - ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/send-non-same-origin.sub.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-non-same-origin.sub.htm.ini
@@ -1,5 +1,0 @@
-[send-non-same-origin.sub.htm]
-  type: testharness
-  [XMLHttpRequest: send() - non same-origin (folder.txt)]
-    expected: FAIL
-


### PR DESCRIPTION
This adds an `api_base_url` function to global objects, which fixes `open-url-base.htm` under XMLHttpRequest.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10502)

<!-- Reviewable:end -->
