### PR TITLE
Changed cursor for labels to "default" so their text doesn't use the text cursor.

### DIFF
--- a/resources/servo.css
+++ b/resources/servo.css
@@ -33,6 +33,8 @@ td[align="right"]   { text-align: right; }
 
 center { text-align: -servo-center; }
 
+label { cursor: default; }
+
 input:not([type=radio i]):not([type=checkbox i]):not([type=reset i]):not([type=button i]):not([type=submit i]),
 textarea {
   cursor: text;


### PR DESCRIPTION
The cursor in Firefox and Chrome for labels is always the default cursor rather than changing to the text cursor on text. In Edge, however, this only applies to the text of the actual label element. 

This PR changes Servo to match Firefox and Chrome.

A convenient example of an element that this style applies to (and has different behavior between Firefox and Edge) is the "This repository" label for the search input at the top on Github.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11079)

<!-- Reviewable:end -->
