### PR TITLE
Use base_url instead of url in HTMLAnchorElement::set_url

### DIFF
--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -64,7 +64,7 @@ impl HTMLAnchorElement {
         let attribute = self.upcast::<Element>().get_attribute(&ns!(), &atom!("href"));
         *self.url.borrow_mut() = attribute.and_then(|attribute| {
             let document = document_from_node(self);
-            document.url().join(&attribute.value()).ok()
+            document.base_url().join(&attribute.value()).ok()
         });
     }
 

--- a/tests/wpt/metadata/url/a-element-xhtml.xhtml.ini
+++ b/tests/wpt/metadata/url/a-element-xhtml.xhtml.ini
@@ -246,39 +246,6 @@
   [Parsing: <data:text/html,test#test> against <http://example.org/foo/bar>]
     expected: FAIL
 
-  [Parsing: <C|/foo/bar> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: </C|\\foo\\bar> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <//C|/foo/bar> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <//server/file> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <\\\\server\\file> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: </\\server/file> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <//> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <///> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <///test> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <test> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file:test> against <file:///tmp/mock/path>]
-    expected: FAIL
-
   [Parsing: <http://example.com/././foo> against <about:blank>]
     expected: FAIL
 
@@ -762,58 +729,7 @@
   [Parsing: <sc::a@example.net> against <about:blank>]
     expected: FAIL
 
-  [Parsing: <http:/:@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:/@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:a:b@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:/a:b@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http::@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:@:www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:/@:www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <i> against <sc:sd>]
-    expected: FAIL
-
-  [Parsing: <i> against <sc:sd/sd>]
-    expected: FAIL
-
-  [Parsing: <../i> against <sc:sd>]
-    expected: FAIL
-
-  [Parsing: <../i> against <sc:sd/sd>]
-    expected: FAIL
-
-  [Parsing: </i> against <sc:sd>]
-    expected: FAIL
-
-  [Parsing: </i> against <sc:sd/sd>]
-    expected: FAIL
-
-  [Parsing: <?i> against <sc:sd>]
-    expected: FAIL
-
-  [Parsing: <?i> against <sc:sd/sd>]
-    expected: FAIL
-
   [Parsing: <http:> against <http://example.org/foo/bar>]
-    expected: FAIL
-
-  [Parsing: <http:> against <https://example.org/foo/bar>]
     expected: FAIL
 
   [Parsing: <sc:> against <https://example.org/foo/bar>]

--- a/tests/wpt/metadata/url/a-element.html.ini
+++ b/tests/wpt/metadata/url/a-element.html.ini
@@ -246,39 +246,6 @@
   [Parsing: <data:text/html,test#test> against <http://example.org/foo/bar>]
     expected: FAIL
 
-  [Parsing: <C|/foo/bar> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: </C|\\foo\\bar> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <//C|/foo/bar> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <//server/file> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <\\\\server\\file> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: </\\server/file> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <//> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <///> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <///test> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <test> against <file:///tmp/mock/path>]
-    expected: FAIL
-
-  [Parsing: <file:test> against <file:///tmp/mock/path>]
-    expected: FAIL
-
   [Parsing: <http://example.com/././foo> against <about:blank>]
     expected: FAIL
 
@@ -762,58 +729,7 @@
   [Parsing: <sc::a@example.net> against <about:blank>]
     expected: FAIL
 
-  [Parsing: <http:/:@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:/@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:a:b@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:/a:b@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http::@/www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:@:www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <http:/@:www.example.com> against <about:blank>]
-    expected: FAIL
-
-  [Parsing: <i> against <sc:sd>]
-    expected: FAIL
-
-  [Parsing: <i> against <sc:sd/sd>]
-    expected: FAIL
-
-  [Parsing: <../i> against <sc:sd>]
-    expected: FAIL
-
-  [Parsing: <../i> against <sc:sd/sd>]
-    expected: FAIL
-
-  [Parsing: </i> against <sc:sd>]
-    expected: FAIL
-
-  [Parsing: </i> against <sc:sd/sd>]
-    expected: FAIL
-
-  [Parsing: <?i> against <sc:sd>]
-    expected: FAIL
-
-  [Parsing: <?i> against <sc:sd/sd>]
-    expected: FAIL
-
   [Parsing: <http:> against <http://example.org/foo/bar>]
-    expected: FAIL
-
-  [Parsing: <http:> against <https://example.org/foo/bar>]
     expected: FAIL
 
   [Parsing: <sc:> against <https://example.org/foo/bar>]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

`script::dom::HTMLAnchorElement::set_url` now uses `document::base_url` instead of `document::url`, allowing correct parsing of relative urls on about:blank and pages with a `<base href="some_url"/>` set.

spec: https://html.spec.whatwg.org/multipage/infrastructure.html#resolving-urls

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11628

<!-- Either: -->
- [x] There are tests for these changes: Some expected test failures have been removed.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11639)

<!-- Reviewable:end -->
