### PR TITLE
Improve properties.mako.rs file structure

### DIFF
--- a/components/style/generate_properties_rs.py
+++ b/components/style/generate_properties_rs.py
@@ -6,11 +6,14 @@ import os
 import sys
 
 from mako import exceptions
+from mako.lookup import TemplateLookup
 from mako.template import Template
 
 try:
+    lookup = TemplateLookup(directories=['.'])
     template = Template(open(os.environ['TEMPLATE'], 'rb').read(),
-                        input_encoding='utf8')
+                        input_encoding='utf8',
+                        lookup=lookup)
     print(template.render(PRODUCT=os.environ['PRODUCT']).encode('utf8'))
 except:
     sys.stderr.write(exceptions.text_error_template().render().encode('utf8'))

--- a/components/style/list_properties.py
+++ b/components/style/list_properties.py
@@ -10,9 +10,14 @@ import json
 
 style = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(style, "Mako-0.9.1.zip"))
+
+from mako.lookup import TemplateLookup
 from mako.template import Template
 
-template = Template(filename=os.path.join(style, "properties.mako.rs"), input_encoding='utf8')
+lookup = TemplateLookup(directories=[style])
+template = Template(filename=os.path.join(style, "properties.mako.rs"),
+                    input_encoding='utf8',
+                    lookup=lookup)
 template.render(PRODUCT='servo')
 properties = dict(
     (p.name, {

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -159,16 +159,39 @@ return ""
 <%
 def active_style_structs():
     return filter(lambda s: s.additional_methods or s.longhands, STYLE_STRUCTS)
-
-def switch_to_style_struct(name):
-    global THIS_STYLE_STRUCT
-
-    for style_struct in STYLE_STRUCTS:
-        if style_struct.trait_name == name:
-            THIS_STYLE_STRUCT = style_struct
-            return ""
-    raise Exception("Failed to find the struct named " + name)
 %>
+
+<%def name="switch_to_style_struct(name)">
+<%
+global THIS_STYLE_STRUCT
+
+for style_struct in STYLE_STRUCTS:
+    if style_struct.trait_name == name:
+        THIS_STYLE_STRUCT = style_struct
+        return ""
+raise Exception(len(STYLE_STRUCTS))
+raise Exception("Failed to find the struct named " + name)
+%>
+</%def>
+
+<%def name="new_method(name, return_type)">
+<%
+
+return Method(name, return_type)
+
+%>
+</%def>
+
+// Regretfully duplicated, since we need it both for binding from the class definitions above as
+// well as from %include:d files.
+<%def name="to_rust_ident(name)">
+<%
+name = name.replace("-", "_")
+if name in ["static", "super", "box", "move"]:  # Rust keywords
+    name += "_"
+return name
+%>
+</%def>
 
 // Work around Mako's really annoying namespacing setup.
 //
@@ -379,310 +402,15 @@ pub mod longhands {
 
     // CSS 2.1, Section 8 - Box model
 
-    ${new_style_struct("Margin", is_inherited=False, gecko_name="nsStyleMargin")}
-
-    % for side in ["top", "right", "bottom", "left"]:
-        ${predefined_type("margin-" + side, "LengthOrPercentageOrAuto",
-                          "computed::LengthOrPercentageOrAuto::Length(Au(0))")}
-    % endfor
-
-    ${new_style_struct("Padding", is_inherited=False, gecko_name="nsStylePadding")}
-
-    % for side in ["top", "right", "bottom", "left"]:
-        ${predefined_type("padding-" + side, "LengthOrPercentage",
-                          "computed::LengthOrPercentage::Length(Au(0))",
-                          "parse_non_negative")}
-    % endfor
-
-    ${new_style_struct("Border", is_inherited=False, gecko_name="nsStyleBorder",
-                       additional_methods=[Method("border_" + side + "_is_none_or_hidden_and_has_nonzero_width",
-                                                  "bool") for side in ["top", "right", "bottom", "left"]])}
-
-    % for side in ["top", "right", "bottom", "left"]:
-        ${predefined_type("border-%s-color" % side, "CSSColor", "::cssparser::Color::CurrentColor")}
-    % endfor
-
-    % for side in ["top", "right", "bottom", "left"]:
-        ${predefined_type("border-%s-style" % side, "BorderStyle", "specified::BorderStyle::none")}
-    % endfor
-
-    % for side in ["top", "right", "bottom", "left"]:
-        <%self:longhand name="border-${side}-width">
-            use app_units::Au;
-            use cssparser::ToCss;
-            use std::fmt;
-
-            impl ToCss for SpecifiedValue {
-                fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-                    self.0.to_css(dest)
-                }
-            }
-
-            #[inline]
-            pub fn parse(_context: &ParserContext, input: &mut Parser)
-                                   -> Result<SpecifiedValue, ()> {
-                specified::parse_border_width(input).map(SpecifiedValue)
-            }
-            #[derive(Debug, Clone, PartialEq, HeapSizeOf)]
-            pub struct SpecifiedValue(pub specified::Length);
-            pub mod computed_value {
-                use app_units::Au;
-                pub type T = Au;
-            }
-            #[inline] pub fn get_initial_value() -> computed_value::T {
-                Au::from_px(3)  // medium
-            }
-
-            impl ToComputedValue for SpecifiedValue {
-                type ComputedValue = computed_value::T;
-
-                #[inline]
-                fn to_computed_value<Cx: TContext>(&self, context: &Cx) -> computed_value::T {
-                    self.0.to_computed_value(context)
-                }
-            }
-        </%self:longhand>
-    % endfor
-
-    // FIXME(#4126): when gfx supports painting it, make this Size2D<LengthOrPercentage>
-    % for corner in ["top-left", "top-right", "bottom-right", "bottom-left"]:
-        ${predefined_type("border-" + corner + "-radius", "BorderRadiusSize",
-                          "computed::BorderRadiusSize::zero()",
-                          "parse")}
-    % endfor
-
-    ${new_style_struct("Outline", is_inherited=False, gecko_name="nsStyleOutline",
-                       additional_methods=[Method("outline_is_none_or_hidden_and_has_nonzero_width", "bool")])}
-
-    // TODO(pcwalton): `invert`
-    ${predefined_type("outline-color", "CSSColor", "::cssparser::Color::CurrentColor")}
-
-    <%self:longhand name="outline-style">
-        pub use values::specified::BorderStyle as SpecifiedValue;
-        pub fn get_initial_value() -> SpecifiedValue { SpecifiedValue::none }
-        pub mod computed_value {
-            pub use values::specified::BorderStyle as T;
-        }
-        pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-            match SpecifiedValue::parse(input) {
-                Ok(SpecifiedValue::hidden) => Err(()),
-                result => result
-            }
-        }
-    </%self:longhand>
-
-    <%self:longhand name="outline-width">
-        use app_units::Au;
-        use cssparser::ToCss;
-        use std::fmt;
-        use values::AuExtensionMethods;
-
-        impl ToCss for SpecifiedValue {
-            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-                self.0.to_css(dest)
-            }
-        }
-
-        pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-            specified::parse_border_width(input).map(SpecifiedValue)
-        }
-        #[derive(Debug, Clone, PartialEq, HeapSizeOf)]
-        pub struct SpecifiedValue(pub specified::Length);
-        pub mod computed_value {
-            use app_units::Au;
-            pub type T = Au;
-        }
-        pub use super::border_top_width::get_initial_value;
-        impl ToComputedValue for SpecifiedValue {
-            type ComputedValue = computed_value::T;
-
-            #[inline]
-            fn to_computed_value<Cx: TContext>(&self, context: &Cx) -> computed_value::T {
-                self.0.to_computed_value(context)
-            }
-        }
-    </%self:longhand>
-
-    ${predefined_type("outline-offset", "Length", "Au(0)")}
-
-    ${new_style_struct("Position", is_inherited=False, gecko_name="nsStylePosition")}
-
-    % for side in ["top", "right", "bottom", "left"]:
-        ${predefined_type(side, "LengthOrPercentageOrAuto",
-                          "computed::LengthOrPercentageOrAuto::Auto")}
-    % endfor
+    <%include file="properties/margin_longhand.mako.rs" args="helpers=self" />
+    <%include file="properties/padding_longhand.mako.rs" args="helpers=self" />
+    <%include file="properties/border_longhand.mako.rs" args="helpers=self" />
+    <%include file="properties/outline_longhand.mako.rs" args="helpers=self" />
+    <%include file="properties/position_longhand.mako.rs" args="helpers=self" />
 
     // CSS 2.1, Section 9 - Visual formatting model
 
-    ${new_style_struct("Box", is_inherited=False, gecko_name="nsStyleDisplay",
-                       additional_methods=[Method("clone_display",
-                                                  "longhands::display::computed_value::T"),
-                                           Method("clone_position",
-                                                  "longhands::position::computed_value::T"),
-                                           Method("is_floated", "bool"),
-                                           Method("overflow_x_is_visible", "bool"),
-                                           Method("overflow_y_is_visible", "bool"),
-                                           Method("transition_count", "usize")])}
-
-    // TODO(SimonSapin): don't parse `inline-table`, since we don't support it
-    <%self:longhand name="display" custom_cascade="${CONFIG['product'] == 'servo'}">
-        <%
-            values = """inline block inline-block
-                table inline-table table-row-group table-header-group table-footer-group
-                table-row table-column-group table-column table-cell table-caption
-                list-item flex
-                none
-            """.split()
-            experimental_values = set("flex".split())
-        %>
-        pub use self::computed_value::T as SpecifiedValue;
-        use values::computed::{Context, ComputedValueAsSpecified};
-
-        pub mod computed_value {
-            #[allow(non_camel_case_types)]
-            #[derive(Clone, Eq, PartialEq, Copy, Hash, RustcEncodable, Debug, HeapSizeOf)]
-            #[derive(Deserialize, Serialize)]
-            pub enum T {
-                % for value in values:
-                    ${to_rust_ident(value)},
-                % endfor
-            }
-
-            impl ::cssparser::ToCss for T {
-                fn to_css<W>(&self, dest: &mut W) -> ::std::fmt::Result
-                where W: ::std::fmt::Write {
-                    match *self {
-                        % for value in values:
-                            T::${to_rust_ident(value)} => dest.write_str("${value}"),
-                        % endfor
-                    }
-                }
-            }
-        }
-        #[inline] pub fn get_initial_value() -> computed_value::T {
-            computed_value::T::${to_rust_ident(values[0])}
-        }
-        pub fn parse(_context: &ParserContext, input: &mut Parser)
-                     -> Result<SpecifiedValue, ()> {
-            match_ignore_ascii_case! { try!(input.expect_ident()),
-                % for value in values:
-                    "${value}" => {
-                        % if value in experimental_values:
-                            if !::util::prefs::get_pref("layout.${value}.enabled")
-                                .as_boolean().unwrap_or(false) {
-                                return Err(())
-                            }
-                        % endif
-                        Ok(computed_value::T::${to_rust_ident(value)})
-                    },
-                % endfor
-                _ => Err(())
-            }
-        }
-
-        impl ComputedValueAsSpecified for SpecifiedValue {}
-
-        % if CONFIG["product"] == "servo":
-            fn cascade_property_custom<C: ComputedValues>(
-                                       _declaration: &PropertyDeclaration,
-                                       _inherited_style: &C,
-                                       context: &mut computed::Context<C>,
-                                       _seen: &mut PropertyBitField,
-                                       _cacheable: &mut bool,
-                                       _error_reporter: &mut StdBox<ParseErrorReporter + Send>) {
-                longhands::_servo_display_for_hypothetical_box::derive_from_display(context);
-                longhands::_servo_text_decorations_in_effect::derive_from_display(context);
-            }
-        % endif
-
-    </%self:longhand>
-
-    ${single_keyword("position", "static absolute relative fixed", extra_gecko_values="sticky")}
-
-    <%self:single_keyword_computed name="float" values="none left right" gecko_ffi_name="mFloats">
-        impl ToComputedValue for SpecifiedValue {
-            type ComputedValue = computed_value::T;
-
-            #[inline]
-            fn to_computed_value<Cx: TContext>(&self, context: &Cx) -> computed_value::T {
-                let positioned = matches!(context.style().get_box().clone_position(),
-                    longhands::position::SpecifiedValue::absolute |
-                    longhands::position::SpecifiedValue::fixed);
-                if positioned {
-                    SpecifiedValue::none
-                } else {
-                    *self
-                }
-            }
-        }
-
-    </%self:single_keyword_computed>
-
-    ${single_keyword("clear", "none left right both", gecko_ffi_name="mBreakType")}
-
-    <%self:longhand name="-servo-display-for-hypothetical-box" derived_from="display" products="servo">
-        pub use super::display::{SpecifiedValue, get_initial_value};
-        pub use super::display::{parse};
-
-        pub mod computed_value {
-            pub type T = super::SpecifiedValue;
-        }
-
-        #[inline]
-        pub fn derive_from_display<Cx: TContext>(context: &mut Cx) {
-            let d = context.style().get_box().clone_display();
-            context.mutate_style().mutate_box().set__servo_display_for_hypothetical_box(d);
-        }
-
-    </%self:longhand>
-
-    ${switch_to_style_struct("Position")}
-
-    <%self:longhand name="z-index">
-        use values::computed::ComputedValueAsSpecified;
-
-        impl ComputedValueAsSpecified for SpecifiedValue {}
-        pub type SpecifiedValue = computed_value::T;
-        pub mod computed_value {
-            use cssparser::ToCss;
-            use std::fmt;
-
-            #[derive(PartialEq, Clone, Eq, Copy, Debug, HeapSizeOf)]
-            pub enum T {
-                Auto,
-                Number(i32),
-            }
-
-            impl ToCss for T {
-                fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-                    match *self {
-                        T::Auto => dest.write_str("auto"),
-                        T::Number(number) => write!(dest, "{}", number),
-                    }
-                }
-            }
-
-            impl T {
-                pub fn number_or_zero(self) -> i32 {
-                    match self {
-                        T::Auto => 0,
-                        T::Number(value) => value,
-                    }
-                }
-            }
-        }
-        #[inline]
-        pub fn get_initial_value() -> computed_value::T {
-            computed_value::T::Auto
-        }
-        fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-            if input.try(|input| input.expect_ident_matching("auto")).is_ok() {
-                Ok(computed_value::T::Auto)
-            } else {
-                specified::parse_integer(input).map(computed_value::T::Number)
-            }
-        }
-    </%self:longhand>
+    <%include file="properties/box_longhand.mako.rs" args="helpers=self" />
 
     ${new_style_struct("InheritedBox", is_inherited=True, gecko_name="nsStyleVisibility",
                        additional_methods=[Method("clone_direction",
@@ -704,22 +432,6 @@ pub mod longhands {
 
     ${predefined_type("height", "LengthOrPercentageOrAuto",
                       "computed::LengthOrPercentageOrAuto::Auto",
-                      "parse_non_negative")}
-
-    ${switch_to_style_struct("Position")}
-
-    ${predefined_type("min-width", "LengthOrPercentage",
-                      "computed::LengthOrPercentage::Length(Au(0))",
-                      "parse_non_negative")}
-    ${predefined_type("max-width", "LengthOrPercentageOrNone",
-                      "computed::LengthOrPercentageOrNone::None",
-                      "parse_non_negative")}
-
-    ${predefined_type("min-height", "LengthOrPercentage",
-                      "computed::LengthOrPercentage::Length(Au(0))",
-                      "parse_non_negative")}
-    ${predefined_type("max-height", "LengthOrPercentageOrNone",
-                      "computed::LengthOrPercentageOrNone::None",
                       "parse_non_negative")}
 
     ${new_style_struct("InheritedText", is_inherited=True, gecko_name="nsStyleText",
@@ -2590,11 +2302,7 @@ pub mod longhands {
         }
     </%self:longhand>
 
-    // CSS Fragmentation Module Level 3
-    // https://www.w3.org/TR/css-break-3/
-    ${switch_to_style_struct("Border")}
-
-    ${single_keyword("box-decoration-break", "slice clone", products="gecko")}
+    <%include file="properties/border_shorthand.mako.rs" args="helpers=self" />
 
     // CSS Writing Modes Level 3
     // http://dev.w3.org/csswg/css-writing-modes/
@@ -2615,10 +2323,6 @@ pub mod longhands {
     ${switch_to_style_struct("Box")}
 
     ${single_keyword("resize", "none both horizontal vertical", products="gecko")}
-
-    ${switch_to_style_struct("Position")}
-
-    ${single_keyword("box-sizing", "content-box border-box")}
 
     ${new_style_struct("Pointing", is_inherited=True, gecko_name="nsStyleUserInterface")}
 
@@ -5411,49 +5115,7 @@ pub mod shorthands {
         })
     </%self:shorthand>
 
-    <%self:shorthand name="outline" sub_properties="outline-color outline-style outline-width">
-        use properties::longhands::outline_width;
-        use values::specified;
-
-        let _unused = context;
-        let mut color = None;
-        let mut style = None;
-        let mut width = None;
-        let mut any = false;
-        loop {
-            if color.is_none() {
-                if let Ok(value) = input.try(specified::CSSColor::parse) {
-                    color = Some(value);
-                    any = true;
-                    continue
-                }
-            }
-            if style.is_none() {
-                if let Ok(value) = input.try(specified::BorderStyle::parse) {
-                    style = Some(value);
-                    any = true;
-                    continue
-                }
-            }
-            if width.is_none() {
-                if let Ok(value) = input.try(|input| outline_width::parse(context, input)) {
-                    width = Some(value);
-                    any = true;
-                    continue
-                }
-            }
-            break
-        }
-        if any {
-            Ok(Longhands {
-                outline_color: color,
-                outline_style: style,
-                outline_width: width,
-            })
-        } else {
-            Err(())
-        }
-    </%self:shorthand>
+    <%include file="properties/outline_shorthand.mako.rs" args="helpers=self" />
 
     <%self:shorthand name="font" sub_properties="font-style font-variant font-weight
                                                  font-size line-height font-family">

--- a/components/style/properties.mako.rs
+++ b/components/style/properties.mako.rs
@@ -402,15 +402,15 @@ pub mod longhands {
 
     // CSS 2.1, Section 8 - Box model
 
-    <%include file="properties/margin_longhand.mako.rs" args="helpers=self" />
-    <%include file="properties/padding_longhand.mako.rs" args="helpers=self" />
-    <%include file="properties/border_longhand.mako.rs" args="helpers=self" />
-    <%include file="properties/outline_longhand.mako.rs" args="helpers=self" />
-    <%include file="properties/position_longhand.mako.rs" args="helpers=self" />
+    <%include file="/properties/margin_longhand.mako.rs" args="helpers=self" />
+    <%include file="/properties/padding_longhand.mako.rs" args="helpers=self" />
+    <%include file="/properties/border_longhand.mako.rs" args="helpers=self" />
+    <%include file="/properties/outline_longhand.mako.rs" args="helpers=self" />
+    <%include file="/properties/position_longhand.mako.rs" args="helpers=self" />
 
     // CSS 2.1, Section 9 - Visual formatting model
 
-    <%include file="properties/box_longhand.mako.rs" args="helpers=self" />
+    <%include file="/properties/box_longhand.mako.rs" args="helpers=self" />
 
     ${new_style_struct("InheritedBox", is_inherited=True, gecko_name="nsStyleVisibility",
                        additional_methods=[Method("clone_direction",
@@ -2302,7 +2302,7 @@ pub mod longhands {
         }
     </%self:longhand>
 
-    <%include file="properties/border_shorthand.mako.rs" args="helpers=self" />
+    <%include file="/properties/border_shorthand.mako.rs" args="helpers=self" />
 
     // CSS Writing Modes Level 3
     // http://dev.w3.org/csswg/css-writing-modes/
@@ -5115,7 +5115,7 @@ pub mod shorthands {
         })
     </%self:shorthand>
 
-    <%include file="properties/outline_shorthand.mako.rs" args="helpers=self" />
+    <%include file="/properties/outline_shorthand.mako.rs" args="helpers=self" />
 
     <%self:shorthand name="font" sub_properties="font-style font-variant font-weight
                                                  font-size line-height font-family">

--- a/components/style/properties/border_longhand.mako.rs
+++ b/components/style/properties/border_longhand.mako.rs
@@ -1,8 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 <%page args="helpers" />
 
 ${helpers.new_style_struct("Border", is_inherited=False, gecko_name="nsStyleBorder",
-                           additional_methods=[helpers.new_method("border_" + side + "_is_none_or_hidden_and_has_nonzero_width",
-                                                                  "bool") for side in ["top", "right", "bottom", "left"]])}
+                           additional_methods=[helpers.new_method("border_" + side +
+                                                                  "_is_none_or_hidden_and_has_nonzero_width",
+                                                                  "bool") for side in ["top", "right",
+                                                                                       "bottom", "left"]])}
 
 % for side in ["top", "right", "bottom", "left"]:
     ${helpers.predefined_type("border-%s-color" % side, "CSSColor", "::cssparser::Color::CurrentColor")}

--- a/components/style/properties/border_longhand.mako.rs
+++ b/components/style/properties/border_longhand.mako.rs
@@ -1,0 +1,58 @@
+<%page args="helpers" />
+
+${helpers.new_style_struct("Border", is_inherited=False, gecko_name="nsStyleBorder",
+                           additional_methods=[helpers.new_method("border_" + side + "_is_none_or_hidden_and_has_nonzero_width",
+                                                                  "bool") for side in ["top", "right", "bottom", "left"]])}
+
+% for side in ["top", "right", "bottom", "left"]:
+    ${helpers.predefined_type("border-%s-color" % side, "CSSColor", "::cssparser::Color::CurrentColor")}
+% endfor
+
+% for side in ["top", "right", "bottom", "left"]:
+    ${helpers.predefined_type("border-%s-style" % side, "BorderStyle", "specified::BorderStyle::none")}
+% endfor
+
+% for side in ["top", "right", "bottom", "left"]:
+    <%helpers:longhand name="border-${side}-width">
+        use app_units::Au;
+        use cssparser::ToCss;
+        use std::fmt;
+
+        impl ToCss for SpecifiedValue {
+            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+                self.0.to_css(dest)
+            }
+        }
+
+        #[inline]
+        pub fn parse(_context: &ParserContext, input: &mut Parser)
+                               -> Result<SpecifiedValue, ()> {
+            specified::parse_border_width(input).map(SpecifiedValue)
+        }
+        #[derive(Debug, Clone, PartialEq, HeapSizeOf)]
+        pub struct SpecifiedValue(pub specified::Length);
+        pub mod computed_value {
+            use app_units::Au;
+            pub type T = Au;
+        }
+        #[inline] pub fn get_initial_value() -> computed_value::T {
+            Au::from_px(3)  // medium
+        }
+
+        impl ToComputedValue for SpecifiedValue {
+            type ComputedValue = computed_value::T;
+
+            #[inline]
+            fn to_computed_value<Cx: TContext>(&self, context: &Cx) -> computed_value::T {
+                self.0.to_computed_value(context)
+            }
+        }
+    </%helpers:longhand>
+% endfor
+
+// FIXME(#4126): when gfx supports painting it, make this Size2D<LengthOrPercentage>
+% for corner in ["top-left", "top-right", "bottom-right", "bottom-left"]:
+    ${helpers.predefined_type("border-" + corner + "-radius", "BorderRadiusSize",
+                              "computed::BorderRadiusSize::zero()",
+                              "parse")}
+% endfor

--- a/components/style/properties/border_shorthand.mako.rs
+++ b/components/style/properties/border_shorthand.mako.rs
@@ -1,0 +1,7 @@
+<%page args="helpers" />
+
+// CSS Fragmentation Module Level 3
+// https://www.w3.org/TR/css-break-3/
+${helpers.switch_to_style_struct("Border")}
+
+${helpers.single_keyword("box-decoration-break", "slice clone", products="gecko")}

--- a/components/style/properties/border_shorthand.mako.rs
+++ b/components/style/properties/border_shorthand.mako.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 <%page args="helpers" />
 
 // CSS Fragmentation Module Level 3

--- a/components/style/properties/box_longhand.mako.rs
+++ b/components/style/properties/box_longhand.mako.rs
@@ -1,0 +1,124 @@
+<%page args="helpers" />
+
+${helpers.new_style_struct("Box", is_inherited=False, gecko_name="nsStyleDisplay",
+                           additional_methods=[
+                                helpers.new_method("clone_display",
+                                                   "longhands::display::computed_value::T"),
+                                helpers.new_method("clone_position",
+                                                   "longhands::position::computed_value::T"),
+                                helpers.new_method("is_floated", "bool"),
+                                helpers.new_method("overflow_x_is_visible", "bool"),
+                                helpers.new_method("overflow_y_is_visible", "bool"),
+                                helpers.new_method("transition_count", "usize")])}
+
+// TODO(SimonSapin): don't parse `inline-table`, since we don't support it
+<%helpers:longhand name="display" custom_cascade="${PRODUCT == 'servo'}">
+    <%
+        values = """inline block inline-block
+            table inline-table table-row-group table-header-group table-footer-group
+            table-row table-column-group table-column table-cell table-caption
+            list-item flex
+            none
+        """.split()
+        experimental_values = set("flex".split())
+    %>
+    pub use self::computed_value::T as SpecifiedValue;
+    use values::computed::{Context, ComputedValueAsSpecified};
+
+    pub mod computed_value {
+        #[allow(non_camel_case_types)]
+        #[derive(Clone, Eq, PartialEq, Copy, Hash, RustcEncodable, Debug, HeapSizeOf)]
+        #[derive(Deserialize, Serialize)]
+        pub enum T {
+            % for value in values:
+                ${helpers.to_rust_ident(value)},
+            % endfor
+        }
+
+        impl ::cssparser::ToCss for T {
+            fn to_css<W>(&self, dest: &mut W) -> ::std::fmt::Result
+            where W: ::std::fmt::Write {
+                match *self {
+                    % for value in values:
+                        T::${helpers.to_rust_ident(value)} => dest.write_str("${value}"),
+                    % endfor
+                }
+            }
+        }
+    }
+    #[inline] pub fn get_initial_value() -> computed_value::T {
+        computed_value::T::${helpers.to_rust_ident(values[0])}
+    }
+    pub fn parse(_context: &ParserContext, input: &mut Parser)
+                 -> Result<SpecifiedValue, ()> {
+        match_ignore_ascii_case! { try!(input.expect_ident()),
+            % for value in values:
+                "${value}" => {
+                    % if value in experimental_values:
+                        if !::util::prefs::get_pref("layout.${value}.enabled")
+                            .as_boolean().unwrap_or(false) {
+                            return Err(())
+                        }
+                    % endif
+                    Ok(computed_value::T::${helpers.to_rust_ident(value)})
+                },
+            % endfor
+            _ => Err(())
+        }
+    }
+
+    impl ComputedValueAsSpecified for SpecifiedValue {}
+
+    % if PRODUCT == "servo":
+        fn cascade_property_custom<C: ComputedValues>(
+                                   _declaration: &PropertyDeclaration,
+                                   _inherited_style: &C,
+                                   context: &mut computed::Context<C>,
+                                   _seen: &mut PropertyBitField,
+                                   _cacheable: &mut bool,
+                                   _error_reporter: &mut StdBox<ParseErrorReporter + Send>) {
+            longhands::_servo_display_for_hypothetical_box::derive_from_display(context);
+            longhands::_servo_text_decorations_in_effect::derive_from_display(context);
+        }
+    % endif
+
+</%helpers:longhand>
+
+${helpers.single_keyword("position", "static absolute relative fixed", extra_gecko_values="sticky")}
+
+<%helpers:single_keyword_computed name="float" values="none left right" gecko_ffi_name="mFloats">
+    impl ToComputedValue for SpecifiedValue {
+        type ComputedValue = computed_value::T;
+
+        #[inline]
+        fn to_computed_value<Cx: TContext>(&self, context: &Cx) -> computed_value::T {
+            let positioned = matches!(context.style().get_box().clone_position(),
+                longhands::position::SpecifiedValue::absolute |
+                longhands::position::SpecifiedValue::fixed);
+            if positioned {
+                SpecifiedValue::none
+            } else {
+                *self
+            }
+        }
+    }
+
+</%helpers:single_keyword_computed>
+
+${helpers.single_keyword("clear", "none left right both", gecko_ffi_name="mBreakType")}
+
+<%helpers:longhand name="-servo-display-for-hypothetical-box" derived_from="display" products="servo">
+    pub use super::display::{SpecifiedValue, get_initial_value};
+    pub use super::display::{parse};
+
+    pub mod computed_value {
+        pub type T = super::SpecifiedValue;
+    }
+
+    #[inline]
+    pub fn derive_from_display<Cx: TContext>(context: &mut Cx) {
+        let d = context.style().get_box().clone_display();
+        context.mutate_style().mutate_box().set__servo_display_for_hypothetical_box(d);
+    }
+
+</%helpers:longhand>

--- a/components/style/properties/box_longhand.mako.rs
+++ b/components/style/properties/box_longhand.mako.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 <%page args="helpers" />
 
 ${helpers.new_style_struct("Box", is_inherited=False, gecko_name="nsStyleDisplay",

--- a/components/style/properties/margin_longhand.mako.rs
+++ b/components/style/properties/margin_longhand.mako.rs
@@ -1,0 +1,8 @@
+<%page args="helpers" />
+
+${helpers.new_style_struct("Margin", is_inherited=False, gecko_name="nsStyleMargin")}
+
+% for side in ["top", "right", "bottom", "left"]:
+    ${helpers.predefined_type("margin-" + side, "LengthOrPercentageOrAuto",
+                              "computed::LengthOrPercentageOrAuto::Length(Au(0))")}
+% endfor

--- a/components/style/properties/margin_longhand.mako.rs
+++ b/components/style/properties/margin_longhand.mako.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 <%page args="helpers" />
 
 ${helpers.new_style_struct("Margin", is_inherited=False, gecko_name="nsStyleMargin")}

--- a/components/style/properties/outline_longhand.mako.rs
+++ b/components/style/properties/outline_longhand.mako.rs
@@ -1,7 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 <%page args="helpers" />
 
 ${helpers.new_style_struct("Outline", is_inherited=False, gecko_name="nsStyleOutline",
-                           additional_methods=[helpers.new_method("outline_is_none_or_hidden_and_has_nonzero_width", "bool")])}
+                           additional_methods=[helpers.new_method("outline_is_none_or_hidden_and_has_nonzero_width",
+                                                                  "bool")])}
 
 // TODO(pcwalton): `invert`
 ${helpers.predefined_type("outline-color", "CSSColor", "::cssparser::Color::CurrentColor")}

--- a/components/style/properties/outline_shorthand.mako.rs
+++ b/components/style/properties/outline_shorthand.mako.rs
@@ -1,0 +1,45 @@
+<%page args="helpers" />
+
+<%helpers:shorthand name="outline" sub_properties="outline-color outline-style outline-width">
+    use properties::longhands::outline_width;
+    use values::specified;
+
+    let _unused = context;
+    let mut color = None;
+    let mut style = None;
+    let mut width = None;
+    let mut any = false;
+    loop {
+        if color.is_none() {
+            if let Ok(value) = input.try(specified::CSSColor::parse) {
+                color = Some(value);
+                any = true;
+                continue
+            }
+        }
+        if style.is_none() {
+            if let Ok(value) = input.try(specified::BorderStyle::parse) {
+                style = Some(value);
+                any = true;
+                continue
+            }
+        }
+        if width.is_none() {
+            if let Ok(value) = input.try(|input| outline_width::parse(context, input)) {
+                width = Some(value);
+                any = true;
+                continue
+            }
+        }
+        break
+    }
+    if any {
+        Ok(Longhands {
+            outline_color: color,
+            outline_style: style,
+            outline_width: width,
+        })
+    } else {
+        Err(())
+    }
+</%helpers:shorthand>

--- a/components/style/properties/outline_shorthand.mako.rs
+++ b/components/style/properties/outline_shorthand.mako.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 <%page args="helpers" />
 
 <%helpers:shorthand name="outline" sub_properties="outline-color outline-style outline-width">

--- a/components/style/properties/padding_longhand.mako.rs
+++ b/components/style/properties/padding_longhand.mako.rs
@@ -1,0 +1,9 @@
+<%page args="helpers" />
+
+${helpers.new_style_struct("Padding", is_inherited=False, gecko_name="nsStylePadding")}
+
+% for side in ["top", "right", "bottom", "left"]:
+    ${helpers.predefined_type("padding-" + side, "LengthOrPercentage",
+                              "computed::LengthOrPercentage::Length(Au(0))",
+                              "parse_non_negative")}
+% endfor

--- a/components/style/properties/padding_longhand.mako.rs
+++ b/components/style/properties/padding_longhand.mako.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 <%page args="helpers" />
 
 ${helpers.new_style_struct("Padding", is_inherited=False, gecko_name="nsStylePadding")}

--- a/components/style/properties/position_longhand.mako.rs
+++ b/components/style/properties/position_longhand.mako.rs
@@ -1,0 +1,70 @@
+<%page args="helpers" />
+
+${helpers.new_style_struct("Position", is_inherited=False, gecko_name="nsStylePosition")}
+
+% for side in ["top", "right", "bottom", "left"]:
+    ${helpers.predefined_type(side, "LengthOrPercentageOrAuto",
+                              "computed::LengthOrPercentageOrAuto::Auto")}
+% endfor
+
+<%helpers:longhand name="z-index">
+    use values::computed::ComputedValueAsSpecified;
+
+    impl ComputedValueAsSpecified for SpecifiedValue {}
+    pub type SpecifiedValue = computed_value::T;
+    pub mod computed_value {
+        use cssparser::ToCss;
+        use std::fmt;
+
+        #[derive(PartialEq, Clone, Eq, Copy, Debug, HeapSizeOf)]
+        pub enum T {
+            Auto,
+            Number(i32),
+        }
+
+        impl ToCss for T {
+            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+                match *self {
+                    T::Auto => dest.write_str("auto"),
+                    T::Number(number) => write!(dest, "{}", number),
+                }
+            }
+        }
+
+        impl T {
+            pub fn number_or_zero(self) -> i32 {
+                match self {
+                    T::Auto => 0,
+                    T::Number(value) => value,
+                }
+            }
+        }
+    }
+    #[inline]
+    pub fn get_initial_value() -> computed_value::T {
+        computed_value::T::Auto
+    }
+    fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
+        if input.try(|input| input.expect_ident_matching("auto")).is_ok() {
+            Ok(computed_value::T::Auto)
+        } else {
+            specified::parse_integer(input).map(computed_value::T::Number)
+        }
+    }
+</%helpers:longhand>
+
+${helpers.predefined_type("min-width", "LengthOrPercentage",
+                          "computed::LengthOrPercentage::Length(Au(0))",
+                          "parse_non_negative")}
+${helpers.predefined_type("max-width", "LengthOrPercentageOrNone",
+                          "computed::LengthOrPercentageOrNone::None",
+                          "parse_non_negative")}
+
+${helpers.predefined_type("min-height", "LengthOrPercentage",
+                          "computed::LengthOrPercentage::Length(Au(0))",
+                          "parse_non_negative")}
+${helpers.predefined_type("max-height", "LengthOrPercentageOrNone",
+                          "computed::LengthOrPercentageOrNone::None",
+                          "parse_non_negative")}
+
+${helpers.single_keyword("box-sizing", "content-box border-box")}

--- a/components/style/properties/position_longhand.mako.rs
+++ b/components/style/properties/position_longhand.mako.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 <%page args="helpers" />
 
 ${helpers.new_style_struct("Position", is_inherited=False, gecko_name="nsStylePosition")}

--- a/ports/geckolib/generate_properties_rs.py
+++ b/ports/geckolib/generate_properties_rs.py
@@ -6,11 +6,14 @@ import os
 import sys
 
 from mako import exceptions
+from mako.lookup import TemplateLookup
 from mako.template import Template
 
 try:
+    lookup = TemplateLookup(directories=['.'])
     style_template = Template(filename=os.environ['STYLE_TEMPLATE'],
-                              input_encoding='utf8')
+                              input_encoding='utf8',
+                              lookup=lookup)
     style_template.render(PRODUCT='gecko')
 
     geckolib_template = Template(filename=os.environ['GECKOLIB_TEMPLATE'], input_encoding='utf8')

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -276,6 +276,8 @@ def check_toml(file_name, lines):
 def check_rust(file_name, lines):
     if not file_name.endswith(".rs") or \
        file_name.endswith("properties.mako.rs") or \
+       file_name.endswith("longhand.mako.rs") or \
+       file_name.endswith("shorthand.mako.rs") or \
        file_name.endswith(os.path.join("style", "build.rs")) or \
        file_name.endswith(os.path.join("geckolib", "build.rs")) or \
        file_name.endswith(os.path.join("unit", "style", "stylesheets.rs")):


### PR DESCRIPTION
Background: when I started hacking on Servo some week(s) ago, I quite quickly came in contact with the `components/style/properties.mako.rs` file. I was surprised to see that it was so large (7000 lines of code). In my book, that's too much; there must clearly be some way to structure things in a more reasonable way, I feel.

I am by no means a Python nor a Mako expert (more like: I've never used it before experiencing it in Servo), but I started googling about it yesterday and saw that Mako has an `%include` system that could be used for this kind of stuff. Said and done, I started playing around with it and managed to get something that compiles today - I have used this approach now for extracting a set of properties from the big file.

I realize this is a significant change to the structure here, and this PR serves more as a starting point for discussion than anything else. There may be other, superior ways of achieving the same end result (i.e. splitting the file into smaller parts), better timing for trying to land stuff like this etc etc. Having that said, I find the way I chose here _pretty decent_ to be honest. The `properties.mako.rs` is down from ~7000 LoC to about 5800, by extracting 24 properties into separate files. There are about 70 properties left (of which some hard more difficult, because of scoping etc - they use local methods declared in the `properties.mako.rs` file which are un-callable from include files (have to use `%def` but it didn't seem trivial when I started looking at that, so skipped those properties for now). So, all in all, I think we should be able to bring down this 7000 line file to maybe 2-3000 lines or something quite easily, which would IMHO be a great start.

Opinions/flames/etc? :sunglasses:

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10586)

<!-- Reviewable:end -->
