### PR TITLE
Update spec link for timers.

### DIFF
--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -65,7 +65,7 @@
 Window implements GlobalEventHandlers;
 Window implements WindowEventHandlers;
 
-// https://html.spec.whatwg.org/multipage/#windowtimers
+// https://html.spec.whatwg.org/multipage/#timers
 [NoInterfaceObject/*, Exposed=Window,Worker*/]
 interface WindowTimers {
   long setTimeout(Function handler, optional long timeout = 0, any... arguments);


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy --faster` does not report any errors
- [X] These changes do not require tests because documentation only

---

The specification link was broken.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11423)

<!-- Reviewable:end -->
