### PR TITLE
Added tox.ini

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,0 +1,3 @@
+[flake8]
+filename = *.py
+max-line-length = 120


### PR DESCRIPTION
The default maximum line length Python linters use is 79, so a bunch of editor plugins complain about line lengths, unless you have a tox.ini telling the linter to ignore line lengths (E501) explicitly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11073)

<!-- Reviewable:end -->
