### PR TITLE
Avoid panics when using HTMLAnchorElement attribute setters

### DIFF
--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -81,9 +81,8 @@ impl HTMLAnchorElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#update-href
-    fn update_href(&self) {
-        self.upcast::<Element>().set_string_attribute(&atom!("href"),
-            self.url.borrow().as_ref().unwrap().as_str().into());
+    fn update_href(&self, url: &Url) {
+        self.upcast::<Element>().set_string_attribute(&atom!("href"), DOMString::from(url.as_str()));
     }
 }
 
@@ -168,7 +167,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             // Steps 4-5.
             UrlHelper::SetHash(url, value);
             // Step 6.
-            self.update_href();
+            self.update_href(url);
         }
     }
 
@@ -204,7 +203,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             // Step 4.
             UrlHelper::SetHost(url, value);
             // Step 5.
-            self.update_href();
+            self.update_href(url);
         }
     }
 
@@ -236,7 +235,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             // Step 4.
             UrlHelper::SetHostname(url, value);
             // Step 5.
-            self.update_href();
+            self.update_href(url);
         }
     }
 
@@ -292,7 +291,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             // Step 4.
             UrlHelper::SetPassword(url, value);
             // Step 5.
-            self.update_href();
+            self.update_href(url);
         }
     }
 
@@ -320,7 +319,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             // Step 5.
             UrlHelper::SetPathname(url, value);
             // Step 6.
-            self.update_href();
+            self.update_href(url);
         }
     }
 
@@ -352,7 +351,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             // Step 4.
             UrlHelper::SetPort(url, value);
             // Step 5.
-            self.update_href();
+            self.update_href(url);
         }
     }
 
@@ -379,7 +378,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             // Step 3.
             UrlHelper::SetProtocol(url, value);
             // Step 4.
-            self.update_href();
+            self.update_href(url);
         }
     }
 
@@ -408,7 +407,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             // encoding override (as described in the spec)
             UrlHelper::SetSearch(url, value);
             // Step 6.
-            self.update_href();
+            self.update_href(url);
         }
     }
 
@@ -439,7 +438,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
             // Step 4.
             UrlHelper::SetUsername(url, value);
             // Step 5.
-            self.update_href();
+            self.update_href(url);
         }
     }
 

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -35936,7 +35936,16 @@
   "local_changes": {
     "deleted": [],
     "deleted_reftests": {},
-    "items": {},
+    "items": {
+      "testharness": {
+        "html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_attribute-getter-setter.html": [
+          {
+            "path": "html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_attribute-getter-setter.html",
+            "url": "/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_attribute-getter-setter.html"
+          }
+        ]
+      }
+    },
     "reftest_nodes": {}
   },
   "reftest_nodes": {

--- a/tests/wpt/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_attribute-getter-setter.html
+++ b/tests/wpt/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_attribute-getter-setter.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<meta charset="utf-8">
+<html>
+<head>
+<title>HTMLAnchorElement getters and setters</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<a>anchor</a>
+<script>
+function test_gettersetter(property, oldresult, newval, newresult, oldurl, newurl) {
+  var a = document.querySelector('a');
+  a.href = oldurl;
+  var r1 = a[property];
+  assert_equals(r1, oldresult);
+  a[property] = newval;
+  var r2 = a[property];
+  assert_equals(r2, newresult);
+  var r3 = a.href;
+  assert_equals(r3, newurl);
+}
+
+//Elements for each test: [property, oldresult, newvalue, newresult, oldurl, newurl]
+//                         [0]       [1]        [2]       [3]        [4]     [5]
+tests = [
+  ["hash", "#somehash", "someother", "#someother",
+   "http://google.com/index.html#somehash",
+   "http://google.com/index.html#someother"],
+  ["hash", "#somehash", "#someother", "#someother",
+   "http://google.com/index.html#somehash",
+   "http://google.com/index.html#someother"],
+  ["host", "google.com:1234", "github.com:4444", "github.com:4444",
+   "http://google.com:1234/somedir",
+   "http://github.com:4444/somedir"],
+  ["hostname", "google.com", "github.com", "github.com",
+   "http://google.com:1234/somedir",
+   "http://github.com:1234/somedir"],
+  ["href", "http://google.com:1234/somedir", "http://goo-gle.com:1234/other/x.html", "http://goo-gle.com:1234/other/x.html",
+   "http://google.com:1234/somedir",
+   "http://goo-gle.com:1234/other/x.html"],
+  ["password", "flabada", "blubb", "blubb",
+   "https://anonymous:flabada@developer.mozilla.org/en-US/docs/",
+   "https://anonymous:blubb@developer.mozilla.org/en-US/docs/"],
+  ["pathname", "/somedir/someotherdir/index.html", "/newpath/x.txt", "/newpath/x.txt",
+   "http://google.com:1234/somedir/someotherdir/index.html",
+   "http://google.com:1234/newpath/x.txt"],
+  ["port", "1234", "4444", "4444", "http://google.com:1234/somedir", "http://google.com:4444/somedir"],
+  ["protocol", "http:", "ftp:", "ftp:", "http://google.com/somedir", "ftp://google.com/somedir"],
+  ["protocol", "http:", "ftp", "ftp:", "http://google.com/somedir", "ftp://google.com/somedir"],
+  ["search", "?ho", "?hi", "?hi", "http://google.com/q.php?ho", "http://google.com/q.php?hi"],
+  ["search", "?ho", "hi", "?hi", "http://google.com/q.php?ho", "http://google.com/q.php?hi"],
+  ["search", "?ho", "?hi", "?hi", "http://google.com/?ho", "http://google.com/?hi"],
+  ["search", "?ho", "hi", "?hi", "http://google.com/?ho", "http://google.com/?hi"],
+  ["username", "anonymous", "wellknown", "wellknown",
+   "https://anonymous:pwd@developer.mozilla.org:1234/en-US/",
+   "https://wellknown:pwd@developer.mozilla.org:1234/en-US/"]
+];
+
+for (var i = 0; i < tests.length; i++) {
+    test(function() {
+        test_gettersetter(tests[i][0], tests[i][1], tests[i][2], tests[i][3], tests[i][4], tests[i][5])
+    }, "Getter and setter for attribute of anchor element(" + i + "):" + tests[i][0] );
+}
+</script>
+</head>
+</html>


### PR DESCRIPTION
`expected: OK` still explicitly mentioned in .ini file. Shall I remove it?

Fixes #10877.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10903)

<!-- Reviewable:end -->
