### PR TITLE
Add -moz-user-* CSS longhands for Gecko

### DIFF
--- a/components/style/properties/longhand/pointing.mako.rs
+++ b/components/style/properties/longhand/pointing.mako.rs
@@ -55,6 +55,9 @@
 // TODO(pcwalton): SVG-only values.
 ${helpers.single_keyword("pointer-events", "auto none")}
 
+${helpers.single_keyword("-moz-user-modify", "read-only read-write write-only", products="gecko",
+                         gecko_ffi_name="mUserModify", gecko_constant_prefix="NS_STYLE_USER_MODIFY")}
+
 ${helpers.single_keyword("-moz-user-focus",
                          "ignore normal select-after select-before select-menu select-same select-all none",
                          products="gecko",

--- a/components/style/properties/longhand/pointing.mako.rs
+++ b/components/style/properties/longhand/pointing.mako.rs
@@ -55,6 +55,9 @@
 // TODO(pcwalton): SVG-only values.
 ${helpers.single_keyword("pointer-events", "auto none")}
 
+${helpers.single_keyword("-moz-user-input", "none enabled disabled", products="gecko",
+                         gecko_ffi_name="mUserInput", gecko_constant_prefix="NS_STYLE_USER_INPUT")}
+
 ${helpers.single_keyword("-moz-user-modify", "read-only read-write write-only", products="gecko",
                          gecko_ffi_name="mUserModify", gecko_constant_prefix="NS_STYLE_USER_MODIFY")}
 

--- a/components/style/properties/longhand/pointing.mako.rs
+++ b/components/style/properties/longhand/pointing.mako.rs
@@ -54,3 +54,9 @@
 // is nonstandard, slated for CSS4-UI.
 // TODO(pcwalton): SVG-only values.
 ${helpers.single_keyword("pointer-events", "auto none")}
+
+${helpers.single_keyword("-moz-user-focus",
+                         "ignore normal select-after select-before select-menu select-same select-all none",
+                         products="gecko",
+                         gecko_ffi_name="mUserFocus",
+                         gecko_constant_prefix="NS_STYLE_USER_FOCUS")}

--- a/components/style/properties/longhand/ui.mako.rs
+++ b/components/style/properties/longhand/ui.mako.rs
@@ -11,3 +11,6 @@
 
 ${helpers.single_keyword("ime-mode", "normal auto active disabled inactive", products="gecko",
                          gecko_ffi_name="mIMEMode")}
+
+${helpers.single_keyword("-moz-user-select", "auto text none all", products="gecko",
+                         gecko_ffi_name="mUserSelect", gecko_constant_prefix="NS_STYLE_USER_SELECT")}


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors
- [x] These changes do not require tests because stylo

r? @bholley

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11222)

<!-- Reviewable:end -->
