### PR TITLE
csstext

### DIFF
--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use cssparser::ToCss;
 use dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::{self, CSSStyleDeclarationMethods};
 use dom::bindings::error::{Error, ErrorResult, Fallible};
 use dom::bindings::global::GlobalRef;
@@ -18,7 +19,7 @@ use std::slice;
 use string_cache::Atom;
 use style::parser::ParserContextExtraData;
 use style::properties::{PropertyDeclaration, Shorthand};
-use style::properties::{is_supported_property, parse_one_declaration};
+use style::properties::{is_supported_property, parse_one_declaration, parse_style_attribute};
 use style::selector_impl::PseudoElement;
 
 // http://dev.w3.org/csswg/cssom/#the-cssstyledeclaration-interface
@@ -340,6 +341,42 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
         rval
     }
 
-    // https://drafts.csswg.org/cssom/#cssstyledeclaration
+    // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-csstext
+    fn CssText(&self) -> DOMString {
+        let elem = self.owner.upcast::<Element>();
+        let style_attribute = elem.style_attribute().borrow();
+
+        if let Some(declarations) = style_attribute.as_ref() {
+            DOMString::from(declarations.to_css_string())
+        } else {
+            DOMString::new()
+        }
+    }
+
+    // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-csstext
+    fn SetCssText(&self, value: DOMString) -> ErrorResult {
+        let window = window_from_node(self.owner.upcast::<Node>());
+        let element = self.owner.upcast::<Element>();
+
+        // Step 1
+        if self.readonly {
+            return Err(Error::NoModificationAllowed);
+        }
+
+        // Step 3
+        let decl_block = parse_style_attribute(&value, &window.get_url(), window.css_error_reporter(),
+                                               ParserContextExtraData::default());
+        *element.style_attribute().borrow_mut() = if decl_block.normal.is_empty() && decl_block.important.is_empty() {
+            None // Step 2
+        } else {
+            Some(decl_block)
+        };
+        element.sync_property_with_attrs_style();
+        let node = element.upcast::<Node>();
+        node.dirty(NodeDamage::NodeStyleDamaged);
+        Ok(())
+    }
+
+    // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-_camel_cased_attribute
     css_properties_accessors!(css_properties);
 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -700,7 +700,7 @@ impl Element {
 
     // this sync method is called upon modification of the style_attribute property,
     // therefore, it should not trigger subsequent mutation events
-    fn sync_property_with_attrs_style(&self) {
+    pub fn sync_property_with_attrs_style(&self) {
         let style_str = if let &Some(ref declarations) = &*self.style_attribute().borrow() {
             declarations.to_css_string()
         } else {

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -9,8 +9,8 @@
  */
 
 interface CSSStyleDeclaration {
-  //[SetterThrows]
-  //         attribute DOMString cssText;
+  [SetterThrows]
+           attribute DOMString cssText;
   readonly attribute unsigned long length;
   getter DOMString item(unsigned long index);
   DOMString getPropertyValue(DOMString property);

--- a/tests/wpt/metadata-css/cssom-1_dev/html/computed-style-001.htm.ini
+++ b/tests/wpt/metadata-css/cssom-1_dev/html/computed-style-001.htm.ini
@@ -1,5 +1,0 @@
-[computed-style-001.htm]
-  type: testharness
-  [read_only]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/cssom-1_dev/html/cssstyledeclaration-csstext.htm.ini
+++ b/tests/wpt/metadata-css/cssom-1_dev/html/cssstyledeclaration-csstext.htm.ini
@@ -1,15 +1,6 @@
 [cssstyledeclaration-csstext.htm]
   type: testharness
-  [uppercase property]
-    expected: FAIL
-
   [uppercase value]
-    expected: FAIL
-
-  [overwriting with invalid value]
-    expected: FAIL
-
-  [use rgb]
     expected: FAIL
 
   [cssText order]

--- a/tests/wpt/metadata-css/cssom-1_dev/html/cssstyledeclaration-mutability.htm.ini
+++ b/tests/wpt/metadata-css/cssom-1_dev/html/cssstyledeclaration-mutability.htm.ini
@@ -1,8 +1,5 @@
 [cssstyledeclaration-mutability.htm]
   type: testharness
-  [HTMLElement's CSSStyleDeclaration is mutable]
-    expected: FAIL
-
   [StyleSheet's CSSStyleDeclaration is mutable]
     expected: FAIL
 

--- a/tests/wpt/metadata-css/cssom-1_dev/html/index-002.htm.ini
+++ b/tests/wpt/metadata-css/cssom-1_dev/html/index-002.htm.ini
@@ -30,27 +30,15 @@
   [border is expected to be border-width: 1px;]
     expected: FAIL
 
-  [overflow is expected to be overflow: scroll hidden;]
-    expected: FAIL
-
   [overflow is expected to be overflow: scroll;]
     expected: FAIL
 
   [outline is expected to be outline: blue dotted 2px;]
     expected: FAIL
 
-  [margin is expected to be margin: 1px 2px 3px 4px;]
-    expected: FAIL
-
   [list is expected to be list-style: circle inside;]
     expected: FAIL
 
-  [list is expected to be list-style-type: lower-alpha;]
-    expected: FAIL
-
   [font-family is expected to be font-family: sans-serif; line-height: 2em; font-size: 3em; font-style: italic; font-weight: bold;]
-    expected: FAIL
-
-  [padding is expected to be padding: 1px 2px 3px 4px;]
     expected: FAIL
 

--- a/tests/wpt/metadata-css/cssom-1_dev/html/interfaces.htm.ini
+++ b/tests/wpt/metadata-css/cssom-1_dev/html/interfaces.htm.ini
@@ -474,9 +474,6 @@
   [CSSNamespaceRule interface: attribute prefix]
     expected: FAIL
 
-  [CSSStyleDeclaration interface: attribute cssText]
-    expected: FAIL
-
   [CSSStyleDeclaration interface: attribute parentRule]
     expected: FAIL
 


### PR DESCRIPTION
- [x] These changes fix #4431.
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --faster` reports one error for the `css_properties_accessors!` macro not having a spec link

```
$ git log -1 --format=oneline
91fb9bf1d388c3ede304a5d649dd21fe975787b0 fixup! implement cssText                                                                                                               
$ ./mach build -d
   Compiling style v0.0.1 (file:///Users/greg/servo/components/style)
   Compiling gfx v0.0.1 (file:///Users/greg/servo/components/gfx)
   Compiling script v0.0.1 (file:///Users/greg/servo/components/script)
   Compiling layout_traits v0.0.1 (file:///Users/greg/servo/components/layout_traits)
   Compiling compositing v0.0.1 (file:///Users/greg/servo/components/compositing)
   Compiling glutin_app v0.0.1 (file:///Users/greg/servo/ports/glutin)
   Compiling constellation v0.0.1 (file:///Users/greg/servo/components/constellation)
   Compiling layout v0.0.1 (file:///Users/greg/servo/components/layout)
   Compiling servo v0.0.1 (file:///Users/greg/servo/components/servo)
Build completed in 0:05:11.475584
$ ./mach test-tidy --faster
Checking files for tidiness...
./components/script/dom/cssstyledeclaration.rs:386: method declared in webidl is missing a comment with a specification link
  Progress: 100% (12/12)
```
- [x] There are tests for these changes.  More CSSOM tests pass, but others fail that probably shouldn't:
- `./mach test-css tests/wpt/css-tests/cssom-1_dev/html/index-002.htm` and a bunch of the other tests in `/css-tests/cssom-1_dev/html/ crash when run individually
- `./mach test-css tests/wpt/css-tests/cssom-1_dev/html/cssom-cssText-serialize.htm` fails to strip a trailing semicolon (`left: 10px` vs `left: 10px;`)
- `./mach test-css tests/wpt/css-tests/cssom-1_dev/html/index-001.htm` shared shorthand values aren't coalesced (`margin: 20px` vs. `margin: 20px 20px 20px 20px`)
- `./mach test-css tests/wpt/css-tests/cssom-1_dev/html/cssstyledeclaration-csstext.htm` also crashes and fails for `color: red;` vs. `color: RED;`,  preserving declaration insertion order, whitespace in the value, and setting an unknown style property.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11428)

<!-- Reviewable:end -->
