### PR TITLE
Lower the logging level of a really chatty fn

### DIFF
--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -253,12 +253,12 @@ pub unsafe fn get_dom_class(obj: *mut JSObject) -> Result<&'static DOMClass, ()>
 
     let clasp = JS_GetClass(obj);
     if is_dom_class(&*clasp) {
-        debug!("plain old dom object");
+        trace!("plain old dom object");
         let domjsclass: *const DOMJSClass = clasp as *const DOMJSClass;
         return Ok(&(&*domjsclass).dom_class);
     }
     if is_dom_proxy(obj) {
-        debug!("proxy dom object");
+        trace!("proxy dom object");
         let dom_class: *const DOMClass = GetProxyHandlerExtra(obj) as *const DOMClass;
         return Ok(&*dom_class);
     }


### PR DESCRIPTION
Reduces the amount of spew when running with settings like `RUST_LOG=script=debug`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10718)

<!-- Reviewable:end -->
