### PR TITLE
Don't re-parse dummy base URL every time in GeckoElement::style_attribute

### DIFF
--- a/ports/geckolib/wrapper.rs
+++ b/ports/geckolib/wrapper.rs
@@ -314,6 +314,12 @@ impl<'le> GeckoElement<'le> {
     }
 }
 
+lazy_static! {
+    pub static ref DUMMY_BASE_URL: Url = {
+        Url::parse("http://www.example.org").unwrap()
+    };
+}
+
 impl<'le> TElement for GeckoElement<'le> {
     type ConcreteNode = GeckoNode<'le>;
     type ConcreteDocument = GeckoDocument<'le>;
@@ -330,7 +336,7 @@ impl<'le> TElement for GeckoElement<'le> {
         // in the nsAttrValue. That will allow us to borrow it from here.
         let attr = self.get_attr(&ns!(), &atom!("style"));
         // FIXME(bholley): Real base URL and error reporter.
-        let base_url = Url::parse("http://www.example.org").unwrap();
+        let base_url = &*DUMMY_BASE_URL;
         // FIXME(heycam): Needs real ParserContextExtraData so that URLs parse
         // properly.
         let extra_data = ParserContextExtraData::default();


### PR DESCRIPTION
Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data:
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Either:
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because geckolib-only

Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. 

---

r? @bholley

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11433)

<!-- Reviewable:end -->
