### PR TITLE
Avoid frequent intermittent failure in tests.

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1083,7 +1083,7 @@ impl ScriptThread {
             load.window_size = Some(size);
             return;
         }
-        panic!("resize sent to nonexistent pipeline");
+        warn!("resize sent to nonexistent pipeline");
     }
 
     fn handle_viewport(&self, id: PipelineId, rect: Rect<f32>) {


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11613 (github issue number if applicable).
- [X] These changes do not require tests because they address a frequent nondeterministic panic that occurs in other tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11707)

<!-- Reviewable:end -->
