### PR TITLE
added dom obj counting to decide sequential/parallel layout (#10110)

### DIFF
--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -32,7 +32,7 @@ range = {path = "../range"}
 rustc-serialize = "0.3"
 script = {path = "../script"}
 script_traits = {path = "../script_traits"}
-selectors = {version = "0.6", features = ["heap_size"]}
+selectors = {git = "https://github.com/avadacatavra/rust-selectors.git", features = ["heap_size"]}
 serde_json = "0.7"
 serde_macros = "0.7"
 smallvec = "0.1"

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1131,6 +1131,8 @@ impl BlockFlow {
         self.base.position = LogicalRect::from_point_size(self.base.writing_mode,
                                                           origin,
                                                           self.base.position.size);
+
+    debug!("{}", self.base.writing_mode);
     }
 
     pub fn explicit_block_containing_size(&self, layout_context: &LayoutContext) -> Option<Au> {
@@ -1345,6 +1347,7 @@ impl BlockFlow {
 
         let mut inline_start_margin_edge = inline_start_content_edge;
         let mut inline_end_margin_edge = inline_end_content_edge;
+        
 
         let mut iterator = self.base.child_iter_mut().enumerate().peekable();
         while let Some((i, kid)) = iterator.next() {
@@ -1358,9 +1361,11 @@ impl BlockFlow {
                 if kid_base.flags.contains(INLINE_POSITION_IS_STATIC) {
                     kid_base.position.start.i =
                         if kid_mode.is_bidi_ltr() == containing_block_mode.is_bidi_ltr() {
+                            debug!("Is LTR");
                             inline_start_content_edge
                         } else {
                             // The kid's inline 'start' is at the parent's 'end'
+                            debug!("Is RTL");
                             inline_end_content_edge
                         };
                 }
@@ -2333,6 +2338,7 @@ pub trait ISizeAndMarginsComputer {
 
             // FIXME (mbrubeck): Get correct containing block for positioned blocks?
             let container_mode = block.base.block_container_writing_mode;
+            debug!("Flow {} is in container writing mode {}", block.base.debug_id(), container_mode);
             let container_size = block.base.block_container_inline_size;
 
             let fragment = block.fragment();

--- a/components/layout/flow_list.rs
+++ b/components/layout/flow_list.rs
@@ -117,6 +117,12 @@ impl<'a> DoubleEndedIterator for FlowListIterator<'a> {
     }
 }
 
+impl<'a> DoubleEndedIterator for MutFlowListIterator<'a> {
+    fn next_back(&mut self) -> Option<&'a mut Flow> {
+        self.it.next_back().map(flow_ref::deref_mut)
+    }
+}
+
 impl<'a> Iterator for MutFlowListIterator<'a> {
     type Item = &'a mut Flow;
     #[inline]

--- a/components/layout/layout_thread.rs
+++ b/components/layout/layout_thread.rs
@@ -189,7 +189,10 @@ pub struct LayoutThread {
     first_reflow: bool,
 
     /// The workers that we use for parallel operation.
-    parallel_traversal: Option<WorkQueue<SharedLayoutContext, WorkQueueData>>,
+    parallel_traversal: WorkQueue<SharedLayoutContext, WorkQueueData>,
+
+    /// Flag to indicate whether to use parallel operations
+    parallel_flag: bool,
 
     /// Starts at zero, and increased by one every time a layout completes.
     /// This can be used to easily check for invalid stale data.
@@ -396,12 +399,13 @@ impl LayoutThread {
         let device = Device::new(
             MediaType::Screen,
             opts::get().initial_window_size.as_f32() * ScaleFactor::new(1.0));
-        let parallel_traversal = if opts::get().layout_threads != 1 {
-            Some(WorkQueue::new("LayoutWorker", thread_state::LAYOUT,
-                                opts::get().layout_threads))
-        } else {
-            None
-        };
+
+        let parallel_traversal = WorkQueue::new("LayoutWorker",
+                                    thread_state::LAYOUT,
+                                    opts::get().layout_threads);
+
+
+        debug!("Possible layout Threads: {}", opts::get().layout_threads);
 
         // Create the channel on which new animations can be sent.
         let (new_animations_sender, new_animations_receiver) = channel();
@@ -448,6 +452,7 @@ impl LayoutThread {
             font_cache_receiver: font_cache_receiver,
             font_cache_sender: ipc_font_cache_sender,
             parallel_traversal: parallel_traversal,
+            parallel_flag: true,
             generation: 0,
             new_animations_sender: new_animations_sender,
             new_animations_receiver: new_animations_receiver,
@@ -721,16 +726,15 @@ impl LayoutThread {
         });
 
         // ... as do each of the LayoutWorkers, if present.
-        if let Some(ref traversal) = self.parallel_traversal {
-            let sizes = traversal.heap_size_of_tls(heap_size_of_local_context);
-            for (i, size) in sizes.iter().enumerate() {
-                reports.push(Report {
-                    path: path![formatted_url,
-                                format!("layout-worker-{}-local-context", i)],
-                    kind: ReportKind::ExplicitJemallocHeapSize,
-                    size: *size,
-                });
-            }
+        let ref traversal = self.parallel_traversal;
+        let sizes = traversal.heap_size_of_tls(heap_size_of_local_context);
+        for (i, size) in sizes.iter().enumerate() {
+            reports.push(Report {
+                path: path![formatted_url,
+                            format!("layout-worker-{}-local-context", i)],
+                kind: ReportKind::ExplicitJemallocHeapSize,
+                size: *size,
+            });
         }
 
         reports_chan.send(reports);
@@ -783,9 +787,8 @@ impl LayoutThread {
     /// Shuts down the layout thread now. If there are any DOM nodes left, layout will now (safely)
     /// crash.
     fn exit_now(&mut self) {
-        if let Some(ref mut traversal) = self.parallel_traversal {
-            traversal.shutdown()
-        }
+        let ref mut traversal = self.parallel_traversal;
+        traversal.shutdown();
 
         self.paint_chan.send(LayoutToPaintMsg::Exit).unwrap();
     }
@@ -1003,7 +1006,12 @@ impl LayoutThread {
         let document = unsafe { ServoLayoutNode::new(&data.document) };
         let document = document.as_document().unwrap();
 
+        // Parallelize if there's more than 750 objects based on rzambre's suggestion
+        // https://github.com/servo/servo/issues/10110
+        self.parallel_flag = opts::get().layout_threads > 1 && data.dom_count > 750;
         debug!("layout: received layout request for: {}", self.url);
+        debug!("Number of objects in DOM: {}", data.dom_count);
+        debug!("layout: parallel? {}", self.parallel_flag);
 
         let mut rw_data = possibly_locked_rw_data.lock();
 
@@ -1127,18 +1135,15 @@ impl LayoutThread {
                     self.time_profiler_chan.clone(),
                     || {
                 // Perform CSS selector matching and flow construction.
-                match self.parallel_traversal {
-                    None => {
-                        sequential::traverse_dom::<ServoLayoutNode, RecalcStyleAndConstructFlows>(
-                            node, &shared_layout_context);
-                    }
-                    Some(ref mut traversal) => {
-                        parallel::traverse_dom::<ServoLayoutNode, RecalcStyleAndConstructFlows>(
-                            node, &shared_layout_context, traversal);
-                    }
-                }
-            });
-
+                if self.parallel_flag {
+                    // Parallel mode
+                    parallel::traverse_dom::<ServoLayoutNode, RecalcStyleAndConstructFlows>(
+                    node, &shared_layout_context, &mut self.parallel_traversal);
+                } else {
+                    // Sequential mode
+                    sequential::traverse_dom::<ServoLayoutNode, RecalcStyleAndConstructFlows>(
+                    node, &shared_layout_context);
+                }});
             // TODO(pcwalton): Measure energy usage of text shaping, perhaps?
             let text_shaping_time =
                 (font::get_and_reset_text_shaping_performance_counter() as u64) /
@@ -1388,19 +1393,18 @@ impl LayoutThread {
                         self.time_profiler_chan.clone(),
                         || {
                     let profiler_metadata = self.profiler_metadata();
-                    match self.parallel_traversal {
-                        None => {
-                            // Sequential mode.
-                            LayoutThread::solve_constraints(&mut root_flow, &layout_context)
-                        }
-                        Some(ref mut parallel) => {
-                            // Parallel mode.
-                            LayoutThread::solve_constraints_parallel(parallel,
-                                                                   &mut root_flow,
-                                                                   profiler_metadata,
-                                                                   self.time_profiler_chan.clone(),
-                                                                   &*layout_context);
-                        }
+
+                    debug!("layout: post style parallel? {}", self.parallel_flag);
+                    if self.parallel_flag {
+                        // Parallel mode.
+                        LayoutThread::solve_constraints_parallel(&mut self.parallel_traversal,
+                                                                 &mut root_flow,
+                                                                 profiler_metadata,
+                                                                 self.time_profiler_chan.clone(),
+                                                                 &*layout_context);
+                    } else {
+                        //Sequential mode
+                        LayoutThread::solve_constraints(&mut root_flow, &layout_context);
                     }
                 });
             }

--- a/components/layout/layout_thread.rs
+++ b/components/layout/layout_thread.rs
@@ -1008,7 +1008,9 @@ impl LayoutThread {
 
         // Parallelize if there's more than 750 objects based on rzambre's suggestion
         // https://github.com/servo/servo/issues/10110
-        self.parallel_flag = opts::get().layout_threads > 1 && data.dom_count > 750;
+        //self.parallel_flag = opts::get().layout_threads > 1;// && data.dom_count > 750;
+        self.parallel_flag = false;
+        //self.parallel_flag = true;
         debug!("layout: received layout request for: {}", self.url);
         debug!("Number of objects in DOM: {}", data.dom_count);
         debug!("layout: parallel? {}", self.parallel_flag);

--- a/components/layout/sequential.rs
+++ b/components/layout/sequential.rs
@@ -50,6 +50,7 @@ pub fn traverse_flow_tree_preorder(root: &mut FlowRef,
         }
 
         for kid in flow::child_iter_mut(flow) {
+            debug!("Assign sizes for KID");     //not called
             doit(kid, assign_inline_sizes, assign_block_sizes);
         }
 

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -54,7 +54,7 @@ ref_slice = "1.0"
 regex = "0.1.43"
 rustc-serialize = "0.3"
 script_traits = {path = "../script_traits"}
-selectors = {version = "0.6", features = ["heap_size"]}
+selectors = {git = "https://github.com/avadacatavra/rust-selectors.git", features = ["heap_size"]}
 serde = "0.7"
 smallvec = "0.1"
 string_cache = {version = "0.2.18", features = ["heap_size", "unstable"]}

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -239,6 +239,8 @@ pub struct Document {
     origin: Origin,
     ///  https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-states
     referrer_policy: Cell<Option<ReferrerPolicy>>,
+    /// track number of dom elements issue #10110
+    dom_count: Cell<u32>,
 }
 
 #[derive(JSTraceable, HeapSizeOf)]
@@ -394,6 +396,14 @@ impl Document {
                        .filter_map(Root::downcast::<HTMLBaseElement>)
                        .find(|element| element.upcast::<Element>().has_attribute(&atom!("href")));
         self.base_element.set(base.r());
+    }
+
+    pub fn dom_count(&self) -> u32 {
+        self.dom_count.get()
+    }
+
+    pub fn increment_dom_count(&self) {
+        self.dom_count.set(self.dom_count.get() + 1);
     }
 
     pub fn quirks_mode(&self) -> QuirksMode {
@@ -1699,6 +1709,7 @@ impl Document {
             origin: origin,
             //TODO - setting this for now so no Referer header set
             referrer_policy: Cell::new(Some(ReferrerPolicy::NoReferrer)),
+            dom_count: Cell::new(0),
         }
     }
 

--- a/components/script/dom/servohtmlparser.rs
+++ b/components/script/dom/servohtmlparser.rs
@@ -255,6 +255,7 @@ impl ServoHTMLParser {
             pipeline: pipeline,
         };
 
+
         reflect_dom_object(box parser, GlobalRef::Window(document.window()),
                            ServoHTMLParserBinding::Wrap)
     }
@@ -312,6 +313,7 @@ impl ServoHTMLParser {
     pub fn pending_input(&self) -> &DOMRefCell<Vec<String>> {
         &self.pending_input
     }
+
 
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1082,6 +1082,7 @@ impl Window {
             window_size: window_size,
             script_join_chan: join_chan,
             query_type: query_type,
+            dom_count: self.Document().dom_count(),
         };
 
         self.layout_chan.send(Msg::Reflow(reflow)).unwrap();

--- a/components/script/layout_interface.rs
+++ b/components/script/layout_interface.rs
@@ -226,6 +226,8 @@ pub struct ScriptReflow {
     pub script_join_chan: Sender<()>,
     /// The type of query if any to perform during this reflow.
     pub query_type: ReflowQueryType,
+    /// The number of objects in the dom #10110
+    pub dom_count: u32,
 }
 
 impl Drop for ScriptReflow {

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -91,6 +91,8 @@ impl<'a> TreeSink for servohtmlparser::Sink {
             elem.set_attribute_from_parser(attr.name, DOMString::from(String::from(attr.value)), None);
         }
 
+        self.document.increment_dom_count();
+
         JS::from_ref(elem.upcast())
     }
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1156,7 +1156,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "script 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.6.0 (git+https://github.com/avadacatavra/rust-selectors.git)",
  "serde_json 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1909,7 +1909,7 @@ dependencies = [
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.6.0 (git+https://github.com/avadacatavra/rust-selectors.git)",
  "serde 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1959,6 +1959,22 @@ dependencies = [
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.0.1",
+]
+
+[[package]]
+name = "selectors"
+version = "0.6.0"
+source = "git+https://github.com/avadacatavra/rust-selectors.git#53b34326085235a7bfafedb8253aad03ae4d00f0"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickersort 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_cache 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2166,7 +2182,7 @@ dependencies = [
  "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.6.0 (git+https://github.com/avadacatavra/rust-selectors.git)",
  "serde 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -29,7 +29,7 @@ matches = "0.1"
 num-traits = "0.1.32"
 plugins = {path = "../plugins"}
 rustc-serialize = "0.3"
-selectors = {version = "0.6", features = ["heap_size", "unstable"]}
+selectors = {git = "https://github.com/avadacatavra/rust-selectors.git", features = ["heap_size", "unstable"]}
 serde = {version = "0.7", features = ["nightly"]}
 serde_macros = "0.7"
 smallvec = "0.1"

--- a/components/style/logical_geometry.rs
+++ b/components/style/logical_geometry.rs
@@ -840,6 +840,7 @@ impl<T: Debug> Debug for LogicalRect<T> {
 impl<T: Zero> LogicalRect<T> {
     #[inline]
     pub fn zero(mode: WritingMode) -> LogicalRect<T> {
+        debug!("LogicalRect(zero) with mode: {:?}", mode);
         LogicalRect {
             start: LogicalPoint::zero(mode),
             size: LogicalSize::zero(mode),
@@ -852,6 +853,8 @@ impl<T: Copy> LogicalRect<T> {
     #[inline]
     pub fn new(mode: WritingMode, inline_start: T, block_start: T, inline: T, block: T)
                -> LogicalRect<T> {
+        debug!("LogicalRect(new) with mode: {:?}", mode);
+                   
         LogicalRect {
             start: LogicalPoint::new(mode, inline_start, block_start),
             size: LogicalSize::new(mode, inline, block),
@@ -862,6 +865,8 @@ impl<T: Copy> LogicalRect<T> {
     #[inline]
     pub fn from_point_size(mode: WritingMode, start: LogicalPoint<T>, size: LogicalSize<T>)
                            -> LogicalRect<T> {
+        debug!("LogicalRect(pt size) with mode: {:?}", mode);
+                               
         start.debug_writing_mode.check(mode);
         size.debug_writing_mode.check(mode);
         LogicalRect {
@@ -922,6 +927,7 @@ impl<T: Copy + Add<T, Output=T> + Sub<T, Output=T>> LogicalRect<T> {
 
     #[inline]
     pub fn to_physical(&self, mode: WritingMode, container_size: Size2D<T>) -> Rect<T> {
+        debug!("To_physical: {:?} vs. debug {:?}", mode, self.debug_writing_mode);
         self.debug_writing_mode.check(mode);
         let x;
         let y;
@@ -959,6 +965,7 @@ impl<T: Copy + Add<T, Output=T> + Sub<T, Output=T>> LogicalRect<T> {
     #[inline]
     pub fn convert(&self, mode_from: WritingMode, mode_to: WritingMode, container_size: Size2D<T>)
                    -> LogicalRect<T> {
+        debug!("Converted mode from {:?} to {:?}", mode_from, mode_to);
         if mode_from == mode_to {
             self.debug_writing_mode.check(mode_from);
             *self

--- a/components/style/parser.rs
+++ b/components/style/parser.rs
@@ -46,6 +46,7 @@ impl<'a> ParserContext<'a> {
                                error_reporter: Box<ParseErrorReporter + Send>,
                                extra_data: ParserContextExtraData)
                                -> ParserContext<'a> {
+        debug!("PARSER WITH EXTRA DATA");
         let mut selector_context = SelectorParserContext::new();
         selector_context.in_user_agent_stylesheet = stylesheet_origin == Origin::UserAgent;
         ParserContext {
@@ -59,6 +60,7 @@ impl<'a> ParserContext<'a> {
 
     pub fn new(stylesheet_origin: Origin, base_url: &'a Url, error_reporter: Box<ParseErrorReporter + Send>)
                -> ParserContext<'a> {
+        debug!("I WANT MY PARSER");
         let extra_data = ParserContextExtraData::default();
         ParserContext::new_with_extra_data(stylesheet_origin, base_url, error_reporter, extra_data)
     }
@@ -67,6 +69,7 @@ impl<'a> ParserContext<'a> {
 
 impl<'a> ParserContext<'a> {
     pub fn parse_url(&self, input: &str) -> Url {
+        debug!("parse city bitch");
         self.base_url.join(input)
             .unwrap_or_else(|_| Url::parse("about:invalid").unwrap())
     }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -592,6 +592,7 @@ fn deduplicate_property_declarations(declarations: Vec<PropertyDeclaration>)
                 seen_custom.push(name.clone())
             }
         }
+        debug!("Last declaration: {:?}", declaration);
         deduplicated.push(declaration)
     }
     deduplicated
@@ -911,6 +912,7 @@ impl PropertyDeclaration {
 
     pub fn parse(name: &str, context: &ParserContext, input: &mut Parser,
                  result_list: &mut Vec<PropertyDeclaration>) -> PropertyDeclarationParseResult {
+        debug!("parse: {}", name);
         if let Ok(name) = ::custom_properties::parse_name(name) {
             let value = match input.try(CSSWideKeyword::parse) {
                 Ok(CSSWideKeyword::UnsetKeyword) |  // Custom properties are alawys inherited
@@ -921,6 +923,7 @@ impl PropertyDeclaration {
                     Err(()) => return PropertyDeclarationParseResult::InvalidValue,
                 }
             };
+            
             result_list.push(PropertyDeclaration::Custom(Atom::from(name), value));
             return PropertyDeclarationParseResult::ValidOrIgnoredDeclaration;
         }
@@ -1509,12 +1512,14 @@ impl ServoComputedValues {
 
 /// Return a WritingMode bitflags from the relevant CSS properties.
 pub fn get_writing_mode<S: style_struct_traits::InheritedBox>(inheritedbox_style: &S) -> WritingMode {
+
     use logical_geometry;
     let mut flags = WritingMode::empty();
     match inheritedbox_style.clone_direction() {
         computed_values::direction::T::ltr => {},
         computed_values::direction::T::rtl => {
             flags.insert(logical_geometry::FLAG_RTL);
+            debug!("IS RTL");
         },
     }
     match inheritedbox_style.clone_writing_mode() {
@@ -1849,6 +1854,7 @@ pub fn cascade<C: ComputedValues>(
 
     let mut style = context.style;
 
+
     let positioned = matches!(style.get_box().clone_position(),
         longhands::position::SpecifiedValue::absolute |
         longhands::position::SpecifiedValue::fixed);
@@ -1943,6 +1949,9 @@ pub fn cascade<C: ComputedValues>(
     }
 
     let mode = get_writing_mode(style.get_inheritedbox());
+
+    debug!("Mode: {}", mode);    //get the property name!!!
+
     style.set_writing_mode(mode);
     (style, cacheable)
 }

--- a/components/style/selector_impl.rs
+++ b/components/style/selector_impl.rs
@@ -167,6 +167,7 @@ impl SelectorImpl for ServoSelectorImpl {
 
     fn parse_non_ts_pseudo_class(context: &ParserContext,
                                  name: &str) -> Result<NonTSPseudoClass, ()> {
+        debug!("parse non ts pseudo class, {}", name);
         use self::NonTSPseudoClass::*;
         let pseudo_class = match_ignore_ascii_case! { name,
             "any-link" => AnyLink,
@@ -196,6 +197,7 @@ impl SelectorImpl for ServoSelectorImpl {
 
     fn parse_pseudo_element(context: &ParserContext,
                             name: &str) -> Result<PseudoElement, ()> {
+        debug!("parse pseudo element: {}", name);
         use self::PseudoElement::*;
         let pseudo_element = match_ignore_ascii_case! { name,
             "before" => Before,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Added dom count to documents to track number of objects in dom. Changed layout_thread to always create the thread pool, then check to see if it should be parallel/or sequential when it's used.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix part of #10110  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because @metajack and I aren't sure how to

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11713)

<!-- Reviewable:end -->
