### PR TITLE
Include <button type=submit> data whilst constructing the form dataset

### DIFF
--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -14,8 +14,9 @@ use dom::event::Event;
 use dom::eventtarget::EventTarget;
 use dom::htmlelement::HTMLElement;
 use dom::htmlfieldsetelement::HTMLFieldSetElement;
-use dom::htmlformelement::{FormControl, FormSubmitter, ResetFrom};
-use dom::htmlformelement::{SubmittedFrom, HTMLFormElement};
+use dom::htmlformelement::HTMLFormElement;
+use dom::htmlformelement::{FormControl, FormDatum, FormDatumValue};
+use dom::htmlformelement::{FormSubmitter, ResetFrom, SubmittedFrom};
 use dom::node::{Node, UnbindContext, document_from_node, window_from_node};
 use dom::nodelist::NodeList;
 use dom::validation::Validatable;
@@ -134,6 +135,39 @@ impl HTMLButtonElementMethods for HTMLButtonElement {
     // https://html.spec.whatwg.org/multipage/#dom-lfe-labels
     fn Labels(&self) -> Root<NodeList> {
         self.upcast::<HTMLElement>().labels()
+    }
+}
+
+impl HTMLButtonElement {
+    /// https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set
+    /// Steps range from 3.1 to 3.7 (specific to HTMLButtonElement)
+    pub fn form_datum(&self, submitter: Option<FormSubmitter>) -> Option<FormDatum> {
+        // Step 3.1: disabled state check is in get_unclean_dataset
+
+        // Step 3.1: only run steps if this is the submitter
+        if let Some(FormSubmitter::ButtonElement(submitter)) = submitter {
+            if submitter != self {
+                return None
+            }
+        } else {
+            return None
+        }
+        // Step 3.2
+        let ty = self.Type();
+        // Step 3.4
+        let name = self.Name();
+
+        if name.is_empty() {
+            // Step 3.1: Must have a name
+            return None;
+        }
+
+        // Step 3.9
+        Some(FormDatum {
+            ty: ty,
+            name: name,
+            value: FormDatumValue::String(self.Value())
+        })
     }
 }
 

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -548,7 +548,12 @@ impl HTMLFormElement {
                             data_set.push(datum);
                         }
                     }
-                    HTMLElementTypeId::HTMLButtonElement |
+                    HTMLElementTypeId::HTMLButtonElement => {
+                        let button = child.downcast::<HTMLButtonElement>().unwrap();
+                        if let Some(datum) = button.form_datum(submitter) {
+                            data_set.push(datum);
+                        }
+                    }
                     HTMLElementTypeId::HTMLObjectElement => {
                         // Unimplemented
                         ()

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -605,8 +605,10 @@ impl HTMLInputElement {
     }
 
     /// https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set
-    /// Steps range from 3.1 to 3.7 which related to the HTMLInputElement
+    /// Steps range from 3.1 to 3.7 (specific to HTMLInputElement)
     pub fn form_datum(&self, submitter: Option<FormSubmitter>) -> Option<FormDatum> {
+        // 3.1: disabled state check is in get_unclean_dataset
+
         // Step 3.2
         let ty = self.type_();
         // Step 3.4
@@ -634,7 +636,7 @@ impl HTMLInputElement {
 
         }
 
-        // Step 3.6
+        // Step 3.9
         Some(FormDatum {
             ty: DOMString::from(&*ty), // FIXME(ajeffrey): Convert directly from Atoms to DOMStrings
             name: name,

--- a/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-0/submit-entity-body.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-0/submit-entity-body.html
@@ -66,6 +66,21 @@ var simple_tests = [
     enctype: "text/plain",
     submitelement: "<input id=inputsubmit type=\"submit\">Submit</input>",
     submitaction: function(doc) { doc.getElementById("inputsubmit").click(); }
+  },
+  {
+    name: "form submission from submit input should contain submit button value",
+    input: "<button type=submit name=notclicked value=nope>not clicked</button>",
+    enctype: "application/x-www-form-urlencoded",
+    submitelement: "<button id=inputsubmit type=\"submit\" name=foo value=bara>Submit</button>",
+    submitaction: function(doc) { doc.getElementById("inputsubmit").click(); }
+  }
+,
+  {
+    name: "form submission from submit button should contain submit button value",
+    input: "<input type=submit name=notclicked value=nope/>",
+    enctype: "application/x-www-form-urlencoded",
+    submitelement: "<input id=inputsubmit type=\"submit\" name=foo value=bara >",
+    submitaction: function(doc) { doc.getElementById("inputsubmit").click(); }
   }
 ];
 simple_tests.forEach(function(test_obj) {


### PR DESCRIPTION
This makes it possible to close things in github (see
https://github.com/Manishearth/mitochondria/issues/1)
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

Either:
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11333)

<!-- Reviewable:end -->
