### PR TITLE
gfx: Add expect messages to FontCacheThread::exit()

### DIFF
--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -438,8 +438,8 @@ impl FontCacheThread {
 
     pub fn exit(&self) {
         let (response_chan, response_port) = ipc::channel().unwrap();
-        self.chan.send(Command::Exit(response_chan)).unwrap();
-        response_port.recv().unwrap();
+        self.chan.send(Command::Exit(response_chan)).expect("Couldn't send FontCacheThread exit message");
+        response_port.recv().expect("Couldn't receive FontCacheThread reply");
     }
 }
 


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they only add debug info.

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

One of these two unwraps is the one that is causing most occurrences
of #8815.

I'd go with removing the second unwrap entirely, but let's get some
debug info first, since it might probably be a race.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11166)

<!-- Reviewable:end -->
