### PR TITLE
Improve implementation and add testing regarding file manager thread

### DIFF
--- a/components/net_traits/blob_url_store.rs
+++ b/components/net_traits/blob_url_store.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use ipc_channel::ipc::IpcSender;
 use std::str::FromStr;
 use url::Url;
 use uuid::Uuid;
@@ -27,13 +26,6 @@ pub struct BlobURLStoreEntry {
     pub size: u64,
     /// Content of blob
     pub bytes: Vec<u8>,
-}
-
-/// Message-passing style interface between store and loader
-#[derive(Serialize, Deserialize)]
-pub enum BlobURLStoreMsg {
-    /// Request for an blob entry identified by uuid
-    Request(Uuid, IpcSender<Result<BlobURLStoreEntry, BlobURLStoreError>>),
 }
 
 /// Parse URL as Blob URL scheme's definition

--- a/components/net_traits/filemanager_thread.rs
+++ b/components/net_traits/filemanager_thread.rs
@@ -5,11 +5,13 @@
 use ipc_channel::ipc::IpcSender;
 use std::path::PathBuf;
 use super::{LoadConsumer, LoadData};
-use uuid::Uuid;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SelectedFileId(pub String);
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SelectedFile {
-    pub id: Uuid,
+    pub id: SelectedFileId,
     pub filename: PathBuf,
     pub modified: u64,
     // https://w3c.github.io/FileAPI/#dfn-type
@@ -25,10 +27,10 @@ pub enum FileManagerThreadMsg {
     SelectFiles(IpcSender<FileManagerResult<Vec<SelectedFile>>>),
 
     /// Read file, return the bytes
-    ReadFile(IpcSender<FileManagerResult<Vec<u8>>>, Uuid),
+    ReadFile(IpcSender<FileManagerResult<Vec<u8>>>, SelectedFileId),
 
     /// Delete the FileID entry
-    DeleteFileID(Uuid),
+    DeleteFileID(SelectedFileId),
 
     /// Load resource by Blob URL
     LoadBlob(LoadData, LoadConsumer),

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -57,6 +57,7 @@ use js::rust::Runtime;
 use layout_interface::LayoutRPC;
 use libc;
 use msg::constellation_msg::{FrameType, PipelineId, SubpageId, WindowSizeData, WindowSizeType, ReferrerPolicy};
+use net_traits::filemanager_thread::SelectedFileId;
 use net_traits::image::base::{Image, ImageMetadata};
 use net_traits::image_cache_thread::{ImageCacheChan, ImageCacheThread};
 use net_traits::response::HttpsState;
@@ -324,6 +325,7 @@ no_jsmanaged_fields!(USVString);
 no_jsmanaged_fields!(ReferrerPolicy);
 no_jsmanaged_fields!(ResourceThreads);
 no_jsmanaged_fields!(SystemTime);
+no_jsmanaged_fields!(SelectedFileId);
 
 impl JSTraceable for Box<ScriptChan + Send> {
     #[inline]

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -14,14 +14,13 @@ use dom::bindings::str::DOMString;
 use encoding::all::UTF_8;
 use encoding::types::{EncoderTrap, Encoding};
 use ipc_channel::ipc;
-use net_traits::filemanager_thread::FileManagerThreadMsg;
+use net_traits::filemanager_thread::{FileManagerThreadMsg, SelectedFileId};
 use num_traits::ToPrimitive;
 use std::ascii::AsciiExt;
 use std::borrow::ToOwned;
 use std::cell::Cell;
 use std::cmp::{max, min};
 use std::sync::Arc;
-use uuid::Uuid;
 
 #[derive(Clone, JSTraceable)]
 pub struct DataSlice {
@@ -95,7 +94,7 @@ impl DataSlice {
 #[derive(Clone, JSTraceable)]
 pub enum BlobImpl {
     /// File-based, cached backend
-    File(Uuid, DOMRefCell<Option<DataSlice>>),
+    File(SelectedFileId, DOMRefCell<Option<DataSlice>>),
     /// Memory-based backend
     Memory(DataSlice),
 }
@@ -107,7 +106,7 @@ impl BlobImpl {
     }
 
     /// Construct file-backed BlobImpl from File ID
-    pub fn new_from_file(file_id: Uuid) -> BlobImpl {
+    pub fn new_from_file(file_id: SelectedFileId) -> BlobImpl {
         BlobImpl::File(file_id, DOMRefCell::new(None))
     }
 
@@ -184,7 +183,7 @@ impl Blob {
     }
 }
 
-fn read_file(global: GlobalRef, id: Uuid) -> Result<DataSlice, ()> {
+fn read_file(global: GlobalRef, id: SelectedFileId) -> Result<DataSlice, ()> {
     let file_manager = global.filemanager_thread();
     let (chan, recv) = ipc::channel().map_err(|_|())?;
     let _ = file_manager.send(FileManagerThreadMsg::ReadFile(chan, id));

--- a/tests/unit/net/filemanager_thread.rs
+++ b/tests/unit/net/filemanager_thread.rs
@@ -5,18 +5,60 @@
 use ipc_channel::ipc::{self, IpcSender};
 use net::filemanager_thread::FileManagerThreadFactory;
 use net_traits::filemanager_thread::{FileManagerThreadMsg, FileManagerThreadError};
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
 
 #[test]
 fn test_filemanager() {
     let chan: IpcSender<FileManagerThreadMsg> = FileManagerThreadFactory::new();
 
-    {
-        let (tx, rx) = ipc::channel().unwrap();
-        let _ = chan.send(FileManagerThreadMsg::SelectFile(tx));
+    // Try to open a dummy file "tests/unit/net/test.txt" in tree
+    let mut handler = File::open("test.txt").expect("test.txt is stolen");
+    let mut test_file_content = vec![];
 
-        match rx.recv().unwrap() {
-            Err(FileManagerThreadError::InvalidSelection) => {},
-            _ => assert!(false, "Should be an invalid selection before dialog is implemented"),
+    handler.read_to_end(&mut test_file_content)
+           .expect("Read tests/unit/net/test.txt error");
+
+
+    {
+        // Try to select a dummy file "tests/unit/net/test.txt"
+        let (tx, rx) = ipc::channel().unwrap();
+        chan.send(FileManagerThreadMsg::SelectFile(tx)).unwrap();
+        let selected = rx.recv().expect("File manager channel is broken")
+                                .expect("The file manager failed to find test.txt");
+
+        // Expecting attributes conforming the spec
+        assert!(selected.filename == PathBuf::from("test.txt"));
+        assert!(selected.type_string == "text/plain".to_string());
+
+        // Test by reading, expecting same content
+        {
+            let (tx2, rx2) = ipc::channel().unwrap();
+            chan.send(FileManagerThreadMsg::ReadFile(tx2, selected.id.clone())).unwrap();
+
+            let msg = rx2.recv().expect("File manager channel is broken");
+
+            let vec = msg.expect("File manager reading failure is unexpected");
+            assert!(test_file_content == vec, "Read content differs");
+        }
+
+        // Delete the id
+        chan.send(FileManagerThreadMsg::DeleteFileID(selected.id.clone())).unwrap();
+
+        // Test by reading again, expecting read error because we invalidated the id
+        {
+            let (tx2, rx2) = ipc::channel().unwrap();
+            chan.send(FileManagerThreadMsg::ReadFile(tx2, selected.id.clone())).unwrap();
+
+            let msg = rx2.recv().expect("File manager channel is broken");
+
+            match msg {
+                Err(FileManagerThreadError::ReadFileError) => {},
+                other => {
+                    assert!(false, "Get unexpected response after deleting the id: {:?}", other);
+                }
+            }
         }
     }
 
@@ -26,9 +68,6 @@ fn test_filemanager() {
         let (tx, rx) = ipc::channel().unwrap();
         let _ = chan.send(FileManagerThreadMsg::SelectFile(tx));
 
-        match rx.try_recv() {
-            Ok(_) => assert!(false, "The thread should not response fine after exited"),
-            Err(_) => {},
-        }
+        assert!(rx.try_recv().is_err(), "The thread should not respond normally after exited");
     }
 }

--- a/tests/unit/net/test.txt
+++ b/tests/unit/net/test.txt
@@ -1,0 +1,1 @@
+hello, servo


### PR DESCRIPTION
First there is a more completed unit test. And in the test running, I found a runtime error `Serde(Custom("bincode does not support Deserializer::deserialize))` when reading response from file manage thread. I analyzed a bit and found that it is probably caused by the `Uuid` field. I temporarily work around it by making the `Id` essentially a string wrapped inside `SelectedFileId`.

Related to PR #11131.

<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11552)

<!-- Reviewable:end -->
