### PR TITLE
Don't double-apply transform and other effect styles for text (fixes #11300)

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2032,12 +2032,15 @@ pub fn modify_style_for_outer_inline_block_fragment(style: &mut Arc<ServoCompute
     box_style.position = longhands::position::computed_value::T::static_
 }
 
-/// Adjusts the `position` and `padding` properties as necessary to account for text.
+/// Adjusts properties as necessary to account for text.
 ///
-/// Text is never directly relatively positioned; it's always contained within an element that is
-/// itself relatively positioned.
+/// `position`, `padding`, `opacity`:
+///   Text is always in an element that takes these properties into account
+///   itself.
 #[inline]
 pub fn modify_style_for_text(style: &mut Arc<ServoComputedValues>) {
+    use computed_values::transform_style;
+
     if style.box_.position == longhands::position::computed_value::T::relative {
         // We leave the `position` property set to `relative` so that we'll still establish a
         // containing block if needed. But we reset all position offsets to `auto`.
@@ -2061,10 +2064,16 @@ pub fn modify_style_for_text(style: &mut Arc<ServoComputedValues>) {
         padding.padding_left = computed::LengthOrPercentage::Length(Au(0));
     }
 
-    if style.effects.opacity != 1.0 {
+    if style.get_used_transform_style() != transform_style::T::auto {
         let mut style = Arc::make_mut(style);
         let mut effects = Arc::make_mut(&mut style.effects);
+
         effects.opacity = 1.0;
+        effects.clip = longhands::clip::get_initial_value();
+        effects.transform = longhands::transform::get_initial_value();
+        effects.filter = longhands::filter::get_initial_value();
+        effects.perspective = computed::LengthOrNone::None;
+        effects.transform_style = transform_style::T::auto;
     }
 }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5044,16 +5044,16 @@
             "url": "/_mozilla/css/text_justify_none_a.html"
           }
         ],
-        "css/text_node_opacity.html": [
+        "css/text_node_effects.html": [
           {
-            "path": "css/text_node_opacity.html",
+            "path": "css/text_node_effects.html",
             "references": [
               [
-                "/_mozilla/css/text_node_opacity_ref.html",
+                "/_mozilla/css/text_node_effects_ref.html",
                 "=="
               ]
             ],
-            "url": "/_mozilla/css/text_node_opacity.html"
+            "url": "/_mozilla/css/text_node_effects.html"
           }
         ],
         "css/text_overflow_a.html": [
@@ -11868,16 +11868,16 @@
           "url": "/_mozilla/css/text_justify_none_a.html"
         }
       ],
-      "css/text_node_opacity.html": [
+      "css/text_node_effects.html": [
         {
-          "path": "css/text_node_opacity.html",
+          "path": "css/text_node_effects.html",
           "references": [
             [
-              "/_mozilla/css/text_node_opacity_ref.html",
+              "/_mozilla/css/text_node_effects_ref.html",
               "=="
             ]
           ],
-          "url": "/_mozilla/css/text_node_opacity.html"
+          "url": "/_mozilla/css/text_node_effects.html"
         }
       ],
       "css/text_overflow_a.html": [

--- a/tests/wpt/mozilla/tests/css/text_node_effects.html
+++ b/tests/wpt/mozilla/tests/css/text_node_effects.html
@@ -1,21 +1,22 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <link rel='match' href='text_node_opacity_ref.html'>
+        <link rel='match' href='text_node_effects_ref.html'>
         <link rel="stylesheet" type="text/css" href="css/ahem.css">
         <style type="text/css">
             html, body {
-                margin: 0;
+                margin: 20px;
                 font-size: 100px;
                 line-height: 1;
             }
             div {
-                opacity: 0.5;
-                color: green;
-            }
+              display: inline-block;
+	      color: green;
+	    }
         </style>
     </head>
     <body>
-        <div>A</div>
+      <div style="opacity: 0.5;">A</div><!--
+      --><div style="transform: rotateZ(45deg);">A</div>
     </body>
 </html>

--- a/tests/wpt/mozilla/tests/css/text_node_effects_ref.html
+++ b/tests/wpt/mozilla/tests/css/text_node_effects_ref.html
@@ -3,18 +3,18 @@
     <head>
         <style type="text/css">
             html, body {
-                margin: 0;
+                margin: 20px;
             }
             div {
-                position: absolute;
                 width: 100px;
                 height: 100px;
-                opacity: 0.5;
+                display: inline-block;
                 background-color: green;
             }
         </style>
     </head>
     <body>
-        <div></div>
+      <div style="opacity: 0.5;"></div><!--
+      --><div style="transform: rotateZ(45deg);"></div>
     </body>
 </html>


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [X] These changes fix #11300 

Either:
- [X] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11421)

<!-- Reviewable:end -->
