### PR TITLE
Make /dom/nodes/CharacterData-surrogates.html not panic.

### DIFF
--- a/tests/wpt/metadata/dom/nodes/CharacterData-surrogates.html.ini
+++ b/tests/wpt/metadata/dom/nodes/CharacterData-surrogates.html.ini
@@ -1,3 +1,26 @@
 [CharacterData-surrogates.html]
   type: testharness
-  expected: CRASH
+  [Text.substringData() splitting surrogate pairs]
+    expected: FAIL
+
+  [Text.replaceData() splitting and creating surrogate pairs]
+    expected: FAIL
+
+  [Text.deleteData() splitting and creating surrogate pairs]
+    expected: FAIL
+
+  [Text.insertData() splitting and creating surrogate pairs]
+    expected: FAIL
+
+  [Comment.substringData() splitting surrogate pairs]
+    expected: FAIL
+
+  [Comment.replaceData() splitting and creating surrogate pairs]
+    expected: FAIL
+
+  [Comment.deleteData() splitting and creating surrogate pairs]
+    expected: FAIL
+
+  [Comment.insertData() splitting and creating surrogate pairs]
+    expected: FAIL
+


### PR DESCRIPTION
It now fails since `DOMString` is currently based on `std::string::String` on the Rust side, which is strictly well-formed UTF-8 and can not contain unpaired surrogate code points.

Fixes #10780

r? @Ms2ger

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10796)

<!-- Reviewable:end -->
