### PR TITLE
mach run --debug: Use nicer syntax in rust-gdb/rust-lldb check

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -118,9 +118,10 @@ class PostBuildCommands(CommandBase):
                 rustCommand = 'rust-' + debugger
                 try:
                     subprocess.check_call([rustCommand, '--version'], env=env, stdout=open(os.devnull, 'w'))
-                    command = rustCommand
                 except (OSError, subprocess.CalledProcessError):
                     pass
+                else:
+                    command = rustCommand
 
             # Prepend the debugger args.
             args = ([command] + self.debuggerInfo.args +


### PR DESCRIPTION
After actually reading a Python tutorial, I realised this can be handled
in a more elegant fashion :-)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11013)

<!-- Reviewable:end -->
