### PR TITLE
Add style property for flex-basis

### DIFF
--- a/components/layout/incremental.rs
+++ b/components/layout/incremental.rs
@@ -218,7 +218,9 @@ pub fn compute_damage(old: Option<&Arc<ServoComputedValues>>, new: &ServoCompute
         get_inheritedtable.border_collapse,
         get_inheritedtable.border_spacing,
         get_column.column_gap,
-        get_position.flex_direction
+        get_position.flex_direction,
+        get_position.flex_basis,
+        get_position.order
     ]) || add_if_not_equal!(old, new, damage,
                             [ REPAINT, STORE_OVERFLOW, REFLOW_OUT_OF_FLOW ], [
         get_position.top, get_position.left,

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -310,5 +310,7 @@ partial interface CSSStyleDeclaration {
 
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flexDirection;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flex-direction;
+  [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flexBasis;
+  [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flex-basis;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString order;
 };

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -4360,6 +4360,9 @@ pub mod longhands {
         }
     </%helpers:longhand>
 
+    ${helpers.predefined_type("flex-basis", "LengthOrPercentageOrAutoOrContent",
+                              "computed::LengthOrPercentageOrAutoOrContent::Auto")}
+
     ${helpers.single_keyword("flex-wrap", "nowrap wrap wrap-reverse", products="gecko")}
 
     // SVG 1.1 (Second Edition)

--- a/tests/wpt/css-tests/css-flexbox-1_dev/html/flexbox_computedstyle_flex-basis-percent.htm
+++ b/tests/wpt/css-tests/css-flexbox-1_dev/html/flexbox_computedstyle_flex-basis-percent.htm
@@ -5,24 +5,23 @@
 <link href="reference/ref-pass-body.htm" rel="match">
 <meta content="dom" name="flags">
 <style>
-html {
+body {
 	display: flex;
 	width: 100px;
 }
-body {
+div {
 	color: red;
-	margin: 0;
 	flex-basis: 100%;
 }
 .PASS {color: black;}
 </style>
-</head><body><h1>FAIL, enable javascript</h1>
+</head><body><div id="test"><h1>FAIL, enable javascript</h1>
 <script>
-    var body = document.body;
+    var test = document.getElementById("test");
 
     var passed =
-	    getComputedStyle(body).getPropertyValue("flex-basis") ==
+	    getComputedStyle(test).getPropertyValue("flex-basis") ==
 	    "100%";
-    body.textContent = body.className = passed ? "PASS" : "FAIL";
+    test.textContent = test.className = passed ? "PASS" : "FAIL";
 </script>
 </body></html>

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-basis-0.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-basis-0.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_flex-basis-0.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-basis-auto.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-basis-auto.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_flex-basis-auto.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-basis-percent.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-basis-percent.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_flex-basis-percent.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
Add the style property for flex-basis. The property should allow all
values acceptable for `width` or `height` with the addition of `content`.

I also disabled the tests that I expect to pass. I am confused by [flexbox_computedstyle-flex-basis-0percent:20](https://github.com/servo/servo/blob/master/tests/wpt/css-tests/css-flexbox-1_dev/html/flexbox_computedstyle_flex-basis-0percent.htm#L20). Should that be `0%` instead of `0px`?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10817)

<!-- Reviewable:end -->
