### PR TITLE
Handle xml parsing error properly

### DIFF
--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -3,17 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use document_loader::DocumentLoader;
-use dom::bindings::codegen::Bindings::DOMParserBinding;
-use dom::bindings::codegen::Bindings::DOMParserBinding::DOMParserMethods;
 use dom::bindings::codegen::Bindings::DOMParserBinding::SupportedType::{Text_html, Text_xml};
+use dom::bindings::codegen::Bindings::DOMParserBinding::{self, DOMParserMethods};
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentReadyState;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, Root};
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
-use dom::document::DocumentSource;
-use dom::document::{Document, IsHTMLDocument};
+use dom::document::{Document,  DocumentSource, IsHTMLDocument};
 use dom::window::Window;
 use parse::html::{ParseContext, parse_html};
 use parse::xml::{self, parse_xml};
@@ -71,14 +69,13 @@ impl DOMParserMethods for DOMParser {
                 Ok(document)
             }
             Text_xml => {
-                // FIXME: this should probably be FromParser when we actually parse the string (#3756).
                 let document = Document::new(&self.window,
                                              None,
                                              Some(url.clone()),
                                              IsHTMLDocument::NonHTMLDocument,
                                              Some(content_type),
                                              None,
-                                             DocumentSource::NotFromParser,
+                                             DocumentSource::FromParser,
                                              loader);
                 parse_xml(document.r(), s, url, xml::ParseContext::Owner(None));
                 Ok(document)

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -69,13 +69,14 @@ impl DOMParserMethods for DOMParser {
                 Ok(document)
             }
             Text_xml => {
+                // FIXME: this should probably be FromParser when we actually parse the string (#3756).
                 let document = Document::new(&self.window,
                                              None,
                                              Some(url.clone()),
                                              IsHTMLDocument::NonHTMLDocument,
                                              Some(content_type),
                                              None,
-                                             DocumentSource::FromParser,
+                                             DocumentSource::NotFromParser,
                                              loader);
                 parse_xml(document.r(), s, url, xml::ParseContext::Owner(None));
                 Ok(document)

--- a/components/script/parse/xml.rs
+++ b/components/script/parse/xml.rs
@@ -4,6 +4,7 @@
 
 #![allow(unrooted_must_root)]
 
+use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{JS, Root, RootedReference};
@@ -33,6 +34,18 @@ impl<'a> TreeSink for servoxmlparser::Sink {
 
     fn parse_error(&mut self, msg: Cow<'static, str>) {
         debug!("Parse error: {}", msg);
+
+        // Remove all elements from document
+        while let Some(node) = self.document.GetDocumentElement() {
+            let document = self.document.upcast::<Node>();
+            document.RemoveChild(node.r().upcast()).expect("Failed to remove element from document.");
+        }
+
+        let root = Element::new(Atom::from("parsererror"),
+                                Namespace(Atom::from("http://www.mozilla.org/newlayout/xml/parsererror.xml")),
+                                None,
+                                &self.document);
+        self.document.upcast::<Node>().AppendChild(root.upcast()).expect("Appending parsererror root element failed");
     }
 
     fn get_document(&mut self) -> JS<Node> {

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
  "uuid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_traits 0.1.0 (git+https://github.com/servo/webrender_traits)",
  "websocket 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml5ever 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml5ever 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "xml5ever"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -1741,7 +1741,7 @@ dependencies = [
  "uuid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_traits 0.1.0 (git+https://github.com/servo/webrender_traits)",
  "websocket 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml5ever 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml5ever 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "xml5ever"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -1724,7 +1724,7 @@ dependencies = [
  "uuid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_traits 0.1.0 (git+https://github.com/servo/webrender_traits)",
  "websocket 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml5ever 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml5ever 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "xml5ever"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Fixes #10925.

No tests results change due to the test expecting `<foo>` to trigger a parsing error.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10939)

<!-- Reviewable:end -->
