### PR TITLE
Remove BluetoothDevice members

### DIFF
--- a/components/net/bluetooth_thread.rs
+++ b/components/net/bluetooth_thread.rs
@@ -368,11 +368,6 @@ impl BluetoothManager {
                 let message = Ok(BluetoothDeviceMsg {
                                      id: address,
                                      name: device.get_name().ok(),
-                                     device_class: device.get_class().ok(),
-                                     vendor_id_source: device.get_vendor_id_source().ok(),
-                                     vendor_id: device.get_vendor_id().ok(),
-                                     product_id: device.get_product_id().ok(),
-                                     product_version: device.get_device_id().ok(),
                                      appearance: device.get_appearance().ok(),
                                      tx_power: device.get_tx_power().ok().map(|p| p as i8),
                                      rssi: device.get_rssi().ok().map(|p| p as i8),

--- a/components/net_traits/bluetooth_thread.rs
+++ b/components/net_traits/bluetooth_thread.rs
@@ -9,11 +9,6 @@ pub struct BluetoothDeviceMsg {
     // Bluetooth Device properties
     pub id: String,
     pub name: Option<String>,
-    pub device_class: Option<u32>,
-    pub vendor_id_source: Option<String>,
-    pub vendor_id: Option<u32>,
-    pub product_id: Option<u32>,
-    pub product_version: Option<u32>,
     // Advertisiong Data properties
     pub appearance: Option<u16>,
     pub tx_power: Option<i8>,

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -6,7 +6,6 @@ use core::clone::Clone;
 use dom::bindings::codegen::Bindings::BluetoothBinding;
 use dom::bindings::codegen::Bindings::BluetoothBinding::RequestDeviceOptions;
 use dom::bindings::codegen::Bindings::BluetoothBinding::{BluetoothScanFilter, BluetoothMethods};
-use dom::bindings::codegen::Bindings::BluetoothDeviceBinding::VendorIDSource;
 use dom::bindings::error::Error::Type;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
@@ -142,20 +141,10 @@ impl BluetoothMethods for Bluetooth {
                                                             device.appearance,
                                                             device.tx_power,
                                                             device.rssi);
-                let vendor_id_source = device.vendor_id_source.map(|vid| match vid.as_str() {
-                    "bluetooth" => VendorIDSource::Bluetooth,
-                    "usb" => VendorIDSource::Usb,
-                    _ => VendorIDSource::Unknown,
-                });
                 Ok(BluetoothDevice::new(self.global().r(),
                                         DOMString::from(device.id),
                                         device.name.map(DOMString::from),
-                                        &ad_data,
-                                        device.device_class,
-                                        vendor_id_source,
-                                        device.vendor_id,
-                                        device.product_id,
-                                        device.product_version))
+                                        &ad_data))
             },
             Err(error) => {
                 Err(Type(error))

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::BluetoothDeviceBinding;
-use dom::bindings::codegen::Bindings::BluetoothDeviceBinding::{BluetoothDeviceMethods, VendorIDSource};
+use dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, Root, MutHeap, MutNullableHeap};
 use dom::bindings::reflector::{Reflectable, Reflector, reflect_dom_object};
@@ -18,34 +18,19 @@ pub struct BluetoothDevice {
     id: DOMString,
     name: Option<DOMString>,
     adData: MutHeap<JS<BluetoothAdvertisingData>>,
-    deviceClass: Option<u32>,
-    vendorIDSource: Option<VendorIDSource>,
-    vendorID: Option<u32>,
-    productID: Option<u32>,
-    productVersion: Option<u32>,
     gatt: MutNullableHeap<JS<BluetoothRemoteGATTServer>>,
 }
 
 impl BluetoothDevice {
     pub fn new_inherited(id: DOMString,
                          name: Option<DOMString>,
-                         adData: &BluetoothAdvertisingData,
-                         deviceClass: Option<u32>,
-                         vendorIDSource: Option<VendorIDSource>,
-                         vendorID: Option<u32>,
-                         productID: Option<u32>,
-                         productVersion: Option<u32>)
+                         adData: &BluetoothAdvertisingData)
                          -> BluetoothDevice {
         BluetoothDevice {
             reflector_: Reflector::new(),
             id: id,
             name: name,
             adData: MutHeap::new(adData),
-            deviceClass: deviceClass,
-            vendorIDSource: vendorIDSource,
-            vendorID: vendorID,
-            productID: productID,
-            productVersion: productVersion,
             gatt: Default::default(),
         }
     }
@@ -53,21 +38,11 @@ impl BluetoothDevice {
     pub fn new(global: GlobalRef,
                id: DOMString,
                name: Option<DOMString>,
-               adData: &BluetoothAdvertisingData,
-               deviceClass: Option<u32>,
-               vendorIDSource: Option<VendorIDSource>,
-               vendorID: Option<u32>,
-               productID: Option<u32>,
-               productVersion: Option<u32>)
+               adData: &BluetoothAdvertisingData)
                -> Root<BluetoothDevice> {
         reflect_dom_object(box BluetoothDevice::new_inherited(id,
                                                               name,
-                                                              adData,
-                                                              deviceClass,
-                                                              vendorIDSource,
-                                                              vendorID,
-                                                              productID,
-                                                              productVersion),
+                                                              adData),
                            global,
                            BluetoothDeviceBinding::Wrap)
     }
@@ -88,31 +63,6 @@ impl BluetoothDeviceMethods for BluetoothDevice {
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-addata
     fn AdData(&self) -> Root<BluetoothAdvertisingData> {
         self.adData.get()
-    }
-
-    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-deviceclass
-    fn GetDeviceClass(&self) -> Option<u32> {
-        self.deviceClass
-    }
-
-    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-vendoridsource
-    fn GetVendorIDSource(&self) -> Option<VendorIDSource> {
-        self.vendorIDSource
-    }
-
-    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-vendorid
-    fn GetVendorID(&self) -> Option<u32> {
-        self.vendorID
-    }
-
-    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-productid
-    fn GetProductID(&self) -> Option<u32> {
-        self.productID
-    }
-
-    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-productversion
-    fn GetProductVersion(&self) -> Option<u32> {
-        self.productVersion
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-gatt

--- a/components/script/dom/webidls/BluetoothDevice.webidl
+++ b/components/script/dom/webidls/BluetoothDevice.webidl
@@ -4,23 +4,11 @@
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdevice
 
-// Allocation authorities for Vendor IDs:
-enum VendorIDSource {
-    "bluetooth",
-    "usb",
-    "unknown"
-};
-
 [Pref="dom.bluetooth.enabled"]
 interface BluetoothDevice {
     readonly attribute DOMString id;
     readonly attribute DOMString? name;
     readonly attribute BluetoothAdvertisingData adData;
-    readonly attribute unsigned long? deviceClass;
-    readonly attribute VendorIDSource? vendorIDSource;
-    readonly attribute unsigned long? vendorID;
-    readonly attribute unsigned long? productID;
-    readonly attribute unsigned long? productVersion;
     readonly attribute BluetoothRemoteGATTServer gatt;
     // readonly attribute FrozenArray[] uuids;
 };

--- a/tests/html/bluetooth_device_info.html
+++ b/tests/html/bluetooth_device_info.html
@@ -34,11 +34,6 @@
             log('Found a device!');
             log('> Name:             ' + device.name);
             log('> Id:               ' + device.id);
-            log('> Device Class:     ' + device.deviceClass);
-            log('> Vendor Id Source: ' + device.vendorIDSource);
-            log('> Vendor Id:        ' + device.vendorID);
-            log('> Product Id:       ' + device.productID);
-            log('> Product Version:  ' + device.productVersion);
             log('> Appearance:       ' + device.adData.appearance);
             log('> Tx Power:         ' + device.adData.txPower + ' dBm');
             log('> RSSI:             ' + device.adData.rssi + ' dBm');


### PR DESCRIPTION
Five of the BluetoothDevice members has been deleted in the spec:
https://github.com/WebBluetoothCG/web-bluetooth/commit/8d148ba3c3bdb034ee148de4ba2e3d28afa57773

These were the vendorID, vendorIDSource, deviceClass, productID, productVersion.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11028)

<!-- Reviewable:end -->
