### PR TITLE
Fixed the build tools to handle cargo being named cargo.exe

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -23,7 +23,7 @@ from mach.decorators import (
     Command,
 )
 
-from servo.command_base import CommandBase, cd, call
+from servo.command_base import CommandBase, cd, call, BIN_SUFFIX
 
 
 def notify_linux(title, text):
@@ -226,8 +226,10 @@ class MachCommands(CommandBase):
             env['OPENSSL_INCLUDE_DIR'] = path.join(openssl_dir, "include")
             env['OPENSSL_STATIC'] = 'TRUE'
 
+        cargo_binary = "cargo" + BIN_SUFFIX
+
         status = call(
-            ["cargo", "build"] + opts,
+            [cargo_binary, "build"] + opts,
             env=env, cwd=self.servo_crate(), verbose=verbose)
         elapsed = time() - build_start
 


### PR DESCRIPTION
It's actually quite weird that I had to do this, but I got errors without it (on Windows). I noted the `BIN_SUFFIX` existed elsewhere so it felt logical to use it here also.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11393)

<!-- Reviewable:end -->
