### PR TITLE
Remove Document.get_html_element() (fixes #8409)

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1228,7 +1228,7 @@ impl Document {
         self.stylesheets_changed_since_reflow.set(true);
         *self.stylesheets.borrow_mut() = None;
         // Mark the document element dirty so a reflow will be performed.
-        self.get_html_element().map(|root| {
+        self.GetDocumentElement().map(|root| {
             root.upcast::<Node>().dirty(NodeDamage::NodeStyleDamaged);
         });
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1228,9 +1228,9 @@ impl Document {
         self.stylesheets_changed_since_reflow.set(true);
         *self.stylesheets.borrow_mut() = None;
         // Mark the document element dirty so a reflow will be performed.
-        self.GetDocumentElement().map(|root| {
-            root.upcast::<Node>().dirty(NodeDamage::NodeStyleDamaged);
-        });
+        if let Some(element) = self.GetDocumentElement() {
+            element.upcast::<Node>().dirty(NodeDamage::NodeStyleDamaged);
+        }
     }
 
     pub fn get_and_reset_stylesheets_changed_since_reflow(&self) -> bool {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #8409 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because small refactor

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Replace uses by calling self.GetDocumentElement(), instead.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11449)

<!-- Reviewable:end -->
