### PR TITLE
Excise SubpageId and use only PipelineIds

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -825,7 +825,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             }
             FromScriptMsg::ScriptLoadedURLInIFrame(load_info) => {
                 debug!("constellation got iframe URL load message {:?} {:?} {:?}",
-                       load_info.containing_pipeline_id,
+                       load_info.parent_pipeline_id,
                        load_info.old_subpage_id,
                        load_info.new_subpage_id);
                 self.handle_script_loaded_url_in_iframe_msg(load_info);
@@ -1227,20 +1227,20 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
 
     // The script thread associated with pipeline_id has loaded a URL in an iframe via script. This
     // will result in a new pipeline being spawned and a frame tree being added to
-    // containing_page_pipeline_id's frame tree's children. This message is never the result of a
+    // parent_pipeline_id's frame tree's children. This message is never the result of a
     // page navigation.
     fn handle_script_loaded_url_in_iframe_msg(&mut self, load_info: IFrameLoadInfo) {
         let old_pipeline_id = load_info.old_subpage_id
-            .and_then(|old_subpage_id| self.subpage_map.get(&(load_info.containing_pipeline_id, old_subpage_id)))
+            .and_then(|old_subpage_id| self.subpage_map.get(&(load_info.parent_pipeline_id, old_subpage_id)))
             .cloned();
 
         let (load_data, script_chan, window_size, is_private) = {
             let old_pipeline = old_pipeline_id
                 .and_then(|old_pipeline_id| self.pipelines.get(&old_pipeline_id));
 
-            let source_pipeline =  match self.pipelines.get(&load_info.containing_pipeline_id) {
+            let source_pipeline =  match self.pipelines.get(&load_info.parent_pipeline_id) {
                 Some(source_pipeline) => source_pipeline,
-                None => return warn!("Script loaded url in closed iframe {}.", load_info.containing_pipeline_id),
+                None => return warn!("Script loaded url in closed iframe {}.", load_info.parent_pipeline_id),
             };
 
             // If no url is specified, reload.
@@ -1290,13 +1290,13 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
 
         // Create the new pipeline, attached to the parent and push to pending frames
         self.new_pipeline(load_info.new_pipeline_id,
-                          Some((load_info.containing_pipeline_id, load_info.new_subpage_id, load_info.frame_type)),
+                          Some((load_info.parent_pipeline_id, load_info.new_subpage_id, load_info.frame_type)),
                           window_size,
                           script_chan,
                           load_data,
                           is_private);
 
-        self.subpage_map.insert((load_info.containing_pipeline_id, load_info.new_subpage_id),
+        self.subpage_map.insert((load_info.parent_pipeline_id, load_info.new_subpage_id),
                                 load_info.new_pipeline_id);
 
         self.push_pending_frame(load_info.new_pipeline_id, old_pipeline_id);
@@ -1585,7 +1585,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
     }
 
     fn handle_mozbrowser_event_msg(&mut self,
-                                   containing_pipeline_id: PipelineId,
+                                   parent_pipeline_id: PipelineId,
                                    subpage_id: Option<SubpageId>,
                                    event: MozBrowserEvent) {
         assert!(PREFS.is_mozbrowser_enabled());
@@ -1594,9 +1594,9 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         // and pass the event to that script thread.
         // If the pipeline lookup fails, it is because we have torn down the pipeline,
         // so it is reasonable to silently ignore the event.
-        match self.pipelines.get(&containing_pipeline_id) {
+        match self.pipelines.get(&parent_pipeline_id) {
             Some(pipeline) => pipeline.trigger_mozbrowser_event(subpage_id, event),
-            None => warn!("Pipeline {:?} handling mozbrowser event after closure.", containing_pipeline_id),
+            None => warn!("Pipeline {:?} handling mozbrowser event after closure.", parent_pipeline_id),
         }
     }
 
@@ -1630,22 +1630,22 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             Some(pipeline) => pipeline.parent_info,
             None => return warn!("Pipeline {:?} focus parent after closure.", pipeline_id),
         };
-        let (containing_pipeline_id, subpage_id, _) = match parent_info {
+        let (parent_pipeline_id, subpage_id, _) = match parent_info {
             Some(info) => info,
             None => return debug!("Pipeline {:?} focus has no parent.", pipeline_id),
         };
 
         // Send a message to the parent of the provided pipeline (if it exists)
         // telling it to mark the iframe element as focused.
-        let msg = ConstellationControlMsg::FocusIFrame(containing_pipeline_id, subpage_id);
-        let result = match self.pipelines.get(&containing_pipeline_id) {
+        let msg = ConstellationControlMsg::FocusIFrame(parent_pipeline_id, subpage_id);
+        let result = match self.pipelines.get(&parent_pipeline_id) {
             Some(pipeline) => pipeline.script_chan.send(msg),
-            None => return warn!("Pipeline {:?} focus after closure.", containing_pipeline_id),
+            None => return warn!("Pipeline {:?} focus after closure.", parent_pipeline_id),
         };
         if let Err(e) = result {
-            self.handle_send_error(containing_pipeline_id, e);
+            self.handle_send_error(parent_pipeline_id, e);
         }
-        self.focus_parent_pipeline(containing_pipeline_id);
+        self.focus_parent_pipeline(parent_pipeline_id);
     }
 
     fn handle_focus_msg(&mut self, pipeline_id: PipelineId) {
@@ -2415,9 +2415,9 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         };
 
         // If this is a mozbrowser iframe, then send the event with new url
-        if let Some((containing_pipeline_id, subpage_id)) = self.get_mozbrowser_ancestor_info(pipeline_id) {
-            if let Some(parent_pipeline) = self.pipelines.get(&containing_pipeline_id) {
-                let pipeline_id = self.subpage_map.get(&(containing_pipeline_id, subpage_id));
+        if let Some((parent_pipeline_id, subpage_id)) = self.get_mozbrowser_ancestor_info(pipeline_id) {
+            if let Some(parent_pipeline) = self.pipelines.get(&parent_pipeline_id) {
+                let pipeline_id = self.subpage_map.get(&(parent_pipeline_id, subpage_id));
                 if let Some(pipeline) = pipeline_id.and_then(|pipeline_id| self.pipelines.get(pipeline_id)) {
                     if let Some(frame_id) = pipeline.frame {
                         let can_go_forward = !self.joint_session_future(frame_id).is_empty();

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -28,7 +28,7 @@ use log::{Log, LogLevel, LogLevelFilter, LogMetadata, LogRecord};
 use msg::constellation_msg::{FrameId, FrameType, PipelineId};
 use msg::constellation_msg::{Key, KeyModifiers, KeyState, LoadData};
 use msg::constellation_msg::{PipelineNamespace, PipelineNamespaceId, TraversalDirection};
-use msg::constellation_msg::{SubpageId, WindowSizeType};
+use msg::constellation_msg::WindowSizeType;
 use net_traits::{self, IpcSend, ResourceThreads};
 use net_traits::bluetooth_thread::BluetoothMethodMsg;
 use net_traits::image_cache_thread::ImageCacheThread;
@@ -134,9 +134,6 @@ pub struct Constellation<Message, LTF, STF> {
 
     /// A list of all the frames
     frames: HashMap<FrameId, Frame>,
-
-    /// Maps from a (parent pipeline, subpage) to the actual child pipeline ID.
-    subpage_map: HashMap<(PipelineId, SubpageId), PipelineId>,
 
     /// A channel through which messages can be sent to the font cache.
     font_cache_thread: FontCacheThread,
@@ -492,7 +489,6 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                 swmanager_sender: sw_mgr_clone,
                 pipelines: HashMap::new(),
                 frames: HashMap::new(),
-                subpage_map: HashMap::new(),
                 pending_frames: vec!(),
                 next_pipeline_namespace_id: PipelineNamespaceId(0),
                 root_frame_id: None,
@@ -551,7 +547,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
     /// Helper function for creating a pipeline
     fn new_pipeline(&mut self,
                     pipeline_id: PipelineId,
-                    parent_info: Option<(PipelineId, SubpageId, FrameType)>,
+                    parent_info: Option<(PipelineId, FrameType)>,
                     initial_window_size: Option<TypedSize2D<f32, PagePx>>,
                     script_channel: Option<IpcSender<ConstellationControlMsg>>,
                     load_data: LoadData,
@@ -564,7 +560,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             self.public_resource_threads.clone()
         };
 
-        let parent_visibility = if let Some((parent_pipeline_id, _, _)) = parent_info {
+        let parent_visibility = if let Some((parent_pipeline_id, _)) = parent_info {
             self.pipelines.get(&parent_pipeline_id).map(|pipeline| pipeline.visible)
         } else {
             None
@@ -826,8 +822,8 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             FromScriptMsg::ScriptLoadedURLInIFrame(load_info) => {
                 debug!("constellation got iframe URL load message {:?} {:?} {:?}",
                        load_info.parent_pipeline_id,
-                       load_info.old_subpage_id,
-                       load_info.new_subpage_id);
+                       load_info.old_pipeline_id,
+                       load_info.new_pipeline_id);
                 self.handle_script_loaded_url_in_iframe_msg(load_info);
             }
             FromScriptMsg::ChangeRunningAnimationsState(pipeline_id, animation_state) => {
@@ -870,10 +866,10 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                     warn!("constellation got set final url message for dead pipeline");
                 }
             }
-            FromScriptMsg::MozBrowserEvent(pipeline_id, subpage_id, event) => {
+            FromScriptMsg::MozBrowserEvent(parent_pipeline_id, pipeline_id, event) => {
                 debug!("constellation got mozbrowser event message");
-                self.handle_mozbrowser_event_msg(pipeline_id,
-                                                 subpage_id,
+                self.handle_mozbrowser_event_msg(parent_pipeline_id,
+                                                 pipeline_id,
                                                  event);
             }
             FromScriptMsg::Focus(pipeline_id) => {
@@ -1230,12 +1226,8 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
     // parent_pipeline_id's frame tree's children. This message is never the result of a
     // page navigation.
     fn handle_script_loaded_url_in_iframe_msg(&mut self, load_info: IFrameLoadInfo) {
-        let old_pipeline_id = load_info.old_subpage_id
-            .and_then(|old_subpage_id| self.subpage_map.get(&(load_info.parent_pipeline_id, old_subpage_id)))
-            .cloned();
-
         let (load_data, script_chan, window_size, is_private) = {
-            let old_pipeline = old_pipeline_id
+            let old_pipeline = load_info.old_pipeline_id
                 .and_then(|old_pipeline_id| self.pipelines.get(&old_pipeline_id));
 
             let source_pipeline =  match self.pipelines.get(&load_info.parent_pipeline_id) {
@@ -1290,16 +1282,13 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
 
         // Create the new pipeline, attached to the parent and push to pending frames
         self.new_pipeline(load_info.new_pipeline_id,
-                          Some((load_info.parent_pipeline_id, load_info.new_subpage_id, load_info.frame_type)),
+                          Some((load_info.parent_pipeline_id, load_info.frame_type)),
                           window_size,
                           script_chan,
                           load_data,
                           is_private);
 
-        self.subpage_map.insert((load_info.parent_pipeline_id, load_info.new_subpage_id),
-                                load_info.new_pipeline_id);
-
-        self.push_pending_frame(load_info.new_pipeline_id, old_pipeline_id);
+        self.push_pending_frame(load_info.new_pipeline_id, load_info.old_pipeline_id);
     }
 
     fn handle_set_cursor_msg(&mut self, cursor: Cursor) {
@@ -1347,14 +1336,14 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                     .map(|root_frame| root_frame.current.pipeline_id);
 
                 let ancestor_info = self.get_mozbrowser_ancestor_info(pipeline_id);
-                if let Some((ancestor_id, subpage_id)) = ancestor_info {
+                if let Some((ancestor_id, mozbrowser_iframe_id)) = ancestor_info {
                     if root_pipeline_id == Some(ancestor_id) {
                         match root_pipeline_id.and_then(|pipeline_id| self.pipelines.get(&pipeline_id)) {
                             Some(root_pipeline) => {
                                 // https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsershowmodalprompt
                                 let event = MozBrowserEvent::ShowModalPrompt("alert".to_owned(), "Alert".to_owned(),
                                                                              String::from(message), "".to_owned());
-                                root_pipeline.trigger_mozbrowser_event(Some(subpage_id), event);
+                                root_pipeline.trigger_mozbrowser_event(Some(mozbrowser_iframe_id), event);
                             }
                             None => return warn!("Alert sent to Pipeline {:?} after closure.", root_pipeline_id),
                         }
@@ -1387,11 +1376,11 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         // requested change so it can update its internal state.
         let parent_info = self.pipelines.get(&source_id).and_then(|source| source.parent_info);
         match parent_info {
-            Some((parent_pipeline_id, subpage_id, _)) => {
+            Some((parent_pipeline_id, _)) => {
                 self.handle_load_start_msg(source_id);
                 // Message the constellation to find the script thread for this iframe
                 // and issue an iframe load through there.
-                let msg = ConstellationControlMsg::Navigate(parent_pipeline_id, subpage_id, load_data);
+                let msg = ConstellationControlMsg::Navigate(parent_pipeline_id, source_id, load_data);
                 let result = match self.pipelines.get(&parent_pipeline_id) {
                     Some(parent_pipeline) => parent_pipeline.script_chan.send(msg),
                     None => {
@@ -1586,7 +1575,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
 
     fn handle_mozbrowser_event_msg(&mut self,
                                    parent_pipeline_id: PipelineId,
-                                   subpage_id: Option<SubpageId>,
+                                   pipeline_id: Option<PipelineId>,
                                    event: MozBrowserEvent) {
         assert!(PREFS.is_mozbrowser_enabled());
 
@@ -1595,7 +1584,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         // If the pipeline lookup fails, it is because we have torn down the pipeline,
         // so it is reasonable to silently ignore the event.
         match self.pipelines.get(&parent_pipeline_id) {
-            Some(pipeline) => pipeline.trigger_mozbrowser_event(subpage_id, event),
+            Some(pipeline) => pipeline.trigger_mozbrowser_event(pipeline_id, event),
             None => warn!("Pipeline {:?} handling mozbrowser event after closure.", parent_pipeline_id),
         }
     }
@@ -1630,14 +1619,14 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             Some(pipeline) => pipeline.parent_info,
             None => return warn!("Pipeline {:?} focus parent after closure.", pipeline_id),
         };
-        let (parent_pipeline_id, subpage_id, _) = match parent_info {
+        let (parent_pipeline_id, _) = match parent_info {
             Some(info) => info,
             None => return debug!("Pipeline {:?} focus has no parent.", pipeline_id),
         };
 
         // Send a message to the parent of the provided pipeline (if it exists)
         // telling it to mark the iframe element as focused.
-        let msg = ConstellationControlMsg::FocusIFrame(parent_pipeline_id, subpage_id);
+        let msg = ConstellationControlMsg::FocusIFrame(parent_pipeline_id, pipeline_id);
         let result = match self.pipelines.get(&parent_pipeline_id) {
             Some(pipeline) => pipeline.script_chan.send(msg),
             None => return warn!("Pipeline {:?} focus after closure.", parent_pipeline_id),
@@ -1685,7 +1674,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
 
     fn handle_visibility_change_complete(&mut self, pipeline_id: PipelineId, visibility: bool) {
         let parent_pipeline_info = self.pipelines.get(&pipeline_id).and_then(|source| source.parent_info);
-        if let Some((parent_pipeline_id, _, _)) = parent_pipeline_info {
+        if let Some((parent_pipeline_id, _)) = parent_pipeline_info {
             let visibility_msg = ConstellationControlMsg::NotifyVisibilityChange(parent_pipeline_id,
                                                                                  pipeline_id,
                                                                                  visibility);
@@ -1855,20 +1844,12 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         self.revoke_paint_permission(prev_pipeline_id);
         self.send_frame_tree_and_grant_paint_permission();
 
-        // Update the owning iframe to point to the new subpage id.
+        // Update the owning iframe to point to the new pipeline id.
         // This makes things like contentDocument work correctly.
-        if let Some((parent_pipeline_id, subpage_id, _)) = pipeline_info {
-            let new_subpage_id = match self.pipelines.get(&next_pipeline_id) {
-                None => return warn!("Pipeline {:?} traversed to after closure.", next_pipeline_id),
-                Some(pipeline) => match pipeline.parent_info {
-                    None => return warn!("Pipeline {:?} has no parent info.", next_pipeline_id),
-                    Some((_, new_subpage_id, _)) => new_subpage_id,
-                },
-            };
-            let msg = ConstellationControlMsg::UpdateSubpageId(parent_pipeline_id,
-                                                               subpage_id,
-                                                               new_subpage_id,
-                                                               next_pipeline_id);
+        if let Some((parent_pipeline_id, _)) = pipeline_info {
+            let msg = ConstellationControlMsg::UpdatePipelineId(parent_pipeline_id,
+                                                                prev_pipeline_id,
+                                                                next_pipeline_id);
             let result = match self.pipelines.get(&parent_pipeline_id) {
                 None => return warn!("Pipeline {:?} child traversed after closure.", parent_pipeline_id),
                 Some(pipeline) => pipeline.script_chan.send(msg),
@@ -1886,8 +1867,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
     fn get_top_level_frame_for_pipeline(&self, pipeline_id: Option<PipelineId>) -> Option<FrameId> {
         if PREFS.is_mozbrowser_enabled() {
             pipeline_id.and_then(|id| self.get_mozbrowser_ancestor_info(id))
-                       .and_then(|info| self.subpage_map.get(&info))
-                       .and_then(|pipeline_id| self.pipelines.get(&pipeline_id))
+                       .and_then(|pipeline_info| self.pipelines.get(&pipeline_info.1))
                        .and_then(|pipeline| pipeline.frame)
                        .or(self.root_frame_id)
         } else {
@@ -1940,7 +1920,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             // If a child frame, add it to the parent pipeline. Otherwise
             // it must surely be the root frame being created!
             match self.pipelines.get(&frame_change.new_pipeline_id).and_then(|pipeline| pipeline.parent_info) {
-                Some((parent_id, _, _)) => {
+                Some((parent_id, _)) => {
                     if let Some(parent) = self.pipelines.get_mut(&parent_id) {
                         parent.add_child(frame_id);
                     }
@@ -1976,7 +1956,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                     let _ = parent_pipeline.script_chan
                                            .send(ConstellationControlMsg::FramedContentChanged(
                                                parent_info.0,
-                                               parent_info.1));
+                                               pipeline_id));
                 }
             }
         }
@@ -2250,7 +2230,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             warn!("Closing frame {:?} twice.", frame_id);
         }
 
-        if let Some((parent_pipeline_id, _, _)) = parent_info {
+        if let Some((parent_pipeline_id, _)) = parent_info {
             let parent_pipeline = match self.pipelines.get_mut(&parent_pipeline_id) {
                 None => return warn!("Pipeline {:?} child closed after parent.", parent_pipeline_id),
                 Some(parent_pipeline) => parent_pipeline,
@@ -2285,10 +2265,6 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             None => return warn!("Closing pipeline {:?} twice.", pipeline_id),
         };
 
-        // If a child pipeline, remove from subpage map
-        if let Some((parent_id, subpage_id, _)) = pipeline.parent_info {
-            self.subpage_map.remove(&(parent_id, subpage_id));
-        }
 
         // Remove assocation between this pipeline and its holding frame
         pipeline.frame = None;
@@ -2388,12 +2364,13 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
 
     /// For a given pipeline, determine the mozbrowser iframe that transitively contains
     /// it. There could be arbitrary levels of nested iframes in between them.
-    fn get_mozbrowser_ancestor_info(&self, mut pipeline_id: PipelineId) -> Option<(PipelineId, SubpageId)> {
+    fn get_mozbrowser_ancestor_info(&self, original_pipeline_id: PipelineId) -> Option<(PipelineId, PipelineId)> {
+        let mut pipeline_id = original_pipeline_id;
         loop {
             match self.pipelines.get(&pipeline_id) {
                 Some(pipeline) => match pipeline.parent_info {
-                    Some((parent_id, subpage_id, FrameType::MozBrowserIFrame)) => return Some((parent_id, subpage_id)),
-                    Some((parent_id, _, _)) => pipeline_id = parent_id,
+                    Some((parent_id, FrameType::MozBrowserIFrame)) => return Some((parent_id, pipeline_id)),
+                    Some((parent_id, _)) => pipeline_id = parent_id,
                     None => return None,
                 },
                 None => {
@@ -2415,15 +2392,14 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         };
 
         // If this is a mozbrowser iframe, then send the event with new url
-        if let Some((parent_pipeline_id, subpage_id)) = self.get_mozbrowser_ancestor_info(pipeline_id) {
-            if let Some(parent_pipeline) = self.pipelines.get(&parent_pipeline_id) {
-                let pipeline_id = self.subpage_map.get(&(parent_pipeline_id, subpage_id));
-                if let Some(pipeline) = pipeline_id.and_then(|pipeline_id| self.pipelines.get(pipeline_id)) {
+        if let Some((ancestor_id, mozbrowser_iframe_id)) = self.get_mozbrowser_ancestor_info(pipeline_id) {
+            if let Some(ancestor) = self.pipelines.get(&ancestor_id) {
+                if let Some(pipeline) = self.pipelines.get(&mozbrowser_iframe_id) {
                     if let Some(frame_id) = pipeline.frame {
                         let can_go_forward = !self.joint_session_future(frame_id).is_empty();
                         let can_go_back = !self.joint_session_past(frame_id).is_empty();
                         let event = MozBrowserEvent::LocationChange(url, can_go_back, can_go_forward);
-                        parent_pipeline.trigger_mozbrowser_event(Some(subpage_id), event);
+                        ancestor.trigger_mozbrowser_event(Some(mozbrowser_iframe_id), event);
                     }
                 }
             }
@@ -2455,9 +2431,9 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         let event = MozBrowserEvent::Error(MozBrowserErrorType::Fatal, reason, report);
 
         if let Some(pipeline_id) = pipeline_id {
-            if let Some((ancestor_id, subpage_id)) = self.get_mozbrowser_ancestor_info(pipeline_id) {
+            if let Some((ancestor_id, mozbrowser_iframe_id)) = self.get_mozbrowser_ancestor_info(pipeline_id) {
                 if let Some(ancestor) = self.pipelines.get(&ancestor_id) {
-                    return ancestor.trigger_mozbrowser_event(Some(subpage_id), event);
+                    return ancestor.trigger_mozbrowser_event(Some(mozbrowser_iframe_id), event);
                 }
             }
         }

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -17,8 +17,7 @@ use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use layers::geometry::DevicePixel;
 use layout_traits::LayoutThreadFactory;
-use msg::constellation_msg::{FrameId, FrameType, LoadData, PipelineId};
-use msg::constellation_msg::{PipelineNamespaceId, SubpageId};
+use msg::constellation_msg::{FrameId, FrameType, LoadData, PipelineId, PipelineNamespaceId};
 use net_traits::{IpcSend, ResourceThreads};
 use net_traits::bluetooth_thread::BluetoothMethodMsg;
 use net_traits::image_cache_thread::ImageCacheThread;
@@ -51,7 +50,7 @@ pub enum ChildProcess {
 /// A uniquely-identifiable pipeline of script thread, layout thread, and paint thread.
 pub struct Pipeline {
     pub id: PipelineId,
-    pub parent_info: Option<(PipelineId, SubpageId, FrameType)>,
+    pub parent_info: Option<(PipelineId, FrameType)>,
     pub script_chan: IpcSender<ConstellationControlMsg>,
     /// A channel to layout, for performing reflows and shutdown.
     pub layout_chan: IpcSender<LayoutControlMsg>,
@@ -84,9 +83,9 @@ pub struct Pipeline {
 pub struct InitialPipelineState {
     /// The ID of the pipeline to create.
     pub id: PipelineId,
-    /// The subpage ID of this pipeline to create in its pipeline parent.
+    /// The ID of the parent pipeline and frame type, if any.
     /// If `None`, this is the root.
-    pub parent_info: Option<(PipelineId, SubpageId, FrameType)>,
+    pub parent_info: Option<(PipelineId, FrameType)>,
     /// A channel to the associated constellation.
     pub constellation_chan: IpcSender<ScriptMsg>,
     /// A channel for the layout thread to send messages to the constellation.
@@ -150,12 +149,11 @@ impl Pipeline {
 
         let (script_chan, content_ports) = match state.script_chan {
             Some(script_chan) => {
-                let (parent_pipeline_id, subpage_id, frame_type) =
-                    state.parent_info.expect("script_pipeline != None but subpage_id == None");
+                let (parent_pipeline_id, frame_type) =
+                    state.parent_info.expect("script_pipeline != None but parent_info == None");
                 let new_layout_info = NewLayoutInfo {
                     parent_pipeline_id: parent_pipeline_id,
                     new_pipeline_id: state.id,
-                    subpage_id: subpage_id,
                     frame_type: frame_type,
                     load_data: state.load_data.clone(),
                     paint_chan: layout_to_paint_chan.clone().to_opaque(),
@@ -273,7 +271,7 @@ impl Pipeline {
     }
 
     fn new(id: PipelineId,
-           parent_info: Option<(PipelineId, SubpageId, FrameType)>,
+           parent_info: Option<(PipelineId, FrameType)>,
            script_chan: IpcSender<ConstellationControlMsg>,
            layout_chan: IpcSender<LayoutControlMsg>,
            compositor_proxy: Box<CompositorProxy + 'static + Send>,
@@ -377,12 +375,12 @@ impl Pipeline {
     }
 
     pub fn trigger_mozbrowser_event(&self,
-                                     subpage_id: Option<SubpageId>,
+                                     child_id: Option<PipelineId>,
                                      event: MozBrowserEvent) {
         assert!(PREFS.is_mozbrowser_enabled());
 
         let event = ConstellationControlMsg::MozBrowserEvent(self.id,
-                                                             subpage_id,
+                                                             child_id,
                                                              event);
         if let Err(e) = self.script_chan.send(event) {
             warn!("Sending mozbrowser event to script failed ({}).", e);
@@ -409,7 +407,7 @@ impl Pipeline {
 #[derive(Deserialize, Serialize)]
 pub struct UnprivilegedPipelineContent {
     id: PipelineId,
-    parent_info: Option<(PipelineId, SubpageId, FrameType)>,
+    parent_info: Option<(PipelineId, FrameType)>,
     constellation_chan: IpcSender<ScriptMsg>,
     layout_to_constellation_chan: IpcSender<LayoutMsg>,
     scheduler_chan: IpcSender<TimerEventRequest>,

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -150,10 +150,10 @@ impl Pipeline {
 
         let (script_chan, content_ports) = match state.script_chan {
             Some(script_chan) => {
-                let (containing_pipeline_id, subpage_id, frame_type) =
+                let (parent_pipeline_id, subpage_id, frame_type) =
                     state.parent_info.expect("script_pipeline != None but subpage_id == None");
                 let new_layout_info = NewLayoutInfo {
-                    containing_pipeline_id: containing_pipeline_id,
+                    parent_pipeline_id: parent_pipeline_id,
                     new_pipeline_id: state.id,
                     subpage_id: subpage_id,
                     frame_type: frame_type,

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -332,9 +332,6 @@ impl fmt::Display for PipelineId {
 }
 
 #[derive(Clone, PartialEq, Eq, Copy, Hash, Debug, Deserialize, Serialize, HeapSizeOf)]
-pub struct SubpageId(pub u32);
-
-#[derive(Clone, PartialEq, Eq, Copy, Hash, Debug, Deserialize, Serialize, HeapSizeOf)]
 pub enum FrameType {
     IFrame,
     MozBrowserIFrame,

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -69,10 +69,10 @@ impl<'a> GlobalRef<'a> {
     }
 
     /// Get the `PipelineId` for this global scope.
-    pub fn pipeline(&self) -> PipelineId {
+    pub fn pipeline_id(&self) -> PipelineId {
         match *self {
-            GlobalRef::Window(window) => window.pipeline(),
-            GlobalRef::Worker(worker) => worker.pipeline(),
+            GlobalRef::Window(window) => window.pipeline_id(),
+            GlobalRef::Worker(worker) => worker.pipeline_id(),
         }
     }
 

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -57,7 +57,7 @@ use js::jsapi::{GCTraceKindToAscii, Heap, JSObject, JSTracer, TraceKind};
 use js::jsval::JSVal;
 use js::rust::Runtime;
 use libc;
-use msg::constellation_msg::{FrameType, PipelineId, ReferrerPolicy, SubpageId, WindowSizeType};
+use msg::constellation_msg::{FrameType, PipelineId, ReferrerPolicy, WindowSizeType};
 use net_traits::{Metadata, NetworkError, ResourceThreads};
 use net_traits::filemanager_thread::RelativePos;
 use net_traits::image::base::{Image, ImageMetadata};
@@ -308,7 +308,7 @@ no_jsmanaged_fields!(PropertyDeclarationBlock);
 no_jsmanaged_fields!(HashSet<T>);
 // These three are interdependent, if you plan to put jsmanaged data
 // in one of these make sure it is propagated properly to containing structs
-no_jsmanaged_fields!(FrameType, SubpageId, WindowSizeData, WindowSizeType, PipelineId);
+no_jsmanaged_fields!(FrameType, WindowSizeData, WindowSizeType, PipelineId);
 no_jsmanaged_fields!(TimerEventId, TimerSource);
 no_jsmanaged_fields!(WorkerId);
 no_jsmanaged_fields!(QuirksMode);

--- a/components/script/dom/browsingcontext.rs
+++ b/components/script/dom/browsingcontext.rs
@@ -26,7 +26,7 @@ use js::jsapi::{JS_GetOwnPropertyDescriptorById, JS_HasPropertyById};
 use js::jsapi::{MutableHandle, MutableHandleObject, MutableHandleValue};
 use js::jsapi::{ObjectOpResult, PropertyDescriptor};
 use js::jsval::{UndefinedValue, PrivateValue};
-use msg::constellation_msg::{PipelineId, SubpageId};
+use msg::constellation_msg::PipelineId;
 use std::cell::Cell;
 use url::Url;
 
@@ -160,10 +160,10 @@ impl BrowsingContext {
         self.children.borrow_mut().push(JS::from_ref(&context));
     }
 
-    pub fn find_child_by_subpage(&self, subpage_id: SubpageId) -> Option<Root<Window>> {
+    pub fn find_child_by_id(&self, pipeline_id: PipelineId) -> Option<Root<Window>> {
         self.children.borrow().iter().find(|context| {
             let window = context.active_window();
-            window.subpage() == Some(subpage_id)
+            window.pipeline_id() == pipeline_id
         }).map(|context| context.active_window())
     }
 

--- a/components/script/dom/browsingcontext.rs
+++ b/components/script/dom/browsingcontext.rs
@@ -152,7 +152,7 @@ impl BrowsingContext {
         old
     }
 
-    pub fn pipeline(&self) -> PipelineId {
+    pub fn pipeline_id(&self) -> PipelineId {
         self.id
     }
 

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -18,7 +18,7 @@ impl Console {
         if let Some(chan) = global.devtools_chan() {
             let console_message = prepare_message(level, message);
             let devtools_message = ScriptToDevtoolsControlMsg::ConsoleAPI(
-                global.pipeline(),
+                global.pipeline_id(),
                 console_message,
                 global.get_worker_id());
             chan.send(devtools_message).unwrap();

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -243,7 +243,7 @@ impl DedicatedWorkerGlobalScope {
         }
     }
 
-    pub fn pipeline(&self) -> PipelineId {
+    pub fn pipeline_id(&self) -> PipelineId {
         self.id
     }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -94,7 +94,7 @@ use js::jsapi::{JSContext, JSObject, JSRuntime};
 use js::jsapi::JS_GetRuntime;
 use msg::constellation_msg::{ALT, CONTROL, SHIFT, SUPER};
 use msg::constellation_msg::{Key, KeyModifiers, KeyState};
-use msg::constellation_msg::{PipelineId, ReferrerPolicy, SubpageId};
+use msg::constellation_msg::{PipelineId, ReferrerPolicy};
 use net_traits::{AsyncResponseTarget, IpcSend, PendingAsyncLoad};
 use net_traits::CookieSource::NonHTTP;
 use net_traits::CoreResourceMsg::{GetCookiesForUrl, SetCookiesForUrl};
@@ -1342,9 +1342,9 @@ impl Document {
 
     pub fn trigger_mozbrowser_event(&self, event: MozBrowserEvent) {
         if PREFS.is_mozbrowser_enabled() {
-            if let Some((parent_pipeline_id, subpage_id, _)) = self.window.parent_info() {
+            if let Some((parent_pipeline_id, _)) = self.window.parent_info() {
                 let event = ConstellationMsg::MozBrowserEvent(parent_pipeline_id,
-                                                              Some(subpage_id),
+                                                              Some(self.window.pipeline_id()),
                                                               event);
                 self.window.constellation_chan().send(event).unwrap();
             }
@@ -1581,15 +1581,7 @@ impl Document {
     }
 
     /// Find an iframe element in the document.
-    pub fn find_iframe(&self, subpage_id: SubpageId) -> Option<Root<HTMLIFrameElement>> {
-        self.upcast::<Node>()
-            .traverse_preorder()
-            .filter_map(Root::downcast::<HTMLIFrameElement>)
-            .find(|node| node.subpage_id() == Some(subpage_id))
-    }
-
-    /// Find an iframe element in the document.
-    pub fn find_iframe_by_pipeline(&self, pipeline: PipelineId) -> Option<Root<HTMLIFrameElement>> {
+    pub fn find_iframe(&self, pipeline: PipelineId) -> Option<Root<HTMLIFrameElement>> {
         self.upcast::<Node>()
             .traverse_preorder()
             .filter_map(Root::downcast::<HTMLIFrameElement>)

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -641,7 +641,7 @@ impl Document {
             // Update the focus state for all elements in the focus chain.
             // https://html.spec.whatwg.org/multipage/#focus-chain
             if focus_type == FocusType::Element {
-                let event = ConstellationMsg::Focus(self.window.pipeline());
+                let event = ConstellationMsg::Focus(self.window.pipeline_id());
                 self.window.constellation_chan().send(event).unwrap();
             }
         }
@@ -661,7 +661,7 @@ impl Document {
     pub fn send_title_to_compositor(&self) {
         let window = self.window();
         window.constellation_chan()
-              .send(ConstellationMsg::SetTitle(window.pipeline(),
+              .send(ConstellationMsg::SetTitle(window.pipeline_id(),
                                                Some(String::from(self.Title()))))
               .unwrap();
     }
@@ -1367,7 +1367,7 @@ impl Document {
         // TODO: Should tick animation only when document is visible
         if !self.running_animation_callbacks.get() {
             let event = ConstellationMsg::ChangeRunningAnimationsState(
-                self.window.pipeline(),
+                self.window.pipeline_id(),
                 AnimationState::AnimationCallbacksPresent);
             self.window.constellation_chan().send(event).unwrap();
         }
@@ -1405,7 +1405,7 @@ impl Document {
         if self.animation_frame_list.borrow().is_empty() {
             mem::swap(&mut *self.animation_frame_list.borrow_mut(),
                       &mut animation_frame_list);
-            let event = ConstellationMsg::ChangeRunningAnimationsState(self.window.pipeline(),
+            let event = ConstellationMsg::ChangeRunningAnimationsState(self.window.pipeline_id(),
                                                                        AnimationState::NoAnimationCallbacksPresent);
             self.window.constellation_chan().send(event).unwrap();
         }
@@ -1469,7 +1469,7 @@ impl Document {
         let loader = self.loader.borrow();
         if !loader.is_blocked() && !loader.events_inhibited() {
             let win = self.window();
-            let msg = MainThreadScriptMsg::DocumentLoadsComplete(win.pipeline());
+            let msg = MainThreadScriptMsg::DocumentLoadsComplete(win.pipeline_id());
             win.main_thread_script_chan().send(msg).unwrap();
         }
     }
@@ -1567,7 +1567,7 @@ impl Document {
     }
 
     pub fn notify_constellation_load(&self) {
-        let pipeline_id = self.window.pipeline();
+        let pipeline_id = self.window.pipeline_id();
         let load_event = ConstellationMsg::LoadComplete(pipeline_id);
         self.window.constellation_chan().send(load_event).unwrap();
     }
@@ -1593,7 +1593,7 @@ impl Document {
         self.upcast::<Node>()
             .traverse_preorder()
             .filter_map(Root::downcast::<HTMLIFrameElement>)
-            .find(|node| node.pipeline() == Some(pipeline))
+            .find(|node| node.pipeline_id() == Some(pipeline))
     }
 
     pub fn get_dom_loading(&self) -> u64 {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1342,8 +1342,8 @@ impl Document {
 
     pub fn trigger_mozbrowser_event(&self, event: MozBrowserEvent) {
         if PREFS.is_mozbrowser_enabled() {
-            if let Some((containing_pipeline_id, subpage_id, _)) = self.window.parent_info() {
-                let event = ConstellationMsg::MozBrowserEvent(containing_pipeline_id,
+            if let Some((parent_pipeline_id, subpage_id, _)) = self.window.parent_info() {
+                let event = ConstellationMsg::MozBrowserEvent(parent_pipeline_id,
                                                               Some(subpage_id),
                                                               event);
                 self.window.constellation_chan().send(event).unwrap();

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -38,7 +38,7 @@ impl History {
 
 impl History {
     fn traverse_history(&self, direction: TraversalDirection) {
-        let pipeline = self.window.pipeline();
+        let pipeline = self.window.pipeline_id();
         let msg = ConstellationMsg::TraverseHistory(Some(pipeline), direction);
         let _ = self.window.constellation_chan().send(msg);
     }
@@ -47,7 +47,7 @@ impl History {
 impl HistoryMethods for History {
     // https://html.spec.whatwg.org/multipage/#dom-history-length
     fn Length(&self) -> u32 {
-        let pipeline = self.window.pipeline();
+        let pipeline = self.window.pipeline_id();
         let (sender, recv) = ipc::channel().expect("Failed to create channel to send jsh length.");
         let msg = ConstellationMsg::JointSessionHistoryLength(pipeline, sender);
         let _ = self.window.constellation_chan().send(msg);

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -435,7 +435,7 @@ impl HTMLFormElement {
         // Step 2
         let nav = box PlannedNavigation {
             load_data: load_data,
-            pipeline_id: window.pipeline(),
+            pipeline_id: window.pipeline_id(),
             script_chan: window.main_thread_script_chan().clone(),
             generation_id: self.generation_id.get(),
             form: Trusted::new(self)

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -133,7 +133,7 @@ impl HTMLIFrameElement {
 
         let load_info = IFrameLoadInfo {
             load_data: load_data,
-            containing_pipeline_id: window.pipeline_id(),
+            parent_pipeline_id: window.pipeline_id(),
             new_subpage_id: new_subpage_id,
             old_subpage_id: old_subpage_id,
             new_pipeline_id: new_pipeline_id,

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -133,7 +133,7 @@ impl HTMLIFrameElement {
 
         let load_info = IFrameLoadInfo {
             load_data: load_data,
-            containing_pipeline_id: window.pipeline(),
+            containing_pipeline_id: window.pipeline_id(),
             new_subpage_id: new_subpage_id,
             old_subpage_id: old_subpage_id,
             new_pipeline_id: new_pipeline_id,
@@ -213,10 +213,6 @@ impl HTMLIFrameElement {
         self.subpage_id.get()
     }
 
-    pub fn pipeline(&self) -> Option<PipelineId> {
-        self.pipeline_id.get()
-    }
-
     pub fn change_visibility_status(&self, visibility: bool) {
         if self.visibility.get() != visibility {
             self.visibility.set(visibility);
@@ -241,7 +237,7 @@ impl HTMLIFrameElement {
     pub fn iframe_load_event_steps(&self, loaded_pipeline: PipelineId) {
         // TODO(#9592): assert that the load blocker is present at all times when we
         //              can guarantee that it's created for the case of iframe.reload().
-        assert_eq!(loaded_pipeline, self.pipeline().unwrap());
+        assert_eq!(loaded_pipeline, self.pipeline_id().unwrap());
 
         // TODO A cross-origin child document would not be easily accessible
         //      from this script thread. It's unclear how to implement
@@ -423,7 +419,7 @@ pub fn Navigate(iframe: &HTMLIFrameElement, direction: TraversalDirection) -> Er
     if iframe.Mozbrowser() {
         if iframe.upcast::<Node>().is_in_doc() {
             let window = window_from_node(iframe);
-            let msg = ConstellationMsg::TraverseHistory(iframe.pipeline(), direction);
+            let msg = ConstellationMsg::TraverseHistory(iframe.pipeline_id(), direction);
             window.constellation_chan().send(msg).unwrap();
         }
 

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -38,7 +38,7 @@ use dom::window::{ReflowReason, Window};
 use ipc_channel::ipc;
 use js::jsapi::{JSAutoCompartment, JSContext, MutableHandleValue};
 use js::jsval::{NullValue, UndefinedValue};
-use msg::constellation_msg::{FrameType, LoadData, PipelineId, SubpageId, TraversalDirection};
+use msg::constellation_msg::{FrameType, LoadData, PipelineId, TraversalDirection};
 use net_traits::response::HttpsState;
 use script_layout_interface::message::ReflowQueryType;
 use script_traits::{IFrameLoadInfo, MozBrowserEvent, ScriptMsg as ConstellationMsg};
@@ -68,7 +68,6 @@ bitflags! {
 pub struct HTMLIFrameElement {
     htmlelement: HTMLElement,
     pipeline_id: Cell<Option<PipelineId>>,
-    subpage_id: Cell<Option<SubpageId>>,
     sandbox: MutNullableHeap<JS<DOMTokenList>>,
     sandbox_allowance: Cell<Option<SandboxAllowance>>,
     load_blocker: DOMRefCell<Option<LoadBlocker>>,
@@ -94,14 +93,11 @@ impl HTMLIFrameElement {
         }).unwrap_or_else(|| Url::parse("about:blank").unwrap())
     }
 
-    pub fn generate_new_subpage_id(&self) -> (SubpageId, Option<SubpageId>) {
-        self.pipeline_id.set(Some(PipelineId::new()));
-
-        let old_subpage_id = self.subpage_id.get();
-        let win = window_from_node(self);
-        let subpage_id = win.get_next_subpage_id();
-        self.subpage_id.set(Some(subpage_id));
-        (subpage_id, old_subpage_id)
+    pub fn generate_new_pipeline_id(&self) -> (Option<PipelineId>, PipelineId) {
+        let old_pipeline_id = self.pipeline_id.get();
+        let new_pipeline_id = PipelineId::new();
+        self.pipeline_id.set(Some(new_pipeline_id));
+        (old_pipeline_id, new_pipeline_id)
     }
 
     pub fn navigate_or_reload_child_browsing_context(&self, load_data: Option<LoadData>) {
@@ -126,16 +122,14 @@ impl HTMLIFrameElement {
         }
 
         let window = window_from_node(self);
-        let (new_subpage_id, old_subpage_id) = self.generate_new_subpage_id();
-        let new_pipeline_id = self.pipeline_id.get().unwrap();
+        let (old_pipeline_id, new_pipeline_id) = self.generate_new_pipeline_id();
         let private_iframe = self.privatebrowsing();
         let frame_type = if self.Mozbrowser() { FrameType::MozBrowserIFrame } else { FrameType::IFrame };
 
         let load_info = IFrameLoadInfo {
             load_data: load_data,
             parent_pipeline_id: window.pipeline_id(),
-            new_subpage_id: new_subpage_id,
-            old_subpage_id: old_subpage_id,
+            old_pipeline_id: old_pipeline_id,
             new_pipeline_id: new_pipeline_id,
             sandbox: sandboxed,
             is_private: private_iframe,
@@ -170,8 +164,7 @@ impl HTMLIFrameElement {
         }
     }
 
-    pub fn update_subpage_id(&self, new_subpage_id: SubpageId, new_pipeline_id: PipelineId) {
-        self.subpage_id.set(Some(new_subpage_id));
+    pub fn update_pipeline_id(&self, new_pipeline_id: PipelineId) {
         self.pipeline_id.set(Some(new_pipeline_id));
 
         let mut blocker = self.load_blocker.borrow_mut();
@@ -186,7 +179,6 @@ impl HTMLIFrameElement {
         HTMLIFrameElement {
             htmlelement: HTMLElement::new_inherited(localName, prefix, document),
             pipeline_id: Cell::new(None),
-            subpage_id: Cell::new(None),
             sandbox: Default::default(),
             sandbox_allowance: Cell::new(None),
             load_blocker: DOMRefCell::new(None),
@@ -206,11 +198,6 @@ impl HTMLIFrameElement {
     #[inline]
     pub fn pipeline_id(&self) -> Option<PipelineId> {
         self.pipeline_id.get()
-    }
-
-    #[inline]
-    pub fn subpage_id(&self) -> Option<SubpageId> {
-        self.subpage_id.get()
     }
 
     pub fn change_visibility_status(&self, visibility: bool) {
@@ -270,11 +257,11 @@ impl HTMLIFrameElement {
     }
 
     pub fn get_content_window(&self) -> Option<Root<Window>> {
-        self.subpage_id.get().and_then(|subpage_id| {
+        self.pipeline_id.get().and_then(|pipeline_id| {
             let window = window_from_node(self);
             let window = window.r();
             let browsing_context = window.browsing_context();
-            browsing_context.find_child_by_subpage(subpage_id)
+            browsing_context.find_child_by_id(pipeline_id)
         })
     }
 
@@ -659,12 +646,11 @@ impl VirtualMethods for HTMLIFrameElement {
                 receiver.recv().unwrap()
             }
 
-            // Resetting the subpage id to None is required here so that
+            // Resetting the pipeline_id to None is required here so that
             // if this iframe is subsequently re-added to the document
             // the load doesn't think that it's a navigation, but instead
             // a new iframe. Without this, the constellation gets very
             // confused.
-            self.subpage_id.set(None);
             self.pipeline_id.set(None);
         }
     }

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -424,7 +424,7 @@ fn net_request_from_global(global: GlobalRef,
                            url: Url,
                            is_service_worker_global_scope: bool) -> NetTraitsRequest {
     let origin = Origin::Origin(global.get_url().origin());
-    let pipeline_id = global.pipeline();
+    let pipeline_id = global.pipeline_id();
     NetTraitsRequest::new(url,
                           Some(origin),
                           is_service_worker_global_scope,

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -100,7 +100,7 @@ impl ServiceWorkerContainerMethods for ServiceWorkerContainer {
                                                                  script_url,
                                                                  scope_str.clone(),
                                                                  self);
-        ScriptThread::set_registration(scope, &*worker_registration, self.global().r().pipeline());
+        ScriptThread::set_registration(scope, &*worker_registration, self.global().r().pipeline_id());
         Ok(worker_registration)
     }
 }

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -285,7 +285,7 @@ impl ServiceWorkerGlobalScope {
         }
     }
 
-    pub fn pipeline(&self) -> PipelineId {
+    pub fn pipeline_id(&self) -> PipelineId {
         self.id
     }
 

--- a/components/script/dom/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworkerregistration.rs
@@ -53,14 +53,14 @@ impl ServiceWorkerRegistration {
         let worker_load_origin = WorkerScriptLoadOrigin {
             referrer_url: None,
             referrer_policy: None,
-            pipeline_id: Some(global.pipeline())
+            pipeline_id: Some(global.pipeline_id())
         };
 
         let worker_id = global.get_next_worker_id();
         let init = prepare_workerscope_init(global, None);
         ScopeThings {
             script_url: script_url,
-            pipeline_id: global.pipeline(),
+            pipeline_id: global.pipeline_id(),
             init: init,
             worker_load_origin: worker_load_origin,
             devtools_chan: global.devtools_chan(),

--- a/components/script/dom/servohtmlparser.rs
+++ b/components/script/dom/servohtmlparser.rs
@@ -30,7 +30,7 @@ use hyper::header::ContentType;
 use hyper::mime::{Mime, SubLevel, TopLevel};
 use hyper_serde::Serde;
 use js::jsapi::JSTracer;
-use msg::constellation_msg::{PipelineId, SubpageId};
+use msg::constellation_msg::PipelineId;
 use net_traits::{AsyncResponseListener, Metadata, NetworkError};
 use network_listener::PreInvoke;
 use parse::{Parser, ParserRef, TrustedParser};
@@ -67,19 +67,16 @@ pub struct ParserContext {
     is_synthesized_document: bool,
     /// The pipeline associated with this document.
     id: PipelineId,
-    /// The subpage associated with this document.
-    subpage: Option<SubpageId>,
     /// The URL for this document.
     url: Url,
 }
 
 impl ParserContext {
-    pub fn new(id: PipelineId, subpage: Option<SubpageId>, url: Url) -> ParserContext {
+    pub fn new(id: PipelineId, url: Url) -> ParserContext {
         ParserContext {
             parser: None,
             is_synthesized_document: false,
             id: id,
-            subpage: subpage,
             url: url,
         }
     }
@@ -102,7 +99,6 @@ impl AsyncResponseListener for ParserContext {
         let content_type =
             metadata.clone().and_then(|meta| meta.content_type).map(Serde::into_inner);
         let parser = match ScriptThread::page_headers_available(&self.id,
-                                                                self.subpage.as_ref(),
                                                                 metadata) {
             Some(parser) => parser,
             None => return,

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -206,7 +206,7 @@ impl Runnable for StorageEventRunnable {
             assert!(UrlHelper::SameOrigin(&ev_url, &it_window.get_url()));
             // TODO: Such a Document object is not necessarily fully active, but events fired on such
             // objects are ignored by the event loop until the Document becomes fully active again.
-            if ev_window.pipeline() != it_window.pipeline() {
+            if ev_window.pipeline_id() != it_window.pipeline_id() {
                 storage_event.upcast::<Event>().fire(it_window.upcast());
             }
         }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -331,7 +331,7 @@ impl Window {
         worker_id
     }
 
-    pub fn pipeline(&self) -> PipelineId {
+    pub fn pipeline_id(&self) -> PipelineId {
         self.id
     }
 
@@ -472,7 +472,7 @@ impl WindowMethods for Window {
         }
 
         let (sender, receiver) = ipc::channel().unwrap();
-        self.constellation_chan().send(ConstellationMsg::Alert(self.pipeline(), s.to_string(), sender)).unwrap();
+        self.constellation_chan().send(ConstellationMsg::Alert(self.pipeline_id(), s.to_string(), sender)).unwrap();
 
         let should_display_alert_dialog = receiver.recv().unwrap();
         if should_display_alert_dialog {
@@ -1058,7 +1058,7 @@ impl Window {
         // TODO (farodin91): Raise an event to stop the current_viewport
         self.update_viewport_for_scroll(x, y);
 
-        let message = ConstellationMsg::ScrollFragmentPoint(self.pipeline(), layer_id, point, smooth);
+        let message = ConstellationMsg::ScrollFragmentPoint(self.pipeline_id(), layer_id, point, smooth);
         self.constellation_chan.send(message).unwrap();
     }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -51,7 +51,7 @@ use js::jsval::UndefinedValue;
 use js::rust::CompileOptionsWrapper;
 use js::rust::Runtime;
 use libc;
-use msg::constellation_msg::{FrameType, LoadData, PipelineId, SubpageId, WindowSizeType};
+use msg::constellation_msg::{FrameType, LoadData, PipelineId, WindowSizeType};
 use net_traits::ResourceThreads;
 use net_traits::bluetooth_thread::BluetoothMethodMsg;
 use net_traits::image_cache_thread::{ImageCacheChan, ImageCacheThread};
@@ -200,16 +200,14 @@ pub struct Window {
     /// page changes.
     devtools_wants_updates: Cell<bool>,
 
-    next_subpage_id: Cell<SubpageId>,
-
     /// Pending resize event, if any.
     resize_event: Cell<Option<(WindowSizeData, WindowSizeType)>>,
 
     /// Pipeline id associated with this page.
     id: PipelineId,
 
-    /// Subpage id associated with this page, if any.
-    parent_info: Option<(PipelineId, SubpageId, FrameType)>,
+    /// Parent id associated with this page, if any.
+    parent_info: Option<(PipelineId, FrameType)>,
 
     /// Global static data related to the DOM.
     dom_static: GlobalStaticData,
@@ -335,11 +333,7 @@ impl Window {
         self.id
     }
 
-    pub fn subpage(&self) -> Option<SubpageId> {
-        self.parent_info.map(|p| p.1)
-    }
-
-    pub fn parent_info(&self) -> Option<(PipelineId, SubpageId, FrameType)> {
+    pub fn parent_info(&self) -> Option<(PipelineId, FrameType)> {
         self.parent_info
     }
 
@@ -1492,13 +1486,6 @@ impl Window {
         WindowProxyHandler(self.dom_static.windowproxy_handler.0)
     }
 
-    pub fn get_next_subpage_id(&self) -> SubpageId {
-        let subpage_id = self.next_subpage_id.get();
-        let SubpageId(id_num) = subpage_id;
-        self.next_subpage_id.set(SubpageId(id_num + 1));
-        subpage_id
-    }
-
     pub fn get_pending_reflow_count(&self) -> u32 {
         self.pending_reflow_count.get()
     }
@@ -1612,7 +1599,7 @@ impl Window {
     // https://html.spec.whatwg.org/multipage/#top-level-browsing-context
     pub fn is_top_level(&self) -> bool {
         match self.parent_info {
-            Some((_, _, FrameType::IFrame)) => false,
+            Some((_, FrameType::IFrame)) => false,
             _ => true,
         }
     }
@@ -1676,7 +1663,7 @@ impl Window {
                timer_event_chan: IpcSender<TimerEvent>,
                layout_chan: Sender<Msg>,
                id: PipelineId,
-               parent_info: Option<(PipelineId, SubpageId, FrameType)>,
+               parent_info: Option<(PipelineId, FrameType)>,
                window_size: Option<WindowSizeData>)
                -> Root<Window> {
         let layout_rpc: Box<LayoutRPC> = {
@@ -1726,7 +1713,6 @@ impl Window {
             page_clip_rect: Cell::new(max_rect()),
             fragment_name: DOMRefCell::new(None),
             resize_event: Cell::new(None),
-            next_subpage_id: Cell::new(SubpageId(0)),
             layout_chan: layout_chan,
             layout_rpc: layout_rpc,
             window_size: Cell::new(window_size),

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -85,13 +85,13 @@ impl Worker {
         let worker_load_origin = WorkerScriptLoadOrigin {
             referrer_url: None,
             referrer_policy: None,
-            pipeline_id: Some(global.pipeline())
+            pipeline_id: Some(global.pipeline_id()),
         };
 
         let (devtools_sender, devtools_receiver) = ipc::channel().unwrap();
         let worker_id = global.get_next_worker_id();
         if let Some(ref chan) = global.devtools_chan() {
-            let pipeline_id = global.pipeline();
+            let pipeline_id = global.pipeline_id();
                 let title = format!("Worker for {}", worker_url);
                 let page_info = DevtoolsPageInfo {
                     title: title,
@@ -105,7 +105,7 @@ impl Worker {
         let init = prepare_workerscope_init(global, Some(devtools_sender));
 
         DedicatedWorkerGlobalScope::run_worker_scope(
-            init, worker_url, global.pipeline(), devtools_receiver, worker.runtime.clone(), worker_ref,
+            init, worker_url, global.pipeline_id(), devtools_receiver, worker.runtime.clone(), worker_ref,
             global.script_chan(), sender, receiver, worker_load_origin, closing);
 
         Ok(worker)

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -238,7 +238,7 @@ impl LoadOrigin for WorkerGlobalScope {
         None
     }
     fn pipeline_id(&self) -> Option<PipelineId> {
-        Some(self.pipeline())
+        Some(self.pipeline_id())
     }
 }
 
@@ -410,13 +410,13 @@ impl WorkerGlobalScope {
         FileReadingTaskSource(self.script_chan())
     }
 
-    pub fn pipeline(&self) -> PipelineId {
+    pub fn pipeline_id(&self) -> PipelineId {
         let dedicated = self.downcast::<DedicatedWorkerGlobalScope>();
         let service_worker = self.downcast::<ServiceWorkerGlobalScope>();
         if let Some(dedicated) = dedicated {
-            return dedicated.pipeline();
+            return dedicated.pipeline_id();
         } else if let Some(service_worker) = service_worker {
-            return service_worker.pipeline();
+            return service_worker.pipeline_id();
         } else {
             panic!("need to implement a sender for SharedWorker")
         }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -278,7 +278,7 @@ impl LoadOrigin for XMLHttpRequest {
     }
     fn pipeline_id(&self) -> Option<PipelineId> {
         let global = self.global();
-        Some(global.r().pipeline())
+        Some(global.r().pipeline_id())
     }
 }
 
@@ -1189,7 +1189,7 @@ impl XMLHttpRequest {
         let decoded = charset.decode(&self.response.borrow(), DecoderTrap::Replace).unwrap();
         let document = self.new_doc(IsHTMLDocument::HTMLDocument);
         // TODO: Disable scripting while parsing
-        parse_html(document.r(), DOMString::from(decoded), wr.get_url(), ParseContext::Owner(Some(wr.pipeline())));
+        parse_html(document.r(), DOMString::from(decoded), wr.get_url(), ParseContext::Owner(Some(wr.pipeline_id())));
         document
     }
 
@@ -1200,7 +1200,10 @@ impl XMLHttpRequest {
         let decoded = charset.decode(&self.response.borrow(), DecoderTrap::Replace).unwrap();
         let document = self.new_doc(IsHTMLDocument::NonHTMLDocument);
         // TODO: Disable scripting while parsing
-        parse_xml(document.r(), DOMString::from(decoded), wr.get_url(), xml::ParseContext::Owner(Some(wr.pipeline())));
+        parse_xml(document.r(),
+                  DOMString::from(decoded),
+                  wr.get_url(),
+                  xml::ParseContext::Owner(Some(wr.pipeline_id())));
         document
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -877,8 +877,8 @@ impl ScriptThread {
 
     fn handle_msg_from_constellation(&self, msg: ConstellationControlMsg) {
         match msg {
-            ConstellationControlMsg::Navigate(pipeline_id, subpage_id, load_data) =>
-                self.handle_navigate(pipeline_id, Some(subpage_id), load_data),
+            ConstellationControlMsg::Navigate(parent_pipeline_id, subpage_id, load_data) =>
+                self.handle_navigate(parent_pipeline_id, Some(subpage_id), load_data),
             ConstellationControlMsg::SendEvent(id, event) =>
                 self.handle_event(id, event),
             ConstellationControlMsg::ResizeInactive(id, new_size) =>
@@ -891,24 +891,24 @@ impl ScriptThread {
                 self.handle_thaw_msg(pipeline_id),
             ConstellationControlMsg::ChangeFrameVisibilityStatus(pipeline_id, visible) =>
                 self.handle_visibility_change_msg(pipeline_id, visible),
-            ConstellationControlMsg::NotifyVisibilityChange(containing_id, pipeline_id, visible) =>
-                self.handle_visibility_change_complete_msg(containing_id, pipeline_id, visible),
+            ConstellationControlMsg::NotifyVisibilityChange(parent_pipeline_id, pipeline_id, visible) =>
+                self.handle_visibility_change_complete_msg(parent_pipeline_id, pipeline_id, visible),
             ConstellationControlMsg::MozBrowserEvent(parent_pipeline_id,
                                                      subpage_id,
                                                      event) =>
                 self.handle_mozbrowser_event_msg(parent_pipeline_id,
                                                  subpage_id,
                                                  event),
-            ConstellationControlMsg::UpdateSubpageId(containing_pipeline_id,
+            ConstellationControlMsg::UpdateSubpageId(parent_pipeline_id,
                                                      old_subpage_id,
                                                      new_subpage_id,
                                                      new_pipeline_id) =>
-                self.handle_update_subpage_id(containing_pipeline_id,
+                self.handle_update_subpage_id(parent_pipeline_id,
                                               old_subpage_id,
                                               new_subpage_id,
                                               new_pipeline_id),
-            ConstellationControlMsg::FocusIFrame(containing_pipeline_id, subpage_id) =>
-                self.handle_focus_iframe_msg(containing_pipeline_id, subpage_id),
+            ConstellationControlMsg::FocusIFrame(parent_pipeline_id, subpage_id) =>
+                self.handle_focus_iframe_msg(parent_pipeline_id, subpage_id),
             ConstellationControlMsg::WebDriverScriptCommand(pipeline_id, msg) =>
                 self.handle_webdriver_msg(pipeline_id, msg),
             ConstellationControlMsg::TickAllAnimations(pipeline_id) =>
@@ -916,10 +916,10 @@ impl ScriptThread {
             ConstellationControlMsg::WebFontLoaded(pipeline_id) =>
                 self.handle_web_font_loaded(pipeline_id),
             ConstellationControlMsg::DispatchFrameLoadEvent {
-                target: pipeline_id, parent: containing_id } =>
-                self.handle_frame_load_event(containing_id, pipeline_id),
-            ConstellationControlMsg::FramedContentChanged(containing_pipeline_id, subpage_id) =>
-                self.handle_framed_content_changed(containing_pipeline_id, subpage_id),
+                target: pipeline_id, parent: parent_pipeline_id } =>
+                self.handle_frame_load_event(parent_pipeline_id, pipeline_id),
+            ConstellationControlMsg::FramedContentChanged(parent_pipeline_id, pipeline_id) =>
+                self.handle_framed_content_changed(parent_pipeline_id, pipeline_id),
             ConstellationControlMsg::ReportCSSError(pipeline_id, filename, line, column, msg) =>
                 self.handle_css_error_reporting(pipeline_id, filename, line, column, msg),
             ConstellationControlMsg::Reload(pipeline_id) =>
@@ -935,8 +935,8 @@ impl ScriptThread {
 
     fn handle_msg_from_script(&self, msg: MainThreadScriptMsg) {
         match msg {
-            MainThreadScriptMsg::Navigate(id, load_data) =>
-                self.handle_navigate(id, None, load_data),
+            MainThreadScriptMsg::Navigate(parent_pipeline_id, load_data) =>
+                self.handle_navigate(parent_pipeline_id, None, load_data),
             MainThreadScriptMsg::ExitWindow(id) =>
                 self.handle_exit_window_msg(id),
             MainThreadScriptMsg::DocumentLoadsComplete(id) =>
@@ -1128,7 +1128,7 @@ impl ScriptThread {
 
     fn handle_new_layout(&self, new_layout_info: NewLayoutInfo) {
         let NewLayoutInfo {
-            containing_pipeline_id,
+            parent_pipeline_id,
             new_pipeline_id,
             subpage_id,
             frame_type,
@@ -1158,7 +1158,7 @@ impl ScriptThread {
         };
 
         let context = self.root_browsing_context();
-        let parent_context = context.find(containing_pipeline_id).expect("ScriptThread: received a layout
+        let parent_context = context.find(parent_pipeline_id).expect("ScriptThread: received a layout
             whose parent has a PipelineId which does not correspond to a pipeline in the script
             thread's browsing context tree. This is a bug.");
         let parent_window = parent_context.active_window();
@@ -1169,7 +1169,7 @@ impl ScriptThread {
                      .unwrap();
 
         // Kick off the fetch for the new resource.
-        let new_load = InProgressLoad::new(new_pipeline_id, Some((containing_pipeline_id, subpage_id, frame_type)),
+        let new_load = InProgressLoad::new(new_pipeline_id, Some((parent_pipeline_id, subpage_id, frame_type)),
                                            layout_chan, parent_window.window_size(),
                                            load_data.url.clone());
         self.start_page_load(new_load, load_data);
@@ -1254,9 +1254,9 @@ impl ScriptThread {
     }
 
     /// Updates iframe element after a change in visibility
-    fn handle_visibility_change_complete_msg(&self, containing_id: PipelineId, id: PipelineId, visible: bool) {
+    fn handle_visibility_change_complete_msg(&self, parent_pipeline_id: PipelineId, id: PipelineId, visible: bool) {
         if let Some(root_context) = self.browsing_context.get() {
-            if let Some(ref inner_context) = root_context.find(containing_id) {
+            if let Some(ref inner_context) = root_context.find(parent_pipeline_id) {
                 if let Some(iframe) = inner_context.active_document().find_iframe_by_pipeline(id) {
                     iframe.change_visibility_status(visible);
                 }
@@ -1372,13 +1372,13 @@ impl ScriptThread {
     }
 
     fn handle_update_subpage_id(&self,
-                                containing_pipeline_id: PipelineId,
+                                parent_pipeline_id: PipelineId,
                                 old_subpage_id: SubpageId,
                                 new_subpage_id: SubpageId,
                                 new_pipeline_id: PipelineId) {
         let borrowed_context = self.root_browsing_context();
 
-        let frame_element = borrowed_context.find(containing_pipeline_id).and_then(|context| {
+        let frame_element = borrowed_context.find(parent_pipeline_id).and_then(|context| {
             let doc = context.active_document();
             doc.find_iframe(old_subpage_id)
         });
@@ -1534,10 +1534,10 @@ impl ScriptThread {
     }
 
     /// Notify the containing document of a child frame that has completed loading.
-    fn handle_frame_load_event(&self, containing_pipeline: PipelineId, id: PipelineId) {
-        let document = match self.root_browsing_context().find(containing_pipeline) {
+    fn handle_frame_load_event(&self, parent_pipeline_id: PipelineId, id: PipelineId) {
+        let document = match self.root_browsing_context().find(parent_pipeline_id) {
             Some(browsing_context) => browsing_context.active_document(),
-            None => return warn!("Message sent to closed pipeline {}.", containing_pipeline),
+            None => return warn!("Message sent to closed pipeline {}.", parent_pipeline_id),
         };
         if let Some(iframe) = document.find_iframe_by_pipeline(id) {
             iframe.iframe_load_event_steps(id);
@@ -2006,19 +2006,19 @@ impl ScriptThread {
     /// https://html.spec.whatwg.org/multipage/#navigating-across-documents
     /// The entry point for content to notify that a new load has been requested
     /// for the given pipeline (specifically the "navigate" algorithm).
-    fn handle_navigate(&self, pipeline_id: PipelineId, subpage_id: Option<SubpageId>, load_data: LoadData) {
+    fn handle_navigate(&self, parent_pipeline_id: PipelineId, subpage_id: Option<SubpageId>, load_data: LoadData) {
         // Step 7.
         {
             let nurl = &load_data.url;
             if let Some(fragment) = nurl.fragment() {
-                let document = match self.root_browsing_context().find(pipeline_id) {
+                let document = match self.root_browsing_context().find(parent_pipeline_id) {
                     Some(browsing_context) => browsing_context.active_document(),
-                    None => return warn!("Message sent to closed pipeline {}.", pipeline_id),
+                    None => return warn!("Message sent to closed pipeline {}.", parent_pipeline_id),
                 };
                 let url = document.url();
                 if &url[..Position::AfterQuery] == &nurl[..Position::AfterQuery] &&
                     load_data.method == Method::Get {
-                    self.check_and_scroll_fragment(fragment, pipeline_id, document.r());
+                    self.check_and_scroll_fragment(fragment, parent_pipeline_id, document.r());
                     return;
                 }
             }
@@ -2027,7 +2027,7 @@ impl ScriptThread {
         match subpage_id {
             Some(subpage_id) => {
                 let root_context = self.root_browsing_context();
-                let iframe = root_context.find(pipeline_id).and_then(|context| {
+                let iframe = root_context.find(parent_pipeline_id).and_then(|context| {
                     let doc = context.active_document();
                     doc.find_iframe(subpage_id)
                 });
@@ -2037,7 +2037,7 @@ impl ScriptThread {
             }
             None => {
                 self.constellation_chan
-                    .send(ConstellationMsg::LoadUrl(pipeline_id, load_data))
+                    .send(ConstellationMsg::LoadUrl(parent_pipeline_id, load_data))
                     .unwrap();
             }
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -644,7 +644,7 @@ impl ScriptThread {
                 let window = context.active_window();
                 let resize_event = window.steal_resize_event();
                 match resize_event {
-                    Some(size) => resizes.push((window.pipeline(), size)),
+                    Some(size) => resizes.push((window.pipeline_id(), size)),
                     None => ()
                 }
             }
@@ -1502,7 +1502,7 @@ impl ScriptThread {
         // If root is being exited, shut down all contexts
         let context = self.root_browsing_context();
         let window = context.active_window();
-        if window.pipeline() == id {
+        if window.pipeline_id() == id {
             debug!("shutting down layout for root context {:?}", id);
             shut_down_layout(&context);
             let _ = self.constellation_chan.send(ConstellationMsg::PipelineExited(id));
@@ -1698,7 +1698,7 @@ impl ScriptThread {
         });
 
         let loader = DocumentLoader::new_with_threads(self.resource_threads.clone(),
-                                                      Some(browsing_context.pipeline()),
+                                                      Some(browsing_context.pipeline_id()),
                                                       Some(incomplete.url.clone()));
 
         let is_html_document = match metadata.content_type {
@@ -1754,7 +1754,7 @@ impl ScriptThread {
             .unwrap();
 
         // Notify devtools that a new script global exists.
-        self.notify_devtools(document.Title(), final_url.clone(), (browsing_context.pipeline(), None));
+        self.notify_devtools(document.Title(), final_url.clone(), (browsing_context.pipeline_id(), None));
 
         let is_javascript = incomplete.url.scheme() == "javascript";
         let parse_input = if is_javascript {
@@ -1818,7 +1818,7 @@ impl ScriptThread {
         }
 
         if !incomplete.is_visible {
-            self.alter_resource_utilization(browsing_context.pipeline(), false);
+            self.alter_resource_utilization(browsing_context.pipeline_id(), false);
         }
 
         context_remover.neuter();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -65,7 +65,7 @@ use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use mem::heap_size_of_self_and_children;
 use msg::constellation_msg::{FrameType, LoadData, PipelineId, PipelineNamespace};
-use msg::constellation_msg::{ReferrerPolicy, SubpageId, WindowSizeType};
+use msg::constellation_msg::{ReferrerPolicy, WindowSizeType};
 use net_traits::{AsyncResponseTarget, CoreResourceMsg, LoadConsumer, LoadContext, Metadata, ResourceThreads};
 use net_traits::{IpcSend, LoadData as NetLoadData};
 use net_traits::bluetooth_thread::BluetoothMethodMsg;
@@ -131,8 +131,8 @@ pub unsafe fn trace_thread(tr: *mut JSTracer) {
 struct InProgressLoad {
     /// The pipeline which requested this load.
     pipeline_id: PipelineId,
-    /// The parent pipeline and child subpage associated with this load, if any.
-    parent_info: Option<(PipelineId, SubpageId, FrameType)>,
+    /// The parent pipeline and frame type associated with this load, if any.
+    parent_info: Option<(PipelineId, FrameType)>,
     /// The current window size associated with this pipeline.
     window_size: Option<WindowSizeData>,
     /// Channel to the layout thread associated with this pipeline.
@@ -150,7 +150,7 @@ struct InProgressLoad {
 impl InProgressLoad {
     /// Create a new InProgressLoad object.
     fn new(id: PipelineId,
-           parent_info: Option<(PipelineId, SubpageId, FrameType)>,
+           parent_info: Option<(PipelineId, FrameType)>,
            layout_chan: Sender<message::Msg>,
            window_size: Option<WindowSizeData>,
            url: Url) -> InProgressLoad {
@@ -484,11 +484,11 @@ impl ScriptThreadFactory for ScriptThread {
 }
 
 impl ScriptThread {
-    pub fn page_headers_available(id: &PipelineId, subpage: Option<&SubpageId>, metadata: Option<Metadata>)
+    pub fn page_headers_available(id: &PipelineId, metadata: Option<Metadata>)
                                   -> Option<ParserRoot> {
         SCRIPT_THREAD_ROOT.with(|root| {
             let script_thread = unsafe { &*root.get().unwrap() };
-            script_thread.handle_page_headers_available(id, subpage, metadata)
+            script_thread.handle_page_headers_available(id, metadata)
         })
     }
 
@@ -877,8 +877,8 @@ impl ScriptThread {
 
     fn handle_msg_from_constellation(&self, msg: ConstellationControlMsg) {
         match msg {
-            ConstellationControlMsg::Navigate(parent_pipeline_id, subpage_id, load_data) =>
-                self.handle_navigate(parent_pipeline_id, Some(subpage_id), load_data),
+            ConstellationControlMsg::Navigate(parent_pipeline_id, pipeline_id, load_data) =>
+                self.handle_navigate(parent_pipeline_id, Some(pipeline_id), load_data),
             ConstellationControlMsg::SendEvent(id, event) =>
                 self.handle_event(id, event),
             ConstellationControlMsg::ResizeInactive(id, new_size) =>
@@ -894,21 +894,19 @@ impl ScriptThread {
             ConstellationControlMsg::NotifyVisibilityChange(parent_pipeline_id, pipeline_id, visible) =>
                 self.handle_visibility_change_complete_msg(parent_pipeline_id, pipeline_id, visible),
             ConstellationControlMsg::MozBrowserEvent(parent_pipeline_id,
-                                                     subpage_id,
+                                                     pipeline_id,
                                                      event) =>
                 self.handle_mozbrowser_event_msg(parent_pipeline_id,
-                                                 subpage_id,
+                                                 pipeline_id,
                                                  event),
-            ConstellationControlMsg::UpdateSubpageId(parent_pipeline_id,
-                                                     old_subpage_id,
-                                                     new_subpage_id,
-                                                     new_pipeline_id) =>
-                self.handle_update_subpage_id(parent_pipeline_id,
-                                              old_subpage_id,
-                                              new_subpage_id,
-                                              new_pipeline_id),
-            ConstellationControlMsg::FocusIFrame(parent_pipeline_id, subpage_id) =>
-                self.handle_focus_iframe_msg(parent_pipeline_id, subpage_id),
+            ConstellationControlMsg::UpdatePipelineId(parent_pipeline_id,
+                                                      old_pipeline_id,
+                                                      new_pipeline_id) =>
+                self.handle_update_pipeline_id(parent_pipeline_id,
+                                               old_pipeline_id,
+                                               new_pipeline_id),
+            ConstellationControlMsg::FocusIFrame(parent_pipeline_id, pipeline_id) =>
+                self.handle_focus_iframe_msg(parent_pipeline_id, pipeline_id),
             ConstellationControlMsg::WebDriverScriptCommand(pipeline_id, msg) =>
                 self.handle_webdriver_msg(pipeline_id, msg),
             ConstellationControlMsg::TickAllAnimations(pipeline_id) =>
@@ -1130,7 +1128,6 @@ impl ScriptThread {
         let NewLayoutInfo {
             parent_pipeline_id,
             new_pipeline_id,
-            subpage_id,
             frame_type,
             load_data,
             paint_chan,
@@ -1169,7 +1166,7 @@ impl ScriptThread {
                      .unwrap();
 
         // Kick off the fetch for the new resource.
-        let new_load = InProgressLoad::new(new_pipeline_id, Some((parent_pipeline_id, subpage_id, frame_type)),
+        let new_load = InProgressLoad::new(new_pipeline_id, Some((parent_pipeline_id, frame_type)),
                                            layout_chan, parent_window.window_size(),
                                            load_data.url.clone());
         self.start_page_load(new_load, load_data);
@@ -1257,7 +1254,7 @@ impl ScriptThread {
     fn handle_visibility_change_complete_msg(&self, parent_pipeline_id: PipelineId, id: PipelineId, visible: bool) {
         if let Some(root_context) = self.browsing_context.get() {
             if let Some(ref inner_context) = root_context.find(parent_pipeline_id) {
-                if let Some(iframe) = inner_context.active_document().find_iframe_by_pipeline(id) {
+                if let Some(iframe) = inner_context.active_document().find_iframe(id) {
                     iframe.change_visibility_status(visible);
                 }
             }
@@ -1323,12 +1320,12 @@ impl ScriptThread {
 
     fn handle_focus_iframe_msg(&self,
                                parent_pipeline_id: PipelineId,
-                               subpage_id: SubpageId) {
+                               pipeline_id: PipelineId) {
         let borrowed_context = self.root_browsing_context();
         let context = borrowed_context.find(parent_pipeline_id).unwrap();
 
         let doc = context.active_document();
-        let frame_element = doc.find_iframe(subpage_id);
+        let frame_element = doc.find_iframe(pipeline_id);
 
         if let Some(ref frame_element) = frame_element {
             doc.begin_focus_transaction();
@@ -1339,11 +1336,11 @@ impl ScriptThread {
 
     fn handle_framed_content_changed(&self,
                                      parent_pipeline_id: PipelineId,
-                                     subpage_id: SubpageId) {
+                                     pipeline_id: PipelineId) {
         let root_context = self.root_browsing_context();
         let context = root_context.find(parent_pipeline_id).unwrap();
         let doc = context.active_document();
-        let frame_element = doc.find_iframe(subpage_id);
+        let frame_element = doc.find_iframe(pipeline_id);
         if let Some(ref frame_element) = frame_element {
             frame_element.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
             let window = context.active_window();
@@ -1357,33 +1354,32 @@ impl ScriptThread {
     /// https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserloadstart
     fn handle_mozbrowser_event_msg(&self,
                                    parent_pipeline_id: PipelineId,
-                                   subpage_id: Option<SubpageId>,
+                                   pipeline_id: Option<PipelineId>,
                                    event: MozBrowserEvent) {
         match self.root_browsing_context().find(parent_pipeline_id) {
             None => warn!("Mozbrowser event after pipeline {:?} closed.", parent_pipeline_id),
-            Some(context) => match subpage_id {
+            Some(context) => match pipeline_id {
                 None => context.active_window().dispatch_mozbrowser_event(event),
-                Some(subpage_id) => match context.active_document().find_iframe(subpage_id) {
-                    None => warn!("Mozbrowser event after iframe {:?}/{:?} closed.", parent_pipeline_id, subpage_id),
+                Some(pipeline_id) => match context.active_document().find_iframe(pipeline_id) {
+                    None => warn!("Mozbrowser event after iframe {:?}/{:?} closed.", parent_pipeline_id, pipeline_id),
                     Some(frame_element) => frame_element.dispatch_mozbrowser_event(event),
                 },
             },
         }
     }
 
-    fn handle_update_subpage_id(&self,
-                                parent_pipeline_id: PipelineId,
-                                old_subpage_id: SubpageId,
-                                new_subpage_id: SubpageId,
-                                new_pipeline_id: PipelineId) {
+    fn handle_update_pipeline_id(&self,
+                                 parent_pipeline_id: PipelineId,
+                                 old_pipeline_id: PipelineId,
+                                 new_pipeline_id: PipelineId) {
         let borrowed_context = self.root_browsing_context();
 
         let frame_element = borrowed_context.find(parent_pipeline_id).and_then(|context| {
             let doc = context.active_document();
-            doc.find_iframe(old_subpage_id)
+            doc.find_iframe(old_pipeline_id)
         });
 
-        frame_element.unwrap().update_subpage_id(new_subpage_id, new_pipeline_id);
+        frame_element.unwrap().update_pipeline_id(new_pipeline_id);
     }
 
     /// Window was resized, but this script was not active, so don't reflow yet
@@ -1412,11 +1408,9 @@ impl ScriptThread {
 
     /// We have received notification that the response associated with a load has completed.
     /// Kick off the document and frame tree creation process using the result.
-    fn handle_page_headers_available(&self, id: &PipelineId, subpage: Option<&SubpageId>,
+    fn handle_page_headers_available(&self, id: &PipelineId,
                                      metadata: Option<Metadata>) -> Option<ParserRoot> {
-        let idx = self.incomplete_loads.borrow().iter().position(|load| {
-            load.pipeline_id == *id && load.parent_info.as_ref().map(|info| &info.1) == subpage
-        });
+        let idx = self.incomplete_loads.borrow().iter().position(|load| { load.pipeline_id == *id });
         // The matching in progress load structure may not exist if
         // the pipeline exited before the page load completed.
         match idx {
@@ -1539,7 +1533,7 @@ impl ScriptThread {
             Some(browsing_context) => browsing_context.active_document(),
             None => return warn!("Message sent to closed pipeline {}.", parent_pipeline_id),
         };
-        if let Some(iframe) = document.find_iframe_by_pipeline(id) {
+        if let Some(iframe) = document.find_iframe(id) {
             iframe.iframe_load_event_steps(id);
         }
     }
@@ -1561,7 +1555,7 @@ impl ScriptThread {
         }
         debug!("ScriptThread: loading {} on pipeline {:?}", incomplete.url, incomplete.pipeline_id);
 
-        let frame_element = incomplete.parent_info.and_then(|(parent_id, subpage_id, _)| {
+        let frame_element = incomplete.parent_info.and_then(|(parent_id, _)| {
             // The root context may not exist yet, if the parent of this frame
             // exists in a different script thread.
             let root_context = self.browsing_context.get();
@@ -1576,7 +1570,7 @@ impl ScriptThread {
             root_context.and_then(|root_context| {
                 root_context.find(parent_id).and_then(|context| {
                     let doc = context.active_document();
-                    doc.find_iframe(subpage_id)
+                    doc.find_iframe(incomplete.pipeline_id)
                 })
             })
         });
@@ -1664,7 +1658,7 @@ impl ScriptThread {
             // We have a new root frame tree.
             self.browsing_context.set(Some(&new_context));
             (new_context, ContextToRemove::Root)
-        } else if let Some((parent, _, _)) = incomplete.parent_info {
+        } else if let Some((parent, _)) = incomplete.parent_info {
             // Create a new context tree entry. This will be a child context.
             let new_context = BrowsingContext::new(&window, frame_element, incomplete.pipeline_id);
 
@@ -2006,7 +2000,7 @@ impl ScriptThread {
     /// https://html.spec.whatwg.org/multipage/#navigating-across-documents
     /// The entry point for content to notify that a new load has been requested
     /// for the given pipeline (specifically the "navigate" algorithm).
-    fn handle_navigate(&self, parent_pipeline_id: PipelineId, subpage_id: Option<SubpageId>, load_data: LoadData) {
+    fn handle_navigate(&self, parent_pipeline_id: PipelineId, pipeline_id: Option<PipelineId>, load_data: LoadData) {
         // Step 7.
         {
             let nurl = &load_data.url;
@@ -2024,12 +2018,12 @@ impl ScriptThread {
             }
         }
 
-        match subpage_id {
-            Some(subpage_id) => {
+        match pipeline_id {
+            Some(pipeline_id) => {
                 let root_context = self.root_browsing_context();
                 let iframe = root_context.find(parent_pipeline_id).and_then(|context| {
                     let doc = context.active_document();
-                    doc.find_iframe(subpage_id)
+                    doc.find_iframe(pipeline_id)
                 });
                 if let Some(iframe) = iframe.r() {
                     iframe.navigate_or_reload_child_browsing_context(Some(load_data));
@@ -2076,9 +2070,8 @@ impl ScriptThread {
     /// argument until a notification is received that the fetch is complete.
     fn start_page_load(&self, incomplete: InProgressLoad, mut load_data: LoadData) {
         let id = incomplete.pipeline_id.clone();
-        let subpage = incomplete.parent_info.clone().map(|p| p.1);
 
-        let context = Arc::new(Mutex::new(ParserContext::new(id, subpage, load_data.url.clone())));
+        let context = Arc::new(Mutex::new(ParserContext::new(id, load_data.url.clone())));
         let (action_sender, action_receiver) = ipc::channel().unwrap();
         let listener = NetworkListener {
             context: context,

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -140,7 +140,7 @@ pub fn handle_get_frame_id(context: &BrowsingContext,
         }
     };
 
-    let frame_id = window.map(|x| x.map(|x| x.pipeline()));
+    let frame_id = window.map(|x| x.map(|x| x.pipeline_id()));
     reply.send(frame_id).unwrap()
 }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -54,7 +54,7 @@ use layers::geometry::DevicePixel;
 use libc::c_void;
 use msg::constellation_msg::{FrameId, FrameType, Image, Key, KeyModifiers, KeyState, LoadData};
 use msg::constellation_msg::{PipelineId, PipelineNamespaceId, ReferrerPolicy};
-use msg::constellation_msg::{SubpageId, TraversalDirection, WindowSizeType};
+use msg::constellation_msg::{TraversalDirection, WindowSizeType};
 use net_traits::{LoadOrigin, ResourceThreads};
 use net_traits::bluetooth_thread::BluetoothMethodMsg;
 use net_traits::image_cache_thread::ImageCacheThread;
@@ -133,8 +133,6 @@ pub struct NewLayoutInfo {
     pub parent_pipeline_id: PipelineId,
     /// Id of the newly-created pipeline.
     pub new_pipeline_id: PipelineId,
-    /// Id of the new frame associated with this pipeline.
-    pub subpage_id: SubpageId,
     /// Type of the new frame associated with this pipeline.
     pub frame_type: FrameType,
     /// Network request data which will be initiated by the script thread.
@@ -178,16 +176,22 @@ pub enum ConstellationControlMsg {
     /// Notifies script thread whether frame is visible
     ChangeFrameVisibilityStatus(PipelineId, bool),
     /// Notifies script thread that frame visibility change is complete
+    /// First PipelineId is for the parent, second PipelineId is for the actual pipeline.
     NotifyVisibilityChange(PipelineId, PipelineId, bool),
     /// Notifies script thread that a url should be loaded in this iframe.
-    Navigate(PipelineId, SubpageId, LoadData),
+    /// First PipelineId is for the parent, second PipelineId is for the actual pipeline.
+    Navigate(PipelineId, PipelineId, LoadData),
     /// Requests the script thread forward a mozbrowser event to an iframe it owns,
-    /// or to the window if no subpage id is provided.
-    MozBrowserEvent(PipelineId, Option<SubpageId>, MozBrowserEvent),
-    /// Updates the current subpage and pipeline IDs of a given iframe
-    UpdateSubpageId(PipelineId, SubpageId, SubpageId, PipelineId),
+    /// or to the window if no child pipeline id is provided.
+    /// First PipelineId is for the parent, second PipelineId is for the actual pipeline.
+    MozBrowserEvent(PipelineId, Option<PipelineId>, MozBrowserEvent),
+    /// Updates the current pipeline ID of a given iframe.
+    /// First PipelineId is for the parent, second is the old PipelineId for the frame,
+    /// third is the new PipelineId for the frame.
+    UpdatePipelineId(PipelineId, PipelineId, PipelineId),
     /// Set an iframe to be focused. Used when an element in an iframe gains focus.
-    FocusIFrame(PipelineId, SubpageId),
+    /// First PipelineId is for the parent, second PipelineId is for the actual pipeline.
+    FocusIFrame(PipelineId, PipelineId),
     /// Passes a webdriver command to the script thread for execution
     WebDriverScriptCommand(PipelineId, WebDriverScriptCommand),
     /// Notifies script thread that all animations are done
@@ -203,7 +207,8 @@ pub enum ConstellationControlMsg {
         parent: PipelineId,
     },
     /// Notifies a parent frame that one of its child frames is now active.
-    FramedContentChanged(PipelineId, SubpageId),
+    /// First PipelineId is for the parent, second PipelineId is for the actual pipeline.
+    FramedContentChanged(PipelineId, PipelineId),
     /// Report an error from a CSS parser for the given pipeline
     ReportCSSError(PipelineId, String, usize, usize, String),
     /// Reload the given page.
@@ -228,7 +233,7 @@ impl fmt::Debug for ConstellationControlMsg {
             NotifyVisibilityChange(..) => "NotifyVisibilityChange",
             Navigate(..) => "Navigate",
             MozBrowserEvent(..) => "MozBrowserEvent",
-            UpdateSubpageId(..) => "UpdateSubpageId",
+            UpdatePipelineId(..) => "UpdatePipelineId",
             FocusIFrame(..) => "FocusIFrame",
             WebDriverScriptCommand(..) => "WebDriverScriptCommand",
             TickAllAnimations(..) => "TickAllAnimations",
@@ -389,7 +394,7 @@ pub struct InitialScriptState {
     pub id: PipelineId,
     /// The subpage ID of this pipeline to create in its pipeline parent.
     /// If `None`, this is the root.
-    pub parent_info: Option<(PipelineId, SubpageId, FrameType)>,
+    pub parent_info: Option<(PipelineId, FrameType)>,
     /// A channel with which messages can be sent to us (the script thread).
     pub control_chan: IpcSender<ConstellationControlMsg>,
     /// A port on which messages sent by the constellation to script can be received.
@@ -445,10 +450,8 @@ pub struct IFrameLoadInfo {
     pub load_data: Option<LoadData>,
     /// Pipeline ID of the parent of this iframe
     pub parent_pipeline_id: PipelineId,
-    /// The new subpage ID for this load
-    pub new_subpage_id: SubpageId,
-    /// The old subpage ID for this iframe, if a page was previously loaded.
-    pub old_subpage_id: Option<SubpageId>,
+    /// The old pipeline ID for this iframe, if a page was previously loaded.
+    pub old_pipeline_id: Option<PipelineId>,
     /// The new pipeline ID that the iframe has generated.
     pub new_pipeline_id: PipelineId,
     /// Sandbox type of this iframe

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -130,7 +130,7 @@ pub enum LayoutControlMsg {
 #[derive(Deserialize, Serialize)]
 pub struct NewLayoutInfo {
     /// Id of the parent of this new pipeline.
-    pub containing_pipeline_id: PipelineId,
+    pub parent_pipeline_id: PipelineId,
     /// Id of the newly-created pipeline.
     pub new_pipeline_id: PipelineId,
     /// Id of the new frame associated with this pipeline.
@@ -444,7 +444,7 @@ pub struct IFrameLoadInfo {
     /// Load data containing the url to load
     pub load_data: Option<LoadData>,
     /// Pipeline ID of the parent of this iframe
-    pub containing_pipeline_id: PipelineId,
+    pub parent_pipeline_id: PipelineId,
     /// The new subpage ID for this load
     pub new_subpage_id: SubpageId,
     /// The old subpage ID for this iframe, if a page was previously loaded.

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -17,7 +17,7 @@ use euclid::size::Size2D;
 use gfx_traits::LayerId;
 use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::{Key, KeyModifiers, KeyState, LoadData};
-use msg::constellation_msg::{PipelineId, SubpageId, TraversalDirection};
+use msg::constellation_msg::{PipelineId, TraversalDirection};
 use net_traits::CoreResourceMsg;
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use style_traits::cursor::Cursor;
@@ -87,7 +87,8 @@ pub enum ScriptMsg {
     LoadUrl(PipelineId, LoadData),
     /// Dispatch a mozbrowser event to a given iframe,
     /// or to the window if no subpage id is provided.
-    MozBrowserEvent(PipelineId, Option<SubpageId>, MozBrowserEvent),
+    /// First PipelineId is for the parent, second PipelineId is for the actual pipeline.
+    MozBrowserEvent(PipelineId, Option<PipelineId>, MozBrowserEvent),
     /// HTMLIFrameElement Forward or Back traversal.
     TraverseHistory(Option<PipelineId>, TraversalDirection),
     /// Gets the length of the joint session history from the constellation.

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -251,7 +251,7 @@ impl Handler {
         }
     }
 
-    fn pipeline(&self, frame_id: Option<FrameId>) -> WebDriverResult<PipelineId> {
+    fn pipeline_id(&self, frame_id: Option<FrameId>) -> WebDriverResult<PipelineId> {
         let interval = 20;
         let iterations = 30_000 / interval;
         let (sender, receiver) = ipc::channel().unwrap();
@@ -271,11 +271,11 @@ impl Handler {
     }
 
     fn root_pipeline(&self) -> WebDriverResult<PipelineId> {
-        self.pipeline(None)
+        self.pipeline_id(None)
     }
 
     fn frame_pipeline(&self) -> WebDriverResult<PipelineId> {
-        self.pipeline(self.session.as_ref().and_then(|session| session.frame_id))
+        self.pipeline_id(self.session.as_ref().and_then(|session| session.frame_id))
     }
 
     fn session(&self) -> WebDriverResult<&WebDriverSession> {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

SubpageId was originally introduced in 2013 to help iframes keep track of
their associated (children) pipelines. However, since each pipeline
already has a PipelineId, and those are unique, those are sufficient
to keep track of children.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11694  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because refactoring

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11698)

<!-- Reviewable:end -->
