### PR TITLE
Account for the font of empty input fields

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1972,16 +1972,16 @@ impl Fragment {
                     ascent: computed_block_size + self.border_padding.block_start,
                 }
             }
-            SpecificFragmentInfo::ScannedText(ref text_fragment) => {
+            SpecificFragmentInfo::ScannedText(ref info) => {
                 // Fragments with no glyphs don't contribute any inline metrics.
                 // TODO: Filter out these fragments during flow construction?
-                if text_fragment.content_size.inline == Au(0) {
+                if info.insertion_point.is_none() && info.content_size.inline == Au(0) {
                     return InlineMetrics::new(Au(0), Au(0), Au(0));
                 }
                 // See CSS 2.1 § 10.8.1.
                 let line_height = self.calculate_line_height(layout_context);
                 let font_derived_metrics =
-                    InlineMetrics::from_font_metrics(&text_fragment.run.font_metrics, line_height);
+                    InlineMetrics::from_font_metrics(&info.run.font_metrics, line_height);
                 InlineMetrics {
                     block_size_above_baseline: font_derived_metrics.block_size_above_baseline +
                                                    self.border_padding.block_start,

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2724,6 +2724,18 @@
             "url": "/_mozilla/css/input_button_size_a.html"
           }
         ],
+        "css/input_empty_equiv.html": [
+          {
+            "path": "css/input_empty_equiv.html",
+            "references": [
+              [
+                "/_mozilla/css/input_empty_equiv_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/input_empty_equiv.html"
+          }
+        ],
         "css/input_height_a.html": [
           {
             "path": "css/input_height_a.html",
@@ -9780,6 +9792,18 @@
             ]
           ],
           "url": "/_mozilla/css/input_button_size_a.html"
+        }
+      ],
+      "css/input_empty_equiv.html": [
+        {
+          "path": "css/input_empty_equiv.html",
+          "references": [
+            [
+              "/_mozilla/css/input_empty_equiv_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/input_empty_equiv.html"
         }
       ],
       "css/input_height_a.html": [

--- a/tests/wpt/mozilla/tests/css/input_empty_equiv.html
+++ b/tests/wpt/mozilla/tests/css/input_empty_equiv.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>An input field is drawn the same with or without content</title>
+<link rel="match" href="input_empty_equiv_ref.html">
+<input></input>
+<script>document.getElementsByTagName("input")[0].focus()</script>

--- a/tests/wpt/mozilla/tests/css/input_empty_equiv_ref.html
+++ b/tests/wpt/mozilla/tests/css/input_empty_equiv_ref.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>An input field is drawn the same with or without content</title>
+<input value=" "></input>
+<script>document.getElementsByTagName("input")[0].focus()</script>


### PR DESCRIPTION
The font of empty fragments is not accounted for in layout. This behavior is incorrect when part of an input field.
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11653
- [X] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11798)

<!-- Reviewable:end -->
