### PR TITLE
Make mach test-tidy consider ignored dirs

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -645,11 +645,12 @@ def get_file_list(directory, only_changed_files=False, exclude_dirs=[]):
         args = ["git", "ls-files", "--others", "--exclude-standard", directory]
         file_list += subprocess.check_output(args)
         for f in file_list.splitlines():
-            yield os.path.join('.', f)
+            if os.path.join('.', os.path.dirname(f)) not in ignored_dirs:
+                yield os.path.join('.', f)
     elif exclude_dirs:
         for root, dirs, files in os.walk(directory, topdown=True):
             # modify 'dirs' in-place so that we don't do unwanted traversals in excluded directories
-            dirs[:] = [d for d in dirs if not any(os.path.join(root, d).startswith(name) for name in ignored_dirs)]
+            dirs[:] = [d for d in dirs if not any(os.path.join(root, d).startswith(name) for name in exclude_dirs)]
             for rel_path in files:
                 yield os.path.join(root, rel_path)
     else:

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -113,6 +113,16 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual(msg, errors.next()[2])
         self.assertNoMoreErrors(errors)
 
+    def test_file_list(self):
+        base_path='./python/tidy/servo_tidy_tests/test_ignored'
+        file_list = tidy.get_file_list(base_path, only_changed_files=False,
+                                       exclude_dirs=[])
+        lst = list(file_list)
+        self.assertEqual([os.path.join(base_path, 'whee', 'test.rs')], lst)
+        file_list = tidy.get_file_list(base_path, only_changed_files=False,
+                                       exclude_dirs=[os.path.join(base_path,'whee')])
+        lst = list(file_list)
+        self.assertEqual([], lst)
 
 def do_tests():
     suite = unittest.TestLoader().loadTestsFromTestCase(CheckTidiness)


### PR DESCRIPTION
Made changes so that mach test-tidy considers the ignored directories 

Fixes #11386

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11621)

<!-- Reviewable:end -->
