### PR TITLE
Implement private browsing for mozbrowser

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -64,6 +64,7 @@ pub struct Pipeline {
     /// animations cause composites to be continually scheduled.
     pub running_animations: bool,
     pub children: Vec<FrameId>,
+    /// Whether this pipeline is considered distinct from public pipelines.
     pub is_private: bool,
     /// Whether this pipeline should be treated as visible for the purposes of scheduling and
     /// resource management.
@@ -119,6 +120,8 @@ pub struct InitialPipelineState {
     pub parent_visibility: Option<bool>,
     /// Optional webrender api (if enabled).
     pub webrender_api_sender: Option<webrender_traits::RenderApiSender>,
+    /// Whether this pipeline is considered private.
+    pub is_private: bool,
 }
 
 impl Pipeline {
@@ -254,6 +257,7 @@ impl Pipeline {
                                      pipeline_chan,
                                      state.compositor_proxy,
                                      chrome_to_paint_chan,
+                                     state.is_private,
                                      state.load_data.url,
                                      state.window_size,
                                      state.parent_visibility.unwrap_or(true));
@@ -269,6 +273,7 @@ impl Pipeline {
            layout_chan: IpcSender<LayoutControlMsg>,
            compositor_proxy: Box<CompositorProxy + 'static + Send>,
            chrome_to_paint_chan: Sender<ChromeToPaintMsg>,
+           is_private: bool,
            url: Url,
            size: Option<TypedSize2D<PagePx, f32>>,
            visible: bool)
@@ -285,8 +290,8 @@ impl Pipeline {
             children: vec!(),
             size: size,
             running_animations: false,
-            is_private: false,
             visible: visible,
+            is_private: is_private,
         }
     }
 

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -39,7 +39,6 @@ use msg::constellation_msg::{PipelineId, ReferrerPolicy};
 use request::{Request, RequestInit};
 use response::{HttpsState, Response};
 use std::io::Error as IOError;
-use std::sync::mpsc::Sender;
 use std::thread;
 use storage_thread::StorageThreadMsg;
 use url::Url;
@@ -649,9 +648,10 @@ pub fn unwrap_websocket_protocol(wsp: Option<&header::WebSocketProtocol>) -> Opt
 #[derive(Clone, PartialEq, Eq, Copy, Hash, Debug, Deserialize, Serialize, HeapSizeOf)]
 pub struct ResourceId(pub u32);
 
+#[derive(Deserialize, Serialize)]
 pub enum ConstellationMsg {
     /// Queries whether a pipeline or its ancestors are private
-    IsPrivate(PipelineId, Sender<bool>),
+    IsPrivate(PipelineId, IpcSender<bool>),
 }
 
 /// Network errors that have to be exported out of the loaders

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -562,6 +562,21 @@ impl HTMLIFrameElementMethods for HTMLIFrameElement {
     make_getter!(Height, "height");
     // https://html.spec.whatwg.org/multipage/#dom-dim-height
     make_dimension_setter!(SetHeight, "height");
+
+    // check-tidy: no specs after this line
+    fn SetMozprivatebrowsing(&self, value: bool) {
+        let element = self.upcast::<Element>();
+        element.set_bool_attribute(&Atom::from("mozprivatebrowsing"), value);
+    }
+
+    fn Mozprivatebrowsing(&self) -> bool {
+        if window_from_node(self).is_mozbrowser() {
+            let element = self.upcast::<Element>();
+            element.has_attribute(&Atom::from("mozprivatebrowsing"))
+        } else {
+            false
+        }
+    }
 }
 
 impl VirtualMethods for HTMLIFrameElement {

--- a/components/script/dom/webidls/HTMLIFrameElement.webidl
+++ b/components/script/dom/webidls/HTMLIFrameElement.webidl
@@ -33,6 +33,9 @@ partial interface HTMLIFrameElement {
 partial interface HTMLIFrameElement {
     [Func="::dom::window::Window::global_is_mozbrowser"]
     attribute boolean mozbrowser;
+
+    [Func="::dom::window::Window::global_is_mozbrowser"]
+    attribute boolean mozprivatebrowsing;
 };
 
 HTMLIFrameElement implements BrowserElement;

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -489,8 +489,8 @@ impl Runnable for ConnectionEstablishedTask {
             for cookie in cookies.iter() {
                 if let Ok(cookie_value) = String::from_utf8(cookie.clone()) {
                     let _ = ws.global().r().core_resource_thread().send(SetCookiesForUrl(ws.url.clone(),
-                                                                                    cookie_value,
-                                                                                    HTTP));
+                                                                                         cookie_value,
+                                                                                         HTTP));
                 }
             }
         }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -208,12 +208,13 @@ fn create_constellation(opts: opts::Opts,
                         webrender_api_sender: Option<webrender_traits::RenderApiSender>) -> Sender<ConstellationMsg> {
     let bluetooth_thread: IpcSender<BluetoothMethodMsg> = BluetoothThreadFactory::new();
 
-    let resource_threads = new_resource_threads(opts.user_agent.clone(),
-                                                devtools_chan.clone(),
-                                                time_profiler_chan.clone());
-    let image_cache_thread = new_image_cache_thread(resource_threads.sender(),
+    let (public_resource_threads, private_resource_threads) =
+        new_resource_threads(opts.user_agent.clone(),
+                             devtools_chan.clone(),
+                             time_profiler_chan.clone());
+    let image_cache_thread = new_image_cache_thread(public_resource_threads.sender(),
                                                     webrender_api_sender.as_ref().map(|wr| wr.create_api()));
-    let font_cache_thread = FontCacheThread::new(resource_threads.sender(),
+    let font_cache_thread = FontCacheThread::new(public_resource_threads.sender(),
                                                  webrender_api_sender.as_ref().map(|wr| wr.create_api()));
 
     let initial_state = InitialConstellationState {
@@ -222,7 +223,8 @@ fn create_constellation(opts: opts::Opts,
         bluetooth_thread: bluetooth_thread,
         image_cache_thread: image_cache_thread,
         font_cache_thread: font_cache_thread,
-        resource_threads: resource_threads,
+        public_resource_threads: public_resource_threads,
+        private_resource_threads: private_resource_threads,
         time_profiler_chan: time_profiler_chan,
         mem_profiler_chan: mem_profiler_chan,
         supports_clipboard: supports_clipboard,

--- a/tests/unit/net/resource_thread.rs
+++ b/tests/unit/net/resource_thread.rs
@@ -40,7 +40,7 @@ impl LoadOrigin for ResourceTest {
 fn test_exit() {
     let (tx, _rx) = ipc::channel().unwrap();
     let (sender, receiver) = ipc::channel().unwrap();
-    let resource_thread = new_core_resource_thread("".to_owned(), None, ProfilerChan(tx));
+    let (resource_thread, _) = new_core_resource_thread("".to_owned(), None, ProfilerChan(tx));
     resource_thread.send(CoreResourceMsg::Exit(sender)).unwrap();
     receiver.recv().unwrap();
 }
@@ -49,7 +49,7 @@ fn test_exit() {
 fn test_bad_scheme() {
     let (tx, _rx) = ipc::channel().unwrap();
     let (sender, receiver) = ipc::channel().unwrap();
-    let resource_thread = new_core_resource_thread("".to_owned(), None, ProfilerChan(tx));
+    let (resource_thread, _) = new_core_resource_thread("".to_owned(), None, ProfilerChan(tx));
     let (start_chan, start) = ipc::channel().unwrap();
     let url = Url::parse("bogus://whatever").unwrap();
     resource_thread.send(CoreResourceMsg::Load(LoadData::new(LoadContext::Browsing, url, &ResourceTest),
@@ -228,7 +228,7 @@ fn test_cancelled_listener() {
 
     let (tx, _rx) = ipc::channel().unwrap();
     let (exit_sender, exit_receiver) = ipc::channel().unwrap();
-    let resource_thread = new_core_resource_thread("".to_owned(), None, ProfilerChan(tx));
+    let (resource_thread, _) = new_core_resource_thread("".to_owned(), None, ProfilerChan(tx));
     let (sender, receiver) = ipc::channel().unwrap();
     let (id_sender, id_receiver) = ipc::channel().unwrap();
     let (sync_sender, sync_receiver) = ipc::channel().unwrap();

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6616,6 +6616,12 @@
             "url": "/_mozilla/mozilla/mozbrowser/mozbrowsertitlechangedeagerly_event.html"
           }
         ],
+        "mozilla/mozbrowser/private_browsing.html": [
+          {
+            "path": "mozilla/mozbrowser/private_browsing.html",
+            "url": "/_mozilla/mozilla/mozbrowser/private_browsing.html"
+          }
+        ],
         "mozilla/mozbrowser/redirect.html": [
           {
             "path": "mozilla/mozbrowser/redirect.html",

--- a/tests/wpt/mozilla/tests/mozilla/mozbrowser/iframe_contentDocument_inner.html
+++ b/tests/wpt/mozilla/tests/mozilla/mozbrowser/iframe_contentDocument_inner.html
@@ -1,0 +1,3 @@
+<html><body><div id="test">Normal iFrame</div></body>
+<script>alert(document.cookie)</script>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/mozbrowser/iframe_privateContent_grandchild.html
+++ b/tests/wpt/mozilla/tests/mozilla/mozbrowser/iframe_privateContent_grandchild.html
@@ -1,0 +1,4 @@
+<span id="cookie"></span>
+<script>
+document.querySelector('#cookie').innerHTML = document.cookie;
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/mozbrowser/iframe_privateContent_inner.html
+++ b/tests/wpt/mozilla/tests/mozilla/mozbrowser/iframe_privateContent_inner.html
@@ -1,0 +1,13 @@
+<html>
+<body>
+<div id="test">Private iFrame</div>
+</body>
+<script>document.cookie = "private=active;path=/";</script>
+<iframe src="iframe_privateContent_grandchild.html"></iframe>
+<script>
+var iframe = document.querySelector('iframe');
+iframe.onload = function() {
+  alert(document.cookie + ' ' + iframe.contentDocument.querySelector('#cookie').textContent);
+};
+</script>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/mozbrowser/private_browsing.html
+++ b/tests/wpt/mozilla/tests/mozilla/mozbrowser/private_browsing.html
@@ -1,0 +1,44 @@
+<head>
+  <meta charset="utf8" />
+  <title>Private browsing</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <script>
+    async_test(function(t) {
+      var privateFrame = document.createElement("iframe");
+      privateFrame.mozbrowser = true;
+      privateFrame.mozprivatebrowsing = true;
+
+      var gotGrandchildResult = false;
+      privateFrame.addEventListener("mozbrowsershowmodalprompt", t.step_func(e => {
+        assert_equals(e.detail.message, 'private=active private=active');
+        gotGrandchildResult = true;
+      }));
+
+      privateFrame.onload = t.step_func(function() {
+        assert_true(gotGrandchildResult);
+
+        var parent = privateFrame.parentNode;
+        parent.removeChild(privateFrame);
+
+        var iframe = document.createElement("iframe");
+        var promptDisplay = false;
+        iframe.mozbrowser = true;
+        iframe.onload = t.step_func(function() {
+          assert_true(promptDisplay);
+          t.done();
+        });
+        iframe.addEventListener("mozbrowsershowmodalprompt", t.step_func(e => {
+          promptDisplay = true;
+          assert_equals(e.detail.message, "");
+        }));
+        iframe.src = "iframe_contentDocument_inner.html";
+        parent.appendChild(iframe);
+      });
+      privateFrame.src = "iframe_privateContent_inner.html";
+      document.body.appendChild(privateFrame);
+    });
+  </script>
+</body>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Support the `mozprivatebrowsing` attribute on mozbrowser iframes. This separates the non-private and private sessions in terms of cookies, HSTS lists, cached HTTP credentials, HTTP connection pools, and web storage. The private session is shared between all private mozbrowsers, and lasts until shutdown. 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11544)

<!-- Reviewable:end -->
