### PR TITLE
Setting current color to black if canvas is not rendered in document

### DIFF
--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.current.removed.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.fillStyle.parse.current.removed.html.ini
@@ -1,6 +1,0 @@
-[2d.fillStyle.parse.current.removed.html]
-  type: testharness
-  bug: https://github.com/servo/servo/issues/10601
-  [currentColor is solid black when the canvas element is not in a document]
-    expected: FAIL
-


### PR DESCRIPTION
Fixes #10601

The change seems deceptively easy, I hope I am not missing anything...

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10651)

<!-- Reviewable:end -->
