### PR TITLE
Pipeline lookup in webdriver

### DIFF
--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -290,7 +290,7 @@ impl Actor for WalkerActor {
             "documentElement" => {
                 let (tx, rx) = ipc::channel().unwrap();
                 self.script_chan.send(GetDocumentElement(self.pipeline, tx)).unwrap();
-                let doc_elem_info = rx.recv().unwrap();
+                let doc_elem_info = try!(rx.recv().unwrap().ok_or(()));
                 let node = doc_elem_info.encode(registry, true, self.script_chan.clone(), self.pipeline);
 
                 let msg = DocumentElementReply {
@@ -316,7 +316,7 @@ impl Actor for WalkerActor {
                                                   registry.actor_to_script(target.to_owned()),
                                                   tx))
                                 .unwrap();
-                let children = rx.recv().unwrap();
+                let children = try!(rx.recv().unwrap().ok_or(()));
 
                 let msg = ChildrenReply {
                     hasFirst: true,
@@ -490,7 +490,7 @@ impl Actor for PageStyleActor {
                     borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth,
                     paddingTop, paddingRight, paddingBottom, paddingLeft,
                     width, height,
-                } = rx.recv().unwrap();
+                } = try!(rx.recv().unwrap().ok_or(()));
 
                 let auto_margins = msg.get("autoMargins")
                     .and_then(&Value::as_boolean).unwrap_or(false);
@@ -564,7 +564,7 @@ impl Actor for InspectorActor {
 
                 let (tx, rx) = ipc::channel().unwrap();
                 self.script_chan.send(GetRootNode(self.pipeline, tx)).unwrap();
-                let root_info = rx.recv().unwrap();
+                let root_info = try!(rx.recv().unwrap().ok_or(()));
 
                 let node = root_info.encode(registry, false, self.script_chan.clone(), self.pipeline);
 

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -194,13 +194,13 @@ pub enum DevtoolScriptControlMsg {
     /// Evaluate a JS snippet in the context of the global for the given pipeline.
     EvaluateJS(PipelineId, String, IpcSender<EvaluateJSReply>),
     /// Retrieve the details of the root node (ie. the document) for the given pipeline.
-    GetRootNode(PipelineId, IpcSender<NodeInfo>),
+    GetRootNode(PipelineId, IpcSender<Option<NodeInfo>>),
     /// Retrieve the details of the document element for the given pipeline.
-    GetDocumentElement(PipelineId, IpcSender<NodeInfo>),
+    GetDocumentElement(PipelineId, IpcSender<Option<NodeInfo>>),
     /// Retrieve the details of the child nodes of the given node in the given pipeline.
-    GetChildren(PipelineId, String, IpcSender<Vec<NodeInfo>>),
+    GetChildren(PipelineId, String, IpcSender<Option<Vec<NodeInfo>>>),
     /// Retrieve the computed layout properties of the given node in the given pipeline.
-    GetLayout(PipelineId, String, IpcSender<ComputedNodeLayout>),
+    GetLayout(PipelineId, String, IpcSender<Option<ComputedNodeLayout>>),
     /// Retrieve all stored console messages for the given pipeline.
     GetCachedMessages(PipelineId, CachedConsoleMessageTypes, IpcSender<Vec<CachedConsoleMessage>>),
     /// Update a given node's attributes with a list of modifications.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1108,7 +1108,10 @@ impl ScriptThread {
 
     fn handle_resize(&self, id: PipelineId, size: WindowSizeData, size_type: WindowSizeType) {
         if let Some(ref context) = self.find_child_context(id) {
-            let window = context.active_window();
+            let window = match context.find(id) {
+                Some(browsing_context) => browsing_context.active_window(),
+                None => return warn!("Message sent to closed pipeline {}.", id),
+            };
             window.set_resize_event(size, size_type);
             return;
         }
@@ -2202,15 +2205,6 @@ fn shut_down_layout(context_tree: &BrowsingContext) {
     for chan in channels {
         chan.send(message::Msg::ExitNow).ok();
     }
-}
-
-// TODO: remove this function, as it's a source of panic.
-pub fn get_browsing_context(context: &BrowsingContext,
-                            pipeline_id: PipelineId)
-                            -> Root<BrowsingContext> {
-    context.find(pipeline_id).expect("ScriptThread: received an event \
-            message for a layout channel that is not associated with this script thread.\
-            This is a bug.")
 }
 
 fn dom_last_modified(tm: &Tm) -> String {

--- a/components/script_traits/webdriver_msg.rs
+++ b/components/script_traits/webdriver_msg.rs
@@ -53,7 +53,10 @@ pub enum WebDriverJSValue {
 #[derive(Deserialize, Serialize)]
 pub enum WebDriverJSError {
     Timeout,
-    UnknownType
+    UnknownType,
+    /// Occurs when handler received an event message for a layout channel that is not
+    /// associated with the current script thread
+    BrowsingContextNotFound
 }
 
 pub type WebDriverJSResult = Result<WebDriverJSValue, WebDriverJSError>;

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -738,7 +738,9 @@ impl Handler {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse::new(value.to_json()))),
             Err(WebDriverJSError::Timeout) => Err(WebDriverError::new(ErrorStatus::Timeout, "")),
             Err(WebDriverJSError::UnknownType) => Err(WebDriverError::new(
-                ErrorStatus::UnsupportedOperation, "Unsupported return type"))
+                ErrorStatus::UnsupportedOperation, "Unsupported return type")),
+            Err(WebDriverJSError::BrowsingContextNotFound) => Err(WebDriverError::new(
+                ErrorStatus::JavascriptError, "Pipeline id not found in browsing context"))
         }
     }
 


### PR DESCRIPTION
Fixes #11712

<!-- Please describe your changes on the following line: -->

Removed a method that seemed to duplicate already existing functionality, and returned BrowsingContextErrors in the web_handler file where panics were previously occurring.

I am not sure if I like all the unwrapping that occurs in the script thread, but the current methods are not set up to return Option/Result.

Also, should line the method on line 37 `find_node_by_unique_id` of components/script/webdriver_handlers.rs return None if the context is not found like I have it currently? Or should it return a `Result<Option...>` instead?

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11712 .

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because I simply removed a method that duplicated already existing functionality. On the other part, I added better error sending instead of forcing a panic, which does not require testing to my knowledge.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11791)

<!-- Reviewable:end -->
