### PR TITLE
Avoid unwinding into C stack frames

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -192,7 +192,9 @@ impl Node {
         debug_assert!(thread_state::get().is_script());
         let win = window_from_node(self);
         self.style_and_layout_data.set(None);
-        win.layout_chan().send(Msg::ReapStyleAndLayoutData(data)).unwrap();
+        if win.layout_chan().send(Msg::ReapStyleAndLayoutData(data)).is_err() {
+            warn!("layout thread unreachable - leaking layout data");
+        }
     }
 
     /// Adds a new child to the end of this node's list of children.

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -580,6 +580,8 @@ impl TestBindingMethods for TestBinding {
             ptr::write_volatile(p, 0xbaadc0de);
         }
     }
+
+    fn Panic(&self) { panic!("explicit panic from script") }
 }
 
 impl TestBinding {

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -455,6 +455,8 @@ interface TestBinding {
   static void funcControlledStaticMethodEnabled();
   [Func="TestBinding::condition_satisfied"]
   const unsigned short funcControlledConstEnabled = 0;
+
+  void panic();
 };
 
 partial interface TestBinding {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -61,7 +61,7 @@ use script_layout_interface::message::{Msg, Reflow, ReflowQueryType, ScriptReflo
 use script_layout_interface::reporter::CSSErrorReporter;
 use script_layout_interface::rpc::{ContentBoxResponse, ContentBoxesResponse, LayoutRPC};
 use script_layout_interface::rpc::{MarginStyleResponse, ResolvedStyleResponse};
-use script_runtime::{ScriptChan, ScriptPort};
+use script_runtime::{ScriptChan, ScriptPort, maybe_take_panic_result};
 use script_thread::SendableMainThreadScriptChan;
 use script_thread::{MainThreadScriptChan, MainThreadScriptMsg, RunnableWrapper};
 use script_traits::{ConstellationControlMsg, UntrustedNodeAddress};
@@ -74,6 +74,7 @@ use std::collections::{HashMap, HashSet};
 use std::default::Default;
 use std::ffi::CString;
 use std::io::{Write, stderr, stdout};
+use std::panic;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::TryRecvError::{Disconnected, Empty};
@@ -913,6 +914,10 @@ impl<'a, T: Reflectable> ScriptHelpers for &'a T {
                         debug!("error evaluating JS string");
                         report_pending_exception(cx, globalhandle.get());
                     }
+                }
+
+                if let Some(error) = maybe_take_panic_result() {
+                    panic::resume_unwind(error);
                 }
             }
         )

--- a/tests/html/panic.html
+++ b/tests/html/panic.html
@@ -1,0 +1,16 @@
+<!-- To exercise these tests, set the `dom.testbinding.enabled` to true.
+     It is expected that the browser will not abort due to failed JS engine assertions. -->
+
+<!-- Straightforward test - invoking a panic from a toplevel script execution -->
+<script>
+(new TestBinding()).panic();
+</script>
+
+<!-- invoking a panic from an event handler which is invoked by native code -->
+<!--<iframe src="data:,hi there" onload="(new TestBinding()).panic()"></iframe>-->
+
+<!-- invoking a panic from an event handler which is invoked by script -->
+<!--<div onclick="(new TestBinding()).panic()"></div>
+<script>
+document.querySelector('div').click();
+</script>-->


### PR DESCRIPTION
Fix the biggest cause of #6462 by wrapping lots of JS->Rust transitions in catch_panic, and calling resume_panic after all Rust->JS transitions return.

Known issue:
- Finalizers can be called in response to any JS engine allocation that triggers a GC, so it's possible for a Rust object's Drop implementation that panics to leave an interrupted panic in TLS. This is why 30d8009 is part of this PR; the underlying problem is that there's no clear place to resume the panic after it is interrupted.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #6462 (github issue number if applicable).
- [X] There are tests for these changes OR

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11803)

<!-- Reviewable:end -->
