### PR TITLE
Added wpt tests for same-origin iframe parentage.

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6442,6 +6442,12 @@
             "url": "/_mozilla/mozilla/iframe-unblock-onload.html"
           }
         ],
+        "mozilla/iframe/same_origin_parentage.html": [
+          {
+            "path": "mozilla/iframe/same_origin_parentage.html",
+            "url": "/_mozilla/mozilla/iframe/same_origin_parentage.html"
+          }
+        ],
         "mozilla/iframe_contentDocument.html": [
           {
             "path": "mozilla/iframe_contentDocument.html",

--- a/tests/wpt/mozilla/tests/mozilla/iframe/iframe_harness.js
+++ b/tests/wpt/mozilla/tests/mozilla/iframe/iframe_harness.js
@@ -1,0 +1,26 @@
+function get_test_results(id) {
+    async_test(function(test) {
+        var timer = window.setInterval(test.step_func(loop), 100);
+        function loop() {
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', 'stash.py?id=' + id);
+            xhr.onreadystatechange = test.step_func(function() {
+                assert_equals(xhr.status, 200);
+                if (xhr.responseText) {
+                    assert_equals(xhr.responseText, "OK");
+                    test.done();
+                    window.clearTimeout(timer);
+                }
+            });
+            xhr.send();
+        }
+    });
+}
+
+function send_test_results(results) {
+    var ok = true;
+    for (result in results) { ok = ok && results[result]; }
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', 'stash.py?id=' + results.id);
+    xhr.send(ok ? "OK" : "FAIL: " + JSON.stringify(results));
+}

--- a/tests/wpt/mozilla/tests/mozilla/iframe/same_origin_child.html
+++ b/tests/wpt/mozilla/tests/mozilla/iframe/same_origin_child.html
@@ -1,0 +1,12 @@
+<script src="iframe_harness.js"></script>
+<body>
+  <iframe src="same_origin_grandchild.html"></iframe>
+</body>
+<script>
+    send_test_results({
+        "id": '08782f28-e313-47ae-8cd7-419f3e194b0a',
+        "parent": window.parent !== window,
+        "grandparent": window.parent.parent === window.parent,
+        "top": window.top === window.parent,
+    });
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/iframe/same_origin_grandchild.html
+++ b/tests/wpt/mozilla/tests/mozilla/iframe/same_origin_grandchild.html
@@ -1,0 +1,11 @@
+<script src="iframe_harness.js"></script>
+<body>
+</body>
+<script>
+    send_test_results({
+        "id": '66de8d44-7da7-47c7-9a52-41cba4f22bfe',
+        "parent": window.parent !== window,
+        "grandparent": window.parent.parent !== window.parent,
+        "top": window.top === window.parent.parent,
+    });
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/iframe/same_origin_parentage.html
+++ b/tests/wpt/mozilla/tests/mozilla/iframe/same_origin_parentage.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Check the frame heriarchy</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="iframe_harness.js"></script>
+<body>
+  <iframe src="same_origin_child.html"></iframe>
+</body>
+<script>
+    get_test_results('17381dae-9c3e-4661-9f2b-28eb07a5f2fc');
+    get_test_results('08782f28-e313-47ae-8cd7-419f3e194b0a');
+    get_test_results('66de8d44-7da7-47c7-9a52-41cba4f22bfe');
+    send_test_results({
+        "id": '17381dae-9c3e-4661-9f2b-28eb07a5f2fc',
+        "parent": window.parent === window,
+        "top": window.top === window,
+    });
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/iframe/stash.py
+++ b/tests/wpt/mozilla/tests/mozilla/iframe/stash.py
@@ -1,0 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+def main(request, response):
+    if request.method == 'POST':
+        request.server.stash.put(request.GET["id"], request.body)
+        return ''
+    return request.server.stash.take(request.GET["id"])


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Added some wpt tests to make sure same-origin iframes have the right parentage.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11476)

<!-- Reviewable:end -->
