### PR TITLE
Remove misleading nonexistant flag hint

### DIFF
--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -549,7 +549,6 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     opts.optflag("x", "exit", "Exit after load flag");
     opts.optopt("y", "layout-threads", "Number of threads to use for layout", "1");
     opts.optflag("i", "nonincremental-layout", "Enable to turn off incremental layout.");
-    opts.optflag("", "no-ssl", "Disables ssl certificate verification.");
     opts.optflagopt("", "userscripts",
                     "Uses userscripts in resources/user-agent-js, or a specified full path", "");
     opts.optmulti("", "user-stylesheet",


### PR DESCRIPTION
`./mach build -d` does not report any errors.
`./mach test-tidy --faster` does not report any errors.
The change fixes #11197.

The change does not require tests because it is a small change that doesn't change any core functionality.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11209)

<!-- Reviewable:end -->
