### PR TITLE
(DO NOT MERGE, but please take a look) Implement exthttp protocol handler

### DIFF
--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -36,6 +36,7 @@ util = {path = "../util"}
 uuid = {version = "0.2", features = ["v4"]}
 webrender_traits = {git = "https://github.com/servo/webrender_traits"}
 websocket = "0.17"
+webbrowser = "0.1"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 tinyfiledialogs = {git = "https://github.com/jdm/tinyfiledialogs"}

--- a/components/net/exthttp_loader.rs
+++ b/components/net/exthttp_loader.rs
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use data_loader;
+use mime_classifier::MIMEClassifier;
+use net_traits::{LoadConsumer, LoadData};
+use resource_thread::CancellationListener;
+use std::borrow::ToOwned;
+use std::sync::Arc;
+use url::Url;
+use util::thread::spawn_named;
+use webbrowser;
+
+pub fn factory(load_data: LoadData,
+               senders: LoadConsumer,
+               classifier: Arc<MIMEClassifier>,
+               cancel_listener: CancellationListener) {
+    assert!(load_data.url.scheme() == "exthttp" || load_data.url.scheme() == "exthttps");
+    spawn_named("exthttp_loader".to_owned(), move || {
+        let mut http_url = load_data.url.clone();
+        let valid_http_url = match load_data.url.scheme() {
+            "exthttp" => http_url.set_scheme("http"),
+            "exthttps" => http_url.set_scheme("https"),
+            _ => unreachable!()
+        }.is_ok();
+        let url_redirect = if !valid_http_url {
+            Url::parse("data:text/plain,Invalid url").unwrap()
+        } else if webbrowser::open(http_url.as_str()).is_ok() {
+            Url::parse("data:text/plain,External browser succesfully opened").unwrap()
+        } else {
+            Url::parse("data:text/plain,Failed to open external browser").unwrap()
+        };
+        let load_data_redirect = LoadData::new(load_data.context, url_redirect, None, None, None);
+        data_loader::factory(load_data_redirect, senders, classifier, cancel_listener);
+    });
+}
+

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -40,6 +40,7 @@ extern crate unicase;
 extern crate url;
 extern crate util;
 extern crate uuid;
+extern crate webbrowser;
 extern crate webrender_traits;
 extern crate websocket;
 
@@ -50,6 +51,7 @@ pub mod connector;
 pub mod cookie;
 pub mod cookie_storage;
 pub mod data_loader;
+pub mod exthttp_loader;
 pub mod file_loader;
 pub mod filemanager_thread;
 pub mod hsts;

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -10,6 +10,7 @@ use cookie;
 use cookie_storage::CookieStorage;
 use data_loader;
 use devtools_traits::{DevtoolsControlMsg};
+use exthttp_loader;
 use file_loader;
 use hsts::HstsList;
 use http_loader::{self, HttpState};
@@ -436,6 +437,7 @@ impl ResourceManager {
         let loader = match load_data.url.scheme() {
             "chrome" => from_factory(chrome_loader::factory),
             "file" => from_factory(file_loader::factory),
+            "exthttp" | "exthttps" => from_factory(exthttp_loader::factory),
             "http" | "https" | "view-source" => {
                 let http_state = HttpState {
                     hsts_list: self.hsts_list.clone(),

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
  "uuid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webbrowser 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_traits 0.1.0 (git+https://github.com/servo/webrender_traits)",
  "websocket 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2431,6 +2432,11 @@ dependencies = [
  "tempfile 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "webbrowser"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "webdriver"


### PR DESCRIPTION
We need the ability from Servo to open an url in a different browser.

We want to build a bug reporter within browserhtml where the user could report an issue to github. We don't want the user to open the issue within Servo, but in a normal web browser.

The idea is to have a link that looks like `<a href="exthttp://foobar.com">`.

Servo would open the link `http://foobar.com` in the OS-default webbrowser.

The actual link we are planning to use will look like this:

`exthttps://github.com/servo/servo/issues/new?title=Crash%20report%20from%20browserhtml&body=very%20long%20backtrace`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11286)

<!-- Reviewable:end -->
