### PR TITLE
Add a default Accept-Language header to HTTP requests.

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -13,9 +13,10 @@ use devtools_traits::{HttpResponse as DevtoolsHttpResponse, NetworkEvent};
 use flate2::read::{DeflateDecoder, GzDecoder};
 use hsts::{HstsEntry, HstsList, secure_url};
 use hyper::Error as HttpError;
+use hyper::LanguageTag;
 use hyper::client::{Pool, Request, Response};
 use hyper::header::{Accept, AcceptEncoding, ContentLength, ContentEncoding, ContentType, Host, Referer};
-use hyper::header::{Authorization, Basic};
+use hyper::header::{Authorization, AcceptLanguage, Basic};
 use hyper::header::{Encoding, Header, Headers, Quality, QualityItem};
 use hyper::header::{Location, SetCookie, StrictTransportSecurity, UserAgent, qitem};
 use hyper::http::RawStatus;
@@ -389,6 +390,22 @@ fn set_default_accept(headers: &mut Headers) {
     }
 }
 
+fn set_default_accept_language(headers: &mut Headers) {
+    if headers.has::<AcceptLanguage>() {
+        return;
+    }
+
+    let mut en_us: LanguageTag = Default::default();
+    en_us.language = Some("en".to_owned());
+    en_us.region = Some("US".to_owned());
+    let mut en: LanguageTag = Default::default();
+    en.language = Some("en".to_owned());
+    headers.set(AcceptLanguage(vec![
+        qitem(en_us),
+        QualityItem::new(en, Quality(500)),
+    ]));
+}
+
 /// https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-state-no-referrer-when-downgrade
 fn no_ref_when_downgrade_header(referrer_url: Url, url: Url) -> Option<Url> {
     if referrer_url.scheme() == "https" && url.scheme() != "https" {
@@ -616,6 +633,7 @@ pub fn modify_request_headers(headers: &mut Headers,
     }
 
     set_default_accept(headers);
+    set_default_accept_language(headers);
     set_default_accept_encoding(headers);
 
     *referrer_url = determine_request_referrer(headers,

--- a/tests/unit/net/http_loader.rs
+++ b/tests/unit/net/http_loader.rs
@@ -9,8 +9,9 @@ use devtools_traits::HttpResponse as DevtoolsHttpResponse;
 use devtools_traits::{ChromeToDevtoolsControlMsg, DevtoolsControlMsg, NetworkEvent};
 use flate2::Compression;
 use flate2::write::{GzEncoder, DeflateEncoder};
+use hyper::LanguageTag;
 use hyper::header::{Accept, AcceptEncoding, ContentEncoding, ContentLength, Cookie as CookieHeader};
-use hyper::header::{Authorization, Basic};
+use hyper::header::{Authorization, AcceptLanguage, Basic};
 use hyper::header::{Encoding, Headers, Host, Location, Quality, QualityItem, qitem, Referer, SetCookie};
 use hyper::header::{StrictTransportSecurity, UserAgent};
 use hyper::http::RawStatus;
@@ -393,10 +394,13 @@ fn test_check_default_headers_loaded_in_every_request() {
     load_data.method = Method::Get;
 
     let mut headers = Headers::new();
+
     headers.set(AcceptEncoding(vec![qitem(Encoding::Gzip),
                                     qitem(Encoding::Deflate),
                                     qitem(Encoding::EncodingExt("br".to_owned()))]));
+
     headers.set(Host { hostname: "mozilla.com".to_owned() , port: None });
+
     let accept = Accept(vec![
                             qitem(Mime(TopLevel::Text, SubLevel::Html, vec![])),
                             qitem(Mime(TopLevel::Application, SubLevel::Ext("xhtml+xml".to_owned()), vec![])),
@@ -404,6 +408,17 @@ fn test_check_default_headers_loaded_in_every_request() {
                             QualityItem::new(Mime(TopLevel::Star, SubLevel::Star, vec![]), Quality(800u16)),
                             ]);
     headers.set(accept);
+
+    let mut en_us: LanguageTag = Default::default();
+    en_us.language = Some("en".to_owned());
+    en_us.region = Some("US".to_owned());
+    let mut en: LanguageTag = Default::default();
+    en.language = Some("en".to_owned());
+    headers.set(AcceptLanguage(vec![
+        qitem(en_us),
+        QualityItem::new(en, Quality(500)),
+    ]));
+
     headers.set(UserAgent(DEFAULT_USER_AGENT.to_owned()));
 
     // Testing for method.GET
@@ -483,12 +498,15 @@ fn test_request_and_response_data_with_network_messages() {
 
     //Creating default headers for request
     let mut headers = Headers::new();
+
     headers.set(AcceptEncoding(vec![
                                    qitem(Encoding::Gzip),
                                    qitem(Encoding::Deflate),
                                    qitem(Encoding::EncodingExt("br".to_owned()))
                                    ]));
+
     headers.set(Host { hostname: "mozilla.com".to_owned() , port: None });
+
     let accept = Accept(vec![
                             qitem(Mime(TopLevel::Text, SubLevel::Html, vec![])),
                             qitem(Mime(TopLevel::Application, SubLevel::Ext("xhtml+xml".to_owned()), vec![])),
@@ -496,7 +514,19 @@ fn test_request_and_response_data_with_network_messages() {
                             QualityItem::new(Mime(TopLevel::Star, SubLevel::Star, vec![]), Quality(800u16)),
                             ]);
     headers.set(accept);
+
+    let mut en_us: LanguageTag = Default::default();
+    en_us.language = Some("en".to_owned());
+    en_us.region = Some("US".to_owned());
+    let mut en: LanguageTag = Default::default();
+    en.language = Some("en".to_owned());
+    headers.set(AcceptLanguage(vec![
+        qitem(en_us),
+        QualityItem::new(en, Quality(500)),
+    ]));
+
     headers.set(UserAgent(DEFAULT_USER_AGENT.to_owned()));
+
     let httprequest = DevtoolsHttpRequest {
         url: url,
         method: Method::Get,

--- a/tests/wpt/metadata/XMLHttpRequest/send-accept-language.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-accept-language.htm.ini
@@ -1,5 +1,0 @@
-[send-accept-language.htm]
-  type: testharness
-  [Send "sensible" default value, whatever that means]
-    expected: FAIL
-


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11008
- [X] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11692)

<!-- Reviewable:end -->
