### PR TITLE
Bump string-cache to 0.2.18

### DIFF
--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -36,7 +36,7 @@ serde = "0.7"
 serde_macros = "0.7"
 servo-skia = "0.20130412.0"
 smallvec = "0.1"
-string_cache = {version = "0.2.17", features = ["heap_size"]}
+string_cache = {version = "0.2.18", features = ["heap_size"]}
 style = {path = "../style"}
 style_traits = {path = "../style_traits"}
 time = "0.1.12"

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -36,7 +36,7 @@ selectors = {version = "0.6", features = ["heap_size"]}
 serde_json = "0.7"
 serde_macros = "0.7"
 smallvec = "0.1"
-string_cache = {version = "0.2.17", features = ["heap_size"]}
+string_cache = {version = "0.2.18", features = ["heap_size"]}
 style = {path = "../style"}
 style_traits = {path = "../style_traits"}
 time = "0.1"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -56,7 +56,7 @@ script_traits = {path = "../script_traits"}
 selectors = {version = "0.6", features = ["heap_size"]}
 serde = "0.7"
 smallvec = "0.1"
-string_cache = {version = "0.2.17", features = ["heap_size", "unstable"]}
+string_cache = {version = "0.2.18", features = ["heap_size", "unstable"]}
 style = {path = "../style"}
 time = "0.1.12"
 unicase = "1.0"

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
  "servo-skia 0.20130412.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "simd 0.1.0 (git+https://github.com/huonw/simd)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -953,7 +953,7 @@ dependencies = [
  "phf 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1151,7 +1151,7 @@ dependencies = [
  "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1890,7 +1890,7 @@ dependencies = [
  "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinyfiledialogs 0.1.0 (git+https://github.com/jdm/tinyfiledialogs)",
@@ -1953,7 +1953,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2149,7 +2149,7 @@ dependencies = [
  "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2166,7 +2166,7 @@ dependencies = [
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2620,7 +2620,7 @@ dependencies = [
  "phf 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -33,7 +33,7 @@ selectors = {version = "0.6", features = ["heap_size", "unstable"]}
 serde = {version = "0.7", features = ["nightly"]}
 serde_macros = "0.7"
 smallvec = "0.1"
-string_cache = {version = "0.2.17", features = ["heap_size"]}
+string_cache = {version = "0.2.18", features = ["heap_size"]}
 style_traits = {path = "../style_traits"}
 time = "0.1"
 url = {version = "1.0.0", features = ["heap_size"]}

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
  "servo-skia 0.20130412.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "simd 0.1.0 (git+https://github.com/huonw/simd)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -865,7 +865,7 @@ dependencies = [
  "phf 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1063,7 +1063,7 @@ dependencies = [
  "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1748,7 +1748,7 @@ dependencies = [
  "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinyfiledialogs 0.1.0 (git+https://github.com/jdm/tinyfiledialogs)",
@@ -1800,7 +1800,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2033,7 +2033,7 @@ dependencies = [
  "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2481,7 +2481,7 @@ dependencies = [
  "phf 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "plugins 0.0.1",
  "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -398,7 +398,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -431,7 +431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "string_cache"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "gecko_bindings 0.0.1",
  "heapsize 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -441,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-replace = "string_cache 0.2.17"
+replace = "string_cache 0.2.18"
 
 [[package]]
 name = "style"
@@ -468,7 +468,7 @@ dependencies = [
  "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -35,7 +35,7 @@ libc = "0.2"
 num_cpus = "0.2.2"
 selectors = {version = "0.6", features = ["unstable"]}
 smallvec = "0.1"
-string_cache = {version = "0.2.17", features = ["unstable"]}
+string_cache = {version = "0.2.18", features = ["unstable"]}
 url = "1.0.0"
 log = {version = "0.3.5", features = ["release_max_level_info"]}
 plugins = {path = "../../components/plugins"}
@@ -46,4 +46,4 @@ style = {path = "../../components/style", features = ["gecko"]}
 env_logger = "0.3"
 
 [replace]
-"string_cache:0.2.17" = {path = "string_cache"}
+"string_cache:0.2.18" = {path = "string_cache"}

--- a/ports/geckolib/string_cache/Cargo.toml
+++ b/ports/geckolib/string_cache/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "string_cache"
 description = "A crate to allow using Gecko's nsIAtom as a replacement for string_cache."
-version = "0.2.17"
+version = "0.2.18"
 authors = ["The Servo Project Developers"]
 publish = false
 

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
  "servo-skia 0.20130412.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "simd 0.1.0 (git+https://github.com/huonw/simd)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -853,7 +853,7 @@ dependencies = [
  "phf 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1051,7 +1051,7 @@ dependencies = [
  "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1736,7 +1736,7 @@ dependencies = [
  "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinyfiledialogs 0.1.0 (git+https://github.com/jdm/tinyfiledialogs)",
@@ -1788,7 +1788,7 @@ dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickersort 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2019,7 +2019,7 @@ dependencies = [
  "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2436,7 +2436,7 @@ dependencies = [
  "phf 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [X] These changes do not require tests because its a crate version bump.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11376)

<!-- Reviewable:end -->
