### PR TITLE
gfx: Map CSS `normal` font weight to Regular font weight on the Mac.

### DIFF
--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -6,6 +6,7 @@ use font::FontHandleMethods;
 use platform::font::FontHandle;
 use platform::font_context::FontContextHandle;
 use platform::font_template::FontTemplateData;
+use std::fmt::{Debug, Error, Formatter};
 use std::sync::{Arc, Weak};
 use std::u32;
 use string_cache::Atom;
@@ -64,6 +65,12 @@ pub struct FontTemplate {
     // GWTODO: Add code path to unset the strong_ref for web fonts!
     strong_ref: Option<Arc<FontTemplateData>>,
     is_valid: bool,
+}
+
+impl Debug for FontTemplate {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        self.identifier.fmt(f)
+    }
 }
 
 /// Holds all of the template information for a font that

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -103,16 +103,20 @@ impl FontHandleMethods for FontHandle {
 
     fn boldness(&self) -> font_weight::T {
         let normalized = self.ctfont.all_traits().normalized_weight();  // [-1.0, 1.0]
-        let normalized = (normalized + 1.0) / 2.0 * 9.0;  // [0.0, 9.0]
-        match normalized {
-            v if v < 1.0 => font_weight::T::Weight100,
-            v if v < 2.0 => font_weight::T::Weight200,
-            v if v < 3.0 => font_weight::T::Weight300,
-            v if v < 4.0 => font_weight::T::Weight400,
-            v if v < 5.0 => font_weight::T::Weight500,
-            v if v < 6.0 => font_weight::T::Weight600,
-            v if v < 7.0 => font_weight::T::Weight700,
-            v if v < 8.0 => font_weight::T::Weight800,
+        let normalized = if normalized <= 0.0 {
+            4.0 + normalized * 3.0  // [1.0, 4.0]
+        } else {
+            4.0 + normalized * 5.0  // [4.0, 9.0]
+        }; // [1.0, 9.0], centered on 4.0
+        match normalized.round() as u32 {
+            1 => font_weight::T::Weight100,
+            2 => font_weight::T::Weight200,
+            3 => font_weight::T::Weight300,
+            4 => font_weight::T::Weight400,
+            5 => font_weight::T::Weight500,
+            6 => font_weight::T::Weight600,
+            7 => font_weight::T::Weight700,
+            8 => font_weight::T::Weight800,
             _ => font_weight::T::Weight900,
         }
     }

--- a/tests/wpt/metadata-css/css-text-3_dev/html/word-break-break-all-007.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/word-break-break-all-007.htm.ini
@@ -1,5 +1,0 @@
-[word-break-break-all-007.htm]
-  type: reftest
-  expected:
-    if os == "linux": PASS
-    FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/word-break-normal-hi-000.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/word-break-normal-hi-000.htm.ini
@@ -1,3 +1,5 @@
 [word-break-normal-hi-000.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL
+    PASS


### PR DESCRIPTION
This series of commits fixes #9487, and improves the look of nytimes.com among others.

r? @metajack

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11103)

<!-- Reviewable:end -->
