### PR TITLE
Remove pub uses from compositor_thread.rs.

### DIFF
--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -5,6 +5,7 @@
 //! Communication with the compositor thread.
 
 use CompositorMsg as ConstellationMsg;
+use SendableFrameTree;
 use compositor::{self, CompositingReason};
 use euclid::point::Point2D;
 use euclid::size::Size2D;
@@ -22,11 +23,9 @@ use std::sync::mpsc::{Receiver, Sender, channel};
 use style_traits::cursor::Cursor;
 use style_traits::viewport::ViewportConstraints;
 use url::Url;
-use windowing::{WindowEvent, WindowMethods};
-pub use SendableFrameTree;
-pub use windowing;
 use webrender;
 use webrender_traits;
+use windowing::{WindowEvent, WindowMethods};
 
 /// Sends messages to the compositor. This is a trait supplied by the port because the method used
 /// to communicate with the compositor may have to kick OS event loops awake, communicate cross-


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because refactoring

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11334)

<!-- Reviewable:end -->
