### PR TITLE
geckolib: Add bindings and minimal sugar for already_AddRefed

### DIFF
--- a/ports/geckolib/gecko_bindings/bindings.rs
+++ b/ports/geckolib/gecko_bindings/bindings.rs
@@ -101,6 +101,26 @@ unsafe impl Send for nsStyleEffects {}
 unsafe impl Sync for nsStyleEffects {}
 impl HeapSizeOf for nsStyleEffects { fn heap_size_of_children(&self) -> usize { 0 } }
 
+/**
+ * This is a class to interface with Servo's FFI bindings in a way that we can
+ * distinguish between a weak and a strong pointer.
+ *
+ * We can't use already_AddRefed<T> directly because when there's a destructor
+ * or a move constructor in the arguments, C++ (g++ at least for sure) assumes
+ * that nothing that isn't C++ is going to call that function, and thus it uses
+ * its own calling convention instead of passing by value.
+ *
+ * This class won't be copiable in Rust, and it will potentially have a
+ * destructor that prevents it from leaking, just as already_AddRefed has in
+ * C++.
+ *
+ * <div rustbindgen nocopy></div>
+ */
+#[repr(C)]
+#[derive(Debug)]
+pub struct ServoFFIAddRefed<T> {
+    pub mRawPtr: *mut T,
+}
 pub enum nsIAtom { }
 pub enum nsINode { }
 pub type RawGeckoNode = nsINode;
@@ -206,12 +226,12 @@ extern "C" {
     pub fn Servo_InitStyleSet() -> *mut RawServoStyleSet;
     pub fn Servo_DropStyleSet(set: *mut RawServoStyleSet);
     pub fn Servo_GetComputedValues(node: *mut RawGeckoNode)
-     -> *mut ServoComputedValues;
+     -> ServoFFIAddRefed<ServoComputedValues>;
     pub fn Servo_GetComputedValuesForAnonymousBox(parentStyleOrNull:
                                                       *mut ServoComputedValues,
                                                   pseudoTag: *mut nsIAtom,
                                                   set: *mut RawServoStyleSet)
-     -> *mut ServoComputedValues;
+     -> ServoFFIAddRefed<ServoComputedValues>;
     pub fn Servo_GetComputedValuesForPseudoElement(parent_style:
                                                        *mut ServoComputedValues,
                                                    match_element:
@@ -219,9 +239,9 @@ extern "C" {
                                                    pseudo_tag: *mut nsIAtom,
                                                    set: *mut RawServoStyleSet,
                                                    is_probe: bool)
-     -> *mut ServoComputedValues;
+     -> ServoFFIAddRefed<ServoComputedValues>;
     pub fn Servo_InheritComputedValues(parent_style: *mut ServoComputedValues)
-     -> *mut ServoComputedValues;
+     -> ServoFFIAddRefed<ServoComputedValues>;
     pub fn Servo_AddRefComputedValues(arg1: *mut ServoComputedValues);
     pub fn Servo_ReleaseComputedValues(arg1: *mut ServoComputedValues);
     pub fn Servo_Initialize();

--- a/ports/geckolib/gecko_bindings/lib.rs
+++ b/ports/geckolib/gecko_bindings/lib.rs
@@ -12,3 +12,4 @@ pub mod bindings;
 pub mod ptr;
 #[allow(dead_code, non_camel_case_types, non_snake_case, non_upper_case_globals)]
 pub mod structs;
+mod sugar;

--- a/ports/geckolib/gecko_bindings/sugar/ffi_addrefed.rs
+++ b/ports/geckolib/gecko_bindings/sugar/ffi_addrefed.rs
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use bindings::ServoFFIAddRefed;
+use std::mem;
+use std::ops;
+
+impl<T> ops::Deref for ServoFFIAddRefed<T> {
+    type Target = T;
+    fn deref<'a>(&'a self) -> &'a T {
+        debug_assert!(!self.mRawPtr.is_null());
+        unsafe { mem::transmute(self.mRawPtr) }
+    }
+}
+
+impl<T> ops::DerefMut for ServoFFIAddRefed<T> {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut T {
+        debug_assert!(!self.mRawPtr.is_null());
+        unsafe { mem::transmute(self.mRawPtr) }
+    }
+}
+
+impl<T> ServoFFIAddRefed<T> {
+    pub fn new(ptr: *mut T) -> ServoFFIAddRefed<T> {
+        ServoFFIAddRefed {
+            mRawPtr: ptr,
+        }
+    }
+
+    pub fn checked<'a>(&'a self) -> Option<&'a T> {
+        // TODO: This can probably just be written as:
+        //
+        // mem::transmute(self.mRawPtr);
+        //
+        // since rust optimises the Option<&T> case with None as the null
+        // pointer.
+        //
+        // Nontheless this is probably optimised away, so we just don't rely on
+        // it.
+        if self.mRawPtr.is_null() {
+            None
+        } else {
+            Some(unsafe { mem::transmute(self.mRawPtr) })
+        }
+    }
+
+    pub fn checked_mut<'a>(&'a mut self) -> Option<&'a mut T> {
+        if self.mRawPtr.is_null() {
+            None
+        } else {
+            Some(unsafe { mem::transmute(self.mRawPtr) })
+        }
+    }
+}

--- a/ports/geckolib/gecko_bindings/sugar/mod.rs
+++ b/ports/geckolib/gecko_bindings/sugar/mod.rs
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! This module contains syntactic sugar for some geckolib types.
+mod ffi_addrefed;

--- a/ports/geckolib/gecko_bindings/tools/regen_style_structs.sh
+++ b/ports/geckolib/gecko_bindings/tools/regen_style_structs.sh
@@ -29,6 +29,7 @@ else
 fi
 
 
+
 # Check for the include directory.
 export DIST_INCLUDE="$1/dist/include"
 if [ ! -d "$DIST_INCLUDE" ]; then
@@ -106,6 +107,12 @@ export RUST_BACKTRACE=1
   -blacklist-type "IsDestructibleFallbackImpl"                      \
   -blacklist-type "IsDestructibleFallback"                          \
   -blacklist-type "nsProxyReleaseEvent"                             \
+  -blacklist-type "__make_pair_return_impl"                         \
+  -blacklist-type "_Itup_cat"                                       \
+  -blacklist-type "__is_tuple_like_impl"                            \
+  -blacklist-type "tuple_size"                                      \
+  -blacklist-type "tuple_element"                                   \
+  -blacklist-type "tuple"                                           \
   -opaque-type "nsIntMargin"                                        \
   -opaque-type "nsIntPoint"                                         \
   -opaque-type "nsIntRect"                                          \


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors

Either:
- [x] These changes do not require tests because geckolib.

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

---

r? @bholley 

Probably can't land as-is, since there are a few build failures that seem unrelated to these changes, but I opened this just to let you know what I had in mind.

With this type imported from `bindings.rs` we should be able to pass `already_AddRefed`s from geckolib.

cc @heycam

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11350)

<!-- Reviewable:end -->
