### PR TITLE
Mach re-dispatch test-wpt and test-css based on path

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -337,7 +337,7 @@ class MachCommands(CommandBase):
              parser=create_parser_wpt)
     def test_wpt(self, **kwargs):
         self.ensure_bootstrapped()
-        return self.run_test_list_or_dispatch("wpt", self._test_wpt, **kwargs)
+        return self.run_test_list_or_dispatch(kwargs["test_list"], "wpt", self._test_wpt, **kwargs)
 
     def _test_wpt(self, **kwargs):
         hosts_file_path = path.join(self.context.topdir, 'tests', 'wpt', 'hosts')
@@ -346,14 +346,13 @@ class MachCommands(CommandBase):
         return self.wptrunner(run_file, **kwargs)
 
     # Helper to ensure all specified paths are handled, otherwise dispatch to appropriate test suite.
-    def run_test_list_or_dispatch(self, correct_suite, correct_function, **kwargs):
-        test_list = kwargs["test_list"]
-        if not test_list:
+    def run_test_list_or_dispatch(self, requested_paths, correct_suite, correct_function, **kwargs):
+        if not requested_paths:
             return correct_function(**kwargs)
         else:
             # Paths specified on command line. Ensure they can be handled, re-dispatch otherwise.
             all_handled = True
-            for test_path in test_list:
+            for test_path in requested_paths:
                 suite = self.suite_for_path(test_path)
                 if correct_suite != suite:
                     all_handled = False
@@ -362,7 +361,7 @@ class MachCommands(CommandBase):
                 return correct_function(**kwargs)
             else:
                 # Dispatch each test to the correct suite via test()
-                Registrar.dispatch("test", context=self.context, params=test_list)
+                Registrar.dispatch("test", context=self.context, params=requested_paths)
 
     # Helper for test_css and test_wpt:
     def wptrunner(self, run_file, **kwargs):
@@ -441,7 +440,7 @@ class MachCommands(CommandBase):
              parser=create_parser_wpt)
     def test_css(self, **kwargs):
         self.ensure_bootstrapped()
-        return self.run_test_list_or_dispatch("css", self._test_css, **kwargs)
+        return self.run_test_list_or_dispatch(kwargs["test_list"], "css", self._test_css, **kwargs)
 
     def _test_css(self, **kwargs):
         run_file = path.abspath(path.join("tests", "wpt", "run_css.py"))

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -337,6 +337,24 @@ class MachCommands(CommandBase):
              parser=create_parser_wpt)
     def test_wpt(self, **kwargs):
         self.ensure_bootstrapped()
+        test_list = kwargs["test_list"]
+        if not test_list:
+            return self._test_wpt(**kwargs)
+        else:
+            # Paths specified on command line. Ensure they are WPT, re-dispatch otherwise.
+            all_wpt = True
+            for test_path in test_list:
+                suite = self.suite_for_path(test_path)
+                if "wpt" != suite:
+                    all_wpt = False
+                    print("Warning: %s is not a WPT test. Delegating to test-%s." % (test_path, suite))
+            if all_wpt:
+                return self._test_wpt(**kwargs)
+            else:
+                # Dispatch each test to the correct suite
+                Registrar.dispatch("test", context=self.context, params=test_list)
+
+    def _test_wpt(self, **kwargs):
         hosts_file_path = path.join(self.context.topdir, 'tests', 'wpt', 'hosts')
         os.environ["hosts_file_path"] = hosts_file_path
         run_file = path.abspath(path.join(self.context.topdir, "tests", "wpt", "run_wpt.py"))

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -14,6 +14,7 @@ import re
 import sys
 import os
 import os.path as path
+import copy
 from collections import OrderedDict
 from time import time
 
@@ -34,6 +35,26 @@ SCRIPT_PATH = os.path.split(__file__)[0]
 PROJECT_TOPLEVEL_PATH = os.path.abspath(os.path.join(SCRIPT_PATH, "..", ".."))
 WEB_PLATFORM_TESTS_PATH = os.path.join("tests", "wpt", "web-platform-tests")
 SERVO_TESTS_PATH = os.path.join("tests", "wpt", "mozilla", "tests")
+
+TEST_SUITES = OrderedDict([
+    ("tidy", {"kwargs": {"all_files": False, "no_progress": False, "self_test": False},
+              "include_arg": "include"}),
+    ("wpt", {"kwargs": {"release": False},
+             "paths": [path.abspath(WEB_PLATFORM_TESTS_PATH),
+                       path.abspath(SERVO_TESTS_PATH)],
+             "include_arg": "include"}),
+    ("css", {"kwargs": {"release": False},
+             "paths": [path.abspath(path.join("tests", "wpt", "css-tests"))],
+             "include_arg": "include"}),
+    ("unit", {"kwargs": {},
+              "paths": [path.abspath(path.join("tests", "unit"))],
+              "include_arg": "test_name"}),
+    ("compiletest", {"kwargs": {"release": False},
+                     "paths": [path.abspath(path.join("tests", "compiletest"))],
+                     "include_arg": "test_name"})
+])
+
+TEST_SUITES_BY_PREFIX = {path: k for k, v in TEST_SUITES.iteritems() if "paths" in v for path in v["paths"]}
 
 
 def create_parser_wpt():
@@ -79,25 +100,12 @@ class MachCommands(CommandBase):
                      help="Run all test suites")
     def test(self, params, render_mode=DEFAULT_RENDER_MODE, release=False, tidy_all=False,
              no_progress=False, self_test=False, all_suites=False):
-        suites = OrderedDict([
-            ("tidy", {"kwargs": {"all_files": tidy_all, "no_progress": no_progress, "self_test": self_test},
-                      "include_arg": "include"}),
-            ("wpt", {"kwargs": {"release": release},
-                     "paths": [path.abspath(path.join("tests", "wpt", "web-platform-tests")),
-                               path.abspath(path.join("tests", "wpt", "mozilla"))],
-                     "include_arg": "include"}),
-            ("css", {"kwargs": {"release": release},
-                     "paths": [path.abspath(path.join("tests", "wpt", "css-tests"))],
-                     "include_arg": "include"}),
-            ("unit", {"kwargs": {},
-                      "paths": [path.abspath(path.join("tests", "unit"))],
-                      "include_arg": "test_name"}),
-            ("compiletest", {"kwargs": {"release": release},
-                             "paths": [path.abspath(path.join("tests", "compiletest"))],
-                             "include_arg": "test_name"})
-        ])
-
-        suites_by_prefix = {path: k for k, v in suites.iteritems() if "paths" in v for path in v["paths"]}
+        suites = copy.deepcopy(TEST_SUITES)
+        suites["tidy"]["kwargs"] = {"all_files": tidy_all, "no_progress": no_progress, "self_test": self_test}
+        suites["wpt"]["kwargs"] = {"release": release}
+        suites["css"]["kwargs"] = {"release": release}
+        suites["unit"]["kwargs"] = {}
+        suites["compiletest"]["kwargs"] = {"release": release}
 
         selected_suites = OrderedDict()
 
@@ -115,16 +123,14 @@ class MachCommands(CommandBase):
             if arg in suites and arg not in selected_suites:
                 selected_suites[arg] = []
                 found = True
-
-            elif os.path.exists(path.abspath(arg)):
-                abs_path = path.abspath(arg)
-                for prefix, suite in suites_by_prefix.iteritems():
-                    if abs_path.startswith(prefix):
-                        if suite not in selected_suites:
-                            selected_suites[suite] = []
-                        selected_suites[suite].append(arg)
-                        found = True
-                        break
+            else:
+                suite = self.suite_for_path(arg)
+                if suite is not None:
+                    if suite not in selected_suites:
+                        selected_suites[suite] = []
+                    selected_suites[suite].append(arg)
+                    found = True
+                    break
 
             if not found:
                 print("%s is not a valid test path or suite name" % arg)
@@ -142,6 +148,15 @@ class MachCommands(CommandBase):
         elapsed = time() - test_start
 
         print("Tests completed in %0.2fs" % elapsed)
+
+    # Helper to determine which test suite owns the path
+    def suite_for_path(self, path_arg):
+        if os.path.exists(path.abspath(path_arg)):
+            abs_path = path.abspath(path_arg)
+            for prefix, suite in TEST_SUITES_BY_PREFIX.iteritems():
+                if abs_path.startswith(prefix):
+                    return suite
+        return None
 
     @Command('test-unit',
              description='Run unit tests',


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Print a warning and dispatch to the correct test suite, when non-WPT test paths are given to `mach test-wpt` or non-CSS paths to `mach test-css`

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #10883 (github issue number if applicable).

<!-- Either: -->
- [X] These changes do not require tests because improving mach test script itself

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11604)

<!-- Reviewable:end -->
