### PR TITLE
Use SIMD in `gfx` when possible

### DIFF
--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -57,7 +57,7 @@ core-text = "2.0"
 freetype = {git = "https://github.com/servo/rust-freetype"}
 servo-fontconfig = "0.2.1"
 
-[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
+[target.'cfg(any(target_feature = "sse2", target_feature = "neon"))'.dependencies]
 simd = {git = "https://github.com/huonw/simd"}
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// For simd (currently x86_64/aarch64)
+// For SIMD
+#![feature(cfg_target_feature)]
 #![cfg_attr(any(target_os = "linux", target_os = "android", target_os = "windows"), feature(heap_api))]
 
 #![feature(alloc)]
@@ -65,7 +66,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate servo_url;
 #[macro_use] extern crate servo_atoms;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(target_feature = "sse2", target_feature = "neon"))]
 extern crate simd;
 extern crate smallvec;
 extern crate style;

--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -5,7 +5,7 @@
 use app_units::Au;
 use euclid::point::Point2D;
 use range::{self, EachIndex, Range, RangeIndex};
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(target_feature = "sse2", target_feature = "neon"))]
 use simd::u32x4;
 use std::{fmt, mem, u16};
 use std::cmp::{Ordering, PartialOrd};
@@ -74,7 +74,7 @@ pub type GlyphId = u32;
 // TODO: make this more type-safe.
 
 const FLAG_CHAR_IS_SPACE: u32       = 0x40000000;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(target_feature = "sse2", target_feature = "neon"))]
 const FLAG_CHAR_IS_SPACE_SHIFT: u32 = 30;
 const FLAG_IS_SIMPLE_GLYPH: u32     = 0x80000000;
 
@@ -570,7 +570,7 @@ impl<'a> GlyphStore {
     }
 
     #[inline]
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(target_feature = "sse2", target_feature = "neon"))]
     fn advance_for_byte_range_simple_glyphs(&self, range: &Range<ByteIndex>, extra_word_spacing: Au) -> Au {
         let advance_mask = u32x4::splat(GLYPH_ADVANCE_MASK);
         let space_flag_mask = u32x4::splat(FLAG_CHAR_IS_SPACE);
@@ -611,16 +611,16 @@ impl<'a> GlyphStore {
         Au(advance) + leftover_advance + extra_word_spacing * (spaces + leftover_spaces)
     }
 
-    /// When SIMD isn't available (non-x86_x64/aarch64), fallback to the slow path.
+    /// When SIMD isn't available, fallback to the slow path.
     #[inline]
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    #[cfg(not(any(target_feature = "sse2", target_feature = "neon")))]
     fn advance_for_byte_range_simple_glyphs(&self, range: &Range<ByteIndex>, extra_word_spacing: Au) -> Au {
         self.advance_for_byte_range_slow_path(range, extra_word_spacing)
     }
 
     /// Used for SIMD.
     #[inline]
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(target_feature = "sse2", target_feature = "neon"))]
     #[allow(unsafe_code)]
     fn transmute_entry_buffer_to_u32_buffer(&self) -> &[u32] {
         unsafe { mem::transmute(self.entry_buffer.as_slice()) }


### PR DESCRIPTION
Currently SIMD support is enabled by checking the target architecture (x86_64 and AArch64). A better approach would be to check if a SIMD feature is actually available on the platform, by using `cfg_target_feature`. This patch enables SIMD code if possible, which will cause speedup on Android and ARM embedded devices.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10900)

<!-- Reviewable:end -->
