### PR TITLE
Use os.path.basename instead of split('/')[-1]

### DIFF
--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import os
+
 from WebIDL import IDLExternalInterface, IDLInterface, WebIDLError
 
 
@@ -360,7 +362,7 @@ class Descriptor(DescriptorProvider):
 
 # Some utility methods
 def getModuleFromObject(object):
-    return object.location.filename().split('/')[-1].split('.webidl')[0] + 'Binding'
+    return os.path.basename(object.location.filename()).split('.webidl')[0] + 'Binding'
 
 
 def getTypesFromDescriptor(descriptor):


### PR DESCRIPTION
Fixes #10596. I have split up this commit from  #10618 as it seem the easiest to review.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10664)

<!-- Reviewable:end -->
