### PR TITLE
Look past restyle root for parent node when restyling.

### DIFF
--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -132,7 +132,10 @@ pub fn recalc_style_at<'a, N, C>(context: &'a C,
     node.initialize_data();
 
     // Get the parent node.
-    let parent_opt = node.layout_parent_node(root);
+    let parent_opt = match node.parent_node() {
+        Some(parent) if parent.is_element() => Some(parent),
+        _ => None,
+    };
 
     // Get the style bloom filter.
     let mut bf = take_thread_local_bloom_filter(parent_opt, root, context.shared_context());


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because existing tests should be sufficient

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

---

Currently when traversing a the tree to restyle, we look at whether a
given element to restyle is the root.  This seems to always be the root
of the entire document, since we start our processing from the top.  If
the current element being restyled is the root of the restyle, then we
use None as the parent node for restyling purposes.

In stylo we want to invoke restyling starting from an arbitrary node in
the document, not just the root of the document, so this change looks
for the parent element regardless of whether we're at the root of the
restyle.

r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11399)

<!-- Reviewable:end -->
