### PR TITLE
Remove redundant code in whitespace stripping

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2403,16 +2403,11 @@ impl Fragment {
                 let whitespace_len = scanned_text_fragment_info.range.length() - whitespace_start;
                 let whitespace_range = Range::new(whitespace_start, whitespace_len);
 
-                // FIXME: This may be unnecessary because these metrics will be recomputed in
-                // LineBreaker::strip_trailing_whitespace_from_pending_line_if_necessary
                 let text_bounds = scanned_text_fragment_info.run
                                                         .metrics_for_range(&whitespace_range)
                                                         .bounding_box;
-                self.border_box.size.inline = self.border_box.size.inline -
-                    text_bounds.size.width;
-
-                scanned_text_fragment_info.content_size.inline =
-                    scanned_text_fragment_info.content_size.inline - text_bounds.size.width;
+                self.border_box.size.inline -= text_bounds.size.width;
+                scanned_text_fragment_info.content_size.inline -= text_bounds.size.width;
 
                 scanned_text_fragment_info.range.extend_by(-whitespace_len);
                 WhitespaceStrippingResult::RetainFragment

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -392,27 +392,12 @@ impl LineBreaker {
         let last_fragment_index = self.pending_line.range.end() - FragmentIndex(1);
         let mut fragment = &mut self.new_fragments[last_fragment_index.get() as usize];
 
-        let mut old_fragment_inline_size = None;
-        if let SpecificFragmentInfo::ScannedText(_) = fragment.specific {
-            old_fragment_inline_size = Some(fragment.border_box.size.inline +
-                                            fragment.margin.inline_start_end());
-        }
+        let old_fragment_inline_size = fragment.border_box.size.inline;
 
         fragment.strip_trailing_whitespace_if_necessary();
 
-        if let SpecificFragmentInfo::ScannedText(ref mut scanned_text_fragment_info) =
-                fragment.specific {
-            let scanned_text_fragment_info = &mut **scanned_text_fragment_info;
-            let range = &mut scanned_text_fragment_info.range;
-
-            scanned_text_fragment_info.content_size.inline =
-                scanned_text_fragment_info.run.metrics_for_range(range).advance_width;
-            fragment.border_box.size.inline = scanned_text_fragment_info.content_size.inline +
-                fragment.border_padding.inline_start_end();
-            self.pending_line.bounds.size.inline = self.pending_line.bounds.size.inline -
-                (old_fragment_inline_size.unwrap() -
-                 (fragment.border_box.size.inline + fragment.margin.inline_start_end()));
-        }
+        self.pending_line.bounds.size.inline +=
+            fragment.border_box.size.inline - old_fragment_inline_size;
     }
 
     // FIXME(eatkinson): this assumes that the tallest fragment in the line determines the line


### PR DESCRIPTION
LineBreaker calls Fragment::strip_trailing_whitespace_if_necessary and then recalculates the fragment's inline size.  But this isn't necessary because strip_trailing_whitespace_if_necessary already recalculates the size.

r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11039)

<!-- Reviewable:end -->
