### PR TITLE
Send the panic reason and backtrace in mozbrowsererror.

### DIFF
--- a/components/compositing/constellation.rs
+++ b/components/compositing/constellation.rs
@@ -873,7 +873,7 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
             let window_size = self.pipelines.get(&pipeline_id).and_then(|pipeline| pipeline.size);
 
             // Notify the browser chrome that the pipeline has failed
-            self.trigger_mozbrowsererror(pipeline_id);
+            self.trigger_mozbrowsererror(pipeline_id, reason, backtrace);
 
             self.close_pipeline(pipeline_id, ExitPipelineMode::Force);
 
@@ -1966,8 +1966,7 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
 
     // https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsererror
     // Note that this does not require the pipeline to be an immediate child of the root
-    // TODO: propagate more error information, e.g. a backtrace
-    fn trigger_mozbrowsererror(&self, pipeline_id: PipelineId) {
+    fn trigger_mozbrowsererror(&self, pipeline_id: PipelineId, reason: String, backtrace: String) {
         if !prefs::get_pref("dom.mozbrowser.enabled").as_boolean().unwrap_or(false) { return; }
 
         if let Some(pipeline) = self.pipelines.get(&pipeline_id) {
@@ -1980,7 +1979,7 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
                             None => return warn!("Mozbrowsererror via closed pipeline {:?}.", ancestor_info.0),
                         };
                     }
-                    let event = MozBrowserEvent::Error(MozBrowserErrorType::Fatal, None, None);
+                    let event = MozBrowserEvent::Error(MozBrowserErrorType::Fatal, Some(reason), Some(backtrace));
                     ancestor.trigger_mozbrowser_event(ancestor_info.1, event);
                 }
             }


### PR DESCRIPTION
Closes #10334.  Glues together PRs #10837 and #10824.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10931)

<!-- Reviewable:end -->
