### PR TITLE
mach: Redirect stderr to /dev/null when locating Python binary

### DIFF
--- a/mach
+++ b/mach
@@ -6,7 +6,7 @@
 # The beginning of this script is both valid shell and valid python,
 # such that the script starts with the shell and is reexecuted with
 # the right python.
-'''which' python2.7 > /dev/null && exec python2.7 "$0" "$@" || exec python "$0" "$@"
+'''which' python2.7 > /dev/null 2> /dev/null && exec python2.7 "$0" "$@" || exec python "$0" "$@"
 '''
 
 from __future__ import print_function, unicode_literals


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [X] These changes do not require tests because it only changes the mach build script

---

We already redirect stdout in `mach`, but the problem is that (at least on Windows/MSYS2), the `which` command tends to output things to stderr when failing:

```
$ ./mach  build -d
which: no python2.7 in (/usr/local/bin:/usr/bin:/bin:/opt/bin:/c/Windows/System32:/c/Windows:/c/Windows/System32/Wbem:/c/Windows/System32/WindowsPowerShell/v1.0/:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/c/Program Files/Java/jdk1.8.0_66/bin:/c/Python27:/c/Python27/Scripts)
```

This PR silences this noise.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11391)

<!-- Reviewable:end -->
