### PR TITLE
Fix unused import warning in script::dom::bindings::js

### DIFF
--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -38,6 +38,7 @@ use script_thread::STACK_ROOTS;
 use std::cell::UnsafeCell;
 use std::default::Default;
 use std::hash::{Hash, Hasher};
+#[cfg(debug_assertions)]
 use std::intrinsics::type_name;
 use std::mem;
 use std::ops::Deref;


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11204)

<!-- Reviewable:end -->
