### PR TITLE
Do not create stacking contexts for text fragments

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2207,6 +2207,13 @@ impl Fragment {
 
     /// Returns true if this fragment establishes a new stacking context and false otherwise.
     pub fn establishes_stacking_context(&self) -> bool {
+        // Text fragments shouldn't create stacking contexts.
+        match self.specific {
+            SpecificFragmentInfo::ScannedText(_) |
+            SpecificFragmentInfo::UnscannedText(_) => return false,
+            _ => {}
+        }
+
         if self.flags.contains(HAS_LAYER) {
             return true
         }

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transforms-3d-on-anonymous-block-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transforms-3d-on-anonymous-block-001.htm.ini
@@ -1,3 +1,4 @@
 [css-transforms-3d-on-anonymous-block-001.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/regions-transforms-019.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/regions-transforms-019.htm.ini
@@ -1,3 +1,3 @@
-[transform-input-013.htm]
+[regions-transforms-019.htm]
   type: reftest
   expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-abspos-002.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-abspos-002.htm.ini
@@ -1,3 +1,0 @@
-[transform-abspos-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-abspos-007.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-abspos-007.htm.ini
@@ -1,3 +1,0 @@
-[transform-abspos-007.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-applies-to-002.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-applies-to-002.htm.ini
@@ -1,3 +1,0 @@
-[transform-applies-to-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-001.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-003.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-003.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-004.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-005.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-005.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-006.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-006.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-007.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-007.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-007.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-008.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-008.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-008.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-009.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-009.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-009.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-010.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-010.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-010.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-011.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-011.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-011.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-012.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-012.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-012.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-014.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-014.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-014.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-015.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-015.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-015.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-016.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-016.htm.ini
@@ -1,3 +1,0 @@
-[transform-input-016.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-003.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-003.htm.ini
@@ -1,3 +1,0 @@
-[transform-origin-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-004.htm.ini
@@ -1,3 +1,0 @@
-[transform-origin-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-005.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-005.htm.ini
@@ -1,3 +1,0 @@
-[transform-origin-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-006.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-006.htm.ini
@@ -1,3 +1,0 @@
-[transform-origin-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-propagate-inherit-boolean-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-propagate-inherit-boolean-001.htm.ini
@@ -1,3 +1,0 @@
-[transform-propagate-inherit-boolean-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-transformable-inline-block.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-transformable-inline-block.htm.ini
@@ -1,0 +1,3 @@
+[transform-transformable-inline-block.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-001.htm.ini
@@ -1,3 +1,0 @@
-[transform-translate-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-002.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-002.htm.ini
@@ -1,3 +1,0 @@
-[transform-translate-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-003.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-003.htm.ini
@@ -1,3 +1,0 @@
-[transform-translate-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-004.htm.ini
@@ -1,3 +1,0 @@
-[transform-translate-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-005.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-005.htm.ini
@@ -1,3 +1,0 @@
-[transform-translate-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-001.htm.ini
@@ -1,3 +1,0 @@
-[transform-translatex-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-002.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-002.htm.ini
@@ -1,3 +1,0 @@
-[transform-translatex-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-003.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-003.htm.ini
@@ -1,3 +1,0 @@
-[transform-translatex-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-004.htm.ini
@@ -1,3 +1,0 @@
-[transform-translatex-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-005.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-005.htm.ini
@@ -1,3 +1,0 @@
-[transform-translatex-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatey-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatey-001.htm.ini
@@ -1,3 +1,0 @@
-[transform-translatey-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatey-002.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatey-002.htm.ini
@@ -1,3 +1,0 @@
-[transform-translatey-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatey-003.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatey-003.htm.ini
@@ -1,3 +1,0 @@
-[transform-translatey-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatey-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatey-004.htm.ini
@@ -1,3 +1,0 @@
-[transform-translatey-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatey-005.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatey-005.htm.ini
@@ -1,3 +1,0 @@
-[transform-translatey-005.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
Without this change, each text fragment in a block that establishes a
stacking context will establish its own stacking context. This is
unnecessary and increases the amount of work done during display list
construction. This change should not change output, but should improve
performance.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11035)

<!-- Reviewable:end -->
