### PR TITLE
Remove --faster flag from test-tidy, go fast by default. Fixes 11217

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ matrix:
   include:
     - sudo: false
       script:
-         - ./mach test-tidy --self-test
-         - ./mach test-tidy --no-progress
+         - ./mach test-tidy --no-progress --all
+         - ./mach test-tidy --no-progress --self-test
       cache: false
     - sudo: 9000
       dist: trusty

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
 - [ ] `./mach build -d` does not report any errors
-- [ ] `./mach test-tidy --faster` does not report any errors
+- [ ] `./mach test-tidy` does not report any errors
 - [ ] These changes fix #__ (github issue number if applicable).
 
 Either:

--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -23,7 +23,7 @@ mac-rel-css:
   - bash ./etc/ci/manifest_changed.sh
 
 linux-dev:
-  - ./mach test-tidy --no-progress
+  - ./mach test-tidy --no-progress --all
   - ./mach test-tidy --no-progress --self-test
   - ./mach build --dev
   - ./mach test-compiletest

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -255,33 +255,18 @@ class MachCommands(CommandBase):
     @Command('test-tidy',
              description='Run the source code tidiness check',
              category='testing')
-    @CommandArgument('--faster', default=False, action="store_true",
-                     help="Only check changed files and skip the WPT lint in tidy, "
-                          "if there are no changes in the WPT files. Cannot be used with --all")
     @CommandArgument('--all', default=False, action="store_true", dest="all_files",
                      help="Check all files, and run the WPT lint in tidy, "
-                          "even if unchanged. Cannot be used with --faster")
+                          "even if unchanged")
     @CommandArgument('--no-progress', default=False, action="store_true",
                      help="Don't show progress for tidy")
     @CommandArgument('--self-test', default=False, action="store_true",
                      help="Run unit tests for tidy")
-    def test_tidy(self, faster, all_files, no_progress, self_test):
+    def test_tidy(self, all_files, no_progress, self_test):
         if self_test:
             return test_tidy.do_tests()
         else:
-            # The `test-tidy` command is currently mid-migration from --faster to --all.
-            # Since --faster and --all are opposites, they cannot both be used at the same time
-            if faster and all_files:
-                print("Cannot tidy --all while also being --faster")
-                return -1
-
-            # |--faster|--all|behaviour of tidy.scan()
-            # |   false|false|scan all files          # This was the behaviour before adding --all
-            # |    true|false|only scan changed files # Expected behaviour if --faster is used
-            # |   false| true|scan all files          # Expected behaviour if --all is used
-            #
-            # The pattern: if `faster` is true, go fast. Otherwise, go slow.
-            return tidy.scan(faster, not no_progress)
+            return tidy.scan(not all_files, not no_progress)
 
     @Command('test-webidl',
              description='Run the WebIDL parser tests',


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11217 (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they just change command-line options, which aren't tested

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

This finishes #11267

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11409)

<!-- Reviewable:end -->
