### PR TITLE
Add FreeBSD to `host_triple`

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -43,6 +43,8 @@ def host_triple():
         os_type = "linux-androideabi"
     elif os_type == "windows" or os_type.startswith("mingw64_nt-") or os_type.startswith("cygwin_nt-"):
         os_type = "pc-windows-gnu"
+    elif os_type == "freebsd":
+        os_type = "unknown-freebsd"
     else:
         os_type = "unknown"
 


### PR DESCRIPTION
## Add freebsd to `host_triple` so that the correct nightly compiler will be downloaded. There are still other crates that need patching to compile, but this is a start.
- [ ] `./mach build -d` does not report any errors
  - Other crates need patches
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because: the correct compiler is not downloaded without this commit

Part of: #11625 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11626)

<!-- Reviewable:end -->
