### PR TITLE
New tidy rule

### DIFF
--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -217,7 +217,7 @@ impl Actor for NetworkEventActor {
                     let headersSize = headers.len() as u8;
                     let mut headerNames = Vec::new();
                     let mut rawHeadersString = "".to_owned();
-                    for item in headers.iter()  {
+                    for item in &headers  {
                         let name = item.name();
                         let value = item.value_string();
                         headerNames.push(name.to_owned());
@@ -392,7 +392,7 @@ impl NetworkEventActor {
         let mut headers_byte_count = 0;
         if let Some(ref headers) = self.response.headers {
             headers_size = headers.len() as u32;
-            for item in headers.iter()  {
+            for item in &headers  {
                 headers_byte_count += item.name().len() + item.value_string().len();
             }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -451,7 +451,7 @@ fn set_cookie_for_url(cookie_jar: &Arc<RwLock<CookieStorage>>,
 
 fn set_cookies_from_response(url: Url, response: &HttpResponse, cookie_jar: &Arc<RwLock<CookieStorage>>) {
     if let Some(cookies) = response.headers().get_raw("set-cookie") {
-        for cookie in cookies.iter() {
+        for cookie in &cookies {
             if let Ok(cookie_value) = String::from_utf8(cookie.clone()) {
                 set_cookie_for_url(&cookie_jar,
                                    url.clone(),
@@ -725,7 +725,7 @@ pub fn obtain_response<A>(request_factory: &HttpRequestFactory<R=A>,
 
         if log_enabled!(log::LogLevel::Info) {
             info!("{}", method);
-            for header in headers.iter() {
+            for header in &headers {
                 info!(" - {}", header);
             }
             info!("{:?}", data);

--- a/ports/gonk/src/input.rs
+++ b/ports/gonk/src/input.rs
@@ -115,7 +115,7 @@ fn read_input_device(device_path: &Path,
     // let buf: [u8; (16 * size_of::<linux_input_event>())];
     let mut buf: [u8; (16 * 16)] = unsafe { zeroed() };
     let mut slots: [InputSlot; 10] = unsafe { zeroed() };
-    for slot in slots.iter_mut() {
+    for slot in &mut slots {
         slot.tracking_id = -1;
     }
 

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -387,7 +387,7 @@ def check_rust(file_name, lines):
             # No benefit over using &str
             (r": &String", "use &str instead of &String", no_filter),
             (r"^&&", "operators should go at the end of the first line", no_filter),
-            (r"(\.iter\(\)|\.iter_mut\(\))(?!\S)", "use &x or &mut x instead of x.iter() or x.iter_mut()", no_filter),
+            (r"^for.+(\.iter\(\)|\.iter_mut\(\))(?!\S)", "use &x or &mut x instead of x.iter() or x.iter_mut()", no_filter),
         ]
 
         for pattern, message, filter_func in regex_rules:

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -387,7 +387,8 @@ def check_rust(file_name, lines):
             # No benefit over using &str
             (r": &String", "use &str instead of &String", no_filter),
             (r"^&&", "operators should go at the end of the first line", no_filter),
-            (r"^for.+(\.iter\(\)|\.iter_mut\(\))(?!\S)", "use &x or &mut x instead of x.iter() or x.iter_mut()", no_filter),
+            (r"^for.+(\.iter\(\)|\.iter_mut\(\))(?!\S)",
+                "use &x or &mut x instead of x.iter() or x.iter_mut()", no_filter),
         ]
 
         for pattern, message, filter_func in regex_rules:

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -387,6 +387,7 @@ def check_rust(file_name, lines):
             # No benefit over using &str
             (r": &String", "use &str instead of &String", no_filter),
             (r"^&&", "operators should go at the end of the first line", no_filter),
+            (r"(\.iter\(\)|\.iter_mut\(\))(?!\S)", "use &x or &mut x instead of x.iter() or x.iter_mut()", no_filter),
         ]
 
         for pattern, message, filter_func in regex_rules:

--- a/python/tidy/servo_tidy_tests/rust_tidy.rs
+++ b/python/tidy/servo_tidy_tests/rust_tidy.rs
@@ -29,6 +29,17 @@ impl test {
             2 => 1,
         };
         let z = &Vec<T>;
+
+        let v = vec![1, 2, 3, 4, 5];
+        //for foo in v.iter() {
+        for foo in &v {
+            println!("{}", foo);
+        }
+
+        //for foo in v.iter_mut()
+        for foo in &mut v {
+            println!("{}", foo);
+        }
     }
 
     fn test_fun2(y : &String, z : &Vec<f32>) -> f32 {

--- a/python/tidy/servo_tidy_tests/rust_tidy.rs
+++ b/python/tidy/servo_tidy_tests/rust_tidy.rs
@@ -31,16 +31,8 @@ impl test {
         let z = &Vec<T>;
 
         let v = vec![1, 2, 3, 4, 5];
-
-        // should be: for foo in &v {
-        for foo in v.iter() {
-            println!("{}", foo);
-        }
-
-        // should be: for foo in &mut v {
-        for foo in v.iter_mut()
-            println!("{}", foo);
-        }
+        for foo in v.iter() {}
+        for foo in v.iter_mut() {}
     }
 
     fn test_fun2(y : &String, z : &Vec<f32>) -> f32 {

--- a/python/tidy/servo_tidy_tests/rust_tidy.rs
+++ b/python/tidy/servo_tidy_tests/rust_tidy.rs
@@ -31,13 +31,14 @@ impl test {
         let z = &Vec<T>;
 
         let v = vec![1, 2, 3, 4, 5];
-        //for foo in v.iter() {
-        for foo in &v {
+
+        // should be: for foo in &v {
+        for foo in v.iter() {
             println!("{}", foo);
         }
 
-        //for foo in v.iter_mut()
-        for foo in &mut v {
+        // should be: for foo in &mut v {
+        for foo in v.iter_mut()
             println!("{}", foo);
         }
     }

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -66,12 +66,13 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('missing space before -', errors.next()[2])
         self.assertEqual('missing space before *', errors.next()[2])
         self.assertEqual('missing space after =>', errors.next()[2])
+        self.assertEqual('use &x or &mut x instead of x.iter() or x.iter_mut()', errors.next()[2])
+        self.assertEqual('use &x or &mut x instead of x.iter() or x.iter_mut()', errors.next()[2])
         self.assertEqual('extra space before :', errors.next()[2])
         self.assertEqual('extra space before :', errors.next()[2])
         self.assertEqual('use &[T] instead of &Vec<T>', errors.next()[2])
         self.assertEqual('use &str instead of &String', errors.next()[2])
         self.assertEqual('operators should go at the end of the first line', errors.next()[2])
-        self.assertEqual('use &x or &mut x instead of x.iter() or x.iter_mut()', errors.next()[2])
         self.assertNoMoreErrors(errors)
 
     def test_spec_link(self):

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -71,6 +71,7 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('use &[T] instead of &Vec<T>', errors.next()[2])
         self.assertEqual('use &str instead of &String', errors.next()[2])
         self.assertEqual('operators should go at the end of the first line', errors.next()[2])
+        self.assertEqual('use &x or &mut x instead of x.iter() or x.iter_mut()', errors.next()[2])
         self.assertNoMoreErrors(errors)
 
     def test_spec_link(self):

--- a/tests/unit/gfx/text_util.rs
+++ b/tests/unit/gfx/text_util.rs
@@ -17,7 +17,7 @@ fn test_transform_compress_none() {
     ];
 
     let mode = CompressionMode::CompressNone;
-    for &test in test_strs.iter() {
+    for &test in &test_strs {
         let mut trimmed_str = String::new();
         transform_text(test, mode, true, &mut trimmed_str);
         assert_eq!(trimmed_str, test)
@@ -50,7 +50,7 @@ fn test_transform_discard_newline() {
     ];
 
     let mode = CompressionMode::DiscardNewline;
-    for &(test, oracle) in test_strs.iter() {
+    for &(test, oracle) in &test_strs {
         let mut trimmed_str = String::new();
         transform_text(test, mode, true, &mut trimmed_str);
         assert_eq!(trimmed_str, oracle)
@@ -83,7 +83,7 @@ fn test_transform_compress_whitespace() {
     ];
 
     let mode = CompressionMode::CompressWhitespace;
-    for &(test, oracle) in test_strs.iter() {
+    for &(test, oracle) in &test_strs {
         let mut trimmed_str = String::new();
         transform_text(test, mode, true, &mut trimmed_str);
         assert_eq!(&*trimmed_str, oracle)
@@ -116,7 +116,7 @@ fn test_transform_compress_whitespace_newline() {
     ];
 
     let mode = CompressionMode::CompressWhitespaceNewline;
-    for &(test, oracle) in test_strs.iter() {
+    for &(test, oracle) in &test_strs {
         let mut trimmed_str = String::new();
         transform_text(test, mode, true, &mut trimmed_str);
         assert_eq!(&*trimmed_str, oracle)
@@ -152,7 +152,7 @@ fn test_transform_compress_whitespace_newline_no_incoming() {
     ];
 
     let mode = CompressionMode::CompressWhitespaceNewline;
-    for &(test, oracle) in test_strs.iter() {
+    for &(test, oracle) in &test_strs {
         let mut trimmed_str = String::new();
         transform_text(test, mode, false, &mut trimmed_str);
         assert_eq!(trimmed_str, oracle)

--- a/tests/unit/net/http_loader.rs
+++ b/tests/unit/net/http_loader.rs
@@ -219,7 +219,7 @@ impl HttpRequestFactory for AssertAuthHeaderRequestFactory {
 
 fn assert_headers_included(expected: &Headers, request: &Headers) {
     assert!(expected.len() != 0);
-    for header in expected.iter() {
+    for header in &expected {
         assert!(request.get_raw(header.name()).is_some());
         assert_eq!(request.get_raw(header.name()).unwrap(),
                    expected.get_raw(header.name()).unwrap())

--- a/tests/unit/style/logical_geometry.rs
+++ b/tests/unit/style/logical_geometry.rs
@@ -25,7 +25,7 @@ fn modes() -> [WritingMode; 10] {
 #[test]
 fn test_size_round_trip() {
     let physical = Size2D::new(1u32, 2u32);
-    for &mode in modes().iter() {
+    for &mode in &modes() {
         let logical = LogicalSize::from_physical(mode, physical);
         assert!(logical.to_physical(mode) == physical);
         assert!(logical.width(mode) == 1);
@@ -37,7 +37,7 @@ fn test_size_round_trip() {
 fn test_point_round_trip() {
     let physical = Point2D::new(1u32, 2u32);
     let container = Size2D::new(100, 200);
-    for &mode in modes().iter() {
+    for &mode in &modes() {
         let logical = LogicalPoint::from_physical(mode, physical, container);
         assert!(logical.to_physical(mode, container) == physical);
         assert!(logical.x(mode, container) == 1);
@@ -48,7 +48,7 @@ fn test_point_round_trip() {
 #[test]
 fn test_margin_round_trip() {
     let physical = SideOffsets2D::new(1u32, 2u32, 3u32, 4u32);
-    for &mode in modes().iter() {
+    for &mode in &modes() {
         let logical = LogicalMargin::from_physical(mode, physical);
         assert!(logical.to_physical(mode) == physical);
         assert!(logical.top(mode) == 1);
@@ -62,7 +62,7 @@ fn test_margin_round_trip() {
 fn test_rect_round_trip() {
     let physical = Rect::new(Point2D::new(1u32, 2u32), Size2D::new(3u32, 4u32));
     let container = Size2D::new(100, 200);
-    for &mode in modes().iter() {
+    for &mode in &modes() {
         let logical = LogicalRect::from_physical(mode, physical, container);
         assert!(logical.to_physical(mode, container) == physical);
     }


### PR DESCRIPTION
addresses #10683 

I wasn't sure if this was only relevant for for-in loops or not so the regex doesn't check on that at all merely if `iter()` or `iter_mut()` are followed by anything other than whitespace.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11116)

<!-- Reviewable:end -->
