### PR TITLE
compositing: Remove CompositorThread struct

### DIFF
--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -5,7 +5,7 @@
 //! Communication with the compositor thread.
 
 use SendableFrameTree;
-use compositor::{CompositingReason, IOCompositor};
+use compositor::CompositingReason;
 use euclid::point::Point2D;
 use euclid::size::Size2D;
 use gfx_traits::{Epoch, FrameTreeId, LayerId, LayerProperties, PaintListener};
@@ -17,14 +17,12 @@ use profile_traits::mem;
 use profile_traits::time;
 use script_traits::{AnimationState, ConstellationMsg, EventResult};
 use std::fmt::{Debug, Error, Formatter};
-use std::rc::Rc;
 use std::sync::mpsc::{Receiver, Sender, channel};
 use style_traits::cursor::Cursor;
 use style_traits::viewport::ViewportConstraints;
 use url::Url;
 use webrender;
 use webrender_traits;
-use windowing::WindowMethods;
 
 /// Sends messages to the compositor. This is a trait supplied by the port because the method used
 /// to communicate with the compositor may have to kick OS event loops awake, communicate cross-
@@ -228,17 +226,6 @@ impl Debug for Msg {
             Msg::PipelineExited(..) => write!(f, "PipelineExited"),
             Msg::GetScrollOffset(..) => write!(f, "GetScrollOffset"),
         }
-    }
-}
-
-pub struct CompositorThread;
-
-impl CompositorThread {
-    pub fn create<Window>(window: Rc<Window>,
-                          state: InitialCompositorState)
-                          -> IOCompositor<Window>
-                          where Window: WindowMethods + 'static {
-        IOCompositor::create(window, state)
     }
 }
 

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -36,7 +36,7 @@ extern crate util;
 extern crate webrender;
 extern crate webrender_traits;
 
-pub use compositor_thread::{CompositorProxy, CompositorThread};
+pub use compositor_thread::CompositorProxy;
 pub use compositor::IOCompositor;
 use euclid::size::TypedSize2D;
 use gfx::paint_thread::ChromeToPaintMsg;

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -60,7 +60,7 @@ fn webdriver(_port: u16, _constellation: Sender<ConstellationMsg>) { }
 use compositing::compositor_thread::InitialCompositorState;
 use compositing::windowing::WindowEvent;
 use compositing::windowing::WindowMethods;
-use compositing::{CompositorProxy, CompositorThread, IOCompositor};
+use compositing::{CompositorProxy, IOCompositor};
 #[cfg(not(target_os = "windows"))]
 use constellation::content_process_sandbox_profile;
 use constellation::{Constellation, InitialConstellationState, UnprivilegedPipelineContent};
@@ -167,7 +167,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
 
         // The compositor coordinates with the client window to create the final
         // rendered page and display it somewhere.
-        let compositor = CompositorThread::create(window, InitialCompositorState {
+        let compositor = IOCompositor::create(window, InitialCompositorState {
             sender: compositor_proxy,
             receiver: compositor_receiver,
             constellation_chan: constellation_chan,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Remove `CompositorThread` struct, since it wraps only `IOCompositor`. Use `IOCompositor` directly.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #10261 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because refactoring

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11569)

<!-- Reviewable:end -->
