### PR TITLE
Added support for additional xml types to DOMParser::parseFromString

### DIFF
--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -5,7 +5,10 @@
 use document_loader::DocumentLoader;
 use dom::bindings::codegen::Bindings::DOMParserBinding;
 use dom::bindings::codegen::Bindings::DOMParserBinding::DOMParserMethods;
-use dom::bindings::codegen::Bindings::DOMParserBinding::SupportedType::{Text_html, Text_xml};
+use dom::bindings::codegen::Bindings::DOMParserBinding::SupportedType::Application_xhtml_xml;
+use dom::bindings::codegen::Bindings::DOMParserBinding::SupportedType::Application_xml;
+use dom::bindings::codegen::Bindings::DOMParserBinding::SupportedType::Text_html;
+use dom::bindings::codegen::Bindings::DOMParserBinding::SupportedType::Text_xml;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentReadyState;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::error::Fallible;
@@ -70,7 +73,7 @@ impl DOMParserMethods for DOMParser {
                 document.set_ready_state(DocumentReadyState::Complete);
                 Ok(document)
             }
-            Text_xml => {
+            Text_xml | Application_xml | Application_xhtml_xml => {
                 // FIXME: this should probably be FromParser when we actually parse the string (#3756).
                 let document = Document::new(&self.window,
                                              None,

--- a/components/script/dom/webidls/DOMParser.webidl
+++ b/components/script/dom/webidls/DOMParser.webidl
@@ -8,9 +8,9 @@
 
 enum SupportedType {
   "text/html",
-  "text/xml"/*,
+  "text/xml",
   "application/xml",
-  "application/xhtml+xml",
+  "application/xhtml+xml"/*,
   "image/svg+xml"*/
 };
 

--- a/tests/wpt/metadata/domparsing/DOMParser-parseFromString-xml.html.ini
+++ b/tests/wpt/metadata/domparsing/DOMParser-parseFromString-xml.html.ini
@@ -3,28 +3,10 @@
   [Should return an error document for XML wellformedness errors in type text/xml]
     expected: FAIL
 
-  [Should parse correctly in type application/xml]
-    expected: FAIL
-
-  [XMLDocument interface for correctly parsed document with type application/xml]
-    expected: FAIL
-
   [Should return an error document for XML wellformedness errors in type application/xml]
     expected: FAIL
 
-  [XMLDocument interface for incorrectly parsed document with type application/xml]
-    expected: FAIL
-
-  [Should parse correctly in type application/xhtml+xml]
-    expected: FAIL
-
-  [XMLDocument interface for correctly parsed document with type application/xhtml+xml]
-    expected: FAIL
-
   [Should return an error document for XML wellformedness errors in type application/xhtml+xml]
-    expected: FAIL
-
-  [XMLDocument interface for incorrectly parsed document with type application/xhtml+xml]
     expected: FAIL
 
   [Should parse correctly in type image/svg+xml]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
## This pull request adds support for "application/xml" and "application/xhtml+xml" to DOMParser::parseFromString.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11505 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11550)

<!-- Reviewable:end -->
