### PR TITLE
Take the stdout lock when printing profile data

### DIFF
--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -12,6 +12,7 @@ use profile_traits::time::{TimerMetadataReflowType, TimerMetadataFrameType};
 use std::borrow::ToOwned;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
+use std::io::{self, Write};
 use std::time::Duration;
 use std::{thread, f64};
 use std_time::precise_time_ns;
@@ -251,10 +252,13 @@ impl Profiler {
     }
 
     fn print_buckets(&mut self) {
-        println!("{:35} {:14} {:9} {:30} {:15} {:15} {:-15} {:-15} {:-15}",
+        let stdout = io::stdout();
+        let mut lock = stdout.lock();
+
+        writeln!(&mut lock, "{:35} {:14} {:9} {:30} {:15} {:15} {:-15} {:-15} {:-15}",
                  "_category_", "_incremental?_", "_iframe?_",
                  "            _url_", "    _mean (ms)_", "  _median (ms)_",
-                 "     _min (ms)_", "     _max (ms)_", "      _events_");
+                 "     _min (ms)_", "     _max (ms)_", "      _events_").unwrap();
         for (&(ref category, ref meta), ref mut data) in &mut self.buckets {
             data.sort_by(|a, b| {
                 if a < b {
@@ -270,11 +274,12 @@ impl Profiler {
                      data[data_len / 2],
                      data.iter().fold(f64::INFINITY, |a, &b| a.min(b)),
                      data.iter().fold(-f64::INFINITY, |a, &b| a.max(b)));
-                println!("{:-35}{} {:15.4} {:15.4} {:15.4} {:15.4} {:15}",
-                         category.format(), meta.format(), mean, median, min, max, data_len);
+                writeln!(&mut lock, "{:-35}{} {:15.4} {:15.4} {:15.4} {:15.4} {:15}",
+                         category.format(), meta.format(), mean, median, min, max,
+                         data_len).unwrap();
             }
         }
-        println!("");
+        writeln!(&mut lock, "").unwrap();
     }
 }
 


### PR DESCRIPTION
Acquiring the stdout lock while printing the profile data prevents other
messages printed to stdout from being interleaved with prints from elsewhere.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10589)

<!-- Reviewable:end -->
