### PR TITLE
Add Blob URL store

### DIFF
--- a/components/script/blob_url_store.rs
+++ b/components/script/blob_url_store.rs
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![allow(dead_code)]
+
+use dom::bindings::js::JS;
+use dom::blob::Blob;
+use origin::Origin;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+#[must_root]
+#[derive(JSTraceable, HeapSizeOf)]
+struct EntryPair(Origin, JS<Blob>);
+
+// HACK: to work around the HeapSizeOf of Uuid
+#[derive(PartialEq, HeapSizeOf, Eq, Hash, JSTraceable)]
+struct BlobUrlId(#[ignore_heap_size_of = "defined in uuid"] Uuid);
+
+#[must_root]
+#[derive(JSTraceable, HeapSizeOf)]
+pub struct BlobURLStore {
+    entries: HashMap<BlobUrlId, EntryPair>,
+}
+
+pub enum BlobURLStoreError {
+    InvalidKey,
+    InvalidOrigin,
+}
+
+impl BlobURLStore {
+    pub fn new() -> BlobURLStore {
+        BlobURLStore {
+            entries: HashMap::new(),
+        }
+    }
+
+    pub fn request(&self, id: Uuid, origin: &Origin) -> Result<&Blob, BlobURLStoreError> {
+        match self.entries.get(&BlobUrlId(id)) {
+            Some(ref pair) => {
+                if pair.0.same_origin(origin) {
+                    Ok(&pair.1)
+                } else {
+                    Err(BlobURLStoreError::InvalidOrigin)
+                }
+            }
+            None => Err(BlobURLStoreError::InvalidKey)
+        }
+    }
+
+    pub fn add_entry(&mut self, id: Uuid, origin: Origin, blob: &Blob) {
+        self.entries.insert(BlobUrlId(id), EntryPair(origin, JS::from_ref(blob)));
+    }
+
+    pub fn delete_entry(&mut self, id: Uuid) {
+        self.entries.remove(&BlobUrlId(id));
+    }
+}

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
+use blob_url_store::BlobURLStore;
 use devtools_traits::{ScriptToDevtoolsControlMsg, TimelineMarker, TimelineMarkerType, WorkerId};
 use dom::bindings::callback::ExceptionHandling;
 use dom::bindings::cell::DOMRefCell;
@@ -164,6 +165,9 @@ pub struct Window {
     #[ignore_heap_size_of = "channels are hard"]
     scheduler_chan: IpcSender<TimerEventRequest>,
     timers: OneshotTimers,
+
+    /// Blob URL store
+    blob_url_store: DOMRefCell<BlobURLStore>,
 
     next_worker_id: Cell<WorkerId>,
 
@@ -1581,6 +1585,7 @@ impl Window {
             console: Default::default(),
             crypto: Default::default(),
             navigator: Default::default(),
+            blob_url_store: DOMRefCell::new(BlobURLStore::new()),
             image_cache_thread: image_cache_thread,
             mem_profiler_chan: mem_profiler_chan,
             time_profiler_chan: time_profiler_chan,

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use blob_url_store::BlobURLStore;
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId, DevtoolsPageInfo};
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use dom::bindings::codegen::Bindings::WorkerGlobalScopeBinding::WorkerGlobalScopeMethods;
 use dom::bindings::error::{Error, ErrorResult, Fallible, report_pending_exception};
@@ -113,6 +115,9 @@ pub struct WorkerGlobalScope {
     console: MutNullableHeap<JS<Console>>,
     crypto: MutNullableHeap<JS<Crypto>>,
     timers: OneshotTimers,
+    /// Blob URL store
+    blob_url_store: DOMRefCell<BlobURLStore>,
+
     #[ignore_heap_size_of = "Defined in std"]
     mem_profiler_chan: mem::ProfilerChan,
     #[ignore_heap_size_of = "Defined in std"]
@@ -172,6 +177,7 @@ impl WorkerGlobalScope {
             console: Default::default(),
             crypto: Default::default(),
             timers: OneshotTimers::new(timer_event_chan, init.scheduler_chan.clone()),
+            blob_url_store: DOMRefCell::new(BlobURLStore::new()),
             mem_profiler_chan: init.mem_profiler_chan,
             time_profiler_chan: init.time_profiler_chan,
             to_devtools_sender: init.to_devtools_sender,

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -88,6 +88,7 @@ extern crate webrender_traits;
 extern crate websocket;
 extern crate xml5ever;
 
+mod blob_url_store;
 pub mod bluetooth_blacklist;
 pub mod clipboard_provider;
 pub mod cors;


### PR DESCRIPTION
Spec: https://w3c.github.io/FileAPI/#BlobURLStore.

I finally decide to put the store under `ScriptThread` and interpret the "global object" as the script thread itself. The new APIs will be used during the page loading (if scheme is `blob`) and `URL.createObjectURL/revokeObjectURL`.

Related to #11131.

<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #10539

<!-- Either: -->
- [x] These changes do not require tests because it is new stub code which needs further integrating PRs.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11534)

<!-- Reviewable:end -->
