### PR TITLE
Add unit tests skeleton for the time profiler

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "offscreen_gl_context 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin_compiletest 0.0.1",
  "profile 0.0.1",
+ "profile_tests 0.0.1",
  "profile_traits 0.0.1",
  "script 0.0.1",
  "script_tests 0.0.1",
@@ -1567,6 +1568,14 @@ dependencies = [
  "task_info 0.0.1",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
+]
+
+[[package]]
+name = "profile_tests"
+version = "0.0.1"
+dependencies = [
+ "profile 0.0.1",
+ "profile_traits 0.0.1",
 ]
 
 [[package]]

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -33,6 +33,9 @@ path = "../../tests/unit/net"
 [dev-dependencies.net_traits_tests]
 path = "../../tests/unit/net_traits"
 
+[dev-dependencies.profile_tests]
+path = "../../tests/unit/profile"
+
 [dev-dependencies.script_tests]
 path = "../../tests/unit/script"
 

--- a/tests/unit/profile/Cargo.toml
+++ b/tests/unit/profile/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "profile_tests"
+version = "0.0.1"
+authors = ["The Servo Project Developers"]
+
+[lib]
+name = "profile_tests"
+path = "lib.rs"
+doctest = false
+
+[dependencies.profile]
+path = "../../../components/profile"
+
+[dependencies.profile_traits]
+path = "../../../components/profile_traits"

--- a/tests/unit/profile/lib.rs
+++ b/tests/unit/profile/lib.rs
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate profile;
+extern crate profile_traits;
+
+#[cfg(test)]
+mod time;

--- a/tests/unit/profile/time.rs
+++ b/tests/unit/profile/time.rs
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use profile::time;
+use profile_traits::time::ProfilerMsg;
+
+#[test]
+fn time_profiler_smoke_test() {
+    let chan = time::Profiler::create(None);
+    assert!(true, "Can create the profiler thread");
+
+    chan.send(ProfilerMsg::Exit);
+    assert!(true, "Can tell the profiler thread to exit");
+}


### PR DESCRIPTION
This commit adds a test crate for the time profiler to `tests/unit/profile`. The
only unit test contained in this crate is a smoke test that the time profiler
thread can be created and destroyed. It serves as a place for adding new tests
in the future.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10729)

<!-- Reviewable:end -->
