### PR TITLE
Fix FileManager thread panic and other misc improvements

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -39,6 +39,7 @@ use msg::constellation_msg::{SubpageId, WindowSizeData, WindowSizeType};
 use msg::constellation_msg::{self, PanicMsg};
 use msg::webdriver_msg;
 use net_traits::bluetooth_thread::BluetoothMethodMsg;
+use net_traits::filemanager_thread::FileManagerThreadMsg;
 use net_traits::image_cache_thread::ImageCacheThread;
 use net_traits::storage_thread::StorageThreadMsg;
 use net_traits::{self, ResourceThreads, IpcSend};
@@ -850,6 +851,11 @@ impl<LTF: LayoutThreadFactory, STF: ScriptThreadFactory> Constellation<LTF, STF>
         if let Err(e) = self.resource_threads.send(StorageThreadMsg::Exit) {
             warn!("Exit storage thread failed ({})", e);
         }
+
+        if let Err(e) = self.resource_threads.send(FileManagerThreadMsg::Exit) {
+            warn!("Exit storage thread failed ({})", e);
+        }
+
         if let Err(e) = self.bluetooth_thread.send(BluetoothMethodMsg::Exit) {
             warn!("Exit bluetooth thread failed ({})", e);
         }

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -53,6 +53,7 @@ impl FileManager {
                 FileManagerThreadMsg::SelectFiles(sender) => self.select_files(sender),
                 FileManagerThreadMsg::ReadFile(sender, id) => self.read_file(sender, id),
                 FileManagerThreadMsg::DeleteFileID(id) => self.delete_fileid(id),
+                FileManagerThreadMsg::Exit => break,
             }
         }
     }

--- a/components/net_traits/filemanager_thread.rs
+++ b/components/net_traits/filemanager_thread.rs
@@ -6,7 +6,7 @@ use ipc_channel::ipc::IpcSender;
 use std::path::PathBuf;
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SelectedFile {
     pub id: Uuid,
     pub filename: PathBuf,
@@ -28,6 +28,9 @@ pub enum FileManagerThreadMsg {
 
     /// Delete the FileID entry
     DeleteFileID(Uuid),
+
+    /// Shut down this thread
+    Exit,
 }
 
 pub type FileManagerResult<T> = Result<T, FileManagerThreadError>;

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -51,8 +51,6 @@ impl File {
     pub fn new_from_selected(window: &Window, selected: SelectedFile) -> Root<File> {
         let name = DOMString::from(selected.filename.to_str().expect("File name encoding error"));
 
-        // FIXME: fix this after PR #11221 is landed
-        let id = selected.id;
         let slice = DataSlice::empty();
 
         let global = GlobalRef::Window(window);

--- a/tests/unit/net/filemanager_thread.rs
+++ b/tests/unit/net/filemanager_thread.rs
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use ipc_channel::ipc::{self, IpcSender};
+use net::filemanager_thread::FileManagerThreadFactory;
+use net_traits::filemanager_thread::{FileManagerThreadMsg, FileManagerThreadError};
+
+#[test]
+fn test_filemanager() {
+    let chan: IpcSender<FileManagerThreadMsg> = FileManagerThreadFactory::new();
+
+    {
+        let (tx, rx) = ipc::channel().unwrap();
+        let _ = chan.send(FileManagerThreadMsg::SelectFile(tx));
+
+        match rx.recv().unwrap() {
+            Err(FileManagerThreadError::InvalidSelection) => {},
+            _ => assert!(false, "Should be an invalid selection before dialog is implemented"),
+        }
+    }
+
+    let _ = chan.send(FileManagerThreadMsg::Exit);
+
+    {
+        let (tx, rx) = ipc::channel().unwrap();
+        let _ = chan.send(FileManagerThreadMsg::SelectFile(tx));
+
+        match rx.try_recv() {
+            Ok(_) => assert!(false, "The thread should not response fine after exited"),
+            Err(_) => {},
+        }
+    }
+}

--- a/tests/unit/net/lib.rs
+++ b/tests/unit/net/lib.rs
@@ -29,3 +29,4 @@ extern crate util;
 #[cfg(test)] mod resource_thread;
 #[cfg(test)] mod hsts;
 #[cfg(test)] mod http_loader;
+#[cfg(test)] mod filemanager_thread;


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors
- [x] There are tests for these changes

Changes:
- Add shut down logic for FileManager thread
- Add an unit test for filemanager_thread

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11368)

<!-- Reviewable:end -->
