### PR TITLE
Add link to git-hook tips in HACKING_QUICKSTART.md

### DIFF
--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -2,7 +2,10 @@
 
 This guide covers the basics things one needs to know to start hacking Servo.
 It doesn't cover how Servo works (see the [documentation](#documentation) section for that),
-but describe how to setup your environment to compile, run and debug Servo.
+but describe how to setup your environment to compile, run, and debug Servo. For information
+on the [Github Workflow](https://github.com/servo/servo/wiki/Github-workflow) and some helpful
+[Git Tips](https://github.com/servo/servo/wiki/Github-workflow#git-tips) see the
+[Wiki](https://github.com/servo/servo/wiki).
 
 ## Building Servo
 


### PR DESCRIPTION
After a conversation with @aneeshusa on IRC starting [here-ish](http://logs.glob.uno/?c=mozilla%23servo#c430067), info about a [git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) that runs `test-tidy` on commit (or push) was added to the wiki [here](https://github.com/servo/servo/wiki/Github-workflow#test-tidy-commit-hook). A suggestion was made to also add a link to this in the PR template.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11193)

<!-- Reviewable:end -->
