### PR TITLE
Remove spurious JS_Init call.

### DIFF
--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -158,7 +158,6 @@ fn perform_platform_specific_initialization() {}
 #[allow(unsafe_code)]
 pub fn init() {
     unsafe {
-        assert_eq!(js::jsapi::JS_Init(), true);
         SetDOMProxyInformation(ptr::null(), 0, Some(script_thread::shadow_check_callback));
     }
 


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] We don't run debug-mozjs tests

Runtime::new() will call JS_Init a second time, leading to an assertion.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11553)

<!-- Reviewable:end -->
