### PR TITLE
Geckolib: Specify eStyleUnit_Enumerated instead of eStyleUnit_Integer for enumerated types

### DIFF
--- a/ports/geckolib/properties.mako.rs
+++ b/ports/geckolib/properties.mako.rs
@@ -666,7 +666,7 @@ fn static_assert() {
         match v {
             % for value in keyword.values_for('gecko'):
                 T::${to_rust_ident(value)} =>
-                    self.gecko.mVerticalAlign.set_int(structs::${keyword.gecko_constant(value)} as i32),
+                    self.gecko.mVerticalAlign.set_enum(structs::${keyword.gecko_constant(value)} as i32),
             % endfor
             T::LengthOrPercentage(v) => self.gecko.mVerticalAlign.set(v),
         }

--- a/ports/geckolib/values.rs
+++ b/ports/geckolib/values.rs
@@ -13,6 +13,7 @@ pub trait StyleCoordHelpers {
     fn set_auto(&mut self);
     fn set_coord(&mut self, val: Au);
     fn set_int(&mut self, val: i32);
+    fn set_enum(&mut self, val: i32);
     fn set_percent(&mut self, val: f32);
 }
 
@@ -38,6 +39,11 @@ impl StyleCoordHelpers for nsStyleCoord {
 
     fn set_int(&mut self, val: i32) {
         self.mUnit = nsStyleUnit::eStyleUnit_Integer;
+        unsafe { *self.mValue.mInt.as_mut() = val; }
+    }
+
+    fn set_enum(&mut self, val: i32) {
+        self.mUnit = nsStyleUnit::eStyleUnit_Enumerated;
         unsafe { *self.mValue.mInt.as_mut() = val; }
     }
 }


### PR DESCRIPTION
This is a regression from #11207.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11258)

<!-- Reviewable:end -->
