### PR TITLE
Fix a build warning in compositor.rs

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1350,10 +1350,9 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 Some(root_pipeline_id) => root_pipeline_id,
                 None => return,
             };
-            let root_pipeline = match self.pipeline(root_pipeline_id) {
-                Some(root_pipeline) => root_pipeline,
-                None => return,
-            };
+            if self.pipeline(root_pipeline_id).is_none() {
+                return;
+            }
 
             let (translated_point, translated_pipeline_id) =
                 webrender_api.translate_point_to_layer_space(&point.to_untyped());
@@ -1395,10 +1394,9 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 Some(root_pipeline_id) => root_pipeline_id,
                 None => return,
             };
-            let root_pipeline = match self.pipeline(root_pipeline_id) {
-                Some(root_pipeline) => root_pipeline,
-                None => return,
-            };
+            if self.pipeline(root_pipeline_id).is_none() {
+                return;
+            }
 
             let (translated_point, translated_pipeline_id) =
                 webrender_api.translate_point_to_layer_space(&cursor.to_untyped());


### PR DESCRIPTION
Stops the compiler complaining about `root_pipeline` being an unused variable.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11042)

<!-- Reviewable:end -->
