### PR TITLE
Removed reference to update-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Install MSYS2 from [here](https://msys2.github.io/). After you have done so, ope
 window and update the core libraries and install new packages:
 
 ```sh
-update-core
+pacman -Su
 pacman -Sy git mingw-w64-x86_64-toolchain mingw-w64-x86_64-freetype \
     mingw-w64-x86_64-icu mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates \
     mingw-w64-x86_64-expat mingw-w64-x86_64-cmake tar diffutils patch \


### PR DESCRIPTION
It's `pacman -Su` nowadays, per https://github.com/Alexpux/MSYS2-pacman/pull/26.

(This is a very selective cherry-pick of #11392. The other parts were more controversial; they didn't fully work so let's disregard them for now.)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11718)

<!-- Reviewable:end -->
