### PR TITLE
Add Servo_RestyleSubtree.

### DIFF
--- a/ports/geckolib/gecko_bindings/bindings.rs
+++ b/ports/geckolib/gecko_bindings/bindings.rs
@@ -223,6 +223,8 @@ extern "C" {
     pub fn Servo_Initialize();
     pub fn Servo_RestyleDocument(doc: *mut RawGeckoDocument,
                                  set: *mut RawServoStyleSet);
+    pub fn Servo_RestyleSubtree(node: *mut RawGeckoNode,
+                                set: *mut RawServoStyleSet);
     pub fn Gecko_GetAttrAsUTF8(element: *mut RawGeckoElement,
                                ns: *mut nsIAtom, name: *mut nsIAtom,
                                length: *mut u32)


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because geckolib-only

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

---

See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1275452

r? @bholley

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11404)

<!-- Reviewable:end -->
