### PR TITLE
Remove an invalid assertion in fire_timer.

### DIFF
--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -176,7 +176,10 @@ impl OneshotTimers {
         let base_time = self.base_time();
 
         // Since the event id was the expected one, at least one timer should be due.
-        assert!(base_time >= self.timers.borrow().last().unwrap().scheduled_for);
+        if base_time < self.timers.borrow().last().unwrap().scheduled_for {
+            warn!("Unexpected timing!");
+            return;
+        }
 
         // select timers to run to prevent firing timers
         // that were installed during fire of another timer


### PR DESCRIPTION
It's not clear to me if this is something we should expect to happen, but it
does indeed happen, so we should disable the assertion while we investigate.

Fixes #9984.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11700)

<!-- Reviewable:end -->
