### PR TITLE
Fix inline size adjustment when stripping trailing whitespace from fragments

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2401,7 +2401,8 @@ impl Fragment {
                 }
                 let whitespace_start = ByteIndex(trailing_whitespace_start_byte as isize);
                 let whitespace_len = scanned_text_fragment_info.range.length() - whitespace_start;
-                let whitespace_range = Range::new(whitespace_start, whitespace_len);
+                let mut whitespace_range = Range::new(whitespace_start, whitespace_len);
+                whitespace_range.shift_by(scanned_text_fragment_info.range.begin());
 
                 let text_bounds = scanned_text_fragment_info.run
                                                         .metrics_for_range(&whitespace_range)


### PR DESCRIPTION
The whitespace range was not properly shifted which caused us to adjust the fragment's inline size by the advance of a different set of characters.
This was causing justified text lines to be too long or too short.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11142)

<!-- Reviewable:end -->
