### PR TITLE
Update heartbeats-simple to 0.3.0

### DIFF
--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -13,7 +13,7 @@ profile_traits = {path = "../profile_traits"}
 plugins = {path = "../plugins"}
 util = {path = "../util"}
 ipc-channel = {git = "https://github.com/servo/ipc-channel"}
-hbs-pow = "0.2"
+heartbeats-simple = "0.3"
 log = "0.3.5"
 serde = "0.7"
 serde_json = "0.7"

--- a/components/profile/heartbeats.rs
+++ b/components/profile/heartbeats.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-use hbs_pow::HeartbeatPow as Heartbeat;
-use hbs_pow::HeartbeatPowContext as HeartbeatContext;
+use heartbeats_simple::HeartbeatPow as Heartbeat;
+use heartbeats_simple::HeartbeatPowContext as HeartbeatContext;
 use profile_traits::time::ProfilerCategory;
 use std::collections::HashMap;
 use std::env::var_os;

--- a/components/profile/lib.rs
+++ b/components/profile/lib.rs
@@ -15,7 +15,7 @@
 #[allow(unused_extern_crates)]
 #[cfg(not(target_os = "windows"))]
 extern crate alloc_jemalloc;
-extern crate hbs_pow;
+extern crate heartbeats_simple;
 extern crate ipc_channel;
 #[cfg(not(target_os = "windows"))]
 extern crate libc;

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -894,42 +894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hbs-builder"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hbs-common-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hbs-pow"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hbs-pow-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hbs-pow-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hbs-builder 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hbs-common-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "heapsize"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +905,25 @@ dependencies = [
 name = "heapsize_plugin"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "heartbeats-simple"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heartbeats-simple-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heartbeats-simple-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "hpack"
@@ -1720,7 +1703,7 @@ dependencies = [
 name = "profile"
 version = "0.0.1"
 dependencies = [
- "hbs-pow 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heartbeats-simple 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.3 (git+https://github.com/servo/ipc-channel)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -807,42 +807,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hbs-builder"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hbs-common-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hbs-pow"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hbs-pow-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hbs-pow-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hbs-builder 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hbs-common-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "heapsize"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +818,25 @@ dependencies = [
 name = "heapsize_plugin"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "heartbeats-simple"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heartbeats-simple-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heartbeats-simple-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "hpack"
@@ -1589,7 +1572,7 @@ dependencies = [
 name = "profile"
 version = "0.0.1"
 dependencies = [
- "hbs-pow 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heartbeats-simple 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.2.3 (git+https://github.com/servo/ipc-channel)",
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Updated heartbeats-simple dependency for native changes:
-Collapse libraries into one.
-Remove overriding of some default CMake behavior.
-Windows compatibility with compiler flags, locking, and sleeping in example (thanks Jack Moffitt and Vladimir Vukicevic).

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's just a dependency update

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11785)

<!-- Reviewable:end -->
