### PR TITLE
htmlanchorelement getter work before href setting is called

### DIFF
--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -71,7 +71,6 @@ impl HTMLAnchorElement {
     fn reinitialize_url(&self) {
         // Step 1.
         match *self.url.borrow() {
-            None => return,
             Some(ref url) if url.scheme() == "blob" && url.cannot_be_a_base() => return,
             _ => (),
         }

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -35943,6 +35943,12 @@
             "path": "html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_attribute-getter-setter.html",
             "url": "/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_attribute-getter-setter.html"
           }
+        ],
+        "html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_getter.html": [
+          {
+            "path": "html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_getter.html",
+            "url": "/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_getter.html"
+          }
         ]
       }
     },

--- a/tests/wpt/metadata/html/dom/reflection-text.html.ini
+++ b/tests/wpt/metadata/html/dom/reflection-text.html.ini
@@ -1251,57 +1251,6 @@
   [a.type: IDL set to object "test-valueOf" followed by IDL get]
     expected: FAIL
 
-  [a.href: setAttribute() to "" followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to " foo " followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to "//site.example/path???@#l" followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to "\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f " followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to undefined followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to 7 followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to true followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to false followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to NaN followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to Infinity followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to null followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [a.href: setAttribute() to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
   [a.charset: typeof IDL attribute]
     expected: FAIL
 

--- a/tests/wpt/metadata/url/a-element-xhtml.xhtml.ini
+++ b/tests/wpt/metadata/url/a-element-xhtml.xhtml.ini
@@ -174,9 +174,6 @@
   [Parsing: <madeupscheme:/example.com/> against <http://example.org/foo/bar>]
     expected: FAIL
 
-  [Parsing: <file:/example.com/> against <http://example.org/foo/bar>]
-    expected: FAIL
-
   [Parsing: <ftps:/example.com/> against <http://example.org/foo/bar>]
     expected: FAIL
 
@@ -249,12 +246,6 @@
   [Parsing: <data:text/html,test#test> against <http://example.org/foo/bar>]
     expected: FAIL
 
-  [Parsing: <file:c:\\foo\\bar.html> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <  File:c|////foo\\bar.html> against <file:///tmp/mock/path>]
-    expected: FAIL
-
   [Parsing: <C|/foo/bar> against <file:///tmp/mock/path>]
     expected: FAIL
 
@@ -273,12 +264,6 @@
   [Parsing: </\\server/file> against <file:///tmp/mock/path>]
     expected: FAIL
 
-  [Parsing: <file:///foo/bar.txt> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file:///home/me> against <file:///tmp/mock/path>]
-    expected: FAIL
-
   [Parsing: <//> against <file:///tmp/mock/path>]
     expected: FAIL
 
@@ -286,18 +271,6 @@
     expected: FAIL
 
   [Parsing: <///test> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file://test> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file://localhost> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file://localhost/> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file://localhost/test> against <file:///tmp/mock/path>]
     expected: FAIL
 
   [Parsing: <test> against <file:///tmp/mock/path>]
@@ -504,9 +477,6 @@
   [Parsing: <madeupscheme:/example.com/> against <about:blank>]
     expected: FAIL
 
-  [Parsing: <file:/example.com/> against <about:blank>]
-    expected: FAIL
-
   [Parsing: <ftps:/example.com/> against <about:blank>]
     expected: FAIL
 
@@ -640,15 +610,6 @@
     expected: FAIL
 
   [Parsing: <//www.example2.com> against <http://www.example.com/test>]
-    expected: FAIL
-
-  [Parsing: <file:...> against <http://www.example.com/test>]
-    expected: FAIL
-
-  [Parsing: <file:..> against <http://www.example.com/test>]
-    expected: FAIL
-
-  [Parsing: <file:a> against <http://www.example.com/test>]
     expected: FAIL
 
   [Parsing: <http://ExAmPlE.CoM> against <http://other.com/>]
@@ -799,5 +760,53 @@
     expected: FAIL
 
   [Parsing: <sc::a@example.net> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:/:@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:/@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:a:b@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:/a:b@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http::@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:@:www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:/@:www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <i> against <sc:sd>]
+    expected: FAIL
+
+  [Parsing: <i> against <sc:sd/sd>]
+    expected: FAIL
+
+  [Parsing: <../i> against <sc:sd>]
+    expected: FAIL
+
+  [Parsing: <../i> against <sc:sd/sd>]
+    expected: FAIL
+
+  [Parsing: </i> against <sc:sd>]
+    expected: FAIL
+
+  [Parsing: </i> against <sc:sd/sd>]
+    expected: FAIL
+
+  [Parsing: <?i> against <sc:sd>]
+    expected: FAIL
+
+  [Parsing: <?i> against <sc:sd/sd>]
     expected: FAIL
 

--- a/tests/wpt/metadata/url/a-element.html.ini
+++ b/tests/wpt/metadata/url/a-element.html.ini
@@ -174,9 +174,6 @@
   [Parsing: <madeupscheme:/example.com/> against <http://example.org/foo/bar>]
     expected: FAIL
 
-  [Parsing: <file:/example.com/> against <http://example.org/foo/bar>]
-    expected: FAIL
-
   [Parsing: <ftps:/example.com/> against <http://example.org/foo/bar>]
     expected: FAIL
 
@@ -249,12 +246,6 @@
   [Parsing: <data:text/html,test#test> against <http://example.org/foo/bar>]
     expected: FAIL
 
-  [Parsing: <file:c:\\foo\\bar.html> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <  File:c|////foo\\bar.html> against <file:///tmp/mock/path>]
-    expected: FAIL
-
   [Parsing: <C|/foo/bar> against <file:///tmp/mock/path>]
     expected: FAIL
 
@@ -273,12 +264,6 @@
   [Parsing: </\\server/file> against <file:///tmp/mock/path>]
     expected: FAIL
 
-  [Parsing: <file:///foo/bar.txt> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file:///home/me> against <file:///tmp/mock/path>]
-    expected: FAIL
-
   [Parsing: <//> against <file:///tmp/mock/path>]
     expected: FAIL
 
@@ -286,18 +271,6 @@
     expected: FAIL
 
   [Parsing: <///test> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file://test> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file://localhost> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file://localhost/> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file://localhost/test> against <file:///tmp/mock/path>]
     expected: FAIL
 
   [Parsing: <test> against <file:///tmp/mock/path>]
@@ -502,9 +475,6 @@
     expected: FAIL
 
   [Parsing: <madeupscheme:/example.com/> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <file:/example.com/> against <about:blank>]
     expected: FAIL
 
   [Parsing: <ftps:/example.com/> against <about:blank>]
@@ -771,15 +741,6 @@
   [Parsing: <sc:\\../> against <about:blank>]
     expected: FAIL
 
-  [Parsing: <file:...> against <http://www.example.com/test>]
-    expected: FAIL
-
-  [Parsing: <file:..> against <http://www.example.com/test>]
-    expected: FAIL
-
-  [Parsing: <file:a> against <http://www.example.com/test>]
-    expected: FAIL
-
   [Parsing: <http://127.0.0.1:10100/relative_import.html> against <about:blank>]
     expected: FAIL
 
@@ -799,5 +760,53 @@
     expected: FAIL
 
   [Parsing: <sc::a@example.net> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:/:@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:/@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:a:b@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:/a:b@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http::@/www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:@:www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <http:/@:www.example.com> against <about:blank>]
+    expected: FAIL
+
+  [Parsing: <i> against <sc:sd>]
+    expected: FAIL
+
+  [Parsing: <i> against <sc:sd/sd>]
+    expected: FAIL
+
+  [Parsing: <../i> against <sc:sd>]
+    expected: FAIL
+
+  [Parsing: <../i> against <sc:sd/sd>]
+    expected: FAIL
+
+  [Parsing: </i> against <sc:sd>]
+    expected: FAIL
+
+  [Parsing: </i> against <sc:sd/sd>]
+    expected: FAIL
+
+  [Parsing: <?i> against <sc:sd>]
+    expected: FAIL
+
+  [Parsing: <?i> against <sc:sd/sd>]
     expected: FAIL
 

--- a/tests/wpt/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_getter.html
+++ b/tests/wpt/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_getter.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<meta charset="utf-8">
+<html>
+<head>
+<title>HTMLAnchorElement getters test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<a id=a1 href="http://google.com?hi">a1</a>
+<a id=a2 href="http://google.com#somehash">a2</a>
+<a id=a3 href="http://google.com:1234/somedir">a3</a>
+<a id=a4 href="http://google.com:1234/somedir">a4</a>
+<a id=a5 href="http://google.com:1234/somedir">a5</a>
+<a id=a6 href="https://anonymous:flabada@developer.mozilla.org/en-US/docs/">a6</a>
+<a id=a7 href="http://google.com:1234/somedir/someotherdir/index.html">a7</a>
+<a id=a8 href="http://google.com:1234/somedir">a8</a>
+<a id=a9 href="http://google.com/somedir">a9</a>
+<a id=a10 href="https://anonymous:pwd@developer.mozilla.org:1234/en-US/">a10</a>
+<script>
+function test_getter(property, result, id) {
+  var a = document.getElementById(id);
+  var r = a[property];
+  assert_equals(r, result);
+}
+
+//Elements for each test: [property, result, id]
+//                         [0]       [1]     [2]
+tests = [
+  ["search", "?hi", "a1"],
+  ["hash", "#somehash", "a2"],
+  ["host", "google.com:1234", "a3"],
+  ["hostname", "google.com", "a4"],
+  ["href", "http://google.com:1234/somedir", "a5"],
+  ["password", "flabada", "a6"],
+  ["pathname", "/somedir/someotherdir/index.html", "a7"],
+  ["port", "1234",  "a8"],
+  ["protocol", "http:", "a9"],
+  ["username", "anonymous", "a10"]
+];
+
+for (var i = 0; i < tests.length; i++) {
+    test(function() {
+        test_getter(tests[i][0], tests[i][1], tests[i][2])
+    }, "Getter for attribute of anchor element(" + i + "):" + tests[i][0]);
+}
+</script>
+</head>
+</html>
+


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [x] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #10876  (github issue number if applicable).

Either:
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11182)

<!-- Reviewable:end -->
