### PR TITLE
Fix Android APK building (packaging)

### DIFF
--- a/support/android/build-apk/src/main.rs
+++ b/support/android/build-apk/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     // Get the target android platform from ANDROID_PLATFORM env. Expecting "android-{version}"
     let android_platform = env::var("ANDROID_PLATFORM")
         .ok()
-        .expect("Please set the ANDROID_PLATFORM environment variable")
+        .expect("Please set the ANDROID_PLATFORM environment variable");
 
     // Get the standalone NDK path from NDK_STANDALONE env.
     //  let standalone_path = env::var("NDK_STANDALONE").ok().unwrap_or("/opt/ndk_standalone".to_string());


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` does not report any errors
- [ ] These changes help with #10339.

Either:
- [x] There are tests for these changes (android-nightly builder) OR
- [ ] These changes do not require tests because _____

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

I missed this syntax error during my review, and we don't check that
packaging succeeds in regular build suite, but only as a Nightly build.

@larsbergstrom should we run the packaging as part of the regular build? I think it is important that this continue to stay working, especially with #9918. In that case, the only difference with the nightly builder is whether or not to upload to S3.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11406)

<!-- Reviewable:end -->
