### PR TITLE
Don't inherit text-transform on input elements

### DIFF
--- a/resources/user-agent.css
+++ b/resources/user-agent.css
@@ -252,6 +252,7 @@ table:matches(
 
 input, select, option, optgroup, button, textarea, keygen {
   text-indent: initial;
+  text-transform: none;
 }
 
 textarea { white-space: pre-wrap; }


### PR DESCRIPTION
Seems to be pretty standard across browsers.

See also: https://www.tjvantoll.com/2012/07/10/default-browser-handling-of-the-css-text-transform-property/

Perhaps we should do this for more font properties? It seems like a bunch aren't
inherited.

Fixes #11362

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11363)

<!-- Reviewable:end -->
