### PR TITLE
constellation: Don't ignore inconsistent frame-tree states when determining when to take a screenshot.

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -73,6 +73,7 @@ enum ReadyToSave {
     EpochMismatch,
     PipelineUnknown,
     Ready,
+    InconsistentFrameTreeState,
 }
 
 /// Maintains the pipelines and navigation context and grants permission to composite.
@@ -257,31 +258,32 @@ struct FrameTreeIterator<'a> {
     pipelines: &'a HashMap<PipelineId, Pipeline>,
 }
 
+enum FrameTreeIteratorItem<'a> {
+    Found(&'a Frame, &'a Pipeline),
+    FrameNotFound(FrameId),
+    PipelineNotFound(FrameId, &'a Frame),
+}
+
 impl<'a> Iterator for FrameTreeIterator<'a> {
-    type Item = &'a Frame;
-    fn next(&mut self) -> Option<&'a Frame> {
-        loop {
-            let frame_id = match self.stack.pop() {
-                Some(frame_id) => frame_id,
-                None => return None,
-            };
-            let frame = match self.frames.get(&frame_id) {
-                Some(frame) => frame,
-                None => {
-                    warn!("Frame {:?} iterated after closure.", frame_id);
-                    continue;
-                },
-            };
-            let pipeline = match self.pipelines.get(&frame.current) {
-                Some(pipeline) => pipeline,
-                None => {
-                    warn!("Pipeline {:?} iterated after closure.", frame.current);
-                    continue;
-                },
-            };
-            self.stack.extend(pipeline.children.iter().map(|&c| c));
-            return Some(frame)
-        }
+    type Item = FrameTreeIteratorItem<'a>;
+    fn next(&mut self) -> Option<FrameTreeIteratorItem<'a>> {
+        let frame_id = match self.stack.pop() {
+            Some(frame_id) => frame_id,
+            None => return None,
+        };
+
+        let frame = match self.frames.get(&frame_id) {
+            Some(frame) => frame,
+            None => return Some(FrameTreeIteratorItem::FrameNotFound(frame_id)),
+        };
+
+        let pipeline = match self.pipelines.get(&frame.current) {
+            Some(pipeline) => pipeline,
+            None => return Some(FrameTreeIteratorItem::PipelineNotFound(frame_id, frame)),
+        };
+
+        self.stack.extend(pipeline.children.iter().map(|&c| c));
+        Some(FrameTreeIteratorItem::Found(frame, pipeline))
     }
 }
 
@@ -1542,9 +1544,12 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
 
     fn handle_set_visible_msg(&mut self, pipeline_id: PipelineId, visible: bool) {
         let frame_id = self.pipelines.get(&pipeline_id).and_then(|pipeline| pipeline.frame);
-        let child_pipeline_ids: Vec<PipelineId> = self.current_frame_tree_iter(frame_id)
-                                                      .map(|frame| frame.current)
-                                                      .collect();
+        let child_pipeline_ids = self.current_frame_tree_iter(frame_id)
+                                     .flat_map(|item| match item {
+                                         FrameTreeIteratorItem::Found(_, pipeline) => Some(pipeline.id),
+                                         _ => None,
+                                     })
+                                     .collect::<Vec<_>>();
         for id in child_pipeline_ids {
             if let Some(pipeline) = self.pipelines.get_mut(&id) {
                 pipeline.change_visibility(visible);
@@ -1857,7 +1862,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         }
 
         // If there are pending loads, wait for those to complete.
-        if self.pending_frames.len() > 0 {
+        if !self.pending_frames.is_empty() {
             return ReadyToSave::PendingFrames;
         }
 
@@ -1869,12 +1874,17 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         // matches what the compositor has painted. If all these conditions
         // are met, then the output image should not change and a reftest
         // screenshot can safely be written.
-        for frame in self.current_frame_tree_iter(self.root_frame_id) {
-            let pipeline_id = frame.current;
-
-            let pipeline = match self.pipelines.get(&pipeline_id) {
-                None => { warn!("Pipeline {:?} screenshot while closing.", pipeline_id); continue; },
-                Some(pipeline) => pipeline,
+        for frame_tree_iter_item in self.current_frame_tree_iter(self.root_frame_id) {
+            let (frame, pipeline) = match frame_tree_iter_item {
+                FrameTreeIteratorItem::Found(frame, pipeline) => (frame, pipeline),
+                FrameTreeIteratorItem::FrameNotFound(frame_id) => {
+                    warn!("Frame {:?} not found while iterating through the tree", frame_id);
+                    return ReadyToSave::InconsistentFrameTreeState;
+                }
+                FrameTreeIteratorItem::PipelineNotFound(frame_id, frame) => {
+                    warn!("Pipeline {:?} for frame {:?} not found", frame.current, frame_id);
+                    return ReadyToSave::InconsistentFrameTreeState;
+                }
             };
 
             // Check to see if there are any webfonts still loading.
@@ -2084,7 +2094,9 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
     fn revoke_paint_permission(&self, pipeline_id: PipelineId) {
         let frame_id = self.pipelines.get(&pipeline_id).and_then(|pipeline| pipeline.frame);
         for frame in self.current_frame_tree_iter(frame_id) {
-            self.pipelines.get(&frame.current).map(|pipeline| pipeline.revoke_paint_permission());
+            if let FrameTreeIteratorItem::Found(_frame, pipeline) = frame {
+                pipeline.revoke_paint_permission();
+            }
         }
     }
 
@@ -2107,7 +2119,9 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         }
 
         for frame in self.current_frame_tree_iter(self.root_frame_id) {
-            self.pipelines.get(&frame.current).map(|pipeline| pipeline.grant_paint_permission());
+            if let FrameTreeIteratorItem::Found(_frame, pipeline) = frame {
+                pipeline.grant_paint_permission();
+            }
         }
     }
 
@@ -2187,7 +2201,10 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                                pipeline_id: PipelineId,
                                root_frame_id: Option<FrameId>) -> bool {
         self.current_frame_tree_iter(root_frame_id)
-            .any(|current_frame| current_frame.current == pipeline_id)
+            .any(|item| match item {
+                FrameTreeIteratorItem::Found(_, pipeline) => pipeline.id == pipeline_id,
+                _ => false,
+            })
     }
 
 }

--- a/tests/wpt/mozilla/meta/mozilla/sslfail.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/sslfail.html.ini
@@ -1,3 +1,0 @@
-[sslfail.html]
-  type: reftest
-  disabled: https://github.com/servo/servo/issues/10760


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Return a significative error instead.

I think this is the cause of most iframe-related intermittents: we stop
iterating early, so we don't detect frames that aren't closed now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11739)

<!-- Reviewable:end -->
