### PR TITLE
Add detail to mozbrowsererror events.

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -48,8 +48,9 @@ use rand::{random, Rng, SeedableRng, StdRng};
 use sandboxing;
 use script_traits::{AnimationState, CompositorEvent, ConstellationControlMsg};
 use script_traits::{DocumentState, LayoutControlMsg};
-use script_traits::{IFrameLoadInfo, IFrameSandboxState, MozBrowserEvent, TimerEventRequest};
+use script_traits::{IFrameLoadInfo, IFrameSandboxState, TimerEventRequest};
 use script_traits::{LayoutMsg as FromLayoutMsg, ScriptMsg as FromScriptMsg, ScriptThreadFactory};
+use script_traits::{MozBrowserEvent, MozBrowserErrorType};
 use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::env;
@@ -1967,7 +1968,7 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
                             None => return warn!("Mozbrowsererror via closed pipeline {:?}.", ancestor_info.0),
                         };
                     }
-                    let event = MozBrowserEvent::Error;
+                    let event = MozBrowserEvent::Error(MozBrowserErrorType::Fatal, None, None);
                     ancestor.trigger_mozbrowser_event(ancestor_info.1, event);
                 }
             }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -5,6 +5,7 @@
 use document_loader::{LoadType, LoadBlocker};
 use dom::attr::{Attr, AttrValue};
 use dom::bindings::cell::DOMRefCell;
+use dom::bindings::codegen::Bindings::BrowserElementBinding::BrowserElementErrorEventDetail;
 use dom::bindings::codegen::Bindings::BrowserElementBinding::BrowserElementIconChangeEventDetail;
 use dom::bindings::codegen::Bindings::BrowserElementBinding::BrowserElementLocationChangeEventDetail;
 use dom::bindings::codegen::Bindings::BrowserElementBinding::BrowserElementSecurityChangeDetail;
@@ -307,11 +308,18 @@ impl MozBrowserEventDetailBuilder for HTMLIFrameElement {
                                             rval: MutableHandleValue) {
         match event {
             MozBrowserEvent::AsyncScroll | MozBrowserEvent::Close | MozBrowserEvent::ContextMenu |
-            MozBrowserEvent::Error | MozBrowserEvent::LoadEnd | MozBrowserEvent::LoadStart |
+            MozBrowserEvent::LoadEnd | MozBrowserEvent::LoadStart |
             MozBrowserEvent::Connected | MozBrowserEvent::OpenWindow | MozBrowserEvent::OpenSearch  |
             MozBrowserEvent::UsernameAndPasswordRequired => {
                 rval.set(NullValue());
             }
+            MozBrowserEvent::Error(error_type, description, report) => {
+                BrowserElementErrorEventDetail {
+                    type_: Some(DOMString::from(error_type.name())),
+                    description: description.map(DOMString::from),
+                    report: report.map(DOMString::from),
+                }.to_jsval(cx, rval);
+            },
             MozBrowserEvent::SecurityChange(https_state) => {
                 BrowserElementSecurityChangeDetail {
                     // https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsersecuritychange

--- a/components/script/dom/webidls/BrowserElement.webidl
+++ b/components/script/dom/webidls/BrowserElement.webidl
@@ -53,6 +53,16 @@ dictionary BrowserElementSecurityChangeDetail {
   boolean mixedContent;
 };
 
+dictionary BrowserElementErrorEventDetail {
+  // https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsererror
+  // just requires a "type" field, but we also provide
+  // an optional human-readable description, and
+  // an optional machine-readable report (e.g. a backtrace for panics)
+  DOMString type;
+  DOMString description;
+  DOMString report;
+};
+
 dictionary BrowserElementLocationChangeEventDetail {
   DOMString uri;
   boolean canGoBack;

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -433,7 +433,7 @@ pub enum MozBrowserEvent {
     /// handling `<menuitem>` element available within the browser `<iframe>`'s content.
     ContextMenu,
     /// Sent when an error occurred while trying to load content within a browser `<iframe>`.
-    Error,
+    Error(MozBrowserErrorType, Option<String>, Option<String>),
     /// Sent when the favicon of a browser `<iframe>` changes.
     IconChange(String, String, String),
     /// Sent when the browser `<iframe>` has reached the server.
@@ -466,7 +466,7 @@ impl MozBrowserEvent {
             MozBrowserEvent::Close => "mozbrowserclose",
             MozBrowserEvent::Connected => "mozbrowserconnected",
             MozBrowserEvent::ContextMenu => "mozbrowsercontextmenu",
-            MozBrowserEvent::Error => "mozbrowsererror",
+            MozBrowserEvent::Error(_, _, _) => "mozbrowsererror",
             MozBrowserEvent::IconChange(_, _, _) => "mozbrowsericonchange",
             MozBrowserEvent::LoadEnd => "mozbrowserloadend",
             MozBrowserEvent::LoadStart => "mozbrowserloadstart",
@@ -477,6 +477,24 @@ impl MozBrowserEvent {
             MozBrowserEvent::TitleChange(_) => "mozbrowsertitlechange",
             MozBrowserEvent::UsernameAndPasswordRequired => "mozbrowserusernameandpasswordrequired",
             MozBrowserEvent::OpenSearch => "mozbrowseropensearch"
+        }
+    }
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsererror
+/// The different types of Browser error events
+#[derive(Deserialize, Serialize)]
+pub enum MozBrowserErrorType {
+    // For the moment, we are just reporting panics, using the "fatal" type.
+    /// A fatal error
+    Fatal,
+}
+
+impl MozBrowserErrorType {
+    /// Get the name of the error type as a `& str`
+    pub fn name(&self) -> &'static str {
+        match *self {
+            MozBrowserErrorType::Fatal => "fatal",
         }
     }
 }


### PR DESCRIPTION
Part of #10334. Once #10824 lands, we can include the panic reason and backtrace in the error report.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10837)

<!-- Reviewable:end -->
