### PR TITLE
Added tests for cross-origin iframe parentage.

### DIFF
--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -36042,6 +36042,12 @@
             "url": "/html/semantics/embedded-content/the-iframe-element/change_parentage.html"
           }
         ],
+        "html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html": [
+          {
+            "path": "html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html",
+            "url": "/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html"
+          }
+        ],
         "html/semantics/embedded-content/the-iframe-element/same_origin_parentage.html": [
           {
             "path": "html/semantics/embedded-content/the-iframe-element/same_origin_parentage.html",

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html.ini
@@ -1,0 +1,6 @@
+[cross_origin_parentage.html]
+  type: testharness
+  [Check the frame heriarchy 1]
+    expected: FAIL
+  [Check the frame heriarchy 2]
+    expected: FAIL

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross_origin_child.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross_origin_child.html
@@ -1,0 +1,12 @@
+<script src="iframe_harness.js"></script>
+<body>
+  <iframe src="cross_origin_grandchild.html"></iframe>
+</body>
+<script>
+    send_test_results({
+        "id": '79a52de8-4222-427e-92db-caec28e75f8e',
+        "parent": window.parent !== window,
+        "grandparent": window.parent.parent === window.parent,
+        "top": window.top === window.parent,
+    });
+</script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross_origin_grandchild.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross_origin_grandchild.html
@@ -1,0 +1,11 @@
+<script src="iframe_harness.js"></script>
+<body>
+</body>
+<script>
+    send_test_results({
+        "id": '6c8da65d-2c5e-44ef-bb0b-b8b9849aab19',
+        "parent": window.parent !== window,
+        "grandparent": window.parent.parent !== window.parent,
+        "top": window.top === window.parent.parent,
+    });
+</script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Check the frame heriarchy</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="iframe_harness.js"></script>
+<body>
+  <iframe src="http://www1.web-platform.test:8000/html/semantics/embedded-content/the-iframe-element/cross_origin_child.html"></iframe>
+</body>
+<script>
+    get_test_results('bffa23ee-b45a-4e9a-9405-87ab437d5cfa');
+    get_test_results('79a52de8-4222-427e-92db-caec28e75f8e');
+    get_test_results('6c8da65d-2c5e-44ef-bb0b-b8b9849aab19');
+    send_test_results({
+        "id": 'bffa23ee-b45a-4e9a-9405-87ab437d5cfa',
+        "parent": window.parent === window,
+        "top": window.top === window,
+    });
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Added (currently failing) tests for cross-origin iframe parentage.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11478
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11666)

<!-- Reviewable:end -->
