### PR TITLE
DOMImplementation::createDocument should set content type based on namespace

### DIFF
--- a/tests/wpt/metadata/dom/nodes/DOMImplementation-createDocument.html.ini
+++ b/tests/wpt/metadata/dom/nodes/DOMImplementation-createDocument.html.ini
@@ -1,9 +1,0 @@
-[DOMImplementation-createDocument.html]
-  type: testharness
-  bug: https://github.com/servo/servo/issues/10743
-  [createDocument test 179: metadata for "http://www.w3.org/1999/xhtml","",null]
-    expected: FAIL
-
-  [createDocument test 180: metadata for "http://www.w3.org/2000/svg","",null]
-    expected: FAIL
-

--- a/tests/wpt/web-platform-tests/dom/nodes/DOMImplementation-createDocument.html
+++ b/tests/wpt/web-platform-tests/dom/nodes/DOMImplementation-createDocument.html
@@ -123,7 +123,7 @@ test(function() {
         var doc = document.implementation.createDocument(namespace, qualifiedName, doctype)
         assert_equals(doc.compatMode, "CSS1Compat")
         assert_equals(doc.characterSet, "UTF-8")
-        assert_equals(doc.contentType, namespace == htmlNamespace ? "text/html"
+        assert_equals(doc.contentType, namespace == htmlNamespace ? "application/xhtml+xml"
                                  : namespace == svgNamespace ?  "image/svg+xml"
                                  : "application/xml")
         assert_equals(doc.URL, "about:blank")

--- a/tests/wpt/web-platform-tests/dom/nodes/Document-contentType/contentType/createDocument.html
+++ b/tests/wpt/web-platform-tests/dom/nodes/Document-contentType/contentType/createDocument.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<title>document.implementation.createDocument: document.contentType === 'application/xml'</title>
+<title>document.implementation.createDocument: document.contentType === 'application/xhtml+xml'</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
 test(function() {
   var doc = document.implementation.createDocument("http://www.w3.org/1999/xhtml", "html", null);
-  assert_equals(doc.contentType, "application/xml");
+  assert_equals(doc.contentType, "application/xhtml+xml");
 });
 </script>


### PR DESCRIPTION
Set document content type based on the namespace.
Standard: https://dom.spec.whatwg.org/#dom-domimplementation-createdocument
Fixes #10743. 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10830)

<!-- Reviewable:end -->
