### PR TITLE
Add webdriver commands for (Get|Add)Cookie

### DIFF
--- a/components/msg/Cargo.toml
+++ b/components/msg/Cargo.toml
@@ -24,3 +24,4 @@ serde_macros = "0.7"
 url = {version = "1.0.0", features = ["heap_size", "serde"]}
 util = {path = "../util", features = ["servo"]}
 webrender_traits = {git = "https://github.com/servo/webrender_traits"}
+cookie = { version = "0.2.5", features = ["serialize-serde", "serialize-rustc" ] }

--- a/components/msg/lib.rs
+++ b/components/msg/lib.rs
@@ -10,6 +10,7 @@
 #[allow(unused_extern_crates)]
 #[macro_use]
 extern crate bitflags;
+extern crate cookie as cookie_rs;
 extern crate euclid;
 extern crate heapsize;
 extern crate hyper;

--- a/components/msg/webdriver_msg.rs
+++ b/components/msg/webdriver_msg.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use constellation_msg::PipelineId;
+use cookie_rs::Cookie;
 use euclid::rect::Rect;
 use ipc_channel::ipc::IpcSender;
 use rustc_serialize::json::{Json, ToJson};
@@ -10,12 +11,15 @@ use url::Url;
 
 #[derive(Deserialize, Serialize)]
 pub enum WebDriverScriptCommand {
+    AddCookie(Cookie, IpcSender<Result<(), WebDriverCookieError>>),
     ExecuteScript(String, IpcSender<WebDriverJSResult>),
     ExecuteAsyncScript(String, IpcSender<WebDriverJSResult>),
     FindElementCSS(String, IpcSender<Result<Option<String>, ()>>),
     FindElementsCSS(String, IpcSender<Result<Vec<String>, ()>>),
     FocusElement(String, IpcSender<Result<(), ()>>),
     GetActiveElement(IpcSender<Option<String>>),
+    GetCookie(String, IpcSender<Vec<Cookie>>),
+    GetCookies(IpcSender<Vec<Cookie>>),
     GetElementAttribute(String, String, IpcSender<Result<Option<String>, ()>>),
     GetElementCSS(String, String, IpcSender<Result<String, ()>>),
     GetElementRect(String, IpcSender<Result<Rect<f64>, ()>>),
@@ -26,6 +30,12 @@ pub enum WebDriverScriptCommand {
     IsEnabled(String, IpcSender<Result<bool, ()>>),
     IsSelected(String, IpcSender<Result<bool, ()>>),
     GetTitle(IpcSender<String>)
+}
+
+#[derive(Deserialize, Serialize)]
+pub enum WebDriverCookieError {
+    InvalidDomain,
+    UnableToSetCookie
 }
 
 #[derive(Deserialize, Serialize)]

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 bitflags = "0.7"
 brotli = {git = "https://github.com/ende76/brotli-rs"}
 content-blocker = "0.2"
-cookie = {version = "0.2.4", features = ["serialize-rustc"]}
+cookie = { version = "0.2.5", features = ["serialize-serde", "serialize-rustc" ] }
 device = {git = "https://github.com/servo/devices"}
 devtools_traits = {path = "../devtools_traits"}
 flate2 = "0.2.0"

--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -6,6 +6,7 @@
 //! http://tools.ietf.org/html/rfc6265
 
 use cookie::Cookie;
+use cookie_rs;
 use net_traits::CookieSource;
 use std::cmp::Ordering;
 use url::Url;
@@ -113,5 +114,13 @@ impl CookieStorage {
             0 => None,
             _ => Some(result)
         }
+    }
+
+    pub fn cookies_data_for_url<'a>(&'a mut self, url: &'a Url,
+                                    source: CookieSource) -> Box<Iterator<Item=cookie_rs::Cookie> + 'a> {
+        Box::new(self.cookies.iter_mut().filter(move |c| { c.appropriate_for_url(url, source) }).map(|c| {
+            c.touch();
+            c.cookie.clone()
+        }))
     }
 }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -8,6 +8,7 @@ use chrome_loader;
 use connector::{Connector, create_http_connector};
 use content_blocker::BLOCKED_CONTENT_RULES;
 use cookie;
+use cookie_rs;
 use cookie_storage::CookieStorage;
 use data_loader;
 use devtools_traits::DevtoolsControlMsg;
@@ -277,9 +278,16 @@ impl ResourceChannelManager {
                 self.resource_manager.websocket_connect(connect, connect_data, group),
             CoreResourceMsg::SetCookiesForUrl(request, cookie_list, source) =>
                 self.resource_manager.set_cookies_for_url(request, cookie_list, source, group),
+            CoreResourceMsg::SetCookiesForUrlWithData(request, cookie, source) =>
+                self.resource_manager.set_cookies_for_url_with_data(request, cookie, source, group),
             CoreResourceMsg::GetCookiesForUrl(url, consumer, source) => {
                 let mut cookie_jar = group.cookie_jar.write().unwrap();
                 consumer.send(cookie_jar.cookies_for_url(&url, source)).unwrap();
+            }
+            CoreResourceMsg::GetCookiesDataForUrl(url, consumer, source) => {
+                let mut cookie_jar = group.cookie_jar.write().unwrap();
+                let cookies = cookie_jar.cookies_data_for_url(&url, source).collect();
+                consumer.send(cookies).unwrap();
             }
             CoreResourceMsg::Cancel(res_id) => {
                 if let Some(cancel_sender) = self.resource_manager.cancel_load_map.get(&res_id) {
@@ -485,6 +493,14 @@ impl CoreResourceManager {
                     cookie_jar.push(cookie, source);
                 }
             }
+        }
+    }
+
+    fn set_cookies_for_url_with_data(&mut self, request: Url, cookie: cookie_rs::Cookie, source: CookieSource,
+                                     resource_group: &ResourceGroup) {
+        if let Some(cookie) = cookie::Cookie::new_wrapped(cookie, &request, source) {
+            let mut cookie_jar = resource_group.cookie_jar.write().unwrap();
+            cookie_jar.push(cookie, source)
         }
     }
 

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -23,3 +23,4 @@ serde_macros = "0.7"
 url = {version = "1.0.0", features = ["heap_size"]}
 websocket = "0.17"
 uuid = { version = "0.2.2", features = ["v4", "serde"] }
+cookie = { version = "0.2.5", features = ["serialize-serde", "serialize-rustc" ] }

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -12,6 +12,7 @@
 
 #![deny(unsafe_code)]
 
+extern crate cookie as cookie_rs;
 extern crate heapsize;
 extern crate hyper;
 extern crate image as piston_image;
@@ -28,6 +29,7 @@ extern crate util;
 extern crate uuid;
 extern crate websocket;
 
+use cookie_rs::Cookie;
 use filemanager_thread::FileManagerThreadMsg;
 use heapsize::HeapSizeOf;
 use hyper::header::{ContentType, Headers};
@@ -423,8 +425,12 @@ pub enum CoreResourceMsg {
     WebsocketConnect(WebSocketCommunicate, WebSocketConnectData),
     /// Store a set of cookies for a given originating URL
     SetCookiesForUrl(Url, String, CookieSource),
+    /// Store a set of cookies for a given originating URL
+    SetCookiesForUrlWithData(Url, Cookie, CookieSource),
     /// Retrieve the stored cookies for a given URL
     GetCookiesForUrl(Url, IpcSender<Option<String>>, CookieSource),
+    /// Get a cookie by name for a given originating URL
+    GetCookiesDataForUrl(Url, IpcSender<Vec<Cookie>>, CookieSource),
     /// Cancel a network request corresponding to a given `ResourceId`
     Cancel(ResourceId),
     /// Synchronization message solely for knowing the state of the ResourceChannelManager loop

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -22,6 +22,7 @@ app_units = {version = "0.2.3", features = ["plugins"]}
 bitflags = "0.7"
 canvas_traits = {path = "../canvas_traits"}
 caseless = "0.1.0"
+cookie = { version = "0.2.5", features = ["serialize-serde", "serialize-rustc" ] }
 cssparser = {version = "0.5.4", features = ["heap_size", "serde-serialization"]}
 devtools_traits = {path = "../devtools_traits"}
 encoding = "0.2"

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1562,7 +1562,7 @@ impl Document {
     }
 
     /// https://html.spec.whatwg.org/multipage/#cookie-averse-document-object
-    fn is_cookie_averse(&self) -> bool {
+    pub fn is_cookie_averse(&self) -> bool {
         self.browsing_context.is_none() || !url_has_network_scheme(&self.url)
     }
 

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -36,6 +36,7 @@ extern crate app_units;
 extern crate bitflags;
 extern crate canvas_traits;
 extern crate caseless;
+extern crate cookie as cookie_rs;
 extern crate core;
 #[macro_use]
 extern crate cssparser;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1059,6 +1059,8 @@ impl ScriptThread {
     fn handle_webdriver_msg(&self, pipeline_id: PipelineId, msg: WebDriverScriptCommand) {
         let context = self.root_browsing_context();
         match msg {
+            WebDriverScriptCommand::AddCookie(params, reply) =>
+                webdriver_handlers::handle_add_cookie(&context, pipeline_id, params, reply),
             WebDriverScriptCommand::ExecuteScript(script, reply) =>
                 webdriver_handlers::handle_execute_script(&context, pipeline_id, script, reply),
             WebDriverScriptCommand::FindElementCSS(selector, reply) =>
@@ -1069,6 +1071,10 @@ impl ScriptThread {
                 webdriver_handlers::handle_focus_element(&context, pipeline_id, element_id, reply),
             WebDriverScriptCommand::GetActiveElement(reply) =>
                 webdriver_handlers::handle_get_active_element(&context, pipeline_id, reply),
+            WebDriverScriptCommand::GetCookies(reply) =>
+                webdriver_handlers::handle_get_cookies(&context, pipeline_id, reply),
+            WebDriverScriptCommand::GetCookie(name, reply) =>
+                webdriver_handlers::handle_get_cookie(&context, pipeline_id, name, reply),
             WebDriverScriptCommand::GetElementTagName(node_id, reply) =>
                 webdriver_handlers::handle_get_name(&context, pipeline_id, node_id, reply),
             WebDriverScriptCommand::GetElementAttribute(node_id, name, reply) =>

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use cookie_rs::Cookie;
 use dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
@@ -26,12 +27,16 @@ use dom::window::ScriptHelpers;
 use euclid::point::Point2D;
 use euclid::rect::Rect;
 use euclid::size::Size2D;
-use ipc_channel::ipc::IpcSender;
+use ipc_channel::ipc::{self, IpcSender};
 use js::jsapi::JSContext;
 use js::jsapi::{HandleValue, RootedValue};
 use js::jsval::UndefinedValue;
 use msg::constellation_msg::PipelineId;
+use msg::webdriver_msg::WebDriverCookieError;
 use msg::webdriver_msg::{WebDriverFrameId, WebDriverJSError, WebDriverJSResult, WebDriverJSValue};
+use net_traits::CookieSource::{HTTP, NonHTTP};
+use net_traits::CoreResourceMsg::{GetCookiesDataForUrl, SetCookiesForUrlWithData};
+use net_traits::IpcSend;
 use script_thread::get_browsing_context;
 use url::Url;
 
@@ -175,6 +180,66 @@ pub fn handle_get_active_element(context: &BrowsingContext,
                                  reply: IpcSender<Option<String>>) {
     reply.send(context.active_document().GetActiveElement().map(
         |elem| elem.upcast::<Node>().unique_id())).unwrap();
+}
+
+pub fn handle_get_cookies(context: &BrowsingContext,
+                         _pipeline: PipelineId,
+                         reply: IpcSender<Vec<Cookie>>) {
+    let document = context.active_document();
+    let url = document.url();
+    let (sender, receiver) = ipc::channel().unwrap();
+    let _ = document.window().resource_threads().send(
+        GetCookiesDataForUrl(url.clone(), sender, NonHTTP)
+        );
+    let cookies = receiver.recv().unwrap();
+    reply.send(cookies).unwrap();
+}
+
+// https://w3c.github.io/webdriver/webdriver-spec.html#get-cookie
+pub fn handle_get_cookie(context: &BrowsingContext,
+                         _pipeline: PipelineId,
+                         name: String,
+                         reply: IpcSender<Vec<Cookie>>) {
+    let document = context.active_document();
+    let url = document.url();
+    let (sender, receiver) = ipc::channel().unwrap();
+    let _ = document.window().resource_threads().send(
+        GetCookiesDataForUrl(url.clone(), sender, NonHTTP)
+        );
+    let cookies = receiver.recv().unwrap();
+    reply.send(cookies.into_iter().filter(|c| c.name == &*name).collect()).unwrap();
+}
+
+// https://w3c.github.io/webdriver/webdriver-spec.html#add-cookie
+pub fn handle_add_cookie(context: &BrowsingContext,
+                         _pipeline: PipelineId,
+                         cookie: Cookie,
+                         reply: IpcSender<Result<(), WebDriverCookieError>>) {
+    let document = context.active_document();
+    let url = document.url();
+    let method = if cookie.httponly {
+        HTTP
+    } else {
+        NonHTTP
+    };
+    reply.send(match (document.is_cookie_averse(), cookie.domain.clone()) {
+        (true, _) => Err(WebDriverCookieError::InvalidDomain),
+        (false, Some(ref domain)) if url.host_str().map(|x| { x == &**domain }).unwrap_or(false) => {
+            let _ = document.window().resource_threads().send(
+                SetCookiesForUrlWithData(url.clone(), cookie, method)
+                );
+            Ok(())
+        },
+        (false, None) => {
+            let _ = document.window().resource_threads().send(
+                SetCookiesForUrlWithData(url.clone(), cookie, method)
+                );
+            Ok(())
+        },
+        (_, _) => {
+            Err(WebDriverCookieError::UnableToSetCookie)
+        },
+    }).unwrap();
 }
 
 pub fn handle_get_title(context: &BrowsingContext, _pipeline: PipelineId, reply: IpcSender<String>) {

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -379,11 +379,12 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "openssl 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -966,7 +967,7 @@ name = "hyper"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1362,6 +1363,7 @@ name = "msg"
 version = "0.0.1"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1385,7 +1387,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "brotli 0.3.23 (git+https://github.com/ende76/brotli-rs)",
  "content-blocker 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "device 0.0.1 (git+https://github.com/servo/devices)",
  "devtools_traits 0.0.1",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1433,7 +1435,7 @@ name = "net_tests"
 version = "0.0.1"
 dependencies = [
  "content-blocker 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1453,6 +1455,7 @@ dependencies = [
 name = "net_traits"
 version = "0.0.1"
 dependencies = [
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1894,6 +1897,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
  "caseless 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2549,6 +2553,7 @@ dependencies = [
 name = "webdriver_server"
 version = "0.0.1"
 dependencies = [
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -23,3 +23,4 @@ script_traits = {path = "../script_traits"}
 url = {version = "1.0.0", features = ["heap_size"]}
 uuid = { version = "0.2", features = ["v4"] }
 webdriver = "0.9"
+cookie = { version = "0.2.5", features = ["serialize-serde", "serialize-rustc" ] }

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -338,11 +338,12 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "openssl 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -875,7 +876,7 @@ name = "hyper"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1264,6 +1265,7 @@ name = "msg"
 version = "0.0.1"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1287,7 +1289,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "brotli 0.3.23 (git+https://github.com/ende76/brotli-rs)",
  "content-blocker 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "device 0.0.1 (git+https://github.com/servo/devices)",
  "devtools_traits 0.0.1",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1334,6 +1336,7 @@ dependencies = [
 name = "net_traits"
 version = "0.0.1"
 dependencies = [
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1748,6 +1751,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
  "caseless 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2411,6 +2415,7 @@ dependencies = [
 name = "webdriver_server"
 version = "0.0.1"
 dependencies = [
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/unit/net/cookie_http_state.rs
+++ b/tests/unit/net/cookie_http_state.rs
@@ -288,7 +288,6 @@ fn test_attribute0003() {
 }
 
 #[test]
-#[should_panic] // Look at cookie_http_state_utils.py if this test fails
 fn test_attribute0004() {
     let r = run("http://home.example.org:8888/cookie-parser?attribute0004",
                 &["foo=bar; Secure="],
@@ -297,7 +296,6 @@ fn test_attribute0004() {
 }
 
 #[test]
-#[should_panic] // Look at cookie_http_state_utils.py if this test fails
 fn test_attribute0005() {
     let r = run("http://home.example.org:8888/cookie-parser?attribute0005",
                 &["foo=bar; Secure=aaaa"],
@@ -314,7 +312,6 @@ fn test_attribute0006() {
 }
 
 #[test]
-#[should_panic] // Look at cookie_http_state_utils.py if this test fails
 fn test_attribute0007() {
     let r = run("http://home.example.org:8888/cookie-parser?attribute0007",
                 &["foo=bar; Secure =aaaaa"],
@@ -323,7 +320,6 @@ fn test_attribute0007() {
 }
 
 #[test]
-#[should_panic] // Look at cookie_http_state_utils.py if this test fails
 fn test_attribute0008() {
     let r = run("http://home.example.org:8888/cookie-parser?attribute0008",
                 &["foo=bar; Secure= aaaaa"],

--- a/tests/unit/net/cookie_http_state_utils.py
+++ b/tests/unit/net/cookie_http_state_utils.py
@@ -23,10 +23,6 @@ SHOULD_PANIC = "\n#[should_panic] // Look at cookie_http_state_utils.py if this 
 
 # Those tests should PASS. But until fixes land in servo, keep them failing
 FAILING_TESTS = [
-    "attribute0004",  # Waiting for issue 46 of alexcrichton/cookie-rs
-    "attribute0005",  # Waiting for issue 46 of alexcrichton/cookie-rs
-    "attribute0007",  # Waiting for issue 46 of alexcrichton/cookie-rs
-    "attribute0008",  # Waiting for issue 46 of alexcrichton/cookie-rs
     "0003",           # Waiting for a way to clean expired cookies
     "0006",           # Waiting for a way to clean expired cookies
     "mozilla0001",    # Waiting for a way to clean expired cookies


### PR DESCRIPTION
Add the webdriver commands for GetCookie and AddCookie. In addition the basic messages for sending cookie data back and forth from the resource thread needed to be created and the handlers for those messages were created as well.

Do we plan to have some sort of test suite for the webdriver at some point? At this point I primarily test my PRs with basic shell scripts with a lot of `curl` and `jq`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10826)

<!-- Reviewable:end -->
