### PR TITLE
Add very simple Android browser page load support

### DIFF
--- a/resources/android_params
+++ b/resources/android_params
@@ -6,4 +6,5 @@
 # lines (the "-p" and "10" are separate even though they are related).
 
 servo
+-w
 http://en.wikipedia.org/wiki/Rust

--- a/support/android/apk/AndroidManifest.xml
+++ b/support/android/apk/AndroidManifest.xml
@@ -20,6 +20,28 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Web browser intents -->
+            <intent-filter>
+              <action android:name="android.intent.action.VIEW" />
+              <category android:name="android.intent.category.DEFAULT" />
+              <category android:name="android.intent.category.BROWSABLE" />
+              <data android:scheme="http" />
+              <data android:scheme="https" />
+              <data android:scheme="data" />
+              <data android:scheme="javascript" />
+            </intent-filter>
+            <intent-filter>
+              <action android:name="android.intent.action.VIEW" />
+              <category android:name="android.intent.category.DEFAULT" />
+              <category android:name="android.intent.category.BROWSABLE" />
+              <data android:scheme="file" />
+              <data android:scheme="http" />
+              <data android:scheme="https" />
+              <data android:mimeType="text/html"/>
+              <data android:mimeType="text/plain"/>
+              <data android:mimeType="application/xhtml+xml"/>
+            </intent-filter>
         </activity>
     </application>
 

--- a/support/android/apk/src/com/mozilla/servo/MainActivity.java
+++ b/support/android/apk/src/com/mozilla/servo/MainActivity.java
@@ -1,8 +1,64 @@
 package com.mozilla.servo;
+import android.app.NativeActivity;
+import android.content.Intent;
+import android.os.Bundle;
 import android.util.Log;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.lang.System;
+
 
 public class MainActivity extends android.app.NativeActivity {
+    private static final String LOGTAG="servo_wrapper";
     static {
-        Log.i("servo_wrapper", "Loading the NativeActivity");
+        Log.i(LOGTAG, "Loading the NativeActivity");
+    }
+
+    private void set_url(String url) {
+        try {
+            PrintStream out = new PrintStream(new FileOutputStream("/sdcard/servo/android_params"));
+            out.println("# The first line here should be the \"servo\" argument (without quotes) and the");
+            out.println("# last should be the URL to load.");
+            out.println("# Blank lines and those beginning with a '#' are ignored.");
+            out.println("# Each line should be a separate parameter as would be parsed by the shell.");
+            out.println("# For example, \"servo -p 10 http://en.wikipedia.org/wiki/Rust\" would take 4");
+            out.println("# lines (the \"-p\" and \"10\" are separate even though they are related).");
+            out.println("servo");
+            out.println("-w");
+            String absUrl = url.replace("file:///storage/emulated/0/", "/sdcard/");
+            out.println(absUrl);
+            out.flush();
+            out.close();
+        } catch (FileNotFoundException e) {
+        }
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        final Intent intent = getIntent();
+        if (intent.getAction().equals(Intent.ACTION_VIEW)) {
+            final String url = intent.getDataString();
+            Log.d(LOGTAG, "Received url "+url);
+            set_url(url);
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();  // Always call the superclass method first
+
+        Log.d(LOGTAG, "got onStop; finishing servo activity");
+        finish();
+
+        // Glutin and the Java wrapper libraries that we use currently do not support restoring
+        // Servo after Android has sent it to the background, as the resources were reclaimed.
+        // Until we either address that in glutin or move to a library that supports recreating
+        // the native resources after being restored, we just forcibly shut Servo down when it
+        // is sent to the background.
+        int pid = android.os.Process.myPid();
+        android.os.Process.killProcess(pid);
+        System.exit(0);
     }
 }


### PR DESCRIPTION
I've long had this set of private patches that enables actually demoing Servo on Android without having the device connected, but they're a bit hackish due to some current limitations in our windowing toolkit library. I'm considering committing them, though, as it makes the resulting APK _actually_ somewhat usable.

Thoughts / r? @mbrubeck

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11691)

<!-- Reviewable:end -->
