### PR TITLE
Determine a flex-items used flex-basis

### DIFF
--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -564,4 +564,9 @@ impl MinMaxConstraint {
             }
         }
     }
+
+    /// The constraint is specified
+    pub fn is_specified(&self) -> bool {
+        self.max.is_some() || self.min != Au(0)
+    }
 }

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -1077,6 +1077,8 @@ pub mod specified {
             match try!(input.next()) {
                 Token::Dimension(ref value, ref unit) if context.is_ok(value.value) =>
                     Length::parse_dimension(value.value, unit).map(LengthOrPercentageOrAutoOrContent::Length),
+                Token::Percentage(ref value) if value.int_value == Some(0) =>
+                    Ok(LengthOrPercentageOrAutoOrContent::Length(Length::Absolute(Au(0)))),
                 Token::Percentage(ref value) if context.is_ok(value.unit_value) =>
                     Ok(LengthOrPercentageOrAutoOrContent::Percentage(Percentage(value.unit_value))),
                 Token::Number(ref value) if value.value == 0. =>

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-001.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-001.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-002.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-002.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-003.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-003.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-004.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-004.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-005.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-005.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-006.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-006.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-008.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-008.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-008.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-basis-0percent.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-basis-0percent.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_flex-basis-0percent.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
Determine a given flex-items flex-basis, use the given flex-basis as the hypothetical main size, and size the item into the available space with this size.

I've been working on this for quite some time, but this is still very much a work in progress. This PR dramiatically changes the way we size flex items. We currently ignore the size and stretch items to fit [evenly in the available space](https://github.com/servo/servo/blob/master/components/layout/flex.rs#L248) and ignore their size. As a result, I suspect a lot of tests that have been passing will fail with this PR.

Comments and critiques would be very welcome!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10945)

<!-- Reviewable:end -->
