### PR TITLE
Remove unsafe Send implementation for GlutinCompositorProxy.

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -828,9 +828,6 @@ struct GlutinCompositorProxy {
     window_proxy: Option<glutin::WindowProxy>,
 }
 
-// TODO: Should this be implemented here or upstream in glutin::WindowProxy?
-unsafe impl Send for GlutinCompositorProxy {}
-
 impl CompositorProxy for GlutinCompositorProxy {
     fn send(&self, msg: compositor_thread::Msg) {
         // Send a message and kick the OS event loop awake.


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because _____

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

Send is now implemented for glutin::WindowProxy.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11299)

<!-- Reviewable:end -->
