### PR TITLE
Obtain backtraces automatically from segfaults

### DIFF
--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -571,6 +571,15 @@ impl TestBindingMethods for TestBinding {
     fn FuncControlledAttributeEnabled(&self) -> bool { false }
     fn FuncControlledMethodDisabled(&self) {}
     fn FuncControlledMethodEnabled(&self) {}
+
+    #[allow(unsafe_code)]
+    fn CrashHard(&self) {
+        static READ_ONLY_VALUE: i32 = 0;
+        unsafe {
+            let p: *mut u32 = &READ_ONLY_VALUE as *const _ as *mut _;
+            ptr::write_volatile(p, 0xbaadc0de);
+        }
+    }
 }
 
 impl TestBinding {

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -456,3 +456,8 @@ interface TestBinding {
   [Func="TestBinding::condition_satisfied"]
   const unsigned short funcControlledConstEnabled = 0;
 };
+
+partial interface TestBinding {
+  [Pref="dom.testable_crash.enabled"]
+  void crashHard();
+};

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -3,6 +3,7 @@ name = "servo"
 version = "0.0.1"
 dependencies = [
  "android_glue 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "browserhtml 0.1.7 (git+https://github.com/browserhtml/browserhtml?branch=gh-pages)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -35,6 +36,7 @@ dependencies = [
  "script 0.0.1",
  "script_tests 0.0.1",
  "script_traits 0.0.1",
+ "sig 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_tests 0.0.1",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2111,6 +2113,11 @@ dependencies = [
  "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "sig"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "simd"

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -73,6 +73,10 @@ euclid = "0.6.4"
 libc = "0.2"
 url = "1.0.0"
 
+[target.'cfg(not(target_os = "android"))'.dependencies]
+sig = "0.1"
+backtrace = "0.2"
+
 [target.'cfg(target_os = "android")'.dependencies]
 log = "0.3"
 android_glue = "0.1.3"

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -1864,6 +1864,7 @@ name = "servo"
 version = "0.0.1"
 dependencies = [
  "android_glue 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "browserhtml 0.1.7 (git+https://github.com/browserhtml/browserhtml?branch=gh-pages)",
  "canvas 0.0.1",
  "canvas_traits 0.0.1",
@@ -1888,6 +1889,7 @@ dependencies = [
  "profile_traits 0.0.1",
  "script 0.0.1",
  "script_traits 0.0.1",
+ "sig 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
@@ -1996,6 +1998,11 @@ dependencies = [
  "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "sig"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "simd"

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -4,6 +4,7 @@
   "dom.mouseevent.which.enabled": false,
   "dom.mozbrowser.enabled": false,
   "dom.serviceworker.timeout_seconds": 60,
+  "dom.testable_crash.enabled": false,
   "dom.testbinding.enabled": false,
   "gfx.webrender.enabled": false,
   "js.baseline.enabled": true,

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6946,6 +6946,12 @@
             "url": "/_mozilla/mozilla/service-workers/service-worker-registration.html"
           }
         ],
+        "mozilla/sigsegv.html": [
+          {
+            "path": "mozilla/sigsegv.html",
+            "url": "/_mozilla/mozilla/sigsegv.html"
+          }
+        ],
         "mozilla/storage.html": [
           {
             "path": "mozilla/storage.html",

--- a/tests/wpt/mozilla/meta/mozilla/sigsegv.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/sigsegv.html.ini
@@ -1,0 +1,4 @@
+[sigsegv.html]
+  type: testharness
+  prefs: [dom.testbinding.enabled:true,dom.testable_crash.enabled:true]
+  expected: CRASH

--- a/tests/wpt/mozilla/tests/mozilla/sigsegv.html
+++ b/tests/wpt/mozilla/tests/mozilla/sigsegv.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+(new TestBinding()).crashHard();
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This enables more meaningful output from observing hard crashes outside of GDB through the judicious use of a SIGSEGV signal handler.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #9371 (github issue number if applicable).
- [X] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11530)

<!-- Reviewable:end -->
