### PR TITLE
servo: Add an `Info.plist` on the Mac and opt into integrated graphics.

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -99,7 +99,7 @@ version = "0.4.5"
 source = "git+https://github.com/servo/rust-azure#a7177c8df81554352bc51de2f5b77cbb47ec2635"
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
@@ -273,11 +273,11 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "core-graphics"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -417,7 +417,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -756,7 +756,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2056,9 +2056,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2525,7 +2525,7 @@ source = "git+https://github.com/servo/webrender#3a6db793d0a2a1c0e55f78ba2ee8ec2
 dependencies = [
  "app_units 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2548,7 +2548,7 @@ source = "git+https://github.com/servo/webrender_traits#e4cbde9880d118e50de425d3
 dependencies = [
  "app_units 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.3 (git+https://github.com/servo/ipc-channel)",

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -37,6 +37,17 @@ use servo::util::opts::{self, ArgumentParsingResult};
 use servo::util::panicking::initiate_panic_hook;
 use std::rc::Rc;
 
+pub mod platform {
+    #[cfg(target_os = "macos")]
+    pub use platform::macos::deinit;
+
+    #[cfg(target_os = "macos")]
+    pub mod macos;
+
+    #[cfg(not(target_os = "macos"))]
+    pub fn deinit() {}
+}
+
 fn main() {
     // Parse the command line options and store them globally
     let opts_result = opts::from_cmdline_args(&*args());
@@ -82,6 +93,8 @@ fn main() {
     };
 
     unregister_glutin_resize_handler(&window);
+
+    platform::deinit()
 }
 
 fn register_glutin_resize_handler(window: &Rc<app::window::Window>,

--- a/components/servo/platform/macos/Info.plist
+++ b/components/servo/platform/macos/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+	<key>CFBundleDisplayName</key>
+	<string>Servo</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleName</key>
+	<string>Servo</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright &#169; 2016 The Servo Authors</string>
+	<key>CFBundleVersion</key>
+	<string>0.0.1</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.servo.servo</string>
+</dict>
+</plist>
+

--- a/components/servo/platform/macos/mod.rs
+++ b/components/servo/platform/macos/mod.rs
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::ptr;
+
+pub fn deinit() {
+    // An unfortunate hack to make sure the linker's dead code stripping doesn't strip our
+    // `Info.plist`.
+    unsafe {
+        ptr::read_volatile(&INFO_PLIST[0]);
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[link_section = "__TEXT,__info_plist"]
+#[no_mangle]
+pub static INFO_PLIST: [u8; 619] = *include_bytes!("Info.plist");
+

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -2,7 +2,7 @@
 name = "embedding"
 version = "0.0.1"
 dependencies = [
- "cocoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "compositing 0.0.1",
  "devtools 0.0.1",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -77,7 +77,7 @@ version = "0.4.5"
 source = "git+https://github.com/servo/rust-azure#a7177c8df81554352bc51de2f5b77cbb47ec2635"
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.1.0 (git+https://github.com/servo/rust-freetype)",
@@ -251,11 +251,11 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "core-graphics"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -380,7 +380,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -678,7 +678,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1941,9 +1941,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2387,7 +2387,7 @@ source = "git+https://github.com/servo/webrender#3a6db793d0a2a1c0e55f78ba2ee8ec2
 dependencies = [
  "app_units 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2410,7 +2410,7 @@ source = "git+https://github.com/servo/webrender_traits#e4cbde9880d118e50de425d3
 dependencies = [
  "app_units 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.3 (git+https://github.com/servo/ipc-channel)",

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -186,6 +186,10 @@ class MachCommands(CommandBase):
 
         if release:
             opts += ["--release"]
+            servo_path = release_path
+        else:
+            servo_path = dev_path
+
         if jobs is not None:
             opts += ["-j", jobs]
         if verbose:
@@ -240,6 +244,20 @@ class MachCommands(CommandBase):
         if sys.platform == "win32" or sys.platform == "msys":
             shutil.copy(path.join(self.get_top_dir(), "components", "servo", "servo.exe.manifest"),
                         path.join(base_path, "debug" if dev else "release"))
+
+        # On the Mac, set a lovely icon. This makes it easier to pick out the Servo binary in tools
+        # like Instruments.app.
+        if sys.platform == "darwin":
+            try:
+                import Cocoa
+                icon_path = path.join(self.get_top_dir(), "resources", "servo.png")
+                icon = Cocoa.NSImage.alloc().initWithContentsOfFile_(icon_path)
+                if icon is not None:
+                    Cocoa.NSWorkspace.sharedWorkspace().setIcon_forFile_options_(icon,
+                                                                                 servo_path,
+                                                                                 0)
+            except ImportError:
+                pass
 
         # Generate Desktop Notification if elapsed-time > some threshold value
         notify_build_done(elapsed)

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -41,6 +41,9 @@ ignored_files = [
     os.path.join(".", "tests", "wpt", "metadata", "MANIFEST.json"),
     os.path.join(".", "tests", "wpt", "metadata-css", "MANIFEST.json"),
     os.path.join(".", "components", "script", "dom", "webidls", "ForceTouchEvent.webidl"),
+    # FIXME(pcwalton, #11679): This is a workaround for a tidy error on the quoted string
+    # `"__TEXT,_info_plist"` inside an attribute.
+    os.path.join(".", "components", "servo", "platform", "macos", "mod.rs"),
     # Hidden files
     os.path.join(".", "."),
 ]


### PR DESCRIPTION
Discrete GPUs cause power use problems and tend to perform badly
with WebRender.

See:
- https://developer.apple.com/library/mac/qa/qa1734/_index.html
- https://reverse.put.as/2013/05/28/gimmedebugah-how-to-embedded-a-info-plist-into-arbitrary-binaries/

r? @metajack

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11646)

<!-- Reviewable:end -->
