### PR TITLE
Disable tinyfiledialogs on non-OS X and Linux platforms.

### DIFF
--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -32,9 +32,6 @@ git = "https://github.com/servo/ipc-channel"
 [dependencies.webrender_traits]
 git = "https://github.com/servo/webrender_traits"
 
-[dependencies.tinyfiledialogs]
-git = "https://github.com/jdm/tinyfiledialogs"
-
 [dependencies]
 cookie = "0.2"
 flate2 = "0.2.0"
@@ -51,3 +48,6 @@ unicase = "1.4.0"
 url = {version = "0.5.7", features = ["heap_size"]}
 uuid = { version = "0.2", features = ["v4"] }
 websocket = "0.16.1"
+
+[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
+tinyfiledialogs = {git = "https://github.com/jdm/tinyfiledialogs"}

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -41,6 +41,7 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, RwLock};
 use time;
 use time::Tm;
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use tinyfiledialogs;
 use url::Url;
 use util::resource_files::resources_dir_path;
@@ -702,9 +703,15 @@ pub trait UIProvider {
 }
 
 impl UIProvider for TFDProvider {
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn input_username_and_password(&self) -> (Option<String>, Option<String>) {
         (tinyfiledialogs::input_box("Enter username", "Username:", ""),
         tinyfiledialogs::input_box("Enter password", "Password:", ""))
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    fn input_username_and_password(&self) -> (Option<String>, Option<String>) {
+        (None, None)
     }
 }
 

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -29,6 +29,7 @@ extern crate openssl;
 extern crate rustc_serialize;
 extern crate threadpool;
 extern crate time;
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 extern crate tinyfiledialogs;
 extern crate unicase;
 extern crate url;


### PR DESCRIPTION
I haven't been able to fix the appveyor build yet, so this gives us back a usable Windows build.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10650)

<!-- Reviewable:end -->
