### PR TITLE
Use the document base url when resolving worker URLs

### DIFF
--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -69,7 +69,7 @@ impl Worker {
     // https://html.spec.whatwg.org/multipage/#dom-worker
     pub fn Constructor(global: GlobalRef, script_url: DOMString) -> Fallible<Root<Worker>> {
         // Step 2-4.
-        let worker_url = match global.get_url().join(&script_url) {
+        let worker_url = match global.api_base_url().join(&script_url) {
             Ok(url) => url,
             Err(_) => return Err(Error::Syntax),
         };

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -35241,6 +35241,12 @@
             "path": "dom/nodes/Node-isSameNode.html",
             "url": "/dom/nodes/Node-isSameNode.html"
           }
+        ],
+        "workers/constructors/Worker/use-base-url.html": [
+          {
+            "path": "workers/constructors/Worker/use-base-url.html",
+            "url": "/workers/constructors/Worker/use-base-url.html"
+          }
         ]
       }
     },

--- a/tests/wpt/web-platform-tests/workers/constructors/Worker/sample_worker/worker.js
+++ b/tests/wpt/web-platform-tests/workers/constructors/Worker/sample_worker/worker.js
@@ -1,0 +1,1 @@
+onmessage = function(event) { postMessage(event.data); }

--- a/tests/wpt/web-platform-tests/workers/constructors/Worker/use-base-url.html
+++ b/tests/wpt/web-platform-tests/workers/constructors/Worker/use-base-url.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Use the document base url when resolving worker URLs</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<base href="/workers/constructors/Worker/sample_worker/">
+<script>
+    async_test(function(t) {
+        var worker = new Worker('worker.js');
+        var data = "foo";
+        worker.postMessage(data);
+        worker.onmessage = t.step_func_done(function(event) {
+            assert_equals(event.data, data, "event.data does not match expected data");
+        });
+        worker.onerror = t.unreached_func("received error event");
+    }, "Use the document base url when resolving worker URLs");
+</script>


### PR DESCRIPTION
This fixes #10577.

I'm not sure if the `worker.js` file needed by this test is in the right location. I placed it within `tests/wpt/web-platform-tests/workers/constructors/Worker/sample_worker/` but thought it could also be placed in `tests/wpt/web-platform-tests/resources/`. Let me know if I should change its location. Thanks! :)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10833)

<!-- Reviewable:end -->
