### PR TITLE
Updated etc/ci/check_no_unwrap.sh for new constellation crate.

### DIFF
--- a/etc/ci/check_no_unwrap.sh
+++ b/etc/ci/check_no_unwrap.sh
@@ -11,6 +11,6 @@ cd "$(git rev-parse --show-toplevel)" # cd into repo root so make sure paths wor
 # files that should not contain "unwrap"
 FILES=("components/compositing/compositor.rs"
        "components/compositing/pipeline.rs"
-       "components/compositing/constellation.rs")
+       "components/constellation/constellation.rs")
 
 ! grep -n "unwrap(\|panic!(" "${FILES[@]}"


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [X] No github issue.

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this is updating our CI test code.

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11249)

<!-- Reviewable:end -->
