### PR TITLE
style: Add infrastructure to support lazy pseudo-elements

### DIFF
--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -1341,6 +1341,18 @@ impl TextContent {
     }
 }
 
+/// This implementation of `::selectors::Element` is used for implementing lazy
+/// pseudo-elements.
+///
+/// Lazy pseudo-elements in Servo only allows selectors using safe properties,
+/// i.e., local_name, attributes, so they can only be used for **private**
+/// pseudo-elements (like `::-servo-details-content`).
+///
+/// Probably a few more of this functions can be implemented (like `has_class`,
+/// `each_class`, etc), but they have no use right now.
+///
+/// Note that the element implementation is needed only for selector matching,
+/// not for inheritance (styles are inherited appropiately).
 impl <'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
     type Impl = ServoSelectorImpl;
 

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -1385,7 +1385,7 @@ impl <'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
     }
 
     fn is_html_element_in_html_document(&self) -> bool {
-        warn!("ServoThreadSafeLayoutElement::is_html_element_in_html_document called");
+        debug!("ServoThreadSafeLayoutElement::is_html_element_in_html_document called");
         true
     }
 
@@ -1406,12 +1406,12 @@ impl <'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
     }
 
     fn get_id(&self) -> Option<Atom> {
-        warn!("ServoThreadSafeLayoutElement::get_id called");
+        debug!("ServoThreadSafeLayoutElement::get_id called");
         None
     }
 
     fn has_class(&self, _name: &Atom) -> bool {
-        warn!("ServoThreadSafeLayoutElement::has_class called");
+        debug!("ServoThreadSafeLayoutElement::has_class called");
         false
     }
 

--- a/components/style/README.md
+++ b/components/style/README.md
@@ -2,3 +2,5 @@ servo-style
 ===========
 
 Style system for Servo, using [rust-cssparser](https://github.com/mozilla-servo/rust-cssparser) for parsing.
+
+ * [Documentation](https://github.com/servo/servo/blob/master/docs/components/style.md).

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -195,7 +195,12 @@ pub trait TDocument : Sized + Copy + Clone {
     fn drain_modified_elements(&self) -> Vec<(Self::ConcreteElement, ElementSnapshot)>;
 }
 
-pub trait TElement : Sized + Copy + Clone + ElementExt {
+pub trait PresentationalHintsSynthetizer {
+    fn synthesize_presentational_hints_for_legacy_attributes<V>(&self, hints: &mut V)
+        where V: VecLike<DeclarationBlock<Vec<PropertyDeclaration>>>;
+}
+
+pub trait TElement : Sized + Copy + Clone + ElementExt + PresentationalHintsSynthetizer {
     type ConcreteNode: TNode<ConcreteElement = Self, ConcreteDocument = Self::ConcreteDocument>;
     type ConcreteDocument: TDocument<ConcreteNode = Self::ConcreteNode, ConcreteElement = Self>;
 
@@ -204,9 +209,6 @@ pub trait TElement : Sized + Copy + Clone + ElementExt {
     fn style_attribute(&self) -> &Option<PropertyDeclarationBlock>;
 
     fn get_state(&self) -> ElementState;
-
-    fn synthesize_presentational_hints_for_legacy_attributes<V>(&self, &mut V)
-        where V: VecLike<DeclarationBlock<Vec<PropertyDeclaration>>>;
 
     fn get_attr<'a>(&'a self, namespace: &Namespace, attr: &Atom) -> Option<&'a str>;
     fn get_attrs<'a>(&'a self, attr: &Atom) -> Vec<&'a str>;

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -540,7 +540,7 @@ pub trait ElementMatchMethods : TElement
             stylist.push_applicable_declarations(self,
                                                  parent_bf,
                                                  None,
-                                                 Some(pseudo.clone()),
+                                                 Some(&pseudo.clone()),
                                                  applicable_declarations.per_pseudo.entry(pseudo).or_insert(vec![]));
         });
 

--- a/components/style/media_queries.rs
+++ b/components/style/media_queries.rs
@@ -117,6 +117,13 @@ impl Device {
             viewport_size: viewport_size,
         }
     }
+
+    #[inline]
+    pub fn au_viewport_size(&self) -> Size2D<Au> {
+        Size2D::new(Au::from_f32_px(self.viewport_size.width.get()),
+                    Au::from_f32_px(self.viewport_size.height.get()))
+    }
+
 }
 
 impl Expression {
@@ -203,8 +210,7 @@ pub fn parse_media_query_list(input: &mut Parser) -> MediaQueryList {
 
 impl MediaQueryList {
     pub fn evaluate(&self, device: &Device) -> bool {
-        let viewport_size = Size2D::new(Au::from_f32_px(device.viewport_size.width.get()),
-                                        Au::from_f32_px(device.viewport_size.height.get()));
+        let viewport_size = device.au_viewport_size();
 
         // Check if any queries match (OR condition)
         self.media_queries.iter().any(|mq| {

--- a/components/style/selector_impl.rs
+++ b/components/style/selector_impl.rs
@@ -104,19 +104,11 @@ pub enum PseudoElement {
 impl PseudoElement {
     #[inline]
     pub fn cascade_type(&self) -> PseudoElementCascadeType {
-        // TODO: Make PseudoElementCascadeType::Lazy work for Servo.
-        //
-        // This can't be done right now since it would require
-        // ServoThreadSafeLayoutElement to implement ::selectors::Element,
-        // and it might not be thread-safe.
-        //
-        // After that, we'd probably want ::selection and
-        // ::-servo-details-summary to be lazy.
         match *self {
             PseudoElement::Before |
             PseudoElement::After |
-            PseudoElement::Selection |
-            PseudoElement::DetailsSummary => PseudoElementCascadeType::Eager,
+            PseudoElement::Selection => PseudoElementCascadeType::Eager,
+            PseudoElement::DetailsSummary => PseudoElementCascadeType::Lazy,
             PseudoElement::DetailsContent => PseudoElementCascadeType::Precomputed,
         }
     }

--- a/components/style/selector_impl.rs
+++ b/components/style/selector_impl.rs
@@ -18,6 +18,10 @@ use stylesheets::Stylesheet;
 /// computed when needed, and not before. They're useful for general
 /// pseudo-elements that are not very common.
 ///
+/// Note that in Servo lazy pseudo-elements are restricted to a subset of
+/// selectors, so you can't use it for public pseudo-elements. This is not the
+/// case with Gecko though.
+///
 /// Precomputed ones skip the cascade process entirely, mostly as an
 /// optimisation since they are private pseudo-elements (like
 /// `::-servo-details-content`).
@@ -26,8 +30,7 @@ use stylesheets::Stylesheet;
 /// (rules of the form `*|*`), and applying them to the parent style.
 ///
 /// If you're implementing a public selector that the end-user might customize,
-/// then you probably need doing the whole cascading process and return true in
-/// this function for that pseudo (either as Eager or Lazy).
+/// then you probably need to make it eager.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PseudoElementCascadeType {
     Eager,

--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -5,7 +5,7 @@
 // For lazy_static
 #![allow(unsafe_code)]
 
-use dom::TElement;
+use dom::PresentationalHintsSynthetizer;
 use element_state::*;
 use error_reporting::{ParseErrorReporter, StdoutErrorReporter};
 use media_queries::{Device, MediaType};
@@ -281,7 +281,8 @@ impl<Impl: SelectorImplExt> Stylist<Impl> {
                                                   pseudo: &Impl::PseudoElement,
                                                   parent: &Arc<Impl::ComputedValues>)
                                                   -> Option<Arc<Impl::ComputedValues>>
-                                                  where E: Element<Impl=Impl> + TElement {
+                                                  where E: Element<Impl=Impl> +
+                                                        PresentationalHintsSynthetizer {
         debug_assert!(Impl::pseudo_element_cascade_type(pseudo).is_lazy());
         if self.pseudos_map.get(pseudo).is_none() {
             return None;
@@ -358,7 +359,7 @@ impl<Impl: SelectorImplExt> Stylist<Impl> {
                                         pseudo_element: Option<&Impl::PseudoElement>,
                                         applicable_declarations: &mut V)
                                         -> bool
-                                        where E: Element<Impl=Impl> + TElement,
+                                        where E: Element<Impl=Impl> + PresentationalHintsSynthetizer,
                                               V: VecLike<DeclarationBlock> {
         assert!(!self.is_device_dirty);
         assert!(style_attribute.is_none() || pseudo_element.is_none(),

--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -8,7 +8,6 @@
 use dom::TElement;
 use element_state::*;
 use error_reporting::{ParseErrorReporter, StdoutErrorReporter};
-use euclid::Size2D;
 use media_queries::{Device, MediaType};
 use properties::{self, ComputedValues, PropertyDeclaration, PropertyDeclarationBlock};
 use restyle_hints::{ElementSnapshot, RestyleHint, DependencySet};
@@ -127,9 +126,9 @@ pub struct Stylist<Impl: SelectorImplExt> {
     /// Applicable declarations for a given non-eagerly cascaded pseudo-element.
     /// These are eagerly computed once, and then used to resolve the new
     /// computed values on the fly on layout.
-    non_eagerly_cascaded_pseudo_element_decls: HashMap<Impl::PseudoElement,
-                                                       Vec<DeclarationBlock>,
-                                                       BuildHasherDefault<::fnv::FnvHasher>>,
+    precomputed_pseudo_element_decls: HashMap<Impl::PseudoElement,
+                                              Vec<DeclarationBlock>,
+                                              BuildHasherDefault<::fnv::FnvHasher>>,
 
     rules_source_order: usize,
 
@@ -148,7 +147,7 @@ impl<Impl: SelectorImplExt> Stylist<Impl> {
 
             element_map: PerPseudoElementSelectorMap::new(),
             pseudos_map: HashMap::with_hasher(Default::default()),
-            non_eagerly_cascaded_pseudo_element_decls: HashMap::with_hasher(Default::default()),
+            precomputed_pseudo_element_decls: HashMap::with_hasher(Default::default()),
             rules_source_order: 0,
             state_deps: DependencySet::new(),
         };
@@ -175,7 +174,7 @@ impl<Impl: SelectorImplExt> Stylist<Impl> {
             self.pseudos_map.insert(pseudo, PerPseudoElementSelectorMap::new());
         });
 
-        self.non_eagerly_cascaded_pseudo_element_decls = HashMap::with_hasher(Default::default());
+        self.precomputed_pseudo_element_decls = HashMap::with_hasher(Default::default());
         self.rules_source_order = 0;
         self.state_deps.clear();
 
@@ -242,37 +241,68 @@ impl<Impl: SelectorImplExt> Stylist<Impl> {
 
         self.rules_source_order = rules_source_order;
 
-        Impl::each_non_eagerly_cascaded_pseudo_element(|pseudo| {
-            // TODO: Don't precompute this, compute it on demand instead and
-            // cache it.
-            //
-            // This is actually kind of hard, because the stylist is shared
-            // between threads.
+        Impl::each_precomputed_pseudo_element(|pseudo| {
+            // TODO: Consider not doing this and just getting the rules on the
+            // fly. It should be a bit slower, but we'd take rid of the
+            // extra field, and avoid this precomputation entirely.
             if let Some(map) = self.pseudos_map.remove(&pseudo) {
                 let mut declarations = vec![];
 
                 map.user_agent.normal.get_universal_rules(&mut declarations);
                 map.user_agent.important.get_universal_rules(&mut declarations);
 
-                self.non_eagerly_cascaded_pseudo_element_decls.insert(pseudo, declarations);
+                self.precomputed_pseudo_element_decls.insert(pseudo, declarations);
             }
         })
     }
 
-    pub fn computed_values_for_pseudo(&self,
-                                      pseudo: &Impl::PseudoElement,
-                                      parent: Option<&Arc<Impl::ComputedValues>>) -> Option<Arc<Impl::ComputedValues>> {
-        debug_assert!(!Impl::is_eagerly_cascaded_pseudo_element(pseudo));
-        if let Some(declarations) = self.non_eagerly_cascaded_pseudo_element_decls.get(pseudo) {
+    /// Computes the style for a given "precomputed" pseudo-element, taking the
+    /// universal rules and applying them.
+    pub fn precomputed_values_for_pseudo(&self,
+                                         pseudo: &Impl::PseudoElement,
+                                         parent: Option<&Arc<Impl::ComputedValues>>)
+                                         -> Option<Arc<Impl::ComputedValues>> {
+        debug_assert!(Impl::pseudo_element_cascade_type(pseudo).is_precomputed());
+        if let Some(declarations) = self.precomputed_pseudo_element_decls.get(pseudo) {
+
             let (computed, _) =
-                properties::cascade::<Impl::ComputedValues>(Size2D::zero(),
-                                                            &declarations, false,
-                                                            parent.map(|p| &**p), None,
-                                                            box StdoutErrorReporter);
+                properties::cascade(self.device.au_viewport_size(),
+                                    &declarations, false,
+                                    parent.map(|p| &**p), None,
+                                    box StdoutErrorReporter);
             Some(Arc::new(computed))
         } else {
             parent.map(|p| p.clone())
         }
+    }
+
+    pub fn lazily_compute_pseudo_element_style<E>(&self,
+                                                  element: &E,
+                                                  pseudo: &Impl::PseudoElement,
+                                                  parent: &Arc<Impl::ComputedValues>)
+                                                  -> Option<Arc<Impl::ComputedValues>>
+                                                  where E: Element<Impl=Impl> + TElement {
+        debug_assert!(Impl::pseudo_element_cascade_type(pseudo).is_lazy());
+        if self.pseudos_map.get(pseudo).is_none() {
+            return None;
+        }
+
+        let mut declarations = vec![];
+
+        // NB: This being cached could be worth it, maybe allow an optional
+        // ApplicableDeclarationsCache?.
+        self.push_applicable_declarations(element,
+                                          None,
+                                          None,
+                                          Some(pseudo),
+                                          &mut declarations);
+
+        let (computed, _) =
+            properties::cascade(self.device.au_viewport_size(),
+                                &declarations, false,
+                                Some(&**parent), None,
+                                box StdoutErrorReporter);
+        Some(Arc::new(computed))
     }
 
     pub fn compute_restyle_hint<E>(&self, element: &E,
@@ -325,7 +355,7 @@ impl<Impl: SelectorImplExt> Stylist<Impl> {
                                         element: &E,
                                         parent_bf: Option<&BloomFilter>,
                                         style_attribute: Option<&PropertyDeclarationBlock>,
-                                        pseudo_element: Option<Impl::PseudoElement>,
+                                        pseudo_element: Option<&Impl::PseudoElement>,
                                         applicable_declarations: &mut V)
                                         -> bool
                                         where E: Element<Impl=Impl> + TElement,
@@ -334,7 +364,7 @@ impl<Impl: SelectorImplExt> Stylist<Impl> {
         assert!(style_attribute.is_none() || pseudo_element.is_none(),
                 "Style attributes do not apply to pseudo-elements");
         debug_assert!(pseudo_element.is_none() ||
-                      Impl::is_eagerly_cascaded_pseudo_element(pseudo_element.as_ref().unwrap()));
+                      !Impl::pseudo_element_cascade_type(pseudo_element.as_ref().unwrap()).is_precomputed());
 
         let map = match pseudo_element {
             Some(ref pseudo) => self.pseudos_map.get(pseudo).unwrap(),

--- a/docs/components/style.md
+++ b/docs/components/style.md
@@ -1,0 +1,158 @@
+# Servo's style system overview
+
+This needs to be filled more extensively. Meanwhile, you can also take a look to
+the [style doc comments][style-doc], or the [Styling
+Overview][wiki-styling-overview] in the wiki, which is a conversation between
+Boris Zbarsky and Patrick Walton about how style sharing works.
+
+<a name="selector-impl"></a>
+## Selector Implementation
+
+The style system is generic over quite a few things, in order to be shareable
+with Servo's layout system, and with [Stylo][stylo], an ambitious project that
+aims to integrate Servo's style system into Gecko.
+
+The main generic trait is [selectors' SelectorImpl][selector-impl], that has all
+the logic related to parsing pseudo-elements and other pseudo-classes appart
+from [tree-structural ones][tree-structural-pseudo-classes].
+
+Servo [extends][selector-impl-ext] that trait in order to allow a few more
+things to be shared between Stylo and Servo.
+
+The main Servo implementation (the one that is used in regular builds) is
+[ServoSelectorImpl][servo-selector-impl].
+
+<a name="dom-glue"></a>
+## DOM glue
+
+In order to keep DOM, layout and style in different modules, there are a few
+traits involved.
+
+Style's [`dom` traits][style-dom-traits] (`TDocument`, `TElement`, `TNode`,
+`TRestyleDamage`) are the main "wall" between layout and style.
+
+Layout's [`wrapper`][layout-wrapper] module is the one that makes sure that
+layout traits have the required traits implemented.
+
+<a name="stylist"></a>
+## The Stylist
+
+The [`stylist`][stylist] structure is the one that holds all the selectors and
+device characteristics for a given document.
+
+The stylesheets' CSS rules are converted into [`Rule`][selectors-rules]s, and
+introduced in a [`SelectorMap`][selectors-selectormap] depending on the
+pseudo-element (see [`PerPseudoElementSelectorMap`][per-pseudo-selectormap]),
+stylesheet origin (see [`PerOriginSelectorMap`][per-origin-selectormap]), and
+priority (see the `normal` and `important` fields in
+[`PerOriginSelectorMap`][per-origin-selectormap]).
+
+This structure is effectively created once per [pipeline][docs-pipeline], in the
+LayoutThread corresponding to that pipeline.
+
+<a name="properties"></a>
+## The `properties` module
+
+The [properties module][properties-module] is a mako template where all the
+properties, computed value computation and cascading logic resides.
+
+It's a complex template with a **lot** of code, but the main function it exposes
+is the [`cascade` function][properties-cascade-fn], which performs all the
+computation.
+
+<a name="pseudo-elements"></a>
+## Pseudo-Element resolution
+
+Pseudo-elements are a tricky section of the style system. Not all
+pseudo-elements are very common, and so some of them might want to skip the
+cascade.
+
+Servo has, as of right now, five [pseudo-elements][servo-pseudo-elements]:
+
+ * [`::before`][mdn-pseudo-before] and [`::after`][mdn-pseudo-after].
+ * [`::selection`][mdn-pseudo-selection]: This one is only partially
+     implemented, and only works for text inputs and textareas as of right now.
+ * `::-servo-details-summary`: This pseudo-element represents the `<summary>` of
+     a `<details>` element.
+ * `::-servo-details-content`: This pseudo-element represents the contents of
+     a `<details>` element.
+
+Both `::-servo-details-*` pseudo-elements are private (i.e. they are only parsed
+from User-Agent stylesheets).
+
+Servo has three different ways of cascading a pseudo-element, which are defined
+in [`PseudoElementCascadeType`][pseudo-cascade-type]:
+
+<a name="pe-cascading-eager"></a>
+### "Eager" cascading
+
+This mode computes the computed values of a given node's pseudo-element over the
+first pass of the style system.
+
+This is used for all public pseudo-elements, and is, as of right now, **the only
+way a public pseudo-element should be cascaded** (the explanation for this is
+below).
+
+<a name="pe-cascading-precomputed"></a>
+### "Precomputed" cascading
+
+Or, better said, no cascading at all. A pseudo-element marked as such is not
+cascaded.
+
+The only rules that apply to the styles of that pseudo-element are universal
+rules (rules with a `*|*` selector), and they are applied directly over the
+element's style if present.
+
+`::-servo-details-content` is an example of this kind of pseudo-element, all the
+rules in the UA stylesheet with the selector `*|*::-servo-details-content` (and
+only those) are evaluated over the element's style (except the `display` value,
+that is overwritten by layout).
+
+This should be the **preferred type for private pseudo-elements** (although some
+of them might need selectors, see below).
+
+<a name="pe-cascading-lazy"></a>
+### "Lazy" cascading
+
+Lazy cascading allows to compute pseudo-element styles lazily, that is, just
+when needed.
+
+Currently (for Servo, not that much for stylo), **selectors supported for this
+kind of pseudo-elements are only a subset of selectors that can be computed
+in a thread-safe way in layout**.
+
+This subset includes tags and attribute selectors, enough for making
+`::-servo-details-summary` a lazy pseudo-element (that only needs to know
+if it is in an `open` details element or not).
+
+Since no other selectors would apply to it, **this is (at least for now) not an
+acceptable type for public pseudo-elements, but should be considered for private
+pseudo-elements**.
+
+#### Not found what you were looking for?
+
+Feel free to ping @SimonSapin, @mbrubeck or @emilio on irc, and please mention
+that you didn't find it here so it can be added :)
+
+[style-doc]: http://doc.servo.org/style/index.html
+[wiki-styling-overview]: https://github.com/servo/servo/wiki/Styling-overview
+[stylo]: https://public.etherpad-mozilla.org/p/stylo
+[selector-impl]: http://doc.servo.org/selectors/parser/trait.SelectorImpl.html
+[selector-impl-ext]: http://doc.servo.org/style/selector_impl/trait.SelectorImplExt.html
+[servo-selector-impl]: http://doc.servo.org/style/selector_impl/struct.ServoSelectorImpl.html
+[tree-structural-pseudo-classes]: https://www.w3.org/TR/selectors4/#structural-pseudos
+[style-dom-traits]: http://doc.servo.org/style/dom/index.html
+[layout-wrapper]: http://doc.servo.org/layout/wrapper/index.html
+[pseudo-cascade-type]: http://doc.servo.org/style/selector_impl/enum.PseudoElementCascadeType.html
+[servo-pseudo-elements]: http://doc.servo.org/style/selector_impl/enum.PseudoElement.html
+[mdn-pseudo-before]: https://developer.mozilla.org/en/docs/Web/CSS/::before
+[mdn-pseudo-after]: https://developer.mozilla.org/en/docs/Web/CSS/::after
+[mdn-pseudo-selection]: https://developer.mozilla.org/en/docs/Web/CSS/::selection
+[stylist]: http://doc.servo.org/style/selector_matching/struct.Stylist.html
+[selectors-selectormap]: http://doc.servo.org/selectors/matching/struct.SelectorMap.html
+[selectors-rule]: http://doc.servo.org/selectors/matching/struct.Rule.html
+[per-pseudo-selectormap]: http://doc.servo.org/style/selector_matching/struct.PerPseudoElementSelectorMap.html
+[per-origin-selectormap]: http://doc.servo.org/style/selector_matching/struct.PerOriginSelectorMap.html
+[docs-pipeline]: https://github.com/servo/servo/blob/master/docs/glossary.md#pipeline
+[properties-module]: http://doc.servo.org/style/properties/index.html
+[properties-cascade-fn]: http://doc.servo.org/style/properties/fn.cascade.html

--- a/docs/components/style.md
+++ b/docs/components/style.md
@@ -118,8 +118,8 @@ Lazy cascading allows to compute pseudo-element styles lazily, that is, just
 when needed.
 
 Currently (for Servo, not that much for stylo), **selectors supported for this
-kind of pseudo-elements are only a subset of selectors that can be computed
-in a thread-safe way in layout**.
+kind of pseudo-elements are only a subset of selectors that can be matched on
+the layout tree, which does not hold all data from the DOM tree**.
 
 This subset includes tags and attribute selectors, enough for making
 `::-servo-details-summary` a lazy pseudo-element (that only needs to know

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -7,7 +7,7 @@ If there is a word or phrase used in Servo's code, issue tracker, mailing list, 
 # Glossary
 
 ### Compositor ###
-    
+
 The thread that receives input events from the operating system and forwards them to the constellation. It is also in charge of compositing complete renders of web content and displaying them on the screen as fast as possible.
 
 ### Constellation ###

--- a/ports/geckolib/bindings.rs
+++ b/ports/geckolib/bindings.rs
@@ -78,11 +78,11 @@ extern "C" {
                                   set: *mut RawServoStyleSet);
     pub fn Servo_PrependStyleSheet(sheet: *mut RawServoStyleSheet,
                                    set: *mut RawServoStyleSet);
+    pub fn Servo_RemoveStyleSheet(sheet: *mut RawServoStyleSheet,
+                                  set: *mut RawServoStyleSet);
     pub fn Servo_InsertStyleSheetBefore(sheet: *mut RawServoStyleSheet,
                                         reference: *mut RawServoStyleSheet,
                                         set: *mut RawServoStyleSet);
-    pub fn Servo_RemoveStyleSheet(sheet: *mut RawServoStyleSheet,
-                                  set: *mut RawServoStyleSet);
     pub fn Servo_StyleSheetHasRules(sheet: *mut RawServoStyleSheet) -> bool;
     pub fn Servo_InitStyleSet() -> *mut RawServoStyleSet;
     pub fn Servo_DropStyleSet(set: *mut RawServoStyleSet);
@@ -92,6 +92,14 @@ extern "C" {
                                                       *mut ServoComputedValues,
                                                   pseudoTag: *mut nsIAtom,
                                                   set: *mut RawServoStyleSet)
+     -> *mut ServoComputedValues;
+    pub fn Servo_GetComputedValuesForPseudoElement(parent_style:
+                                                       *mut ServoComputedValues,
+                                                   match_element:
+                                                       *mut RawGeckoElement,
+                                                   pseudo_tag: *mut nsIAtom,
+                                                   set: *mut RawServoStyleSet,
+                                                   is_probe: bool)
      -> *mut ServoComputedValues;
     pub fn Servo_AddRefComputedValues(arg1: *mut ServoComputedValues);
     pub fn Servo_ReleaseComputedValues(arg1: *mut ServoComputedValues);

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -267,7 +267,7 @@ pub extern "C" fn Servo_GetComputedValuesForAnonymousBox(parent_style_or_null: *
     type Helpers = ArcHelpers<ServoComputedValues, GeckoComputedValues>;
 
     Helpers::maybe_with(parent_style_or_null, |maybe_parent| {
-        let new_computed = data.stylist.computed_values_for_pseudo(&pseudo, maybe_parent);
+        let new_computed = data.stylist.precomputed_values_for_pseudo(&pseudo, maybe_parent);
         new_computed.map_or(ptr::null_mut(), |c| Helpers::from(c))
     })
 }

--- a/ports/geckolib/selector_impl.rs
+++ b/ports/geckolib/selector_impl.rs
@@ -23,7 +23,6 @@ pub enum PseudoElement {
     // TODO: Probably a few more are missing here
 
     AnonBox(AnonBoxPseudoElement),
-
 }
 
 // https://mxr.mozilla.org/mozilla-central/source/layout/style/nsCSSAnonBoxList.h
@@ -262,8 +261,8 @@ impl SelectorImplExt for GeckoSelectorImpl {
     #[inline]
     fn each_pseudo_element<F>(mut fun: F)
         where F: FnMut(PseudoElement) {
-        use self::PseudoElement::*;
         use self::AnonBoxPseudoElement::*;
+        use self::PseudoElement::*;
 
         fun(Before);
         fun(After);

--- a/ports/geckolib/wrapper.rs
+++ b/ports/geckolib/wrapper.rs
@@ -32,7 +32,8 @@ use std::slice;
 use std::str::from_utf8_unchecked;
 use std::sync::Arc;
 use string_cache::{Atom, Namespace};
-use style::dom::{OpaqueNode, TDocument, TElement, TNode, TRestyleDamage, UnsafeNode};
+use style::dom::{OpaqueNode, PresentationalHintsSynthetizer};
+use style::dom::{TDocument, TElement, TNode, TRestyleDamage, UnsafeNode};
 use style::element_state::ElementState;
 #[allow(unused_imports)] // Used in commented-out code.
 use style::error_reporting::StdoutErrorReporter;
@@ -339,12 +340,6 @@ impl<'le> TElement for GeckoElement<'le> {
         }
     }
 
-    fn synthesize_presentational_hints_for_legacy_attributes<V>(&self, _hints: &mut V)
-        where V: VecLike<DeclarationBlock<Vec<PropertyDeclaration>>>
-    {
-        // FIXME(bholley) - Need to implement this.
-    }
-
     #[inline]
     fn get_attr<'a>(&'a self, namespace: &Namespace, name: &Atom) -> Option<&'a str> {
         unsafe {
@@ -357,6 +352,14 @@ impl<'le> TElement for GeckoElement<'le> {
     #[inline]
     fn get_attrs<'a>(&'a self, _name: &Atom) -> Vec<&'a str> {
         unimplemented!()
+    }
+}
+
+impl<'le> PresentationalHintsSynthetizer for GeckoElement<'le> {
+    fn synthesize_presentational_hints_for_legacy_attributes<V>(&self, _hints: &mut V)
+        where V: VecLike<DeclarationBlock<Vec<PropertyDeclaration>>>
+    {
+        // FIXME(bholley) - Need to implement this.
     }
 }
 


### PR DESCRIPTION
This builds on top of #10815, so it's really just the last commit the one that should be reviewed.

I tried to apply the new infrastructure to servo, but failed (for now?).

The problem with it is that it'd require `ThreadSafeLayoutElement` to implement `selectors::Element`, which is a lot of work and might be racy (not totally sure about it though). Thus, I prefered to keep selectors eager until knowing that it's safe to do it.

r? @mbrubeck for style changes, @bholley for the geckolib changes (minimal for now, glue + a list of lazy PEs must be added)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10934)

<!-- Reviewable:end -->
