### PR TITLE
Drop support for keyevents in Document::createEvent

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2156,7 +2156,7 @@ impl DocumentMethods for Document {
                 Ok(Root::upcast(CustomEvent::new_uninitialized(GlobalRef::Window(&self.window)))),
             "htmlevents" | "events" | "event" =>
                 Ok(Event::new_uninitialized(GlobalRef::Window(&self.window))),
-            "keyboardevent" | "keyevents" =>
+            "keyboardevent" =>
                 Ok(Root::upcast(KeyboardEvent::new_uninitialized(&self.window))),
             "messageevent" =>
                 Ok(Root::upcast(MessageEvent::new_uninitialized(GlobalRef::Window(&self.window)))),

--- a/tests/wpt/metadata/dom/nodes/Document-createEvent.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-createEvent.html.ini
@@ -456,8 +456,3 @@
 
   [createEvent('WHEELEVENT') should be initialized correctly.]
     expected: FAIL
-
-  [Should throw NOT_SUPPORTED_ERR for pluralized non-legacy event interface "KeyEvents"]
-    expected: FAIL
-    bug: https://github.com/servo/servo/issues/10735
-


### PR DESCRIPTION
Fix #10735

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10769)

<!-- Reviewable:end -->
