### PR TITLE
Enable history interface tests

### DIFF
--- a/tests/wpt/metadata/FileAPI/blob/Blob-XHR-revoke.html.ini
+++ b/tests/wpt/metadata/FileAPI/blob/Blob-XHR-revoke.html.ini
@@ -4,3 +4,4 @@
   [Revoking blob URL used with XMLHttpRequest]
     expected: TIMEOUT
     bug: https://github.com/servo/servo/issues/10539
+

--- a/tests/wpt/metadata/html/browsers/history/joint-session-history/joint-session-history-only-fully-active.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/joint-session-history/joint-session-history-only-fully-active.html.ini
@@ -2,3 +2,4 @@
   type: testharness
   [Do only fully active documents count for session history?]
     expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/001.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/001.html.ini
@@ -1,0 +1,3 @@
+[001.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/002.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/002.html.ini
@@ -1,0 +1,3 @@
+[002.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/004.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/004.html.ini
@@ -1,0 +1,3 @@
+[004.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/005.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/005.html.ini
@@ -1,0 +1,6 @@
+[005.html]
+  type: testharness
+  expected: TIMEOUT
+  [history.pushState support is needed for this testcase]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/006.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/006.html.ini
@@ -1,0 +1,14 @@
+[006.html]
+  type: testharness
+  [history.state should initially be null]
+    expected: FAIL
+
+  [history.state should still be null onload]
+    expected: FAIL
+
+  [history.state should still be null after onload]
+    expected: FAIL
+
+  [writing to history.state should be silently ignored and not throw an error]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/007.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/007.html.ini
@@ -1,0 +1,12 @@
+[007.html]
+  type: testharness
+  expected: TIMEOUT
+  [history.state should initially be null]
+    expected: FAIL
+
+  [history.pushState support is needed for this testcase]
+    expected: FAIL
+
+  [history.state should reflect pushed state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/008.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/008.html.ini
@@ -1,0 +1,3 @@
+[008.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/009.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/009.html.ini
@@ -1,0 +1,3 @@
+[009.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/010.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/010.html.ini
@@ -1,0 +1,3 @@
+[010.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/011.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/011.html.ini
@@ -1,0 +1,11 @@
+[011.html]
+  type: testharness
+  [pushState should be able to set the location state]
+    expected: FAIL
+
+  [pushed location should be reflected immediately]
+    expected: FAIL
+
+  [pushed location should be retained after the page has loaded]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/012.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/012.html.ini
@@ -1,0 +1,11 @@
+[012.html]
+  type: testharness
+  [replaceState should be able to set the location state]
+    expected: FAIL
+
+  [replaced location should be reflected immediately]
+    expected: FAIL
+
+  [replaced location should be retained after the page has loaded]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/__dir__.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/__dir__.ini
@@ -1,1 +1,0 @@
-disabled: for now

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_001.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_001.html.ini
@@ -1,0 +1,5 @@
+[combination_history_001.html]
+  type: testharness
+  [Combine pushState and replaceSate methods]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_002.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_002.html.ini
@@ -1,0 +1,5 @@
+[combination_history_002.html]
+  type: testharness
+  [After calling of pushState method, check length]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_003.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_003.html.ini
@@ -1,0 +1,5 @@
+[combination_history_003.html]
+  type: testharness
+  [After calling of pushState and replaceState methods, check length]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_004.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_004.html.ini
@@ -1,0 +1,5 @@
+[combination_history_004.html]
+  type: testharness
+  [After calling of back method, check length]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_005.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_005.html.ini
@@ -1,0 +1,5 @@
+[combination_history_005.html]
+  type: testharness
+  [After calling of forward method, check length]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_006.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_006.html.ini
@@ -1,0 +1,5 @@
+[combination_history_006.html]
+  type: testharness
+  [After calling of go method, check length]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_007.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/combination_history_007.html.ini
@@ -1,0 +1,5 @@
+[combination_history_007.html]
+  type: testharness
+  [After calling of back and pushState method, check length]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_back.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_back.html.ini
@@ -1,0 +1,5 @@
+[history_back.html]
+  type: testharness
+  [history back]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_back_1.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_back_1.html.ini
@@ -1,0 +1,5 @@
+[history_back_1.html]
+  type: testharness
+  [history.back() with session history]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_forward.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_forward.html.ini
@@ -1,0 +1,5 @@
+[history_forward.html]
+  type: testharness
+  [history forward]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_forward_1.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_forward_1.html.ini
@@ -1,0 +1,5 @@
+[history_forward_1.html]
+  type: testharness
+  [history.forward() with session history]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_go_minus.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_go_minus.html.ini
@@ -1,0 +1,5 @@
+[history_go_minus.html]
+  type: testharness
+  [history go minus]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_go_no_argument.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_go_no_argument.html.ini
@@ -1,0 +1,5 @@
+[history_go_no_argument.html]
+  type: testharness
+  [history.go()]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_go_plus.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_go_plus.html.ini
@@ -1,0 +1,5 @@
+[history_go_plus.html]
+  type: testharness
+  [history go plus]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_go_undefined.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_go_undefined.html.ini
@@ -1,0 +1,5 @@
+[history_go_undefined.html]
+  type: testharness
+  [history.forward() with session history]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_go_zero.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_go_zero.html.ini
@@ -1,0 +1,5 @@
+[history_go_zero.html]
+  type: testharness
+  [history.go(0)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_pushstate.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_pushstate.html.ini
@@ -1,0 +1,5 @@
+[history_pushstate.html]
+  type: testharness
+  [history pushState]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_pushstate_err.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_pushstate_err.html.ini
@@ -1,0 +1,5 @@
+[history_pushstate_err.html]
+  type: testharness
+  [history pushState SECURITY_ERR]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_pushstate_nooptionalparam.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_pushstate_nooptionalparam.html.ini
@@ -1,0 +1,5 @@
+[history_pushstate_nooptionalparam.html]
+  type: testharness
+  [history pushState NoOptionalParam]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_replacestate.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_replacestate.html.ini
@@ -1,0 +1,5 @@
+[history_replacestate.html]
+  type: testharness
+  [history replaceState]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_replacestate_err.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_replacestate_err.html.ini
@@ -1,0 +1,5 @@
+[history_replacestate_err.html]
+  type: testharness
+  [history replaceState SECURITY_ERR]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_replacestate_nooptionalparam.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_replacestate_nooptionalparam.html.ini
@@ -1,0 +1,5 @@
+[history_replacestate_nooptionalparam.html]
+  type: testharness
+  [history replaceStateNoOptionalParam]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/history_state.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/history_state.html.ini
@@ -1,0 +1,5 @@
+[history_state.html]
+  type: testharness
+  [history state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/joint_session_history/001.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/joint_session_history/001.html.ini
@@ -1,0 +1,24 @@
+[001.html]
+  type: testharness
+  expected: TIMEOUT
+  [Session history length on initial load]
+    expected: NOTRUN
+
+  [Session history length on adding new iframe]
+    expected: NOTRUN
+
+  [Navigating second iframe]
+    expected: NOTRUN
+
+  [Traversing history back (1)]
+    expected: NOTRUN
+
+  [Navigating first iframe]
+    expected: NOTRUN
+
+  [Traversing history back (2)]
+    expected: NOTRUN
+
+  [Traversing history forward]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/joint_session_history/002.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/joint_session_history/002.html.ini
@@ -1,0 +1,12 @@
+[002.html]
+  type: testharness
+  expected: TIMEOUT
+  [Session history length on initial load]
+    expected: NOTRUN
+
+  [Session history length on adding new iframe]
+    expected: NOTRUN
+
+  [Navigating second iframe]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/non-automated/traverse_the_session_history_unload_prompt_1.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/non-automated/traverse_the_session_history_unload_prompt_1.html.ini
@@ -1,0 +1,5 @@
+[traverse_the_session_history_unload_prompt_1.html]
+  type: testharness
+  [Traversing the history, unload event is fired on doucment]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_1.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_1.html.ini
@@ -1,0 +1,5 @@
+[traverse_the_history_1.html]
+  type: testharness
+  [Multiple history traversals from the same task]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_2.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_2.html.ini
@@ -1,0 +1,5 @@
+[traverse_the_history_2.html]
+  type: testharness
+  [Multiple history traversals, last would be aborted]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_3.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_3.html.ini
@@ -1,0 +1,5 @@
+[traverse_the_history_3.html]
+  type: testharness
+  [Multiple history traversals, last would be aborted]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_4.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_4.html.ini
@@ -1,0 +1,5 @@
+[traverse_the_history_4.html]
+  type: testharness
+  [Multiple history traversals, last would be aborted]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_5.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_5.html.ini
@@ -1,0 +1,5 @@
+[traverse_the_history_5.html]
+  type: testharness
+  [Multiple history traversals, last would be aborted]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_unload_1.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_unload_1.html.ini
@@ -1,0 +1,5 @@
+[traverse_the_history_unload_1.html]
+  type: testharness
+  [Traversing the history, unload event is fired on doucment]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_write_after_load_1.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_write_after_load_1.html.ini
@@ -1,0 +1,5 @@
+[traverse_the_history_write_after_load_1.html]
+  type: testharness
+  [Traverse the history after document.write after the load event]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_write_after_load_2.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_write_after_load_2.html.ini
@@ -1,0 +1,5 @@
+[traverse_the_history_write_after_load_2.html]
+  type: testharness
+  [Traverse the history back and forward when a history entry is written after the load event]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_write_onload_1.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_write_onload_1.html.ini
@@ -1,0 +1,5 @@
+[traverse_the_history_write_onload_1.html]
+  type: testharness
+  [Traverse the history when a history entry is written in the load event]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_write_onload_2.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse_the_history_write_onload_2.html.ini
@@ -1,0 +1,5 @@
+[traverse_the_history_write_onload_2.html]
+  type: testharness
+  [Traverse the history back and forward when a history entry is written in the load event]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -9575,3 +9575,4 @@
 
   [HTMLInputElement interface: createInput("button") must inherit property "useMap" with the proper type (57)]
     expected: FAIL
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html.ini
@@ -2,5 +2,7 @@
   type: testharness
   [Check the frame heriarchy 1]
     expected: FAIL
+
   [Check the frame heriarchy 2]
     expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html.ini
@@ -1,6 +1,5 @@
 [tex-image-and-sub-image-2d-with-array-buffer-view.html]
   type: testharness
-
   [WebGL test #0: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: FAIL
 
@@ -105,3 +104,4 @@
 
   [WebGL test #52: successfullyParsed should be true. Was false.]
     expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-size.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-size.html.ini
@@ -353,3 +353,4 @@
 
   [WebGL test #254: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors.]
     expected: FAIL
+


### PR DESCRIPTION
This is needed for #10992.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because enabling the history interface tests.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11793)

<!-- Reviewable:end -->
