### PR TITLE
./mach run --browserhtml on Windows

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -103,6 +103,24 @@ def check_call(*args, **kwargs):
     return subprocess.check_call(*args, shell=sys.platform == 'win32', **kwargs)
 
 
+def is_windows():
+    """ Detect windows, mingw, cygwin """
+    if sys.platform == 'win32':
+        return True
+    if platform.system() == 'Windows':
+        return True
+    if platform.system().startswith("CYGWIN_NT"):
+        return True
+    if platform.system().startswith("MINGW"):
+        return True
+
+    return False
+
+
+def is_macosx():
+    return sys.platform == 'darwin'
+
+
 class BuildNotFound(Exception):
     def __init__(self, message):
         self.message = message

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -23,7 +23,7 @@ from mach.decorators import (
     Command,
 )
 
-from servo.command_base import CommandBase, cd, call, check_call, BuildNotFound
+from servo.command_base import CommandBase, cd, call, check_call, BuildNotFound, is_windows, is_macosx
 
 
 def read_file(filename, if_exists=False):
@@ -130,7 +130,15 @@ class PostBuildCommands(CommandBase):
             if browserhtml_path is None:
                 print("Could not find browserhtml package; perhaps you haven't built Servo.")
                 return 1
-            args = args + ['-w', '-b', '--pref', 'dom.mozbrowser.enabled',
+
+            if is_macosx():
+                # Enable borderless on OSX
+                args = args + ['-b']
+            elif is_windows():
+                # Convert to a relative path to avoid mingw -> Windows path conversions
+                browserhtml_path = path.relpath(browserhtml_path, os.getcwd())
+
+            args = args + ['-w', '--pref', 'dom.mozbrowser.enabled',
                            path.join(browserhtml_path, 'out', 'index.html')]
             args = args + params
         else:


### PR DESCRIPTION
This adds some windows specific behaviour to the ./mach run --browserhtml command:

Remove the webrender option
Convert the browserhtml path into a relative path to avoid a mingw->windows path conversion.

@larsbergstrom said that webrender support will come to windows ( https://github.com/servo/servo/issues/10243#issuecomment-215968632 ), which will remove the need for part of this soon. But it makes testing slightly nicer.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10943)

<!-- Reviewable:end -->
