### PR TITLE
Set max log level on all platforms

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -19,7 +19,8 @@ doc = false
 bench = false
 
 [features]
-default = ["glutin_app", "webdriver"]
+default = ["glutin_app", "webdriver", "max_log_level"]
+max_log_level = ["env_logger/log/release_max_level_info"]
 webdriver = ["webdriver_server"]
 energy-profiling = ["profile_traits/energy-profiling"]
 
@@ -75,7 +76,7 @@ libc = "0.2"
 url = {version = "1.0.0", features = ["heap_size", "serde", "query_encoding"]}
 
 [target.'cfg(target_os = "android")'.dependencies]
-log = {version = "0.3", features = ["release_max_level_info"]}
+log = "0.3"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 gaol = {git = "https://github.com/servo/gaol"}


### PR DESCRIPTION
Servo currently enabled the `release_max_level_info` feature for the log crate
in an Android-specific dependency.  Currently this works for all platforms
because of rust-lang/cargo#2524, but it might break if that issue is fixed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11033)

<!-- Reviewable:end -->
