### PR TITLE
Explicitly list inputs to the style crate's build script

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -2135,6 +2135,7 @@ dependencies = [
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
+ "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2391,6 +2392,15 @@ dependencies = [
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "wayland-client"

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -37,3 +37,6 @@ smallvec = "0.1"
 string_cache = {version = "0.2.12", features = ["heap_size"]}
 time = "0.1"
 url = {version = "1.0.0", features = ["heap_size"]}
+
+[build-dependencies]
+walkdir = "0.1"

--- a/components/style/build.rs
+++ b/components/style/build.rs
@@ -2,9 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+extern crate walkdir;
+
 use std::env;
 use std::path::Path;
 use std::process::{Command, exit};
+use walkdir::WalkDir;
 
 #[cfg(windows)]
 fn find_python() -> String {
@@ -29,6 +32,17 @@ fn find_python() -> String {
 }
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    for entry in WalkDir::new("properties") {
+        let entry = entry.unwrap();
+        match entry.path().extension().and_then(|e| e.to_str()) {
+            Some("mako") | Some("rs") | Some("py") | Some("zip") => {
+                println!("cargo:rerun-if-changed={}", entry.path().display());
+            }
+            _ => {}
+        }
+    }
+
     let python = env::var("PYTHON").ok().unwrap_or_else(find_python);
     let script = Path::new(file!()).parent().unwrap().join("properties").join("build.py");
     let product = if cfg!(feature = "gecko") { "gecko" } else { "servo" };

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -2029,6 +2029,7 @@ dependencies = [
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
+ "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2256,6 +2257,15 @@ dependencies = [
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "wayland-client"

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -543,6 +543,7 @@ dependencies = [
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
+ "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -672,6 +673,15 @@ dependencies = [
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -2010,6 +2010,7 @@ dependencies = [
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
+ "walkdir 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2237,6 +2238,15 @@ dependencies = [
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "wayland-client"


### PR DESCRIPTION
This avoids unncessary build script runs caused by changes to unrelated files.

Note: Adds a dependency on https://crates.io/crates/walkdir which is MIT licensed and maintained by BurntSushi.

r? @metajack

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11134)

<!-- Reviewable:end -->
