### PR TITLE
Add a fast path for shaping ASCII text

### DIFF
--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -47,6 +47,7 @@ webrender_traits = {git = "https://github.com/servo/webrender_traits"}
 xi-unicode = "0.0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+byteorder = "0.5"
 core-foundation = "0.2"
 core-graphics = "0.3"
 core-text = "1.1"

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -30,6 +30,8 @@ macro_rules! ot_tag {
     );
 }
 
+pub const GPOS: u32 = ot_tag!('G', 'P', 'O', 'S');
+pub const GSUB: u32 = ot_tag!('G', 'S', 'U', 'B');
 pub const KERN: u32 = ot_tag!('k', 'e', 'r', 'n');
 
 static TEXT_SHAPING_PERFORMANCE_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
@@ -51,7 +53,9 @@ pub trait FontHandleMethods: Sized {
 
     fn glyph_index(&self, codepoint: char) -> Option<GlyphId>;
     fn glyph_h_advance(&self, GlyphId) -> Option<FractionalPixel>;
-    fn glyph_h_kerning(&self, GlyphId, GlyphId) -> FractionalPixel;
+    fn glyph_h_kerning(&self, glyph0: GlyphId, glyph1: GlyphId) -> FractionalPixel;
+    /// Can this font do basic horizontal LTR shaping without Harfbuzz?
+    fn can_do_fast_shaping(&self) -> bool;
     fn metrics(&self) -> FontMetrics;
     fn table_for_tag(&self, FontTableTag) -> Option<FontTable>;
 }

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -53,7 +53,7 @@ pub trait FontHandleMethods: Sized {
     fn glyph_h_advance(&self, GlyphId) -> Option<FractionalPixel>;
     fn glyph_h_kerning(&self, GlyphId, GlyphId) -> FractionalPixel;
     fn metrics(&self) -> FontMetrics;
-    fn table_for_tag(&self, FontTableTag) -> Option<Box<FontTable>>;
+    fn table_for_tag(&self, FontTableTag) -> Option<FontTable>;
 }
 
 // Used to abstract over the shaper's choice of fixed int representation.
@@ -206,7 +206,7 @@ impl Font {
         self.shaper.as_ref().unwrap()
     }
 
-    pub fn table_for_tag(&self, tag: FontTableTag) -> Option<Box<FontTable>> {
+    pub fn table_for_tag(&self, tag: FontTableTag) -> Option<FontTable> {
         let result = self.handle.table_for_tag(tag);
         let status = if result.is_some() { "Found" } else { "Didn't find" };
 

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -68,7 +68,7 @@ impl FontTableTagConversions for FontTableTag {
 }
 
 pub trait FontTableMethods {
-    fn with_buffer<F>(&self, F) where F: FnOnce(*const u8, usize);
+    fn buffer(&self) -> &[u8];
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -24,6 +24,14 @@ use unicode_script::Script;
 use util::cache::HashCache;
 use webrender_traits;
 
+macro_rules! ot_tag {
+    ($t1:expr, $t2:expr, $t3:expr, $t4:expr) => (
+        (($t1 as u32) << 24) | (($t2 as u32) << 16) | (($t3 as u32) << 8) | ($t4 as u32)
+    );
+}
+
+pub const KERN: u32 = ot_tag!('k', 'e', 'r', 'n');
+
 static TEXT_SHAPING_PERFORMANCE_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
 
 // FontHandle encapsulates access to the platform's font API,

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -95,7 +95,7 @@ mod paint_context;
 pub mod display_list;
 
 // Fonts
-pub mod font;
+#[macro_use] pub mod font;
 pub mod font_cache_thread;
 pub mod font_context;
 pub mod font_template;

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -28,6 +28,7 @@ extern crate azure;
 extern crate bitflags;
 
 // Mac OS-specific library dependencies
+#[cfg(target_os = "macos")] extern crate byteorder;
 #[cfg(target_os = "macos")] extern crate core_foundation;
 #[cfg(target_os = "macos")] extern crate core_graphics;
 #[cfg(target_os = "macos")] extern crate core_text;

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -260,7 +260,7 @@ impl FontHandleMethods for FontHandle {
         metrics
     }
 
-    fn table_for_tag(&self, tag: FontTableTag) -> Option<Box<FontTable>> {
+    fn table_for_tag(&self, tag: FontTableTag) -> Option<FontTable> {
         let tag = tag as FT_ULong;
 
         unsafe {
@@ -274,7 +274,7 @@ impl FontHandleMethods for FontHandle {
             if !FT_Load_Sfnt_Table(self.face, tag, 0, buf.as_mut_ptr(), &mut len).succeeded() {
                 return None
             }
-            Some(box FontTable { buffer: buf })
+            Some(FontTable { buffer: buf })
         }
     }
 }

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -49,9 +49,9 @@ impl FontTableMethods for FontTable {
 pub struct FontHandle {
     // The font binary. This must stay valid for the lifetime of the font,
     // if the font is created using FT_Memory_Face.
-    pub font_data: Arc<FontTemplateData>,
-    pub face: FT_Face,
-    pub handle: FontContextHandle
+    font_data: Arc<FontTemplateData>,
+    face: FT_Face,
+    handle: FontContextHandle,
 }
 
 impl Drop for FontHandle {

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -40,8 +40,8 @@ pub struct FontTable {
 }
 
 impl FontTableMethods for FontTable {
-    fn with_buffer<F>(&self, blk: F) where F: FnOnce(*const u8, usize) {
-        blk(self.buffer.as_ptr(), self.buffer.len())
+    fn buffer(&self) -> &[u8] {
+        &self.buffer
     }
 }
 

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -6,7 +6,7 @@ extern crate freetype;
 
 use app_units::Au;
 use font::{FontHandleMethods, FontMetrics, FontTableMethods};
-use font::{FontTableTag, FractionalPixel};
+use font::{FontTableTag, FractionalPixel, GPOS, GSUB, KERN};
 use freetype::freetype::{FTErrorMethods, FT_F26Dot6, FT_Face, FT_FaceRec};
 use freetype::freetype::{FT_Done_Face, FT_New_Memory_Face};
 use freetype::freetype::{FT_Get_Char_Index, FT_Get_Postscript_Name};
@@ -35,6 +35,7 @@ fn fixed_to_float_ft(f: i32) -> f64 {
     fixed_to_float(6, f)
 }
 
+#[derive(Debug)]
 pub struct FontTable {
     buffer: Vec<u8>,
 }
@@ -52,6 +53,7 @@ pub struct FontHandle {
     font_data: Arc<FontTemplateData>,
     face: FT_Face,
     handle: FontContextHandle,
+    can_do_fast_shaping: bool,
 }
 
 impl Drop for FontHandle {
@@ -74,11 +76,16 @@ impl FontHandleMethods for FontHandle {
         if ft_ctx.is_null() { return Err(()); }
 
         return create_face_from_buffer(ft_ctx, &template.bytes, pt_size).map(|face| {
-            let handle = FontHandle {
+            let mut handle = FontHandle {
                   face: face,
                   font_data: template.clone(),
                   handle: fctx.clone(),
+                  can_do_fast_shaping: false,
             };
+            // TODO (#11310): Implement basic support for GPOS and GSUB.
+            handle.can_do_fast_shaping = handle.has_table(KERN) &&
+                                         !handle.has_table(GPOS) &&
+                                         !handle.has_table(GSUB);
             handle
         });
 
@@ -170,6 +177,10 @@ impl FontHandleMethods for FontHandle {
             FT_Get_Kerning(self.face, first_glyph, second_glyph, FT_KERNING_DEFAULT, &mut delta);
         }
         fixed_to_float_ft(delta.x as i32)
+    }
+
+    fn can_do_fast_shaping(&self) -> bool {
+        self.can_do_fast_shaping
     }
 
     fn glyph_h_advance(&self, glyph: GlyphId) -> Option<FractionalPixel> {
@@ -273,6 +284,12 @@ impl<'a> FontHandle {
         unsafe {
             let result = FT_Set_Char_Size(face, char_width, 0, 0, 0);
             if result.succeeded() { Ok(()) } else { Err(()) }
+        }
+    }
+
+    fn has_table(&self, tag: FontTableTag) -> bool {
+        unsafe {
+            FT_Load_Sfnt_Table(self.face, tag as FT_ULong, 0, ptr::null_mut(), &mut 0).succeeded()
         }
     }
 

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -9,6 +9,7 @@ extern crate core_graphics;
 extern crate core_text;
 
 use app_units::Au;
+use byteorder::{BigEndian, ByteOrder};
 use core_foundation::base::CFIndex;
 use core_foundation::data::CFData;
 use core_foundation::string::UniChar;
@@ -17,15 +18,17 @@ use core_graphics::geometry::CGRect;
 use core_text::font::CTFont;
 use core_text::font_descriptor::{SymbolicTraitAccessors, TraitAccessors};
 use core_text::font_descriptor::{kCTFontDefaultOrientation};
-use font::FontTableTag;
-use font::FractionalPixel;
-use font::{FontHandleMethods, FontMetrics, FontTableMethods};
+use font::{FontHandleMethods, FontMetrics, FontTableTag, FontTableMethods, FractionalPixel};
+use font::{GPOS, GSUB, KERN};
 use platform::font_template::FontTemplateData;
 use platform::macos::font_context::FontContextHandle;
-use std::ptr;
+use std::ops::Range;
 use std::sync::Arc;
+use std::{fmt, ptr};
 use style::computed_values::{font_stretch, font_weight};
 use text::glyph::GlyphId;
+
+const KERN_PAIR_LEN: usize = 6;
 
 pub struct FontTable {
     data: CFData,
@@ -61,7 +64,106 @@ impl FontTableMethods for FontTable {
 pub struct FontHandle {
     font_data: Arc<FontTemplateData>,
     ctfont: CTFont,
+    h_kern_subtable: Option<CachedKernTable>,
+    can_do_fast_shaping: bool,
 }
+
+impl FontHandle {
+    /// Cache all the data needed for basic horizontal kerning. This is used only as a fallback or
+    /// fast path (when the GPOS table is missing or unnecessary) so it needn't handle every case.
+    fn find_h_kern_subtable(&self) -> Option<CachedKernTable> {
+        let font_table = match self.table_for_tag(KERN) {
+            Some(table) => table,
+            None => return None
+        };
+
+        let mut result = CachedKernTable {
+            font_table: font_table,
+            pair_data_range: 0..0,
+            px_per_font_unit: 0.0,
+        };
+
+        // Look for a subtable with horizontal kerning in format 0.
+        // https://www.microsoft.com/typography/otspec/kern.htm
+        const KERN_COVERAGE_HORIZONTAL_FORMAT_0: u16 = 1;
+        const SUBTABLE_HEADER_LEN: usize = 6;
+        const FORMAT_0_HEADER_LEN: usize = 8;
+        {
+            let table = result.font_table.buffer();
+            let version = BigEndian::read_u16(table);
+            if version != 0 {
+                return None;
+            }
+            let num_subtables = BigEndian::read_u16(&table[2..]);
+            let mut start = 4;
+            for _ in 0..num_subtables {
+                // TODO: Check the subtable version number?
+                let len = BigEndian::read_u16(&table[start + 2..]) as usize;
+                let cov = BigEndian::read_u16(&table[start + 4..]);
+                let end = start + len;
+                if cov == KERN_COVERAGE_HORIZONTAL_FORMAT_0 {
+                    // Found a matching subtable.
+                    if result.pair_data_range.len() > 0 {
+                        debug!("Found multiple horizontal kern tables. Disable fast path.");
+                        return None;
+                    }
+                    // Read the subtable header.
+                    let subtable_start = start + SUBTABLE_HEADER_LEN;
+                    let n_pairs = BigEndian::read_u16(&table[subtable_start..]) as usize;
+                    let pair_data_start = subtable_start + FORMAT_0_HEADER_LEN;
+
+                    result.pair_data_range = pair_data_start..end;
+                    let pt_per_font_unit = self.ctfont.pt_size() as f64 /
+                                           self.ctfont.units_per_em() as f64;
+                    result.px_per_font_unit = pt_to_px(pt_per_font_unit);
+
+                    debug_assert_eq!(n_pairs * KERN_PAIR_LEN, result.pair_data_range.len());
+                }
+                start = end;
+            }
+        }
+        if result.pair_data_range.len() > 0 {
+            Some(result)
+        } else {
+            None
+        }
+    }
+}
+
+struct CachedKernTable {
+    font_table: FontTable,
+    pair_data_range: Range<usize>,
+    px_per_font_unit: f64,
+}
+
+impl CachedKernTable {
+    /// Search for a glyph pair in the kern table and return the corresponding value.
+    fn binary_search(&self, first_glyph: GlyphId, second_glyph: GlyphId) -> Option<i16> {
+        let pairs = &self.font_table.buffer()[self.pair_data_range.clone()];
+
+        let query = first_glyph << 16 | second_glyph;
+        let (mut start, mut end) = (0, pairs.len() / KERN_PAIR_LEN);
+        while start < end {
+            let i = (start + end) / 2;
+            let key = BigEndian::read_u32(&pairs[i * KERN_PAIR_LEN..]);
+            if key > query {
+                end = i;
+            } else if key < query {
+                start = i + 1;
+            } else {
+                return Some(BigEndian::read_i16(&pairs[i * KERN_PAIR_LEN + 4..]));
+            }
+        }
+        None
+    }
+}
+
+impl fmt::Debug for CachedKernTable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "CachedKernTable")
+    }
+}
+
 
 impl FontHandleMethods for FontHandle {
     fn new_from_template(_fctx: &FontContextHandle,
@@ -74,10 +176,18 @@ impl FontHandleMethods for FontHandle {
         };
         match template.ctfont(size) {
             Some(ref ctfont) => {
-                Ok(FontHandle {
+                let mut handle = FontHandle {
                     font_data: template.clone(),
                     ctfont: ctfont.clone_with_font_size(size),
-                })
+                    h_kern_subtable: None,
+                    can_do_fast_shaping: false,
+                };
+                handle.h_kern_subtable = handle.find_h_kern_subtable();
+                // TODO (#11310): Implement basic support for GPOS and GSUB.
+                handle.can_do_fast_shaping = handle.h_kern_subtable.is_some() &&
+                                             handle.table_for_tag(GPOS).is_none() &&
+                                             handle.table_for_tag(GSUB).is_none();
+                Ok(handle)
             }
             None => {
                 Err(())
@@ -155,10 +265,17 @@ impl FontHandleMethods for FontHandle {
         return Some(glyphs[0] as GlyphId);
     }
 
-    fn glyph_h_kerning(&self, _first_glyph: GlyphId, _second_glyph: GlyphId)
-                        -> FractionalPixel {
-        // TODO: Implement on mac
+    fn glyph_h_kerning(&self, first_glyph: GlyphId, second_glyph: GlyphId) -> FractionalPixel {
+        if let Some(ref table) = self.h_kern_subtable {
+            if let Some(font_units) = table.binary_search(first_glyph, second_glyph) {
+                return font_units as f64 * table.px_per_font_unit;
+            }
+        }
         0.0
+    }
+
+    fn can_do_fast_shaping(&self) -> bool {
+        self.can_do_fast_shaping
     }
 
     fn glyph_h_advance(&self, glyph: GlyphId) -> Option<FractionalPixel> {

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -52,8 +52,8 @@ impl FontTable {
 }
 
 impl FontTableMethods for FontTable {
-    fn with_buffer<F>(&self, blk: F) where F: FnOnce(*const u8, usize) {
-        blk(self.data.bytes().as_ptr(), self.data.len() as usize);
+    fn buffer(&self) -> &[u8] {
+        self.data.bytes()
     }
 }
 

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -209,10 +209,10 @@ impl FontHandleMethods for FontHandle {
         metrics
     }
 
-    fn table_for_tag(&self, tag: FontTableTag) -> Option<Box<FontTable>> {
+    fn table_for_tag(&self, tag: FontTableTag) -> Option<FontTable> {
         let result: Option<CFData> = self.ctfont.get_font_table(tag);
         result.and_then(|data| {
-            Some(box FontTable::wrap(data))
+            Some(FontTable::wrap(data))
         })
     }
 }

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -59,8 +59,8 @@ impl FontTableMethods for FontTable {
 
 #[derive(Debug)]
 pub struct FontHandle {
-    pub font_data: Arc<FontTemplateData>,
-    pub ctfont: CTFont,
+    font_data: Arc<FontTemplateData>,
+    ctfont: CTFont,
 }
 
 impl FontHandleMethods for FontHandle {

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -529,15 +529,13 @@ extern fn font_table_func(_: *mut hb_face_t,
                 // this raw pointer back to `destroy_blob_func` which will deallocate the Box.
                 let font_table_ptr = Box::into_raw(font_table);
 
-                let mut blob: *mut hb_blob_t = ptr::null_mut();
-                (*font_table_ptr).with_buffer(|buf: *const u8, len: usize| {
-                    // HarfBuzz calls `destroy_blob_func` when the buffer is no longer needed.
-                    blob = hb_blob_create(buf as *const c_char,
-                                          len as c_uint,
+                let buf = (*font_table_ptr).buffer();
+                // HarfBuzz calls `destroy_blob_func` when the buffer is no longer needed.
+                let blob = hb_blob_create(buf.as_ptr() as *const c_char,
+                                          buf.len() as c_uint,
                                           HB_MEMORY_MODE_READONLY,
                                           font_table_ptr as *mut c_void,
                                           Some(destroy_blob_func));
-                });
 
                 assert!(!blob.is_null());
                 blob

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -4,7 +4,7 @@
 
 use app_units::Au;
 use euclid::Point2D;
-use font::{DISABLE_KERNING_SHAPING_FLAG, Font, FontTableMethods, FontTableTag};
+use font::{DISABLE_KERNING_SHAPING_FLAG, Font, FontHandleMethods, FontTableMethods, FontTableTag};
 use font::{IGNORE_LIGATURES_SHAPING_FLAG, KERN, RTL_FLAG, ShapingOptions};
 use harfbuzz::{HB_DIRECTION_LTR, HB_DIRECTION_RTL, HB_MEMORY_MODE_READONLY};
 use harfbuzz::{hb_blob_create, hb_face_create_for_tables};
@@ -34,10 +34,12 @@ use harfbuzz::{hb_glyph_position_t};
 use harfbuzz::{hb_position_t, hb_tag_t};
 use libc::{c_char, c_int, c_uint, c_void};
 use platform::font::FontTable;
+use std::ascii::AsciiExt;
 use std::{char, cmp, ptr};
 use text::glyph::{ByteIndex, GlyphData, GlyphId, GlyphStore};
 use text::shaping::ShaperMethods;
 use text::util::{fixed_to_float, float_to_fixed, is_bidi_control};
+use unicode_script::Script;
 
 const NO_GLYPH: i32 = -1;
 const LIGA: u32 = ot_tag!('l', 'i', 'g', 'a');
@@ -199,7 +201,14 @@ impl ShaperMethods for Shaper {
     /// Calculate the layout metrics associated with the given text when painted in a specific
     /// font.
     fn shape_text(&self, text: &str, options: &ShapingOptions, glyphs: &mut GlyphStore) {
+        if self.can_use_fast_path(text, options) {
+            debug!("shape_text: Using ASCII fast path.");
+            self.shape_text_fast(text, options, glyphs);
+            return;
+        }
         unsafe {
+            debug!("shape_text: Using Harfbuzz.");
+
             let hb_buffer: *mut hb_buffer_t = hb_buffer_create();
             hb_buffer_set_direction(hb_buffer, if options.flags.contains(RTL_FLAG) {
                 HB_DIRECTION_RTL
@@ -241,6 +250,47 @@ impl ShaperMethods for Shaper {
 }
 
 impl Shaper {
+    fn can_use_fast_path(&self, text: &str, options: &ShapingOptions) -> bool {
+        let font = self.font_and_shaping_options.font;
+
+        options.script == Script::Latin &&
+            !options.flags.contains(RTL_FLAG) &&
+            unsafe { (*font).handle.can_do_fast_shaping() } &&
+            text.is_ascii()
+    }
+
+    /// Fast path for ASCII text that only needs simple horizontal LTR kerning.
+    fn shape_text_fast(&self, text: &str, options: &ShapingOptions, glyphs: &mut GlyphStore) {
+        let font = unsafe { &mut *self.font_and_shaping_options.font };
+
+        let mut prev_glyph_id = None;
+        for (i, byte) in text.bytes().enumerate() {
+            let character = byte as char;
+            let glyph_id = match font.glyph_index(character) {
+                Some(id) => id,
+                None => continue,
+            };
+
+            let mut advance = Au::from_f64_px(font.glyph_h_advance(glyph_id));
+            if character == ' ' {
+                advance += options.word_spacing;
+            }
+            if let Some(letter_spacing) = options.letter_spacing {
+                advance += letter_spacing;
+            }
+            let offset = prev_glyph_id.map(|prev| {
+                let h_kerning = Au::from_f64_px(font.glyph_h_kerning(prev, glyph_id));
+                advance += h_kerning;
+                Point2D::new(h_kerning, Au(0))
+            });
+
+            let glyph = GlyphData::new(glyph_id, advance, offset, true, true);
+            glyphs.add_glyph_for_byte_index(ByteIndex(i as isize), character, &glyph);
+            prev_glyph_id = Some(glyph_id);
+        }
+        glyphs.finalize_changes();
+    }
+
     fn save_glyph_results(&self,
                           text: &str,
                           options: &ShapingOptions,

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -5,7 +5,7 @@
 use app_units::Au;
 use euclid::Point2D;
 use font::{DISABLE_KERNING_SHAPING_FLAG, Font, FontTableMethods, FontTableTag};
-use font::{IGNORE_LIGATURES_SHAPING_FLAG, RTL_FLAG, ShapingOptions};
+use font::{IGNORE_LIGATURES_SHAPING_FLAG, KERN, RTL_FLAG, ShapingOptions};
 use harfbuzz::{HB_DIRECTION_LTR, HB_DIRECTION_RTL, HB_MEMORY_MODE_READONLY};
 use harfbuzz::{hb_blob_create, hb_face_create_for_tables};
 use harfbuzz::{hb_blob_t};
@@ -39,16 +39,8 @@ use text::glyph::{ByteIndex, GlyphData, GlyphId, GlyphStore};
 use text::shaping::ShaperMethods;
 use text::util::{fixed_to_float, float_to_fixed, is_bidi_control};
 
-macro_rules! hb_tag {
-    ($t1:expr, $t2:expr, $t3:expr, $t4:expr) => (
-        (($t1 as u32) << 24) | (($t2 as u32) << 16) | (($t3 as u32) << 8) | ($t4 as u32)
-    );
-}
-
 const NO_GLYPH: i32 = -1;
-
-static KERN: u32 = hb_tag!('k', 'e', 'r', 'n');
-static LIGA: u32 = hb_tag!('l', 'i', 'g', 'a');
+const LIGA: u32 = ot_tag!('l', 'i', 'g', 'a');
 
 pub struct ShapedGlyphData {
     count: usize,

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -519,7 +519,7 @@ extern fn font_table_func(_: *mut hb_face_t,
                 // `Box::into_raw` intentionally leaks the FontTable so we don't destroy the buffer
                 // while HarfBuzz is using it.  When HarfBuzz is done with the buffer, it will pass
                 // this raw pointer back to `destroy_blob_func` which will deallocate the Box.
-                let font_table_ptr = Box::into_raw(font_table);
+                let font_table_ptr = Box::into_raw(box font_table);
 
                 let buf = (*font_table_ptr).buffer();
                 // HarfBuzz calls `destroy_blob_func` when the buffer is no longer needed.

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -101,7 +101,7 @@ source = "git+https://github.com/servo/rust-azure#a7177c8df81554352bc51de2f5b77c
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "heapsize 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "core-text"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -742,9 +742,10 @@ dependencies = [
  "app_units 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.4.5 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
@@ -2498,7 +2499,7 @@ dependencies = [
  "app_units 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -78,7 +78,7 @@ source = "git+https://github.com/servo/rust-azure#a7177c8df81554352bc51de2f5b77c
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "heapsize 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "core-text"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -663,9 +663,10 @@ dependencies = [
  "app_units 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.4.5 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
@@ -2359,7 +2360,7 @@ dependencies = [
  "app_units 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -80,7 +80,7 @@ source = "git+https://github.com/servo/rust-azure#a7177c8df81554352bc51de2f5b77c
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
  "heapsize 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "core-text"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -675,9 +675,10 @@ dependencies = [
  "app_units 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure 0.4.5 (git+https://github.com/servo/rust-azure)",
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
@@ -2319,7 +2320,7 @@ dependencies = [
  "app_units 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-text 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",


### PR DESCRIPTION
On both my Linux laptop and iMac, this is about twice as fast as Harfbuzz text shaping on https://en.wikipedia.org/wiki/Barack_Obama.

I haven't tested this on any high-DPI (retina) displays, and I'm not 100% certain that the font unit scaling is correct there.

Depends on servo/core-text-rs#50.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11273)

<!-- Reviewable:end -->
