### PR TITLE
Change the font-size property for input and textarea

### DIFF
--- a/resources/servo.css
+++ b/resources/servo.css
@@ -8,7 +8,7 @@ input {
   border: solid lightgrey 1px;
   color: black;
   font-family: sans-serif;
-  font-size: 0.7em;
+  font-size: 0.8333em;
   white-space: nowrap;
   text-align: left;
   line-height: 1.8;
@@ -23,7 +23,7 @@ textarea {
   border: solid lightgrey 1px;
   color: black;
   font-family: sans-serif;
-  font-size: 0.7em;
+  font-size: 0.8333em;
   white-space: pre;
 }
 


### PR DESCRIPTION
Change the `font-size` property for `input` and `textarea` from 0.7em to 0.8333em.
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11529 (github issue number if applicable).
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the issue has the label `C-has-test` Forgive me if I'm wrong; this is my first time contributing to Servo!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11540)

<!-- Reviewable:end -->
