### PR TITLE
write cookie_jar, hsts_list, auth_cache to file if profile_dir option is present

### DIFF
--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -7,16 +7,20 @@
 
 use cookie::Cookie;
 use net_traits::CookieSource;
+use rustc_serialize::{Encodable, Encoder};
 use std::cmp::Ordering;
 use url::Url;
 
+#[derive(RustcEncodable, Clone)]
 pub struct CookieStorage {
+    version: u32,
     cookies: Vec<Cookie>
 }
 
 impl CookieStorage {
     pub fn new() -> CookieStorage {
         CookieStorage {
+            version: 1,
             cookies: Vec::new()
         }
     }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -31,10 +31,10 @@ use net_traits::{CookieSource, IncludeSubdomains, LoadConsumer, LoadContext, Loa
 use net_traits::{Metadata, NetworkError};
 use openssl::ssl::error::{SslError, OpensslError};
 use openssl::ssl::{SSL_OP_NO_SSLV2, SSL_OP_NO_SSLV3, SSL_VERIFY_PEER, SslContext, SslMethod};
-use resource_thread::{CancellationListener, send_error, start_sending_sniffed_opt, AuthCacheEntry};
+use resource_thread::{CancellationListener, send_error, start_sending_sniffed_opt, AuthCache, AuthCacheEntry};
 use std::borrow::ToOwned;
 use std::boxed::FnBox;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::error::Error;
 use std::io::{self, Read, Write};
 use std::sync::mpsc::Sender;
@@ -128,7 +128,7 @@ fn inner_url(url: &Url) -> Url {
 pub struct HttpState {
     pub hsts_list: Arc<RwLock<HstsList>>,
     pub cookie_jar: Arc<RwLock<CookieStorage>>,
-    pub auth_cache: Arc<RwLock<HashMap<Url, AuthCacheEntry>>>,
+    pub auth_cache: Arc<RwLock<AuthCache>>,
 }
 
 impl HttpState {
@@ -136,7 +136,7 @@ impl HttpState {
         HttpState {
             hsts_list: Arc::new(RwLock::new(HstsList::new())),
             cookie_jar: Arc::new(RwLock::new(CookieStorage::new())),
-            auth_cache: Arc::new(RwLock::new(HashMap::new())),
+            auth_cache: Arc::new(RwLock::new(AuthCache::new())),
         }
     }
 }
@@ -522,7 +522,7 @@ pub fn modify_request_headers(headers: &mut Headers,
                               url: &Url,
                               user_agent: &str,
                               cookie_jar: &Arc<RwLock<CookieStorage>>,
-                              auth_cache: &Arc<RwLock<HashMap<Url, AuthCacheEntry>>>,
+                              auth_cache: &Arc<RwLock<AuthCache>>,
                               load_data: &LoadData) {
     // Ensure that the host header is set from the original url
     let host = Host {
@@ -555,13 +555,13 @@ pub fn modify_request_headers(headers: &mut Headers,
 
 fn set_auth_header(headers: &mut Headers,
                    url: &Url,
-                   auth_cache: &Arc<RwLock<HashMap<Url, AuthCacheEntry>>>) {
+                   auth_cache: &Arc<RwLock<AuthCache>>) {
 
     if !headers.has::<Authorization<Basic>>() {
         if let Some(auth) = auth_from_url(url) {
             headers.set(auth);
         } else {
-            if let Some(ref auth_entry) = auth_cache.read().unwrap().get(url) {
+            if let Some(ref auth_entry) = auth_cache.read().unwrap().entries.get(url) {
                 auth_from_entry(&auth_entry, headers);
             }
         }
@@ -820,7 +820,7 @@ pub fn load<A, B>(load_data: &LoadData,
                     password: auth_header.password.to_owned().unwrap(),
                 };
 
-                http_state.auth_cache.write().unwrap().insert(doc_url.clone(), auth_entry);
+                http_state.auth_cache.write().unwrap().entries.insert(doc_url.clone(), auth_entry);
             }
         }
 

--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -4,10 +4,12 @@
 
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use net_traits::storage_thread::{StorageThread, StorageThreadMsg, StorageType};
+use resource_thread;
 use std::borrow::ToOwned;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use url::Url;
+use util::opts;
 use util::thread::spawn_named;
 
 const QUOTA_SIZE_LIMIT: usize = 5 * 1024 * 1024;
@@ -69,6 +71,9 @@ impl StorageManager {
                     self.clear(sender, url, storage_type)
                 }
                 StorageThreadMsg::Exit => {
+                    if let Some(ref profile_dir) = opts::get().profile_dir {
+                        resource_thread::write_json_to_file(&self.local_data, profile_dir, "local_data.json");
+                    }
                     break
                 }
             }

--- a/tests/unit/net/http_loader.rs
+++ b/tests/unit/net/http_loader.rs
@@ -1382,7 +1382,7 @@ fn test_if_auth_creds_not_in_url_but_in_cache_it_sets_it() {
                         password: "test".to_owned(),
                      };
 
-    http_state.auth_cache.write().unwrap().insert(url.clone(), auth_entry);
+    http_state.auth_cache.write().unwrap().entries.insert(url.clone(), auth_entry);
 
     let mut load_data = LoadData::new(LoadContext::Browsing, url, None);
     load_data.credentials_flag = true;


### PR DESCRIPTION
For Persistent sessions student project

"if the profile directory command-line option is present when the ResourceThread is instructed to exit, serialize the data contained in cookie_storage, hsts_list, and the new HTTP authorization cache, and write the serialized data in separate files inside the profile directory."

and 

"perform the same serialization on shutdown for local_data in storage_thread.rs, which represents the LocalStorage API."

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10661)

<!-- Reviewable:end -->
