### PR TITLE
Fix 9283 - space or comma separated rect() arguments

### DIFF
--- a/components/style/properties/longhand/effects.mako.rs
+++ b/components/style/properties/longhand/effects.mako.rs
@@ -344,31 +344,45 @@ ${helpers.predefined_type("opacity",
         use std::ascii::AsciiExt;
         use values::specified::Length;
 
+        fn parse_argument(input: &mut Parser) -> Result<Option<Length>, ()> {
+            if input.try(|input| input.expect_ident_matching("auto")).is_ok() {
+                Ok(None)
+            } else {
+                Length::parse(input).map(Some)
+            }
+        }
+
         if input.try(|input| input.expect_ident_matching("auto")).is_ok() {
             return Ok(SpecifiedValue(None))
         }
         if !try!(input.expect_function()).eq_ignore_ascii_case("rect") {
             return Err(())
         }
-        let sides = try!(input.parse_nested_block(|input| {
-            input.parse_comma_separated(|input| {
-                if input.try(|input| input.expect_ident_matching("auto")).is_ok() {
-                    Ok(None)
-                } else {
-                    Length::parse(input).map(Some)
-                }
-            })
-        }));
-        if sides.len() == 4 {
+
+        input.parse_nested_block(|input| {
+            let top = try!(parse_argument(input));
+            let right;
+            let bottom;
+            let left;
+
+            if input.try(|input| input.expect_comma()).is_ok() {
+                right = try!(parse_argument(input));
+                try!(input.expect_comma());
+                bottom = try!(parse_argument(input));
+                try!(input.expect_comma());
+                left = try!(parse_argument(input));
+            } else {
+                right = try!(parse_argument(input));
+                bottom = try!(parse_argument(input));
+                left = try!(parse_argument(input));
+            }
             Ok(SpecifiedValue(Some(SpecifiedClipRect {
-                top: sides[0].unwrap_or(Length::Absolute(Au(0))),
-                right: sides[1],
-                bottom: sides[2],
-                left: sides[3].unwrap_or(Length::Absolute(Au(0))),
+                top: top.unwrap_or(Length::Absolute(Au(0))),
+                right: right,
+                bottom: bottom,
+                left: left.unwrap_or(Length::Absolute(Au(0))),
             })))
-        } else {
-            Err(())
-        }
+        })
     }
 </%helpers:longhand>
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Allow either commas or space to separate `rect()` arguments, but not both. Don't allocate unnecessary `Vec`

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #9283

<!-- Either: -->
- [X] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11495)

<!-- Reviewable:end -->
