### PR TITLE
Add --all option to `mach test-tidy`, with compatibility with --faster

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -257,15 +257,30 @@ class MachCommands(CommandBase):
              category='testing')
     @CommandArgument('--faster', default=False, action="store_true",
                      help="Only check changed files and skip the WPT lint in tidy, "
-                          "if there are no changes in the WPT files")
+                          "if there are no changes in the WPT files. Cannot be used with --all")
+    @CommandArgument('--all', default=False, action="store_true", dest="all_files",
+                     help="Check all files, and run the WPT lint in tidy, "
+                          "even if unchanged. Cannot be used with --faster")
     @CommandArgument('--no-progress', default=False, action="store_true",
                      help="Don't show progress for tidy")
     @CommandArgument('--self-test', default=False, action="store_true",
                      help="Run unit tests for tidy")
-    def test_tidy(self, faster, no_progress, self_test):
+    def test_tidy(self, faster, all_files, no_progress, self_test):
         if self_test:
             return test_tidy.do_tests()
         else:
+            # The `test-tidy` command is currently mid-migration from --faster to --all.
+            # Since --faster and --all are opposites, they cannot both be used at the same time
+            if faster and all_files:
+                print("Cannot tidy --all while also being --faster")
+                return -1
+
+            # |--faster|--all|behaviour of tidy.scan()
+            # |   false|false|scan all files          # This was the behaviour before adding --all
+            # |    true|false|only scan changed files # Expected behaviour if --faster is used
+            # |   false| true|scan all files          # Expected behaviour if --all is used
+            #
+            # The pattern: if `faster` is true, go fast. Otherwise, go slow.
             return tidy.scan(faster, not no_progress)
 
     @Command('test-webidl',

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -101,8 +101,8 @@ def filter_file(file_name):
     return True
 
 
-def filter_files(start_dir, faster, progress):
-    file_iter = get_file_list(start_dir, faster, ignored_dirs)
+def filter_files(start_dir, only_changed_files, progress):
+    file_iter = get_file_list(start_dir, only_changed_files, ignored_dirs)
     (has_element, file_iter) = is_iter_empty(file_iter)
     if not has_element:
         raise StopIteration
@@ -649,14 +649,14 @@ def get_file_list(directory, only_changed_files=False, exclude_dirs=[]):
                 yield os.path.join(root, f)
 
 
-def scan(faster=False, progress=True):
+def scan(only_changed_files=False, progress=True):
     # standard checks
-    files_to_check = filter_files('.', faster, progress)
+    files_to_check = filter_files('.', only_changed_files, progress)
     checking_functions = (check_flake8, check_lock, check_webidl_spec, check_json)
     line_checking_functions = (check_license, check_by_line, check_toml, check_rust, check_spec, check_modeline)
     errors = collect_errors_for_files(files_to_check, checking_functions, line_checking_functions)
     # wpt lint checks
-    wpt_lint_errors = check_wpt_lint_errors(get_wpt_files(faster, progress))
+    wpt_lint_errors = check_wpt_lint_errors(get_wpt_files(only_changed_files, progress))
     # collect errors
     errors = itertools.chain(errors, wpt_lint_errors)
     error = None


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors
- [X] These changes partially fix #11217

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it just affects `mach` script parameters

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11267)

<!-- Reviewable:end -->
