### PR TITLE
Override $CARGO_HOME only if cargo-home-dir is in .servobuild

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -149,8 +149,9 @@ class CommandBase(object):
         self.config["tools"].setdefault("cache-dir", default_cache_dir)
         resolverelative("tools", "cache-dir")
 
-        self.config["tools"].setdefault("cargo-home-dir",
-                                        path.join(context.topdir, ".cargo"))
+        default_cargo_home = os.environ.get("CARGO_HOME",
+                                            path.join(context.topdir, ".cargo"))
+        self.config["tools"].setdefault("cargo-home-dir", default_cargo_home)
         resolverelative("tools", "cargo-home-dir")
 
         context.sharedir = self.config["tools"]["cache-dir"]


### PR DESCRIPTION
This preserves the fix from #11097 in the situation where `$CARGO_HOME` and `cargo-home-dir` in `.servobuild` are both present: `.servobuild` should win.

But it changes the behavior when `$CARGO_HOME` is present and `.servobuild` is not:  Then `$CARGO_HOME` should be used.

We now check the following values in order of priority and use the first one that is found:
1. `cargo-home-dir` in `.servobuild`
2. `CARGO_HOME` in the environment
3. default value (`<servo-repo>/.cargo`)

r? @larsbergstrom

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11135)

<!-- Reviewable:end -->
