### PR TITLE
Implement the errorevent argument to Document::createEvent

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -38,6 +38,7 @@ use dom::documentfragment::DocumentFragment;
 use dom::documenttype::DocumentType;
 use dom::domimplementation::DOMImplementation;
 use dom::element::{Element, ElementCreator};
+use dom::errorevent::ErrorEvent;
 use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::eventtarget::EventTarget;
 use dom::focusevent::FocusEvent;
@@ -2188,6 +2189,8 @@ impl DocumentMethods for Document {
                 Ok(Root::upcast(ProgressEvent::new_uninitialized(&self.window))),
             "focusevent" =>
                 Ok(Root::upcast(FocusEvent::new_uninitialized(GlobalRef::Window(&self.window)))),
+            "errorevent" =>
+                Ok(Root::upcast(ErrorEvent::new_uninitialized(GlobalRef::Window(&self.window)))),
             _ =>
                 Err(Error::NotSupported),
         }

--- a/tests/wpt/metadata/dom/nodes/Document-createEvent.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-createEvent.html.ini
@@ -133,30 +133,6 @@
   [createEvent('DRAGEVENT') should be initialized correctly.]
     expected: FAIL
 
-  [ErrorEvent should be an alias for ErrorEvent.]
-    bug: https://github.com/servo/servo/issues/10738
-    expected: FAIL
-
-  [createEvent('ErrorEvent') should be initialized correctly.]
-    bug: https://github.com/servo/servo/issues/10738
-    expected: FAIL
-
-  [errorevent should be an alias for ErrorEvent.]
-    bug: https://github.com/servo/servo/issues/10738
-    expected: FAIL
-
-  [createEvent('errorevent') should be initialized correctly.]
-    bug: https://github.com/servo/servo/issues/10738
-    expected: FAIL
-
-  [ERROREVENT should be an alias for ErrorEvent.]
-    bug: https://github.com/servo/servo/issues/10738
-    expected: FAIL
-
-  [createEvent('ERROREVENT') should be initialized correctly.]
-    bug: https://github.com/servo/servo/issues/10738
-    expected: FAIL
-
   [HashChangeEvent should be an alias for HashChangeEvent.]
     expected: FAIL
 

--- a/tests/wpt/metadata/workers/Worker_dispatchEvent_ErrorEvent.htm.ini
+++ b/tests/wpt/metadata/workers/Worker_dispatchEvent_ErrorEvent.htm.ini
@@ -1,5 +1,0 @@
-[Worker_dispatchEvent_ErrorEvent.htm]
-  type: testharness
-  [document.createEvent('ErrorEvent')]
-    expected: FAIL
-


### PR DESCRIPTION
new_uninitialized function on ErrorEvent has already been in components/script/dom/errorevent.rs

close #10738

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10816)

<!-- Reviewable:end -->
