### PR TITLE
Don't kill the root pipeline when randomly killing pipelines.

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -1862,6 +1862,8 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
         if let Some((ref mut rng, _)) = self.random_pipeline_closure {
             if let Some(pipeline_id) = rng.choose(&*pipeline_ids) {
                 if let Some(pipeline) = self.pipelines.get(pipeline_id) {
+                    // Don't kill the root pipeline
+                    if pipeline.parent_info.is_none() { return; }
                     // Note that we deliberately do not do any of the tidying up
                     // associated with closing a pipeline. The constellation should cope!
                     info!("Randomly closing pipeline {}.", pipeline_id);


### PR DESCRIPTION
Useful for stress-testing the browser chrome, e.g. testing #10334.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10862)

<!-- Reviewable:end -->
