### PR TITLE
Adding vscode and intellij settings folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,12 @@ servo-test
 Servo.app
 .config.mk.last
 /glfw
+
+# Editors
+
+# IntelliJ
+.idea
+*.iws
+
+# VSCode
+.vscode


### PR DESCRIPTION
I was going to try VSCode to see if the debugger works well or not with Rust. Since VSCode (as well as other editors) add their own project files to git, I figured they should be accounted for in the .gitignore file.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10825)

<!-- Reviewable:end -->
