### PR TITLE
Upgrade pip after virtualenv is created

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -9,6 +9,7 @@ import platform
 import subprocess
 import sys
 from distutils.spawn import find_executable
+from distutils.version import LooseVersion
 
 SEARCH_PATHS = [
     os.path.join("python", "tidy"),
@@ -110,6 +111,10 @@ def _activate_virtualenv(topdir):
         virtualenv = _get_exec(*VIRTUALENV_NAMES)
         if virtualenv is None:
             sys.exit("Python virtualenv is not installed. Please install it prior to running mach.")
+
+        virtualenv_version = subprocess.check_output([virtualenv, "--version"])
+        if LooseVersion(virtualenv_version) < LooseVersion("14.0.0"):
+            sys.exit("virtualenv is too old. Please upgrade to at least version 14.0.0.")
 
         process = subprocess.Popen(
             [virtualenv, "-p", python, virtualenv_path],


### PR DESCRIPTION
- [X] `./mach build` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11074 (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they execute before the test runner is installed. I would actually like to test them but I didn't find any system in place for testing the bootstraping code.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11149)

<!-- Reviewable:end -->
