### PR TITLE
Remove unused dev-dependency on image

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -18,7 +18,6 @@ dependencies = [
  "gfx_tests 0.0.1",
  "gleam 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin_app 0.0.1",
- "image 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.3 (git+https://github.com/servo/ipc-channel)",
  "layout 0.0.1",
  "layout_tests 0.0.1",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -31,7 +31,6 @@ opt-level = 3
 # lto = false
 
 [dev-dependencies]
-image = "0.10"
 gfx_tests = {path = "../../tests/unit/gfx"}
 layout_tests = {path = "../../tests/unit/layout"}
 net_tests = {path = "../../tests/unit/net"}


### PR DESCRIPTION
This was used by Servo's old reftest harness, which was replaced with WPT.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11590)

<!-- Reviewable:end -->
