### PR TITLE
'closeevent' argument for Document::createEvent

### DIFF
--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -33,6 +33,12 @@ impl CloseEvent {
         }
     }
 
+    pub fn new_uninitialized(global: GlobalRef) -> Root<CloseEvent> {
+        reflect_dom_object(box CloseEvent::new_inherited(false, 0, DOMString::new()),
+                           global,
+                           CloseEventBinding::Wrap)
+    }
+
     pub fn new(global: GlobalRef,
                type_: Atom,
                bubbles: EventBubbles,
@@ -66,6 +72,7 @@ impl CloseEvent {
                            init.code,
                            init.reason.clone()))
     }
+
 }
 
 impl CloseEventMethods for CloseEvent {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -32,6 +32,7 @@ use dom::bindings::trace::RootedVec;
 use dom::bindings::xmlname::XMLName::InvalidXMLName;
 use dom::bindings::xmlname::{validate_and_extract, namespace_from_domstring, xml_name_type};
 use dom::browsingcontext::BrowsingContext;
+use dom::closeevent::CloseEvent;
 use dom::comment::Comment;
 use dom::customevent::CustomEvent;
 use dom::documentfragment::DocumentFragment;
@@ -2190,6 +2191,8 @@ impl DocumentMethods for Document {
                 Ok(Root::upcast(FocusEvent::new_uninitialized(GlobalRef::Window(&self.window)))),
             "errorevent" =>
                 Ok(Root::upcast(ErrorEvent::new_uninitialized(GlobalRef::Window(&self.window)))),
+            "closeevent" =>
+                Ok(Root::upcast(CloseEvent::new_uninitialized(GlobalRef::Window(&self.window)))),
             _ =>
                 Err(Error::NotSupported),
         }

--- a/tests/wpt/metadata/dom/nodes/Document-createEvent.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-createEvent.html.ini
@@ -37,30 +37,6 @@
   [createEvent('BEFOREUNLOADEVENT') should be initialized correctly.]
     expected: FAIL
 
-  [CloseEvent should be an alias for CloseEvent.]
-    bug: https://github.com/servo/servo/issues/10737
-    expected: FAIL
-
-  [createEvent('CloseEvent') should be initialized correctly.]
-    bug: https://github.com/servo/servo/issues/10737
-    expected: FAIL
-
-  [closeevent should be an alias for CloseEvent.]
-    bug: https://github.com/servo/servo/issues/10737
-    expected: FAIL
-
-  [createEvent('closeevent') should be initialized correctly.]
-    bug: https://github.com/servo/servo/issues/10737
-    expected: FAIL
-
-  [CLOSEEVENT should be an alias for CloseEvent.]
-    bug: https://github.com/servo/servo/issues/10737
-    expected: FAIL
-
-  [createEvent('CLOSEEVENT') should be initialized correctly.]
-    bug: https://github.com/servo/servo/issues/10737
-    expected: FAIL
-
   [CompositionEvent should be an alias for CompositionEvent.]
     expected: FAIL
 

--- a/tests/wpt/web-platform-tests/websockets/interfaces/CloseEvent/historical.html
+++ b/tests/wpt/web-platform-tests/websockets/interfaces/CloseEvent/historical.html
@@ -6,12 +6,6 @@
 <div id=log></div>
 <script>
 test(function() {
-  assert_throws("NotSupportedError", function() {
-    document.createEvent("CloseEvent")
-  });
-}, "createEvent(\"CloseEvent\")");
-
-test(function() {
   assert_false("initCloseEvent" in CloseEvent.prototype);
   assert_false("initCloseEvent" in new CloseEvent('close'));
 }, "initCloseEvent");


### PR DESCRIPTION
Add "close event" argument for Document::createEvent
Fixes #10737

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11051)

<!-- Reviewable:end -->
