### PR TITLE
Add performance timing properties (requestStart / responseStart / responseEnd)

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -252,6 +252,8 @@ pub struct Document {
     load_event_start: Cell<u64>,
     load_event_end: Cell<u64>,
     request_start: Cell<u64>,
+    response_start: Cell<u64>,
+    response_end: Cell<u64>,
     /// https://html.spec.whatwg.org/multipage/#concept-document-https-state
     https_state: Cell<HttpsState>,
     touchpad_pressure_phase: Cell<TouchpadPressurePhase>,
@@ -1673,6 +1675,22 @@ impl Document {
         self.request_start.get()
     }
 
+    pub fn set_response_start(&self, t: u64) {
+        self.response_start.set(t);
+    }
+
+    pub fn get_response_start(&self) -> u64 {
+        self.response_start.get()
+    }
+
+    pub fn set_response_end(&self, t: u64) {
+        self.response_end.set(t);
+    }
+
+    pub fn get_response_end(&self) -> u64 {
+        self.response_end.get()
+    }
+
     // https://html.spec.whatwg.org/multipage/#fire-a-focus-event
     fn fire_focus_event(&self, focus_event_type: FocusEventType, node: &Node, related_target: Option<&EventTarget>) {
         let (event_name, does_bubble) = match focus_event_type {
@@ -1848,6 +1866,8 @@ impl Document {
             load_event_start: Cell::new(Default::default()),
             load_event_end: Cell::new(Default::default()),
             request_start: Cell::new(Default::default()),
+            response_start: Cell::new(Default::default()),
+            response_end: Cell::new(Default::default()),
             https_state: Cell::new(HttpsState::None),
             touchpad_pressure_phase: Cell::new(TouchpadPressurePhase::BeforeClick),
             origin: origin,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -251,6 +251,7 @@ pub struct Document {
     dom_complete: Cell<u64>,
     load_event_start: Cell<u64>,
     load_event_end: Cell<u64>,
+    request_start: Cell<u64>,
     /// https://html.spec.whatwg.org/multipage/#concept-document-https-state
     https_state: Cell<HttpsState>,
     touchpad_pressure_phase: Cell<TouchpadPressurePhase>,
@@ -1664,6 +1665,14 @@ impl Document {
         self.load_event_end.get()
     }
 
+    pub fn set_request_start(&self, t: u64) {
+        self.request_start.set(t);
+    }
+
+    pub fn get_request_start(&self) -> u64 {
+        self.request_start.get()
+    }
+
     // https://html.spec.whatwg.org/multipage/#fire-a-focus-event
     fn fire_focus_event(&self, focus_event_type: FocusEventType, node: &Node, related_target: Option<&EventTarget>) {
         let (event_name, does_bubble) = match focus_event_type {
@@ -1838,6 +1847,7 @@ impl Document {
             dom_complete: Cell::new(Default::default()),
             load_event_start: Cell::new(Default::default()),
             load_event_end: Cell::new(Default::default()),
+            request_start: Cell::new(Default::default()),
             https_state: Cell::new(HttpsState::None),
             touchpad_pressure_phase: Cell::new(TouchpadPressurePhase::BeforeClick),
             origin: origin,
@@ -2015,7 +2025,6 @@ impl Document {
                            ReflowReason::ElementStateChanged);
     }
 }
-
 
 impl Element {
     fn click_event_filter_by_disabled_state(&self) -> bool {

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -91,6 +91,16 @@ impl PerformanceTimingMethods for PerformanceTiming {
         self.document.get_request_start()
     }
 
+    // https://w3c.github.io/navigation-timing/#widl-PerformanceTiming-responseStart
+    fn ResponseStart(&self) -> u64 {
+        self.document.get_response_start()
+    }
+
+    // https://w3c.github.io/navigation-timing/#widl-PerformanceTiming-responseEnd
+    fn ResponseEnd(&self) -> u64 {
+        self.document.get_response_end()
+    }
+
 }
 
 impl PerformanceTiming {

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -85,8 +85,13 @@ impl PerformanceTimingMethods for PerformanceTiming {
     fn LoadEventEnd(&self) -> u64 {
         self.document.get_load_event_end()
     }
-}
 
+    // https://w3c.github.io/navigation-timing/#widl-PerformanceTiming-requestStart
+    fn RequestStart(&self) -> u64 {
+        self.document.get_request_start()
+    }
+
+}
 
 impl PerformanceTiming {
     pub fn navigation_start_precise(&self) -> f64 {

--- a/components/script/dom/webidls/PerformanceTiming.webidl
+++ b/components/script/dom/webidls/PerformanceTiming.webidl
@@ -20,8 +20,8 @@ interface PerformanceTiming {
   readonly attribute unsigned long long connectEnd;
   readonly attribute unsigned long long secureConnectionStart; */
   readonly attribute unsigned long long requestStart;
-  /* readonly attribute unsigned long long responseStart; */
-  /* readonly attribute unsigned long long responseEnd; */
+  readonly attribute unsigned long long responseStart;
+  readonly attribute unsigned long long responseEnd;
   readonly attribute unsigned long long domLoading;
   readonly attribute unsigned long long domInteractive;
   readonly attribute unsigned long long domContentLoadedEventStart;

--- a/components/script/dom/webidls/PerformanceTiming.webidl
+++ b/components/script/dom/webidls/PerformanceTiming.webidl
@@ -18,10 +18,10 @@ interface PerformanceTiming {
   readonly attribute unsigned long long domainLookupEnd;
   readonly attribute unsigned long long connectStart;
   readonly attribute unsigned long long connectEnd;
-  readonly attribute unsigned long long secureConnectionStart;
+  readonly attribute unsigned long long secureConnectionStart; */
   readonly attribute unsigned long long requestStart;
-  readonly attribute unsigned long long responseStart;
-  readonly attribute unsigned long long responseEnd; */
+  /* readonly attribute unsigned long long responseStart; */
+  /* readonly attribute unsigned long long responseEnd; */
   readonly attribute unsigned long long domLoading;
   readonly attribute unsigned long long domInteractive;
   readonly attribute unsigned long long domContentLoadedEventStart;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -405,7 +405,7 @@ pub struct ScriptThread {
     promise_job_queue: PromiseJobQueue,
 
     /// Navigation Timing properties:
-    /// https://w3c.github.io/navigation-timing/#sec-PerformanceNavigationTiming
+    /// https://w3c.github.io/navigation-timing/#widl-PerformanceTiming-requestStart
     request_start: Cell<u64>,
 }
 
@@ -2133,7 +2133,7 @@ impl ScriptThread {
             load_data.url = Url::parse("about:blank").unwrap();
         }
 
-        // http://w3c.github.io/navigation-timing/#widl-PerformanceNavigationTiming-requestStart
+        // https://w3c.github.io/navigation-timing/#widl-PerformanceTiming-requestStart
         update_with_current_time_ms(&self.request_start);
 
         let request = RequestInit {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -110,6 +110,7 @@ use task_source::history_traversal::HistoryTraversalTaskSource;
 use task_source::networking::NetworkingTaskSource;
 use task_source::user_interaction::{UserInteractionTask, UserInteractionTaskSource};
 use time::Tm;
+use time::get_time;
 use url::{Position, Url};
 use util::opts;
 use util::thread;
@@ -402,6 +403,10 @@ pub struct ScriptThread {
     content_process_shutdown_chan: IpcSender<()>,
 
     promise_job_queue: PromiseJobQueue,
+
+    /// Navigation Timing properties:
+    /// https://w3c.github.io/navigation-timing/#sec-PerformanceNavigationTiming
+    request_start: Cell<u64>,
 }
 
 /// In the event of thread panic, all data on the stack runs its destructor. However, there
@@ -609,6 +614,7 @@ impl ScriptThread {
             content_process_shutdown_chan: state.content_process_shutdown_chan,
 
             promise_job_queue: PromiseJobQueue::new(),
+            request_start: Cell::new(Default::default()),
         }
     }
 
@@ -1773,6 +1779,7 @@ impl ScriptThread {
                                      referrer_policy);
         browsing_context.set_active_document(&document);
         document.set_ready_state(DocumentReadyState::Loading);
+        document.set_request_start(self.request_start.get());
 
         self.constellation_chan
             .send(ConstellationMsg::ActivateDocument(incomplete.pipeline_id))
@@ -2126,6 +2133,9 @@ impl ScriptThread {
             load_data.url = Url::parse("about:blank").unwrap();
         }
 
+        // http://w3c.github.io/navigation-timing/#widl-PerformanceNavigationTiming-requestStart
+        update_with_current_time_ms(&self.request_start);
+
         let request = RequestInit {
             url: load_data.url.clone(),
             method: load_data.method,
@@ -2282,4 +2292,10 @@ fn shut_down_layout(context_tree: &BrowsingContext) {
 
 fn dom_last_modified(tm: &Tm) -> String {
     tm.to_local().strftime("%m/%d/%Y %H:%M:%S").unwrap().to_string()
+}
+
+fn update_with_current_time_ms(marker: &Cell<u64>) {
+    let time = get_time();
+    let current_time_ms = time.sec * 1000 + time.nsec as i64 / 1000000;
+    marker.set(current_time_ms as u64);
 }

--- a/tests/wpt/metadata/navigation-timing/idlharness.html.ini
+++ b/tests/wpt/metadata/navigation-timing/idlharness.html.ini
@@ -30,15 +30,6 @@
   [PerformanceTiming interface: attribute secureConnectionStart]
     expected: FAIL
 
-  [PerformanceTiming interface: attribute requestStart]
-    expected: FAIL
-
-  [PerformanceTiming interface: attribute responseStart]
-    expected: FAIL
-
-  [PerformanceTiming interface: attribute responseEnd]
-    expected: FAIL
-
   [PerformanceTiming interface: window.performance.timing must inherit property "unloadEventStart" with the proper type (1)]
     expected: FAIL
 
@@ -176,4 +167,3 @@
 
   [EventTarget interface: calling dispatchEvent(Event) on window.performance with too few arguments must throw TypeError]
     expected: FAIL
-

--- a/tests/wpt/metadata/navigation-timing/test_timing_attributes_exist.html.ini
+++ b/tests/wpt/metadata/navigation-timing/test_timing_attributes_exist.html.ini
@@ -21,18 +21,8 @@
   [window.performance.timing.redirectStart is defined.]
     expected: FAIL
 
-  [window.performance.timing.requestStart is defined.]
-    expected: FAIL
-
-  [window.performance.timing.responseEnd is defined.]
-    expected: FAIL
-
-  [window.performance.timing.responseStart is defined.]
-    expected: FAIL
-
   [window.performance.timing.unloadEventEnd is defined.]
     expected: FAIL
 
   [window.performance.timing.unloadEventStart is defined.]
     expected: FAIL
-

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13736,6 +13736,12 @@
             "url": "/_mozilla/mozilla/timer_eventInvalidation.html"
           }
         ],
+        "mozilla/timing_attributes_order.html": [
+          {
+            "path": "mozilla/timing_attributes_order.html",
+            "url": "/_mozilla/mozilla/timing_attributes_order.html"
+          }
+        ],
         "mozilla/title.html": [
           {
             "path": "mozilla/title.html",

--- a/tests/wpt/mozilla/tests/mozilla/resources/blank_page_green.html
+++ b/tests/wpt/mozilla/tests/mozilla/resources/blank_page_green.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+        <title>Green Test Page</title>
+    </head>
+    <body style="background-color:#00FF00;">
+        <h1>Placeholder</h1>
+    </body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/resources/blank_page_unload.html
+++ b/tests/wpt/mozilla/tests/mozilla/resources/blank_page_unload.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+
+        <title>Yellow Test Page</title>
+
+        <script type="text/javascript">
+            function onbeforeunload_handler()
+            {
+                var temp = "onbeforeunload";
+            }
+
+            function onunload_handler()
+            {
+                var temp = "onunload";
+            }
+        </script>
+    </head>
+    <body onbeforeunload="onbeforeunload_handler();"
+          onunload="onunload_handler();"
+          style="background-color:#FFFF00;">
+        <h1>Unload</h1>
+    </body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/resources/webperftestharness.js
+++ b/tests/wpt/mozilla/tests/mozilla/resources/webperftestharness.js
@@ -1,0 +1,155 @@
+/*
+Distributed under both the W3C Test Suite License [1] and the W3C
+3-clause BSD License [2]. To contribute to a W3C Test Suite, see the
+policies and contribution forms [3].
+
+[1] http://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+[2] http://www.w3.org/Consortium/Legal/2008/03-bsd-license
+[3] http://www.w3.org/2004/10/27-testcases
+ */
+
+//
+// Helper Functions for NavigationTiming W3C tests
+//
+
+var performanceNamespace = window.performance;
+var timingAttributes = [
+    'connectEnd',
+    'connectStart',
+    'domComplete',
+    'domContentLoadedEventEnd',
+    'domContentLoadedEventStart',
+    'domInteractive',
+    'domLoading',
+    'domainLookupEnd',
+    'domainLookupStart',
+    'fetchStart',
+    'loadEventEnd',
+    'loadEventStart',
+    'navigationStart',
+    'redirectEnd',
+    'redirectStart',
+    'requestStart',
+    'responseEnd',
+    'responseStart',
+    'unloadEventEnd',
+    'unloadEventStart'
+];
+
+var namespace_check = false;
+
+//
+// All test() functions in the WebPerf test suite should use wp_test() instead.
+//
+// wp_test() validates the window.performance namespace exists prior to running tests and
+// immediately shows a single failure if it does not.
+//
+
+function wp_test(func, msg, properties)
+{
+    // only run the namespace check once
+    if (!namespace_check)
+    {
+        namespace_check = true;
+
+        if (performanceNamespace === undefined || performanceNamespace == null)
+        {
+            // show a single error that window.performance is undefined
+            test(function() { assert_true(performanceNamespace !== undefined && performanceNamespace != null, "window.performance is defined and not null"); }, "window.performance is defined and not null.", {author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute",assert:"The window.performance attribute provides a hosting area for performance related attributes. "});
+        }
+    }
+
+    test(func, msg, properties);
+}
+
+function test_namespace(child_name, skip_root)
+{
+    if (skip_root === undefined) {
+        var msg = 'window.performance is defined';
+        wp_test(function () { assert_true(performanceNamespace !== undefined, msg); }, msg,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute",assert:"The window.performance attribute provides a hosting area for performance related attributes. "});
+    }
+
+    if (child_name !== undefined) {
+        var msg2 = 'window.performance.' + child_name + ' is defined';
+        wp_test(function() { assert_true(performanceNamespace[child_name] !== undefined, msg2); }, msg2,{author:"W3C http://www.w3.org/",help:"http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute",assert:"The window.performance attribute provides a hosting area for performance related attributes. "});
+    }
+}
+
+function test_attribute_exists(parent_name, attribute_name, properties)
+{
+    var msg = 'window.performance.' + parent_name + '.' + attribute_name + ' is defined.';
+    wp_test(function() { assert_true(performanceNamespace[parent_name][attribute_name] !== undefined, msg); }, msg, properties);
+}
+
+function test_enum(parent_name, enum_name, value, properties)
+{
+    var msg = 'window.performance.' + parent_name + '.' + enum_name + ' is defined.';
+    wp_test(function() { assert_true(performanceNamespace[parent_name][enum_name] !== undefined, msg); }, msg, properties);
+
+    msg = 'window.performance.' + parent_name + '.' + enum_name + ' = ' + value;
+    wp_test(function() { assert_equals(performanceNamespace[parent_name][enum_name], value, msg); }, msg, properties);
+}
+
+function test_timing_order(attribute_name, greater_than_attribute, properties)
+{
+    // ensure it's not 0 first
+    var msg = "window.performance.timing." + attribute_name + " > 0";
+    wp_test(function() { assert_true(performanceNamespace.timing[attribute_name] > 0, msg); }, msg, properties);
+
+    // ensure it's in the right order
+    msg = "window.performance.timing." + attribute_name + " >= window.performance.timing." + greater_than_attribute;
+    wp_test(function() { assert_true(performanceNamespace.timing[attribute_name] >= performanceNamespace.timing[greater_than_attribute], msg); }, msg, properties);
+}
+
+function test_timing_greater_than(attribute_name, greater_than, properties)
+{
+    var msg = "window.performance.timing." + attribute_name + " > " + greater_than;
+    test_greater_than(performanceNamespace.timing[attribute_name], greater_than, msg, properties);
+}
+
+function test_timing_equals(attribute_name, equals, msg, properties)
+{
+    var test_msg = msg || "window.performance.timing." + attribute_name + " == " + equals;
+    test_equals(performanceNamespace.timing[attribute_name], equals, test_msg, properties);
+}
+
+//
+// Non-test related helper functions
+//
+
+function sleep_milliseconds(n)
+{
+    var start = new Date().getTime();
+    while (true) {
+        if ((new Date().getTime() - start) >= n) break;
+    }
+}
+
+//
+// Common helper functions
+//
+
+function test_true(value, msg, properties)
+{
+    wp_test(function () { assert_true(value, msg); }, msg, properties);
+}
+
+function test_equals(value, equals, msg, properties)
+{
+    wp_test(function () { assert_equals(value, equals, msg); }, msg, properties);
+}
+
+function test_greater_than(value, greater_than, msg, properties)
+{
+    wp_test(function () { assert_true(value > greater_than, msg); }, msg, properties);
+}
+
+function test_greater_or_equals(value, greater_than, msg, properties)
+{
+    wp_test(function () { assert_true(value >= greater_than, msg); }, msg, properties);
+}
+
+function test_not_equals(value, notequals, msg, properties)
+{
+    wp_test(function() { assert_true(value !== notequals, msg); }, msg, properties);
+}

--- a/tests/wpt/mozilla/tests/mozilla/timing_attributes_order.html
+++ b/tests/wpt/mozilla/tests/mozilla/timing_attributes_order.html
@@ -1,0 +1,84 @@
+<html>
+	<head>
+        <meta charset="utf-8" />
+        <title>window.performance.timing attribute ordering on a simple navigation</title>
+        <link rel="author" title="Mozilla" href="http://www.mozilla.org/" />
+        <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-timing-interface"/>
+		<script src="/resources/testharness.js"></script>
+		<script src="/resources/testharnessreport.js"></script>
+		<script src="resources/webperftestharness.js"></script>
+
+		<script>
+            setup({explicit_done: true});
+            test_namespace('timing');
+
+            var step = 1;
+            function onload_test()
+            {
+                if (step === 1 && window.performance === undefined)
+                {
+                    // avoid script errors
+                    done();
+                    return;
+                }
+
+                var navigation_frame = document.getElementById("frameContext").contentWindow;
+                performanceNamespace = navigation_frame.performance;
+                switch (step)
+                {
+                    case 1:
+                    {
+                        navigation_frame.location.href = 'resources/blank_page_green.html';
+                        step++;
+                        break;
+                    }
+					case 2:
+                    {
+                        //
+                        // Tests
+
+                        // navigiation must be non-0
+                        test_timing_greater_than('navigationStart', 0);
+
+                        // validate attribute ordering
+                        test_timing_order('responseStart', 'requestStart');
+                        test_timing_order('responseEnd', 'responseStart');
+                        test_timing_order('domInteractive', 'responseEnd');
+                        test_timing_order('domContentLoadedEventStart', 'domInteractive');
+                        test_timing_order('domContentLoadedEventEnd', 'domContentLoadedEventStart');
+                        test_timing_order('domComplete', 'domContentLoadedEventEnd');
+                        test_timing_order('loadEventStart', 'domContentLoadedEventEnd');
+                        test_timing_order('loadEventEnd', 'loadEventStart');
+
+                        step++;
+                        done();
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+		</script>
+	</head>
+	<body>
+		<h1>Description</h1>
+		<p>This test validates the ordering of the window.performance.timing attributes.</p>
+
+		<p>This page should be loaded with a yellow background frame below which contains an unload event handler.</p>
+
+		<p>After the page loads, the frame is navigated to a new blank page with a green background.  At this point, the navigation timeline is verified</p>
+
+		<p>This test passes if all of the checks to the frame.window.performance.timing attributes are correct throughout the navigation scenario and the frame below ends with a green background.  Otherwise, this test fails.</p>
+
+		<h1>Setup</h1>
+
+		<div id="log"></div>
+		<br />
+		<iframe id="frameContext"
+			onload="/* Need to make sure we don't examine loadEventEnd
+			until after the load event has finished firing */
+			setTimeout(onload_test, 0);"
+			src="resources/blank_page_unload.html"
+			style="width: 250px; height: 250px;"></iframe>
+	</body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add the following properties to performance timing API:
- requestStart
- responseStart
- responseEnd

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #10428 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11792)

<!-- Reviewable:end -->
