### PR TITLE
Support remaining text-decoration related properties in geckolib

### DIFF
--- a/components/style/properties/longhand/text.mako.rs
+++ b/components/style/properties/longhand/text.mako.rs
@@ -105,7 +105,7 @@ ${helpers.single_keyword("unicode-bidi", "normal embed isolate bidi-override iso
 </%helpers:longhand>
 
 ${helpers.single_keyword("text-decoration-style",
-                         "-moz-none solid double dotted dashed wavy",
+                         "solid double dotted dashed wavy -moz-none",
                          products="gecko")}
 
 ${helpers.predefined_type(

--- a/components/style/properties/longhand/text.mako.rs
+++ b/components/style/properties/longhand/text.mako.rs
@@ -75,19 +75,27 @@ ${helpers.single_keyword("unicode-bidi", "normal embed isolate bidi-override iso
         }
         let mut blink = false;
         let mut empty = true;
-        while let Ok(ident) = input.expect_ident() {
-            match_ignore_ascii_case! { ident,
-                "underline" => if result.underline { return Err(()) }
-                              else { empty = false; result.underline = true },
-                "overline" => if result.overline { return Err(()) }
-                              else { empty = false; result.overline = true },
-                "line-through" => if result.line_through { return Err(()) }
-                                  else { empty = false; result.line_through = true },
-                "blink" => if blink { return Err(()) }
-                           else { empty = false; blink = true },
-                _ => break
-            }
+
+        while input.try(|input| {
+                if let Ok(ident) = input.expect_ident() {
+                    match_ignore_ascii_case! { ident,
+                        "underline" => if result.underline { return Err(()) }
+                                       else { empty = false; result.underline = true },
+                        "overline" => if result.overline { return Err(()) }
+                                      else { empty = false; result.overline = true },
+                        "line-through" => if result.line_through { return Err(()) }
+                                          else { empty = false; result.line_through = true },
+                        "blink" => if blink { return Err(()) }
+                                   else { empty = false; blink = true },
+                        _ => return Err(())
+                    }
+                } else {
+                    return Err(());
+                }
+                Ok(())
+            }).is_ok() {
         }
+
         if !empty { Ok(result) } else { Err(()) }
     }
 

--- a/components/style/properties/longhand/text.mako.rs
+++ b/components/style/properties/longhand/text.mako.rs
@@ -16,7 +16,8 @@ ${helpers.single_keyword("text-overflow", "clip ellipsis")}
 
 ${helpers.single_keyword("unicode-bidi", "normal embed isolate bidi-override isolate-override plaintext")}
 
-<%helpers:longhand name="text-decoration" custom_cascade="${product == 'servo'}">
+<%helpers:longhand name="${'text-decoration' if product == 'servo' else 'text-decoration-line'}"
+                   custom_cascade="${product == 'servo'}">
     use cssparser::ToCss;
     use std::fmt;
     use values::computed::ComputedValueAsSpecified;

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -130,6 +130,7 @@ pub mod shorthands {
     <%include file="/shorthand/margin.mako.rs" />
     <%include file="/shorthand/outline.mako.rs" />
     <%include file="/shorthand/padding.mako.rs" />
+    <%include file="/shorthand/text.mako.rs" />
 }
 
 
@@ -815,14 +816,15 @@ pub mod style_structs {
                     self.outline_width != ::app_units::Au(0)
                 }
             % elif style_struct.trait_name == "Text":
+                <% text_decoration_field = 'text_decoration' if product == 'servo' else 'text_decoration_line' %>
                 fn has_underline(&self) -> bool {
-                    self.text_decoration.underline
+                    self.${text_decoration_field}.underline
                 }
                 fn has_overline(&self) -> bool {
-                    self.text_decoration.overline
+                    self.${text_decoration_field}.overline
                 }
                 fn has_line_through(&self) -> bool {
-                    self.text_decoration.line_through
+                    self.${text_decoration_field}.line_through
                 }
             % endif
         }
@@ -1463,7 +1465,7 @@ pub fn cascade<C: ComputedValues>(
                         PropertyDeclaration::Color(_) |
                         PropertyDeclaration::Position(_) |
                         PropertyDeclaration::Float(_) |
-                        PropertyDeclaration::TextDecoration(_)
+                        PropertyDeclaration::TextDecoration${'' if product == 'servo' else 'Line'}(_)
                     );
                     if
                         % if category_to_cascade_now == "early":

--- a/components/style/properties/shorthand/text.mako.rs
+++ b/components/style/properties/shorthand/text.mako.rs
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+<%namespace name="helpers" file="/helpers.mako.rs" />
+
+<%helpers:shorthand name="text-decoration"
+                    sub_properties="text-decoration-color
+                                    text-decoration-line
+                                    text-decoration-style"
+                    products="gecko">
+    use cssparser::Color as CSSParserColor;
+    use properties::longhands::{text_decoration_color, text_decoration_line, text_decoration_style};
+    use values::specified::CSSColor;
+
+    let (mut color, mut line, mut style, mut any) = (None, None, None, false);
+    loop {
+        macro_rules! parse_component {
+            ($value:ident, $module:ident) => (
+                if $value.is_none() {
+                    if let Ok(value) = input.try(|input| $module::parse(context, input)) {
+                        $value = Some(value);
+                        any = true;
+                        continue;
+                    }
+                }
+            )
+        }
+
+        parse_component!(color, text_decoration_color);
+        parse_component!(line, text_decoration_line);
+        parse_component!(style, text_decoration_style);
+        break;
+    }
+
+    if !any {
+        return Err(());
+    }
+
+    Ok(Longhands {
+        text_decoration_color: color.or(Some(CSSColor { parsed: CSSParserColor::CurrentColor,
+                                                        authored: None })),
+        text_decoration_line: line.or(Some(text_decoration_line::computed_value::none)),
+        text_decoration_style: style.or(Some(text_decoration_style::computed_value::T::solid)),
+    })
+</%helpers:shorthand>

--- a/ports/geckolib/properties.mako.rs
+++ b/ports/geckolib/properties.mako.rs
@@ -727,20 +727,36 @@ fn static_assert() {
 </%self:impl_trait>
 
 <%self:impl_trait style_struct_name="Text"
-                  skip_longhands="text-decoration-color"
+                  skip_longhands="text-decoration-color text-decoration-line"
                   skip_additionals="*">
 
     <% impl_color("text_decoration_color", "mTextDecorationColor",
                   color_flags_ffi_name="mTextDecorationStyle") %>
 
+    fn set_text_decoration_line(&mut self, v: longhands::text_decoration_line::computed_value::T) {
+        let mut bits: u8 = 0;
+        if v.underline {
+            bits |= structs::NS_STYLE_TEXT_DECORATION_LINE_UNDERLINE as u8;
+        }
+        if v.overline {
+            bits |= structs::NS_STYLE_TEXT_DECORATION_LINE_OVERLINE as u8;
+        }
+        if v.line_through {
+            bits |= structs::NS_STYLE_TEXT_DECORATION_LINE_LINE_THROUGH as u8;
+        }
+        self.gecko.mTextDecorationLine = bits;
+    }
+
+    <%call expr="impl_simple_copy('text_decoration_line', 'mTextDecorationLine')"></%call>
+
     fn has_underline(&self) -> bool {
-        (self.gecko.mTextDecorationStyle & (structs::NS_STYLE_TEXT_DECORATION_LINE_UNDERLINE as u8)) != 0
+        (self.gecko.mTextDecorationLine & (structs::NS_STYLE_TEXT_DECORATION_LINE_UNDERLINE as u8)) != 0
     }
     fn has_overline(&self) -> bool {
-        (self.gecko.mTextDecorationStyle & (structs::NS_STYLE_TEXT_DECORATION_LINE_OVERLINE as u8)) != 0
+        (self.gecko.mTextDecorationLine & (structs::NS_STYLE_TEXT_DECORATION_LINE_OVERLINE as u8)) != 0
     }
     fn has_line_through(&self) -> bool {
-        (self.gecko.mTextDecorationStyle & (structs::NS_STYLE_TEXT_DECORATION_LINE_LINE_THROUGH as u8)) != 0
+        (self.gecko.mTextDecorationLine & (structs::NS_STYLE_TEXT_DECORATION_LINE_LINE_THROUGH as u8)) != 0
     }
 </%self:impl_trait>
 

--- a/tests/wpt/metadata-css/css21_dev/html4/c71-fwd-parsing-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/c71-fwd-parsing-003.htm.ini
@@ -1,3 +1,0 @@
-[c71-fwd-parsing-003.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because mostly it's geckolib-only, and the servo-relevant changes should be covered by existing tests

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

---

Not sure if there's a better way to do the loop in the text-decoration(-line) longhand parsing, having all of the guts in the loop condition is a bit awkward.

r? @mbrubeck

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11412)

<!-- Reviewable:end -->
