### PR TITLE
webgl: Unlock WebRender by default by adding a readback based fallback to WebGL context creation.

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -31,7 +31,7 @@ impl<'a> CanvasPaintThread<'a> {
         let canvas_rect = Rect::new(Point2D::new(0i32, 0i32), canvas_size);
         let src_read_rect = canvas_rect.intersection(&read_rect).unwrap_or(Rect::zero());
 
-        let mut image_data = Vec::new();
+        let mut image_data = vec![];
         if src_read_rect.is_empty() || canvas_size.width <= 0 && canvas_size.height <= 0 {
           return image_data;
         }
@@ -111,7 +111,7 @@ impl<'a> CanvasPaintThread<'a> {
             drawtarget: draw_target,
             path_builder: path_builder,
             state: CanvasPaintState::new(),
-            saved_states: Vec::new(),
+            saved_states: vec![],
             webrender_api: webrender_api,
             webrender_image_key: webrender_image_key,
         }
@@ -518,13 +518,11 @@ impl<'a> CanvasPaintThread<'a> {
         self.drawtarget.snapshot().get_data_surface().with_data(|element| {
             if let Some(ref webrender_api) = self.webrender_api {
                 let size = self.drawtarget.get_size();
-                let mut bytes = Vec::new();
-                bytes.extend_from_slice(element);
                 webrender_api.update_image(self.webrender_image_key.unwrap(),
                                            size.width as u32,
                                            size.height as u32,
                                            webrender_traits::ImageFormat::RGBA8,
-                                           bytes);
+                                           element.into());
             }
 
             let pixel_data = CanvasPixelData {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because refactoring.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

This should give us the chance to use WebRender by default in OSX.

r? @pcwalton 

cc @glennw @larsbergstrom

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11744)

<!-- Reviewable:end -->
