### PR TITLE
Remove ConstellationChan.

### DIFF
--- a/components/compositing/pipeline.rs
+++ b/components/compositing/pipeline.rs
@@ -14,9 +14,8 @@ use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use layers::geometry::DevicePixel;
 use layout_traits::{LayoutControlChan, LayoutThreadFactory};
-use msg::constellation_msg::{ConstellationChan, PanicMsg, FrameId, PipelineId, SubpageId};
-use msg::constellation_msg::{LoadData, WindowSizeData};
-use msg::constellation_msg::{PipelineNamespaceId};
+use msg::constellation_msg::{FrameId, LoadData, PanicMsg, PipelineId};
+use msg::constellation_msg::{PipelineNamespaceId, SubpageId, WindowSizeData};
 use net_traits::ResourceThread;
 use net_traits::bluetooth_thread::BluetoothMethodMsg;
 use net_traits::image_cache_thread::ImageCacheThread;
@@ -82,11 +81,11 @@ pub struct InitialPipelineState {
     /// If `None`, this is the root.
     pub parent_info: Option<(PipelineId, SubpageId)>,
     /// A channel to the associated constellation.
-    pub constellation_chan: ConstellationChan<ScriptMsg>,
+    pub constellation_chan: IpcSender<ScriptMsg>,
     /// A channel for the layout thread to send messages to the constellation.
-    pub layout_to_constellation_chan: ConstellationChan<LayoutMsg>,
+    pub layout_to_constellation_chan: IpcSender<LayoutMsg>,
     /// A channel to report panics
-    pub panic_chan: ConstellationChan<PanicMsg>,
+    pub panic_chan: IpcSender<PanicMsg>,
     /// A channel to schedule timer events.
     pub scheduler_chan: IpcSender<TimerEventRequest>,
     /// A channel to the compositor.
@@ -389,8 +388,8 @@ impl Pipeline {
 pub struct UnprivilegedPipelineContent {
     id: PipelineId,
     parent_info: Option<(PipelineId, SubpageId)>,
-    constellation_chan: ConstellationChan<ScriptMsg>,
-    layout_to_constellation_chan: ConstellationChan<LayoutMsg>,
+    constellation_chan: IpcSender<ScriptMsg>,
+    layout_to_constellation_chan: IpcSender<LayoutMsg>,
     scheduler_chan: IpcSender<TimerEventRequest>,
     devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
     script_to_compositor_chan: IpcSender<ScriptToCompositorMsg>,
@@ -404,7 +403,7 @@ pub struct UnprivilegedPipelineContent {
     window_size: Option<WindowSizeData>,
     script_chan: IpcSender<ConstellationControlMsg>,
     load_data: LoadData,
-    panic_chan: ConstellationChan<PanicMsg>,
+    panic_chan: IpcSender<PanicMsg>,
     script_port: Option<IpcReceiver<ConstellationControlMsg>>,
     layout_to_paint_chan: OptionalIpcSender<LayoutToPaintMsg>,
     opts: Opts,
@@ -488,7 +487,7 @@ pub struct PrivilegedPipelineContent {
     time_profiler_chan: time::ProfilerChan,
     mem_profiler_chan: profile_mem::ProfilerChan,
     load_data: LoadData,
-    panic_chan: ConstellationChan<PanicMsg>,
+    panic_chan: IpcSender<PanicMsg>,
     layout_to_paint_port: Receiver<LayoutToPaintMsg>,
     chrome_to_paint_chan: Sender<ChromeToPaintMsg>,
     chrome_to_paint_port: Receiver<ChromeToPaintMsg>,

--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -7,7 +7,8 @@
 use flow::{self, Flow};
 use gfx::display_list::OpaqueNode;
 use incremental::RestyleDamage;
-use msg::constellation_msg::{ConstellationChan, PipelineId};
+use ipc_channel::ipc::IpcSender;
+use msg::constellation_msg::PipelineId;
 use script_traits::{AnimationState, LayoutMsg as ConstellationMsg};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -17,7 +18,7 @@ use time;
 
 /// Processes any new animations that were discovered after style recalculation.
 /// Also expire any old animations that have completed, inserting them into `expired_animations`.
-pub fn update_animation_state(constellation_chan: &ConstellationChan<ConstellationMsg>,
+pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
                               running_animations: &mut HashMap<OpaqueNode, Vec<Animation>>,
                               expired_animations: &mut HashMap<OpaqueNode, Vec<Animation>>,
                               new_animations_receiver: &Receiver<Animation>,
@@ -77,8 +78,7 @@ pub fn update_animation_state(constellation_chan: &ConstellationChan<Constellati
         animation_state = AnimationState::AnimationsPresent;
     }
 
-    constellation_chan.0
-                      .send(ConstellationMsg::ChangeRunningAnimationsState(pipeline_id, animation_state))
+    constellation_chan.send(ConstellationMsg::ChangeRunningAnimationsState(pipeline_id, animation_state))
                       .unwrap();
 }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -15,7 +15,6 @@ use fragment::{Fragment, FragmentBorderBoxIterator, SpecificFragmentInfo};
 use gfx::display_list::OpaqueNode;
 use gfx_traits::{LayerId};
 use layout_thread::LayoutThreadData;
-use msg::constellation_msg::ConstellationChan;
 use opaque_node::OpaqueNodeMethods;
 use script::layout_interface::{ContentBoxResponse, NodeOverflowResponse, ContentBoxesResponse, NodeGeometryResponse};
 use script::layout_interface::{HitTestResponse, LayoutRPC, OffsetParentResponse, NodeLayerIdResponse};
@@ -79,8 +78,7 @@ impl LayoutRPC for LayoutRPCImpl {
                 None => Cursor::DefaultCursor,
                 Some(dim) => dim.pointing.unwrap(),
             };
-            let ConstellationChan(ref constellation_chan) = rw_data.constellation_chan;
-            constellation_chan.send(ConstellationMsg::SetCursor(cursor)).unwrap();
+            rw_data.constellation_chan.send(ConstellationMsg::SetCursor(cursor)).unwrap();
         }
         HitTestResponse {
             node_address: result.map(|dim| dim.node.to_untrusted_node_address()),

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -26,7 +26,7 @@ extern crate webrender_traits;
 use gfx::font_cache_thread::FontCacheThread;
 use gfx::paint_thread::LayoutToPaintMsg;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
-use msg::constellation_msg::{ConstellationChan, PanicMsg, PipelineId, PipelineNamespaceId, PipelineIndex};
+use msg::constellation_msg::{PanicMsg, PipelineId, PipelineNamespaceId, PipelineIndex};
 use net_traits::image_cache_thread::ImageCacheThread;
 use profile_traits::{mem, time};
 use script_traits::LayoutMsg as ConstellationMsg;
@@ -48,8 +48,8 @@ pub trait LayoutThreadFactory {
               is_iframe: bool,
               chan: OpaqueScriptLayoutChannel,
               pipeline_port: IpcReceiver<LayoutControlMsg>,
-              constellation_chan: ConstellationChan<ConstellationMsg>,
-              panic_chan: ConstellationChan<PanicMsg>,
+              constellation_chan: IpcSender<ConstellationMsg>,
+              panic_chan: IpcSender<PanicMsg>,
               script_chan: IpcSender<ConstellationControlMsg>,
               layout_to_paint_chan: OptionalIpcSender<LayoutToPaintMsg>,
               image_cache_thread: ImageCacheThread,

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -9,31 +9,14 @@ use euclid::scale_factor::ScaleFactor;
 use euclid::size::TypedSize2D;
 use hyper::header::Headers;
 use hyper::method::Method;
-use ipc_channel::ipc::{self, IpcReceiver, IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
 use layers::geometry::DevicePixel;
-use serde::{Deserialize, Serialize};
 use std::cell::Cell;
 use std::fmt;
 use url::Url;
 use util::geometry::{PagePx, ViewportPx};
 use webdriver_msg::{LoadStatus, WebDriverScriptCommand};
 use webrender_traits;
-
-#[derive(Deserialize, Serialize)]
-pub struct ConstellationChan<T: Deserialize + Serialize>(pub IpcSender<T>);
-
-impl<T: Deserialize + Serialize> ConstellationChan<T> {
-    pub fn new() -> (IpcReceiver<T>, ConstellationChan<T>) {
-        let (chan, port) = ipc::channel().unwrap();
-        (port, ConstellationChan(chan))
-    }
-}
-
-impl<T: Serialize + Deserialize> Clone for ConstellationChan<T> {
-    fn clone(&self) -> ConstellationChan<T> {
-        ConstellationChan(self.0.clone())
-    }
-}
 
 pub type PanicMsg = (Option<PipelineId>, String, String);
 

--- a/components/script/clipboard_provider.rs
+++ b/components/script/clipboard_provider.rs
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use ipc_channel::ipc;
-use msg::constellation_msg::ConstellationChan;
+use ipc_channel::ipc::{self, IpcSender};
 use script_traits::ScriptMsg as ConstellationMsg;
 use std::borrow::ToOwned;
 
@@ -14,14 +13,14 @@ pub trait ClipboardProvider {
     fn set_clipboard_contents(&mut self, String);
 }
 
-impl ClipboardProvider for ConstellationChan<ConstellationMsg> {
+impl ClipboardProvider for IpcSender<ConstellationMsg> {
     fn clipboard_contents(&mut self) -> String {
         let (tx, rx) = ipc::channel().unwrap();
-        self.0.send(ConstellationMsg::GetClipboardContents(tx)).unwrap();
+        self.send(ConstellationMsg::GetClipboardContents(tx)).unwrap();
         rx.recv().unwrap()
     }
     fn set_clipboard_contents(&mut self, s: String) {
-        self.0.send(ConstellationMsg::SetClipboardContents(s)).unwrap();
+        self.send(ConstellationMsg::SetClipboardContents(s)).unwrap();
     }
 }
 

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -18,7 +18,7 @@ use ipc_channel::ipc::IpcSender;
 use js::jsapi::{CurrentGlobalOrNull, GetGlobalForObjectCrossCompartment};
 use js::jsapi::{JSContext, JSObject, JS_GetClass, MutableHandleValue};
 use js::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
-use msg::constellation_msg::{ConstellationChan, PanicMsg, PipelineId};
+use msg::constellation_msg::{PanicMsg, PipelineId};
 use net_traits::ResourceThread;
 use profile_traits::{mem, time};
 use script_runtime::{CommonScriptMsg, ScriptChan, ScriptPort};
@@ -89,8 +89,8 @@ impl<'a> GlobalRef<'a> {
         }
     }
 
-    /// Get a `ConstellationChan` to send messages to the constellation channel when available.
-    pub fn constellation_chan(&self) -> &ConstellationChan<ConstellationMsg> {
+    /// Get a `IpcSender` to send messages to the constellation when available.
+    pub fn constellation_chan(&self) -> &IpcSender<ConstellationMsg> {
         match *self {
             GlobalRef::Window(window) => window.constellation_chan(),
             GlobalRef::Worker(worker) => worker.constellation_chan(),

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -55,7 +55,6 @@ use js::jsval::JSVal;
 use js::rust::Runtime;
 use layout_interface::{LayoutChan, LayoutRPC};
 use libc;
-use msg::constellation_msg::ConstellationChan;
 use msg::constellation_msg::{PipelineId, SubpageId, WindowSizeData, WindowSizeType, ReferrerPolicy};
 use net_traits::image::base::{Image, ImageMetadata};
 use net_traits::image_cache_thread::{ImageCacheChan, ImageCacheThread};
@@ -66,7 +65,7 @@ use offscreen_gl_context::GLLimits;
 use profile_traits::mem::ProfilerChan as MemProfilerChan;
 use profile_traits::time::ProfilerChan as TimeProfilerChan;
 use script_runtime::ScriptChan;
-use script_traits::{LayoutMsg, ScriptMsg, TimerEventId, TimerSource, TouchpadPressurePhase, UntrustedNodeAddress};
+use script_traits::{TimerEventId, TimerSource, TouchpadPressurePhase, UntrustedNodeAddress};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::boxed::FnBox;
@@ -322,20 +321,6 @@ no_jsmanaged_fields!(HttpsState);
 no_jsmanaged_fields!(SharedRt);
 no_jsmanaged_fields!(TouchpadPressurePhase);
 no_jsmanaged_fields!(ReferrerPolicy);
-
-impl JSTraceable for ConstellationChan<ScriptMsg> {
-    #[inline]
-    fn trace(&self, _trc: *mut JSTracer) {
-        // Do nothing
-    }
-}
-
-impl JSTraceable for ConstellationChan<LayoutMsg> {
-    #[inline]
-    fn trace(&self, _trc: *mut JSTracer) {
-        // Do nothing
-    }
-}
 
 impl JSTraceable for Box<ScriptChan + Send> {
     #[inline]

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -123,7 +123,7 @@ impl CanvasRenderingContext2D {
                      -> CanvasRenderingContext2D {
         let (sender, receiver) = ipc::channel().unwrap();
         let constellation_chan = global.constellation_chan();
-        constellation_chan.0.send(ConstellationMsg::CreateCanvasPaintThread(size, sender)).unwrap();
+        constellation_chan.send(ConstellationMsg::CreateCanvasPaintThread(size, sender)).unwrap();
         let ipc_renderer = receiver.recv().unwrap();
         CanvasRenderingContext2D {
             reflector_: Reflector::new(),

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -15,7 +15,6 @@ use dom::eventtarget::EventTarget;
 use dom::htmlelement::HTMLElement;
 use dom::node::{Node, document_from_node, window_from_node};
 use dom::virtualmethods::VirtualMethods;
-use msg::constellation_msg::ConstellationChan;
 use script_traits::ScriptMsg as ConstellationMsg;
 use std::rc::Rc;
 use string_cache::Atom;
@@ -153,9 +152,8 @@ impl VirtualMethods for HTMLBodyElement {
         let window = window_from_node(self);
         let document = window.Document();
         document.set_reflow_timeout(time::precise_time_ns() + INITIAL_REFLOW_DELAY);
-        let ConstellationChan(ref chan) = *window.constellation_chan();
         let event = ConstellationMsg::HeadParsed;
-        chan.send(event).unwrap();
+        window.constellation_chan().send(event).unwrap();
     }
 
     fn parse_plain_attribute(&self, name: &Atom, value: DOMString) -> AttrValue {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -27,7 +27,7 @@ use dom::node::{document_from_node, window_from_node};
 use dom::nodelist::NodeList;
 use dom::validation::Validatable;
 use dom::virtualmethods::VirtualMethods;
-use msg::constellation_msg::ConstellationChan;
+use ipc_channel::ipc::IpcSender;
 use script_traits::ScriptMsg as ConstellationMsg;
 use std::borrow::ToOwned;
 use std::cell::Cell;
@@ -76,7 +76,7 @@ pub struct HTMLInputElement {
     size: Cell<u32>,
     maxlength: Cell<i32>,
     #[ignore_heap_size_of = "#7193"]
-    textinput: DOMRefCell<TextInput<ConstellationChan<ConstellationMsg>>>,
+    textinput: DOMRefCell<TextInput<IpcSender<ConstellationMsg>>>,
     activation_state: DOMRefCell<InputActivationState>,
     // https://html.spec.whatwg.org/multipage/#concept-input-value-dirty-flag
     value_dirty: Cell<bool>,

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -26,7 +26,6 @@ use hyper::mime::{Mime, TopLevel, SubLevel};
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use layout_interface::{LayoutChan, Msg};
-use msg::constellation_msg::ConstellationChan;
 use net_traits::{AsyncResponseListener, AsyncResponseTarget, Metadata, NetworkError};
 use network_listener::{NetworkListener, PreInvoke};
 use script_traits::{MozBrowserEvent, ScriptMsg as ConstellationMsg};
@@ -242,9 +241,8 @@ impl HTMLLinkElement {
         let document = document_from_node(self);
         match document.base_url().join(href) {
             Ok(url) => {
-                let ConstellationChan(ref chan) = *document.window().constellation_chan();
                 let event = ConstellationMsg::NewFavicon(url.clone());
-                chan.send(event).unwrap();
+                document.window().constellation_chan().send(event).unwrap();
 
                 let mozbrowser_event = match *sizes {
                     Some(ref sizes) => MozBrowserEvent::IconChange(rel.to_owned(), url.to_string(), sizes.to_owned()),

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -23,7 +23,7 @@ use dom::node::{document_from_node, window_from_node};
 use dom::nodelist::NodeList;
 use dom::validation::Validatable;
 use dom::virtualmethods::VirtualMethods;
-use msg::constellation_msg::ConstellationChan;
+use ipc_channel::ipc::IpcSender;
 use script_traits::ScriptMsg as ConstellationMsg;
 use std::cell::Cell;
 use std::ops::Range;
@@ -36,7 +36,7 @@ use util::str::DOMString;
 pub struct HTMLTextAreaElement {
     htmlelement: HTMLElement,
     #[ignore_heap_size_of = "#7193"]
-    textinput: DOMRefCell<TextInput<ConstellationChan<ConstellationMsg>>>,
+    textinput: DOMRefCell<TextInput<IpcSender<ConstellationMsg>>>,
     // https://html.spec.whatwg.org/multipage/#concept-textarea-dirty
     value_changed: Cell<bool>,
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -95,8 +95,7 @@ impl WebGLRenderingContext {
                      -> Result<WebGLRenderingContext, String> {
         let (sender, receiver) = ipc::channel().unwrap();
         let constellation_chan = global.constellation_chan();
-        constellation_chan.0
-                          .send(ConstellationMsg::CreateWebGLPaintThread(size, attrs, sender))
+        constellation_chan.send(ConstellationMsg::CreateWebGLPaintThread(size, attrs, sender))
                           .unwrap();
         let result = receiver.recv().unwrap();
 

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -21,7 +21,7 @@ use ipc_channel::ipc::IpcSender;
 use js::jsapi::{HandleValue, JSContext, JSRuntime, RootedValue};
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
-use msg::constellation_msg::{ConstellationChan, PanicMsg, PipelineId};
+use msg::constellation_msg::{PanicMsg, PipelineId};
 use net_traits::{LoadContext, ResourceThread, load_whole_resource};
 use profile_traits::{mem, time};
 use script_runtime::{CommonScriptMsg, ScriptChan, ScriptPort};
@@ -48,7 +48,7 @@ pub struct WorkerGlobalScopeInit {
     pub time_profiler_chan: time::ProfilerChan,
     pub to_devtools_sender: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
     pub from_devtools_sender: Option<IpcSender<DevtoolScriptControlMsg>>,
-    pub constellation_chan: ConstellationChan<ConstellationMsg>,
+    pub constellation_chan: IpcSender<ConstellationMsg>,
     pub scheduler_chan: IpcSender<TimerEventRequest>,
     pub panic_chan: IpcSender<PanicMsg>,
     pub worker_id: WorkerId,
@@ -94,7 +94,7 @@ pub struct WorkerGlobalScope {
     devtools_wants_updates: Cell<bool>,
 
     #[ignore_heap_size_of = "Defined in std"]
-    constellation_chan: ConstellationChan<ConstellationMsg>,
+    constellation_chan: IpcSender<ConstellationMsg>,
 
     #[ignore_heap_size_of = "Defined in std"]
     scheduler_chan: IpcSender<TimerEventRequest>,
@@ -156,7 +156,7 @@ impl WorkerGlobalScope {
         &self.from_devtools_receiver
     }
 
-    pub fn constellation_chan(&self) -> &ConstellationChan<ConstellationMsg> {
+    pub fn constellation_chan(&self) -> &IpcSender<ConstellationMsg> {
         &self.constellation_chan
     }
 

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -12,8 +12,7 @@ use euclid::point::Point2D;
 use euclid::rect::Rect;
 use gfx_traits::{Epoch, LayerId};
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
-use msg::constellation_msg::{ConstellationChan, PanicMsg, PipelineId};
-use msg::constellation_msg::{WindowSizeData};
+use msg::constellation_msg::{PanicMsg, PipelineId, WindowSizeData};
 use net_traits::image_cache_thread::ImageCacheThread;
 use profile_traits::mem::ReportsChan;
 use script_traits::{ConstellationControlMsg, LayoutControlMsg, LayoutMsg as ConstellationMsg};
@@ -262,8 +261,8 @@ pub struct NewLayoutThreadInfo {
     pub is_parent: bool,
     pub layout_pair: OpaqueScriptLayoutChannel,
     pub pipeline_port: IpcReceiver<LayoutControlMsg>,
-    pub constellation_chan: ConstellationChan<ConstellationMsg>,
-    pub panic_chan: ConstellationChan<PanicMsg>,
+    pub constellation_chan: IpcSender<ConstellationMsg>,
+    pub panic_chan: IpcSender<PanicMsg>,
     pub script_chan: IpcSender<ConstellationControlMsg>,
     pub image_cache_thread: ImageCacheThread,
     pub paint_chan: OptionalOpaqueIpcSender,

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -41,9 +41,9 @@ use gfx_traits::Epoch;
 use gfx_traits::LayerId;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use libc::c_void;
-use msg::constellation_msg::{ConstellationChan, PanicMsg, PipelineId, WindowSizeData, WindowSizeType};
 use msg::constellation_msg::{Key, KeyModifiers, KeyState, LoadData};
-use msg::constellation_msg::{PipelineNamespaceId, SubpageId};
+use msg::constellation_msg::{PanicMsg, PipelineId, PipelineNamespaceId};
+use msg::constellation_msg::{SubpageId, WindowSizeData, WindowSizeType};
 use msg::webdriver_msg::WebDriverScriptCommand;
 use net_traits::ResourceThread;
 use net_traits::bluetooth_thread::BluetoothMethodMsg;
@@ -96,7 +96,7 @@ pub struct NewLayoutInfo {
     /// A port on which layout can receive messages from the pipeline.
     pub pipeline_port: IpcReceiver<LayoutControlMsg>,
     /// A channel for sending panics on
-    pub panic_chan: ConstellationChan<PanicMsg>,
+    pub panic_chan: IpcSender<PanicMsg>,
     /// A shutdown channel so that layout can notify others when it's done.
     pub layout_shutdown_chan: IpcSender<()>,
     /// A shutdown channel so that layout can tell the content process to shut down when it's done.
@@ -312,11 +312,11 @@ pub struct InitialScriptState {
     /// A port on which messages sent by the constellation to script can be received.
     pub control_port: IpcReceiver<ConstellationControlMsg>,
     /// A channel on which messages can be sent to the constellation from script.
-    pub constellation_chan: ConstellationChan<ScriptMsg>,
+    pub constellation_chan: IpcSender<ScriptMsg>,
     /// A channel for the layout thread to send messages to the constellation.
-    pub layout_to_constellation_chan: ConstellationChan<LayoutMsg>,
+    pub layout_to_constellation_chan: IpcSender<LayoutMsg>,
     /// A channel for sending panics to the constellation.
-    pub panic_chan: ConstellationChan<PanicMsg>,
+    pub panic_chan: IpcSender<PanicMsg>,
     /// A channel to schedule timer events.
     pub scheduler_chan: IpcSender<TimerEventRequest>,
     /// A channel to the resource manager thread.


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because _____

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

It's a pointless abstraction that propagates the obsolete chan terminology,
swaps the order in which the sender and receiver are returned, and hides a
source of panics.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11270)

<!-- Reviewable:end -->
