### PR TITLE
Merge DisplayListEntry into DisplayItem

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -39,9 +39,8 @@ use std::hash::{BuildHasherDefault, Hash};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
-use style::computed_values::{border_style, cursor, filter, image_rendering, mix_blend_mode};
-use style::computed_values::{pointer_events};
-use style::properties::{ComputedValues, ServoComputedValues};
+use style::computed_values::{border_style, filter, image_rendering, mix_blend_mode};
+use style::properties::{ComputedValues};
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::CharIndex;
@@ -97,13 +96,6 @@ impl LayerInfo {
     }
 }
 
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
-pub struct DisplayListEntry {
-    pub stacking_context_id: StackingContextId,
-    pub section: DisplayListSection,
-    pub item: DisplayItem,
-}
-
 pub struct DisplayListTraversal<'a> {
     pub display_list: &'a DisplayList,
     pub current_item_index: usize,
@@ -115,11 +107,11 @@ impl<'a> DisplayListTraversal<'a> {
        index <= self.last_item_index && index < self.display_list.list.len()
     }
 
-    pub fn advance(&mut self, context: &StackingContext) -> Option<&'a DisplayListEntry> {
+    pub fn advance(&mut self, context: &StackingContext) -> Option<&'a DisplayItem> {
         if !self.can_draw_item_at_index(self.current_item_index) {
             return None
         }
-        if self.display_list.list[self.current_item_index].stacking_context_id != context.id {
+        if self.display_list.list[self.current_item_index].base().stacking_context_id != context.id {
             return None
         }
 
@@ -216,14 +208,14 @@ impl<K, V> Visitor for FnvHashMapVisitor<K, V> where K: Eq + Hash + Deserialize,
 
 #[derive(HeapSizeOf, Deserialize, Serialize)]
 pub struct DisplayList {
-    pub list: Vec<DisplayListEntry>,
+    pub list: Vec<DisplayItem>,
     pub offsets: FnvHashMap<StackingContextId, StackingContextOffsets>,
     pub root_stacking_context: StackingContext,
 }
 
 impl DisplayList {
     pub fn new(mut root_stacking_context: StackingContext,
-               items: &mut Option<Vec<DisplayListEntry>>)
+               items: &mut Option<Vec<DisplayItem>>)
                -> DisplayList {
         let items = match items.take() {
             Some(items) => items,
@@ -242,9 +234,9 @@ impl DisplayList {
         display_list
     }
 
-    pub fn get_offset_for_item(&self, item: &DisplayListEntry) -> u32 {
-        let offsets = &self.offsets[&item.stacking_context_id];
-        match item.section {
+    pub fn get_offset_for_item(&self, item: &DisplayItem) -> u32 {
+        let offsets = &self.offsets[&item.base().stacking_context_id];
+        match item.base().section {
             DisplayListSection::BackgroundAndBorders => offsets.start,
             DisplayListSection::BlockBackgroundsAndBorders =>
                 offsets.block_backgrounds_and_borders,
@@ -258,8 +250,8 @@ impl DisplayList {
         list.append(&mut self.list);
 
         list.sort_by(|a, b| {
-            if a.stacking_context_id == b.stacking_context_id {
-                return a.section.cmp(&b.section);
+            if a.base().stacking_context_id == b.base().stacking_context_id {
+                return a.base().section.cmp(&b.base().section);
             }
             self.get_offset_for_item(a).cmp(&self.get_offset_for_item(b))
         });
@@ -333,8 +325,8 @@ impl DisplayList {
         print_tree.new_level("Items".to_owned());
         for item in &self.list {
             print_tree.add_item(format!("{:?} StackingContext: {:?}",
-                                        item.item,
-                                        item.stacking_context_id));
+                                        item,
+                                        item.base().stacking_context_id));
         }
         print_tree.end_level();
 
@@ -354,8 +346,8 @@ impl DisplayList {
                            transform.m21, transform.m22,
                            transform.m41, transform.m42));
 
-        let entry = &self.list[index];
-        entry.item.draw_into_context(paint_context);
+        let item = &self.list[index];
+        item.draw_into_context(paint_context);
 
         paint_context.draw_target.set_transform(&old_transform);
     }
@@ -407,8 +399,8 @@ impl DisplayList {
                                           tile_rect: Option<Rect<Au>>) {
         for child in stacking_context.children.iter() {
             while let Some(item) = traversal.advance(stacking_context) {
-                if item.item.intersects_rect_in_parent_context(tile_rect) {
-                    item.item.draw_into_context(paint_context);
+                if item.intersects_rect_in_parent_context(tile_rect) {
+                    item.draw_into_context(paint_context);
                 }
             }
 
@@ -420,8 +412,8 @@ impl DisplayList {
         }
 
         while let Some(item) = traversal.advance(stacking_context) {
-            if item.item.intersects_rect_in_parent_context(tile_rect) {
-                item.item.draw_into_context(paint_context);
+            if item.intersects_rect_in_parent_context(tile_rect) {
+                item.draw_into_context(paint_context);
             }
         }
     }
@@ -636,13 +628,13 @@ impl StackingContext {
 
         for child in self.children.iter() {
             while let Some(item) = traversal.advance(self) {
-                item.item.hit_test(point, result);
+                item.hit_test(point, result);
             }
             child.hit_test(traversal, point, result);
         }
 
         while let Some(item) = traversal.advance(self) {
-            item.item.hit_test(point, result);
+            item.hit_test(point, result);
         }
     }
 
@@ -766,11 +758,21 @@ pub struct BaseDisplayItem {
 
     /// The region to clip to.
     pub clip: ClippingRegion,
+
+    /// The section of the display list that this item belongs to.
+    pub section: DisplayListSection,
+
+    /// The id of the stacking context this item belongs to.
+    pub stacking_context_id: StackingContextId,
 }
 
 impl BaseDisplayItem {
     #[inline(always)]
-    pub fn new(bounds: &Rect<Au>, metadata: DisplayItemMetadata, clip: &ClippingRegion)
+    pub fn new(bounds: &Rect<Au>,
+               metadata: DisplayItemMetadata,
+               clip: &ClippingRegion,
+               section: DisplayListSection,
+               stacking_context_id: StackingContextId)
                -> BaseDisplayItem {
         // Detect useless clipping regions here and optimize them to `ClippingRegion::max()`.
         // The painting backend may want to optimize out clipping regions and this makes it easier
@@ -782,7 +784,9 @@ impl BaseDisplayItem {
                 ClippingRegion::max()
             } else {
                 (*clip).clone()
-            }
+            },
+            section: section,
+            stacking_context_id: stacking_context_id,
         }
     }
 }
@@ -962,25 +966,6 @@ pub struct DisplayItemMetadata {
     /// The value of the `cursor` property when the mouse hovers over this display item. If `None`,
     /// this display item is ineligible for pointer events (`pointer-events: none`).
     pub pointing: Option<Cursor>,
-}
-
-impl DisplayItemMetadata {
-    /// Creates a new set of display metadata for a display item constributed by a DOM node.
-    /// `default_cursor` specifies the cursor to use if `cursor` is `auto`. Typically, this will
-    /// be `PointerCursor`, but for text display items it may be `TextCursor` or
-    /// `VerticalTextCursor`.
-    #[inline]
-    pub fn new(node: OpaqueNode, style: &ServoComputedValues, default_cursor: Cursor)
-               -> DisplayItemMetadata {
-        DisplayItemMetadata {
-            node: node,
-            pointing: match (style.get_pointing().pointer_events, style.get_pointing().cursor) {
-                (pointer_events::T::none, _) => None,
-                (pointer_events::T::auto, cursor::T::AutoCursor) => Some(default_cursor),
-                (pointer_events::T::auto, cursor::T::SpecifiedCursor(cursor)) => Some(cursor),
-            },
-        }
-    }
 }
 
 /// Paints a solid color.

--- a/components/gfx/paint_thread.rs
+++ b/components/gfx/paint_thread.rs
@@ -7,7 +7,7 @@
 use app_units::Au;
 use azure::AzFloat;
 use azure::azure_hl::{BackendType, Color, DrawTarget, SurfaceFormat};
-use display_list::{DisplayItem, DisplayList, DisplayListEntry, DisplayListTraversal};
+use display_list::{DisplayItem, DisplayList, DisplayListTraversal};
 use display_list::{LayerInfo, StackingContext, StackingContextId, StackingContextType};
 use euclid::Matrix4D;
 use euclid::point::Point2D;
@@ -160,7 +160,7 @@ struct LayerCreator {
     layers: Vec<PaintLayer>,
     layer_details_stack: Vec<PaintLayer>,
     current_layer: Option<PaintLayer>,
-    current_entry_index: usize,
+    current_item_index: usize,
 }
 
 impl LayerCreator {
@@ -169,7 +169,7 @@ impl LayerCreator {
             layers: Vec::new(),
             layer_details_stack: Vec::new(),
             current_layer: None,
-            current_entry_index: 0,
+            current_item_index: 0,
         };
         let mut traversal = DisplayListTraversal {
             display_list: display_list,
@@ -280,12 +280,12 @@ impl LayerCreator {
 
 
     fn create_layers_for_item<'a>(&mut self,
-                                  item: &DisplayListEntry,
+                                  item: &DisplayItem,
                                   parent_origin: &Point2D<Au>,
                                   transform: &Matrix4D<f32>,
                                   perspective: &Matrix4D<f32>) {
-        if let DisplayItem::LayeredItemClass(ref layered_item) = item.item {
-            // We need to finalize the last layer here before incrementing the entry
+        if let &DisplayItem::LayeredItemClass(ref layered_item) = item {
+            // We need to finalize the last layer here before incrementing the item
             // index, otherwise this item will be placed into the parent layer.
             self.finalize_current_layer();
             let layer = PaintLayer::new_for_display_item(
@@ -296,9 +296,9 @@ impl LayerCreator {
                 perspective,
                 self.current_parent_layer_id(),
                 self.current_parent_stacking_context_id(),
-                self.current_entry_index);
+                self.current_item_index);
             self.layers.push(layer);
-            self.current_entry_index += 1;
+            self.current_item_index += 1;
             return;
         }
 
@@ -320,9 +320,9 @@ impl LayerCreator {
         }
 
         if let Some(ref mut current_layer) = self.current_layer {
-            current_layer.add_item(self.current_entry_index);
+            current_layer.add_item(self.current_item_index);
         }
-        self.current_entry_index += 1;
+        self.current_item_index += 1;
     }
 }
 

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -29,7 +29,7 @@ use gfx::display_list::{GradientDisplayItem};
 use gfx::display_list::{GradientStop, IframeDisplayItem, ImageDisplayItem, WebGLDisplayItem, LayeredItem, LayerInfo};
 use gfx::display_list::{LineDisplayItem, OpaqueNode, SolidColorDisplayItem};
 use gfx::display_list::{StackingContext, StackingContextId, StackingContextType};
-use gfx::display_list::{TextDisplayItem, TextOrientation, DisplayListEntry, WebRenderImageInfo};
+use gfx::display_list::{TextDisplayItem, TextOrientation, WebRenderImageInfo};
 use gfx::paint_thread::THREAD_TINT_COLORS;
 use gfx::text::glyph::CharIndex;
 use gfx_traits::{color, ScrollPolicy};
@@ -46,8 +46,8 @@ use std::{cmp, f32};
 use style::computed_values::filter::Filter;
 use style::computed_values::{_servo_overflow_clip_box as overflow_clip_box};
 use style::computed_values::{background_attachment, background_clip, background_origin};
-use style::computed_values::{background_repeat, background_size};
-use style::computed_values::{border_style, image_rendering, overflow_x, position};
+use style::computed_values::{background_repeat, background_size, border_style};
+use style::computed_values::{cursor, image_rendering, overflow_x, pointer_events, position};
 use style::computed_values::{transform, transform_style, visibility};
 use style::logical_geometry::{LogicalPoint, LogicalRect, LogicalSize, WritingMode};
 use style::properties::style_structs::ServoBorder;
@@ -63,7 +63,7 @@ use util::opts;
 
 pub struct DisplayListBuildState<'a> {
     pub layout_context: &'a LayoutContext<'a>,
-    pub items: Vec<DisplayListEntry>,
+    pub items: Vec<DisplayItem>,
     pub stacking_context_id_stack: Vec<StackingContextId>,
 }
 
@@ -77,14 +77,8 @@ impl<'a> DisplayListBuildState<'a> {
         }
     }
 
-    fn add_display_item(&mut self, display_item: DisplayItem, section: DisplayListSection) {
-        let stacking_context_id = self.stacking_context_id();
-        self.items.push(
-            DisplayListEntry {
-                stacking_context_id: stacking_context_id,
-                section: section,
-                item: display_item
-            });
+    fn add_display_item(&mut self, display_item: DisplayItem) {
+        self.items.push(display_item);
     }
 
     fn stacking_context_id(&self) -> StackingContextId {
@@ -98,6 +92,23 @@ impl<'a> DisplayListBuildState<'a> {
     pub fn pop_stacking_context_id(&mut self) {
         self.stacking_context_id_stack.pop();
         assert!(!self.stacking_context_id_stack.is_empty());
+    }
+
+    fn create_base_display_item(&self,
+                                bounds: &Rect<Au>,
+                                clip: &ClippingRegion,
+                                node: OpaqueNode,
+                                cursor: Option<Cursor>,
+                                section: DisplayListSection)
+                                -> BaseDisplayItem {
+        BaseDisplayItem::new(&bounds,
+                             DisplayItemMetadata {
+                                 node: node,
+                                 pointing: cursor,
+                             },
+                             &clip,
+                             section,
+                             self.stacking_context_id())
     }
 }
 
@@ -365,15 +376,16 @@ impl FragmentDisplayListBuilding for Fragment {
             }
         }
 
+        let base = state.create_base_display_item(&bounds,
+                                                  &clip,
+                                                  self.node,
+                                                  style.get_cursor(Cursor::DefaultCursor),
+                                                  display_list_section);
         state.add_display_item(
             DisplayItem::SolidColorClass(box SolidColorDisplayItem {
-                base: BaseDisplayItem::new(&bounds,
-                                           DisplayItemMetadata::new(self.node,
-                                                                    style,
-                                                                    Cursor::DefaultCursor),
-                                           &clip),
+                base: base,
                 color: background_color.to_gfx_color(),
-            }), display_list_section);
+            }));
 
         // The background image is painted on top of the background color.
         // Implements background image, per spec:
@@ -556,17 +568,18 @@ impl FragmentDisplayListBuilding for Fragment {
             };
 
             // Create the image display item.
+            let base = state.create_base_display_item(&bounds,
+                                                      &clip,
+                                                      self.node,
+                                                      style.get_cursor(Cursor::DefaultCursor),
+                                                      display_list_section);
             state.add_display_item(DisplayItem::ImageClass(box ImageDisplayItem {
-                base: BaseDisplayItem::new(&bounds,
-                                           DisplayItemMetadata::new(self.node,
-                                                                    style,
-                                                                    Cursor::DefaultCursor),
-                                           &clip),
+                base: base,
                 webrender_image: webrender_image,
                 image_data: image_data.map(Arc::new),
                 stretch_size: Size2D::new(image_size.width, image_size.height),
                 image_rendering: style.get_inheritedbox().image_rendering.clone(),
-            }), display_list_section);
+            }));
         }
     }
 
@@ -676,18 +689,19 @@ impl FragmentDisplayListBuilding for Fragment {
         let center = Point2D::new(absolute_bounds.origin.x + absolute_bounds.size.width / 2,
                                   absolute_bounds.origin.y + absolute_bounds.size.height / 2);
 
+        let base = state.create_base_display_item(absolute_bounds,
+                                                  &clip,
+                                                  self.node,
+                                                  style.get_cursor(Cursor::DefaultCursor),
+                                                  display_list_section);
         let gradient_display_item = DisplayItem::GradientClass(box GradientDisplayItem {
-            base: BaseDisplayItem::new(absolute_bounds,
-                                       DisplayItemMetadata::new(self.node,
-                                                                style,
-                                                                Cursor::DefaultCursor),
-                                       &clip),
+            base: base,
             start_point: center - delta,
             end_point: center + delta,
             stops: stops,
         });
 
-        state.add_display_item(gradient_display_item, display_list_section);
+        state.add_display_item(gradient_display_item);
     }
 
     fn build_display_list_for_box_shadow_if_applicable(&self,
@@ -705,12 +719,13 @@ impl FragmentDisplayListBuilding for Fragment {
                               box_shadow.spread_radius);
 
             // TODO(pcwalton): Multiple border radii; elliptical border radii.
+            let base = state.create_base_display_item(&bounds,
+                                                      &clip,
+                                                      self.node,
+                                                      style.get_cursor(Cursor::DefaultCursor),
+                                                      display_list_section);
             state.add_display_item(DisplayItem::BoxShadowClass(box BoxShadowDisplayItem {
-                base: BaseDisplayItem::new(&bounds,
-                                           DisplayItemMetadata::new(self.node,
-                                                                    style,
-                                                                    Cursor::DefaultCursor),
-                                           clip),
+                base: base,
                 box_bounds: *absolute_bounds,
                 color: style.resolve_color(box_shadow.color).to_gfx_color(),
                 offset: Point2D::new(box_shadow.offset_x, box_shadow.offset_y),
@@ -724,7 +739,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 } else {
                     BoxShadowClipMode::Outset
                 },
-            }), display_list_section);
+            }));
         }
     }
 
@@ -776,12 +791,13 @@ impl FragmentDisplayListBuilding for Fragment {
         }
 
         // Append the border to the display list.
+        let base = state.create_base_display_item(&bounds,
+                                                  &clip,
+                                                  self.node,
+                                                  style.get_cursor(Cursor::DefaultCursor),
+                                                  display_list_section);
         state.add_display_item(DisplayItem::BorderClass(box BorderDisplayItem {
-            base: BaseDisplayItem::new(&bounds,
-                                       DisplayItemMetadata::new(self.node,
-                                                                style,
-                                                                Cursor::DefaultCursor),
-                                       clip),
+            base: base,
             border_widths: border.to_physical(style.writing_mode),
             color: SideOffsets2D::new(colors.top.to_gfx_color(),
                                       colors.right.to_gfx_color(),
@@ -789,7 +805,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                       colors.left.to_gfx_color()),
             style: border_style,
             radius: build_border_radius(&bounds, border_style_struct),
-        }), display_list_section);
+        }));
     }
 
     fn build_display_list_for_outline_if_applicable(&self,
@@ -818,17 +834,18 @@ impl FragmentDisplayListBuilding for Fragment {
 
         // Append the outline to the display list.
         let color = style.resolve_color(style.get_outline().outline_color).to_gfx_color();
+        let base = state.create_base_display_item(&bounds,
+                                                  &clip,
+                                                  self.node,
+                                                  style.get_cursor(Cursor::DefaultCursor),
+                                                  DisplayListSection::Outlines);
         state.add_display_item(DisplayItem::BorderClass(box BorderDisplayItem {
-            base: BaseDisplayItem::new(&bounds,
-                                       DisplayItemMetadata::new(self.node,
-                                                                style,
-                                                                Cursor::DefaultCursor),
-                                       clip),
+            base: base,
             border_widths: SideOffsets2D::new_all_same(width),
             color: SideOffsets2D::new_all_same(color),
             style: SideOffsets2D::new_all_same(outline_style),
             radius: Default::default(),
-        }), DisplayListSection::Outlines);
+        }));
     }
 
     fn build_debug_borders_around_text_fragments(&self,
@@ -842,17 +859,18 @@ impl FragmentDisplayListBuilding for Fragment {
         let container_size = Size2D::zero();
 
         // Compute the text fragment bounds and draw a border surrounding them.
+        let base = state.create_base_display_item(stacking_relative_border_box,
+                                                  clip,
+                                                  self.node,
+                                                  style.get_cursor(Cursor::DefaultCursor),
+                                                  DisplayListSection::Content);
         state.add_display_item(DisplayItem::BorderClass(box BorderDisplayItem {
-            base: BaseDisplayItem::new(stacking_relative_border_box,
-                                       DisplayItemMetadata::new(self.node,
-                                                                style,
-                                                                Cursor::DefaultCursor),
-                                       clip),
+            base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
             color: SideOffsets2D::new_all_same(color::rgb(0, 0, 200)),
             style: SideOffsets2D::new_all_same(border_style::T::solid),
             radius: Default::default(),
-        }), DisplayListSection::Content);
+        }));
 
         // Draw a rectangle representing the baselines.
         let mut baseline = LogicalRect::from_physical(self.style.writing_mode,
@@ -862,15 +880,16 @@ impl FragmentDisplayListBuilding for Fragment {
         baseline.size.block = Au(0);
         let baseline = baseline.to_physical(self.style.writing_mode, container_size);
 
+        let base = state.create_base_display_item(&baseline,
+                                                  clip,
+                                                  self.node,
+                                                  style.get_cursor(Cursor::DefaultCursor),
+                                                  DisplayListSection::Content);
         state.add_display_item(DisplayItem::LineClass(box LineDisplayItem {
-            base: BaseDisplayItem::new(&baseline,
-                                       DisplayItemMetadata::new(self.node,
-                                                                style,
-                                                                Cursor::DefaultCursor),
-                                       clip),
+            base: base,
             color: color::rgb(0, 200, 0),
             style: border_style::T::dashed,
-        }), DisplayListSection::Content);
+        }));
     }
 
     fn build_debug_borders_around_fragment(&self,
@@ -878,17 +897,18 @@ impl FragmentDisplayListBuilding for Fragment {
                                            stacking_relative_border_box: &Rect<Au>,
                                            clip: &ClippingRegion) {
         // This prints a debug border around the border of this fragment.
+        let base = state.create_base_display_item(stacking_relative_border_box,
+                                                  clip,
+                                                  self.node,
+                                                  self.style.get_cursor(Cursor::DefaultCursor),
+                                                  DisplayListSection::Content);
         state.add_display_item(DisplayItem::BorderClass(box BorderDisplayItem {
-            base: BaseDisplayItem::new(stacking_relative_border_box,
-                                       DisplayItemMetadata::new(self.node,
-                                                                &*self.style,
-                                                                Cursor::DefaultCursor),
-                                       clip),
+            base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
             color: SideOffsets2D::new_all_same(color::rgb(0, 0, 200)),
             style: SideOffsets2D::new_all_same(border_style::T::solid),
             radius: Default::default(),
-        }), DisplayListSection::Content);
+        }));
     }
 
     fn adjust_clip_for_style(&self,
@@ -928,15 +948,16 @@ impl FragmentDisplayListBuilding for Fragment {
         if scanned_text_fragment_info.selected() {
             let style = self.selected_style();
             let background_color = style.resolve_color(style.get_background().background_color);
+            let base = state.create_base_display_item(stacking_relative_border_box,
+                                                      &clip,
+                                                      self.node,
+                                                      self.style.get_cursor(Cursor::DefaultCursor),
+                                                      display_list_section);
             state.add_display_item(
                 DisplayItem::SolidColorClass(box SolidColorDisplayItem {
-                    base: BaseDisplayItem::new(stacking_relative_border_box,
-                                               DisplayItemMetadata::new(self.node,
-                                                                        &*self.style,
-                                                                        Cursor::DefaultCursor),
-                                               &clip),
+                    base: base,
                     color: background_color.to_gfx_color(),
-            }), display_list_section);
+            }));
         }
 
         // Draw a caret at the insertion point.
@@ -965,12 +986,15 @@ impl FragmentDisplayListBuilding for Fragment {
             cursor = Cursor::VerticalTextCursor;
         };
 
+        let base = state.create_base_display_item(&insertion_point_bounds,
+                                                  &clip,
+                                                  self.node,
+                                                  self.style.get_cursor(cursor),
+                                                  display_list_section);
         state.add_display_item(DisplayItem::SolidColorClass(box SolidColorDisplayItem {
-            base: BaseDisplayItem::new(&insertion_point_bounds,
-                                       DisplayItemMetadata::new(self.node, &*self.style, cursor),
-                                       &clip),
+            base: base,
             color: self.style().get_color().color.to_gfx_color(),
-        }), display_list_section);
+        }));
     }
 
     fn build_display_list(&mut self,
@@ -1175,18 +1199,19 @@ impl FragmentDisplayListBuilding for Fragment {
             }
             SpecificFragmentInfo::Iframe(ref fragment_info) => {
                 if !stacking_relative_content_box.is_empty() {
+                    let base = state.create_base_display_item(
+                        &stacking_relative_content_box,
+                        clip,
+                        self.node,
+                        self.style.get_cursor(Cursor::DefaultCursor),
+                        DisplayListSection::Content);
                     let item = DisplayItem::IframeClass(box IframeDisplayItem {
-                        base: BaseDisplayItem::new(
-                            &stacking_relative_content_box,
-                            DisplayItemMetadata::new(self.node,
-                                                     &*self.style,
-                                                     Cursor::DefaultCursor),
-                            clip),
+                        base: base,
                         iframe: fragment_info.pipeline_id,
                     });
 
                     if opts::get().use_webrender {
-                        state.add_display_item(item, DisplayListSection::Content);
+                        state.add_display_item(item);
                     } else {
                         state.add_display_item(DisplayItem::LayeredItemClass(box LayeredItem {
                             item: item,
@@ -1194,24 +1219,26 @@ impl FragmentDisplayListBuilding for Fragment {
                                                        ScrollPolicy::Scrollable,
                                                        Some(fragment_info.pipeline_id),
                                                        color::transparent()),
-                        }), DisplayListSection::Content);
+                        }));
                     }
                 }
             }
             SpecificFragmentInfo::Image(ref mut image_fragment) => {
                 // Place the image into the display list.
                 if let Some(ref image) = image_fragment.image {
+                    let base = state.create_base_display_item(
+                        &stacking_relative_content_box,
+                        clip,
+                        self.node,
+                        self.style.get_cursor(Cursor::DefaultCursor),
+                        DisplayListSection::Content);
                     state.add_display_item(DisplayItem::ImageClass(box ImageDisplayItem {
-                        base: BaseDisplayItem::new(&stacking_relative_content_box,
-                                                   DisplayItemMetadata::new(self.node,
-                                                                            &*self.style,
-                                                                            Cursor::DefaultCursor),
-                                                   clip),
+                        base: base,
                         webrender_image: WebRenderImageInfo::from_image(image),
                         image_data: Some(Arc::new(image.bytes.clone())),
                         stretch_size: stacking_relative_content_box.size,
                         image_rendering: self.style.get_inheritedbox().image_rendering.clone(),
-                    }), DisplayListSection::Content);
+                    }));
                 }
             }
             SpecificFragmentInfo::Canvas(ref canvas_fragment_info) => {
@@ -1235,14 +1262,16 @@ impl FragmentDisplayListBuilding for Fragment {
                         }),
                     };
 
+                    let base = state.create_base_display_item(
+                        &stacking_relative_content_box,
+                        clip,
+                        self.node,
+                        self.style.get_cursor(Cursor::DefaultCursor),
+                        DisplayListSection::Content);
                     let display_item = match canvas_data {
                         CanvasData::Pixels(canvas_data) => {
                             DisplayItem::ImageClass(box ImageDisplayItem {
-                                base: BaseDisplayItem::new(&stacking_relative_content_box,
-                                                           DisplayItemMetadata::new(self.node,
-                                                                                    &*self.style,
-                                                                                    Cursor::DefaultCursor),
-                                                           clip),
+                                base: base,
                                 image_data: Some(Arc::new(canvas_data.image_data)),
                                 webrender_image: WebRenderImageInfo {
                                     width: width as u32,
@@ -1256,18 +1285,14 @@ impl FragmentDisplayListBuilding for Fragment {
                         }
                         CanvasData::WebGL(context_id) => {
                             DisplayItem::WebGLClass(box WebGLDisplayItem {
-                                base: BaseDisplayItem::new(&stacking_relative_content_box,
-                                                           DisplayItemMetadata::new(self.node,
-                                                                                    &*self.style,
-                                                                                    Cursor::DefaultCursor),
-                                                           clip),
+                                base: base,
                                 context_id: context_id,
                             })
                         }
                     };
 
                     if opts::get().use_webrender {
-                        state.add_display_item(display_item, DisplayListSection::Content);
+                        state.add_display_item(display_item);
                     } else {
                         state.add_display_item(DisplayItem::LayeredItemClass(box LayeredItem {
                             item: display_item,
@@ -1275,7 +1300,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                        ScrollPolicy::Scrollable,
                                                        None,
                                                        color::transparent()),
-                        }), DisplayListSection::Content);
+                        }));
                     }
                 }
             }
@@ -1532,17 +1557,20 @@ impl FragmentDisplayListBuilding for Fragment {
                                                           container_size);
 
         // Create the text display item.
+        let base = state.create_base_display_item(&stacking_relative_content_box,
+                                                  clip,
+                                                  self.node,
+                                                  self.style().get_cursor(cursor),
+                                                  DisplayListSection::Content);
         state.add_display_item(DisplayItem::TextClass(box TextDisplayItem {
-            base: BaseDisplayItem::new(&stacking_relative_content_box,
-                                       DisplayItemMetadata::new(self.node, self.style(), cursor),
-                                       clip),
+            base: base,
             text_run: text_fragment.run.clone(),
             range: text_fragment.range,
             text_color: text_color.to_gfx_color(),
             orientation: orientation,
             baseline_origin: baseline_origin,
             blur_radius: shadow_blur_radius.unwrap_or(Au(0)),
-        }), DisplayListSection::Content);
+        }));
 
         // Create display items for text decorations.
         let mut text_decorations = self.style()
@@ -1608,11 +1636,14 @@ impl FragmentDisplayListBuilding for Fragment {
         let container_size = Size2D::zero();
         let stacking_relative_box = stacking_relative_box.to_physical(self.style.writing_mode,
                                                                       container_size);
-        let metadata = DisplayItemMetadata::new(self.node, &*self.style, Cursor::DefaultCursor);
+        let base = state.create_base_display_item(
+            &shadow_bounds(&stacking_relative_box, blur_radius, Au(0)),
+            clip,
+            self.node,
+            self.style.get_cursor(Cursor::DefaultCursor),
+            DisplayListSection::Content);
         state.add_display_item(DisplayItem::BoxShadowClass(box BoxShadowDisplayItem {
-            base: BaseDisplayItem::new(&shadow_bounds(&stacking_relative_box, blur_radius, Au(0)),
-                                       metadata,
-                                       clip),
+            base: base,
             box_bounds: stacking_relative_box,
             color: color.to_gfx_color(),
             offset: Point2D::zero(),
@@ -1620,7 +1651,7 @@ impl FragmentDisplayListBuilding for Fragment {
             spread_radius: Au(0),
             border_radius: Au(0),
             clip_mode: BoxShadowClipMode::None,
-        }), DisplayListSection::Content);
+        }));
     }
 }
 
@@ -1927,19 +1958,37 @@ impl BaseFlowDisplayListBuilding for BaseFlow {
 
         let mut color = THREAD_TINT_COLORS[thread_id as usize % THREAD_TINT_COLORS.len()];
         color.a = 1.0;
+        let base = state.create_base_display_item(
+            &stacking_context_relative_bounds.inflate(Au::from_px(2), Au::from_px(2)),
+            &self.clip,
+            node,
+            None,
+            DisplayListSection::Content);
         state.add_display_item(DisplayItem::BorderClass(box BorderDisplayItem {
-            base: BaseDisplayItem::new(&stacking_context_relative_bounds.inflate(Au::from_px(2),
-                                                                                Au::from_px(2)),
-                                       DisplayItemMetadata {
-                                           node: node,
-                                           pointing: None,
-                                       },
-                                       &self.clip),
+            base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(2)),
             color: SideOffsets2D::new_all_same(color),
             style: SideOffsets2D::new_all_same(border_style::T::solid),
             radius: BorderRadii::all_same(Au(0)),
-        }), DisplayListSection::Content);
+        }));
+    }
+}
+
+trait ServoComputedValuesCursorUtility {
+    fn get_cursor(&self, default_cursor: Cursor) -> Option<Cursor>;
+}
+
+impl ServoComputedValuesCursorUtility for ServoComputedValues {
+    /// Gets the cursor to use given the specific ServoComputedValues.  `default_cursor` specifies
+    /// the cursor to use if `cursor` is `auto`. Typically, this will be `PointerCursor`, but for
+    /// text display items it may be `TextCursor` or `VerticalTextCursor`.
+    #[inline]
+    fn get_cursor(&self, default_cursor: Cursor) -> Option<Cursor> {
+        match (self.get_pointing().pointer_events, self.get_pointing().cursor) {
+            (pointer_events::T::none, _) => None,
+            (pointer_events::T::auto, cursor::T::AutoCursor) => Some(default_cursor),
+            (pointer_events::T::auto, cursor::T::SpecifiedCursor(cursor)) => Some(cursor),
+        }
     }
 }
 

--- a/components/layout/sequential.rs
+++ b/components/layout/sequential.rs
@@ -15,7 +15,7 @@ use flow::{self, Flow, ImmutableFlowUtils, InorderFlowTraversal, MutableFlowUtil
 use flow_ref::{self, FlowRef};
 use fragment::FragmentBorderBoxIterator;
 use generated_content::ResolveGeneratedContent;
-use gfx::display_list::{DisplayListEntry, StackingContext};
+use gfx::display_list::{DisplayItem, StackingContext};
 use incremental::{REFLOW, STORE_OVERFLOW};
 use style::dom::TNode;
 use style::traversal::DomTraversalContext;
@@ -82,7 +82,7 @@ pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
 pub fn build_display_list_for_subtree(root: &mut FlowRef,
                                       root_stacking_context: &mut StackingContext,
                                       shared_layout_context: &SharedLayoutContext)
-                                      -> Vec<DisplayListEntry> {
+                                      -> Vec<DisplayItem> {
     let flow_root = flow_ref::deref_mut(root);
     let layout_context = LayoutContext::new(shared_layout_context);
     flow_root.traverse_preorder(&ComputeAbsolutePositions { layout_context: &layout_context });

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -264,7 +264,7 @@ impl WebRenderStackingContextConverter for StackingContext {
                                          _force_positioned_stacking_level: bool) {
         for child in self.children.iter() {
             while let Some(item) = traversal.advance(self) {
-                item.item.convert_to_webrender(builder, frame_builder);
+                item.convert_to_webrender(builder, frame_builder);
             }
 
             if child.context_type == StackingContextType::Real {
@@ -290,7 +290,7 @@ impl WebRenderStackingContextConverter for StackingContext {
         }
 
         while let Some(item) = traversal.advance(self) {
-            item.item.convert_to_webrender(builder, frame_builder);
+            item.convert_to_webrender(builder, frame_builder);
         }
     }
 


### PR DESCRIPTION
We don't really need two levels of abstraction for every element in the
DisplayList. This simplifies the complexity of the data structure in
preparation for providing documentation and properly handling scrolling
roots.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10810)

<!-- Reviewable:end -->
