### PR TITLE
Android basedir

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1336,7 +1336,7 @@ version = "0.0.0"
 source = "git+https://github.com/servo/mozjs#2af5849a97a9f18acd482940ba3fa0c6797ed7eb"
 dependencies = [
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/util/Cargo.toml
+++ b/components/util/Cargo.toml
@@ -31,7 +31,7 @@ serde_macros = "0.7"
 smallvec = "0.1"
 url = {version = "1.0.0", features = ["heap_size", "serde"]}
 
-[target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios")))'.dependencies]
+[target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
 xdg = "2.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/components/util/basedir.rs
+++ b/components/util/basedir.rs
@@ -9,28 +9,43 @@
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::env;
 use std::path::PathBuf;
-#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios")))]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
 use xdg;
 
-#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios")))]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
 pub fn default_config_dir() -> Option<PathBuf> {
     let xdg_dirs = xdg::BaseDirectories::with_profile("servo", "default").unwrap();
     let config_dir = xdg_dirs.get_config_home();
     Some(config_dir)
 }
 
-#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios")))]
+#[cfg(target_os = "android")]
+pub fn default_config_dir() -> Option<PathBuf> {
+    Some(PathBuf::from("/sdcard/servo"))
+}
+
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
 pub fn default_data_dir() -> Option<PathBuf> {
     let xdg_dirs = xdg::BaseDirectories::with_profile("servo", "default").unwrap();
     let data_dir = xdg_dirs.get_data_home();
     Some(data_dir)
 }
 
-#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios")))]
+#[cfg(target_os = "android")]
+pub fn default_data_dir() -> Option<PathBuf> {
+    Some(PathBuf::from("/sdcard/servo"))
+}
+
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
 pub fn default_cache_dir() -> Option<PathBuf> {
     let xdg_dirs = xdg::BaseDirectories::with_profile("servo", "default").unwrap();
     let cache_dir = xdg_dirs.get_cache_home();
     Some(cache_dir)
+}
+
+#[cfg(target_os = "android")]
+pub fn default_cache_dir() -> Option<PathBuf> {
+    Some(PathBuf::from("/sdcard/servo"))
 }
 
 #[cfg(target_os = "macos")]

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -37,7 +37,7 @@ extern crate rustc_serialize;
 extern crate serde;
 extern crate smallvec;
 extern crate url;
-#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios")))]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
 extern crate xdg;
 
 use std::sync::Arc;

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1242,7 +1242,7 @@ version = "0.0.0"
 source = "git+https://github.com/servo/mozjs#2af5849a97a9f18acd482940ba3fa0c6797ed7eb"
 dependencies = [
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/support/android/apk/build.xml
+++ b/support/android/apk/build.xml
@@ -36,9 +36,17 @@
     <condition property="sdk.dir" value="${env.ANDROID_HOME}">
         <isset property="env.ANDROID_HOME" />
     </condition>
-    <condition property="target" value="${env.ANDROID_PLATFORM}">
-        <isset property="env.ANDROID_PLATFORM" />
-    </condition>
+
+    <!-- The project.properties file is created and updated by the 'android'
+         tool, as well as ADT.
+
+         This contains project specific properties such as project target, and library
+         dependencies. Lower level build properties are stored in ant.properties
+         (or in .classpath for Eclipse projects).
+
+         This file is an integral part of the build system for your
+         application and should be checked into Version Control Systems. -->
+    <loadproperties srcFile="project.properties" />
 
     <!-- quick check on sdk.dir -->
     <fail


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This fixes #11633, as when the new basedir stuff that uses xdg was added, it did not preserve the previous Android behavior, which used `/sdcard/servo`. Obviously, long-term we should be calling into the Android runtime to determine the per-run installation path and be both unpacking and loading resources from there, but this restores the previous behavior.

r? @mbrubeck 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #11633 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [x] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11687)

<!-- Reviewable:end -->
