### PR TITLE
Allow multiple sequential webdriver sessions

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -70,6 +70,7 @@ pub fn start_server(port: u16, constellation_chan: Sender<ConstellationMsg>) {
     });
 }
 
+#[derive(Clone, PartialEq)]
 struct WebDriverSession {
     id: Uuid,
     frame_id: Option<FrameId>
@@ -253,7 +254,7 @@ impl Handler {
     fn session(&self) -> WebDriverResult<&WebDriverSession> {
         match self.session {
             Some(ref x) => Ok(x),
-            None => Err(WebDriverError::new(ErrorStatus::SessionNotCreated,
+            None => Err(WebDriverError::new(ErrorStatus::InvalidSessionId,
                                             "Session not created"))
         }
     }
@@ -264,7 +265,7 @@ impl Handler {
                 x.frame_id = frame_id;
                 Ok(())
             },
-            None => Err(WebDriverError::new(ErrorStatus::SessionNotCreated,
+            None => Err(WebDriverError::new(ErrorStatus::InvalidSessionId,
                                             "Session not created"))
         }
     }
@@ -282,17 +283,19 @@ impl Handler {
                 NewSessionResponse::new(
                     session.id.to_string(),
                     Json::Object(capabilities))));
+            try!(self.handle_get(&GetParameters { url: String::from("about:blank") }));
             self.session = Some(session);
             rv
         } else {
-            Err(WebDriverError::new(ErrorStatus::UnknownError,
+            Err(WebDriverError::new(ErrorStatus::SessionNotCreated,
                                     "Session already created"))
         }
     }
 
     fn handle_delete_session(&mut self) -> WebDriverResult<WebDriverResponse> {
+        try!(self.handle_get(&GetParameters { url: String::from("about:blank") }));
         self.session = None;
-        Ok(WebDriverResponse::Void)
+        Ok(WebDriverResponse::DeleteSession)
     }
 
     #[inline]
@@ -757,6 +760,7 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
         match msg.command {
             WebDriverCommand::NewSession => {},
             _ => {
+                // TODO: check that the session id is the same as the current session
                 try!(self.session());
             }
         }
@@ -806,8 +810,6 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
     }
 
     fn delete_session(&mut self, _session: &Option<Session>) {
-        // Servo doesn't support multiple sessions, so we exit on session deletion
-        let _ = self.constellation_chan.send(ConstellationMsg::Exit);
-        self.session = None;
+        // We don't do any post-processing after a session is deleted
     }
 }


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [X] These changes fix #11253

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the wdspec tests are in wpt/webdriver

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11306)

<!-- Reviewable:end -->
