### PR TITLE
When webdriver is getting a pipeline id, it should wait for the pipeline document to be ready

### DIFF
--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -88,8 +88,9 @@ pub enum CompositorMsg {
     /// with the provided pipeline id
     GetFrame(PipelineId, IpcSender<Option<FrameId>>),
     /// Request that the constellation send the current pipeline id for the provided frame
-    /// id, or for the root frame if this is None, over a provided channel
-    GetPipeline(Option<FrameId>, IpcSender<Option<PipelineId>>),
+    /// id, or for the root frame if this is None, over a provided channel.
+    /// Also returns a boolean saying whether the document has finished loading or not.
+    GetPipeline(Option<FrameId>, IpcSender<Option<(PipelineId, bool)>>),
     /// Requests that the constellation inform the compositor of the title of the pipeline
     /// immediately.
     GetPipelineTitle(PipelineId),


### PR DESCRIPTION
Thank you for contributing to Servo! Please add an `X` inside each `[ ]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11117 (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they only impact webdriver

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11140)

<!-- Reviewable:end -->
