### PR TITLE
Stop parsing style attributes during restyle in geckolib.

### DIFF
--- a/ports/geckolib/gecko_bindings/bindings.rs
+++ b/ports/geckolib/gecko_bindings/bindings.rs
@@ -134,6 +134,8 @@ pub enum ServoNodeData { }
 pub enum ServoComputedValues { }
 pub enum RawServoStyleSheet { }
 pub enum RawServoStyleSet { }
+pub enum nsHTMLCSSStyleSheet { }
+pub enum ServoDeclarationBlock { }
 pub type ThreadSafePrincipalHolder = nsMainThreadPtrHolder<nsIPrincipal>;
 pub type ThreadSafeURIHolder = nsMainThreadPtrHolder<nsIURI>;
 extern "C" {
@@ -170,6 +172,8 @@ extern "C" {
     pub fn Gecko_ClassOrClassList(element: *mut RawGeckoElement,
                                   class_: *mut *mut nsIAtom,
                                   classList: *mut *mut *mut nsIAtom) -> u32;
+    pub fn Gecko_GetServoDeclarationBlock(element: *mut RawGeckoElement)
+     -> *mut ServoDeclarationBlock;
     pub fn Gecko_GetNodeData(node: *mut RawGeckoNode) -> *mut ServoNodeData;
     pub fn Gecko_SetNodeData(node: *mut RawGeckoNode,
                              data: *mut ServoNodeData);
@@ -242,6 +246,18 @@ extern "C" {
     pub fn Servo_StyleSheetHasRules(sheet: *mut RawServoStyleSheet) -> bool;
     pub fn Servo_InitStyleSet() -> *mut RawServoStyleSet;
     pub fn Servo_DropStyleSet(set: *mut RawServoStyleSet);
+    pub fn Servo_ParseStyleAttribute(bytes: *const u8, length: u8,
+                                     cache: *mut nsHTMLCSSStyleSheet)
+     -> *mut ServoDeclarationBlock;
+    pub fn Servo_DropDeclarationBlock(declarations:
+                                          *mut ServoDeclarationBlock);
+    pub fn Servo_GetDeclarationBlockCache(declarations:
+                                              *mut ServoDeclarationBlock)
+     -> *mut nsHTMLCSSStyleSheet;
+    pub fn Servo_SetDeclarationBlockImmutable(declarations:
+                                                  *mut ServoDeclarationBlock);
+    pub fn Servo_ClearDeclarationBlockCachePointer(declarations:
+                                                       *mut ServoDeclarationBlock);
     pub fn Servo_GetComputedValues(node: *mut RawGeckoNode)
      -> *mut ServoComputedValues;
     pub fn Servo_GetComputedValuesForAnonymousBox(parentStyleOrNull:

--- a/ports/geckolib/wrapper.rs
+++ b/ports/geckolib/wrapper.rs
@@ -15,12 +15,14 @@ use gecko_bindings::bindings::{Gecko_GetLastChild, Gecko_GetLastChildElement};
 use gecko_bindings::bindings::{Gecko_GetNextSibling, Gecko_GetNextSiblingElement};
 use gecko_bindings::bindings::{Gecko_GetParentElement, Gecko_GetParentNode};
 use gecko_bindings::bindings::{Gecko_GetPrevSibling, Gecko_GetPrevSiblingElement};
-use gecko_bindings::bindings::{Gecko_IsHTMLElementInHTMLDocument, Gecko_IsLink, Gecko_IsRootElement, Gecko_IsTextNode};
+use gecko_bindings::bindings::{Gecko_GetServoDeclarationBlock, Gecko_IsHTMLElementInHTMLDocument};
+use gecko_bindings::bindings::{Gecko_IsLink, Gecko_IsRootElement, Gecko_IsTextNode};
 use gecko_bindings::bindings::{Gecko_IsUnvisitedLink, Gecko_IsVisitedLink};
 #[allow(unused_imports)] // Used in commented-out code.
 use gecko_bindings::bindings::{Gecko_LocalName, Gecko_Namespace, Gecko_NodeIsElement, Gecko_SetNodeData};
 use gecko_bindings::bindings::{RawGeckoDocument, RawGeckoElement, RawGeckoNode};
 use gecko_bindings::structs::nsIAtom;
+use glue::GeckoDeclarationBlock;
 use libc::uintptr_t;
 use properties::GeckoComputedValues;
 use selector_impl::{GeckoSelectorImpl, NonTSPseudoClass, PrivateStyleData};
@@ -317,6 +319,15 @@ impl<'le> GeckoElement<'le> {
     unsafe fn from_ref(el: &RawGeckoElement) -> GeckoElement<'le> {
         GeckoElement::from_raw(el as *const RawGeckoElement as *mut RawGeckoElement)
     }
+
+    pub fn parse_style_attribute(value: &str) -> Option<PropertyDeclarationBlock> {
+        // FIXME(bholley): Real base URL and error reporter.
+        let base_url = &*DUMMY_BASE_URL;
+        // FIXME(heycam): Needs real ParserContextExtraData so that URLs parse
+        // properly.
+        let extra_data = ParserContextExtraData::default();
+        Some(parse_style_attribute(value, &base_url, Box::new(StdoutErrorReporter), extra_data))
+    }
 }
 
 lazy_static! {
@@ -324,6 +335,8 @@ lazy_static! {
         Url::parse("http://www.example.org").unwrap()
     };
 }
+
+static NO_STYLE_ATTRIBUTE: Option<PropertyDeclarationBlock> = None;
 
 impl<'le> TElement for GeckoElement<'le> {
     type ConcreteNode = GeckoNode<'le>;
@@ -334,20 +347,10 @@ impl<'le> TElement for GeckoElement<'le> {
     }
 
     fn style_attribute(&self) -> &Option<PropertyDeclarationBlock> {
-        panic!("Requires signature modification - only implemented in stylo branch");
-        /*
-        // FIXME(bholley): We should do what Servo does here. Gecko needs to
-        // call into the Servo CSS parser and then cache the resulting block
-        // in the nsAttrValue. That will allow us to borrow it from here.
-        let attr = self.get_attr(&ns!(), &atom!("style"));
-        // FIXME(bholley): Real base URL and error reporter.
-        let base_url = &*DUMMY_BASE_URL;
-        // FIXME(heycam): Needs real ParserContextExtraData so that URLs parse
-        // properly.
-        let extra_data = ParserContextExtraData::default();
-        attr.map(|v| parse_style_attribute(&v, &base_url, Box::new(StdoutErrorReporter),
-                                           extra_data))
-        */
+        unsafe {
+            let ptr = Gecko_GetServoDeclarationBlock(self.element) as *mut GeckoDeclarationBlock;
+            ptr.as_ref().map(|d| &d.declarations).unwrap_or(&NO_STYLE_ATTRIBUTE)
+        }
     }
 
     fn get_state(&self) -> ElementState {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This allows `PropertyDeclarationBlock`s parsed for `style=""` attributes to be stored on a Gecko node so that we don't have to re-parse it each time we compute style for an element.  Works with [Gecko bug 1280772](https://bugzilla.mozilla.org/show_bug.cgi?id=1280772).

r? @bholley 
CC @emilio 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11787)

<!-- Reviewable:end -->
