### PR TITLE
wpt cookie path tests

### DIFF
--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -37745,6 +37745,12 @@
         ]
       },
       "testharness": {
+        "cookies/path/match.html": [
+          {
+            "path": "cookies/path/match.html",
+            "url": "/cookies/path/match.html"
+          }
+        ],
         "html/semantics/forms/the-form-element/form-action-url.html": [
           {
             "path": "html/semantics/forms/the-form-element/form-action-url.html",

--- a/tests/wpt/web-platform-tests/cookies/path/echo-cookie.html
+++ b/tests/wpt/web-platform-tests/cookies/path/echo-cookie.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset=utf-8>
+  <title>helper iframe for matching cookie path tests</title>
+  <meta name=help href="http://tools.ietf.org/html/rfc6265#section-5.1.4">
+</head>
+<body>
+<script>
+window.setCookie = function (name, path) {
+  document.cookie = name + '=1; path = ' + path + ';';
+}
+window.fetchCookieThen = function (name, path) {
+  return fetch("/cookies/resources/set-cookie.py?name=" + encodeURIComponent(name) + "&path=" + encodeURIComponent(path));
+};
+window.isCookieSet = function (name, path) {
+  return document.cookie.match(name + '=1');
+};
+window.expireCookie = function (name, path) {
+  document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=' + path + ';';
+};
+</script>
+</body>
+</html>

--- a/tests/wpt/web-platform-tests/cookies/path/match.html
+++ b/tests/wpt/web-platform-tests/cookies/path/match.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset=utf-8>
+  <title>tests for matching cookie paths</title>
+  <meta name=help href="http://tools.ietf.org/html/rfc6265#section-5.1.4">
+
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/cookies/resources/testharness-helpers.js"></script>
+</head>
+<body>
+<div id=log></div>
+
+<script>
+var body = document.getElementsByTagName('body')[0];
+var createIframeThen = function (callback) {
+  var iframe = document.createElement('iframe');
+  iframe.src = "echo-cookie.html";
+  body.appendChild(iframe);
+  iframe.onload = callback;
+  return iframe;
+};
+var testCookiePathFromDOM = function (testCase, test) {
+  var iframe = createIframeThen(test.step_func(function () {
+    iframe.contentWindow.setCookie(testCase.name, testCase.path);
+    var cookieSet = iframe.contentWindow.isCookieSet(testCase.name, testCase.path);
+    if (testCase.match === false) {
+      assert_equals(cookieSet, null);
+    } else {
+      assert_not_equals(cookieSet, null);
+    }
+
+    iframe.contentWindow.expireCookie(testCase.name, testCase.path);
+    test.done();
+  }));
+};
+var testCookiePathFromHeader = function (testCase, test) {
+  var iframe = createIframeThen(test.step_func(function () {
+    iframe.contentWindow.fetchCookieThen(testCase.name, testCase.path).then(test.step_func(function (response) {
+      assert_true(response.ok);
+
+      var cookieSet = iframe.contentWindow.isCookieSet(testCase.name, testCase.path);
+      iframe.contentWindow.expireCookie(testCase.name, testCase.path);
+      if (testCase.match === false) {
+        assert_equals(cookieSet, null);
+      } else {
+        assert_not_equals(cookieSet, null);
+      }
+
+      test.done();
+    })).catch(test.unreached_func());
+  }));
+};
+
+var tests = [{
+  "name": "match-slash",
+  "path": "/",
+}, {
+  "name": "match-page",
+  "path": "match.html",
+}, {
+  "name": "match-prefix",
+  "path": "cookies",
+}, {
+  "name": "match-slash-prefix",
+  "path": "/cookies",
+}, {
+  "name": "match-slash-prefix-slash",
+  "path": "/cookies/",
+}, {
+  "name": "match-exact-page",
+  "path": "/cookies/path/echo-cookie.html",
+}, {
+  "name": "no-match",
+  "path": "/cook",
+  "match": false
+}, {
+  "name": "no-match-subpath",
+  "path": "/w/",
+  "match": false
+}];
+
+var domTests = tests.map(function (testCase) {
+  var testName = "`document.cookie` on /cookies/path/echo-cookie.html sets cookie with path: " + testCase.path;
+  if (testCase.match === false) {
+    testName = "`document.cookie` on /cookies/path/echo-cookie.html DOES NOT set cookie for path: " + testCase.path;
+  }
+  return [
+    testName,
+    function () {
+      testCookiePathFromDOM(testCase, this);
+    }
+  ];
+});
+
+var headerTests = tests.map(function (testCase) {
+  var testName = "`Set-Cookie` on /cookies/path/echo-cookie.html sets cookie with path: " + testCase.path;
+  if (testCase.match === false) {
+    testName = "`Set-Cookie` on /cookies/path/echo-cookie.html DOES NOT set cookie for path: " + testCase.path;
+  }
+  return [
+    testName,
+    function () {
+      testCookiePathFromHeader(testCase, this);
+    }
+  ];
+});
+
+executeTestsSerially(domTests.concat(headerTests));
+</script>
+</body>
+</html>

--- a/tests/wpt/web-platform-tests/cookies/resources/set-cookie.py
+++ b/tests/wpt/web-platform-tests/cookies/resources/set-cookie.py
@@ -1,0 +1,29 @@
+
+import sys
+import urlparse
+
+def main(request, response):
+    """
+    Returns cookie name and path from query params in a Set-Cookie header.
+
+    e.g.
+
+    > GET /cookies/resources/set-cookie.py?name=match-slash&path=%2F HTTP/1.1
+    > Host: localhost:8000
+    > User-Agent: curl/7.43.0
+    > Accept: */*
+    >
+    < HTTP/1.1 200 OK
+    < Content-Type: application/json
+    < Set-Cookie: match-slash=1; Path=/; Expires=Wed, 09 Jun 2021 10:18:14 GMT
+    < Server: BaseHTTP/0.3 Python/2.7.12
+    < Date: Tue, 04 Oct 2016 18:16:06 GMT
+    < Content-Length: 80
+    """
+    params = urlparse.parse_qs(request.url_parts.query)
+    headers = [
+        ("Content-Type", "application/json"),
+        ("Set-Cookie", "{name[0]}=1; Path={path[0]}; Expires=Wed, 09 Jun 2021 10:18:14 GMT".format(**params))
+    ]
+    body = "{}"
+    return headers, body


### PR DESCRIPTION
Adds wpt tests for the cookie path attribute. 

Notes:
- I included polyfills for fetch and promise to get tests running.  Assuming these changes are OK, I'll remove them and add failure expectations so they don't get synced to w3c.
- I didn't work out a way to test sending cookies when the request and cookie paths exactly match (e.g. request path `/cookies/path/match-exact-page.sub.html` and cookie path `/cookies/path/match-exact-page.sub.html` will not send cookies to `/cookies/resources/echo-json.py`) 
- test names could be clearer
- everything can be squashed to one commit

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #8756 (github issue number if applicable).
- [x] These changes do not require tests because they are tests (and if we test our tests do we need to test our test tests? ...)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11624)

<!-- Reviewable:end -->
