### PR TITLE
Minor fixes to documentation

### DIFF
--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -112,11 +112,6 @@
 //!
 //! Legacy callers are not yet implemented.
 //!
-//! Rust reflections of getters and setters
-//! ---------------------------------------
-//!
-//! *To be written.*
-//!
 //! Throwing exceptions
 //! ===================
 //!

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -32,13 +32,11 @@
 //! * rooting pointers on the stack:
 //!   the [`Root`](bindings/js/struct.Root.html) smart pointer;
 //! * tracing pointers in member fields: the [`JS`](bindings/js/struct.JS.html),
-//!   [`MutNullableJS`](bindings/js/struct.MutNullableJS.html) and
+//!   [`MutNullableHeap`](bindings/js/struct.MutNullableHeap.html) and
 //!   [`MutHeap`](bindings/js/struct.MutHeap.html) smart pointers and
 //!   [the tracing implementation](bindings/trace/index.html);
 //! * rooting pointers from across thread boundaries or in channels: the
 //!   [`Trusted`](bindings/refcounted/struct.Trusted.html) smart pointer;
-//! * extracting pointers to DOM objects from their reflectors: the
-//!   [`Unrooted`](bindings/js/struct.Unrooted.html) smart pointer.
 //!
 //! Inheritance
 //! ===========


### PR DESCRIPTION
1. Looks like getters and setters are specified here already. https://github.com/servo/servo/blob/0385f60310090178dda0182b4677c8e51133c159/components/script/dom/bindings/mod.rs#L62
2. The `MutNullableJS` and `Unrooted` looks obsolete

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/10958)

<!-- Reviewable:end -->
