### PR TITLE
Work around a Mako bug on Windows

### DIFF
--- a/components/style/build.rs
+++ b/components/style/build.rs
@@ -50,8 +50,8 @@ import sys
 from mako.template import Template
 from mako import exceptions
 try:
-    print(Template(filename=os.environ['TEMPLATE'], input_encoding='utf8').render(PRODUCT=os.environ['PRODUCT'])
-                                                                          .encode('utf8'))
+    template = Template(open(os.environ['TEMPLATE'], 'rb').read(), input_encoding='utf8')
+    print(template.render(PRODUCT=os.environ['PRODUCT']).encode('utf8'))
 except:
     sys.stderr.write(exceptions.text_error_template().render().encode('utf8'))
     sys.exit(1)


### PR DESCRIPTION
http://logs.glob.uno/?c=mozilla%23servo#c403766
https://i.imgur.com/j5Zv4LX.png
https://bitbucket.org/zzzeek/mako/issues/150/line-ending-handling-broken-on-win32

r? @larsbergstrom

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10527)

<!-- Reviewable:end -->
