### PR TITLE
Added test that files exist to etc/ci/check_no_unwrap.sh.

### DIFF
--- a/etc/ci/check_no_unwrap.sh
+++ b/etc/ci/check_no_unwrap.sh
@@ -13,4 +13,8 @@ FILES=("components/compositing/compositor.rs"
        "components/compositing/pipeline.rs"
        "components/compositing/constellation.rs")
 
-! grep -n "unwrap(\|panic!(" "${FILES[@]}"
+# make sure the files exist
+ls -1 "${FILES[@]}"
+
+# make sure the files do not contain "unwrap" or "panic!"
+! grep --line-number --with-filename "unwrap(\|panic!(" "${FILES[@]}"


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [X] No github issue.

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this PR updates test code.

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11251)

<!-- Reviewable:end -->
