### PR TITLE
Use xi-unicode for line breaking

### DIFF
--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -44,6 +44,7 @@ azure = {git = "https://github.com/servo/rust-azure", features = ["plugins"]}
 layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
 ipc-channel = {git = "https://github.com/servo/ipc-channel"}
 webrender_traits = {git = "https://github.com/servo/webrender_traits"}
+xi-unicode = "0.0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.2"

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -80,6 +80,7 @@ extern crate unicode_script;
 extern crate url;
 extern crate util;
 extern crate webrender_traits;
+extern crate xi_unicode;
 
 pub use paint_context::PaintContext;
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -740,6 +740,7 @@ dependencies = [
  "url 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "webrender_traits 0.1.0 (git+https://github.com/servo/webrender_traits)",
+ "xi-unicode 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2509,6 +2510,11 @@ dependencies = [
  "dylib 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "xi-unicode"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xml-rs"

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
  "url 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "webrender_traits 0.1.0 (git+https://github.com/servo/webrender_traits)",
+ "xi-unicode 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2374,6 +2375,11 @@ dependencies = [
  "dylib 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "xi-unicode"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xml-rs"

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -672,6 +672,7 @@ dependencies = [
  "url 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "webrender_traits 0.1.0 (git+https://github.com/servo/webrender_traits)",
+ "xi-unicode 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2325,6 +2326,11 @@ dependencies = [
  "dylib 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "xi-unicode"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xml-rs"

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/css-flexbox-column-reverse.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/css-flexbox-column-reverse.htm.ini
@@ -1,4 +1,0 @@
-[css-flexbox-column-reverse.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-002.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-002.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-002.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-003.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-003.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-003.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-004.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-004.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-004.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-005.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-005.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-005.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-006.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-006.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-006.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-007.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-007.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-007.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-008.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-008.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-008.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-009.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-009.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-009.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-010.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-010.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-010.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-011.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-011.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-011.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-012.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-012.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-012.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-015.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-015.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-015.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-017.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-017.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-017.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-018.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-018.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-018.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-019.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-019.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-019.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-025.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-025.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-025.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-026.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-026.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-026.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-030.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-030.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-030.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-031.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-031.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-031.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-032.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-032.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-032.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-033.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-033.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-033.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-034.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-034.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-034.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-035.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-035.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-035.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-036.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-036.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-036.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-037.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-037.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-037.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-038.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-038.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-038.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-039.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-039.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-039.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-040.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-040.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-040.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-041.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-041.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-041.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-042.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-042.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-042.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-043.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-043.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-043.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-044.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-044.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-044.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-045.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-045.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-045.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-046.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-046.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-046.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-047.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-047.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-047.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-048.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-048.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-048.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-060.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-060.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-060.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-061.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-061.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-061.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-066.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-066.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-066.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-067.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-067.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-067.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-091.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-091.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-091.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-108.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-108.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-108.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-111.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-baspglwj-111.htm.ini
@@ -1,5 +1,0 @@
-[css3-text-line-break-baspglwj-111.htm]
-  type: testharness
-  [ ]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-001.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-001.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-001.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-002.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-002.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-002.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-003.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-003.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-003.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-004.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-004.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-004.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-005.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-005.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-005.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-006.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-006.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-006.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-007.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-007.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-007.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-008.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-008.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-008.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-009.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-009.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-009.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-010.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-010.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-010.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-011.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-011.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-011.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-012.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-012.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-012.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-013.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-013.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-013.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-014.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-014.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-014.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-015.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-015.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-015.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-016.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-016.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-016.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-017.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-017.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-017.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-018.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-018.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-018.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-019.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-019.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-019.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-020.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-020.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-020.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-021.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-021.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-021.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-022.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-022.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-022.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-023.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-023.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-023.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-024.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-024.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-024.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-025.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-025.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-025.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-027.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-027.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-027.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-028.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-028.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-028.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-029.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-029.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-029.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-030.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-030.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-030.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-032.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-032.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-032.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-034.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-034.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-034.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-036.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-036.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-036.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-038.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-038.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-038.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-039.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-039.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-039.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-040.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-040.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-040.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-042.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-042.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-042.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-043.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-043.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-043.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-044.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-044.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-044.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-045.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-045.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-045.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-046.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-046.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-046.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-047.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-047.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-047.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-048.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-048.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-048.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-049.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-049.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-049.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-051.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-051.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-051.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-052.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-052.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-052.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-054.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-054.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-054.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-056.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-056.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-056.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-057.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-057.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-057.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-058.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-058.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-058.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-060.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-060.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-060.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-230.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-230.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-230.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-232.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-232.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-232.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-234.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-234.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-234.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-236.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-236.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-236.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-238.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-238.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-238.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-239.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-239.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-239.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-240.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-240.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-240.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-242.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-242.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-242.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-243.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-243.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-243.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-244.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-244.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-244.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-245.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-245.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-245.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-246.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-246.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-246.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-247.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-247.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-247.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-248.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-248.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-248.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-249.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-249.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-249.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-251.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-251.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-251.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-252.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-252.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-252.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-254.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-254.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-254.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-256.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-256.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-256.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-257.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-257.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-257.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-258.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-258.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-258.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-302.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-302.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-302.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-303.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-303.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-303.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-304.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-304.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-304.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-306.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-306.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-306.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-308.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-308.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-308.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-309.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-309.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-309.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-310.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-310.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-310.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-311.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-311.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-311.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-312.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-312.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-312.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-313.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-313.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-313.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-314.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-314.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-314.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-315.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-315.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-315.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-316.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-316.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-316.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-317.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-317.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-317.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-319.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-319.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-319.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-320.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-320.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-320.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-322.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-322.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-322.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-324.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-324.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-324.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-325.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-325.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-325.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-326.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-326.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-326.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-404.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-404.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-404.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-406.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-406.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-406.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-408.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-408.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-408.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-409.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-409.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-409.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-410.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-410.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-410.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-411.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-411.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-411.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-412.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-412.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-412.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-413.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-413.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-413.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-414.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-414.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-414.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-415.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-415.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-415.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-416.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-416.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-416.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-417.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-417.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-417.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-419.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-419.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-419.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-420.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-420.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-420.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-422.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-422.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-422.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-424.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-424.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-424.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-425.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-425.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-425.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-426.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-426.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-426.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-001.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-001.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-001.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-002.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-002.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-002.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-003.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-003.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-003.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-007.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-007.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-007.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-008.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-008.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-008.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-010.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-010.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-010.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-011.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-011.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-011.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-012.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-012.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-012.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-021.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-021.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-021.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-022.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-022.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-022.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-038.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-038.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-038.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-040.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-040.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-040.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-043.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-043.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-043.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-045.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-045.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-045.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-047.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-047.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-047.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-061.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-061.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-061.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-063.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-063.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-063.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-064.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-064.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-064.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-101.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-101.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-101.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-104.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-104.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-104.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-105.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-105.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-105.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-106.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-106.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-106.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-107.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-107.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-107.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-108.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-108.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-108.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-109.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-109.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-109.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-114.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-114.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-114.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-115.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-115.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-115.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-116.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-116.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-116.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-117.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-117.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-117.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-126.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-126.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-126.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-127.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-127.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-127.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-143.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-143.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-143.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-144.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-144.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-144.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-146.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-146.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-146.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-147.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-147.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-147.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-148.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-148.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-148.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-149.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-149.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-149.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-150.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-150.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-150.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-151.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-151.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-151.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-152.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-152.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-152.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-153.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-153.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-153.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-167.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-167.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-167.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-168.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-168.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-168.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-169.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-169.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-169.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-170.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-170.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-170.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-171.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-171.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-171.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-206.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-206.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-206.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-207.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-207.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-207.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-208.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-208.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-208.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-209.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-209.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-209.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-210.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-210.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-210.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-211.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-211.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-211.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-214.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-214.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-214.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-215.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-215.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-215.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-216.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-216.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-216.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-221.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-221.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-221.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-222.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-222.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-222.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-223.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-223.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-223.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-224.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-224.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-224.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-225.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-225.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-225.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-226.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-226.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-226.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-250.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-250.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-250.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-251.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-251.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-251.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-252.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-252.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-252.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-253.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-253.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-253.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-254.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-254.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-254.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-255.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-255.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-255.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-256.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-256.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-256.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-257.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-257.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-257.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-258.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-258.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-258.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-259.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-259.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-259.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-260.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-260.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-260.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-261.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-261.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-261.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-262.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-262.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-262.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-263.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-263.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-263.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-264.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-264.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-264.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-265.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-265.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-265.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-266.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-266.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-266.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-267.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-267.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-267.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-268.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-268.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-268.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-269.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-269.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-269.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/word-break-normal-bo-000.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/word-break-normal-bo-000.htm.ini
@@ -1,3 +1,4 @@
 [word-break-normal-bo-000.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/bidi-010b.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/bidi-010b.htm.ini
@@ -1,4 +1,3 @@
 [bidi-010b.htm]
   type: reftest
-  disabled: intermittent failure on reference, starting from PR #10458
-
+  disabled: intermittent failure on reference, starting from PR 10458

--- a/tests/wpt/metadata-css/css21_dev/html4/floats-145.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/floats-145.htm.ini
@@ -1,3 +1,3 @@
 [floats-145.htm]
   type: reftest
-  disabled: depends on unspecified line-height behavior, see PR #10458
+  disabled: depends on unspecified line-height behavior, see PR 10458


### PR DESCRIPTION
This uses the [xi-unicode](https://crates.io/crates/xi-unicode) crate by @raphlinus to detect line-break opportunities, replacing Servo's custom code that only detects ASCII whitespace.  xi-unicode is licensed under the Apache-2.0 license.

See mbrubeck/servo#2 for some discussion on an earlier draft of this code.  This PR implements the "search backward to find trailing whitespace" solution discussed there.

r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10913)

<!-- Reviewable:end -->
