### PR TITLE
remove virtualenv usage from mach, pep-370 is fine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,14 @@ matrix:
   include:
     - sudo: false
       script:
+         - pip install -r python/requirements.txt
          - ./mach test-tidy --self-test
          - ./mach test-tidy --no-progress
       cache: false
     - sudo: 9000
       dist: trusty
       script:
+         - pip install -r python/requirements.txt
          - ./mach build -d --verbose
          - ./mach test-unit
          - ./mach test-compiletest
@@ -31,7 +33,6 @@ matrix:
             - gperf
             - libosmesa6-dev
             - libgles2-mesa-dev
-            - python-virtualenv
             - xorg-dev
             - ccache
             - libdbus-glib-1-dev

--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@ On OS X (homebrew):
 
 ``` sh
 brew install automake pkg-config python cmake
-pip install virtualenv
 ```
 
 On OS X (MacPorts):
 
 ``` sh
-sudo port install python27 py27-virtualenv cmake
+sudo port install python27 cmake
 ```
 
 On OS X 10.11 (El Capitan), you also have to install openssl:
@@ -39,27 +38,25 @@ On Debian-based Linuxes:
 ``` sh
 sudo apt-get install git curl freeglut3-dev autoconf \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
-    gperf g++ build-essential cmake virtualenv python-pip \
+    gperf g++ build-essential cmake python-pip \
     libssl-dev libbz2-dev libosmesa6-dev libxmu6 libxmu-dev \
     libglu1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev
 ```
 If you are on **Ubuntu 14.04** and encountered errors on installing these dependencies involving `libcheese`, see [#6158](https://github.com/servo/servo/issues/6158) for a workaround.
-
-If `virtualenv` does not exist, try `python-virtualenv`.
 
 On Fedora:
 
 ``` sh
 sudo dnf install curl freeglut-devel libtool gcc-c++ libXi-devel \
     freetype-devel mesa-libGL-devel mesa-libEGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
-    fontconfig-devel cabextract ttmkfdir python python-virtualenv python-pip expat-devel \
+    fontconfig-devel cabextract ttmkfdir python python-pip expat-devel \
     rpm-build openssl-devel cmake bzip2-devel libXcursor-devel libXmu-devel mesa-libOSMesa-devel
 ```
 
 On Arch Linux:
 
 ``` sh
-sudo pacman -S --needed base-devel git python2 python2-virtualenv python2-pip mesa cmake bzip2 libxmu glu
+sudo pacman -S --needed base-devel git python2 python2-pip mesa cmake bzip2 libxmu glu
 ```
 
 On Gentoo Linux:
@@ -67,7 +64,7 @@ On Gentoo Linux:
 ```sh
 sudo emerge net-misc/curl media-libs/freeglut \
     media-libs/freetype media-libs/mesa dev-util/gperf \
-    dev-python/virtualenv dev-python/pip dev-libs/openssl \
+    dev-python/pip dev-libs/openssl \
     x11-libs/libXmu media-libs/glu x11-base/xorg-server
 ```
 
@@ -85,7 +82,7 @@ pacman -Sy git mingw-w64-x86_64-toolchain mingw-w64-x86_64-freetype \
     mingw-w64-x86_64-icu mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates \
     mingw-w64-x86_64-expat mingw-w64-x86_64-cmake tar diffutils patch \
     patchutils make python2-setuptools
-easy_install-2.7 pip virtualenv
+easy_install-2.7 pip
 ```
 
 Open a new MSYS shell window as Administrator and remove the Python binaries (they

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - bash -lc "echo $MSYSTEM; pacman --needed --noconfirm -Sy pacman-mirrors"
   - bash -lc "pacman --noconfirm -Sy"
   - bash -lc "pacman -Sy --needed --noconfirm git mingw-w64-x86_64-toolchain mingw-w64-x86_64-freetype mingw-w64-x86_64-icu mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates mingw-w64-x86_64-expat mingw-w64-x86_64-cmake tar diffutils patch patchutils make python2-setuptools"
-  - bash -lc "easy_install-2.7 pip virtualenv"
+  - bash -lc "easy_install-2.7 pip"
   - bash -lc "mv /mingw64/bin/python2.exe /mingw64/bin/python2-mingw64.exe"
   - bash -lc "mv /mingw64/bin/python2.7.exe /mingw64/bin/python2.7-mingw64.exe"
 

--- a/mach
+++ b/mach
@@ -6,7 +6,11 @@
 # The beginning of this script is both valid shell and valid python,
 # such that the script starts with the shell and is reexecuted with
 # the right python.
-'''which' python2.7 > /dev/null && exec python2.7 "$0" "$@" || exec python "$0" "$@"
+'''true'
+HERE=`readlink -f $0`
+HERE=`dirname $HERE`
+export PYTHONUSERBASE=$HERE/python/_virtualenv
+which python2.7 > /dev/null && exec python2.7 "$0" "$@" || exec python "$0" "$@"
 '''
 
 from __future__ import print_function, unicode_literals
@@ -15,11 +19,22 @@ import os
 import sys
 
 def main(args):
-    topdir = os.path.dirname(sys.argv[0])
+    topdir = os.path.dirname(args[0])
+    try:
+        import mach.main as _dummy
+    except ImportError:
+        import pip
+        requirements = os.path.join(topdir, 'python', 'requirements.txt')
+        ret = pip.main(['install', '--ignore-installed', '--user', '-r', requirements])
+        if ret != 0:
+            sys.exit(ret)
+        # re-exec to pick up the new libraries
+        python = sys.executable
+        os.execl(python, python, *sys.argv)
     sys.path.insert(0, os.path.join(topdir, "python"))
     import mach_bootstrap
     mach = mach_bootstrap.bootstrap(topdir)
-    sys.exit(mach.run(sys.argv[1:]))
+    sys.exit(mach.run(args[1:]))
 
 if __name__ == '__main__':
     main(sys.argv)


### PR DESCRIPTION
use pep-370 and PYTHONUSERBASE env variable instead

./mach is modified so it sets PYTHONUSERBASE to python/_virtualenv
also, it tries to import mach.main and if that fails it'll invoke
pip install. when that finishes it re-execs itself (otherwise python won't pick
up the PYTHONUSERBASE as a library path).

all of the virtualenv supporting code is removed from python/mach_bootstrap.py

Why:
virtualenv is an ugly hack, and most of the times a pain. it depends on a copy of the `python` executable, is
very fragile, and also makes non-relocatable environments.

pep-370 and PYTHONUSERBASE fix all of those, and is officially supported by the
python interpreter.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11060)

<!-- Reviewable:end -->
