### PR TITLE
Support display:-moz-(inline-)box in geckolib.

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -19,6 +19,8 @@
             list-item flex
             none
         """.split()
+        if product == "gecko":
+            values += "-moz-box -moz-inline-box".split()
         experimental_values = set("flex".split())
     %>
     pub use self::computed_value::T as SpecifiedValue;

--- a/ports/geckolib/properties.mako.rs
+++ b/ports/geckolib/properties.mako.rs
@@ -632,7 +632,8 @@ fn static_assert() {
     // infrastructure for preffing certain values.
     <% display_keyword = Keyword("display", "inline block inline-block table inline-table table-row-group " +
                                             "table-header-group table-footer-group table-row table-column-group " +
-                                            "table-column table-cell table-caption list-item flex none") %>
+                                            "table-column table-cell table-caption list-item flex none " +
+                                            "-moz-box -moz-inline-box") %>
     <%call expr="impl_keyword('display', 'mDisplay', display_keyword, True)"></%call>
 
     // overflow-y is implemented as a newtype of overflow-x, so we need special handling.


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they are geckolib-only changes

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

r? @mbrubeck

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11401)

<!-- Reviewable:end -->
