### PR TITLE
add tidy test for space after ":" in stucts

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -336,7 +336,8 @@ def check_rust(file_name, lines):
 
         # get rid of strings and chars because cases like regex expression, keep attributes
         if not line_is_attribute(line):
-            line = re.sub(r'"(\\.|[^\\"])*?"|' + r"'(\\.|[^\\'])*?'", '', line)
+            line = re.sub(r'"(\\.|[^\\"])*?"', '""', line)
+            line = re.sub(r"'(\\.|[^\\'])*?'", "''", line)
 
         # get rid of comments
         line = re.sub('//.*?$|/\*.*?$|^\*.*?$', '', line)
@@ -373,7 +374,7 @@ def check_rust(file_name, lines):
             (r" :[^:]", "extra space before :",
                 lambda match, line: 'trait ' not in line[:match.start()]),
             # ignore "crate::mod" and ignore flagging macros like "$t1:expr"
-            (r"[^:]:[A-Za-z]", "missing space after :",
+            (r"[^:]:[A-Za-z0-9\"]", "missing space after :",
                 lambda match, line: '$' not in line[:match.end()]),
             (r"[A-Za-z0-9\)]{", "missing space before {{", no_filter),
             # ignore cases like "{}", "}`", "}}" and "use::std::{Foo, Bar}"

--- a/python/tidy/servo_tidy_tests/rust_tidy.rs
+++ b/python/tidy/servo_tidy_tests/rust_tidy.rs
@@ -29,6 +29,10 @@ impl test {
             2 => 1,
         };
         let z = &Vec<T>;
+        struct Member {
+            member_name:"Foo"
+            member_id:5
+        }
     }
 
     fn test_fun2(y : &String, z : &Vec<f32>) -> f32 {

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -66,6 +66,8 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('missing space before -', errors.next()[2])
         self.assertEqual('missing space before *', errors.next()[2])
         self.assertEqual('missing space after =>', errors.next()[2])
+        self.assertEqual('missing space after :', errors.next()[2])
+        self.assertEqual('missing space after :', errors.next()[2])
         self.assertEqual('extra space before :', errors.next()[2])
         self.assertEqual('extra space before :', errors.next()[2])
         self.assertEqual('use &[T] instead of &Vec<T>', errors.next()[2])


### PR DESCRIPTION
Addresses issue #10702 

the tidy self-test doesn't seem to catch the `member_name:"Foo"` line like it should. the regex follows similar pattern in the file and works in my regex tester tool, so not really sure what is going on there.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10713)

<!-- Reviewable:end -->
