### PR TITLE
webrender: Don't use OpenGL round() for snapping pixels

### DIFF
--- a/resources/shaders/es2_common.vs.glsl
+++ b/resources/shaders/es2_common.vs.glsl
@@ -65,6 +65,6 @@ vec2 SnapToPixels(vec2 pos)
     // Snap the vertex to pixel position to guarantee correct texture
     // sampling when using bilinear filtering.
 
-    // TODO(gw): ES2 doesn't have round(). Do we ever get negative coords here?
+    // TODO(gw): Do we ever get negative coords here?
     return floor(0.5 + pos * uDevicePixelRatio) / uDevicePixelRatio;
 }

--- a/resources/shaders/gl3_common.vs.glsl
+++ b/resources/shaders/gl3_common.vs.glsl
@@ -62,5 +62,8 @@ vec2 SnapToPixels(vec2 pos)
 {
     // Snap the vertex to pixel position to guarantee correct texture
     // sampling when using bilinear filtering.
-    return round(pos * uDevicePixelRatio) / uDevicePixelRatio;
+
+    // Don't use round() because its behavior is implementation-defined on 0.5.
+    // TODO: Do we ever get negative coords here?
+    return floor(0.5 + pos * uDevicePixelRatio) / uDevicePixelRatio;
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -3986,6 +3986,18 @@
             "viewport_size": "300x300"
           }
         ],
+        "css/pixel_snapping_glyphs.html": [
+          {
+            "path": "css/pixel_snapping_glyphs.html",
+            "references": [
+              [
+                "/_mozilla/css/pixel_snapping_glyphs_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/pixel_snapping_glyphs.html"
+          }
+        ],
         "css/pixel_snapping_position_a.html": [
           {
             "dpi": "2",
@@ -11024,6 +11036,18 @@
           ],
           "url": "/_mozilla/css/pixel_snapping_border_a.html",
           "viewport_size": "300x300"
+        }
+      ],
+      "css/pixel_snapping_glyphs.html": [
+        {
+          "path": "css/pixel_snapping_glyphs.html",
+          "references": [
+            [
+              "/_mozilla/css/pixel_snapping_glyphs_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/pixel_snapping_glyphs.html"
         }
       ],
       "css/pixel_snapping_position_a.html": [

--- a/tests/wpt/mozilla/meta/css/pixel_snapping_glyphs.html.ini
+++ b/tests/wpt/mozilla/meta/css/pixel_snapping_glyphs.html.ini
@@ -1,0 +1,4 @@
+[pixel_snapping_glyphs.html]
+  type: reftest
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/mozilla/tests/css/pixel_snapping_glyphs.html
+++ b/tests/wpt/mozilla/tests/css/pixel_snapping_glyphs.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>pixel snapping glyphs test</title>
+<link rel="match" href="pixel_snapping_glyphs_ref.html">
+<div style="font: 13px 'Helvetica Neue'; padding: 0.5px;">illisible</div>

--- a/tests/wpt/mozilla/tests/css/pixel_snapping_glyphs_ref.html
+++ b/tests/wpt/mozilla/tests/css/pixel_snapping_glyphs_ref.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>pixel snapping glyphs reference</title>
+<div style="font: 13px 'Helvetica Neue'; padding: 1px;">illisible</div>


### PR DESCRIPTION
Fixes #11751. See servo/webrender#294 for some details. r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11801)

<!-- Reviewable:end -->
