### PR TITLE
Added detection for case-sensitive file systems

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -160,7 +160,22 @@ def _activate_virtualenv(topdir):
         open(marker_path, 'w').close()
 
 
+def _ensure_case_insensitive_if_windows():
+    # The folder is called 'python'. By deliberately checking for it with the wrong case, we determine if the file
+    # system is case sensitive or not.
+    if _is_windows() and not os.path.exists('Python'):
+        print('Cannot run mach in a path on a case-sensitive file system on Windows.')
+        print('For more details, see https://github.com/pypa/virtualenv/issues/935')
+        sys.exit(1)
+
+
+def _is_windows():
+    return sys.platform == 'win32' or sys.platform == 'msys'
+
+
 def bootstrap(topdir):
+    _ensure_case_insensitive_if_windows()
+
     topdir = os.path.abspath(topdir)
 
     # We don't support paths with Unicode characters for now


### PR DESCRIPTION
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they only change Mach code

This is needed for the moment because of a bug in virtualenv (reported upstream).

r? @metajack (you were the one who suggested that we check this. I did it in a slightly simpler way since I realized we over-complicated things a bit when talking about it the other day.)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11740)

<!-- Reviewable:end -->
