### PR TITLE
Remove pipeline_to_frame_map

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -69,6 +69,9 @@ pub struct Pipeline {
     /// Whether this pipeline should be treated as visible for the purposes of scheduling and
     /// resource management.
     pub visible: bool,
+    /// Frame that contains this Pipeline. Can be `None` if the pipeline is not apart of the
+    /// frame tree.
+    pub frame: Option<FrameId>,
 }
 
 /// Initial setup data needed to construct a pipeline.
@@ -292,6 +295,7 @@ impl Pipeline {
             running_animations: false,
             visible: visible,
             is_private: is_private,
+            frame: None,
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

I think storing the `FrameId` on the `Pipeline` is cleaner than maintaining an extra `HashMap`. If not, I am ok with not making this change.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because refactoring.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11809)

<!-- Reviewable:end -->
