### PR TITLE
Be clear in ports/cef/README.md about using build-cef

### DIFF
--- a/ports/cef/README.md
+++ b/ports/cef/README.md
@@ -3,7 +3,7 @@ How to test:
 1. Go to http://cefbuilds.com/ and download a binary for your OS/arch
 2. Unpack the (huge) archive
 3. Create both Debug and Release build types for CEF (```./build.sh [Debug|Release]```)
-4. Build servo
+4. Build servo with ```./mach build-cef [--release]```
 5. Run a CEF-based executable with the embedding crate preloaded:
 	* Linux: ```LD_LIBRARY_PATH=/path/to/cef-bin-unpack-dir/out/$build_type LD_PRELOAD=/path/to/servo/build/libembedding-*.so [CEF EXE]```
 6. Enjoy CEF-powered crashes


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

I believe ./mach build-cef is required, so just updating the document to be clear

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's documentation change

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11807)

<!-- Reviewable:end -->
