### PR TITLE
Fix an incorect behavior, when converting optional services.

### DIFF
--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -125,10 +125,9 @@ fn convert_request_device_options(options: &RequestDeviceOptions,
     if let Some(ref opt_services) = options.optionalServices {
         for opt_service in opt_services {
             let uuid = try!(BluetoothUUID::GetService(global, opt_service.clone())).to_string();
-            if uuid_is_blacklisted(uuid.as_ref(), Blacklist::All) {
-                return Err(Security)
+            if !uuid_is_blacklisted(uuid.as_ref(), Blacklist::All) {
+                optional_services.push(uuid);
             }
-            optional_services.push(uuid);
         }
     }
 


### PR DESCRIPTION
As specified in https://webbluetoothcg.github.io/web-bluetooth/#ref-for-blacklisted-2 if any service in the optionalServices are blacklisted, there is no need to throw an error (just remove the service). In this case we don't add the service to the result of conversion.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there are no webbluetooth test api implementation yet.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11636)

<!-- Reviewable:end -->
