### PR TITLE
Don't create HarfBuzz shaper if it isn't used

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -172,7 +172,7 @@ struct ShapeCacheEntry {
 
 impl Font {
     pub fn shape_text(&mut self, text: &str, options: &ShapingOptions) -> Arc<GlyphStore> {
-        self.make_shaper(options);
+        self.make_shaper();
 
         //FIXME: find the equivalent of Equiv and the old ShapeCacheEntryRef
         let shaper = &self.shaper;
@@ -198,16 +198,10 @@ impl Font {
         })
     }
 
-    fn make_shaper<'a>(&'a mut self, options: &ShapingOptions) -> &'a Shaper {
-        // fast path: already created a shaper
-        if let Some(ref mut shaper) = self.shaper {
-            shaper.set_options(options);
-            return shaper
+    fn make_shaper(&mut self) {
+        if self.shaper.is_none() {
+            self.shaper = Some(Shaper::new(self));
         }
-
-        let shaper = Shaper::new(self, options);
-        self.shaper = Some(shaper);
-        self.shaper.as_ref().unwrap()
     }
 
     pub fn table_for_tag(&self, tag: FontTableTag) -> Option<FontTable> {


### PR DESCRIPTION
Move the fast shaping code out of `text::shaping::harfbuzz`, and initialize the HarfBuzz shaper lazily to avoid allocating unnecessary HarfBuzz objects.

Note: As the fast shaping code grows and gains OpenType support, I'll probably factor it out into a whole new `text::shaping::fast` module.

r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11347)

<!-- Reviewable:end -->
