### PR TITLE
use onload in iframe test

### DIFF
--- a/tests/wpt/mozilla/tests/mozilla/iframe_contentDocument.html
+++ b/tests/wpt/mozilla/tests/mozilla/iframe_contentDocument.html
@@ -9,19 +9,11 @@
 <iframe src="resources/iframe_contentDocument_inner.html" id="iframe"></iframe>
 <script>
 async_test(function() {
-  var timeout = 100;
   var iframe = document.getElementById('iframe');
-  function test_contentWindow() {
-    if (!iframe.contentWindow) {
-      // Iframe not loaded yet, try again.
-      // No load event for iframe, insert bug number here.
-      setTimeout(this.step_func(test_contentWindow), timeout);
-      return;
-    }
+  iframe.onload = this.step_func_done(function() {
     assert_equals(iframe.contentDocument.getElementById('test').textContent, 'value');
     this.done();
-  }
-  this.step(test_contentWindow);
+  })
 });
 </script>
 </body>


### PR DESCRIPTION
#11036

the iframe test is implemented using setTimeout function
Since the iframe already implement load event, replacing
timeout function with load event.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11053)

<!-- Reviewable:end -->
