### PR TITLE
Make Node::BaseURI use the document's base URL

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1865,7 +1865,7 @@ impl NodeMethods for Node {
 
     // https://dom.spec.whatwg.org/#dom-node-baseuri
     fn BaseURI(&self) -> DOMString {
-        self.owner_doc().URL()
+        DOMString::from(self.owner_doc().base_url().as_str())
     }
 
     // https://dom.spec.whatwg.org/#dom-node-ownerdocument

--- a/tests/wpt/metadata/html/infrastructure/urls/terminology-0/document-base-url.html.ini
+++ b/tests/wpt/metadata/html/infrastructure/urls/terminology-0/document-base-url.html.ini
@@ -1,8 +1,5 @@
 [document-base-url.html]
   type: testharness
-  [The document base URL of a document containing one or more base elements with href attributes is the frozen base URL of the first base element in the document that has an href attribute, in tree order.]
-    expected: FAIL
-
   [The fallback base URL of a document whose address is about:blank is the document base URL of the creator document.]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/infrastructure/urls/terminology-0/multiple-base.sub.html.ini
+++ b/tests/wpt/metadata/html/infrastructure/urls/terminology-0/multiple-base.sub.html.ini
@@ -1,5 +1,0 @@
-[multiple-base.sub.html]
-  type: testharness
-  [If there are multiple <base> elements, the document base URL is the frozen base URL of the first one that has an href attribute]
-    expected: FAIL
-


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11145  (github issue number if applicable).

Either:
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11178)

<!-- Reviewable:end -->
