### PR TITLE
Always include the last-resort font

### DIFF
--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -223,38 +223,35 @@ impl FontContext {
             }
         }
 
-        // If unable to create any of the specified fonts, create one from the
-        // list of last resort fonts for this platform.
-        if fonts.is_empty() {
-            let mut cache_hit = false;
-            for cached_font_entry in &self.fallback_font_cache {
-                let cached_font = cached_font_entry.font.borrow();
-                if cached_font.descriptor == desc &&
-                            cached_font.requested_pt_size == style.font_size &&
-                            cached_font.variant == style.font_variant {
-                    fonts.push(cached_font_entry.font.clone());
-                    cache_hit = true;
-                    break;
-                }
+        // Add a last resort font as a fallback option.
+        let mut cache_hit = false;
+        for cached_font_entry in &self.fallback_font_cache {
+            let cached_font = cached_font_entry.font.borrow();
+            if cached_font.descriptor == desc &&
+                        cached_font.requested_pt_size == style.font_size &&
+                        cached_font.variant == style.font_variant {
+                fonts.push(cached_font_entry.font.clone());
+                cache_hit = true;
+                break;
             }
+        }
 
-            if !cache_hit {
-                let template_info = self.font_cache_thread.last_resort_font_template(desc.clone());
-                let layout_font = self.create_layout_font(template_info.font_template,
-                                                          desc.clone(),
-                                                          style.font_size,
-                                                          style.font_variant,
-                                                          template_info.font_key);
-                match layout_font {
-                    Ok(layout_font) => {
-                        let layout_font = Rc::new(RefCell::new(layout_font));
-                        self.fallback_font_cache.push(FallbackFontCacheEntry {
-                            font: layout_font.clone(),
-                        });
-                        fonts.push(layout_font);
-                    }
-                    Err(_) => debug!("Failed to create fallback layout font!")
+        if !cache_hit {
+            let template_info = self.font_cache_thread.last_resort_font_template(desc.clone());
+            let layout_font = self.create_layout_font(template_info.font_template,
+                                                      desc.clone(),
+                                                      style.font_size,
+                                                      style.font_variant,
+                                                      template_info.font_key);
+            match layout_font {
+                Ok(layout_font) => {
+                    let layout_font = Rc::new(RefCell::new(layout_font));
+                    self.fallback_font_cache.push(FallbackFontCacheEntry {
+                        font: layout_font.clone(),
+                    });
+                    fonts.push(layout_font);
                 }
+                Err(_) => debug!("Failed to create fallback layout font!")
             }
         }
 

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1971,6 +1971,11 @@ impl Fragment {
                 }
             }
             SpecificFragmentInfo::ScannedText(ref text_fragment) => {
+                // Fragments with no glyphs don't contribute any inline metrics.
+                // TODO: Filter out these fragments during flow construction?
+                if text_fragment.content_size.inline == Au(0) {
+                    return InlineMetrics::new(Au(0), Au(0), Au(0));
+                }
                 // See CSS 2.1 § 10.8.1.
                 let line_height = self.calculate_line_height(layout_context);
                 let font_derived_metrics =

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -197,17 +197,12 @@ impl TextRunScanner {
                 for (byte_index, character) in text.char_indices() {
                     // Search for the first font in this font group that contains a glyph for this
                     // character.
-                    let mut font_index = 0;
+                    let font_index = fontgroup.fonts.iter().position(|font| {
+                        font.borrow().glyph_index(character).is_some()
+                    }).unwrap_or(0);
+
                     // The following code panics one way or another if this condition isn't met.
                     assert!(fontgroup.fonts.len() > 0);
-                    while font_index < fontgroup.fonts.len() - 1 {
-                        if fontgroup.fonts.get(font_index).unwrap().borrow()
-                                          .glyph_index(character)
-                                          .is_some() {
-                            break
-                        }
-                        font_index += 1;
-                    }
 
                     let bidi_level = match bidi_levels {
                         Some(levels) => levels[*paragraph_bytes_processed],

--- a/tests/wpt/metadata-css/css-color-3_dev/html4/t422-rgba-onscreen-multiple-boxes-c.htm.ini
+++ b/tests/wpt/metadata-css/css-color-3_dev/html4/t422-rgba-onscreen-multiple-boxes-c.htm.ini
@@ -1,0 +1,3 @@
+[t422-rgba-onscreen-multiple-boxes-c.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-color-3_dev/html4/t425-hsla-onscreen-multiple-boxes-c.htm.ini
+++ b/tests/wpt/metadata-css/css-color-3_dev/html4/t425-hsla-onscreen-multiple-boxes-c.htm.ini
@@ -1,0 +1,3 @@
+[t425-hsla-onscreen-multiple-boxes-c.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-001.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-001.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-001.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-002.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-002.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-002.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-003.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-003.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-003.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-004.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-004.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-004.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-005.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-005.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-005.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-006.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-006.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-006.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-007.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-007.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-007.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-008.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-008.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-008.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-009.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-009.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-009.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-010.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-010.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-010.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-011.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-011.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-011.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-012.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-012.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-012.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-013.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-013.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-013.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-014.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-014.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-014.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-015.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-015.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-015.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-016.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-016.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-016.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-017.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-017.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-017.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-018.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-018.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-018.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-019.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-019.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-019.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-020.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-020.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-020.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-021.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-021.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-021.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-022.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-022.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-022.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-023.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-023.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-023.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-024.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-024.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-024.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-025.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-025.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-025.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-027.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-027.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-027.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-028.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-028.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-028.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-029.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-029.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-029.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-030.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-030.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-030.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-032.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-032.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-032.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-034.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-034.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-034.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-036.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-036.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-036.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-038.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-038.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-038.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-039.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-039.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-039.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-040.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-040.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-040.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-042.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-042.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-042.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-043.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-043.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-043.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-044.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-044.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-044.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-045.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-045.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-045.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-046.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-046.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-046.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-047.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-047.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-047.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-048.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-048.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-048.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-049.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-049.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-049.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-051.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-051.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-051.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-052.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-052.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-052.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-054.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-054.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-054.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-056.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-056.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-056.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-057.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-057.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-057.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-058.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-058.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-058.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-059.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-059.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-059.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-060.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-060.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-060.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-230.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-230.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-230.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-232.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-232.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-232.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-234.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-234.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-234.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-236.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-236.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-236.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-238.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-238.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-238.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-239.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-239.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-239.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-240.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-240.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-240.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-242.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-242.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-242.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-243.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-243.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-243.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-244.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-244.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-244.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-245.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-245.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-245.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-246.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-246.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-246.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-247.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-247.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-247.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-248.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-248.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-248.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-249.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-249.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-249.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-251.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-251.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-251.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-252.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-252.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-252.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-254.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-254.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-254.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-256.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-256.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-256.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-257.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-257.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-257.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-258.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-258.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-258.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-259.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-259.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-259.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-302.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-302.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-302.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-303.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-303.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-303.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-304.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-304.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-304.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-306.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-306.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-306.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-308.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-308.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-308.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-309.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-309.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-309.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-310.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-310.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-310.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-311.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-311.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-311.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-312.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-312.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-312.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-313.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-313.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-313.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-314.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-314.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-314.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-315.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-315.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-315.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-316.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-316.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-316.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-317.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-317.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-317.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-319.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-319.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-319.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-320.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-320.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-320.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-322.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-322.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-322.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-324.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-324.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-324.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-325.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-325.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-325.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-326.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-326.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-326.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-327.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-327.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-327.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-404.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-404.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-404.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-406.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-406.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-406.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-408.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-408.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-408.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-409.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-409.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-409.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-410.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-410.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-410.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-411.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-411.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-411.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-412.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-412.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-412.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-413.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-413.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-413.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-414.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-414.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-414.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-415.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-415.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-415.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-416.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-416.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-416.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-417.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-417.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-417.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-419.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-419.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-419.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-420.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-420.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-420.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-422.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-422.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-422.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-424.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-424.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-424.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-425.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-425.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-425.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-426.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-426.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-jazh-426.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-427.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-427.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-jazh-427.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-001.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-001.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-001.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-002.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-002.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-002.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-003.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-003.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-003.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-007.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-007.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-007.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-008.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-008.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-008.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-010.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-010.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-010.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-011.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-011.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-011.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-012.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-012.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-012.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-014.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-014.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-014.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-015.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-015.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-015.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-016.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-016.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-016.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-018.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-018.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-018.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-019.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-019.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-019.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-020.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-020.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-020.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-021.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-021.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-021.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-022.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-022.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-022.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-023.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-023.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-023.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-025.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-025.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-025.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-027.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-027.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-027.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-028.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-028.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-028.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-029.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-029.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-029.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-031.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-031.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-031.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-032.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-032.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-032.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-033.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-033.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-033.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-034.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-034.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-034.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-035.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-035.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-035.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-037.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-037.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-037.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-038.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-038.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-038.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-040.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-040.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-040.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-045.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-045.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-045.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-047.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-047.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-047.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-049.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-049.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-049.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-051.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-051.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-051.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-052.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-052.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-052.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-053.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-053.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-053.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-055.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-055.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-055.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-056.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-056.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-056.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-057.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-057.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-057.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-058.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-058.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-058.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-060.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-060.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-060.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-061.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-061.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-061.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-063.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-063.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-063.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-064.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-064.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-064.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-101.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-101.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-101.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-102.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-102.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-102.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-103.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-103.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-103.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-104.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-104.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-104.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-105.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-105.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-105.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-106.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-106.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-106.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-107.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-107.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-107.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-108.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-108.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-108.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-109.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-109.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-109.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-114.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-114.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-114.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-115.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-115.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-115.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-116.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-116.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-116.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-117.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-117.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-117.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-119.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-119.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-119.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-120.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-120.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-120.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-122.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-122.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-122.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-123.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-123.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-123.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-124.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-124.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-124.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-125.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-125.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-125.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-126.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-126.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-126.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-127.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-127.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-127.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-128.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-128.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-128.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-131.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-131.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-131.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-132.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-132.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-132.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-133.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-133.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-133.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-136.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-136.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-136.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-137.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-137.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-137.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-138.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-138.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-138.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-139.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-139.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-139.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-142.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-142.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-142.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-143.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-143.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-143.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-144.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-144.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-144.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-146.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-146.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-146.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-147.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-147.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-147.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-148.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-148.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-148.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-149.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-149.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-149.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-150.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-150.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-150.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-151.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-151.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-151.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-152.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-152.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-152.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-153.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-153.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-153.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-155.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-155.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-155.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-156.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-156.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-156.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-157.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-157.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-157.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-158.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-158.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-158.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-159.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-159.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-159.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-160.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-160.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-160.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-161.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-161.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-161.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-162.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-162.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-162.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-163.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-163.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-163.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-166.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-166.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-166.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-167.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-167.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-167.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-168.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-168.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-168.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-169.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-169.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-169.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-170.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-170.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-170.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-171.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-171.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-171.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-206.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-206.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-206.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-207.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-207.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-207.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-208.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-208.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-208.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-209.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-209.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-209.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-210.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-210.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-210.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-211.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-211.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-211.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-214.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-214.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-214.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-215.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-215.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-215.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-216.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-216.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-216.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-219.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-219.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-219.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-220.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-220.htm.ini
@@ -1,3 +1,4 @@
 [css3-text-line-break-opclns-220.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-221.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-221.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-221.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-222.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-222.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-222.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-223.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-223.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-223.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-224.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-224.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-224.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-225.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-225.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-225.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-226.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-226.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-226.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-250.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-250.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-250.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-251.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-251.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-251.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-252.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-252.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-252.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-253.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-253.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-253.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-254.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-254.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-254.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-255.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-255.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-255.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-256.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-256.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-256.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-257.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-257.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-257.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-258.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-258.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-258.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-259.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-259.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-259.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-260.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-260.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-260.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-261.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-261.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-261.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-262.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-262.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-262.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-263.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-263.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-263.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-264.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-264.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-264.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-265.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-265.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-265.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-266.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-266.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-266.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-267.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-267.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-267.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-268.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-268.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-268.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-269.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-269.htm.ini
@@ -1,4 +1,0 @@
-[css3-text-line-break-opclns-269.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/word-break-normal-hi-000.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/word-break-normal-hi-000.htm.ini
@@ -1,5 +1,4 @@
 [word-break-normal-hi-000.htm]
   type: reftest
   expected:
-    if os == "linux": FAIL
-    PASS
+    FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/font-family-013.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/font-family-013.htm.ini
@@ -1,3 +1,0 @@
-[font-family-013.htm]
-  type: reftest
-  disabled: https://github.com/servo/servo/issues/7625

--- a/tests/wpt/metadata-css/css21_dev/html4/fonts-012.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/fonts-012.htm.ini
@@ -1,4 +1,4 @@
-[css3-text-line-break-opclns-043.htm]
+[fonts-012.htm]
   type: reftest
   expected:
     if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/fonts-013.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/fonts-013.htm.ini
@@ -1,3 +1,0 @@
-[fonts-013.htm]
-  type: reftest
-  disabled: https://github.com/servo/servo/issues/7625

--- a/tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html
+++ b/tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html
@@ -9,12 +9,15 @@ body {
     font-size: 24px;
     line-height: 24px;
 }
+span {
+    font-family: sans-serif;
+}
 </style>
 </head>
 <body>
-<section>x&larr;</section>
-<section>&rarr;x</section>
-<section>&rarr;x&larr;</section>
+<section>x&larr;<span>&nbsp;</span></section>
+<section>&rarr;x<span>&nbsp;</span></section>
+<section>&rarr;x&larr;<span>&nbsp;</span></section>
 </body>
 </html>
 


### PR DESCRIPTION
This is used as a fallback for any characters that don't have glyphs in the specified font.  Without this, per-glyph font fallback doesn't work because the FontGroup always contains only one font.  Fixes missing glyphs on many pages on my Linux box.

As a follow-up, we should probably have a smarter strategy for finding fallback fonts, possibly varying by script.  (Currently we just have a few hard-coded family names.)

r? @glennw

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11303)

<!-- Reviewable:end -->
