### PR TITLE
Use the same build environment and features for CEF, Servo, Gonk, Geckolib

### DIFF
--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -63,6 +63,6 @@ smallvec = "0.1"
 string_cache = {version = "0.2.12", features = ["heap_size", "unstable"]}
 time = "0.1.12"
 unicase = "1.0"
-url = {version = "1.0.0", features = ["heap_size"]}
+url = {version = "1.0.0", features = ["heap_size", "query_encoding"]}
 uuid = { version = "0.2", features = ["v4"] }
 websocket = "0.17"

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -19,7 +19,6 @@ dependencies = [
  "glutin_app 0.0.1",
  "image 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.2 (git+https://github.com/servo/ipc-channel)",
- "layers 0.2.5 (git+https://github.com/servo/rust-layers)",
  "layout 0.0.1",
  "layout_tests 0.0.1",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -65,18 +65,17 @@ devtools = {path = "../devtools"}
 webdriver_server = {path = "../webdriver_server", optional = true}
 devtools_traits = {path = "../devtools_traits"}
 glutin_app = {path = "../../ports/glutin", optional = true}
-android_glue = {version = "0.1.3", optional = true}
 ipc-channel = {git = "https://github.com/servo/ipc-channel"}
-layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
 gleam = "0.2"
 browserhtml = {git = "https://github.com/browserhtml/browserhtml", branch = "gh-pages"}
 env_logger = "0.3"
-euclid = {version = "0.6.4", features = ["plugins"]}
+euclid = "0.6.4"
 libc = "0.2"
-url = {version = "1.0.0", features = ["heap_size", "serde", "query_encoding"]}
+url = "1.0.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 log = "0.3"
+android_glue = "0.1.3"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 gaol = {git = "https://github.com/servo/gaol"}

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -30,7 +30,6 @@ pub extern crate devtools_traits;
 pub extern crate euclid;
 pub extern crate gfx;
 pub extern crate ipc_channel;
-pub extern crate layers;
 pub extern crate layout;
 pub extern crate msg;
 pub extern crate net;

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -2,7 +2,6 @@
 name = "embedding"
 version = "0.0.1"
 dependencies = [
- "azure 0.4.5 (git+https://github.com/servo/rust-azure)",
  "cgl 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "compositing 0.0.1",
@@ -11,10 +10,8 @@ dependencies = [
  "core-text 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools 0.0.1",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx 0.0.1",
  "gleam 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin_app 0.0.1",
- "js 0.1.2 (git+https://github.com/servo/rust-mozjs)",
  "layers 0.2.5 (git+https://github.com/servo/rust-layers)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -22,10 +19,8 @@ dependencies = [
  "net_traits 0.0.1",
  "objc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
- "script 0.0.1",
  "script_traits 0.0.1",
  "servo 0.0.1",
- "style 0.0.1",
  "style_traits 0.0.1",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1836,6 +1831,7 @@ dependencies = [
 name = "servo"
 version = "0.0.1"
 dependencies = [
+ "android_glue 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "browserhtml 0.1.5 (git+https://github.com/browserhtml/browserhtml?branch=gh-pages)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -1849,7 +1845,6 @@ dependencies = [
  "gleam 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin_app 0.0.1",
  "ipc-channel 0.2.2 (git+https://github.com/servo/ipc-channel)",
- "layers 0.2.5 (git+https://github.com/servo/rust-layers)",
  "layout 0.0.1",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.toml
+++ b/ports/cef/Cargo.toml
@@ -16,27 +16,22 @@ codegen-units = 4
 # lto = false
 
 [dependencies]
-euclid = {version = "0.6.4", features = ["plugins"]}
+euclid = "0.6.4"
 gleam = "0.2.8"
 libc = "0.2"
-url = {version = "1.0.0", features = ["heap_size"]}
+url = "1.0.0"
 servo = {path = "../../components/servo"}
 glutin_app = {path = "../glutin"}
 plugins = {path = "../../components/plugins"}
 compositing = {path = "../../components/compositing"}
-gfx = {path = "../../components/gfx"}
 log = {version = "0.3.5", features = ["release_max_level_info"]}
-script = {path = "../../components/script"}
 script_traits = {path = "../../components/script_traits"}
 net_traits = {path = "../../components/net_traits"}
 msg = {path = "../../components/msg"}
 util = {path = "../../components/util", features = ["non-geckolib"]}
-style = {path = "../../components/style"}
 style_traits = {path = "../../components/style_traits"}
 devtools = {path = "../../components/devtools"}
-azure = {git = "https://github.com/servo/rust-azure", features = ["plugins"]}
-js = {git = "https://github.com/servo/rust-mozjs"}
-layers = {git = "https://github.com/servo/rust-layers", features = ["plugins"]}
+layers = {git = "https://github.com/servo/rust-layers"}
 
 [target.'cfg(target_os="macos")'.dependencies]
 objc = "0.2"

--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -22,21 +22,16 @@ extern crate log;
 extern crate servo;
 extern crate compositing;
 
-extern crate azure;
 extern crate euclid;
-extern crate gfx;
 extern crate gleam;
 extern crate glutin_app;
-extern crate js;
 extern crate layers;
 extern crate rustc_unicode;
-extern crate script;
 extern crate script_traits;
 
 extern crate net_traits;
 extern crate msg;
 extern crate util;
-extern crate style;
 extern crate style_traits;
 
 extern crate libc;

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -618,7 +618,6 @@ name = "url"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -11,18 +11,18 @@ path = "lib.rs"
 crate-type = ["staticlib"]
 
 [dependencies]
-app_units = {version = "0.2.3", features = ["plugins"]}
-cssparser = {version = "0.5.4", features = ["heap_size", "serde-serialization"]}
-euclid = {version = "0.6.4", features = ["plugins"]}
+app_units = "0.2.3"
+cssparser = "0.5.4"
+euclid = "0.6.4"
 heapsize = "0.3.0"
 heapsize_plugin = "0.1.2"
 lazy_static = "0.2"
 libc = "0.2"
 num_cpus = "0.2.2"
-selectors = {version = "0.5", features = ["heap_size", "unstable"]}
+selectors = "0.5"
 smallvec = "0.1"
-string_cache = {version = "0.2.12", features = ["heap_size", "unstable"]}
-url = {version = "1.0.0", features = ["heap_size", "query_encoding", "serde"]}
+string_cache = "0.2.12"
+url = "1.0.0"
 log = {version = "0.3.5", features = ["release_max_level_info"]}
 plugins = {path = "../../components/plugins"}
 util = {path = "../../components/util"}

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -1819,6 +1819,7 @@ dependencies = [
 name = "servo"
 version = "0.0.1"
 dependencies = [
+ "android_glue 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "browserhtml 0.1.5 (git+https://github.com/browserhtml/browserhtml?branch=gh-pages)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -1831,7 +1832,6 @@ dependencies = [
  "gfx 0.0.1",
  "gleam 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.2 (git+https://github.com/servo/ipc-channel)",
- "layers 0.2.5 (git+https://github.com/servo/rust-layers)",
  "layout 0.0.1",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -197,9 +197,6 @@ class MachCommands(CommandBase):
         if debug_mozjs or self.config["build"]["debug-mozjs"]:
             features += ["script/debugmozjs"]
 
-        if android:
-            features += ["android_glue"]
-
         if features:
             opts += ["--features", "%s" % ' '.join(features)]
 

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -204,12 +204,7 @@ class MachCommands(CommandBase):
             opts += ["--features", "%s" % ' '.join(features)]
 
         build_start = time()
-        env = self.build_env()
-
-        # Ensure Rust uses hard floats and SIMD on ARM devices
-        if target:
-            if target.startswith('arm') or target.startswith('aarch64'):
-                env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C target-feature=+neon"
+        env = self.build_env(target=target)
 
         if android:
             # Build OpenSSL for android
@@ -225,7 +220,7 @@ class MachCommands(CommandBase):
             with cd(openssl_dir):
                 status = call(
                     make_cmd + ["-f", "openssl.makefile"],
-                    env=self.build_env(),
+                    env=env,
                     verbose=verbose)
                 if status:
                     return status
@@ -233,11 +228,6 @@ class MachCommands(CommandBase):
             env['OPENSSL_LIB_DIR'] = openssl_dir
             env['OPENSSL_INCLUDE_DIR'] = path.join(openssl_dir, "include")
             env['OPENSSL_STATIC'] = 'TRUE'
-
-        if not (self.config["build"]["ccache"] == ""):
-            env['CCACHE'] = self.config["build"]["ccache"]
-
-        env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -W unused-extern-crates"
 
         status = call(
             ["cargo", "build"] + opts,

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -255,7 +255,7 @@ class CommandBase(object):
                                   " --release" if release else ""))
         sys.exit()
 
-    def build_env(self, gonk=False, hosts_file_path=None):
+    def build_env(self, gonk=False, hosts_file_path=None, target=None):
         """Return an extended environment dictionary."""
         env = os.environ.copy()
         if sys.platform == "win32" and type(env['PATH']) == unicode:
@@ -398,6 +398,16 @@ class CommandBase(object):
         if self.config["tools"]["rustc-with-gold"] and sys.platform not in ("win32", "msys"):
             if subprocess.call(['which', 'ld.gold'], stdout=PIPE, stderr=PIPE) == 0:
                 env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C link-args=-fuse-ld=gold"
+
+        if not (self.config["build"]["ccache"] == ""):
+            env['CCACHE'] = self.config["build"]["ccache"]
+
+        # Ensure Rust uses hard floats and SIMD on ARM devices
+        if target:
+            if target.startswith('arm') or target.startswith('aarch64'):
+                env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C target-feature=+neon"
+
+        env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -W unused-extern-crates"
 
         return env
 


### PR DESCRIPTION
- Remove unnecessary dependencies and features from top-level Cargo.tomls.  The features for each crate will be computed based on the union of features specified in the dependency graph.  Specifying the same ones again just adds more ways for them to get out of sync.
- Move all cargo build environment variables into CommandBase

Fixes #11112. r? @metajack

(Not included: CI test to make sure #11112 doesn't regress again.)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11122)

<!-- Reviewable:end -->
