### PR TITLE
Map glutin modifier keycodes to servo keycodes.

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -243,16 +243,16 @@ impl Window {
                     VirtualKeyCode::RAlt => self.toggle_modifier(RIGHT_ALT),
                     VirtualKeyCode::LWin => self.toggle_modifier(LEFT_SUPER),
                     VirtualKeyCode::RWin => self.toggle_modifier(RIGHT_SUPER),
-                    _ => {
-                        if let Ok(key) = Window::glutin_key_to_script_key(virtual_key_code) {
-                            let state = match element_state {
-                                ElementState::Pressed => KeyState::Pressed,
-                                ElementState::Released => KeyState::Released,
-                            };
-                            let modifiers = Window::glutin_mods_to_script_mods(self.key_modifiers.get());
-                            self.event_queue.borrow_mut().push(WindowEvent::KeyEvent(key, state, modifiers));
-                        }
-                    }
+                    _ => {}
+                }
+
+                if let Ok(key) = Window::glutin_key_to_script_key(virtual_key_code) {
+                    let state = match element_state {
+                        ElementState::Pressed => KeyState::Pressed,
+                        ElementState::Released => KeyState::Released,
+                    };
+                    let modifiers = Window::glutin_mods_to_script_mods(self.key_modifiers.get());
+                    self.event_queue.borrow_mut().push(WindowEvent::KeyEvent(key, state, modifiers));
                 }
             }
             Event::KeyboardInput(_, _, None) => {
@@ -547,6 +547,15 @@ impl Window {
             VirtualKeyCode::Up => Ok(Key::Up),
             VirtualKeyCode::Right => Ok(Key::Right),
             VirtualKeyCode::Down => Ok(Key::Down),
+
+            VirtualKeyCode::LShift => Ok(Key::LeftShift),
+            VirtualKeyCode::LControl => Ok(Key::LeftControl),
+            VirtualKeyCode::LAlt => Ok(Key::LeftAlt),
+            VirtualKeyCode::LWin => Ok(Key::LeftSuper),
+            VirtualKeyCode::RShift => Ok(Key::RightShift),
+            VirtualKeyCode::RControl => Ok(Key::RightControl),
+            VirtualKeyCode::RAlt => Ok(Key::RightAlt),
+            VirtualKeyCode::RWin => Ok(Key::RightSuper),
 
             VirtualKeyCode::Apostrophe => Ok(Key::Apostrophe),
             VirtualKeyCode::Backslash => Ok(Key::Backslash),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Make it possible to receive DOM events for modifiers keys.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11547
- [X] These changes do not require tests because we don't support automated tests for keyboard input

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11594)

<!-- Reviewable:end -->
