### PR TITLE
Make geckolib build dependencies with the same features as Servo by default

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 
 [features]
 default = ["glutin_app", "webdriver", "max_log_level"]
-max_log_level = ["env_logger/log/release_max_level_info"]
+max_log_level = ["log/release_max_level_info"]
 webdriver = ["webdriver_server"]
 energy-profiling = ["profile_traits/energy-profiling"]
 
@@ -68,6 +68,7 @@ glutin_app = {path = "../../ports/glutin", optional = true}
 ipc-channel = {git = "https://github.com/servo/ipc-channel"}
 gleam = "0.2"
 browserhtml = {git = "https://github.com/browserhtml/browserhtml", branch = "gh-pages"}
+log = "0.3"
 env_logger = "0.3"
 euclid = "0.6.4"
 libc = "0.2"

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -18,8 +18,10 @@ dependencies = [
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
+ "uuid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -517,6 +519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -546,10 +549,12 @@ name = "url"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "encoding 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -592,6 +597,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -10,6 +10,19 @@ name = "geckoservo"
 path = "lib.rs"
 crate-type = ["staticlib"]
 
+[features]
+default = ["servo_features"]
+
+# Features that aren't actually required for geckolib, but match the ones used
+# in the full Servo build.  Enabling this reduces the number of things
+# recompiled when building both Servo and geckolib in the same source tree.
+servo_features = [
+  "time",
+  "url/query_encoding",
+  "url/rustc-serialize",
+  "uuid",
+]
+
 [dependencies]
 app_units = "0.2.3"
 cssparser = "0.5.4"
@@ -20,13 +33,15 @@ heapsize_plugin = "0.1.2"
 lazy_static = "0.2"
 libc = "0.2"
 num_cpus = "0.2.2"
-selectors = "0.6"
+selectors = {version = "0.6", features = ["unstable"]}
 smallvec = "0.1"
-string_cache = "0.2.17"
+string_cache = {version = "0.2.17", features = ["unstable"]}
 url = "1.0.0"
 log = {version = "0.3.5", features = ["release_max_level_info"]}
 plugins = {path = "../../components/plugins"}
+time = {version = "0.1", optional = true, features = ["rustc-serialize"]}
 util = {path = "../../components/util"}
+uuid = {version = "0.2", optional = true, features = ["v4", "serde"]}
 style = {path = "../../components/style", features = ["gecko"]}
 env_logger = "0.3"
 

--- a/ports/gonk/Cargo.lock
+++ b/ports/gonk/Cargo.lock
@@ -2234,7 +2234,6 @@ dependencies = [
  "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_cache 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 


### PR DESCRIPTION
This reduces the number of things that need to be recompiled when building Geckolib and Servo in the same source tree.

This is a bit fragile and will need to be maintained by hand, but it's a nice improvement for developers.

r? @nox

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11381)

<!-- Reviewable:end -->
