### PR TITLE
Remove extra definition of WHITESPACE under components/util/str.rs

### DIFF
--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -15,7 +15,7 @@ use dom::node::Node;
 use dom::virtualmethods::VirtualMethods;
 use string_cache::Atom;
 use style::values::specified;
-use util::str::{DOMString, WHITESPACE, read_numbers};
+use util::str::{DOMString, HTML_SPACE_CHARACTERS, read_numbers};
 
 #[dom_struct]
 pub struct HTMLFontElement {
@@ -124,7 +124,7 @@ pub fn parse_legacy_font_size(mut input: &str) -> Option<&'static str> {
     // Steps 1 & 2 are not relevant
 
     // Step 3
-    input = input.trim_matches(WHITESPACE);
+    input = input.trim_matches(HTML_SPACE_CHARACTERS);
 
     enum ParseMode {
         RelativePlus,

--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -11,7 +11,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 use string_cache::{Atom, Namespace};
 use url::Url;
-use util::str::{DOMString, LengthOrPercentageOrAuto, HTML_SPACE_CHARACTERS, WHITESPACE};
+use util::str::{DOMString, LengthOrPercentageOrAuto, HTML_SPACE_CHARACTERS};
 use util::str::{read_numbers, split_html_space_chars, str_join};
 use values::specified::{Length};
 
@@ -279,7 +279,7 @@ pub fn parse_legacy_color(mut input: &str) -> Result<RGBA, ()> {
     }
 
     // Step 3.
-    input = input.trim_matches(WHITESPACE);
+    input = input.trim_matches(HTML_SPACE_CHARACTERS);
 
     // Step 4.
     if input.eq_ignore_ascii_case("transparent") {
@@ -407,7 +407,7 @@ pub fn parse_length(mut value: &str) -> LengthOrPercentageOrAuto {
     // Steps 1 & 2 are not relevant
 
     // Step 3
-    value = value.trim_left_matches(WHITESPACE);
+    value = value.trim_left_matches(HTML_SPACE_CHARACTERS);
 
     // Step 4
     if value.is_empty() {

--- a/components/util/str.rs
+++ b/components/util/str.rs
@@ -124,19 +124,6 @@ impl Extend<char> for DOMString {
 pub type StaticCharVec = &'static [char];
 pub type StaticStringVec = &'static [&'static str];
 
-/// Whitespace as defined by HTML5 § 2.4.1.
-// TODO(SimonSapin) Maybe a custom Pattern can be more efficient?
-pub const WHITESPACE: &'static [char] = &[' ', '\t', '\x0a', '\x0c', '\x0d'];
-
-pub fn is_whitespace(s: &str) -> bool {
-    s.chars().all(char_is_whitespace)
-}
-
-#[inline]
-pub fn char_is_whitespace(c: char) -> bool {
-    WHITESPACE.contains(&c)
-}
-
 /// A "space character" according to:
 ///
 /// https://html.spec.whatwg.org/multipage/#space-character
@@ -147,6 +134,15 @@ pub static HTML_SPACE_CHARACTERS: StaticCharVec = &[
     '\u{000c}',
     '\u{000d}',
 ];
+
+#[inline]
+pub fn char_is_whitespace(c: char) -> bool {
+    HTML_SPACE_CHARACTERS.contains(&c)
+}
+
+pub fn is_whitespace(s: &str) -> bool {
+    s.chars().all(char_is_whitespace)
+}
 
 pub fn split_html_space_chars<'a>(s: &'a str) ->
                                   Filter<Split<'a, StaticCharVec>, fn(&&str) -> bool> {


### PR DESCRIPTION
issue: #10709
found another `const WHITESPACE: &'static [char] = &['\t', '\n', '\r', ' '];` in `components/style/viewports.rs` maybe this could be replaced too with the `util::str::HTML_SPACE_CHARACTERS`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10745)

<!-- Reviewable:end -->
