### PR TITLE
Make script origins sendable and immutable.

### DIFF
--- a/components/script/origin.rs
+++ b/components/script/origin.rs
@@ -2,63 +2,53 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use ref_filter_map::ref_filter_map;
-use std::cell::{RefCell, Ref};
-use std::rc::Rc;
+use std::sync::Arc;
 use url::Origin as UrlOrigin;
 use url::{Url, Host};
 
 /// A representation of an [origin](https://html.spec.whatwg.org/multipage/#origin-2).
-#[derive(HeapSizeOf)]
+#[derive(HeapSizeOf, JSTraceable)]
 pub struct Origin {
-    #[ignore_heap_size_of = "Rc<T> has unclear ownership semantics"]
-    inner: Rc<RefCell<UrlOrigin>>,
+    #[ignore_heap_size_of = "Arc<T> has unclear ownership semantics"]
+    inner: Arc<UrlOrigin>,
 }
-
-// We can't use RefCell inside JSTraceable, but Origin doesn't contain JS values and
-// DOMRefCell makes it much harder to write unit tests (due to setting up required TLS).
-no_jsmanaged_fields!(Origin);
 
 impl Origin {
     /// Create a new origin comprising a unique, opaque identifier.
     pub fn opaque_identifier() -> Origin {
         Origin {
-            inner: Rc::new(RefCell::new(UrlOrigin::new_opaque())),
+            inner: Arc::new(UrlOrigin::new_opaque()),
         }
     }
 
     /// Create a new origin for the given URL.
     pub fn new(url: &Url) -> Origin {
         Origin {
-            inner: Rc::new(RefCell::new(url.origin())),
+            inner: Arc::new(url.origin()),
         }
-    }
-
-    pub fn set(&self, origin: UrlOrigin) {
-        *self.inner.borrow_mut() = origin;
     }
 
     /// Does this origin represent a host/scheme/port tuple?
     pub fn is_scheme_host_port_tuple(&self) -> bool {
-        self.inner.borrow().is_tuple()
+        self.inner.is_tuple()
     }
 
     /// Return the host associated with this origin.
-    pub fn host(&self) -> Option<Ref<Host<String>>> {
-        ref_filter_map(self.inner.borrow(), |origin| match *origin {
+    pub fn host(&self) -> Option<&Host<String>> {
+        match *self.inner {
             UrlOrigin::Tuple(_, ref host, _) => Some(host),
             UrlOrigin::Opaque(..) => None,
-        })
+        }
     }
 
     /// https://html.spec.whatwg.org/multipage/#same-origin
     pub fn same_origin(&self, other: &Origin) -> bool {
-        *self.inner.borrow() == *other.inner.borrow()
+        self.inner == other.inner
     }
 
     pub fn copy(&self) -> Origin {
         Origin {
-            inner: Rc::new(RefCell::new(self.inner.borrow().clone())),
+            inner: Arc::new((*self.inner).clone()),
         }
     }
 

--- a/tests/unit/script/origin.rs
+++ b/tests/unit/script/origin.rs
@@ -48,48 +48,6 @@ fn alias_cross_origin() {
 }
 
 #[test]
-fn alias_update_same_origin() {
-    let a = Origin::new(&Url::parse("http://example.com/a.html").unwrap());
-    let b = Origin::new(&Url::parse("http://example.org/b.html").unwrap());
-    let c = b.alias();
-    b.set(Url::parse("http://example.com/c.html").unwrap().origin());
-    assert!(a.same_origin(&c));
-    assert!(b.same_origin(&c));
-    assert!(c.same_origin(&c));
-}
-
-#[test]
-fn alias_update_cross_origin() {
-    let a = Origin::new(&Url::parse("http://example.com/a.html").unwrap());
-    let b = Origin::new(&Url::parse("http://example.com/b.html").unwrap());
-    let c = b.alias();
-    b.set(Url::parse("http://example.org/c.html").unwrap().origin());
-    assert!(!a.same_origin(&c));
-    assert!(b.same_origin(&c));
-    assert!(c.same_origin(&c));
-}
-
-#[test]
-fn alias_chain() {
-    let a = Origin::new(&Url::parse("http://example.com/a.html").unwrap());
-    let b = Origin::new(&Url::parse("http://example.com/b.html").unwrap());
-    let c = b.copy();
-    let d = c.alias();
-    let e = d.alias();
-    assert!(a.same_origin(&e));
-    assert!(b.same_origin(&e));
-    assert!(c.same_origin(&e));
-    assert!(d.same_origin(&e));
-    assert!(e.same_origin(&e));
-    c.set(Url::parse("http://example.org/c.html").unwrap().origin());
-    assert!(a.same_origin(&b));
-    assert!(!b.same_origin(&c));
-    assert!(c.same_origin(&d));
-    assert!(d.same_origin(&e));
-    assert!(!e.same_origin(&a));
-}
-
-#[test]
 fn opaque() {
     let a = Origin::opaque_identifier();
     let b = Origin::opaque_identifier();


### PR DESCRIPTION
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because no behaviour change

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11470)

<!-- Reviewable:end -->
