### PR TITLE
Replacing CSV profiling with TSV profiling

### DIFF
--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -47,7 +47,7 @@ impl Formattable for Option<TimerMetadata> {
                             TimerMetadataFrameType::RootWindow => "yes",
                             TimerMetadataFrameType::IFrame => "no",
                         };
-                        format!(" {}, {}, {}", incremental, iframe, url)
+                        format!(" {}\t{}\t{}", incremental, iframe, url)
                     },
                     _ => {
                         /* The profiling output is the terminal */
@@ -71,7 +71,7 @@ impl Formattable for Option<TimerMetadata> {
             None => {
                 match *output {
                     Some(OutputOptions::FileName(_)) => {
-                        format!(" {}, {}, {}", "    N/A", "  N/A", "             N/A")
+                        format!(" {}\t{}\t{}", "    N/A", "  N/A", "             N/A")
                     },
                     _ => {
                         format!(" {:14} {:9} {:30}", "    N/A", "  N/A", "             N/A")
@@ -336,8 +336,8 @@ impl Profiler {
                                      Error::description(&e)),
                     Ok(file) => file,
                 };
-                write!(file, "_category_, _incremental?_, _iframe?_, _url_, _mean (ms)_, _median (ms)_, _min (ms)_, \
-                _max (ms)_, _events_\n").unwrap();
+                write!(file, "_category_\t_incremental?_\t_iframe?_\t_url_\t_mean (ms)_\t\
+                    _median (ms)_\t_min (ms)_\t_max (ms)_\t_events_\n").unwrap();
                 for (&(ref category, ref meta), ref mut data) in &mut self.buckets {
                     data.sort_by(|a, b| {
                         if a < b {
@@ -353,7 +353,7 @@ impl Profiler {
                              data[data_len / 2],
                              data.iter().fold(f64::INFINITY, |a, &b| a.min(b)),
                              data.iter().fold(-f64::INFINITY, |a, &b| a.max(b)));
-                        write!(file, "{}, {}, {:15.4}, {:15.4}, {:15.4}, {:15.4}, {:15}\n",
+                        write!(file, "{}\t{}\t{:15.4}\t{:15.4}\t{:15.4}\t{:15.4}\t{:15}\n",
                             category.format(&self.output), meta.format(&self.output),
                             mean, median, min, max, data_len).unwrap();
                     }

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -539,9 +539,9 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     opts.optopt("s", "size", "Size of tiles", "512");
     opts.optopt("", "device-pixel-ratio", "Device pixels per px", "");
     opts.optopt("t", "threads", "Number of paint threads", "1");
-    opts.optflagopt("p", "profile", "Time profiler flag and either a CSV output filename \
+    opts.optflagopt("p", "profile", "Time profiler flag and either a TSV output filename \
         OR an interval for output to Stdout (blank for Stdout with interval of 5s)", "10 \
-        OR time.csv");
+        OR time.tsv");
     opts.optflagopt("", "profiler-trace-path",
                     "Path to dump a self-contained HTML timeline of profiler traces",
                     "");


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [X] These changes add to issue #10886 that has already been fixed.

Either:
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11282)

<!-- Reviewable:end -->
