### PR TITLE
Hide unnecessary information in the rendered PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,10 @@
+Replace this paragraph with a description of the changes, then follow the instructions in the next section.
+
+---
 <!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
 - [ ] `./mach build -d` does not report any errors
 - [ ] `./mach test-tidy` does not report any errors
-- [ ] These changes fix #__ <!-- (github issue number if applicable). -->
+- [ ] These changes fix #__ (github issue number if applicable).
 
 <!-- Either: -->
 - [ ] There are tests for these changes OR

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
-Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
+<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
 - [ ] `./mach build -d` does not report any errors
 - [ ] `./mach test-tidy` does not report any errors
-- [ ] These changes fix #__ (github issue number if applicable).
+- [ ] These changes fix #__ <!-- (github issue number if applicable). -->
 
-Either:
+<!-- Either: -->
 - [ ] There are tests for these changes OR
 - [ ] These changes do not require tests because _____
 
-Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 
+<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Replace this paragraph with a description of the changes, then follow the instructions in the next section.
+<!-- Please describe your changes on the following line: -->
 
 ---
 <!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->


### PR DESCRIPTION
These changes attempt to make the initial PR view less cluttered. Instructions are hidden in HTML comments, and there's a clear distinction between the PR description and the checklist.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:-->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because not part of the build

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11383)

<!-- Reviewable:end -->
