### PR TITLE
Added panic message to failures.

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -643,9 +643,9 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
             // Messages from script
 
 
-            Request::Script(FromScriptMsg::Failure(Failure { pipeline_id, parent_info })) => {
-                debug!("handling script failure message from pipeline {:?}, {:?}", pipeline_id, parent_info);
-                self.handle_failure_msg(pipeline_id, parent_info);
+            Request::Script(FromScriptMsg::Failure(failure)) => {
+                debug!("handling script failure message from pipeline {:?}", failure);
+                self.handle_failure_msg(failure);
             }
             Request::Script(FromScriptMsg::ScriptLoadedURLInIFrame(load_info)) => {
                 debug!("constellation got iframe URL load message {:?} {:?} {:?}",
@@ -776,9 +776,9 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
             Request::Layout(FromLayoutMsg::ChangeRunningAnimationsState(pipeline_id, animation_state)) => {
                 self.handle_change_running_animations_state(pipeline_id, animation_state)
             }
-            Request::Layout(FromLayoutMsg::Failure(Failure { pipeline_id, parent_info })) => {
-                debug!("handling paint failure message from pipeline {:?}, {:?}", pipeline_id, parent_info);
-                self.handle_failure_msg(pipeline_id, parent_info);
+            Request::Layout(FromLayoutMsg::Failure(failure)) => {
+                debug!("handling paint failure message from pipeline {:?}", failure);
+                self.handle_failure_msg(failure);
             }
             Request::Layout(FromLayoutMsg::SetCursor(cursor)) => {
                 self.handle_set_cursor_msg(cursor)
@@ -793,9 +793,9 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
 
 
             // Notification that painting has finished and is requesting permission to paint.
-            Request::Paint(FromPaintMsg::Failure(Failure { pipeline_id, parent_info })) => {
-                debug!("handling paint failure message from pipeline {:?}, {:?}", pipeline_id, parent_info);
-                self.handle_failure_msg(pipeline_id, parent_info);
+            Request::Paint(FromPaintMsg::Failure(failure)) => {
+                debug!("handling paint failure message from pipeline {:?}", failure);
+                self.handle_failure_msg(failure);
             }
 
         }
@@ -825,12 +825,11 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
             Some(pipeline) => pipeline.parent_info,
         };
         // Treat send error the same as receiving a failure message
-        self.handle_failure_msg(pipeline_id, parent_info);
+        let failure = Failure::new(pipeline_id, parent_info);
+        self.handle_failure_msg(failure);
     }
 
-    fn handle_failure_msg(&mut self,
-                          pipeline_id: PipelineId,
-                          parent_info: Option<(PipelineId, SubpageId)>) {
+    fn handle_failure_msg(&mut self, failure: Failure) {
         if opts::get().hard_fail {
             // It's quite difficult to make Servo exit cleanly if some threads have failed.
             // Hard fail exists for test runners so we crash and that's good enough.
@@ -840,12 +839,12 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
             process::exit(1);
         }
 
-        let window_size = self.pipelines.get(&pipeline_id).and_then(|pipeline| pipeline.size);
+        let window_size = self.pipelines.get(&failure.pipeline_id).and_then(|pipeline| pipeline.size);
 
-        self.close_pipeline(pipeline_id, ExitPipelineMode::Force);
+        self.close_pipeline(failure.pipeline_id, ExitPipelineMode::Force);
 
         while let Some(pending_pipeline_id) = self.pending_frames.iter().find(|pending| {
-            pending.old_pipeline_id == Some(pipeline_id)
+            pending.old_pipeline_id == Some(failure.pipeline_id)
         }).map(|frame| frame.new_pipeline_id) {
             debug!("removing pending frame change for failed pipeline");
             self.close_pipeline(pending_pipeline_id, ExitPipelineMode::Force);
@@ -855,12 +854,12 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
 
         let new_pipeline_id = PipelineId::new();
         self.new_pipeline(new_pipeline_id,
-                          parent_info,
+                          failure.parent_info,
                           window_size,
                           None,
                           LoadData::new(url!("about:failure")));
 
-        self.push_pending_frame(new_pipeline_id, Some(pipeline_id));
+        self.push_pending_frame(new_pipeline_id, Some(failure.pipeline_id));
 
     }
 

--- a/components/compositing/pipeline.rs
+++ b/components/compositing/pipeline.rs
@@ -139,10 +139,7 @@ impl Pipeline {
             .expect("Pipeline script to compositor chan");
         let mut pipeline_port = Some(pipeline_port);
 
-        let failure = Failure {
-            pipeline_id: state.id,
-            parent_info: state.parent_info,
-        };
+        let failure = Failure::new(state.id, state.parent_info);
 
         let window_size = state.window_size.map(|size| {
             WindowSizeData {
@@ -181,7 +178,7 @@ impl Pipeline {
                     subpage_id: subpage_id,
                     load_data: state.load_data.clone(),
                     paint_chan: layout_to_paint_chan.clone().to_opaque(),
-                    failure: failure,
+                    failure: failure.clone(),
                     pipeline_port: mem::replace(&mut pipeline_port, None)
                         .expect("script_pipeline != None but pipeline_port == None"),
                     layout_shutdown_chan: layout_shutdown_chan.clone(),
@@ -229,7 +226,7 @@ impl Pipeline {
             layout_to_constellation_chan: state.layout_to_constellation_chan,
             script_chan: script_chan,
             load_data: state.load_data.clone(),
-            failure: failure,
+            failure: failure.clone(),
             script_port: script_port,
             opts: (*opts::get()).clone(),
             layout_to_paint_chan: layout_to_paint_chan,

--- a/components/gfx/paint_thread.rs
+++ b/components/gfx/paint_thread.rs
@@ -441,7 +441,7 @@ impl<C> PaintThread<C> where C: PaintListener + Send + 'static {
 
             debug!("paint_thread: shutdown_chan send");
             shutdown_chan.send(()).unwrap();
-        }, ConstellationMsg::Failure(failure_msg), c);
+        }, failure_msg, c);
     }
 
     #[allow(unsafe_code)]

--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -34,6 +34,12 @@ pub enum PaintMsg {
     Failure(Failure),
 }
 
+impl From<Failure> for PaintMsg {
+    fn from(failure: Failure) -> PaintMsg {
+        PaintMsg::Failure(failure)
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LayerKind {
     NoTransform,

--- a/components/layout/layout_thread.rs
+++ b/components/layout/layout_thread.rs
@@ -286,7 +286,7 @@ impl LayoutThreadFactory for LayoutThread {
             }
             let _ = shutdown_chan.send(());
             let _ = content_process_shutdown_chan.send(());
-        }, ConstellationMsg::Failure(failure_msg), con_chan);
+        }, failure_msg, con_chan);
     }
 }
 

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -16,6 +16,7 @@ use std::cell::Cell;
 use std::fmt;
 use url::Url;
 use util::geometry::{PagePx, ViewportPx};
+use util::thread::AddFailureDetails;
 use webdriver_msg::{LoadStatus, WebDriverScriptCommand};
 use webrender_traits;
 
@@ -36,10 +37,27 @@ impl<T: Serialize + Deserialize> Clone for ConstellationChan<T> {
 }
 
 // We pass this info to various threads, so it lives in a separate, cloneable struct.
-#[derive(Clone, Copy, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct Failure {
     pub pipeline_id: PipelineId,
     pub parent_info: Option<(PipelineId, SubpageId)>,
+    pub panic_message: Option<String>,
+}
+
+impl Failure {
+    pub fn new(pipeline_id: PipelineId, parent_info: Option<(PipelineId, SubpageId)>) -> Failure {
+        Failure {
+            pipeline_id: pipeline_id,
+            parent_info: parent_info,
+            panic_message: None,
+        }
+    }
+}
+
+impl AddFailureDetails for Failure {
+    fn add_panic_message(&mut self, message: String) {
+        self.panic_message = Some(message);
+    }
 }
 
 #[derive(Copy, Clone, Deserialize, Serialize, HeapSizeOf)]

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -445,7 +445,7 @@ impl ScriptThreadFactory for ScriptThread {
         let ConstellationChan(const_chan) = state.constellation_chan.clone();
         let (script_chan, script_port) = channel();
         let layout_chan = LayoutChan(layout_chan.sender());
-        let failure_info = state.failure_info;
+        let failure_info = state.failure_info.clone();
         thread::spawn_named_with_send_on_failure(format!("ScriptThread {:?}", state.id),
                                                thread_state::SCRIPT,
                                                move || {
@@ -481,7 +481,7 @@ impl ScriptThreadFactory for ScriptThread {
 
             // This must always be the very last operation performed before the thread completes
             failsafe.neuter();
-        }, ConstellationMsg::Failure(failure_info), const_chan);
+        }, failure_info, const_chan);
     }
 }
 

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -32,6 +32,12 @@ pub enum LayoutMsg {
     ViewportConstrained(PipelineId, ViewportConstraints),
 }
 
+impl From<Failure> for LayoutMsg {
+    fn from(failure: Failure) -> LayoutMsg {
+        LayoutMsg::Failure(failure)
+    }
+}
+
 /// Messages from the script to the constellation.
 #[derive(Deserialize, Serialize)]
 pub enum ScriptMsg {
@@ -85,4 +91,10 @@ pub enum ScriptMsg {
     SetDocumentState(PipelineId, DocumentState),
     /// Update the pipeline Url, which can change after redirections.
     SetFinalUrl(PipelineId, Url),
+}
+
+impl From<Failure> for ScriptMsg {
+    fn from(failure: Failure) -> ScriptMsg {
+        ScriptMsg::Failure(failure)
+    }
 }


### PR DESCRIPTION
Added the panic message to failures. This is a step towards #10334, since it gives us access to the panic error message when we fire a `mozbrowsererror` event. The remaining steps are also to record the backtrace, and to report the failure in the event.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10587)

<!-- Reviewable:end -->
