### PR TITLE
Start implementing protocolDescription and canCurrentlyRecord in devtools

### DIFF
--- a/components/devtools/actors/performance.rs
+++ b/components/devtools/actors/performance.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use actor::{Actor, ActorMessageStatus, ActorRegistry};
-use protocol::JsonPacketStream;
+use protocol::{ActorDescription, JsonPacketStream, Method};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::net::TcpStream;
@@ -68,6 +68,14 @@ impl PerformanceActor {
     pub fn new(name: String) -> PerformanceActor {
         PerformanceActor {
             name: name,
+        }
+    }
+
+    pub fn description() -> ActorDescription {
+        ActorDescription {
+            category: "actor",
+            typeName: "performance",
+            methods: vec![],
         }
     }
 }

--- a/components/devtools/actors/performance.rs
+++ b/components/devtools/actors/performance.rs
@@ -32,6 +32,21 @@ struct ConnectReply {
     traits: PerformanceTraits,
 }
 
+#[derive(Serialize)]
+struct CanCurrentlyRecordReply {
+    from: String,
+    value: SuccessMsg,
+}
+
+#[derive(Serialize)]
+struct SuccessMsg {
+    success: bool,
+    errors: Vec<Error>,
+}
+
+#[derive(Serialize)]
+enum Error {}
+
 impl Actor for PerformanceActor {
     fn name(&self) -> String {
         self.name.clone()
@@ -59,6 +74,17 @@ impl Actor for PerformanceActor {
                 stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed
             },
+            "canCurrentlyRecord" => {
+                let msg = CanCurrentlyRecordReply {
+                    from: self.name(),
+                    value: SuccessMsg {
+                        success: true,
+                        errors: vec![],
+                    }
+                };
+                stream.write_json_packet(&msg);
+                ActorMessageStatus::Processed
+            }
             _ => ActorMessageStatus::Ignored,
         })
     }
@@ -75,7 +101,19 @@ impl PerformanceActor {
         ActorDescription {
             category: "actor",
             typeName: "performance",
-            methods: vec![],
+            methods: vec![
+                Method {
+                    name: "canCurrentlyRecord",
+                    request: Value::Object(vec![
+                        ("type".to_owned(), Value::String("canCurrentlyRecord".to_owned())),
+                    ].into_iter().collect()),
+                    response: Value::Object(vec![
+                        ("value".to_owned(), Value::Object(vec![
+                            ("_retval".to_owned(), Value::String("json".to_owned())),
+                        ].into_iter().collect())),
+                    ].into_iter().collect()),
+                },
+            ],
         }
     }
 }

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -8,8 +8,9 @@
 /// that perform more specific actions (tabs, addons, browser chrome, etc.)
 
 use actor::{Actor, ActorMessageStatus, ActorRegistry};
+use actors::performance::PerformanceActor;
 use actors::tab::{TabActor, TabActorMsg};
-use protocol::JsonPacketStream;
+use protocol::{ActorDescription, JsonPacketStream};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::net::TcpStream;
@@ -42,6 +43,17 @@ pub struct RootActorMsg {
     from: String,
     applicationType: String,
     traits: ActorTraits,
+}
+
+#[derive(Serialize)]
+pub struct ProtocolDescriptionReply {
+    from: String,
+    types: Types,
+}
+
+#[derive(Serialize)]
+pub struct Types {
+    performance: ActorDescription,
 }
 
 pub struct RootActor {
@@ -78,6 +90,17 @@ impl Actor for RootActor {
                     }).collect()
                 };
                 stream.write_json_packet(&actor);
+                ActorMessageStatus::Processed
+            }
+
+            "protocolDescription" => {
+                let msg = ProtocolDescriptionReply {
+                    from: self.name(),
+                    types: Types {
+                        performance: PerformanceActor::description(),
+                    },
+                };
+                stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed
             }
 

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -39,6 +39,15 @@ struct ReconfigureReply {
     from: String
 }
 
+#[derive(Serialize)]
+struct SourcesReply {
+    from: String,
+    sources: Vec<Source>,
+}
+
+#[derive(Serialize)]
+enum Source {}
+
 pub struct ThreadActor {
     name: String,
 }
@@ -85,6 +94,15 @@ impl Actor for ThreadActor {
 
             "reconfigure" => {
                 stream.write_json_packet(&ReconfigureReply { from: self.name() });
+                ActorMessageStatus::Processed
+            }
+
+            "sources" => {
+                let msg = SourcesReply {
+                    from: self.name(),
+                    sources: vec![],
+                };
+                stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed
             }
 

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -12,6 +12,20 @@ use std::error::Error;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 
+#[derive(Serialize)]
+pub struct ActorDescription {
+    pub category: &'static str,
+    pub typeName: &'static str,
+    pub methods: Vec<Method>,
+}
+
+#[derive(Serialize)]
+pub struct Method {
+    pub name: &'static str,
+    pub request: Value,
+    pub response: Value,
+}
+
 pub trait JsonPacketStream {
     fn write_json_packet<T: Serialize>(&mut self, obj: &T);
     fn read_json_packet(&mut self) -> Result<Option<Value>, String>;


### PR DESCRIPTION
We can merge it but it doesn't make things work more than before. Mostly filing it for comments, especially the `description` method. If you feel it's too verbose I guess the way to go would be to properly formalise all types involved in the devtools server, but that's going to be a gigantic task.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11094)

<!-- Reviewable:end -->
