### PR TITLE
Don't block the script listener thread on window.close().

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -529,9 +529,8 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 return false
             }
 
-            (Msg::Exit(channel), _) => {
+            (Msg::Exit, _) => {
                 self.start_shutting_down();
-                let _ = channel.send(());
             }
 
             (Msg::ShutdownComplete, _) => {

--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -9,7 +9,7 @@ use compositor::{self, CompositingReason};
 use euclid::point::Point2D;
 use euclid::size::Size2D;
 use gfx_traits::{Epoch, FrameTreeId, LayerId, LayerProperties, PaintListener};
-use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
+use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use layers::layers::{BufferRequest, LayerBufferSet};
 use layers::platform::surface::{NativeDisplay, NativeSurface};
 use msg::constellation_msg::{Image, Key, KeyModifiers, KeyState, PipelineId};
@@ -81,9 +81,7 @@ pub fn run_script_listener_thread(compositor_proxy: Box<CompositorProxy + 'stati
             }
 
             ScriptToCompositorMsg::Exit => {
-                let (chan, port) = ipc::channel().unwrap();
-                compositor_proxy.send(Msg::Exit(chan));
-                port.recv().unwrap();
+                compositor_proxy.send(Msg::Exit);
             }
 
             ScriptToCompositorMsg::SetTitle(pipeline_id, title) => {
@@ -169,7 +167,7 @@ impl PaintListener for Box<CompositorProxy + 'static + Send> {
 /// Messages from the painting thread and the constellation thread to the compositor thread.
 pub enum Msg {
     /// Requests that the compositor shut down.
-    Exit(IpcSender<()>),
+    Exit,
 
     /// Informs the compositor that the constellation has completed shutdown.
     /// Required because the constellation can have pending calls to make
@@ -248,7 +246,7 @@ pub enum Msg {
 impl Debug for Msg {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match *self {
-            Msg::Exit(..) => write!(f, "Exit"),
+            Msg::Exit => write!(f, "Exit"),
             Msg::ShutdownComplete => write!(f, "ShutdownComplete"),
             Msg::GetNativeDisplay(..) => write!(f, "GetNativeDisplay"),
             Msg::InitializeLayersForPipeline(..) => write!(f, "InitializeLayersForPipeline"),


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because no tangible effect

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

This does not appear to have any effect. I believe this has been the case
since e84106535175211526729e532058a7514a0de372, when the helper thread was
introduced.

It was added in a7ef1cd35e9347a285f245041db4eb94047f4ab0, where it blocked the
script thread rather than this helper thread.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11337)

<!-- Reviewable:end -->
