### PR TITLE
gfx: Map `sans-serif` to Helvetica on Mac and DejaVu Sans on Linux.

### DIFF
--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -8,6 +8,7 @@ use ipc_channel::router::ROUTER;
 use mime::{TopLevel, SubLevel};
 use net_traits::{AsyncResponseTarget, LoadContext, PendingAsyncLoad, ResourceThread, ResponseAction};
 use platform::font_context::FontContextHandle;
+use platform::font_list::SANS_SERIF_FONT_FAMILY;
 use platform::font_list::for_each_available_family;
 use platform::font_list::for_each_variation;
 use platform::font_list::last_resort_font_families;
@@ -120,7 +121,7 @@ fn populate_generic_fonts() -> HashMap<FontFamily, LowercaseString> {
     let mut generic_fonts = HashMap::with_capacity(5);
 
     append_map(&mut generic_fonts, FontFamily::Serif, "Times New Roman");
-    append_map(&mut generic_fonts, FontFamily::SansSerif, "Arial");
+    append_map(&mut generic_fonts, FontFamily::SansSerif, SANS_SERIF_FONT_FAMILY);
     append_map(&mut generic_fonts, FontFamily::Cursive, "Apple Chancery");
     append_map(&mut generic_fonts, FontFamily::Fantasy, "Papyrus");
     append_map(&mut generic_fonts, FontFamily::Monospace, "Menlo");

--- a/components/gfx/platform/freetype/font_list.rs
+++ b/components/gfx/platform/freetype/font_list.rs
@@ -157,3 +157,13 @@ pub fn last_resort_font_families() -> Vec<String> {
         "Arial".to_owned()
     )
 }
+
+#[cfg(target_os = "android")]
+pub static SANS_SERIF_FONT_FAMILY: &'static str = "Roboto";
+
+#[cfg(target_os = "linux")]
+pub static SANS_SERIF_FONT_FAMILY: &'static str = "DejaVu Sans";
+
+#[cfg(target_os = "windows")]
+pub static SANS_SERIF_FONT_FAMILY: &'static str = "Arial";
+

--- a/components/gfx/platform/macos/font_list.rs
+++ b/components/gfx/platform/macos/font_list.rs
@@ -41,3 +41,7 @@ pub fn system_default_family(_generic_name: &str) -> Option<String> {
 pub fn last_resort_font_families() -> Vec<String> {
     vec!("Arial Unicode MS".to_owned(), "Arial".to_owned())
 }
+
+#[cfg(target_os = "macos")]
+pub static SANS_SERIF_FONT_FAMILY: &'static str = "Helvetica";
+

--- a/tests/wpt/metadata-css/css-text-3_dev/html/word-break-normal-bo-000.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/word-break-normal-bo-000.htm.ini
@@ -1,4 +1,3 @@
 [word-break-normal-bo-000.htm]
   type: reftest
-  expected:
-    if os == "linux": FAIL
+  expected: FAIL

--- a/tests/wpt/mozilla/tests/css/input_selection_incremental_ref.html
+++ b/tests/wpt/mozilla/tests/css/input_selection_incremental_ref.html
@@ -4,16 +4,17 @@
     <meta charset="utf-8">
     <title>input selection incremental reference</title>
     <style>
-      body {
-        font: 16px sans-serif;
-      }
       .selection {
         color: white;
         background: rgba(176, 214, 255, 1.0);
       }
+      div {
+        font: 16px sans-serif;
+        display: inline-block;
+      }
     </style>
   </head>
   <body>
-    <span class="selection">H</span>ello
+    <div><span class="selection">H</span>ello</div>
   </body>
 </html>


### PR DESCRIPTION
This matches what I believe the OS native defaults to be.

Partially addresses #9487.

r? @metajack 
cc @paulrouget

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10937)

<!-- Reviewable:end -->
