### PR TITLE
Dedicated panic channel

### DIFF
--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -25,20 +25,8 @@ pub use paint_listener::PaintListener;
 use azure::azure_hl::Color;
 use euclid::Matrix4D;
 use euclid::rect::Rect;
-use msg::constellation_msg::{Failure, PipelineId};
+use msg::constellation_msg::{PipelineId};
 use std::fmt::{self, Debug, Formatter};
-
-/// Messages from the paint task to the constellation.
-#[derive(Deserialize, Serialize)]
-pub enum PaintMsg {
-    Failure(Failure),
-}
-
-impl From<Failure> for PaintMsg {
-    fn from(failure: Failure) -> PaintMsg {
-        PaintMsg::Failure(failure)
-    }
-}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LayerKind {

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -26,7 +26,7 @@ extern crate webrender_traits;
 use gfx::font_cache_thread::FontCacheThread;
 use gfx::paint_thread::LayoutToPaintMsg;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
-use msg::constellation_msg::{ConstellationChan, Failure, PipelineId};
+use msg::constellation_msg::{ConstellationChan, PanicMsg, PipelineId};
 use net_traits::image_cache_thread::ImageCacheThread;
 use profile_traits::{mem, time};
 use script_traits::LayoutMsg as ConstellationMsg;
@@ -49,7 +49,7 @@ pub trait LayoutThreadFactory {
               chan: OpaqueScriptLayoutChannel,
               pipeline_port: IpcReceiver<LayoutControlMsg>,
               constellation_chan: ConstellationChan<ConstellationMsg>,
-              failure_msg: Failure,
+              panic_chan: ConstellationChan<PanicMsg>,
               script_chan: IpcSender<ConstellationControlMsg>,
               layout_to_paint_chan: OptionalIpcSender<LayoutToPaintMsg>,
               image_cache_thread: ImageCacheThread,

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -16,7 +16,6 @@ use std::cell::Cell;
 use std::fmt;
 use url::Url;
 use util::geometry::{PagePx, ViewportPx};
-use util::thread::AddFailureDetails;
 use webdriver_msg::{LoadStatus, WebDriverScriptCommand};
 use webrender_traits;
 
@@ -36,29 +35,7 @@ impl<T: Serialize + Deserialize> Clone for ConstellationChan<T> {
     }
 }
 
-// We pass this info to various threads, so it lives in a separate, cloneable struct.
-#[derive(Clone, Deserialize, Serialize, Debug)]
-pub struct Failure {
-    pub pipeline_id: PipelineId,
-    pub parent_info: Option<(PipelineId, SubpageId)>,
-    pub panic_message: Option<String>,
-}
-
-impl Failure {
-    pub fn new(pipeline_id: PipelineId, parent_info: Option<(PipelineId, SubpageId)>) -> Failure {
-        Failure {
-            pipeline_id: pipeline_id,
-            parent_info: parent_info,
-            panic_message: None,
-        }
-    }
-}
-
-impl AddFailureDetails for Failure {
-    fn add_panic_message(&mut self, message: String) {
-        self.panic_message = Some(message);
-    }
-}
+pub type PanicMsg = (Option<PipelineId>, String);
 
 #[derive(Copy, Clone, Deserialize, Serialize, HeapSizeOf)]
 pub struct WindowSizeData {

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -12,7 +12,7 @@ use euclid::point::Point2D;
 use euclid::rect::Rect;
 use gfx_traits::{Epoch, LayerId};
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
-use msg::constellation_msg::{ConstellationChan, Failure, PipelineId};
+use msg::constellation_msg::{ConstellationChan, PanicMsg, PipelineId};
 use msg::constellation_msg::{WindowSizeData};
 use net_traits::image_cache_thread::ImageCacheThread;
 use profile_traits::mem::ReportsChan;
@@ -250,7 +250,7 @@ pub struct NewLayoutThreadInfo {
     pub layout_pair: OpaqueScriptLayoutChannel,
     pub pipeline_port: IpcReceiver<LayoutControlMsg>,
     pub constellation_chan: ConstellationChan<ConstellationMsg>,
-    pub failure: Failure,
+    pub panic_chan: ConstellationChan<PanicMsg>,
     pub script_chan: IpcSender<ConstellationControlMsg>,
     pub image_cache_thread: ImageCacheThread,
     pub paint_chan: OptionalOpaqueIpcSender,

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -41,7 +41,7 @@ use gfx_traits::Epoch;
 use gfx_traits::LayerId;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use libc::c_void;
-use msg::constellation_msg::{ConstellationChan, Failure, PipelineId, WindowSizeData};
+use msg::constellation_msg::{ConstellationChan, PanicMsg, PipelineId, WindowSizeData};
 use msg::constellation_msg::{Key, KeyModifiers, KeyState, LoadData};
 use msg::constellation_msg::{PipelineNamespaceId, SubpageId};
 use msg::webdriver_msg::WebDriverScriptCommand;
@@ -93,10 +93,10 @@ pub struct NewLayoutInfo {
     /// The paint channel, cast to `OptionalOpaqueIpcSender`. This is really an
     /// `Sender<LayoutToPaintMsg>`.
     pub paint_chan: OptionalOpaqueIpcSender,
-    /// Information on what to do on thread failure.
-    pub failure: Failure,
     /// A port on which layout can receive messages from the pipeline.
     pub pipeline_port: IpcReceiver<LayoutControlMsg>,
+    /// A channel for sending panics on
+    pub panic_chan: ConstellationChan<PanicMsg>,
     /// A shutdown channel so that layout can notify others when it's done.
     pub layout_shutdown_chan: IpcSender<()>,
     /// A shutdown channel so that layout can tell the content process to shut down when it's done.
@@ -315,10 +315,10 @@ pub struct InitialScriptState {
     pub constellation_chan: ConstellationChan<ScriptMsg>,
     /// A channel for the layout thread to send messages to the constellation.
     pub layout_to_constellation_chan: ConstellationChan<LayoutMsg>,
+    /// A channel for sending panics to the constellation.
+    pub panic_chan: ConstellationChan<PanicMsg>,
     /// A channel to schedule timer events.
     pub scheduler_chan: IpcSender<TimerEventRequest>,
-    /// Information that script sends out when it panics.
-    pub failure_info: Failure,
     /// A channel to the resource manager thread.
     pub resource_thread: ResourceThread,
     /// A channel to the storage thread.

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -12,8 +12,8 @@ use canvas_traits::CanvasMsg;
 use euclid::point::Point2D;
 use euclid::size::Size2D;
 use ipc_channel::ipc::IpcSender;
-use msg::constellation_msg::{Failure, NavigationDirection, PipelineId};
 use msg::constellation_msg::{LoadData, SubpageId};
+use msg::constellation_msg::{NavigationDirection, PipelineId};
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use style_traits::cursor::Cursor;
 use style_traits::viewport::ViewportConstraints;
@@ -24,18 +24,10 @@ use url::Url;
 pub enum LayoutMsg {
     /// Indicates whether this pipeline is currently running animations.
     ChangeRunningAnimationsState(PipelineId, AnimationState),
-    /// Layout thread failure.
-    Failure(Failure),
     /// Requests that the constellation inform the compositor of the a cursor change.
     SetCursor(Cursor),
     /// Notifies the constellation that the viewport has been constrained in some manner
     ViewportConstrained(PipelineId, ViewportConstraints),
-}
-
-impl From<Failure> for LayoutMsg {
-    fn from(failure: Failure) -> LayoutMsg {
-        LayoutMsg::Failure(failure)
-    }
 }
 
 /// Messages from the script to the constellation.
@@ -55,8 +47,6 @@ pub enum ScriptMsg {
     /// Causes a `load` event to be dispatched to any enclosing frame context element
     /// for the given pipeline.
     DOMLoad(PipelineId),
-    /// Script thread failure.
-    Failure(Failure),
     /// Notifies the constellation that this frame has received focus.
     Focus(PipelineId),
     /// Re-send a mouse button event that was sent to the parent window.
@@ -91,10 +81,4 @@ pub enum ScriptMsg {
     SetDocumentState(PipelineId, DocumentState),
     /// Update the pipeline Url, which can change after redirections.
     SetFinalUrl(PipelineId, Url),
-}
-
-impl From<Failure> for ScriptMsg {
-    fn from(failure: Failure) -> ScriptMsg {
-        ScriptMsg::Failure(failure)
-    }
 }

--- a/components/util/panicking.rs
+++ b/components/util/panicking.rs
@@ -17,10 +17,15 @@ static HOOK_SET: Once = ONCE_INIT;
 /// TLS data pertaining to how failures should be reported
 pub struct PanicHandlerLocal {
     /// failure handler passed through spawn_named_with_send_on_failure
-    pub fail: Box<(FnBox(&(Any + Send))) + Send + 'static>
+    pub fail: Box<FnBox(&Any)>
 }
 
 thread_local!(pub static LOCAL_INFO: RefCell<Option<PanicHandlerLocal>> = RefCell::new(None));
+
+/// Set the thread-local panic hook
+pub fn set_thread_local_hook(local: Box<FnBox(&Any)>) {
+    LOCAL_INFO.with(|i| *i.borrow_mut() = Some(PanicHandlerLocal { fail: local }));
+}
 
 /// Initiates the custom panic hook
 /// Should be called in main() after arguments have been parsed

--- a/components/util/thread.rs
+++ b/components/util/thread.rs
@@ -6,97 +6,33 @@ use ipc_channel::ipc::IpcSender;
 use panicking;
 use serde::Serialize;
 use std::any::Any;
-use std::borrow::ToOwned;
-use std::sync::mpsc::Sender;
 use std::thread;
 use thread_state;
-
-pub type PanicReason = Option<String>;
 
 pub fn spawn_named<F>(name: String, f: F)
     where F: FnOnce() + Send + 'static
 {
-    spawn_named_with_send_on_failure_maybe(name, None, f, |_| {});
-}
-
-pub trait AddFailureDetails {
-    fn add_panic_message(&mut self, message: String);
-    fn add_panic_object(&mut self, object: &Any) {
-        if let Some(message) = object.downcast_ref::<String>() {
-            self.add_panic_message(message.to_owned());
-        } else if let Some(&message) = object.downcast_ref::<&'static str>() {
-            self.add_panic_message(message.to_owned());
-        }
-    }
-}
-
-/// An abstraction over `Sender<T>` and `IpcSender<T>`, for use in
-/// `spawn_named_with_send_on_failure`.
-pub trait SendOnFailure {
-    type Value;
-    fn send_on_failure(&mut self, value: Self::Value);
-}
-
-impl<T> SendOnFailure for Sender<T> where T: Send + 'static {
-    type Value = T;
-    fn send_on_failure(&mut self, value: T) {
-        // Discard any errors to avoid double-panic
-        let _ = self.send(value);
-    }
-}
-
-impl<T> SendOnFailure for IpcSender<T> where T: Send + Serialize + 'static {
-    type Value = T;
-    fn send_on_failure(&mut self, value: T) {
-        // Discard any errors to avoid double-panic
-        let _ = self.send(value);
-    }
+    thread::Builder::new().name(name).spawn(f).expect("Thread spawn failed");
 }
 
 /// Arrange to send a particular message to a channel if the thread fails.
-pub fn spawn_named_with_send_on_failure<F, T, S>(name: String,
-                                                 state: thread_state::ThreadState,
-                                                 f: F,
-                                                 mut msg: T,
-                                                 mut dest: S)
+pub fn spawn_named_with_send_on_panic<F, Id>(name: String,
+                                             state: thread_state::ThreadState,
+                                             f: F,
+                                             id: Id,
+                                             panic_chan: IpcSender<(Id, String)>)
     where F: FnOnce() + Send + 'static,
-          T: Send + AddFailureDetails + 'static,
-          S: Send + SendOnFailure + 'static,
-          S::Value: From<T>,
+          Id: Copy + Send + Serialize + 'static,
 {
-    spawn_named_with_send_on_failure_maybe(name, Some(state), f,
-                                           move |err| {
-                                               msg.add_panic_object(err);
-                                               dest.send_on_failure(S::Value::from(msg));
-                                           });
-}
-
-fn spawn_named_with_send_on_failure_maybe<F, G>(name: String,
-                                                 state: Option<thread_state::ThreadState>,
-                                                 f: F,
-                                                 fail: G)
-                                                 where F: FnOnce() + Send + 'static,
-                                                       G: FnOnce(&(Any + Send)) + Send + 'static {
-
-
-    let builder = thread::Builder::new().name(name.clone());
-
-    let local = panicking::PanicHandlerLocal {
-        fail: Box::new(fail),
-    };
-
-    let f_with_state = move || {
-        if let Some(state) = state {
-            thread_state::initialize(state);
-        }
-
-        // set the handler
-        panicking::LOCAL_INFO.with(|i| {
-            *i.borrow_mut() = Some(local);
-        });
-        f();
-    };
-
-
-    builder.spawn(f_with_state).unwrap();
+    thread::Builder::new().name(name).spawn(move || {
+        thread_state::initialize(state);
+        panicking::set_thread_local_hook(Box::new(move |payload: &Any| {
+            debug!("Thread failed, notifying constellation");
+            let reason = payload.downcast_ref::<String>().map(|s| String::from(&**s))
+                .or(payload.downcast_ref::<&'static str>().map(|s| String::from(*s)))
+                .unwrap_or_else(|| String::from("<unknown reason>"));
+            let _ = panic_chan.send((id, reason));
+        }));
+        f()
+    }).expect("Thread spawn failed");
 }


### PR DESCRIPTION
Added a dedicated panic channel, and removed the panic messages for the script and layout threads. This is needed so that other threads can report panics, which is part of #10334.

Note that this PR includes the commit from #10572, so should land after it lands.

r? @Manishearth

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10641)

<!-- Reviewable:end -->
