### PR TITLE
Extracted Mako-based code generation invokation to separate .py files.

### DIFF
--- a/components/style/build.rs
+++ b/components/style/build.rs
@@ -43,19 +43,7 @@ fn main() {
         .env("PYTHONPATH", &mako)
         .env("TEMPLATE", &template)
         .env("PRODUCT", product)
-        .arg("-c")
-        .arg(r#"
-import os
-import sys
-from mako.template import Template
-from mako import exceptions
-try:
-    template = Template(open(os.environ['TEMPLATE'], 'rb').read(), input_encoding='utf8')
-    print(template.render(PRODUCT=os.environ['PRODUCT']).encode('utf8'))
-except:
-    sys.stderr.write(exceptions.text_error_template().render().encode('utf8'))
-    sys.exit(1)
-"#)
+        .arg("generate_properties_rs.py")
         .stderr(Stdio::inherit())
         .output()
         .unwrap();

--- a/components/style/generate_properties_rs.py
+++ b/components/style/generate_properties_rs.py
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+from mako import exceptions
+from mako.template import Template
+
+try:
+    template = Template(open(os.environ['TEMPLATE'], 'rb').read(),
+                        input_encoding='utf8')
+    print(template.render(PRODUCT=os.environ['PRODUCT']).encode('utf8'))
+except:
+    sys.stderr.write(exceptions.text_error_template().render().encode('utf8'))
+    sys.exit(1)

--- a/ports/geckolib/build.rs
+++ b/ports/geckolib/build.rs
@@ -50,25 +50,7 @@ fn main() {
         .env("PYTHONPATH", &mako)
         .env("STYLE_TEMPLATE", &style_template)
         .env("GECKOLIB_TEMPLATE", &geckolib_template)
-        .arg("-c")
-        .arg(r#"
-import json
-import os
-import sys
-from mako.template import Template
-from mako import exceptions
-try:
-    style_template = Template(filename=os.environ['STYLE_TEMPLATE'], input_encoding='utf8')
-    style_template.render(PRODUCT='gecko')
-
-    geckolib_template = Template(filename=os.environ['GECKOLIB_TEMPLATE'], input_encoding='utf8')
-    output = geckolib_template.render(STYLE_STRUCTS = style_template.module.STYLE_STRUCTS,
-                                      to_rust_ident = style_template.module.to_rust_ident)
-    print(output.encode('utf8'))
-except:
-    sys.stderr.write(exceptions.text_error_template().render().encode('utf8'))
-    sys.exit(1)
-"#)
+        .arg("ports/geckolib/generate_properties_rs.py")
         .stderr(Stdio::inherit())
         .output()
         .unwrap();

--- a/ports/geckolib/generate_properties_rs.py
+++ b/ports/geckolib/generate_properties_rs.py
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+from mako import exceptions
+from mako.template import Template
+
+try:
+    style_template = Template(filename=os.environ['STYLE_TEMPLATE'],
+                              input_encoding='utf8')
+    style_template.render(PRODUCT='gecko')
+
+    geckolib_template = Template(filename=os.environ['GECKOLIB_TEMPLATE'], input_encoding='utf8')
+    output = geckolib_template.render(STYLE_STRUCTS=style_template.module.STYLE_STRUCTS,
+                                      to_rust_ident=style_template.module.to_rust_ident)
+    print(output.encode('utf8'))
+except:
+    sys.stderr.write(exceptions.text_error_template().render().encode('utf8'))
+    sys.exit(1)


### PR DESCRIPTION
This breaks out some of the parts on #10586, that should be easily mergeable (hopefully pretty much a no-brainer really). The idea would be to let you review & merge it first, and then I'll complete the other PR rebase off of this stuff.

@bholley - I did like you suggested and broke it out for `geckolib` as well. The tests should also be running without problems (tested `./mach test-unit` locally).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10617)

<!-- Reviewable:end -->
