### PR TITLE
Use NEON build flag on ARM and AArch64

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -204,9 +204,13 @@ class MachCommands(CommandBase):
 
         build_start = time()
         env = self.build_env()
+
+        # Ensure Rust uses hard floats and SIMD on ARM devices
+        if target:
+            if target.startswith('arm') or target.startswith('aarch64'):
+                env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C target-feature=+neon"
+
         if android:
-            # Ensure Rust uses hard floats on Android
-            env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C target-feature=+neon"
             # Build OpenSSL for android
             make_cmd = ["make"]
             if jobs is not None:

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -175,21 +175,23 @@ class MachCommands(CommandBase):
             print("Please specify either --dev or --release.")
             sys.exit(1)
 
-        targets = []
+        if target and android:
+            print("Please specify either --target or --android.")
+            sys.exit(1)
+
         if release:
             opts += ["--release"]
-        if target:
-            opts += ["--target", target]
-            targets.append(target)
         if jobs is not None:
             opts += ["-j", jobs]
         if verbose:
             opts += ["-v"]
         if android:
-            opts += ["--target", self.config["android"]["target"]]
-            targets.append("arm-linux-androideabi")
+            target = self.config["android"]["target"]
 
-        self.ensure_bootstrapped(targets=targets)
+        if target:
+            opts += ["--target", target]
+
+        self.ensure_bootstrapped(target=target)
 
         if debug_mozjs or self.config["build"]["debug-mozjs"]:
             features += ["script/debugmozjs"]
@@ -330,8 +332,8 @@ class MachCommands(CommandBase):
                      action='store_true',
                      help='Build in release mode')
     def build_gonk(self, jobs=None, verbose=False, release=False):
-        targets = ["arm-linux-androideabi"]
-        self.ensure_bootstrapped(targets=targets)
+        target = "arm-linux-androideabi"
+        self.ensure_bootstrapped(target=target)
 
         opts = []
         if jobs is not None:

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -411,7 +411,7 @@ class CommandBase(object):
     def android_build_dir(self, dev):
         return path.join(self.get_target_dir(), "arm-linux-androideabi", "debug" if dev else "release")
 
-    def ensure_bootstrapped(self, targets=[]):
+    def ensure_bootstrapped(self, target=None):
         if self.context.bootstrapped:
             return
 
@@ -422,13 +422,14 @@ class CommandBase(object):
         rustc_binary_exists = path.exists(rustc_path)
 
         base_target_path = path.join(rust_root, "rustc", "lib", "rustlib")
-        target_paths = [path.join(base_target_path, t) for t in targets]
-        all_targets_exist = all([path.exists(p) for p in target_paths])
+        target_exists = True
+        if target is not None:
+            target_path = path.join(base_target_path, target)
+            target_exists = path.exists(target_path)
 
-        if (not self.config['tools']['system-rust'] and
-                (not rustc_binary_exists or not all_targets_exist)):
+        if not (self.config['tools']['system-rust'] or (rustc_binary_exists and target_exists)):
             print("looking for rustc at %s" % (rustc_path))
-            Registrar.dispatch("bootstrap-rust", context=self.context, target=targets)
+            Registrar.dispatch("bootstrap-rust", context=self.context, target=filter(None, [target]))
 
         cargo_path = path.join(self.config["tools"]["cargo-root"], "cargo", "bin",
                                "cargo" + BIN_SUFFIX)


### PR DESCRIPTION
The NEON flag is already used when building for Android, this patch enables it on other ARM devices too.

Note that this patch just adds the build flag to the compilation, for actually enabling the SIMD code in Servo, we'll also need #10900 (but it's not a dependency).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10916)

<!-- Reviewable:end -->
