### PR TITLE
Improve tidy's license validation logic

### DIFF
--- a/python/tidy/HISTORY.rst
+++ b/python/tidy/HISTORY.rst
@@ -1,6 +1,17 @@
 Release History
 ---------------
 
+0.1.0 (2016-04-19)
+++++++++++++++++++
+
+- Improve license checking to disregard comments and line breaks
+- License checking verifies that COPYRIGHT is specified when apache2 is used
+
+0.0.3 (2016-04-19)
+++++++++++++++++++
+
+- Add alternate wording of apache2 license
+
 0.0.2 (2016-04-17)
 ++++++++++++++++++
 - Cleanup Tidy to work on external deps

--- a/python/tidy/servo_tidy/licenseck.py
+++ b/python/tidy/servo_tidy/licenseck.py
@@ -7,67 +7,14 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+# when wrapped to 80 chars, the longest license is 10 lines.
+# TODO actually grab whatever commented block is before the second blank line
+# of the file instead of hard-coding this.
+MAX_LICENSE_LINESPAN = 12
 
-# These licenses are valid for use in Servo
-licenses = [
+mpl = "This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/"
 
-"""\
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-""",
+apache = "Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option. This file may not be copied, modified, or distributed except according to those terms."
 
-"""\
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-""",
-
-"""\
-#!/usr/bin/env python
-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-""",
-
-"""\
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-""",
-
-"""\
-// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-""",
-
-"""\
-# Copyright 2013 The Servo Project Developers. See the COPYRIGHT
-# file at the top-level directory of this distribution.
-#
-# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-# option. This file may not be copied, modified, or distributed
-# except according to those terms.
-""",
-
-"""\
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-"""
-]  # noqa: Indicate to flake8 that we do not want to check indentation here
+copyright = "See the COPYRIGHT file at the top-level directory of this distribution"
+# noqa: Indicate to flake8 that we do not want to check indentation here

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -17,7 +17,11 @@ import site
 import StringIO
 import subprocess
 import sys
-from licenseck import licenses
+import licenseck
+
+EMACS_HEADER = "/* -*- Mode:"
+VIM_HEADER = "/* vim:"
+COMMENTS = ["// ", "# ", " *", "/* ", "*/ "]
 
 # File patterns to include in the non-WPT tidy check.
 file_patterns_to_check = ["*.rs", "*.rc", "*.cpp", "*.c",
@@ -116,18 +120,37 @@ def filter_files(start_dir, faster, progress):
         yield file_name
 
 
-EMACS_HEADER = "/* -*- Mode:"
-VIM_HEADER = "/* vim:"
-MAX_LICENSE_LINESPAN = max(len(license.splitlines()) for license in licenses)
+def check_header(file_name, lines):
+    for l in lines[:3]:
+        if EMACS_HEADER in l or VIM_HEADER in l:
+            # yield(1, "editor detritus in file")
+            pass
+
+def uncomment(line):
+    for c in COMMENTS:
+        if line.startswith(c):
+            return line[len(c):]
+
+
+def licensed_mpl(header):
+    if licenseck.mpl in header:
+        return True
+    return False
+
+
+def licensed_apache(header):
+    if licenseck.apache in header:
+        if licenseck.copyright in header:
+            return True
+    return False
 
 
 def check_license(file_name, lines):
     if any(file_name.endswith(ext) for ext in (".toml", ".lock", ".json")):
         raise StopIteration
-    while lines and (lines[0].startswith(EMACS_HEADER) or lines[0].startswith(VIM_HEADER)):
-        lines = lines[1:]
-    contents = "".join(lines[:MAX_LICENSE_LINESPAN])
-    valid_license = any(contents.startswith(license) for license in licenses)
+    block = min(len(lines), licenseck.MAX_LICENSE_LINESPAN)
+    contents = "".join([uncomment(l) for l in lines[:block]])
+    valid_license = licensed_mpl(contents) or licensed_apache(contents)
     acknowledged_bad_license = "xfail-license" in contents
     if not (valid_license or acknowledged_bad_license):
         yield (1, "incorrect license")
@@ -638,7 +661,7 @@ def scan(faster=False, progress=True):
     # standard checks
     files_to_check = filter_files('.', faster, progress)
     checking_functions = (check_flake8, check_lock, check_webidl_spec, check_json)
-    line_checking_functions = (check_license, check_by_line, check_toml, check_rust, check_spec)
+    line_checking_functions = (check_header, check_license, check_by_line, check_toml, check_rust, check_spec)
     errors = collect_errors_for_files(files_to_check, checking_functions, line_checking_functions)
     # wpt lint checks
     wpt_lint_errors = check_wpt_lint_errors(get_wpt_files(faster, progress))

--- a/python/tidy/servo_tidy_tests/apache2_license.rs
+++ b/python/tidy/servo_tidy_tests/apache2_license.rs
@@ -1,0 +1,5 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -39,6 +39,14 @@ class CheckTidiness(unittest.TestCase):
         errors = tidy.collect_errors_for_files(iterFile('incorrect_license.rs'), [], [tidy.check_license])
         self.assertEqual('incorrect license', errors.next()[2])
 
+    #def test_modeline(self):
+    #    errors = tidy.collect_errors_for_files(iterFile('emacs_modeline.rs'), [], [tidy.check_header])
+    #    self.assertEqual('editor detritus in file', errors.next()[2])
+
+    def test_apache2_incomplete(self):
+        errors = tidy.collect_errors_for_files(iterFile('apache2_license.rs'), [], [tidy.check_license])
+        self.assertEqual('incorrect license', errors.next()[2])
+
     def test_rust(self):
         errors = tidy.collect_errors_for_files(iterFile('rust_tidy.rs'), [], [tidy.check_rust])
         self.assertEqual('use statement spans multiple lines', errors.next()[2])
@@ -79,3 +87,6 @@ class CheckTidiness(unittest.TestCase):
 def do_tests():
     suite = unittest.TestLoader().loadTestsFromTestCase(CheckTidiness)
     unittest.TextTestRunner(verbosity=2).run(suite)
+
+if __name__ == "__main__":
+    do_tests()

--- a/python/tidy/setup.py
+++ b/python/tidy/setup.py
@@ -11,7 +11,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = '0.0.3'
+VERSION = '0.1.0'
 
 install_requires = [
     "flake8==2.4.1",
@@ -51,7 +51,7 @@ if __name__ == '__main__':
         zip_safe=False,
         entry_points={
             'console_scripts': [
-                'servo-tidy=servo_tidy.tidy:scan'
+                'servo-tidy=servo_tidy.tidy:scan',
             ],
         },
     )


### PR DESCRIPTION
fixes #10716

I took the lazy way out and hardcoded the size of block we examine for licenses.

This also gets us set to fix #10719 by uncommenting a few lines, but I'd like to get all the modelines out of servo before starting to lint on them so we don't break the build.

Includes tests for new functionality.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10721)

<!-- Reviewable:end -->
