### PR TITLE
Implement same-origin Window.postMessage

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -349,6 +349,10 @@ impl Document {
         true
     }
 
+    pub fn origin(&self) -> &Origin {
+        &self.origin
+    }
+
     // https://dom.spec.whatwg.org/#concept-document-url
     pub fn url(&self) -> &Url {
         &self.url

--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -54,6 +54,8 @@
   void cancelAnimationFrame(unsigned long handle);
 
   //void postMessage(any message, DOMString targetOrigin, optional sequence<Transferable> transfer);
+  [Throws]
+  void postMessage(any message, DOMString targetOrigin);
 
   // also has obsolete members
 };

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-sync-block-defer-scripts.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-sync-block-defer-scripts.html.ini
@@ -1,6 +1,0 @@
-[xmlhttprequest-sync-block-defer-scripts.html]
-  type: testharness
-  expected: TIMEOUT
-  [Check that a sync XHR in a defer script blocks later defer scripts from running]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-sync-not-hang-scriptloader.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-sync-not-hang-scriptloader.html.ini
@@ -1,6 +1,0 @@
-[xmlhttprequest-sync-not-hang-scriptloader.html]
-  type: testharness
-  expected: TIMEOUT
-  [Ensure that an async script added during a defer script that then does a\n  sync XHR still runs]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-aborted.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-aborted.html.ini
@@ -1,3 +1,0 @@
-[xmlhttprequest-timeout-aborted.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-abortedonmain.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-abortedonmain.html.ini
@@ -1,3 +1,0 @@
-[xmlhttprequest-timeout-abortedonmain.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-overrides.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-overrides.html.ini
@@ -1,3 +1,0 @@
-[xmlhttprequest-timeout-overrides.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-overridesexpires.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-overridesexpires.html.ini
@@ -1,3 +1,0 @@
-[xmlhttprequest-timeout-overridesexpires.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-simple.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-simple.html.ini
@@ -1,3 +1,0 @@
-[xmlhttprequest-timeout-simple.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-synconmain.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-synconmain.html.ini
@@ -1,3 +1,0 @@
-[xmlhttprequest-timeout-synconmain.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-twice.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/xmlhttprequest-timeout-twice.html.ini
@@ -1,3 +1,0 @@
-[xmlhttprequest-timeout-twice.html]
-  type: testharness
-  expected: TIMEOUT

--- a/tests/wpt/metadata/fetch/api/headers/headers-structure.html.ini
+++ b/tests/wpt/metadata/fetch/api/headers/headers-structure.html.ini
@@ -1,6 +1,5 @@
 [headers-structure.html]
   type: testharness
-  expected: OK
   [Headers has entries method]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/001.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/001.html.ini
@@ -1,6 +1,0 @@
-[001.html]
-  type: testharness
-  expected: TIMEOUT
-  [Cross-origin navigation started from unload handler]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/002.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/002.html.ini
@@ -1,6 +1,0 @@
-[002.html]
-  type: testharness
-  expected: TIMEOUT
-  [Multiple simultaneous navigations]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/003.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/003.html.ini
@@ -2,5 +2,5 @@
   type: testharness
   expected: TIMEOUT
   [Navigation from unload whilst traversing history]
-    expected: NOTRUN
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/004.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/004.html.ini
@@ -2,5 +2,5 @@
   type: testharness
   expected: TIMEOUT
   [Navigation from unload whilst traversing cross-origin history]
-    expected: NOTRUN
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/child_navigates_parent_location.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/child_navigates_parent_location.html.ini
@@ -2,5 +2,5 @@
   type: testharness
   expected: TIMEOUT
   [Child document navigating parent via location ]
-    expected: NOTRUN
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/child_navigates_parent_submit.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/child_navigates_parent_submit.html.ini
@@ -2,5 +2,5 @@
   type: testharness
   expected: TIMEOUT
   [Child document navigating parent via submit ]
-    expected: NOTRUN
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/navigation_unload_same_origin.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/navigation_unload_same_origin.html.ini
@@ -1,6 +1,5 @@
 [navigation_unload_same_origin.html]
   type: testharness
-  expected: TIMEOUT
   [Same-origin navigation started from unload handler]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping.html.ini
@@ -2,5 +2,5 @@
   type: testharness
   expected: TIMEOUT
   [Check that popups from a sandboxed iframe escape the sandbox if\n       allow-popups-to-escape-sandbox is used]
-    expected: NOTRUN
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/insecure-protocol.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/insecure-protocol.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[insecure-protocol.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/insecure-protocol.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/insecure-protocol.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[insecure-protocol.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/insecure-protocol.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/script-tag/insecure-protocol.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[insecure-protocol.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/insecure-protocol.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/insecure-protocol.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[insecure-protocol.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/insecure-protocol.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/insecure-protocol.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[insecure-protocol.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/insecure-protocol.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/script-tag/insecure-protocol.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[insecure-protocol.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/generic.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/cross-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/generic.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer/http-rp/same-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[same-origin-insecure.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[same-origin-insecure.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[same-origin-insecure.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/generic.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/generic.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/meta-csp/cross-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-csp/cross-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,6 +1,5 @@
 [generic.keep-origin-redirect.http.html]
   type: testharness
-  expected: TIMEOUT
   [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/referrer-policy/origin/meta-csp/cross-origin/http-http/script-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-csp/cross-origin/http-http/script-tag/generic.no-redirect.http.html.ini
@@ -1,6 +1,5 @@
 [generic.no-redirect.http.html]
   type: testharness
-  expected: TIMEOUT
   [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/referrer-policy/origin/meta-csp/cross-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-csp/cross-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,6 +1,5 @@
 [generic.swap-origin-redirect.http.html]
   type: testharness
-  expected: TIMEOUT
   [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/referrer-policy/origin/meta-csp/same-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-csp/same-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,6 +1,5 @@
 [generic.keep-origin-redirect.http.html]
   type: testharness
-  expected: TIMEOUT
   [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/referrer-policy/origin/meta-csp/same-origin/http-http/script-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-csp/same-origin/http-http/script-tag/generic.no-redirect.http.html.ini
@@ -1,6 +1,5 @@
 [generic.no-redirect.http.html]
   type: testharness
-  expected: TIMEOUT
   [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/referrer-policy/origin/meta-csp/same-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-csp/same-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,6 +1,5 @@
 [generic.swap-origin-redirect.http.html]
   type: testharness
-  expected: TIMEOUT
   [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/generic.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-referrer/cross-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/generic.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/meta-referrer/same-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/http-rp/cross-origin/http-http/script-tag/cross-origin.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[same-origin-insecure.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[same-origin-insecure.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/http-rp/same-origin/http-http/script-tag/same-origin-insecure.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[same-origin-insecure.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/cross-origin/http-http/script-tag/cross-origin.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/cross-origin/http-http/script-tag/cross-origin.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/cross-origin/http-http/script-tag/cross-origin.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/cross-origin/http-http/script-tag/cross-origin.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/cross-origin/http-http/script-tag/cross-origin.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/cross-origin/http-http/script-tag/cross-origin.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/same-origin/http-http/script-tag/same-origin-insecure.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/same-origin/http-http/script-tag/same-origin-insecure.keep-origin-redirect.http.html.ini
@@ -1,6 +1,5 @@
 [same-origin-insecure.keep-origin-redirect.http.html]
   type: testharness
-  expected: TIMEOUT
   [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/same-origin/http-http/script-tag/same-origin-insecure.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/same-origin/http-http/script-tag/same-origin-insecure.no-redirect.http.html.ini
@@ -1,6 +1,5 @@
 [same-origin-insecure.no-redirect.http.html]
   type: testharness
-  expected: TIMEOUT
   [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/same-origin/http-http/script-tag/same-origin-insecure.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-csp/same-origin/http-http/script-tag/same-origin-insecure.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[same-origin-insecure.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-csp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/cross-origin.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/cross-origin.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/cross-origin.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/cross-origin.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/cross-origin.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/cross-origin/http-http/script-tag/cross-origin.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[cross-origin.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/same-origin-insecure.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/same-origin-insecure.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[same-origin-insecure.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/same-origin-insecure.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/same-origin-insecure.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[same-origin-insecure.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/same-origin-insecure.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/meta-referrer/same-origin/http-http/script-tag/same-origin-insecure.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[same-origin-insecure.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the meta-referrer\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/generic.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/generic.no-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/script-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,6 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  expected: TIMEOUT
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via script-tag using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: NOTRUN
-

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -9102,6 +9102,12 @@
             "url": "/_mozilla/mozilla/websocket_connection_fail.html"
           }
         ],
+        "mozilla/window-postmessage-sameorigin.html": [
+          {
+            "path": "mozilla/window-postmessage-sameorigin.html",
+            "url": "/_mozilla/mozilla/window-postmessage-sameorigin.html"
+          }
+        ],
         "mozilla/window.html": [
           {
             "path": "mozilla/window.html",

--- a/tests/wpt/mozilla/tests/mozilla/window-postmessage-sameorigin.html
+++ b/tests/wpt/mozilla/tests/mozilla/window-postmessage-sameorigin.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Same-origin postMessage on the Window object</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/origin_helpers.js?pipe=sub"></script>
+<script>
+setup({
+  explicit_done: true
+});
+
+function expect_error(error, message, origin, description) {
+  return function(setlistener, removelistener, type) {
+    test(function(t) {
+      assert_throws(error, function() { postMessage(message, origin) });
+    }, description + ' (' + type + ')');
+  }
+}
+
+function expect_message(message, origin, test) {
+  return function(setlistener, removelistener, type) {
+    async_test(function(t) {
+      setlistener(t.step_func_done(function(e) {
+        removelistener(arguments.callee);
+        assert_true(e.isTrusted);
+        assert_equals(e.data, message);
+      }));
+      postMessage(message, origin);
+    }, test + ' (' + type + ')');
+  }
+}
+
+function expect_no_message(message, origin, test) {
+  return function(setlistener, removelistener, type) {
+    async_test(function(t) {
+      setlistener(t.step_func_done(function(e) {
+        removelistener(arguments.callee);
+        assert_equals(e.data, 'expected-sequencing-message');
+      }));
+      postMessage(message, origin);
+      postMessage('expected-sequencing-message', '*');
+    }, test + ' (' + type + ')');
+  }
+}
+
+var base_tests = [
+  function() { return expect_message('basic', '*', 'any origin, cloneable string message') },
+  function() { return expect_message('basic', '/', 'same origin, cloneable string message') },
+  function() { return expect_message('basic', HTTP_ORIGIN, 'explicit same origin, cloneable string message') },
+  function() { return expect_no_message('basic', HTTPS_ORIGIN, 'explicit cross origin, cloneable string message') },
+  function() { return expect_error(new SyntaxError(), 'basic', 'not-a-url', 'explicit invalid url, cloneable string message') },
+  function() { return expect_error('DATA_CLONE_ERR', window, '*', 'any origin, non-cloneable message') },
+];
+
+var tests = [];
+var add_handler = function(listener) { window.onmessage = listener; };
+var remove_handler = function(listener) { window.onmessage = null; };
+var remove_listener = function(listener) { window.removeEventListener('message', listener); }
+var add_listener = function(listener) { window.addEventListener('message', listener); };
+for (var i = 0; i < base_tests.length; i++) {
+  var f = base_tests[i]();
+  tests.push(f.bind(window, add_listener, remove_listener, "listener"));
+  tests.push(f.bind(window, add_handler, remove_handler, "handler"));
+}
+
+var current_test = 0;
+function next_test() {
+  if (current_test < tests.length) {
+    tests[current_test++]();
+  } else {
+    done();
+  }
+}
+
+add_result_callback(function() {
+  next_test();
+});
+
+next_test();
+</script>


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11161)

<!-- Reviewable:end -->
