### PR TITLE
Use JS_NewStringCopyN for the representation of interface objects

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1993,17 +1993,16 @@ class CGInterfaceObjectJSClass(CGThing):
         args = {
             "constructorBehavior": constructorBehavior,
             "id": name,
-            "representation": str_to_const_array("function %s() {\\n    [native code]\\n}" % name),
+            "representation": 'b"function %s() {\\n    [native code]\\n}"' % name,
             "depth": self.descriptor.prototypeDepth
         }
         return """\
-static InterfaceObjectClass: NonCallbackInterfaceObjectClass = unsafe {
+static InterfaceObjectClass: NonCallbackInterfaceObjectClass =
     NonCallbackInterfaceObjectClass::new(
         %(constructorBehavior)s,
         %(representation)s,
         PrototypeList::ID::%(id)s,
-        %(depth)s)
-};
+        %(depth)s);
 """ % args
 
 


### PR DESCRIPTION
This removes the need for the final null byte and we can make NonCallbackInterfaceObjectClass::new safe again I guess.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11188)

<!-- Reviewable:end -->
