### PR TITLE
Make HTMLMEtaElement `name` attribute an Atom.

### DIFF
--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::attr::AttrValue;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::HTMLMetaElementBinding;
 use dom::bindings::codegen::Bindings::HTMLMetaElementBinding::HTMLMetaElementMethods;
@@ -90,7 +91,7 @@ impl HTMLMetaElementMethods for HTMLMetaElement {
     make_getter!(Name, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-meta-name
-    make_setter!(SetName, "name");
+    make_atomic_setter!(SetName, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-meta-content
     make_getter!(Content, "content");
@@ -111,6 +112,13 @@ impl VirtualMethods for HTMLMetaElement {
 
         if tree_in_doc {
             self.process_attributes();
+        }
+    }
+
+    fn parse_plain_attribute(&self, name: &Atom, value: DOMString) -> AttrValue {
+        match name {
+            &atom!("name") => AttrValue::from_atomic(value),
+            _ => self.super_type().unwrap().parse_plain_attribute(name, value),
         }
     }
 }


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X ] `./mach build -d` does not report any errors
- [X ] `./mach test-tidy --faster` does not report any errors
- [X ] These changes fix #11247 (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [X ] These changes do not require tests because it is already covered by existing tests ~@jdm

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11257)

<!-- Reviewable:end -->
