### PR TITLE
Make quit-on-escape optional

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -34,6 +34,7 @@ use util::geometry::ScreenPx;
 use util::opts;
 #[cfg(not(target_os = "android"))]
 use util::opts::RenderApi;
+use util::prefs;
 use util::resource_files;
 
 static mut g_nested_event_loop_listener: Option<*mut (NestedEventLoopListener + 'static)> = None;
@@ -768,7 +769,9 @@ impl WindowMethods for Window {
             }
 
             (NONE, Key::Escape) => {
-                self.event_queue.borrow_mut().push(WindowEvent::Quit);
+                if let Some(true) = prefs::get_pref("shell.quit-on-escape.enabled").as_boolean() {
+                    self.event_queue.borrow_mut().push(WindowEvent::Quit);
+                }
             }
 
             (CMD_OR_ALT, Key::Right) => {

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -55,6 +55,7 @@
   "layout.writing-mode.enabled": false,
   "network.http.redirection-limit": 20,
   "network.mime.sniff": false,
+  "shell.homepage": "http://servo.org",
   "shell.native-titlebar.enabled": true,
-  "shell.homepage": "http://servo.org"
+  "shell.quit-on-escape.enabled": true
 }


### PR DESCRIPTION
For browserhtml, we don't want Servo to shut down when the user presses the escape key.
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #11194

Either:
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because I don't know how to test shutdown and how to dispatch a non-DOM key event

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11200)

<!-- Reviewable:end -->
