### PR TITLE
Override always 'CARGO_HOME' env variable.

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -293,8 +293,7 @@ class CommandBase(object):
         if extra_path:
             env["PATH"] = "%s%s%s" % (os.pathsep.join(extra_path), os.pathsep, env["PATH"])
 
-        if "CARGO_HOME" not in env:
-            env["CARGO_HOME"] = self.config["tools"]["cargo-home-dir"]
+        env["CARGO_HOME"] = self.config["tools"]["cargo-home-dir"]
 
         if "CARGO_TARGET_DIR" not in env:
             env["CARGO_TARGET_DIR"] = path.join(self.context.topdir, "target")


### PR DESCRIPTION
## Summary

This use always `cargo-home-dir` in `/.servobuild` even if you set `CARGO_HOME` in your shell.
## Motivation

If you use [racer](https://github.com/phildawes/racer) with [rustup (multirust.rs)](https://github.com/rust-lang-nursery/rustup.rs), you may set `CARGO_HOME` env variable to your shell. Then the previous code would be a problem which does not use `cargo-home-dir` in `/.servobuild`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11097)

<!-- Reviewable:end -->
