### PR TITLE
Invalidate appveyor cache when rust or cargo rev

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ platform:
   - x64
 
 cache:
-  - .servo
-  - .cargo
+  - .servo -> rust-nightly-date, cargo-nightly-build
+  - .cargo -> rust-nightly-date, cargo-nightly-build
 
 install:
     # Check if commit in auto branch exists in master, if exists build will be canceled.


### PR DESCRIPTION
r? @edunham 

AppVeyor builds are currently failing due to exceeding the cache size limits (https://ci.appveyor.com/project/servo/servo/history). This happened after the rustup. This patch should ensure we blow away the cache if the rust or cargo versions change.

See:
http://help.appveyor.com/discussions/questions/1788-multiple-build-cache-dependencies

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10528)

<!-- Reviewable:end -->
