### PR TITLE
Added test for whether only fully active documents contribute to the joint session history

### DIFF
--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -266,6 +266,10 @@
         "url": "/html-media-capture/capture_video_cancel-manual.html"
       },
       {
+        "path": "html/browsers/history/joint-session-history/joint-session-history-only-fully-active.html",
+        "url": "/html/browsers/history/joint-session-history/joint-session-history-only-fully-active.html"
+      },
+      {
         "path": "html/browsers/history/the-history-interface/non-automated/traverse_the_history_unload_prompt_1-manual.html",
         "url": "/html/browsers/history/the-history-interface/non-automated/traverse_the_history_unload_prompt_1-manual.html"
       },
@@ -36034,6 +36038,12 @@
           {
             "path": "cssom-view/scrolling-no-browsing-context.html",
             "url": "/cssom-view/scrolling-no-browsing-context.html"
+          }
+        ],
+        "html/browsers/history/joint-session-history/joint-session-history-only-fully-active.html": [
+          {
+            "path": "html/browsers/history/joint-session-history/joint-session-history-only-fully-active.html",
+            "url": "/html/browsers/history/joint-session-history/joint-session-history-only-fully-active.html"
           }
         ],
         "html/semantics/embedded-content/the-iframe-element/change_parentage.html": [

--- a/tests/wpt/metadata/html/browsers/history/joint-session-history/joint-session-history-only-fully-active.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/joint-session-history/joint-session-history-only-fully-active.html.ini
@@ -1,0 +1,4 @@
+[joint-session-history-only-fully-active.html]
+  type: testharness
+  [Do only fully active documents count for session history?]
+    expected: FAIL

--- a/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-child1.html
+++ b/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-child1.html
@@ -1,0 +1,18 @@
+<body>
+  <a id="link" href="joint-session-history-child2.html">Child1</a>.
+  <iframe id="grandchild"></iframe>
+</body>
+<script>
+  window.onload = function() {
+    var link = document.getElementById("link");
+    var grandchild = document.getElementById("grandchild");
+    var timer = window.setInterval(poll, 100);
+    function poll() {
+      if (grandchild.getAttribute("data-grandchild-loaded")) {
+        window.clearInterval(timer);
+        link.click();
+      }
+    }
+    grandchild.src="joint-session-history-grandchild1.html";
+  };
+</script>

--- a/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-child2.html
+++ b/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-child2.html
@@ -1,0 +1,5 @@
+<body>Child 2.</body>
+<script>
+  // Servo doesn't support postMessage yet, so we poll on attributes.
+  window.frameElement.setAttribute("data-child-loaded", true);
+</script>

--- a/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-grandchild1.html
+++ b/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-grandchild1.html
@@ -1,0 +1,8 @@
+<body>
+  <a id="link" href="joint-session-history-grandchild2.html">Grandchild1</a>.
+</body>
+<script>
+  window.onload = function() {
+    document.getElementById("link").click();
+  }
+</script>

--- a/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-grandchild2.html
+++ b/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-grandchild2.html
@@ -1,0 +1,5 @@
+<body>Grandchild2.</body>
+<script>
+  // Servo doesn't support postMessage yet, so we poll on attributes.
+  window.frameElement.setAttribute("data-grandchild-loaded", true);
+</script>

--- a/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-only-fully-active.html
+++ b/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-only-fully-active.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Do only fully active documents count for session history?</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <iframe id="child"></iframe>
+</body>
+<script>
+  async_test(function(t) {
+    var old_history_len = window.history.length;
+    var child = document.getElementById("child");
+    var timer = window.setInterval(t.step_func(poll), 100);
+    function poll() {
+      if (child.getAttribute("data-child-loaded")) {
+        // Check to see how many entries have been added to the session history.
+        // The spec https://html.spec.whatwg.org/multipage/#joint-session-history
+        // says that only fully active documents are included in the joint session history.
+        // If only fully active documents count, then the only fully active document
+        // is the child, with session length 1, so the joint session length change will be 1.
+        // If all documents count, then the grandchild is reachable via the session history,
+        // and it has session length 1, so the joint session length change will be 2.
+        assert_equals(2, window.history.length - old_history_len);
+        window.clearInterval(timer);
+        t.done();
+      }
+    }
+    child.src = "joint-session-history-child1.html";
+  });
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The spec https://html.spec.whatwg.org/multipage/#joint-session-history says that only fully active documents contribute to the joint session history, but this appears not to be what's implemented.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11690)

<!-- Reviewable:end -->
