### PR TITLE
Pass a parent JS runtime when creating DOM Worker runtimes

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -213,7 +213,8 @@ impl DedicatedWorkerGlobalScope {
                             worker_url: Url,
                             id: PipelineId,
                             from_devtools_receiver: IpcReceiver<DevtoolScriptControlMsg>,
-                            main_thread_rt: Arc<Mutex<Option<SharedRt>>>,
+                            parent_rt: SharedRt,
+                            worker_rt_for_mainthread: Arc<Mutex<Option<SharedRt>>>,
                             worker: TrustedWorkerAddress,
                             parent_sender: Box<ScriptChan + Send>,
                             own_sender: Sender<(TrustedWorkerAddress, WorkerScriptMsg)>,
@@ -240,8 +241,8 @@ impl DedicatedWorkerGlobalScope {
                 }
             };
 
-            let runtime = unsafe { new_rt_and_cx() };
-            *main_thread_rt.lock().unwrap() = Some(SharedRt::new(&runtime));
+            let runtime = unsafe { new_rt_and_cx(parent_rt.rt()) };
+            *worker_rt_for_mainthread.lock().unwrap() = Some(SharedRt::new(&runtime));
 
             let (devtools_mpsc_chan, devtools_mpsc_port) = channel();
             ROUTER.route_ipc_receiver_to_mpsc_sender(from_devtools_receiver, devtools_mpsc_chan);

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -95,9 +95,9 @@ impl<'a> Drop for StackRootTLS<'a> {
 }
 
 #[allow(unsafe_code)]
-pub unsafe fn new_rt_and_cx() -> Runtime {
+pub unsafe fn new_rt_and_cx(parent_rt: *mut JSRuntime) -> Runtime {
     LiveDOMReferences::initialize();
-    let runtime = Runtime::new();
+    let runtime = Runtime::new(parent_rt);
 
     JS_AddExtraGCRootsTracer(runtime.rt(), Some(trace_rust_roots), ptr::null_mut());
     JS_AddExtraGCRootsTracer(runtime.rt(), Some(trace_refcounted_objects), ptr::null_mut());

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -88,6 +88,7 @@ use std::borrow::ToOwned;
 use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::option::Option;
+use std::ptr;
 use std::rc::Rc;
 use std::result::Result;
 use std::sync::atomic::{Ordering, AtomicBool};
@@ -456,8 +457,8 @@ impl ScriptThreadFactory for ScriptThread {
             let mem_profiler_chan = state.mem_profiler_chan.clone();
             let window_size = state.window_size;
             let script_thread = ScriptThread::new(state,
-                                              script_port,
-                                              script_chan.clone());
+                                                  script_port,
+                                                  script_chan.clone());
 
             SCRIPT_THREAD_ROOT.with(|root| {
                 *root.borrow_mut() = Some(&script_thread as *const _);
@@ -531,7 +532,7 @@ impl ScriptThread {
                port: Receiver<MainThreadScriptMsg>,
                chan: Sender<MainThreadScriptMsg>)
                -> ScriptThread {
-        let runtime = unsafe { new_rt_and_cx() };
+        let runtime = unsafe { new_rt_and_cx(ptr::null_mut()) };
 
         unsafe {
             JS_SetWrapObjectCallbacks(runtime.rt(),

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.3"
-source = "git+https://github.com/servo/rust-mozjs#3352139c1dedbdff5fe1078152f46522cd04b2f3"
+source = "git+https://github.com/servo/rust-mozjs#fae7efd0adf42c0dde517382b83734525e11c6cc"
 dependencies = [
  "heapsize 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.3"
-source = "git+https://github.com/servo/rust-mozjs#3352139c1dedbdff5fe1078152f46522cd04b2f3"
+source = "git+https://github.com/servo/rust-mozjs#fae7efd0adf42c0dde517382b83734525e11c6cc"
 dependencies = [
  "heapsize 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.3"
-source = "git+https://github.com/servo/rust-mozjs#3352139c1dedbdff5fe1078152f46522cd04b2f3"
+source = "git+https://github.com/servo/rust-mozjs#fae7efd0adf42c0dde517382b83734525e11c6cc"
 dependencies = [
  "heapsize 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This enables sharing data with the parent runtime, decreasing memory usage and startup time. Also contains an update to current rust-mozjs, because that's required for this to work.
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors
- [x] These changes don't fix a github issue

Either:
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the changes don't change any observable behavior

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11372)

<!-- Reviewable:end -->
