### PR TITLE
Provide a better error message when downloading rustc fails

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -69,8 +69,8 @@ def download(desc, src, writer, start_byte=0):
             print("No Rust compiler binary available for this platform. "
                   "Please see https://github.com/servo/servo/#prerequisites")
         sys.exit(1)
-    except urllib2.URLError:
-        print("Error downloading Rust compiler; are you connected to the internet?")
+    except urllib2.URLError, e:
+        print("Error downloading Rust compiler: " + str(e.reason) + ". The failing URL was: " + src)
         sys.exit(1)
     except KeyboardInterrupt:
         writer.flush()


### PR DESCRIPTION
I was running into the error below locally. The previous version of the code hid away important details that helps when debugging; hence, this suggested change.

> Error downloading Rust compiler: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590). URL: https://static-rust-lang-org.s3.amazonaws.com/dist/2016-05-17/rustc-nightly-x86_64-pc-windows-gnu.tar.gz

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11525)

<!-- Reviewable:end -->
