### PR TITLE
Implement WebGL TexSubImage2D

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -40,6 +40,7 @@ use util::vec::byte_swap;
 use webrender_traits::WebGLError::*;
 use webrender_traits::{WebGLCommand, WebGLError, WebGLFramebufferBindingRequest, WebGLParameter};
 
+type ImagePixelResult = Result<(Vec<u8>, Size2D<i32>), ()>;
 pub const MAX_UNIFORM_AND_ATTRIBUTE_LEN: usize = 256;
 
 macro_rules! handle_potential_webgl_error {
@@ -263,6 +264,73 @@ impl WebGLRenderingContext {
         }
     }
 
+    fn get_image_pixels(&self,
+                        source: Option<ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement>)
+                        -> ImagePixelResult {
+        let source = match source {
+            Some(s) => s,
+            None => return Err(()),
+        };
+
+        // NOTE: Getting the pixels probably can be short-circuited if some
+        // parameter is invalid.
+        //
+        // Nontheless, since it's the error case, I'm not totally sure the
+        // complexity is worth it.
+        let (pixels, size) = match source {
+            ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement::ImageData(image_data) => {
+                let global = self.global();
+                (image_data.get_data_array(&global.r()), image_data.get_size())
+            },
+            ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement::HTMLImageElement(image) => {
+                let img_url = match image.get_url() {
+                    Some(url) => url,
+                    None => return Err(()),
+                };
+
+                let window = window_from_node(&*self.canvas);
+
+                let img = match canvas_utils::request_image_from_cache(window.r(), img_url) {
+                    ImageResponse::Loaded(img) => img,
+                    ImageResponse::PlaceholderLoaded(_) | ImageResponse::None |
+                    ImageResponse::MetadataLoaded(_)
+                        => return Err(()),
+                };
+
+                let size = Size2D::new(img.width as i32, img.height as i32);
+
+                // TODO(emilio): Validate that the format argument
+                // is coherent with the image.
+                //
+                // RGB8 should be easy to support too
+                let mut data = match img.format {
+                    PixelFormat::RGBA8 => img.bytes.to_vec(),
+                    _ => unimplemented!(),
+                };
+
+                byte_swap(&mut data);
+
+                (data, size)
+            },
+            // TODO(emilio): Getting canvas data is implemented in CanvasRenderingContext2D,
+            // but we need to refactor it moving it to `HTMLCanvasElement` and support
+            // WebGLContext (probably via GetPixels()).
+            ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement::HTMLCanvasElement(canvas) => {
+                let canvas = canvas.r();
+                if let Some((mut data, size)) = canvas.fetch_all_data() {
+                    byte_swap(&mut data);
+                    (data, size)
+                } else {
+                    return Err(());
+                }
+            },
+            ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement::HTMLVideoElement(_rooted_video)
+                => unimplemented!(),
+        };
+
+        return Ok((pixels, size));
+    }
+
     fn validate_tex_internal_format(&self, internal_format: u32) -> bool {
         // GL_INVALID_VALUE is generated if internal_format is not an
         // accepted format.
@@ -281,6 +349,79 @@ impl WebGLRenderingContext {
         }
     }
 
+    fn validate_tex_format(&self, format: u32) -> bool {
+        // GL_INVALID_VALUE is generated if internal_format is not an
+        // accepted format.
+        match format {
+            constants::DEPTH_COMPONENT |
+            constants::ALPHA |
+            constants::RGB |
+            constants::RGBA |
+            constants::LUMINANCE |
+            constants::LUMINANCE_ALPHA => true,
+
+            _ => {
+                self.webgl_error(InvalidEnum);
+                false
+            },
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn validate_tex_image_2d_data(&self,
+                                  width: i32,
+                                  height: i32,
+                                  format: u32,
+                                  data_type: u32,
+                                  data: Option<*mut JSObject>)
+                                  -> Result<i32, ()> {
+        // TODO(emilio, #10693): Add type-safe wrappers to validations
+        let (element_size, components_per_element) = match data_type {
+            constants::UNSIGNED_BYTE => (1, 1),
+            constants::UNSIGNED_SHORT_5_6_5 => (2, 3),
+            constants::UNSIGNED_SHORT_5_5_5_1 |
+            constants::UNSIGNED_SHORT_4_4_4_4 => (2, 4),
+            _ => unreachable!(), // previously validated
+        };
+
+        let components = match format {
+            constants::DEPTH_COMPONENT => 1,
+            constants::ALPHA => 1,
+            constants::LUMINANCE => 1,
+            constants::LUMINANCE_ALPHA => 2,
+            constants::RGB => 3,
+            constants::RGBA => 4,
+            _ => unreachable!(), // previously validated
+        };
+
+        // If data is non-null, the type of pixels must match the type of the
+        // data to be read.
+        // If it is UNSIGNED_BYTE, a Uint8Array must be supplied;
+        // if it is UNSIGNED_SHORT_5_6_5, UNSIGNED_SHORT_4_4_4_4,
+        // or UNSIGNED_SHORT_5_5_5_1, a Uint16Array must be supplied.
+        // If the types do not match, an INVALID_OPERATION error is generated.
+        let received_size = if let Some(data) = data {
+            if unsafe { array_buffer_view_data_checked::<u16>(data).is_some() } {
+                2
+            } else if unsafe { array_buffer_view_data_checked::<u8>(data).is_some() } {
+                1
+            } else {
+                self.webgl_error(InvalidOperation);
+                return Err(());
+            }
+        } else {
+            element_size
+        };
+
+        if received_size != element_size {
+            self.webgl_error(InvalidOperation);
+            return Err(());
+        }
+
+        // NOTE: width and height are positive or zero due to validate()
+        let expected_byte_length = width * height * element_size * components / components_per_element;
+        return Ok(expected_byte_length);
+    }
 
     fn validate_tex_image_2d_parameters(&self,
                                         target: u32,
@@ -306,6 +447,10 @@ impl WebGLRenderingContext {
                 self.webgl_error(InvalidEnum);
                 return false;
             },
+        }
+        // Validate format
+        if !self.validate_tex_format(format) {
+            return false;
         }
 
         // Validate internal_format
@@ -461,12 +606,77 @@ impl WebGLRenderingContext {
                                                                width as u32,
                                                                height as u32, 1,
                                                                internal_format,
-                                                               level as u32));
-
+                                                               level as u32,
+                                                               Some(data_type)));
 
         // TODO(emilio): Invert axis, convert colorspace, premultiply alpha if requested
         let msg = WebGLCommand::TexImage2D(target, level, internal_format as i32,
                                            width, height, format, data_type, pixels);
+
+        self.ipc_renderer
+            .send(CanvasMsg::WebGL(msg))
+            .unwrap()
+    }
+
+    fn tex_sub_image_2d(&self,
+                        target: u32,
+                        level: i32,
+                        xoffset: i32,
+                        yoffset: i32,
+                        width: i32,
+                        height: i32,
+                        format: u32,
+                        data_type: u32,
+                        pixels: Vec<u8>) {  // NB: pixels should NOT be premultipied
+        // This should be validated before reaching this function
+        debug_assert!(self.validate_tex_image_2d_parameters(target, level,
+                                                            format,
+                                                            width, height,
+                                                            0, format,
+                                                            data_type));
+
+        let slot = match target {
+            constants::TEXTURE_2D
+                => self.bound_texture_2d.get(),
+            constants::TEXTURE_CUBE_MAP
+                => self.bound_texture_cube_map.get(),
+
+            _ => return self.webgl_error(InvalidEnum),
+        };
+
+        let texture = slot.as_ref().expect("No bound texture found after validation");
+
+        if format == constants::RGBA &&
+           data_type == constants::UNSIGNED_BYTE &&
+           self.texture_unpacking_settings.get().contains(PREMULTIPLY_ALPHA) {
+            // TODO(emilio): premultiply here.
+        }
+
+        // We have already validated level
+        let face_index = self.face_index_for_target(target).unwrap();
+        let image_info = texture.image_info_at_face(face_index, level as u32);
+
+        // GL_INVALID_VALUE is generated if:
+        //   - xoffset or yoffset is less than 0
+        //   - x offset plus the width is greater than the texture width
+        //   - y offset plus the height is greater than the texture height
+        if xoffset < 0 || ((xoffset + width) as u32) > image_info.width() ||
+            yoffset < 0 || ((yoffset + height) as u32) > image_info.height() {
+            return self.webgl_error(InvalidValue);
+        }
+
+        // Using internal_format() to do this check
+        // because we are sure format is as same as internal_format.
+        if format != image_info.internal_format().unwrap() ||
+            data_type != image_info.data_type().unwrap() {
+            return self.webgl_error(InvalidOperation);
+        }
+
+        // TODO(emilio): Flip Y axis if necessary here
+
+        // TODO(emilio): Invert axis, convert colorspace, premultiply alpha if requested
+        let msg = WebGLCommand::TexSubImage2D(target, level, xoffset, yoffset,
+                                            width, height, format, data_type, pixels);
 
         self.ipc_renderer
             .send(CanvasMsg::WebGL(msg))
@@ -889,7 +1099,8 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                                                                width as u32,
                                                                height as u32, 1,
                                                                internal_format,
-                                                               level as u32));
+                                                               level as u32,
+                                                               None));
 
         let msg = WebGLCommand::CopyTexImage2D(target, level, internal_format, x, y,
                                                width, height, border);
@@ -1881,7 +2092,6 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             .unwrap()
     }
 
-    #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
     fn TexImage2D(&self,
                   _cx: *mut JSContext,
@@ -1904,50 +2114,14 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             return; // Error handled in validate()
         }
 
-        // TODO(emilio, #10693): Add type-safe wrappers to validations
-        let (element_size, components_per_element) = match data_type {
-            constants::UNSIGNED_BYTE => (1, 1),
-            constants::UNSIGNED_SHORT_5_6_5 => (2, 3),
-            constants::UNSIGNED_SHORT_5_5_5_1 |
-            constants::UNSIGNED_SHORT_4_4_4_4 => (2, 4),
-            _ => unreachable!(), // previously validated
+        let expected_byte_length = match self.validate_tex_image_2d_data(width,
+                                                                         height,
+                                                                         format,
+                                                                         data_type,
+                                                                         data) {
+            Ok(byte_length) => byte_length,
+            Err(_) => return,
         };
-
-        let components = match format {
-            constants::DEPTH_COMPONENT => 1,
-            constants::ALPHA => 1,
-            constants::LUMINANCE => 1,
-            constants::LUMINANCE_ALPHA => 2,
-            constants::RGB => 3,
-            constants::RGBA => 4,
-            _ => unreachable!(), // previously validated
-        };
-
-        // If data is non-null, the type of pixels must match the type of the
-        // data to be read.
-        // If it is UNSIGNED_BYTE, a Uint8Array must be supplied;
-        // if it is UNSIGNED_SHORT_5_6_5, UNSIGNED_SHORT_4_4_4_4,
-        // or UNSIGNED_SHORT_5_5_5_1, a Uint16Array must be supplied.
-        // If the types do not match, an INVALID_OPERATION error is generated.
-        let received_size = if let Some(data) = data {
-            if unsafe { array_buffer_view_data_checked::<u16>(data).is_some() } {
-                2
-            } else if unsafe { array_buffer_view_data_checked::<u8>(data).is_some() } {
-                1
-            } else {
-                return self.webgl_error(InvalidOperation);
-            }
-        } else {
-            element_size
-        };
-
-        if received_size != element_size {
-            return self.webgl_error(InvalidOperation);
-        }
-
-        // NOTE: width and height are positive or zero due to validate()
-        let expected_byte_length = width * height * element_size * components / components_per_element;
-
 
         // If data is null, a buffer of sufficient size
         // initialized to 0 is passed.
@@ -1976,66 +2150,10 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                    format: u32,
                    data_type: u32,
                    source: Option<ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement>) {
-        let source = match source {
-            Some(s) => s,
-            None => return,
-        };
-
-
-        // NOTE: Getting the pixels probably can be short-circuited if some
-        // parameter is invalid.
-        //
-        // Nontheless, since it's the error case, I'm not totally sure the
-        // complexity is worth it.
-        let (pixels, size) = match source {
-            ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement::ImageData(image_data) => {
-                let global = self.global();
-                (image_data.get_data_array(&global.r()), image_data.get_size())
-            },
-            ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement::HTMLImageElement(image) => {
-                let img_url = match image.get_url() {
-                    Some(url) => url,
-                    None => return,
-                };
-
-                let window = window_from_node(&*self.canvas);
-
-                let img = match canvas_utils::request_image_from_cache(window.r(), img_url) {
-                    ImageResponse::Loaded(img) => img,
-                    ImageResponse::PlaceholderLoaded(_) | ImageResponse::None |
-                    ImageResponse::MetadataLoaded(_)
-                        => return,
-                };
-
-                let size = Size2D::new(img.width as i32, img.height as i32);
-
-                // TODO(emilio): Validate that the format argument
-                // is coherent with the image.
-                //
-                // RGB8 should be easy to support too
-                let mut data = match img.format {
-                    PixelFormat::RGBA8 => img.bytes.to_vec(),
-                    _ => unimplemented!(),
-                };
-
-                byte_swap(&mut data);
-
-                (data, size)
-            },
-            // TODO(emilio): Getting canvas data is implemented in CanvasRenderingContext2D,
-            // but we need to refactor it moving it to `HTMLCanvasElement` and support
-            // WebGLContext (probably via GetPixels()).
-            ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement::HTMLCanvasElement(canvas) => {
-                let canvas = canvas.r();
-                if let Some((mut data, size)) = canvas.fetch_all_data() {
-                    byte_swap(&mut data);
-                    (data, size)
-                } else {
-                    return
-                }
-            },
-            ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement::HTMLVideoElement(_rooted_video)
-                => unimplemented!(),
+        // Get pixels from image source
+        let (pixels, size) = match self.get_image_pixels(source) {
+            Ok((pixels, size)) => (pixels, size),
+            Err(_) => return,
         };
 
         // NB: Border must be zero
@@ -2048,7 +2166,86 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         self.tex_image_2d(target, level,
                           internal_format,
                           size.width, size.height, 0,
-                          format, data_type, pixels)
+                          format, data_type, pixels);
+    }
+
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    fn TexSubImage2D(&self,
+                     _cx: *mut JSContext,
+                     target: u32,
+                     level: i32,
+                     xoffset: i32,
+                     yoffset: i32,
+                     width: i32,
+                     height: i32,
+                     format: u32,
+                     data_type: u32,
+                     data: Option<*mut JSObject>) {
+        if !self.validate_tex_image_2d_parameters(target,
+                                                  level,
+                                                  format,
+                                                  width, height,
+                                                  0,
+                                                  format,
+                                                  data_type) {
+            return; // Error handled in validate()
+        }
+
+        let expected_byte_length = match self.validate_tex_image_2d_data(width,
+                                                                         height,
+                                                                         format,
+                                                                         data_type,
+                                                                         data) {
+            Ok(byte_length) => byte_length,
+            Err(()) => return,
+        };
+
+        // If data is null, a buffer of sufficient size
+        // initialized to 0 is passed.
+        let buff = if let Some(data) = data {
+            array_buffer_view_to_vec::<u8>(data)
+                .expect("Can't reach here without being an ArrayBufferView!")
+        } else {
+            vec![0u8; expected_byte_length as usize]
+        };
+
+        if expected_byte_length != 0 &&
+            buff.len() != expected_byte_length as usize {
+            return self.webgl_error(InvalidOperation);
+        }
+
+        self.tex_sub_image_2d(target, level,
+                              xoffset, yoffset,
+                              width, height,
+                              format, data_type, buff);
+    }
+
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    fn TexSubImage2D_(&self,
+                      target: u32,
+                      level: i32,
+                      xoffset: i32,
+                      yoffset: i32,
+                      format: u32,
+                      data_type: u32,
+                      source: Option<ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement>) {
+        // Get pixels from image source
+        let (pixels, size) = match self.get_image_pixels(source) {
+            Ok((pixels, size)) => (pixels, size),
+            Err(_) => return,
+        };
+
+        // NB: Border must be zero
+        if !self.validate_tex_image_2d_parameters(target, level, format,
+                                                  size.width, size.height, 0,
+                                                  format, data_type) {
+            return; // Error handled in validate()
+        }
+
+        self.tex_sub_image_2d(target, level,
+                            xoffset, yoffset,
+                            size.width, size.height,
+                            format, data_type, pixels);
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -109,13 +109,15 @@ impl WebGLTexture {
                       height: u32,
                       depth: u32,
                       internal_format: u32,
-                      level: u32) -> WebGLResult<()> {
+                      level: u32,
+                      data_type: Option<u32>) -> WebGLResult<()> {
         let image_info = ImageInfo {
             width: width,
             height: height,
             depth: depth,
             internal_format: Some(internal_format),
             is_initialized: true,
+            data_type: data_type,
         };
 
         let face = match target {
@@ -274,6 +276,7 @@ impl WebGLTexture {
                 depth: 0,
                 internal_format: base_image_info.internal_format,
                 is_initialized: base_image_info.is_initialized(),
+                data_type: base_image_info.data_type,
             };
 
             self.set_image_infos_at_level(level, image_info);
@@ -346,6 +349,7 @@ pub struct ImageInfo {
     depth: u32,
     internal_format: Option<u32>,
     is_initialized: bool,
+    data_type: Option<u32>,
 }
 
 impl ImageInfo {
@@ -356,6 +360,7 @@ impl ImageInfo {
             depth: 0,
             internal_format: None,
             is_initialized: false,
+            data_type: None,
         }
     }
 
@@ -369,6 +374,10 @@ impl ImageInfo {
 
     pub fn internal_format(&self) -> Option<u32> {
         self.internal_format
+    }
+
+    pub fn data_type(&self) -> Option<u32> {
+        self.data_type
     }
 
     fn is_power_of_two(&self) -> bool {

--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -646,11 +646,11 @@ interface WebGLRenderingContextBase
     void texParameterf(GLenum target, GLenum pname, GLfloat param);
     void texParameteri(GLenum target, GLenum pname, GLint param);
 
-    //void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
-    //                   GLsizei width, GLsizei height,
-    //                   GLenum format, GLenum type, ArrayBufferView? pixels);
-    //void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
-    //                   GLenum format, GLenum type, TexImageSource? source); // May throw DOMException
+    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+                      GLsizei width, GLsizei height,
+                      GLenum format, GLenum type, optional object data);
+    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+                      GLenum format, GLenum type, TexImageSource? source); // May throw DOMException
 
     void uniform1f(WebGLUniformLocation? location, GLfloat x);
     //void uniform1fv(WebGLUniformLocation? location, Float32Array v);

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/texSubImage2DBadArgs.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/texSubImage2DBadArgs.html.ini
@@ -1,5 +1,0 @@
-[texSubImage2DBadArgs.html]
-  type: testharness
-  [WebGL test #0: testTexImage2D]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/texSubImage2DHTMLBadArgs.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/texSubImage2DHTMLBadArgs.html.ini
@@ -1,5 +1,0 @@
-[texSubImage2DHTMLBadArgs.html]
-  type: testharness
-  [WebGL test #0: testTexImage2D]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html.ini
@@ -1,13 +1,5 @@
 [tex-image-and-sub-image-2d-with-array-buffer-view.html]
   type: testharness
-  [WebGL test #0: successfullyParsed should be true. Was false.]
-    expected: FAIL
-
-  [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
-    expected: FAIL
-
-  [WebGL test #1: successfullyParsed should be true. Was false.]
-    expected: FAIL
 
   [WebGL test #0: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: FAIL
@@ -15,6 +7,101 @@
   [WebGL test #1: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
     expected: FAIL
 
-  [WebGL test #2: successfullyParsed should be true. Was false.]
+  [WebGL test #2: at (0, 0) expected: 0,0,255,255 was 255,0,0,255]
     expected: FAIL
 
+  [WebGL test #3: at (0, 4) expected: 255,0,0,255 was 0,0,255,255]
+    expected: FAIL
+
+  [WebGL test #4: at (8, 0) expected: 0,255,0,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #5: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #6: at (0, 0) expected: 0,0,255,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #7: at (0, 4) expected: 255,0,0,255 was 0,0,255,255]
+    expected: FAIL
+
+  [WebGL test #8: at (8, 0) expected: 0,255,0,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #9: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #10: at (8, 8) expected: 0,0,255,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #11: at (8, 12) expected: 255,0,0,255 was 0,0,255,255]
+    expected: FAIL
+
+  [WebGL test #12: GL error before texture upload]
+    expected: FAIL
+
+  [WebGL test #25: GL error before texture upload]
+    expected: FAIL
+
+  [WebGL test #26: at (0, 0) expected: 0,0,0,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #27: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #28: at (0, 0) expected: 0,0,0,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #29: at (0, 4) expected: 255,0,0,255 was 0,0,255,255]
+    expected: FAIL
+
+  [WebGL test #30: at (8, 0) expected: 0,0,0,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #31: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #32: at (0, 0) expected: 0,0,0,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #33: at (0, 4) expected: 255,0,0,255 was 0,0,255,255]
+    expected: FAIL
+
+  [WebGL test #34: at (8, 0) expected: 0,0,0,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #35: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #36: at (8, 8) expected: 0,0,0,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #37: at (8, 12) expected: 255,0,0,255 was 0,0,255,255]
+    expected: FAIL
+
+  [WebGL test #38: GL error before texture upload]
+    expected: FAIL
+
+  [WebGL test #40: at (0, 8) expected: 0,0,0,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #42: at (0, 4) expected: 0,0,0,255 was 0,0,255,255]
+    expected: FAIL
+
+  [WebGL test #44: at (0, 8) expected: 0,0,0,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #46: at (0, 4) expected: 0,0,0,255 was 0,0,255,255]
+    expected: FAIL
+
+  [WebGL test #48: at (0, 8) expected: 0,0,0,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #50: at (8, 12) expected: 0,0,0,255 was 0,0,255,255]
+    expected: FAIL
+
+  [WebGL test #51: GL error before texture upload]
+    expected: FAIL
+
+  [WebGL test #52: successfullyParsed should be true. Was false.]
+    expected: FAIL

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-size.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-size.html.ini
@@ -6,3 +6,350 @@
   [WebGL test #1: unexpected gl error: INVALID_ENUM]
     expected: FAIL
 
+  [WebGL test #4: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #6: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #9: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #11: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #16: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #18: at (0, 0) expected: 0,0,255,255 was 0,255,255,255]
+    expected: FAIL
+
+  [WebGL test #19: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #21: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #24: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #26: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #29: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #31: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #34: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #36: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #38: at (0, 0) expected: 0,0,255,255 was 0,255,255,255]
+    expected: FAIL
+
+  [WebGL test #39: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #41: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #44: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #46: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #49: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #51: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #54: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #51: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #54: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #55: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #59: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #60: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #64: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #65: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #69: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #70: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #73: at (0, 0) expected: 0,0,255,255 was 0,255,255,255]
+    expected: FAIL
+
+  [WebGL test #74: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #75: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #79: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #80: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #84: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #85: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #89: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #90: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #93: at (0, 0) expected: 0,0,255,255 was 0,255,255,255]
+    expected: FAIL
+
+  [WebGL test #94: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #95: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #99: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #100: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #104: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #105: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #109: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #105: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #108: at (0, 0) expected: 0,0,255,255 was 0,255,255,255]
+    expected: FAIL
+
+  [WebGL test #109: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #110: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #114: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #115: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #119: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #120: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #124: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #125: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #128: at (0, 0) expected: 0,0,255,255 was 0,255,255,255]
+    expected: FAIL
+
+  [WebGL test #129: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #130: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #134: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #135: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #139: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #140: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #144: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #145: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #148: at (0, 0) expected: 0,0,255,255 was 0,255,255,255]
+    expected: FAIL
+
+  [WebGL test #149: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #150: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #154: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #155: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #159: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #160: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #164: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #165: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #168: at (0, 0) expected: 0,0,255,255 was 0,255,255,255]
+    expected: FAIL
+
+  [WebGL test #169: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #170: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #174: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #175: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #179: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #180: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #184: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #185: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #188: at (0, 0) expected: 0,0,255,255 was 0,255,255,255]
+    expected: FAIL
+
+  [WebGL test #189: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #190: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #194: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #195: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #199: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #200: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #204: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #205: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #208: at (0, 0) expected: 0,0,255,255 was 0,255,255,255]
+    expected: FAIL
+
+  [WebGL test #209: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #210: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #214: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #215: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #219: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #220: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #224: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #225: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #229: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #230: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #234: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #235: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #239: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #240: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #244: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #245: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #249: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL
+
+  [WebGL test #250: unexpected gl error: INVALID_ENUM]
+    expected: FAIL
+
+  [WebGL test #253: at (0, 0) expected: 0,0,255,255 was 0,255,255,255]
+    expected: FAIL
+
+  [WebGL test #254: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
+    expected: FAIL


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because I have run the wpt test of texSubImage2D.html, and it works.

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

I have implemented `TexSubImage2D` follow [the spec](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8). This is my first version of implementation, and I notice I can reuse the code from `TexImage2D`. Therefore, I would like to discuss make `validate_tex_image2D_from_buffer` and `validate_tex_image2D_from_source` to remove duplicate code.

Part of #10209

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11168)

<!-- Reviewable:end -->
