### PR TITLE
Update Android build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,14 @@ real-world use, add the `--release` flag to create an optimized build:
 ``` sh
 git clone https://github.com/servo/servo
 cd servo
-ANDROID_TOOLCHAIN=/path/to/toolchain ANDROID_NDK=/path/to/ndk PATH=$PATH:/path/to/toolchain/bin ./mach build --android
-cd ports/android
-ANDROID_SDK=/path/to/sdk make install
+
+export ANDROID_SDK="/path/to/sdk"
+export ANDROID_NDK="/path/to/ndk"
+export ANDROID_TOOLCHAIN="/path/to/toolchain"
+export PATH="$PATH:/path/to/toolchain/bin"
+
+./mach build --release --android
+./mach package --release
 ```
 
 Rather than setting the `ANDROID_*` environment variables every time, you can


### PR DESCRIPTION
The Android build instructions haven't been updated for a while in the README;
instead of `cd ports/android && ANDROID_SDK=/path/to/sdk make install`, we have `./mach package --release` now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11360)

<!-- Reviewable:end -->
