### PR TITLE
Use the document base url when resolving stylesheets

### DIFF
--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -190,9 +190,8 @@ impl VirtualMethods for HTMLLinkElement {
 
 impl HTMLLinkElement {
     fn handle_stylesheet_url(&self, href: &str) {
-        let window = window_from_node(self);
-        let window = window.r();
-        match window.get_url().join(href) {
+        let document = document_from_node(self);
+        match document.base_url().join(href) {
             Ok(url) => {
                 let element = self.upcast::<Element>();
 
@@ -206,8 +205,7 @@ impl HTMLLinkElement {
                 let media = parse_media_query_list(&mut css_parser);
 
                 // TODO: #8085 - Don't load external stylesheets if the node's mq doesn't match.
-                let doc = window.Document();
-                let script_chan = window.networking_task_source();
+                let script_chan = document.window().networking_task_source();
                 let elem = Trusted::new(self, script_chan.clone());
 
                 let context = Arc::new(Mutex::new(StylesheetContext {
@@ -231,20 +229,19 @@ impl HTMLLinkElement {
                 });
 
                 if self.parser_inserted.get() {
-                    doc.increment_script_blocking_stylesheet_count();
+                    document.increment_script_blocking_stylesheet_count();
                 }
-                doc.load_async(LoadType::Stylesheet(url), response_target);
+                document.load_async(LoadType::Stylesheet(url), response_target);
             }
             Err(e) => debug!("Parsing url {} failed: {}", href, e)
         }
     }
 
     fn handle_favicon_url(&self, rel: &str, href: &str, sizes: &Option<String>) {
-        let window = window_from_node(self);
-        let window = window.r();
-        match window.get_url().join(href) {
+        let document = document_from_node(self);
+        match document.base_url().join(href) {
             Ok(url) => {
-                let ConstellationChan(ref chan) = window.constellation_chan();
+                let ConstellationChan(ref chan) = document.window().constellation_chan();
                 let event = ConstellationMsg::NewFavicon(url.clone());
                 chan.send(event).unwrap();
 
@@ -252,7 +249,7 @@ impl HTMLLinkElement {
                     Some(ref sizes) => MozBrowserEvent::IconChange(rel.to_owned(), url.to_string(), sizes.to_owned()),
                     None => MozBrowserEvent::IconChange(rel.to_owned(), url.to_string(), "".to_owned())
                 };
-                window.Document().trigger_mozbrowser_event(mozbrowser_event);
+                document.trigger_mozbrowser_event(mozbrowser_event);
             }
             Err(e) => debug!("Parsing url {} failed: {}", href, e)
         }

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -37233,6 +37233,18 @@
             "url": "/html/rendering/replaced-elements/images/space.html"
           }
         ],
+        "html/semantics/document-metadata/the-link-element/stylesheet-with-base.html": [
+          {
+            "path": "html/semantics/document-metadata/the-link-element/stylesheet-with-base.html",
+            "references": [
+              [
+                "/html/semantics/document-metadata/the-link-element/stylesheet-with-base-ref.html",
+                "=="
+              ]
+            ],
+            "url": "/html/semantics/document-metadata/the-link-element/stylesheet-with-base.html"
+          }
+        ],
         "html/semantics/document-metadata/the-style-element/html_style_in_comment.xhtml": [
           {
             "path": "html/semantics/document-metadata/the-style-element/html_style_in_comment.xhtml",
@@ -40514,6 +40526,18 @@
       }
     },
     "reftest_nodes": {
+      "html/semantics/document-metadata/the-link-element/stylesheet-with-base.html": [
+        {
+          "path": "html/semantics/document-metadata/the-link-element/stylesheet-with-base.html",
+          "references": [
+            [
+              "/html/semantics/document-metadata/the-link-element/stylesheet-with-base-ref.html",
+              "=="
+            ]
+          ],
+          "url": "/html/semantics/document-metadata/the-link-element/stylesheet-with-base.html"
+        }
+      ],
       "html/semantics/embedded-content/the-iframe-element/iframe-with-base.html": [
         {
           "path": "html/semantics/embedded-content/the-iframe-element/iframe-with-base.html",

--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet.css
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet.css
@@ -1,0 +1,3 @@
+body {
+    background-color: green;
+}

--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-with-base-ref.html
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-with-base-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Stylesheet Without Base Tag</title>
+    <style>
+        body { background-color: green; }
+    </style>
+</head>
+<body>
+</body>
+</html>

--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-with-base.html
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-with-base.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Stylesheet With Base Tag</title>
+    <link rel="match" href="stylesheet-with-base-ref.html">
+    <base href="resources/">
+    <link rel="stylesheet" href="stylesheet.css">
+</head>
+<body>
+</body>
+</html>

--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet.css
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet.css
@@ -1,0 +1,3 @@
+body {
+    background-color: red;
+}


### PR DESCRIPTION
Use the document base url when resolving stylesheets. Fixes #10575 .

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10592)

<!-- Reviewable:end -->
