### PR TITLE
Fixed issue #11651 (Do not fire a blur event when calling .focus() on…

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -598,25 +598,27 @@ impl Document {
     /// Reassign the focus context to the element that last requested focus during this
     /// transaction, or none if no elements requested it.
     pub fn commit_focus_transaction(&self, focus_type: FocusType) {
-        if let Some(ref elem) = self.focused.get() {
-            let node = elem.upcast::<Node>();
-            elem.set_focus_state(false);
-            // FIXME: pass appropriate relatedTarget
-            self.fire_focus_event(FocusEventType::Blur, node, None);
-        }
+        if self.focused != self.possibly_focused.get().r() {
+            if let Some(ref elem) = self.focused.get() {
+                let node = elem.upcast::<Node>();
+                elem.set_focus_state(false);
+                // FIXME: pass appropriate relatedTarget
+                self.fire_focus_event(FocusEventType::Blur, node, None);
+            }
 
-        self.focused.set(self.possibly_focused.get().r());
+            self.focused.set(self.possibly_focused.get().r());
 
-        if let Some(ref elem) = self.focused.get() {
-            elem.set_focus_state(true);
-            let node = elem.upcast::<Node>();
-            // FIXME: pass appropriate relatedTarget
-            self.fire_focus_event(FocusEventType::Focus, node, None);
-            // Update the focus state for all elements in the focus chain.
-            // https://html.spec.whatwg.org/multipage/#focus-chain
-            if focus_type == FocusType::Element {
-                let event = ConstellationMsg::Focus(self.window.pipeline());
-                self.window.constellation_chan().send(event).unwrap();
+            if let Some(ref elem) = self.focused.get() {
+                elem.set_focus_state(true);
+                let node = elem.upcast::<Node>();
+                // FIXME: pass appropriate relatedTarget
+                self.fire_focus_event(FocusEventType::Focus, node, None);
+                // Update the focus state for all elements in the focus chain.
+                // https://html.spec.whatwg.org/multipage/#focus-chain
+                if focus_type == FocusType::Element {
+                    let event = ConstellationMsg::Focus(self.window.pipeline());
+                    self.window.constellation_chan().send(event).unwrap();
+                }
             }
         }
     }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -251,9 +251,6 @@ impl HTMLElementMethods for HTMLElement {
     fn Focus(&self) {
         // TODO: Mark the element as locked for focus and run the focusing steps.
         // https://html.spec.whatwg.org/multipage/#focusing-steps
-        if self.upcast::<Element>().focus_state() {
-            return;
-        }
         let document = document_from_node(self);
         document.begin_focus_transaction();
         document.request_focus(self.upcast());

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -251,6 +251,9 @@ impl HTMLElementMethods for HTMLElement {
     fn Focus(&self) {
         // TODO: Mark the element as locked for focus and run the focusing steps.
         // https://html.spec.whatwg.org/multipage/#focusing-steps
+        if self.upcast::<Element>().focus_state() {
+            return;
+        }
         let document = document_from_node(self);
         document.begin_focus_transaction();
         document.request_focus(self.upcast());


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Added check in `HTMLElement.Focus` to avoid requesting focus when the element already has it.
Added check in `Document.commit_focus_transaction` to avoid sending `blur` and `focus` events when clicking on an already focused element.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11651

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11665)

<!-- Reviewable:end -->
