### PR TITLE
Improve PerformanceTiming Interface

### DIFF
--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -76,6 +76,16 @@ impl PerformanceTimingMethods for PerformanceTiming {
     fn DomComplete(&self) -> u64 {
         self.document.get_dom_complete()
     }
+
+    // https://w3c.github.io/navigation-timing/#widl-PerformanceTiming-loadEventStart
+    fn LoadEventStart(&self) -> u64 {
+        self.document.get_load_event_start()
+    }
+
+    // https://w3c.github.io/navigation-timing/#widl-PerformanceTiming-loadEventEnd
+    fn LoadEventEnd(&self) -> u64 {
+        self.document.get_load_event_end()
+    }
 }
 
 

--- a/components/script/dom/webidls/PerformanceTiming.webidl
+++ b/components/script/dom/webidls/PerformanceTiming.webidl
@@ -27,6 +27,6 @@ interface PerformanceTiming {
   readonly attribute unsigned long long domContentLoadedEventStart;
   readonly attribute unsigned long long domContentLoadedEventEnd;
   readonly attribute unsigned long long domComplete;
-  /* readonly attribute unsigned long long loadEventStart;
-  readonly attribute unsigned long long loadEventEnd; */
+  readonly attribute unsigned long long loadEventStart;
+  readonly attribute unsigned long long loadEventEnd;
 };

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1383,6 +1383,7 @@ impl Window {
             pipelineid: id,
             script_chan: Arc::new(Mutex::new(control_chan)),
         };
+        let current_time = time::get_time();
         let win = box Window {
             eventtarget: EventTarget::new_inherited(),
             script_chan: script_chan,
@@ -1402,7 +1403,7 @@ impl Window {
             devtools_chan: devtools_chan,
             browsing_context: Default::default(),
             performance: Default::default(),
-            navigation_start: time::get_time().sec as u64,
+            navigation_start: (current_time.sec * 1000 + current_time.nsec as i64 / 1000000) as u64,
             navigation_start_precise: time::precise_time_ns() as f64,
             screen: Default::default(),
             session_storage: Default::default(),

--- a/tests/wpt/metadata/hr-time/test_cross_frame_start.html.ini
+++ b/tests/wpt/metadata/hr-time/test_cross_frame_start.html.ini
@@ -1,8 +1,0 @@
-[test_cross_frame_start.html]
-  type: testharness
-  [Child created at least 1 second after parent]
-    expected: FAIL
-
-  [Child and parent time bases are correct]
-    expected: FAIL
-


### PR DESCRIPTION
Solving https://github.com/servo/servo/issues/10428
- Fix timing precision in old `update_with_current_time`
- Correct time unit in `navigation_start`
- Add `LoadEventStart` and `LoadEventEnd` timing properties

There are still many properties left unimplemented. I tend to leave the for future PRs.

Welcome comments!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10538)

<!-- Reviewable:end -->
