### PR TITLE
Use the local clang++ to find system directories

### DIFF
--- a/ports/geckolib/tools/regen_style_structs.sh
+++ b/ports/geckolib/tools/regen_style_structs.sh
@@ -20,7 +20,8 @@ export LIBCLANG_PATH="$(pwd)/llvm/build/Release+Asserts/lib"
 export DYLD_LIBRARY_PATH="$(pwd)/llvm/build/Release+Asserts/lib"
 export LD_LIBRARY_PATH="$(pwd)/llvm/build/Release+Asserts/lib"
 export DIST_INCLUDE="$1/dist/include"
-CLANG_SEARCH_DIRS=$(clang++ -E -x c++ - -v < /dev/null 2>&1 | awk '{ \
+LLVM_BIN=llvm/build/Release+Asserts/bin
+CLANG_SEARCH_DIRS=$($LLVM_BIN/clang++ -E -x c++ - -v < /dev/null 2>&1 | awk '{ \
   if ($0 == "#include <...> search starts here:")                    \
     in_headers = 1;                                                  \
   else if ($0 == "End of search list.")                              \


### PR DESCRIPTION
Rather than the system clang++ (which might not be available).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10801)

<!-- Reviewable:end -->
