### PR TITLE
Only use zeroed memory for gecko style structs, not the wrapper servo struct.

### DIFF
--- a/ports/geckolib/properties.mako.rs
+++ b/ports/geckolib/properties.mako.rs
@@ -340,7 +340,7 @@ impl Drop for ${style_struct.gecko_struct_name} {
 impl Clone for ${style_struct.gecko_struct_name} {
     fn clone(&self) -> Self {
         unsafe {
-            let mut result: Self = zeroed();
+            let mut result = ${style_struct.gecko_struct_name} { gecko: zeroed() };
             Gecko_CopyConstruct_${style_struct.gecko_ffi_name}(&mut result.gecko, &self.gecko);
             result
         }


### PR DESCRIPTION
So that we don't clobber the drop flags.

This is a regression from #11121.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11160)

<!-- Reviewable:end -->
