### PR TITLE
Fragment debug_id u16 only exists in debug, prod will format mem address

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -22,6 +22,7 @@ use incremental::{RECONSTRUCT_FLOW, RestyleDamage};
 use inline::{FIRST_FRAGMENT_OF_ELEMENT, InlineFragmentContext, InlineFragmentNodeInfo};
 use inline::{InlineMetrics, LAST_FRAGMENT_OF_ELEMENT};
 use ipc_channel::ipc::IpcSender;
+#[cfg(debug_assertions)]
 use layout_debug;
 use model::{self, IntrinsicISizes, IntrinsicISizesContribution, MaybeAuto, specified};
 use msg::constellation_msg::PipelineId;
@@ -118,7 +119,9 @@ pub struct Fragment {
     pub flags: FragmentFlags,
 
     /// A debug ID that is consistent for the life of this fragment (via transform etc).
-    pub debug_id: u16,
+    /// This ID should not be considered stable across multiple layouts or fragment
+    /// manipulations.
+    debug_id: DebugId,
 
     /// The ID of the StackingContext that contains this fragment. This is initialized
     /// to 0, but it assigned during the collect_stacking_contexts phase of display
@@ -129,7 +132,7 @@ pub struct Fragment {
 impl Encodable for Fragment {
     fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
         e.emit_struct("fragment", 0, |e| {
-            try!(e.emit_struct_field("id", 0, |e| self.debug_id().encode(e)));
+            try!(e.emit_struct_field("id", 0, |e| self.debug_id.encode(e)));
             try!(e.emit_struct_field("border_box", 1, |e| self.border_box.encode(e)));
             e.emit_struct_field("margin", 2, |e| self.margin.encode(e))
         })
@@ -809,7 +812,7 @@ impl Fragment {
             inline_context: None,
             pseudo: node.get_pseudo_element_type().strip(),
             flags: FragmentFlags::empty(),
-            debug_id: layout_debug::generate_unique_debug_id(),
+            debug_id: DebugId::new(),
             stacking_context_id: StackingContextId::new(0),
         }
     }
@@ -838,15 +841,9 @@ impl Fragment {
             inline_context: None,
             pseudo: pseudo,
             flags: FragmentFlags::empty(),
-            debug_id: layout_debug::generate_unique_debug_id(),
+            debug_id: DebugId::new(),
             stacking_context_id: StackingContextId::new(0),
         }
-    }
-
-    /// Returns a debug ID of this fragment. This ID should not be considered stable across
-    /// multiple layouts or fragment manipulations.
-    pub fn debug_id(&self) -> u16 {
-        self.debug_id
     }
 
     /// Transforms this fragment into another fragment of the given type, with the given size,
@@ -872,7 +869,7 @@ impl Fragment {
             inline_context: self.inline_context.clone(),
             pseudo: self.pseudo.clone(),
             flags: FragmentFlags::empty(),
-            debug_id: self.debug_id,
+            debug_id: self.debug_id.clone(),
             stacking_context_id: StackingContextId::new(0),
         }
     }
@@ -2624,7 +2621,7 @@ impl fmt::Debug for Fragment {
 
         write!(f, "{}({}) [{:?}] border_box={:?}{}{}{}",
             self.specific.get_type(),
-            self.debug_id(),
+            self.debug_id,
             self.specific,
             self.border_box,
             border_padding_string,
@@ -2779,4 +2776,54 @@ bitflags! {
 pub struct SpeculatedInlineContentEdgeOffsets {
     pub start: Au,
     pub end: Au,
+}
+
+#[cfg(not(debug_assertions))]
+#[derive(Clone)]
+struct DebugId;
+
+#[cfg(debug_assertions)]
+#[derive(Clone)]
+struct DebugId(u16);
+
+#[cfg(not(debug_assertions))]
+impl DebugId {
+    pub fn new() -> DebugId {
+        DebugId
+    }
+}
+
+#[cfg(debug_assertions)]
+impl DebugId {
+    pub fn new() -> DebugId {
+        DebugId(layout_debug::generate_unique_debug_id())
+    }
+}
+
+#[cfg(not(debug_assertions))]
+impl fmt::Display for DebugId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:p}", &self)
+    }
+}
+
+#[cfg(debug_assertions)]
+impl fmt::Display for DebugId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(not(debug_assertions))]
+impl Encodable for DebugId {
+    fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
+        e.emit_str(&format!("{:p}", &self))
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Encodable for DebugId {
+    fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
+        e.emit_u16(self.0)
+    }
 }

--- a/components/layout/layout_debug.rs
+++ b/components/layout/layout_debug.rs
@@ -15,10 +15,12 @@ use std::borrow::ToOwned;
 use std::cell::RefCell;
 use std::fs::File;
 use std::io::Write;
+#[cfg(debug_assertions)]
 use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 
 thread_local!(static STATE_KEY: RefCell<Option<State>> = RefCell::new(None));
 
+#[cfg(debug_assertions)]
 static DEBUG_ID_COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
 
 pub struct Scope;
@@ -96,6 +98,7 @@ impl Drop for Scope {
 /// Generate a unique ID. This is used for items such as Fragment
 /// which are often reallocated but represent essentially the
 /// same data.
+#[cfg(debug_assertions)]
 pub fn generate_unique_debug_id() -> u16 {
     DEBUG_ID_COUNTER.fetch_add(1, Ordering::SeqCst) as u16
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Each fragment has a `u16` `debug_id` in debug mode, but no `debug_id` in production to save memory. To format a debug id in production, the address of the empty `debug_id` is displayed.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #87 (github issue number if applicable).

<!-- Either: -->
- [X] These changes do not require tests because it looks like it's not possible to mock out `cfg` options in `#[test]`s

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11442)

<!-- Reviewable:end -->
