### PR TITLE
Fix ./mach --browserhtml

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -105,6 +105,15 @@ def check_call(*args, **kwargs):
     return subprocess.check_call(*args, shell=sys.platform == 'win32', **kwargs)
 
 
+def is_windows():
+    """ Detect windows, mingw, cygwin """
+    return sys.platform == 'win32' or sys.platform == 'msys' or sys.platform == 'cygwin'
+
+
+def is_macosx():
+    return sys.platform == 'darwin'
+
+
 class BuildNotFound(Exception):
     def __init__(self, message):
         self.message = message

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -23,7 +23,7 @@ from mach.decorators import (
     Command,
 )
 
-from servo.command_base import CommandBase, cd, call, check_call
+from servo.command_base import CommandBase, cd, call, check_call, is_windows, is_macosx
 
 
 def read_file(filename, if_exists=False):
@@ -131,7 +131,15 @@ class PostBuildCommands(CommandBase):
             if browserhtml_path is None:
                 print("Could not find browserhtml package; perhaps you haven't built Servo.")
                 return 1
-            args = args + ['-w', '-b',
+
+            if is_macosx():
+                # Enable borderless on OSX
+                args = args + ['-b']
+            elif is_windows():
+                # Convert to a relative path to avoid mingw -> Windows path conversions
+                browserhtml_path = path.relpath(browserhtml_path, os.getcwd())
+
+            args = args + ['-w',
                            '--pref', 'dom.mozbrowser.enabled',
                            '--pref', 'dom.forcetouch.enabled',
                            '--pref', 'shell.quit-on-escape.enabled=false',


### PR DESCRIPTION
Rebased https://github.com/servo/servo/pull/10943 and simplified by https://github.com/servo/servo/pull/10943#issuecomment-221643014.
Fixes path related issue with browser.html on Windows and enable borderless window only on OSX.

r? @metajack

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11543)

<!-- Reviewable:end -->
