### PR TITLE
Simplify TOML syntax

### DIFF
--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -8,29 +8,14 @@ publish = false
 name = "canvas"
 path = "lib.rs"
 
-[dependencies.azure]
-git = "https://github.com/servo/rust-azure"
-features = ["plugins"]
-
-[dependencies.canvas_traits]
-path = "../canvas_traits"
-
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.gfx_traits]
-path = "../gfx_traits"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.webrender_traits]
-git = "https://github.com/servo/webrender_traits"
-
 [dependencies]
+azure = {git = "https://github.com/servo/rust-azure", features = ["plugins"]}
+canvas_traits = {path = "../canvas_traits"}
+plugins = {path = "../plugins"}
+util = {path = "../util"}
+gfx_traits = {path = "../gfx_traits"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+webrender_traits = {git = "https://github.com/servo/webrender_traits"}
 euclid = {version = "0.6.4", features = ["plugins"]}
 gleam = "0.2.8"
 log = "0.3.5"

--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -8,27 +8,13 @@ publish = false
 name = "canvas_traits"
 path = "lib.rs"
 
-[dependencies.gfx_traits]
-path = "../gfx_traits"
-
-[dependencies.azure]
-git = "https://github.com/servo/rust-azure"
-features = ["plugins"]
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.serde]
-version = "0.7"
-features = [ "nightly" ]
-
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.webrender_traits]
-git = "https://github.com/servo/webrender_traits"
-
 [dependencies]
+gfx_traits = {path = "../gfx_traits"}
+azure = {git = "https://github.com/servo/rust-azure", features = ["plugins"]}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+serde = {version = "0.7", features = [ "nightly" ]}
+plugins = {path = "../plugins"}
+webrender_traits = {git = "https://github.com/servo/webrender_traits"}
 cssparser = {version = "0.5.4", features = ["heap_size", "serde-serialization"]}
 euclid = {version = "0.6.4", features = ["plugins"]}
 heapsize = "0.3.0"

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -8,84 +8,26 @@ publish = false
 name = "compositing"
 path = "lib.rs"
 
-[dependencies.gfx]
-path = "../gfx"
-
-[dependencies.gfx_traits]
-path = "../gfx_traits"
-
-[dependencies.layout_traits]
-path = "../layout_traits"
-
-[dependencies.script_traits]
-path = "../script_traits"
-
-[dependencies.style_traits]
-path = "../style_traits"
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.profile_traits]
-path = "../profile_traits"
-
-[dependencies.net_traits]
-path = "../net_traits"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.devtools_traits]
-path = "../devtools_traits"
-
-[dependencies.canvas_traits]
-path = "../canvas_traits"
-
-[dependencies.canvas]
-path = "../canvas"
-
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.azure]
-git = "https://github.com/servo/rust-azure"
-features = ["plugins"]
-
-[dependencies.layers]
-git = "https://github.com/servo/rust-layers"
-features = ["plugins"]
-
-[dependencies.clipboard]
-git = "https://github.com/aweinstock314/rust-clipboard"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[target.arm-linux-androideabi.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[target.x86_64-apple-darwin.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[target.x86_64-unknown-linux-gnu.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[target.i686-unknown-linux-gnu.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[target.arm-unknown-linux-gnueabihf.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[target.aarch64-unknown-linux-gnu.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[dependencies.webrender_traits]
-git = "https://github.com/servo/webrender_traits"
-
-[dependencies.webrender]
-git = "https://github.com/servo/webrender"
-
 [dependencies]
+gfx = {path = "../gfx"}
+gfx_traits = {path = "../gfx_traits"}
+layout_traits = {path = "../layout_traits"}
+script_traits = {path = "../script_traits"}
+style_traits = {path = "../style_traits"}
+msg = {path = "../msg"}
+profile_traits = {path = "../profile_traits"}
+net_traits = {path = "../net_traits"}
+util = {path = "../util"}
+devtools_traits = {path = "../devtools_traits"}
+canvas_traits = {path = "../canvas_traits"}
+canvas = {path = "../canvas"}
+plugins = {path = "../plugins"}
+azure = {git = "https://github.com/servo/rust-azure", features = ["plugins"]}
+layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
+clipboard = {git = "https://github.com/aweinstock314/rust-clipboard"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+webrender_traits = {git = "https://github.com/servo/webrender_traits"}
+webrender = {git = "https://github.com/servo/webrender"}
 app_units = {version = "0.2.3", features = ["plugins"]}
 euclid = {version = "0.6.4", features = ["plugins"]}
 gleam = "0.2.8"
@@ -98,3 +40,6 @@ serde = "0.7"
 serde_macros = "0.7"
 time = "0.1.17"
 url = {version = "1.0.0", features = ["heap_size"]}
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+gaol = {git = "https://github.com/servo/gaol"}

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -8,22 +8,12 @@ publish = false
 name = "devtools"
 path = "lib.rs"
 
-[dependencies.devtools_traits]
-path = "../devtools_traits"
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
 [dependencies]
+devtools_traits = {path = "../devtools_traits"}
+msg = {path = "../msg"}
+util = {path = "../util"}
+plugins = {path = "../plugins"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
 hyper = { version = "0.9", features = [ "serde-serialization" ] }
 serde = "0.7"
 serde_json = "0.7"

--- a/components/devtools_traits/Cargo.toml
+++ b/components/devtools_traits/Cargo.toml
@@ -8,16 +8,10 @@ publish = false
 name = "devtools_traits"
 path = "lib.rs"
 
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.plugins]
-path = "../plugins"
-
 [dependencies]
+msg = {path = "../msg"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+plugins = {path = "../plugins"}
 heapsize = "0.3.0"
 heapsize_plugin = "0.1.2"
 hyper = { version = "0.9", features = [ "serde-serialization" ] }
@@ -26,4 +20,3 @@ bitflags = "0.3"
 serde = "0.7"
 serde_macros = "0.7"
 url = {version = "1.0.0", features = ["heap_size"]}
-

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -31,100 +31,28 @@ string_cache = {version = "0.2.12", features = ["heap_size"]}
 time = "0.1.12"
 unicode-script = { version = "0.1", features = ["harfbuzz"] }
 url = {version = "1.0.0", features = ["heap_size"]}
+plugins = {path = "../plugins"}
+gfx_traits = {path = "../gfx_traits"}
+net_traits = {path = "../net_traits"}
+util = {path = "../util"}
+msg = {path = "../msg"}
+profile_traits = {path = "../profile_traits"}
+range = {path = "../range"}
+style = {path = "../style"}
+style_traits = {path = "../style_traits"}
+azure = {git = "https://github.com/servo/rust-azure", features = ["plugins"]}
+layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+webrender_traits = {git = "https://github.com/servo/webrender_traits"}
 
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.gfx_traits]
-path = "../gfx_traits"
-
-[dependencies.net_traits]
-path = "../net_traits"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.profile_traits]
-path = "../profile_traits"
-
-[dependencies.range]
-path = "../range"
-
-[dependencies.style]
-path = "../style"
-
-[dependencies.style_traits]
-path = "../style_traits"
-
-[dependencies.azure]
-git = "https://github.com/servo/rust-azure"
-features = ["plugins"]
-
-[dependencies.layers]
-git = "https://github.com/servo/rust-layers"
-features = ["plugins"]
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.webrender_traits]
-git = "https://github.com/servo/webrender_traits"
-
-[target.x86_64-apple-darwin.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.2"
 core-graphics = "0.3"
 core-text = "1.1"
 
-[target.i686-unknown-linux-gnu.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))'.dependencies]
 servo-fontconfig = "0.2"
+freetype = {git = "https://github.com/servo/rust-freetype"}
 
-[target.x86_64-unknown-linux-gnu.dependencies]
-servo-fontconfig = "0.2"
-
-[target.arm-unknown-linux-gnueabihf.dependencies]
-servo-fontconfig = "0.2"
-
-[target.aarch64-unknown-linux-gnu.dependencies]
-servo-fontconfig = "0.2"
-
-[target.arm-linux-androideabi.dependencies]
-servo-fontconfig = "0.2"
-
-[target.x86_64-pc-windows-gnu.dependencies]
-servo-fontconfig = "0.2"
-
-[target.i686-unknown-linux-gnu.dependencies.freetype]
-git = "https://github.com/servo/rust-freetype"
-
-[target.x86_64-unknown-linux-gnu.dependencies.freetype]
-git = "https://github.com/servo/rust-freetype"
-
-[target.arm-unknown-linux-gnueabihf.dependencies.freetype]
-git = "https://github.com/servo/rust-freetype"
-
-[target.aarch64-unknown-linux-gnu.dependencies.freetype]
-git = "https://github.com/servo/rust-freetype"
-
-[target.arm-linux-androideabi.dependencies.freetype]
-git = "https://github.com/servo/rust-freetype"
-
-[target.x86_64-pc-windows-gnu.dependencies.freetype]
-git = "https://github.com/servo/rust-freetype"
-
-[target.x86_64-unknown-linux-gnu.dependencies.simd]
-git = "https://github.com/huonw/simd"
-
-[target.x86_64-apple-darwin.dependencies.simd]
-git = "https://github.com/huonw/simd"
-
-[target.aarch64-unknown-linux-gnu.dependencies.simd]
-git = "https://github.com/huonw/simd"
-
-[target.x86_64-pc-windows-gnu.dependencies.simd]
-git = "https://github.com/huonw/simd"
-
-[target.x86_64-pc-windows-msvc.dependencies.simd]
-git = "https://github.com/huonw/simd"
+[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
+simd = {git = "https://github.com/huonw/simd"}

--- a/components/gfx_traits/Cargo.toml
+++ b/components/gfx_traits/Cargo.toml
@@ -8,21 +8,11 @@ publish = false
 name = "gfx_traits"
 path = "lib.rs"
 
-[dependencies.azure]
-git = "https://github.com/servo/rust-azure"
-features = ["plugins"]
-
-[dependencies.layers]
-git = "https://github.com/servo/rust-layers"
-features = ["plugins"]
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.plugins]
-path = "../plugins"
-
 [dependencies]
+azure = {git = "https://github.com/servo/rust-azure", features = ["plugins"]}
+layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
+msg = {path = "../msg"}
+plugins = {path = "../plugins"}
 euclid = {version = "0.6.5", features = ["plugins"]}
 heapsize = "0.3.0"
 heapsize_plugin = "0.1.2"

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -8,59 +8,24 @@ publish = false
 name = "layout"
 path = "lib.rs"
 
-[dependencies.azure]
-git = "https://github.com/servo/rust-azure"
-features = ["plugins"]
-
-[dependencies.canvas_traits]
-path = "../canvas_traits"
-
-[dependencies.gfx]
-path = "../gfx"
-
-[dependencies.gfx_traits]
-path = "../gfx_traits"
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.script]
-path = "../script"
-
-[dependencies.layout_traits]
-path = "../layout_traits"
-
-[dependencies.range]
-path = "../range"
-
-[dependencies.script_traits]
-path = "../script_traits"
-
-[dependencies.style]
-path = "../style"
-
-[dependencies.style_traits]
-path = "../style_traits"
-
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.net_traits]
-path = "../net_traits"
-
-[dependencies.profile_traits]
-path = "../profile_traits"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.webrender_traits]
-git = "https://github.com/servo/webrender_traits"
-
 [dependencies]
+azure = {git = "https://github.com/servo/rust-azure", features = ["plugins"]}
+canvas_traits = {path = "../canvas_traits"}
+gfx = {path = "../gfx"}
+gfx_traits = {path = "../gfx_traits"}
+msg = {path = "../msg"}
+script = {path = "../script"}
+layout_traits = {path = "../layout_traits"}
+range = {path = "../range"}
+script_traits = {path = "../script_traits"}
+style = {path = "../style"}
+style_traits = {path = "../style_traits"}
+plugins = {path = "../plugins"}
+net_traits = {path = "../net_traits"}
+profile_traits = {path = "../profile_traits"}
+util = {path = "../util"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+webrender_traits = {git = "https://github.com/servo/webrender_traits"}
 app_units = {version = "0.2.3", features = ["plugins"]}
 bitflags = "0.3"
 cssparser = {version = "0.5.4", features = ["heap_size", "serde-serialization"]}

--- a/components/layout_traits/Cargo.toml
+++ b/components/layout_traits/Cargo.toml
@@ -8,31 +8,15 @@ publish = false
 name = "layout_traits"
 path = "lib.rs"
 
-[dependencies.gfx]
-path = "../gfx"
-
-[dependencies.script_traits]
-path = "../script_traits"
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.net_traits]
-path = "../net_traits"
-
-[dependencies.profile_traits]
-path = "../profile_traits"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.webrender_traits]
-git = "https://github.com/servo/webrender_traits"
-
 [dependencies]
+gfx = {path = "../gfx"}
+script_traits = {path = "../script_traits"}
+msg = {path = "../msg"}
+net_traits = {path = "../net_traits"}
+profile_traits = {path = "../profile_traits"}
+util = {path = "../util"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+webrender_traits = {git = "https://github.com/servo/webrender_traits"}
 serde = "0.7"
 serde_macros = "0.7"
 url = {version = "1.0.0", features = ["heap_size"]}

--- a/components/msg/Cargo.toml
+++ b/components/msg/Cargo.toml
@@ -8,23 +8,12 @@ publish = false
 name = "msg"
 path = "lib.rs"
 
-[dependencies.util]
-path = "../util"
-
-[dependencies.layers]
-git = "https://github.com/servo/rust-layers"
-features = ["plugins"]
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.webrender_traits]
-git = "https://github.com/servo/webrender_traits"
-
 [dependencies]
+util = {path = "../util"}
+layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+plugins = {path = "../plugins"}
+webrender_traits = {git = "https://github.com/servo/webrender_traits"}
 bitflags = "0.3"
 cssparser = {version = "0.5.4", features = ["heap_size", "serde-serialization"]}
 euclid = {version = "0.6.4", features = ["plugins"]}

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -8,31 +8,15 @@ publish = false
 name = "net"
 path = "lib.rs"
 
-[dependencies.net_traits]
-path = "../net_traits"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.devtools_traits]
-path = "../devtools_traits"
-
-[dependencies.brotli]
-git = "https://github.com/ende76/brotli-rs"
-
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.webrender_traits]
-git = "https://github.com/servo/webrender_traits"
-
 [dependencies]
+net_traits = {path = "../net_traits"}
+util = {path = "../util"}
+devtools_traits = {path = "../devtools_traits"}
+brotli = {git = "https://github.com/ende76/brotli-rs"}
+plugins = {path = "../plugins"}
+msg = {path = "../msg"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+webrender_traits = {git = "https://github.com/servo/webrender_traits"}
 cookie = { version = "0.2.4", features = [ "serialize-rustc" ] }
 flate2 = "0.2.0"
 hyper = { version = "0.9", features = [ "serde-serialization" ] }

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -8,19 +8,11 @@ publish = false
 name = "net_traits"
 path = "lib.rs"
 
-[dependencies.util]
-path = "../util"
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.plugins]
-path = "../plugins"
-
 [dependencies]
+util = {path = "../util"}
+msg = {path = "../msg"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+plugins = {path = "../plugins"}
 heapsize = "0.3.0"
 heapsize_plugin = "0.1.2"
 hyper = { version = "0.9", features = [ "serde-serialization" ] }

--- a/components/plugins/Cargo.toml
+++ b/components/plugins/Cargo.toml
@@ -9,13 +9,13 @@ name = "plugins"
 path = "lib.rs"
 plugin = true
 
+[dependencies]
+tenacious = "0.2.0"
+
 [dependencies.clippy]
 git = "https://github.com/Manishearth/rust-clippy"
 rev = "9dca15de3e8ea266d3e7e868c0f358ed4fa5f195"
 optional = true
-
-[dependencies]
-tenacious = "0.2.0"
 
 [features]
 default = []

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -8,27 +8,18 @@ publish = false
 name = "profile"
 path = "lib.rs"
 
-[dependencies.profile_traits]
-path = "../profile_traits"
-
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
 [dependencies]
+profile_traits = {path = "../profile_traits"}
+plugins = {path = "../plugins"}
+util = {path = "../util"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
 hbs-pow = "0.2"
 log = "0.3.5"
 libc = "0.2"
-regex = "0.1.55"
 time = "0.1.12"
 
-[target.x86_64-apple-darwin.dependencies.task_info]
-path = "../../support/rust-task_info"
+[target.'cfg(target_os = "macos")'.dependencies]
+task_info = {path = "../../support/rust-task_info"}
 
-[target.i686-apple-darwin.dependencies.task_info]
-path = "../../support/rust-task_info"
+[target.'cfg(target_os = "linux")'.dependencies]
+regex = "0.1.55"

--- a/components/profile_traits/Cargo.toml
+++ b/components/profile_traits/Cargo.toml
@@ -11,21 +11,11 @@ path = "lib.rs"
 [features]
 energy-profiling = ["energymon", "energy-monitor"]
 
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.energymon]
-git = "https://github.com/energymon/energymon-rust.git"
-optional = true
-
-[dependencies.energy-monitor]
-version = "0.2.0"
-optional = true
-
-[dependencies.plugins]
-path = "../plugins"
-
 [dependencies]
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+energymon = {git = "https://github.com/energymon/energymon-rust.git", optional = true}
+energy-monitor = {version = "0.2.0", optional = true}
+plugins = {path = "../plugins"}
 serde = "0.7"
 serde_macros = "0.7"
 time = "0.1.12"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -13,57 +13,23 @@ path = "lib.rs"
 [features]
 debugmozjs = ['js/debugmozjs']
 
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.net_traits]
-path = "../net_traits"
-
-[dependencies.profile_traits]
-path = "../profile_traits"
-
-[dependencies.script_traits]
-path = "../script_traits"
-
-[dependencies.devtools_traits]
-path = "../devtools_traits"
-
-[dependencies.style]
-path = "../style"
-
-[dependencies.canvas]
-path = "../canvas"
-
-[dependencies.canvas_traits]
-path = "../canvas_traits"
-
-[dependencies.js]
-git = "https://github.com/servo/rust-mozjs"
-
-[dependencies.angle]
-git = "https://github.com/emilio/angle"
-branch = "servo"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.xml5ever]
-git = "https://github.com/Ygg01/xml5ever"
-features = ["unstable"]
-
-[dependencies.gfx_traits]
-path = "../gfx_traits"
-
-[dependencies.webrender_traits]
-git = "https://github.com/servo/webrender_traits"
-
 [dependencies]
+plugins = {path = "../plugins"}
+util = {path = "../util"}
+msg = {path = "../msg"}
+net_traits = {path = "../net_traits"}
+profile_traits = {path = "../profile_traits"}
+script_traits = {path = "../script_traits"}
+devtools_traits = {path = "../devtools_traits"}
+style = {path = "../style"}
+canvas = {path = "../canvas"}
+canvas_traits = {path = "../canvas_traits"}
+js = {git = "https://github.com/servo/rust-mozjs"}
+angle = {git = "https://github.com/emilio/angle", branch = "servo"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+xml5ever = {git = "https://github.com/Ygg01/xml5ever", features = ["unstable"]}
+gfx_traits = {path = "../gfx_traits"}
+webrender_traits = {git = "https://github.com/servo/webrender_traits"}
 app_units = {version = "0.2.3", features = ["plugins"]}
 bitflags = "0.3"
 caseless = "0.1.0"

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -8,37 +8,17 @@ publish = false
 name = "script_traits"
 path = "lib.rs"
 
-[dependencies.canvas_traits]
-path = "../canvas_traits"
-
-[dependencies.gfx_traits]
-path = "../gfx_traits"
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.net_traits]
-path = "../net_traits"
-
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.profile_traits]
-path = "../profile_traits"
-
-[dependencies.style_traits]
-path = "../style_traits"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.devtools_traits]
-path = "../devtools_traits"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
 [dependencies]
+canvas_traits = {path = "../canvas_traits"}
+gfx_traits = {path = "../gfx_traits"}
+msg = {path = "../msg"}
+net_traits = {path = "../net_traits"}
+plugins = {path = "../plugins"}
+profile_traits = {path = "../profile_traits"}
+style_traits = {path = "../style_traits"}
+util = {path = "../util"}
+devtools_traits = {path = "../devtools_traits"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
 app_units = {version = "0.2.3", features = ["plugins"]}
 euclid = {version = "0.6.4", features = ["plugins"]}
 heapsize = "0.3.0"

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -18,45 +18,6 @@ test = false
 doc = false
 bench = false
 
-[dev-dependencies]
-image = "0.9"
-
-[dev-dependencies.gfx_tests]
-path = "../../tests/unit/gfx"
-
-[dev-dependencies.layout_tests]
-path = "../../tests/unit/layout"
-
-[dev-dependencies.net_tests]
-path = "../../tests/unit/net"
-
-[dev-dependencies.net_traits_tests]
-path = "../../tests/unit/net_traits"
-
-[dev-dependencies.profile_tests]
-path = "../../tests/unit/profile"
-
-[dev-dependencies.script_tests]
-path = "../../tests/unit/script"
-
-[dev-dependencies.style_tests]
-path = "../../tests/unit/style"
-
-[dev-dependencies.util_tests]
-path = "../../tests/unit/util"
-
-[dev-dependencies.compiletest_helper]
-path = "../../tests/compiletest/helper"
-
-[dev-dependencies.plugin_compiletest]
-path = "../../tests/compiletest/plugin"
-
-[dependencies.webrender_traits]
-git = "https://github.com/servo/webrender_traits"
-
-[dependencies.webrender]
-git = "https://github.com/servo/webrender"
-
 [features]
 default = ["glutin_app", "webdriver"]
 webdriver = ["webdriver_server"]
@@ -69,106 +30,53 @@ codegen-units = 4
 # debug = true
 # lto = false
 
-[dependencies.compositing]
-path = "../compositing"
-
-[dependencies.net]
-path = "../net"
-
-[dependencies.net_traits]
-path = "../net_traits"
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.profile]
-path = "../profile"
-
-[dependencies.profile_traits]
-path = "../profile_traits"
-
-[dependencies.util]
-path = "../util"
-features = ["non-geckolib"]
-
-[dependencies.script]
-path = "../script"
-
-[dependencies.script_traits]
-path = "../script_traits"
-
-[dependencies.layout]
-path = "../layout"
-
-[dependencies.gfx]
-path = "../gfx"
-
-[dependencies.style]
-path = "../style"
-
-[dependencies.canvas]
-path = "../canvas"
-
-[dependencies.canvas_traits]
-path = "../canvas_traits"
-
-[dependencies.devtools]
-path = "../devtools"
-
-[dependencies.webdriver_server]
-path     = "../webdriver_server"
-optional = true
-
-[dependencies.devtools_traits]
-path = "../devtools_traits"
-
-[dependencies.glutin_app]
-path = "../../ports/glutin"
-optional = true
-
-[dependencies.android_glue]
-version = "0.1.3"
-optional = true
-
-[target.arm-linux-androideabi.dependencies.log]
-version = "0.3"
-features = ["release_max_level_info"]
-
-[target.arm-linux-androideabi.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[target.x86_64-apple-darwin.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[target.x86_64-unknown-linux-gnu.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[target.i686-unknown-linux-gnu.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[target.arm-unknown-linux-gnueabihf.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[target.aarch64-unknown-linux-gnu.dependencies.gaol]
-git = "https://github.com/servo/gaol"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.layers]
-git = "https://github.com/servo/rust-layers"
-features = ["plugins"]
-
-[dependencies.gleam]
-version = "0.2"
-
-[dependencies.browserhtml]
-git = "https://github.com/browserhtml/browserhtml"
-branch = "gh-pages"
+[dev-dependencies]
+image = "0.9"
+gfx_tests = {path = "../../tests/unit/gfx"}
+layout_tests = {path = "../../tests/unit/layout"}
+net_tests = {path = "../../tests/unit/net"}
+net_traits_tests = {path = "../../tests/unit/net_traits"}
+profile_tests = {path = "../../tests/unit/profile"}
+script_tests = {path = "../../tests/unit/script"}
+style_tests = {path = "../../tests/unit/style"}
+util_tests = {path = "../../tests/unit/util"}
+compiletest_helper = {path = "../../tests/compiletest/helper"}
+plugin_compiletest = {path = "../../tests/compiletest/plugin"}
 
 [dependencies]
+webrender_traits = {git = "https://github.com/servo/webrender_traits"}
+webrender = {git = "https://github.com/servo/webrender"}
+compositing = {path = "../compositing"}
+net = {path = "../net"}
+net_traits = {path = "../net_traits"}
+msg = {path = "../msg"}
+profile = {path = "../profile"}
+profile_traits = {path = "../profile_traits"}
+util = {path = "../util", features = ["non-geckolib"]}
+script = {path = "../script"}
+script_traits = {path = "../script_traits"}
+layout = {path = "../layout"}
+gfx = {path = "../gfx"}
+style = {path = "../style"}
+canvas = {path = "../canvas"}
+canvas_traits = {path = "../canvas_traits"}
+devtools = {path = "../devtools"}
+webdriver_server = {path = "../webdriver_server", optional = true}
+devtools_traits = {path = "../devtools_traits"}
+glutin_app = {path = "../../ports/glutin", optional = true}
+android_glue = {version = "0.1.3", optional = true}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
+gleam = "0.2"
+browserhtml = {git = "https://github.com/browserhtml/browserhtml", branch = "gh-pages"}
 bitflags = "0.3"
 env_logger = "0.3"
 euclid = {version = "0.6.4", features = ["plugins"]}
 libc = "0.2"
 url = {version = "1.0.0", features = ["heap_size", "serde", "query_encoding"]}
+
+[target.'cfg(target_os = "android")'.dependencies]
+log = {version = "0.3", features = ["release_max_level_info"]}
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+gaol = {git = "https://github.com/servo/gaol"}

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -13,16 +13,10 @@ path = "lib.rs"
 [features]
 gecko = []
 
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.style_traits]
-path = "../style_traits"
-
 [dependencies]
+plugins = {path = "../plugins"}
+util = {path = "../util"}
+style_traits = {path = "../style_traits"}
 app_units = {version = "0.2.3", features = ["plugins"]}
 bitflags = "0.3"
 cssparser = {version = "0.5.5", features = ["heap_size", "serde-serialization"]}

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -8,13 +8,9 @@ publish = false
 name = "style_traits"
 path = "lib.rs"
 
-[dependencies.util]
-path = "../util"
-
-[dependencies.plugins]
-path = "../plugins"
-
 [dependencies]
+util = {path = "../util"}
+plugins = {path = "../plugins"}
 cssparser = {version = "0.5.4", features = ["heap_size", "serde-serialization"]}
 euclid = {version = "0.6.4", features = ["plugins"]}
 heapsize = "0.3.0"

--- a/components/util/Cargo.toml
+++ b/components/util/Cargo.toml
@@ -17,17 +17,10 @@ path = "lib.rs"
 # set this feature.
 non-geckolib = ["js"]
 
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.js]
-git = "https://github.com/servo/rust-mozjs"
-optional = true
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
 [dependencies]
+plugins = {path = "../plugins"}
+js = {git = "https://github.com/servo/rust-mozjs", optional = true}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
 app_units = {version = "0.2.3", features = ["plugins"]}
 bitflags = "0.3"
 deque = "0.3.1"
@@ -47,5 +40,5 @@ smallvec = "0.1"
 string_cache = {version = "0.2.12", features = ["heap_size"]}
 url = {version = "1.0.0", features = ["heap_size", "serde"]}
 
-[target.x86_64-pc-windows-gnu.dependencies]
+[target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2"

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -8,22 +8,12 @@ publish = false
 name = "webdriver_server"
 path = "lib.rs"
 
-[dependencies.compositing]
-path = "../compositing"
-
-[dependencies.msg]
-path = "../msg"
-
-[dependencies.plugins]
-path = "../plugins"
-
-[dependencies.util]
-path = "../util"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
 [dependencies]
+compositing = {path = "../compositing"}
+msg = {path = "../msg"}
+plugins = {path = "../plugins"}
+util = {path = "../util"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
 image = "0.9"
 log = "0.3.5"
 hyper = "0.9"

--- a/ports/cef/Cargo.toml
+++ b/ports/cef/Cargo.toml
@@ -20,63 +20,25 @@ euclid = {version = "0.6.4", features = ["plugins"]}
 gleam = "0.2.8"
 libc = "0.2"
 url = {version = "1.0.0", features = ["heap_size"]}
+servo = {path = "../../components/servo"}
+glutin_app = {path = "../glutin"}
+plugins = {path = "../../components/plugins"}
+compositing = {path = "../../components/compositing"}
+gfx = {path = "../../components/gfx"}
+log = {version = "0.3.5", features = ["release_max_level_info"]}
+script = {path = "../../components/script"}
+script_traits = {path = "../../components/script_traits"}
+net_traits = {path = "../../components/net_traits"}
+msg = {path = "../../components/msg"}
+util = {path = "../../components/util", features = ["non-geckolib"]}
+style = {path = "../../components/style"}
+style_traits = {path = "../../components/style_traits"}
+devtools = {path = "../../components/devtools"}
+azure = {git = "https://github.com/servo/rust-azure", features = ["plugins"]}
+js = {git = "https://github.com/servo/rust-mozjs"}
+layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
 
-[dependencies.servo]
-path = "../../components/servo"
-
-[dependencies.glutin_app]
-path = "../glutin"
-
-[dependencies.plugins]
-path = "../../components/plugins"
-
-[dependencies.compositing]
-path = "../../components/compositing"
-
-[dependencies.gfx]
-path = "../../components/gfx"
-
-[dependencies.log]
-version = "0.3.5"
-features = ["release_max_level_info"]
-
-[dependencies.script]
-path = "../../components/script"
-
-[dependencies.script_traits]
-path = "../../components/script_traits"
-
-[dependencies.net_traits]
-path = "../../components/net_traits"
-
-[dependencies.msg]
-path = "../../components/msg"
-
-[dependencies.util]
-path = "../../components/util"
-features = ["non-geckolib"]
-
-[dependencies.style]
-path = "../../components/style"
-
-[dependencies.style_traits]
-path = "../../components/style_traits"
-
-[dependencies.devtools]
-path = "../../components/devtools"
-
-[dependencies.azure]
-git = "https://github.com/servo/rust-azure"
-features = ["plugins"]
-
-[dependencies.js]
-git = "https://github.com/servo/rust-mozjs"
-
-[dependencies.layers]
-git = "https://github.com/servo/rust-layers"
-features = ["plugins"]
-
-[target.x86_64-apple-darwin.dependencies]
+[target.'cfg(target_os="macos")'.dependencies]
 objc = "0.2"
 cocoa = "0.3"
 core-foundation = "0.2"
@@ -84,8 +46,5 @@ core-graphics = "0.3"
 core-text = "1.1"
 cgl = "0.1"
 
-[target.i686-unknown-linux-gnu.dependencies]
-x11 = "2.3"
-
-[target.x86_64-unknown-linux-gnu.dependencies]
+[target.'cfg(target_os="linux")'.dependencies]
 x11 = "2.3"

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -24,17 +24,7 @@ selectors = {version = "0.5", features = ["heap_size", "unstable"]}
 smallvec = "0.1"
 string_cache = {version = "0.2.12", features = ["heap_size", "unstable"]}
 url = {version = "1.0.0", features = ["heap_size", "query_encoding", "serde"]}
-
-[dependencies.log]
-version = "0.3.5"
-features = ["release_max_level_info"]
-
-[dependencies.plugins]
-path = "../../components/plugins"
-
-[dependencies.util]
-path = "../../components/util"
-
-[dependencies.style]
-path = "../../components/style"
-features = ["gecko"]
+log = {version = "0.3.5", features = ["release_max_level_info"]}
+plugins = {path = "../../components/plugins"}
+util = {path = "../../components/util"}
+style = {path = "../../components/style", features = ["gecko"]}

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -13,40 +13,16 @@ url = {version = "1.0.0", features = ["heap_size"]}
 gleam = "0.2.8"
 euclid = {version = "0.6.4", features = ["plugins"]}
 servo-glutin = "0.4"
+compositing = {path = "../../components/compositing"}
+script_traits = {path = "../../components/script_traits"}
+layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
+msg = {path = "../../components/msg"}
+net_traits = {path = "../../components/net_traits"}
+style_traits = {path = "../../components/style_traits"}
+util = {path = "../../components/util"}
 
-[dependencies.compositing]
-path = "../../components/compositing"
-
-[dependencies.script_traits]
-path = "../../components/script_traits"
-
-[dependencies.layers]
-git = "https://github.com/servo/rust-layers"
-features = ["plugins"]
-
-[dependencies.msg]
-path = "../../components/msg"
-
-[dependencies.net_traits]
-path = "../../components/net_traits"
-
-[dependencies.style_traits]
-path = "../../components/style_traits"
-
-[dependencies.util]
-path = "../../components/util"
-
-[target.i686-unknown-linux-gnu.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 x11 = "2.0.0"
 
-[target.x86_64-unknown-linux-gnu.dependencies]
-x11 = "2.0.0"
-
-[target.arm-unknown-linux-gnueabihf.dependencies]
-x11 = "2.0.0"
-
-[target.aarch64-unknown-linux-gnu.dependencies]
-x11 = "2.0.0"
-
-[target.arm-linux-androideabi.dependencies]
+[target.'cfg(target_os = "android")'.dependencies]
 servo-egl = "0.2"

--- a/ports/gonk/Cargo.toml
+++ b/ports/gonk/Cargo.toml
@@ -5,49 +5,20 @@ authors = ["The Servo Project Developers"]
 
 build = "build.rs"
 
-[dependencies.compositing]
-path = "../../components/compositing"
-
-[dependencies.layers]
-git = "https://github.com/servo/rust-layers"
-features = ["plugins"]
-
-[dependencies.msg]
-path = "../../components/msg"
-
-[dependencies.script]
-path = "../../components/script"
-
-[dependencies.script_traits]
-path = "../../components/script_traits"
-
-[dependencies.style_traits]
-path = "../../components/style_traits"
-
-[dependencies.net_traits]
-path = "../../components/net_traits"
-
-[dependencies.gfx]
-path = "../../components/gfx"
-
-[dependencies.layout]
-path = "../../components/layout"
-
-[dependencies.devtools]
-path = "../../components/devtools"
-
-[dependencies.servo]
-path = "../../components/servo"
-default-features = false
-
-[dependencies.profile]
-path = "../../components/profile"
-
-[dependencies.util]
-path = "../../components/util"
-features = ["non-geckolib"]
-
 [dependencies]
+compositing = {path = "../../components/compositing"}
+layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
+msg = {path = "../../components/msg"}
+script = {path = "../../components/script"}
+script_traits = {path = "../../components/script_traits"}
+style_traits = {path = "../../components/style_traits"}
+net_traits = {path = "../../components/net_traits"}
+gfx = {path = "../../components/gfx"}
+layout = {path = "../../components/layout"}
+devtools = {path = "../../components/devtools"}
+servo = {path = "../../components/servo", default-features = false}
+profile = {path = "../../components/profile"}
+util = {path = "../../components/util", features = ["non-geckolib"]}
 env_logger = "0.3"
 url = {version = "1.0.0", features = ["heap_size"]}
 time = "0.1.17"

--- a/tests/compiletest/helper/Cargo.toml
+++ b/tests/compiletest/helper/Cargo.toml
@@ -8,5 +8,5 @@ name = "compiletest_helper"
 path = "lib.rs"
 doctest = false
 
-[dependencies.compiletest_rs]
-compiletest_rs = "0.11"
+[dependencies]
+compiletest_rs = "0.1.1"

--- a/tests/compiletest/plugin/Cargo.toml
+++ b/tests/compiletest/plugin/Cargo.toml
@@ -8,11 +8,7 @@ name = "plugin_compiletest"
 path = "lib.rs"
 doctest = false
 
-[dependencies.compiletest_helper]
-path = "../helper"
-
-[dependencies.plugins]
-path = "../../../components/plugins"
-
-[dependencies.script]
-path = "../../../components/script"
+[dependencies]
+compiletest_helper = {path = "../helper"}
+plugins = {path = "../../../components/plugins"}
+script = {path = "../../../components/script"}

--- a/tests/unit/gfx/Cargo.toml
+++ b/tests/unit/gfx/Cargo.toml
@@ -8,11 +8,7 @@ name = "gfx_tests"
 path = "lib.rs"
 doctest = false
 
-[dependencies.gfx]
-path = "../../../components/gfx"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
-[dependencies.style]
-path = "../../../components/style"
+[dependencies]
+gfx = {path = "../../../components/gfx"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
+style = {path = "../../../components/style"}

--- a/tests/unit/layout/Cargo.toml
+++ b/tests/unit/layout/Cargo.toml
@@ -8,5 +8,5 @@ name = "layout_tests"
 path = "lib.rs"
 doctest = false
 
-[dependencies.layout]
-path = "../../../components/layout"
+[dependencies]
+layout = {path = "../../../components/layout"}

--- a/tests/unit/net/Cargo.toml
+++ b/tests/unit/net/Cargo.toml
@@ -8,28 +8,14 @@ name = "net_tests"
 path = "lib.rs"
 doctest = false
 
-[dependencies.net]
-path = "../../../components/net"
-
-[dependencies.net_traits]
-path = "../../../components/net_traits"
-
-[dependencies.util]
-path = "../../../components/util"
-
-[dependencies.msg]
-path = "../../../components/msg"
-
-[dependencies.plugins]
-path = "../../../components/plugins"
-
-[dependencies.devtools_traits]
-path = "../../../components/devtools_traits"
-
-[dependencies.ipc-channel]
-git = "https://github.com/servo/ipc-channel"
-
 [dependencies]
+net = {path = "../../../components/net"}
+net_traits = {path = "../../../components/net_traits"}
+util = {path = "../../../components/util"}
+msg = {path = "../../../components/msg"}
+plugins = {path = "../../../components/plugins"}
+devtools_traits = {path = "../../../components/devtools_traits"}
+ipc-channel = {git = "https://github.com/servo/ipc-channel"}
 cookie = "0.2"
 hyper = "0.9"
 url = {version = "1.0.0", features = ["heap_size"]}

--- a/tests/unit/net_traits/Cargo.toml
+++ b/tests/unit/net_traits/Cargo.toml
@@ -8,5 +8,5 @@ name = "net_traits_tests"
 path = "lib.rs"
 doctest = false
 
-[dependencies.net_traits]
-path = "../../../components/net_traits"
+[dependencies]
+net_traits = {path = "../../../components/net_traits"}

--- a/tests/unit/profile/Cargo.toml
+++ b/tests/unit/profile/Cargo.toml
@@ -8,8 +8,6 @@ name = "profile_tests"
 path = "lib.rs"
 doctest = false
 
-[dependencies.profile]
-path = "../../../components/profile"
-
-[dependencies.profile_traits]
-path = "../../../components/profile_traits"
+[dependencies]
+profile = {path = "../../../components/profile"}
+profile_traits = {path = "../../../components/profile_traits"}

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -8,17 +8,9 @@ name = "script_tests"
 path = "lib.rs"
 doctest = false
 
-[dependencies.msg]
-path = "../../../components/msg"
-
-[dependencies.plugins]
-path = "../../../components/plugins"
-
-[dependencies.script]
-path = "../../../components/script"
-
-[dependencies.util]
-path = "../../../components/util"
-
 [dependencies]
+msg = {path = "../../../components/msg"}
+plugins = {path = "../../../components/plugins"}
+script = {path = "../../../components/script"}
+util = {path = "../../../components/util"}
 url = {version = "1.0.0", features = ["heap_size"]}

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -8,22 +8,12 @@ name = "style_tests"
 path = "lib.rs"
 doctest = false
 
-[dependencies.msg]
-path = "../../../components/msg"
-
-[dependencies.plugins]
-path = "../../../components/plugins"
-
-[dependencies.style]
-path = "../../../components/style"
-
-[dependencies.style_traits]
-path = "../../../components/style_traits"
-
-[dependencies.util]
-path = "../../../components/util"
-
 [dependencies]
+msg = {path = "../../../components/msg"}
+plugins = {path = "../../../components/plugins"}
+style = {path = "../../../components/style"}
+style_traits = {path = "../../../components/style_traits"}
+util = {path = "../../../components/util"}
 app_units = {version = "0.2.3", features = ["plugins"]}
 cssparser = {version = "0.5.4", features = ["heap_size"]}
 euclid = {version = "0.6.4", features = ["plugins"]}

--- a/tests/unit/util/Cargo.toml
+++ b/tests/unit/util/Cargo.toml
@@ -8,15 +8,9 @@ name = "util_tests"
 path = "lib.rs"
 doctest = false
 
-[dependencies.util]
-path = "../../../components/util"
-
-
-[dependencies.plugins]
-path = "../../../components/plugins"
-
 [dependencies]
+util = {path = "../../../components/util"}
+plugins = {path = "../../../components/plugins"}
 app_units = {version = "0.2.3", features = ["plugins"]}
 euclid = {version = "0.6.4", features = ["plugins"]}
 libc = "0.2"
-


### PR DESCRIPTION
- Sections like `[dependencies.foo]` can be entries in a `[dependencies]` section with the `{key = value}` syntax.
- Per-target dependencies can be expressed with more general `cfg(…)` conditions instead of exact target triples: https://github.com/rust-lang/cargo/pull/2328

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10857)

<!-- Reviewable:end -->
