### PR TITLE
Do not support XHR.responseXML in worker globals. Fixes #8931.

### DIFF
--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -828,6 +828,12 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
 
     // https://xhr.spec.whatwg.org/#the-responsexml-attribute
     fn GetResponseXML(&self) -> Fallible<Option<Root<Document>>> {
+        // TODO(#2823): Until [Exposed] is implemented, this attribute needs to return null
+        //              explicitly in the worker scope.
+        if let GlobalRoot::Worker(_) = self.global() {
+            return Ok(None);
+        }
+
         match self.response_type.get() {
             XMLHttpRequestResponseType::_empty | XMLHttpRequestResponseType::Document => {
                 // Step 3

--- a/tests/wpt/metadata/workers/semantics/xhr/001.html.ini
+++ b/tests/wpt/metadata/workers/semantics/xhr/001.html.ini
@@ -1,3 +1,0 @@
-[001.html]
-  type: testharness
-  expected: CRASH

--- a/tests/wpt/metadata/workers/semantics/xhr/002.html.ini
+++ b/tests/wpt/metadata/workers/semantics/xhr/002.html.ini
@@ -1,6 +1,0 @@
-[002.html]
-  type: testharness
-  expected: TIMEOUT
-  [sync XMLHttpRequest in dedicated worker]
-    expected: TIMEOUT
-


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10573)

<!-- Reviewable:end -->
