### PR TITLE
Don't let restyle damage infect siblings

### DIFF
--- a/components/layout/incremental.rs
+++ b/components/layout/incremental.rs
@@ -274,13 +274,15 @@ impl<'a> LayoutDamageComputation for &'a mut Flow {
 
         {
             let self_base = flow::mut_base(self);
+            // Take a snapshot of the parent damage before updating it with damage from children.
+            let parent_damage = self_base.restyle_damage;
+
             for kid in self_base.children.iter_mut() {
                 let child_is_absolutely_positioned =
                     flow::base(kid).flags.contains(IS_ABSOLUTELY_POSITIONED);
-                flow::mut_base(kid).restyle_damage
-                                   .insert(self_base.restyle_damage.damage_for_child(
-                                            is_absolutely_positioned,
-                                            child_is_absolutely_positioned));
+                flow::mut_base(kid).restyle_damage.insert(
+                    parent_damage.damage_for_child(is_absolutely_positioned,
+                                                   child_is_absolutely_positioned));
                 {
                     let kid: &mut Flow = kid;
                     special_damage.insert(kid.compute_layout_damage());


### PR DESCRIPTION
Currently `compute_layout_damage` does the following for each child of the node it's processing.
1. Update the child with damage from the parent.
2. Update the parent with damage from the child.

When these steps are repeated for the next child, the parent's damage may include flags that came from its previous sibling(s).  This means that damage ends up propagating to later siblings, and not just between parents and children as indended.

This patch propagates the same damage to all children, not including any damage from their siblings.

r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11037)

<!-- Reviewable:end -->
