### PR TITLE
read cookie_jar, hsts_list, auth_cache, and local_data from file if profile_dir option is present

### DIFF
--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -33,7 +33,7 @@ git = "https://github.com/servo/ipc-channel"
 git = "https://github.com/servo/webrender_traits"
 
 [dependencies]
-cookie = "0.2"
+cookie = { version = "0.2.4", features = [ "serialize-rustc" ] }
 flate2 = "0.2.0"
 hyper = { version = "0.9", features = [ "serde-serialization" ] }
 immeta = "0.3.1"

--- a/components/net/cookie.rs
+++ b/components/net/cookie.rs
@@ -8,7 +8,6 @@
 use cookie_rs;
 use net_traits::CookieSource;
 use pub_domains::PUB_DOMAINS;
-use rustc_serialize::{Encodable, Encoder};
 use std::borrow::ToOwned;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use time::{Tm, now, at, Duration};
@@ -17,7 +16,7 @@ use url::Url;
 /// A stored cookie that wraps the definition in cookie-rs. This is used to implement
 /// various behaviours defined in the spec that rely on an associated request URL,
 /// which cookie-rs and hyper's header parsing do not support.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, RustcDecodable, RustcEncodable)]
 pub struct Cookie {
     pub cookie: cookie_rs::Cookie,
     pub host_only: bool,
@@ -172,67 +171,5 @@ impl Cookie {
         }
 
         true
-    }
-}
-
-impl Encodable for Cookie {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_struct("Cookie", 6, |e| {
-            try!(e.emit_struct_field("cookie", 0, |e| RsCookie(self.cookie.clone()).encode(e)));
-            try!(e.emit_struct_field("host_only", 1, |e| self.host_only.encode(e)));
-            try!(e.emit_struct_field("persistent", 2, |e| self.persistent.encode(e)));
-            try!(e.emit_struct_field("creation_time", 3, |e| Time(self.creation_time).encode(e)));
-            try!(e.emit_struct_field("last_access", 4, |e| Time(self.last_access).encode(e)));
-            match self.expiry_time {
-                Some(time) => try!(e.emit_struct_field("expiry_time", 5, |e| Time(time).encode(e))),
-                None => {},
-            }
-            Ok(())
-        })
-    }
-}
-
-struct Time(Tm);
-
-impl Encodable for Time {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        let Time(time) = *self;
-        s.emit_struct("Time", 11, |e| {
-            try!(e.emit_struct_field("tm_sec", 0, |e| time.tm_sec.encode(e)));
-            try!(e.emit_struct_field("tm_min", 1, |e| time.tm_min.encode(e)));
-            try!(e.emit_struct_field("tm_hour", 2, |e| time.tm_hour.encode(e)));
-            try!(e.emit_struct_field("tm_mday", 3, |e| time.tm_mday.encode(e)));
-            try!(e.emit_struct_field("tm_mon", 4, |e| time.tm_mon.encode(e)));
-            try!(e.emit_struct_field("tm_year", 5, |e| time.tm_year.encode(e)));
-            try!(e.emit_struct_field("tm_wday", 6, |e| time.tm_wday.encode(e)));
-            try!(e.emit_struct_field("tm_yday", 7, |e| time.tm_yday.encode(e)));
-            try!(e.emit_struct_field("tm_isdst", 8, |e| time.tm_isdst.encode(e)));
-            try!(e.emit_struct_field("tm_utcoff", 9, |e| time.tm_utcoff.encode(e)));
-            try!(e.emit_struct_field("tm_nsec", 10, |e| time.tm_nsec.encode(e)));
-            Ok(())
-        })
-    }
-}
-
-struct RsCookie(cookie_rs::Cookie);
-
-impl Encodable for RsCookie {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        let RsCookie(ref rs_cookie) = *self;
-        s.emit_struct("RsCookie", 9, |e| {
-            try!(e.emit_struct_field("name", 0, |e| rs_cookie.name.encode(e)));
-            try!(e.emit_struct_field("value", 1, |e| rs_cookie.value.encode(e)));
-            match rs_cookie.expires {
-                Some(time) => try!(e.emit_struct_field("expires", 2, |e| Time(time).encode(e))),
-                None => {},
-            }
-            try!(e.emit_struct_field("max_age", 3, |e| rs_cookie.max_age.encode(e)));
-            try!(e.emit_struct_field("domain", 4, |e| rs_cookie.domain.encode(e)));
-            try!(e.emit_struct_field("path", 5, |e| rs_cookie.path.encode(e)));
-            try!(e.emit_struct_field("secure", 6, |e| rs_cookie.secure.encode(e)));
-            try!(e.emit_struct_field("httponly", 7, |e| rs_cookie.httponly.encode(e)));
-            try!(e.emit_struct_field("custom", 8, |e| rs_cookie.custom.encode(e)));
-            Ok(())
-        })
     }
 }

--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -11,7 +11,7 @@ use rustc_serialize::{Encodable, Encoder};
 use std::cmp::Ordering;
 use url::Url;
 
-#[derive(RustcEncodable, Clone)]
+#[derive(Clone, RustcDecodable, RustcEncodable)]
 pub struct CookieStorage {
     version: u32,
     cookies: Vec<Cookie>

--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -37,10 +37,14 @@ struct StorageManager {
 
 impl StorageManager {
     fn new(port: IpcReceiver<StorageThreadMsg>) -> StorageManager {
+        let mut local_data = HashMap::new();
+        if let Some(ref profile_dir) = opts::get().profile_dir {
+            resource_thread::read_json_from_file(&mut local_data, profile_dir, "local_data.json");
+        }
         StorageManager {
             port: port,
             session_data: HashMap::new(),
-            local_data: HashMap::new(),
+            local_data: local_data,
         }
     }
 }

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "openssl 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -886,7 +886,7 @@ name = "hyper"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cookie 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1270,7 +1270,7 @@ name = "net"
 version = "0.0.1"
 dependencies = [
  "brotli 0.3.20 (git+https://github.com/ende76/brotli-rs)",
- "cookie 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "flate2 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1312,7 +1312,7 @@ dependencies = [
 name = "net_tests"
 version = "0.0.1"
 dependencies = [
- "cookie 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "flate2 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2153,6 +2153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "openssl 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,7 +806,7 @@ name = "hyper"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cookie 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1183,7 +1183,7 @@ name = "net"
 version = "0.0.1"
 dependencies = [
  "brotli 0.3.20 (git+https://github.com/ende76/brotli-rs)",
- "cookie 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "flate2 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2030,6 +2030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "openssl 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -789,7 +789,7 @@ name = "hyper"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cookie 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1166,7 +1166,7 @@ name = "net"
 version = "0.0.1"
 dependencies = [
  "brotli 0.3.20 (git+https://github.com/ende76/brotli-rs)",
- "cookie 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "flate2 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2011,6 +2011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 


### PR DESCRIPTION
Last step in Persistent sessions student project 

"check for the presence of the profile directory command-line option in the ResourceThread constructor and look for files that will contain serialized versions of the previous steps. If they exist, populate the appropriate fields with deserialized versions of the file contents."

Also populated local_data in StorageManager constructor

I am not sure if the handling of decoding and encoding the Option Tm type was done in the cleanest way here.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10800)

<!-- Reviewable:end -->
