### PR TITLE
Delete outdated test cases ini, addressing issue #11075

### DIFF
--- a/tests/wpt/metadata/FileAPI/blob/Blob-constructor.html.ini
+++ b/tests/wpt/metadata/FileAPI/blob/Blob-constructor.html.ini
@@ -3,9 +3,6 @@
   [Passing non-objects, Dates and RegExps for blobParts should throw a TypeError.]
     expected: FAIL
 
-  [Passing an platform object that supports indexed properties as the blobParts array should work (window).]
-    expected: FAIL
-
   [Getters and value conversions should happen in order until an exception is thrown.]
     expected: FAIL
 
@@ -22,9 +19,6 @@
     expected: FAIL
 
   [Passing a Float64Array as element of the blobParts array should work.]
-    expected: FAIL
-
-  [Passing an platform object that supports indexed properties as the blobParts array should work (window with custom toString).]
     expected: FAIL
 
   [Passing an platform object that supports indexed properties as the blobParts array should work (select).]


### PR DESCRIPTION
As discussed in issue #11075 , these two are no longer found in current `tests/wpt/web-platform-tests/FileAPI/blob/Blob-constructor.html`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11078)

<!-- Reviewable:end -->
