### PR TITLE
Disable codegen-units due to performance regressions

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -26,7 +26,6 @@ energy-profiling = ["profile_traits/energy-profiling"]
 
 [profile.release]
 opt-level = 3
-codegen-units = 4
 # Uncomment to profile on Linux:
 # debug = true
 # lto = false


### PR DESCRIPTION
r? @pcwalton 

Fixes #11102.

CC @alexcrichton, @nmatsakis - basically, `codegen-units` is nice for local compilation speedups but results in too many perf regressions to keep it for release builds.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11123)

<!-- Reviewable:end -->
