### PR TITLE
Rename the variants of the SubmittedFrom and ResetFrom enums to be less repetitive

### DIFF
--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -266,14 +266,14 @@ impl Activatable for HTMLButtonElement {
             ButtonType::Submit => {
                 // TODO: is document owner fully active?
                 if let Some(owner) = self.form_owner() {
-                    owner.submit(SubmittedFrom::NotFromFormSubmitMethod,
+                    owner.submit(SubmittedFrom::NotFromForm,
                                  FormSubmitter::ButtonElement(self.clone()));
                 }
             }
             ButtonType::Reset => {
                 // TODO: is document owner fully active?
                 if let Some(owner) = self.form_owner() {
-                    owner.reset(ResetFrom::NotFromFormResetMethod);
+                    owner.reset(ResetFrom::NotFromForm);
                 }
             }
             _ => (),

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -155,12 +155,12 @@ impl HTMLFormElementMethods for HTMLFormElement {
 
     // https://html.spec.whatwg.org/multipage/#the-form-element:concept-form-submit
     fn Submit(&self) {
-        self.submit(SubmittedFrom::FromFormSubmitMethod, FormSubmitter::FormElement(self));
+        self.submit(SubmittedFrom::FromForm, FormSubmitter::FormElement(self));
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-form-reset
     fn Reset(&self) {
-        self.reset(ResetFrom::FromFormResetMethod);
+        self.reset(ResetFrom::FromForm);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-form-elements
@@ -233,14 +233,14 @@ impl HTMLFormElementMethods for HTMLFormElement {
 
 #[derive(Copy, Clone, HeapSizeOf, PartialEq)]
 pub enum SubmittedFrom {
-    FromFormSubmitMethod,
-    NotFromFormSubmitMethod
+    FromForm,
+    NotFromForm
 }
 
 #[derive(Copy, Clone, HeapSizeOf)]
 pub enum ResetFrom {
-    FromFormResetMethod,
-    NotFromFormResetMethod
+    FromForm,
+    NotFromForm
 }
 
 
@@ -368,7 +368,7 @@ impl HTMLFormElement {
         let base = doc.url();
         // TODO: Handle browsing contexts
         // Step 4
-        if submit_method_flag == SubmittedFrom::NotFromFormSubmitMethod &&
+        if submit_method_flag == SubmittedFrom::NotFromForm &&
            !submitter.no_validate(self)
         {
             if self.interactive_validation().is_err() {
@@ -378,7 +378,7 @@ impl HTMLFormElement {
             }
         }
         // Step 5
-        if submit_method_flag == SubmittedFrom::NotFromFormSubmitMethod {
+        if submit_method_flag == SubmittedFrom::NotFromForm {
             let event = self.upcast::<EventTarget>()
                 .fire_event("submit",
                             EventBubbles::Bubbles,

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1091,7 +1091,7 @@ impl Activatable for HTMLInputElement {
                 // FIXME (Manishearth): support document owners (needs ability to get parent browsing context)
                 // Check if document owner is fully active
                 self.form_owner().map(|o| {
-                    o.submit(SubmittedFrom::NotFromFormSubmitMethod,
+                    o.submit(SubmittedFrom::NotFromForm,
                              FormSubmitter::InputElement(self.clone()))
                 });
             },
@@ -1100,7 +1100,7 @@ impl Activatable for HTMLInputElement {
                 // FIXME (Manishearth): support document owners (needs ability to get parent browsing context)
                 // Check if document owner is fully active
                 self.form_owner().map(|o| {
-                    o.reset(ResetFrom::NotFromFormResetMethod)
+                    o.reset(ResetFrom::NotFromForm)
                 });
             },
             InputType::InputCheckbox | InputType::InputRadio => {
@@ -1204,7 +1204,7 @@ impl Activatable for HTMLInputElement {
                     // lazily test for > 1 submission-blocking inputs
                     return;
                 }
-                form.submit(SubmittedFrom::NotFromFormSubmitMethod,
+                form.submit(SubmittedFrom::NotFromForm,
                             FormSubmitter::FormElement(form.r()));
             }
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

delete suffixes for variants SubmittedFrom, ResetFrom

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #11557 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11605)

<!-- Reviewable:end -->
