### PR TITLE
Ensure that a navigation to the same URL is aborted. Fixes #10952.

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1833,24 +1833,25 @@ impl ScriptThread {
     /// The entry point for content to notify that a new load has been requested
     /// for the given pipeline (specifically the "navigate" algorithm).
     fn handle_navigate(&self, pipeline_id: PipelineId, subpage_id: Option<SubpageId>, load_data: LoadData) {
-        // Step 8.
+        // Step 6.
         {
             let nurl = &load_data.url;
-            if let Some(fragment) = nurl.fragment() {
-                let context = get_browsing_context(&self.root_browsing_context(), pipeline_id);
-                let document = context.active_document();
-                let document = document.r();
-                let url = document.url();
-                if &url[..Position::AfterQuery] == &nurl[..Position::AfterQuery] &&
-                    load_data.method == Method::Get {
-                    match document.find_fragment_node(fragment) {
-                        Some(ref node) => {
-                            self.scroll_fragment_point(pipeline_id, node.r());
-                        }
-                        None => {}
+            let context = get_browsing_context(&self.root_browsing_context(), pipeline_id);
+            let document = context.active_document();
+            let document = document.r();
+            let url = document.url();
+            if &url[..Position::AfterQuery] == &nurl[..Position::AfterQuery] &&
+                load_data.method == Method::Get {
+                if let Some(fragment) = nurl.fragment() {
+                    if let Some(ref node) = document.find_fragment_node(fragment) {
+                        self.scroll_fragment_point(pipeline_id, node.r());
                     }
-                    return;
                 }
+                // TODO: Revisit this return statement when a decission is taken
+                // in https://github.com/whatwg/html/issues/1177.
+                //
+                // See #10954 for discussion and background.
+                return;
             }
         }
 

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -35938,6 +35938,12 @@
     "deleted_reftests": {},
     "items": {
       "testharness": {
+        "html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html": [
+          {
+            "path": "html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html",
+            "url": "/html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html"
+          }
+        ],
         "html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_attribute-getter-setter.html": [
           {
             "path": "html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_attribute-getter-setter.html",

--- a/tests/wpt/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html
+++ b/tests/wpt/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Navigating to the same URL with an empty fragment aborts the navigation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe src="empty_fragment_iframe.html"></iframe>
+<script>
+// If the navigation were not aborted, we would expect multiple load events
+// as the page continually reloads itself.
+async_test(function(t) {
+  var count = 0;
+  var iframe = document.querySelector('iframe');
+  iframe.onload = t.step_func(function() {
+    count++;
+  });
+  window.child_succeeded = t.step_func_done(function() {
+    assert_equals(count, 1);
+  });
+});
+</script>

--- a/tests/wpt/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/empty_fragment_iframe.html
+++ b/tests/wpt/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/empty_fragment_iframe.html
@@ -1,0 +1,11 @@
+<script>
+var timeout;
+onload = function() {
+  location.hash = "";
+  timeout = setTimeout(function() { parent.child_succeeded() }, 2000);
+};
+
+onbeforeunload = function() {
+  clearTimeout(timeout);
+}
+</script>


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors
- [x] These changes fix #10952 (github issue number if applicable).

Either:
- [x] There are tests for these changes.

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

---

Rebase of #10954 

r? @jdm for the rebase (r=me for the original changes)

@jdm: Should this test still live in wpt? I'm tempted to move it to `mozilla/` until https://github.com/whatwg/html/issues/1177 is resolved.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11321)

<!-- Reviewable:end -->
