### PR TITLE
Make `read_resource_file` param simpler and more idiomatic.

### DIFF
--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -112,7 +112,7 @@ impl HSTSList {
 }
 
 pub fn preload_hsts_domains() -> Option<HSTSList> {
-    read_resource_file(&["hsts_preload.json"]).ok().and_then(|bytes| {
+    read_resource_file("hsts_preload.json").ok().and_then(|bytes| {
         from_utf8(&bytes).ok().and_then(|hsts_preload_content| {
             HSTSList::new_from_preload(hsts_preload_content)
         })

--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -38,7 +38,7 @@ lazy_static! {
         // FIXME: presentational-hints.css should be at author origin with zero specificity.
         //        (Does it make a difference?)
         for &filename in &["user-agent.css", "servo.css", "presentational-hints.css"] {
-            match read_resource_file(&[filename]) {
+            match read_resource_file(filename) {
                 Ok(res) => {
                     let ua_stylesheet = Stylesheet::from_bytes(
                         &res,
@@ -65,7 +65,7 @@ lazy_static! {
 
 lazy_static! {
     pub static ref QUIRKS_MODE_STYLESHEET: Stylesheet<ServoSelectorImpl> = {
-        match read_resource_file(&["quirks-mode.css"]) {
+        match read_resource_file("quirks-mode.css") {
             Ok(res) => {
                 Stylesheet::from_bytes(
                     &res,

--- a/components/util/resource_files.rs
+++ b/components/util/resource_files.rs
@@ -5,7 +5,7 @@
 use std::env;
 use std::fs::File;
 use std::io::{self, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 lazy_static! {
@@ -57,11 +57,9 @@ pub fn resources_dir_path() -> PathBuf {
     path
 }
 
-pub fn read_resource_file(relative_path_components: &[&str]) -> io::Result<Vec<u8>> {
+pub fn read_resource_file<P: AsRef<Path>>(relative_path: P) -> io::Result<Vec<u8>> {
     let mut path = resources_dir_path();
-    for component in relative_path_components {
-        path.push(component);
-    }
+    path.push(relative_path);
     let mut file = try!(File::open(&path));
     let mut data = Vec::new();
     try!(file.read_to_end(&mut data));


### PR DESCRIPTION
`<P: AsRef<Path>>` is also what `File::open` uses as a generic type for
the parameter.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10662)

<!-- Reviewable:end -->
