### PR TITLE
Reduce 'android-18' duplication by putting it in $ANDROID_TARGET env variable

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -178,6 +178,7 @@ class CommandBase(object):
         self.config["android"].setdefault("sdk", "")
         self.config["android"].setdefault("ndk", "")
         self.config["android"].setdefault("toolchain", "")
+        self.config["android"].setdefault("platform", "android-18")
         self.config["android"].setdefault("target", "arm-linux-androideabi")
 
         self.config.setdefault("gonk", {})
@@ -318,6 +319,8 @@ class CommandBase(object):
             env["ANDROID_NDK"] = self.config["android"]["ndk"]
         if self.config["android"]["toolchain"]:
             env["ANDROID_TOOLCHAIN"] = self.config["android"]["toolchain"]
+        if self.config["android"]["platform"]:
+            env["ANDROID_PLATFORM"] = self.config["android"]["platform"]
 
         if gonk:
             if self.config["gonk"]["b2g"]:

--- a/servobuild.example
+++ b/servobuild.example
@@ -41,10 +41,11 @@ debug-mozjs = false
 
 # Android information
 [android]
-# Defaults to the value of $ANDROID_SDK, $ANDROID_NDK, $ANDROID_TOOLCHAIN respectively
+# Defaults to the value of $ANDROID_SDK, $ANDROID_NDK, $ANDROID_TOOLCHAIN, $ANDROID_PLATFORM respectively
 #sdk = "/opt/android-sdk"
 #ndk = "/opt/android-ndk"
 #toolchain = "/opt/android-toolchain"
+#platform = "android-18"
 
 # Gonk information
 # Please fill the ndk/toolchain for Android too

--- a/support/android/apk/build.xml
+++ b/support/android/apk/build.xml
@@ -36,17 +36,9 @@
     <condition property="sdk.dir" value="${env.ANDROID_HOME}">
         <isset property="env.ANDROID_HOME" />
     </condition>
-
-    <!-- The project.properties file is created and updated by the 'android'
-         tool, as well as ADT.
-
-         This contains project specific properties such as project target, and library
-         dependencies. Lower level build properties are stored in ant.properties
-         (or in .classpath for Eclipse projects).
-
-         This file is an integral part of the build system for your
-         application and should be checked into Version Control Systems. -->
-    <loadproperties srcFile="project.properties" />
+    <condition property="target" value="${env.ANDROID_PLATFORM}">
+        <isset property="env.ANDROID_PLATFORM" />
+    </condition>
 
     <!-- quick check on sdk.dir -->
     <fail

--- a/support/android/apk/jni/Application.mk
+++ b/support/android/apk/jni/Application.mk
@@ -1,2 +1,2 @@
 APP_ABI := armeabi
-APP_PLATFORM := android-18
+APP_PLATFORM := $(ANDROID_PLATFORM)

--- a/support/android/apk/project.properties
+++ b/support/android/apk/project.properties
@@ -1,1 +1,0 @@
-target=android-18

--- a/support/android/build-apk/src/main.rs
+++ b/support/android/build-apk/src/main.rs
@@ -27,6 +27,11 @@ fn main() {
     let ndk_path = env::var("NDK_HOME").ok().expect("Please set the NDK_HOME environment variable");
     let ndk_path = Path::new(&ndk_path);
 
+    // Get the target android platform from ANDROID_PLATFORM env. Expecting "android-{version}"
+    let android_platform = env::var("ANDROID_PLATFORM")
+        .ok()
+        .expect("Please set the ANDROID_PLATFORM environment variable")
+
     // Get the standalone NDK path from NDK_STANDALONE env.
     //  let standalone_path = env::var("NDK_STANDALONE").ok().unwrap_or("/opt/ndk_standalone".to_string());
     //  let standalone_path = Path::new(&standalone_path);
@@ -97,7 +102,7 @@ fn main() {
                                   .arg("--name")
                                   .arg("Servo")
                                   .arg("--target")
-                                  .arg("android-18")
+                                  .arg(&android_platform)
                                   .arg("--path")
                                   .arg(".")
                                   .stdout(Stdio::inherit())

--- a/support/android/openssl.sh
+++ b/support/android/openssl.sh
@@ -36,7 +36,7 @@ _ANDROID_ARCH=arch-arm
 # Android 5.0, there will likely be another platform added (android-22?).
 # This value is always used.
 # _ANDROID_API="android-14"
-_ANDROID_API="android-18"
+_ANDROID_API="$ANDROID_PLATFORM"
 # _ANDROID_API="android-19"
 
 #####################################################################


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors
- [x] These changes fix #8348

Either:
- [X] These changes do not require tests because ~~I'm lazy~~ it's a configuration change, and asserting default values is usually tedious and not very helpful

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

---

Allegedly, this broke the build [back in the day](https://github.com/servo/servo/pull/8519).
Going to see if it's a piece of cake to land now

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11278)

<!-- Reviewable:end -->
