### PR TITLE
Implement WebGLRenderingContextBase::readPixels().

### DIFF
--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -614,6 +614,8 @@ interface WebGLRenderingContextBase
 
     //void readPixels(GLint x, GLint y, GLsizei width, GLsizei height,
     //                GLenum format, GLenum type, ArrayBufferView? pixels);
+    void readPixels(GLint x, GLint y, GLsizei width, GLsizei height,
+                    GLenum format, GLenum type, object? pixels);
 
     //void renderbufferStorage(GLenum target, GLenum internalformat,
     //                         GLsizei width, GLsizei height);

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-disabled-vertex-attrib.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-disabled-vertex-attrib.html.ini
@@ -3,3 +3,9 @@
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #15: at (0, 0) expected: 0,255,0,255 was 255,255,255,255]
+    expected: FAIL
+
+  [WebGL test #16: getError expected: NO_ERROR. Was INVALID_ENUM : should be no errors]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-vertex-attrib-zero-issues.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-vertex-attrib-zero-issues.html.ini
@@ -3,3 +3,6 @@
   [WebGL test #3: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #4: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/buffers/element-array-buffer-delete-recreate.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/buffers/element-array-buffer-delete-recreate.html.ini
@@ -6,3 +6,6 @@
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #1: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/limits/gl-min-uniforms.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/limits/gl-min-uniforms.html.ini
@@ -6,3 +6,6 @@
   [WebGL test #0: getError expected: NO_ERROR. Was INVALID_OPERATION : Should be no errors from setup.]
     expected: FAIL
 
+  [WebGL test #4: at (0, 0) expected: 32,64,127,255 was 255,128,64,255]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/readPixels.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/readPixels.html.ini
@@ -1,5 +1,0 @@
-[readPixels.html]
-  type: testharness
-  [WebGL test #0: testReadPixels]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/readPixelsBadArgs.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/readPixelsBadArgs.html.ini
@@ -1,5 +1,6 @@
 [readPixelsBadArgs.html]
   type: testharness
+  expected: CRASH
   [WebGL test #0: testReadPixels]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/programs/gl-bind-attrib-location-long-names-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/programs/gl-bind-attrib-location-long-names-test.html.ini
@@ -3,3 +3,9 @@
   [WebGL test #4: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #4: at (0, 0) expected: 0,255,0,255 was 255,255,255,255]
+    expected: FAIL
+
+  [WebGL test #5: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/programs/gl-bind-attrib-location-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/programs/gl-bind-attrib-location-test.html.ini
@@ -3,3 +3,9 @@
   [WebGL test #6: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #7: at (20, 15) expected: 0,255,0,255 was 0,0,0,255]
+    expected: FAIL
+
+  [WebGL test #9: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/reading/read-pixels-pack-alignment.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/reading/read-pixels-pack-alignment.html.ini
@@ -1,5 +1,6 @@
 [read-pixels-pack-alignment.html]
   type: testharness
+  expected: CRASH
   [WebGL test #3: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/reading/read-pixels-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/reading/read-pixels-test.html.ini
@@ -1,3 +1,3 @@
 [read-pixels-test.html]
   type: testharness
-  expected: TIMEOUT
+  expected: CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/renderbuffers/renderbuffer-initialization.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/renderbuffers/renderbuffer-initialization.html.ini
@@ -3,3 +3,6 @@
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/culling.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/culling.html.ini
@@ -3,3 +3,24 @@
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #0: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #1: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #4: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #7: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #9: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #10: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-scissor-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-scissor-test.html.ini
@@ -3,3 +3,60 @@
   [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #50: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #53: at (1, 1) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #56: at (2, 2) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #59: at (3, 3) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #62: at (4, 4) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #65: at (5, 5) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #68: at (6, 6) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #71: at (7, 7) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #74: at (8, 8) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #77: at (9, 9) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #80: at (10, 10) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #83: at (11, 11) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #86: at (12, 12) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #89: at (13, 13) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #92: at (14, 14) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #95: at (15, 15) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #97: getError expected: NO_ERROR. Was INVALID_ENUM : there should be no errors]
+    expected: FAIL
+
+  [WebGL test #98: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #99: context does not exist]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-viewport-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-viewport-test.html.ini
@@ -3,3 +3,48 @@
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #1: at (16, 32) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #6: at (8, 8) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #11: at (4, 16) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #16: at (32, 64) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #41: at (32, 96) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #46: at (24, 72) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #51: at (36, 48) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #56: at (48, 96) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #61: at (0, 32) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #66: at (8, 0) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #71: at (0, 16) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #76: at (32, 0) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #81: getError expected: NO_ERROR. Was INVALID_ENUM : there should be no errors]
+    expected: FAIL
+
+  [WebGL test #82: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #83: context does not exist]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/point-no-attributes.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/point-no-attributes.html.ini
@@ -3,3 +3,6 @@
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #1: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/polygon-offset.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/polygon-offset.html.ini
@@ -3,3 +3,30 @@
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #0: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #1: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #3: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #4: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #5: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #6: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #7: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #8: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/simple.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/simple.html.ini
@@ -3,3 +3,6 @@
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : there should be no errors]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/state/state-uneffected-after-compositing.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/state/state-uneffected-after-compositing.html.ini
@@ -1,6 +1,5 @@
 [state-uneffected-after-compositing.html]
   type: testharness
-  expected: TIMEOUT
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/default-texture.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/default-texture.html.ini
@@ -3,3 +3,9 @@
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #0: at (0, 0) expected: 0,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #0: at (0, 0) expected: 0,0,0,255 was 64,255,191,128]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html.ini
@@ -9,3 +9,12 @@
   [WebGL test #1: successfullyParsed should be true. Was false.]
     expected: FAIL
 
+  [WebGL test #0: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #1: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #2: successfullyParsed should be true. Was false.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgb565.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgb565.html.ini
@@ -1,3 +1,5 @@
 [tex-image-and-sub-image-2d-with-canvas-rgb565.html]
   type: testharness
-  expected: TIMEOUT
+  [WebGL test #0: at (0, 16) expected: 255,0,0 was 255,227,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba4444.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba4444.html.ini
@@ -1,3 +1,5 @@
 [tex-image-and-sub-image-2d-with-canvas-rgba4444.html]
   type: testharness
-  expected: TIMEOUT
+  [WebGL test #0: at (0, 16) expected: 255,0,0 was 255,255,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba5551.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba5551.html.ini
@@ -1,6 +1,11 @@
 [tex-image-and-sub-image-2d-with-canvas-rgba5551.html]
   type: testharness
-  expected: TIMEOUT
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #0: at (0, 16) expected: 255,0,0 was 255,231,0]
+    expected: FAIL
+
+  [WebGL test #0: at (0, 16) expected: 255,0,0 was 255,230,0]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas.html.ini
@@ -1,6 +1,8 @@
 [tex-image-and-sub-image-2d-with-canvas.html]
   type: testharness
-  expected: TIMEOUT
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #0: at (0, 16) expected: 255,0,0 was 0,255,0]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-data-rgb565.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-data-rgb565.html.ini
@@ -1,6 +1,8 @@
 [tex-image-and-sub-image-2d-with-image-data-rgb565.html]
   type: testharness
-  expected: TIMEOUT
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #0: at (0, 0) expected: 0,255,0,255 was 0,28,255,255]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-data-rgba4444.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-data-rgba4444.html.ini
@@ -1,8 +1,8 @@
 [tex-image-and-sub-image-2d-with-image-data-rgba4444.html]
   type: testharness
-  expected:
-    if os == "osx": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): TIMEOUT
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #0: at (0, 0) expected: 0,255,0,255 was 0,0,255,255]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-data-rgba5551.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-data-rgba5551.html.ini
@@ -1,6 +1,11 @@
 [tex-image-and-sub-image-2d-with-image-data-rgba5551.html]
   type: testharness
-  expected: TIMEOUT
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #0: at (0, 0) expected: 0,255,0,255 was 0,24,255,255]
+    expected: FAIL
+
+  [WebGL test #0: at (0, 0) expected: 0,255,0,255 was 0,25,255,255]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-data.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-data.html.ini
@@ -1,6 +1,8 @@
 [tex-image-and-sub-image-2d-with-image-data.html]
   type: testharness
-  expected: TIMEOUT
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #0: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-rgb565.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-rgb565.html.ini
@@ -1,6 +1,8 @@
 [tex-image-and-sub-image-2d-with-image-rgb565.html]
   type: testharness
-  expected: TIMEOUT
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #0: at (4, 4) expected: 0,255,0 was 0,28,255]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-rgba4444.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-rgba4444.html.ini
@@ -1,6 +1,8 @@
 [tex-image-and-sub-image-2d-with-image-rgba4444.html]
   type: testharness
-  expected: TIMEOUT
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #0: at (4, 4) expected: 0,255,0 was 0,0,255]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-rgba5551.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-rgba5551.html.ini
@@ -1,6 +1,11 @@
 [tex-image-and-sub-image-2d-with-image-rgba5551.html]
   type: testharness
-  expected: TIMEOUT
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #0: at (4, 4) expected: 0,255,0 was 0,24,255]
+    expected: FAIL
+
+  [WebGL test #0: at (4, 4) expected: 0,255,0 was 0,25,255]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image.html.ini
@@ -1,3 +1,5 @@
 [tex-image-and-sub-image-2d-with-image.html]
   type: testharness
-  expected: TIMEOUT
+  [WebGL test #0: at (4, 4) expected: 0,255,0 was 255,0,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-svg-image.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-svg-image.html.ini
@@ -1,3 +1,5 @@
 [tex-image-and-sub-image-2d-with-svg-image.html]
   type: testharness
-  expected: TIMEOUT
+  [WebGL test #0: at (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565.html.ini
@@ -1,3 +1,5 @@
 [tex-image-and-sub-image-2d-with-webgl-canvas-rgb565.html]
   type: testharness
-  expected: TIMEOUT
+  [WebGL test #0: at (0, 0) expected: 255,0,0 was 255,227,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4444.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4444.html.ini
@@ -1,3 +1,5 @@
 [tex-image-and-sub-image-2d-with-webgl-canvas-rgba4444.html]
   type: testharness
-  expected: TIMEOUT
+  [WebGL test #0: at (0, 0) expected: 255,0,0 was 255,255,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgba5551.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgba5551.html.ini
@@ -1,3 +1,8 @@
 [tex-image-and-sub-image-2d-with-webgl-canvas-rgba5551.html]
   type: testharness
-  expected: TIMEOUT
+  [WebGL test #0: at (0, 0) expected: 255,0,0 was 255,231,0]
+    expected: FAIL
+
+  [WebGL test #0: at (0, 0) expected: 255,0,0 was 255,230,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas.html.ini
@@ -1,3 +1,5 @@
 [tex-image-and-sub-image-2d-with-webgl-canvas.html]
   type: testharness
-  expected: TIMEOUT
+  [WebGL test #0: at (0, 0) expected: 255,0,0 was 0,255,0]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-webgl.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-webgl.html.ini
@@ -3,3 +3,9 @@
   [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #2: at (1, 0) expected: 255,0,0,255 was 255,255,0,255]
+    expected: FAIL
+
+  [WebGL test #3: at (1, 0) expected: 0,255,0,255 was 255,0,255,255]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-with-format-and-type.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-with-format-and-type.html.ini
@@ -1,3 +1,0 @@
-[tex-image-with-format-and-type.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-hd-dpi.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-hd-dpi.html.ini
@@ -3,3 +3,6 @@
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #4: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-npot.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-npot.html.ini
@@ -6,3 +6,15 @@
   [WebGL test #4: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #4: at (0, 0) expected: 0,0,0,255 was 192,0,128,64]
+    expected: FAIL
+
+  [WebGL test #5: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
+    expected: FAIL
+
+  [WebGL test #7: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
+    expected: FAIL
+
+  [WebGL test #9: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-size.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-size.html.ini
@@ -1,6 +1,8 @@
 [texture-size.html]
   type: testharness
-  expected: TIMEOUT
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
+    expected: FAIL
+
+  [WebGL test #1: unexpected gl error: INVALID_ENUM]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-transparent-pixels-initialized.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-transparent-pixels-initialized.html.ini
@@ -2,5 +2,3 @@
   type: testharness
   expected:
     if os == "linux": CRASH
-    if os == "osx": TIMEOUT
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): TIMEOUT

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/uniform-values-per-program.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/uniform-values-per-program.html.ini
@@ -5,3 +5,579 @@
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #0: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #1: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #2: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #3: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #4: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #5: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #6: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #7: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #8: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #9: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #10: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #11: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #12: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #13: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #14: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #15: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #16: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #17: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #18: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #19: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #20: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #21: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #22: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #23: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #24: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #25: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #26: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #27: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #28: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #29: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #30: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #31: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #32: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #33: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #34: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #35: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #36: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #37: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #38: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #39: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #40: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #41: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #42: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #43: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #44: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #45: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #46: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #47: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #48: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #49: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #50: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #51: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #52: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #53: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #54: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #55: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #56: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #57: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #58: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #59: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #60: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #61: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #62: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #63: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #64: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #65: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #66: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #67: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #68: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #69: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #70: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #71: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #72: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #73: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #74: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #75: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #76: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #77: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #78: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #79: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #80: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #81: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #82: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #83: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #84: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #85: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #86: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #87: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #88: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #89: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #90: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #91: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #92: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #93: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #94: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #95: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #96: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #97: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #98: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #99: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #100: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #101: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #102: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #103: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #104: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #105: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #106: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #107: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #108: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #109: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #110: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #111: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #112: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #113: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #114: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #115: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #116: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #117: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #118: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #119: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #120: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #121: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #122: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #123: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #124: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #125: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #126: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #127: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #128: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #129: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #130: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #131: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #132: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #133: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #134: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #135: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #136: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #137: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #138: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #139: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #140: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #141: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #142: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #143: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #144: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #145: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #146: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #147: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #148: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #149: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #150: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #151: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #152: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #153: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #154: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #155: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #156: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #157: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #158: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #159: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #160: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #161: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #162: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #163: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #164: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #165: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #166: at (0, 0) expected: 128 was 0]
+    expected: FAIL
+
+  [WebGL test #167: at (0, 0) expected: 64 was 0]
+    expected: FAIL
+
+  [WebGL test #168: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #169: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #170: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #171: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #172: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #173: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #174: at (0, 0) expected: 128,64 was 0,0]
+    expected: FAIL
+
+  [WebGL test #175: at (0, 0) expected: 64,128 was 0,0]
+    expected: FAIL
+
+  [WebGL test #176: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #177: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #178: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #179: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #180: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #181: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #182: at (0, 0) expected: 192,128,64 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #183: at (0, 0) expected: 64,128,192 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #184: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #185: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #186: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #187: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #188: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #189: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #190: at (0, 0) expected: 255,192,128,64 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #191: at (0, 0) expected: 64,128,192,255 was 0,0,0,0]
+    expected: FAIL
+


### PR DESCRIPTION
@emilio 
Anything obviously wrong stick out to you? Haven't had a chance to debug why tests/wpt/web-platform-tests/webgl/conformance-1.0.3/conformance/programs/gl-bind-attrib-location-long-names-test.html and co. get the wrong results from ReadPixels.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10668)

<!-- Reviewable:end -->
