### PR TITLE
Implement HTMLBaseElement attributes

### DIFF
--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::attr::Attr;
+use dom::attr::{Attr, AttrValue};
 use dom::bindings::codegen::Bindings::HTMLBaseElementBinding;
+use dom::bindings::codegen::Bindings::HTMLBaseElementBinding::HTMLBaseElementMethods;
 use dom::bindings::inheritance::Castable;
 use dom::bindings::js::Root;
 use dom::document::Document;
@@ -58,6 +59,33 @@ impl HTMLBaseElement {
             document.refresh_base_element();
         }
     }
+}
+
+impl HTMLBaseElementMethods for HTMLBaseElement {
+    // https://html.spec.whatwg.org/multipage/#dom-base-href
+    fn Href(&self) -> DOMString {
+        let document = document_from_node(self);
+
+        // Step 1.
+        if !self.upcast::<Element>().has_attribute(&atom!("href")) {
+            return DOMString::from(document.base_url().serialize());
+        }
+
+        // Step 2.
+        let fallback_base_url = document.fallback_base_url();
+
+        // Step 3.
+        let url = self.upcast::<Element>().get_url_attribute(&atom!("href"));
+
+        // Step 4.
+        let url_record = fallback_base_url.join(&*url);
+
+        // Step 5, 6.
+        DOMString::from(url_record.ok().map_or("".to_owned(), |record| record.serialize()))
+    }
+
+    // https://html.spec.whatwg.org/multipage/#dom-base-href
+    make_url_setter!(SetHref, "href");
 }
 
 impl VirtualMethods for HTMLBaseElement {

--- a/components/script/dom/webidls/HTMLBaseElement.webidl
+++ b/components/script/dom/webidls/HTMLBaseElement.webidl
@@ -5,6 +5,6 @@
 
 // https://html.spec.whatwg.org/multipage/#htmlbaseelement
 interface HTMLBaseElement : HTMLElement {
-  //         attribute DOMString href;
-  //         attribute DOMString target;
+           attribute DOMString href;
+//           attribute DOMString target;
 };

--- a/tests/wpt/metadata/XMLHttpRequest/open-url-base-inserted.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/open-url-base-inserted.htm.ini
@@ -1,5 +1,0 @@
-[open-url-base-inserted.htm]
-  type: testharness
-  [XMLHttpRequest: open() resolving URLs - insert ]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -1977,16 +1977,13 @@
   [HTMLHtmlElement interface: document.createElement("html") must inherit property "version" with the proper type (0)]
     expected: FAIL
 
-  [HTMLBaseElement interface: attribute href]
-    expected: FAIL
-
   [HTMLBaseElement interface: attribute target]
     expected: FAIL
 
-  [HTMLBaseElement interface: document.createElement("base") must inherit property "href" with the proper type (0)]
+  [HTMLBaseElement interface: document.createElement("base") must inherit property "target" with the proper type (1)]
     expected: FAIL
 
-  [HTMLBaseElement interface: document.createElement("base") must inherit property "target" with the proper type (1)]
+  [HTMLLinkElement interface: attribute crossOrigin]
     expected: FAIL
 
   [HTMLLinkElement interface: attribute sizes]
@@ -8902,8 +8899,5 @@
     expected: FAIL
 
   [Document interface: new Document() must inherit property "onwaiting" with the proper type (156)]
-    expected: FAIL
-
-  [HTMLLinkElement interface: attribute crossOrigin]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_href_empty.html.ini
+++ b/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_href_empty.html.ini
@@ -1,8 +1,0 @@
-[base_href_empty.html]
-  type: testharness
-  [The value of the href attribute must be the document's address if it is empty]
-    expected: FAIL
-
-  [The src attribute of the img element must relative to document's address]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_href_specified.sub.html.ini
+++ b/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_href_specified.sub.html.ini
@@ -1,5 +1,0 @@
-[base_href_specified.sub.html]
-  type: testharness
-  [The href attribute of the base element is specified]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_href_unspecified.html.ini
+++ b/tests/wpt/metadata/html/semantics/document-metadata/the-base-element/base_href_unspecified.html.ini
@@ -1,8 +1,0 @@
-[base_href_unspecified.html]
-  type: testharness
-  [The value of the href attribute must be the document's address if it is unspecified]
-    expected: FAIL
-
-  [The src attribute of the img element must relative to document's address]
-    expected: FAIL
-


### PR DESCRIPTION
The remaining test failure in `base_multiple.html` looks like there's a problem with the test itself (it does not have a `<base>` tag at all).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10512)

<!-- Reviewable:end -->
