### PR TITLE
Add random Device ID generation

### DIFF
--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -28,6 +28,7 @@ openssl = "0.7.6"
 openssl-verify = "0.1"
 plugins = {path = "../plugins"}
 profile_traits = {path = "../profile_traits"}
+rand = "0.3"
 rustc-serialize = "0.3"
 threadpool = "1.0"
 time = "0.1.17"

--- a/components/net/bluetooth_thread.rs
+++ b/components/net/bluetooth_thread.rs
@@ -14,6 +14,7 @@ use net_traits::bluetooth_thread::{BluetoothCharacteristicMsg, BluetoothCharacte
 use net_traits::bluetooth_thread::{BluetoothDescriptorMsg, BluetoothDescriptorsMsg};
 use net_traits::bluetooth_thread::{BluetoothDeviceMsg, BluetoothMethodMsg};
 use net_traits::bluetooth_thread::{BluetoothResult, BluetoothServiceMsg, BluetoothServicesMsg};
+use rand::{self, Rng};
 use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::string::String;
@@ -121,6 +122,7 @@ fn matches_filters(device: &BluetoothDevice, filters: &BluetoothScanfilterSequen
 pub struct BluetoothManager {
     receiver: IpcReceiver<BluetoothMethodMsg>,
     adapter: Option<BluetoothAdapter>,
+    address_to_id: HashMap<String, String>,
     service_to_device: HashMap<String, String>,
     characteristic_to_service: HashMap<String, String>,
     descriptor_to_characteristic: HashMap<String, String>,
@@ -135,6 +137,7 @@ impl BluetoothManager {
         BluetoothManager {
             receiver: receiver,
             adapter: adapter,
+            address_to_id: HashMap::new(),
             service_to_device: HashMap::new(),
             characteristic_to_service: HashMap::new(),
             descriptor_to_characteristic: HashMap::new(),
@@ -210,7 +213,11 @@ impl BluetoothManager {
         let devices = adapter.get_devices().unwrap_or(vec!());
         for device in &devices {
             if let Ok(address) = device.get_address() {
-                self.cached_devices.insert(address, device.clone());
+                if !self.address_to_id.contains_key(&address) {
+                    let generated_id = self.generate_device_id();
+                    self.address_to_id.insert(address, generated_id.clone());
+                    self.cached_devices.insert(generated_id, device.clone());
+                }
             }
         }
         self.cached_devices.iter().map(|(_, d)| d.clone()).collect()
@@ -252,6 +259,18 @@ impl BluetoothManager {
             }
         }
         None
+    }
+
+    fn generate_device_id(&mut self) -> String {
+        let mut device_id;
+        let mut rng = rand::thread_rng();
+        loop {
+            device_id = rng.gen::<u32>().to_string();
+            if !self.cached_devices.contains_key(&device_id) {
+                break;
+            }
+        }
+        device_id
     }
 
     // Service
@@ -417,9 +436,13 @@ impl BluetoothManager {
                                                            .filter(|d| matches_filters(d, options.get_filters()))
                                                            .collect();
         if let Some(address) = self.select_device(matched_devices) {
-            if let Some(device) = self.get_device(&mut adapter, address.as_str()) {
+            let device_id = match self.address_to_id.get(&address) {
+                Some(id) => id.clone(),
+                None => return drop(sender.send(Err(String::from(DEVICE_MATCH_ERROR)))),
+            };
+            if let Some(device) = self.get_device(&mut adapter, &device_id) {
                 let message = Ok(BluetoothDeviceMsg {
-                                     id: address,
+                                     id: device_id,
                                      name: device.get_name().ok(),
                                      appearance: device.get_appearance().ok(),
                                      tx_power: device.get_tx_power().ok().map(|p| p as i8),

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -33,6 +33,7 @@ extern crate net_traits;
 extern crate openssl;
 extern crate openssl_verify;
 extern crate profile_traits;
+extern crate rand;
 extern crate rustc_serialize;
 extern crate threadpool;
 extern crate time;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1374,6 +1374,7 @@ dependencies = [
  "openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "profile_traits 0.0.1",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -1279,6 +1279,7 @@ dependencies = [
  "openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "profile_traits 0.0.1",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The [spec](https://webbluetoothcg.github.io/web-bluetooth/#add-an-allowed-bluetooth-device) (2. step) defines that the device id can't be the public address, therefore we generate a random id.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there are no webbluetooth test api implementation yet.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11523)

<!-- Reviewable:end -->
