### PR TITLE
Generate geckolib structs with -no-bitfield-methods

### DIFF
--- a/ports/geckolib/gecko_bindings/lib.rs
+++ b/ports/geckolib/gecko_bindings/lib.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(const_fn)]
-
 extern crate heapsize;
 
 #[allow(dead_code, non_camel_case_types)]

--- a/ports/geckolib/gecko_bindings/structs_debug.rs
+++ b/ports/geckolib/gecko_bindings/structs_debug.rs
@@ -2647,19 +2647,6 @@ pub struct nsTArrayHeader {
     pub mLength: u32,
     pub _bitfield_1: u32,
 }
-impl nsTArrayHeader {
-    pub fn set_mCapacity(&mut self, val: u32) {
-        self._bitfield_1 &= !(((1 << (31u32 as u32)) - 1) << 0usize);
-        self._bitfield_1 |= (val as u32) << 0usize;
-    }
-    pub fn set_mIsAutoArray(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u32)) - 1) << 31usize);
-        self._bitfield_1 |= (val as u32) << 31usize;
-    }
-    pub const fn new_bitfield_1(mCapacity: u32, mIsAutoArray: bool) -> u32 {
-        0 | ((mCapacity as u32) << 0u32) | ((mIsAutoArray as u32) << 31u32)
-    }
-}
 impl ::std::clone::Clone for nsTArrayHeader {
     fn clone(&self) -> Self { *self }
 }
@@ -4214,91 +4201,7 @@ pub struct nsCSSValue_nsCSSValue_h_unnamed_9 {
     pub mFontFamilyList: __BindgenUnionField<*mut FontFamilyListRefCnt>,
     pub _bindgen_data_: u64,
 }
-impl nsCSSValue_nsCSSValue_h_unnamed_9 {
-    pub unsafe fn mInt(&mut self) -> *mut i32 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mFloat(&mut self) -> *mut f32 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mString(&mut self) -> *mut *mut nsStringBuffer {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mColor(&mut self) -> *mut nscolor {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mArray(&mut self) -> *mut *mut Array {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mURL(&mut self) -> *mut *mut URLValue {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mImage(&mut self) -> *mut *mut ImageValue {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mGridTemplateAreas(&mut self)
-     -> *mut *mut GridTemplateAreasValue {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mGradient(&mut self) -> *mut *mut nsCSSValueGradient {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mTokenStream(&mut self) -> *mut *mut nsCSSValueTokenStream {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mPair(&mut self) -> *mut *mut nsCSSValuePair_heap {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mRect(&mut self) -> *mut *mut nsCSSRect_heap {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mTriplet(&mut self) -> *mut *mut nsCSSValueTriplet_heap {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mList(&mut self) -> *mut *mut nsCSSValueList_heap {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mListDependent(&mut self) -> *mut *mut nsCSSValueList {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mSharedList(&mut self) -> *mut *mut nsCSSValueSharedList {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mPairList(&mut self) -> *mut *mut nsCSSValuePairList_heap {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mPairListDependent(&mut self)
-     -> *mut *mut nsCSSValuePairList {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mFloatColor(&mut self) -> *mut *mut nsCSSValueFloatColor {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mFontFamilyList(&mut self)
-     -> *mut *mut FontFamilyListRefCnt {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsCSSValue_nsCSSValue_h_unnamed_9 { }
 impl ::std::clone::Clone for nsCSSValue_nsCSSValue_h_unnamed_9 {
     fn clone(&self) -> Self { *self }
 }
@@ -4669,19 +4572,6 @@ pub struct nsIAtom {
 pub struct _vftable_nsIAtom {
     pub _base: _vftable_nsISupports,
 }
-impl nsIAtom {
-    pub fn set_mLength(&mut self, val: u32) {
-        self._bitfield_1 &= !(((1 << (31u32 as u32)) - 1) << 0usize);
-        self._bitfield_1 |= (val as u32) << 0usize;
-    }
-    pub fn set_mIsStatic(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u32)) - 1) << 31usize);
-        self._bitfield_1 |= (val as u32) << 31usize;
-    }
-    pub const fn new_bitfield_1(mLength: u32, mIsStatic: bool) -> u32 {
-        0 | ((mLength as u32) << 0u32) | ((mIsStatic as u32) << 31u32)
-    }
-}
 impl ::std::clone::Clone for nsIAtom {
     fn clone(&self) -> Self { *self }
 }
@@ -4892,20 +4782,7 @@ pub struct nsStyleCoord_h_unnamed_15 {
     pub mPointer: __BindgenUnionField<*mut ::std::os::raw::c_void>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleCoord_h_unnamed_15 {
-    pub unsafe fn mInt(&mut self) -> *mut i32 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mFloat(&mut self) -> *mut f32 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mPointer(&mut self) -> *mut *mut ::std::os::raw::c_void {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleCoord_h_unnamed_15 { }
 impl ::std::clone::Clone for nsStyleCoord_h_unnamed_15 {
     fn clone(&self) -> Self { *self }
 }
@@ -5120,21 +4997,7 @@ pub struct nsStyleImage_nsStyleStruct_h_unnamed_18 {
     pub mElementId: __BindgenUnionField<*mut ::std::os::raw::c_ushort>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleImage_nsStyleStruct_h_unnamed_18 {
-    pub unsafe fn mImage(&mut self) -> *mut *mut imgRequestProxy {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mGradient(&mut self) -> *mut *mut nsStyleGradient {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mElementId(&mut self)
-     -> *mut *mut ::std::os::raw::c_ushort {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleImage_nsStyleStruct_h_unnamed_18 { }
 impl ::std::clone::Clone for nsStyleImage_nsStyleStruct_h_unnamed_18 {
     fn clone(&self) -> Self { *self }
 }
@@ -5484,19 +5347,6 @@ pub struct nsStyleGridTemplate {
     pub mRepeatAutoIndex: i16,
     pub _bitfield_1: u8,
 }
-impl nsStyleGridTemplate {
-    pub fn set_mIsAutoFill(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 0usize);
-        self._bitfield_1 |= (val as u8) << 0usize;
-    }
-    pub fn set_mIsSubgrid(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 1usize);
-        self._bitfield_1 |= (val as u8) << 1usize;
-    }
-    pub const fn new_bitfield_1(mIsAutoFill: bool, mIsSubgrid: bool) -> u8 {
-        0 | ((mIsAutoFill as u8) << 0u32) | ((mIsSubgrid as u8) << 1u32)
-    }
-}
 #[test]
 fn bindgen_test_layout_nsStyleGridTemplate() {
     assert_eq!(::std::mem::size_of::<nsStyleGridTemplate>() , 48usize);
@@ -5616,40 +5466,6 @@ pub struct nsStyleText {
     pub mTextShadow: RefPtr<nsCSSShadowArray>,
     pub mTextEmphasisStyleString: nsString,
 }
-impl nsStyleText {
-    pub fn set_mTextAlignTrue(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 0usize);
-        self._bitfield_1 |= (val as u8) << 0usize;
-    }
-    pub fn set_mTextAlignLastTrue(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 1usize);
-        self._bitfield_1 |= (val as u8) << 1usize;
-    }
-    pub fn set_mTextEmphasisColorForeground(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 2usize);
-        self._bitfield_1 |= (val as u8) << 2usize;
-    }
-    pub fn set_mWebkitTextFillColorForeground(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 3usize);
-        self._bitfield_1 |= (val as u8) << 3usize;
-    }
-    pub fn set_mWebkitTextStrokeColorForeground(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 4usize);
-        self._bitfield_1 |= (val as u8) << 4usize;
-    }
-    pub const fn new_bitfield_1(mTextAlignTrue: bool,
-                                mTextAlignLastTrue: bool,
-                                mTextEmphasisColorForeground: bool,
-                                mWebkitTextFillColorForeground: bool,
-                                mWebkitTextStrokeColorForeground: bool)
-     -> u8 {
-        0 | ((mTextAlignTrue as u8) << 0u32) |
-            ((mTextAlignLastTrue as u8) << 1u32) |
-            ((mTextEmphasisColorForeground as u8) << 2u32) |
-            ((mWebkitTextFillColorForeground as u8) << 3u32) |
-            ((mWebkitTextStrokeColorForeground as u8) << 4u32)
-    }
-}
 #[test]
 fn bindgen_test_layout_nsStyleText() {
     assert_eq!(::std::mem::size_of::<nsStyleText>() , 136usize);
@@ -5735,20 +5551,7 @@ pub struct nsTimingFunction_nsStyleStruct_h_unnamed_20 {
     pub nsTimingFunction_nsStyleStruct_h_unnamed_20_nsStyleStruct_h_unnamed_22: __BindgenUnionField<nsTimingFunction_nsStyleStruct_h_unnamed_20_nsStyleStruct_h_unnamed_22>,
     pub _bindgen_data_: [u32; 4usize],
 }
-impl nsTimingFunction_nsStyleStruct_h_unnamed_20 {
-    pub unsafe fn mFunc(&mut self)
-     ->
-         *mut nsTimingFunction_nsStyleStruct_h_unnamed_20_nsStyleStruct_h_unnamed_21 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn nsTimingFunction_nsStyleStruct_h_unnamed_20_nsStyleStruct_h_unnamed_22(&mut self)
-     ->
-         *mut nsTimingFunction_nsStyleStruct_h_unnamed_20_nsStyleStruct_h_unnamed_22 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsTimingFunction_nsStyleStruct_h_unnamed_20 { }
 impl ::std::clone::Clone for nsTimingFunction_nsStyleStruct_h_unnamed_20 {
     fn clone(&self) -> Self { *self }
 }
@@ -5948,20 +5751,7 @@ pub struct nsStyleContentData_nsStyleStruct_h_unnamed_23 {
     pub mCounters: __BindgenUnionField<*mut Array>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleContentData_nsStyleStruct_h_unnamed_23 {
-    pub unsafe fn mString(&mut self) -> *mut *mut ::std::os::raw::c_ushort {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mImage(&mut self) -> *mut *mut imgRequestProxy {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mCounters(&mut self) -> *mut *mut Array {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleContentData_nsStyleStruct_h_unnamed_23 { }
 impl ::std::clone::Clone for nsStyleContentData_nsStyleStruct_h_unnamed_23 {
     fn clone(&self) -> Self { *self }
 }
@@ -6114,16 +5904,7 @@ pub struct nsStyleSVGPaint_nsStyleStruct_h_unnamed_24 {
     pub mPaintServer: __BindgenUnionField<*mut nsIURI>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleSVGPaint_nsStyleStruct_h_unnamed_24 {
-    pub unsafe fn mColor(&mut self) -> *mut nscolor {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mPaintServer(&mut self) -> *mut *mut nsIURI {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleSVGPaint_nsStyleStruct_h_unnamed_24 { }
 impl ::std::clone::Clone for nsStyleSVGPaint_nsStyleStruct_h_unnamed_24 {
     fn clone(&self) -> Self { *self }
 }
@@ -6218,16 +5999,7 @@ pub struct nsStyleClipPath_nsStyleStruct_h_unnamed_26 {
     pub mURL: __BindgenUnionField<*mut nsIURI>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleClipPath_nsStyleStruct_h_unnamed_26 {
-    pub unsafe fn mBasicShape(&mut self) -> *mut *mut nsStyleBasicShape {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mURL(&mut self) -> *mut *mut nsIURI {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleClipPath_nsStyleStruct_h_unnamed_26 { }
 impl ::std::clone::Clone for nsStyleClipPath_nsStyleStruct_h_unnamed_26 {
     fn clone(&self) -> Self { *self }
 }
@@ -6257,16 +6029,7 @@ pub struct nsStyleFilter_nsStyleStruct_h_unnamed_27 {
     pub mDropShadow: __BindgenUnionField<*mut nsCSSShadowArray>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleFilter_nsStyleStruct_h_unnamed_27 {
-    pub unsafe fn mURL(&mut self) -> *mut *mut nsIURI {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mDropShadow(&mut self) -> *mut *mut nsCSSShadowArray {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleFilter_nsStyleStruct_h_unnamed_27 { }
 impl ::std::clone::Clone for nsStyleFilter_nsStyleStruct_h_unnamed_27 {
     fn clone(&self) -> Self { *self }
 }

--- a/ports/geckolib/gecko_bindings/structs_release.rs
+++ b/ports/geckolib/gecko_bindings/structs_release.rs
@@ -2626,19 +2626,6 @@ pub struct nsTArrayHeader {
     pub mLength: u32,
     pub _bitfield_1: u32,
 }
-impl nsTArrayHeader {
-    pub fn set_mCapacity(&mut self, val: u32) {
-        self._bitfield_1 &= !(((1 << (31u32 as u32)) - 1) << 0usize);
-        self._bitfield_1 |= (val as u32) << 0usize;
-    }
-    pub fn set_mIsAutoArray(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u32)) - 1) << 31usize);
-        self._bitfield_1 |= (val as u32) << 31usize;
-    }
-    pub const fn new_bitfield_1(mCapacity: u32, mIsAutoArray: bool) -> u32 {
-        0 | ((mCapacity as u32) << 0u32) | ((mIsAutoArray as u32) << 31u32)
-    }
-}
 impl ::std::clone::Clone for nsTArrayHeader {
     fn clone(&self) -> Self { *self }
 }
@@ -4193,91 +4180,7 @@ pub struct nsCSSValue_nsCSSValue_h_unnamed_9 {
     pub mFontFamilyList: __BindgenUnionField<*mut FontFamilyListRefCnt>,
     pub _bindgen_data_: u64,
 }
-impl nsCSSValue_nsCSSValue_h_unnamed_9 {
-    pub unsafe fn mInt(&mut self) -> *mut i32 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mFloat(&mut self) -> *mut f32 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mString(&mut self) -> *mut *mut nsStringBuffer {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mColor(&mut self) -> *mut nscolor {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mArray(&mut self) -> *mut *mut Array {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mURL(&mut self) -> *mut *mut URLValue {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mImage(&mut self) -> *mut *mut ImageValue {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mGridTemplateAreas(&mut self)
-     -> *mut *mut GridTemplateAreasValue {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mGradient(&mut self) -> *mut *mut nsCSSValueGradient {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mTokenStream(&mut self) -> *mut *mut nsCSSValueTokenStream {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mPair(&mut self) -> *mut *mut nsCSSValuePair_heap {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mRect(&mut self) -> *mut *mut nsCSSRect_heap {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mTriplet(&mut self) -> *mut *mut nsCSSValueTriplet_heap {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mList(&mut self) -> *mut *mut nsCSSValueList_heap {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mListDependent(&mut self) -> *mut *mut nsCSSValueList {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mSharedList(&mut self) -> *mut *mut nsCSSValueSharedList {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mPairList(&mut self) -> *mut *mut nsCSSValuePairList_heap {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mPairListDependent(&mut self)
-     -> *mut *mut nsCSSValuePairList {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mFloatColor(&mut self) -> *mut *mut nsCSSValueFloatColor {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mFontFamilyList(&mut self)
-     -> *mut *mut FontFamilyListRefCnt {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsCSSValue_nsCSSValue_h_unnamed_9 { }
 impl ::std::clone::Clone for nsCSSValue_nsCSSValue_h_unnamed_9 {
     fn clone(&self) -> Self { *self }
 }
@@ -4648,19 +4551,6 @@ pub struct nsIAtom {
 pub struct _vftable_nsIAtom {
     pub _base: _vftable_nsISupports,
 }
-impl nsIAtom {
-    pub fn set_mLength(&mut self, val: u32) {
-        self._bitfield_1 &= !(((1 << (31u32 as u32)) - 1) << 0usize);
-        self._bitfield_1 |= (val as u32) << 0usize;
-    }
-    pub fn set_mIsStatic(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u32)) - 1) << 31usize);
-        self._bitfield_1 |= (val as u32) << 31usize;
-    }
-    pub const fn new_bitfield_1(mLength: u32, mIsStatic: bool) -> u32 {
-        0 | ((mLength as u32) << 0u32) | ((mIsStatic as u32) << 31u32)
-    }
-}
 impl ::std::clone::Clone for nsIAtom {
     fn clone(&self) -> Self { *self }
 }
@@ -4871,20 +4761,7 @@ pub struct nsStyleCoord_h_unnamed_15 {
     pub mPointer: __BindgenUnionField<*mut ::std::os::raw::c_void>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleCoord_h_unnamed_15 {
-    pub unsafe fn mInt(&mut self) -> *mut i32 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mFloat(&mut self) -> *mut f32 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mPointer(&mut self) -> *mut *mut ::std::os::raw::c_void {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleCoord_h_unnamed_15 { }
 impl ::std::clone::Clone for nsStyleCoord_h_unnamed_15 {
     fn clone(&self) -> Self { *self }
 }
@@ -5098,21 +4975,7 @@ pub struct nsStyleImage_nsStyleStruct_h_unnamed_18 {
     pub mElementId: __BindgenUnionField<*mut ::std::os::raw::c_ushort>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleImage_nsStyleStruct_h_unnamed_18 {
-    pub unsafe fn mImage(&mut self) -> *mut *mut imgRequestProxy {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mGradient(&mut self) -> *mut *mut nsStyleGradient {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mElementId(&mut self)
-     -> *mut *mut ::std::os::raw::c_ushort {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleImage_nsStyleStruct_h_unnamed_18 { }
 impl ::std::clone::Clone for nsStyleImage_nsStyleStruct_h_unnamed_18 {
     fn clone(&self) -> Self { *self }
 }
@@ -5462,19 +5325,6 @@ pub struct nsStyleGridTemplate {
     pub mRepeatAutoIndex: i16,
     pub _bitfield_1: u8,
 }
-impl nsStyleGridTemplate {
-    pub fn set_mIsAutoFill(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 0usize);
-        self._bitfield_1 |= (val as u8) << 0usize;
-    }
-    pub fn set_mIsSubgrid(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 1usize);
-        self._bitfield_1 |= (val as u8) << 1usize;
-    }
-    pub const fn new_bitfield_1(mIsAutoFill: bool, mIsSubgrid: bool) -> u8 {
-        0 | ((mIsAutoFill as u8) << 0u32) | ((mIsSubgrid as u8) << 1u32)
-    }
-}
 #[test]
 fn bindgen_test_layout_nsStyleGridTemplate() {
     assert_eq!(::std::mem::size_of::<nsStyleGridTemplate>() , 48usize);
@@ -5594,40 +5444,6 @@ pub struct nsStyleText {
     pub mTextShadow: RefPtr<nsCSSShadowArray>,
     pub mTextEmphasisStyleString: nsString,
 }
-impl nsStyleText {
-    pub fn set_mTextAlignTrue(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 0usize);
-        self._bitfield_1 |= (val as u8) << 0usize;
-    }
-    pub fn set_mTextAlignLastTrue(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 1usize);
-        self._bitfield_1 |= (val as u8) << 1usize;
-    }
-    pub fn set_mTextEmphasisColorForeground(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 2usize);
-        self._bitfield_1 |= (val as u8) << 2usize;
-    }
-    pub fn set_mWebkitTextFillColorForeground(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 3usize);
-        self._bitfield_1 |= (val as u8) << 3usize;
-    }
-    pub fn set_mWebkitTextStrokeColorForeground(&mut self, val: bool) {
-        self._bitfield_1 &= !(((1 << (1u32 as u8)) - 1) << 4usize);
-        self._bitfield_1 |= (val as u8) << 4usize;
-    }
-    pub const fn new_bitfield_1(mTextAlignTrue: bool,
-                                mTextAlignLastTrue: bool,
-                                mTextEmphasisColorForeground: bool,
-                                mWebkitTextFillColorForeground: bool,
-                                mWebkitTextStrokeColorForeground: bool)
-     -> u8 {
-        0 | ((mTextAlignTrue as u8) << 0u32) |
-            ((mTextAlignLastTrue as u8) << 1u32) |
-            ((mTextEmphasisColorForeground as u8) << 2u32) |
-            ((mWebkitTextFillColorForeground as u8) << 3u32) |
-            ((mWebkitTextStrokeColorForeground as u8) << 4u32)
-    }
-}
 #[test]
 fn bindgen_test_layout_nsStyleText() {
     assert_eq!(::std::mem::size_of::<nsStyleText>() , 136usize);
@@ -5713,20 +5529,7 @@ pub struct nsTimingFunction_nsStyleStruct_h_unnamed_20 {
     pub nsTimingFunction_nsStyleStruct_h_unnamed_20_nsStyleStruct_h_unnamed_22: __BindgenUnionField<nsTimingFunction_nsStyleStruct_h_unnamed_20_nsStyleStruct_h_unnamed_22>,
     pub _bindgen_data_: [u32; 4usize],
 }
-impl nsTimingFunction_nsStyleStruct_h_unnamed_20 {
-    pub unsafe fn mFunc(&mut self)
-     ->
-         *mut nsTimingFunction_nsStyleStruct_h_unnamed_20_nsStyleStruct_h_unnamed_21 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn nsTimingFunction_nsStyleStruct_h_unnamed_20_nsStyleStruct_h_unnamed_22(&mut self)
-     ->
-         *mut nsTimingFunction_nsStyleStruct_h_unnamed_20_nsStyleStruct_h_unnamed_22 {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsTimingFunction_nsStyleStruct_h_unnamed_20 { }
 impl ::std::clone::Clone for nsTimingFunction_nsStyleStruct_h_unnamed_20 {
     fn clone(&self) -> Self { *self }
 }
@@ -5925,20 +5728,7 @@ pub struct nsStyleContentData_nsStyleStruct_h_unnamed_23 {
     pub mCounters: __BindgenUnionField<*mut Array>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleContentData_nsStyleStruct_h_unnamed_23 {
-    pub unsafe fn mString(&mut self) -> *mut *mut ::std::os::raw::c_ushort {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mImage(&mut self) -> *mut *mut imgRequestProxy {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mCounters(&mut self) -> *mut *mut Array {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleContentData_nsStyleStruct_h_unnamed_23 { }
 impl ::std::clone::Clone for nsStyleContentData_nsStyleStruct_h_unnamed_23 {
     fn clone(&self) -> Self { *self }
 }
@@ -6091,16 +5881,7 @@ pub struct nsStyleSVGPaint_nsStyleStruct_h_unnamed_24 {
     pub mPaintServer: __BindgenUnionField<*mut nsIURI>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleSVGPaint_nsStyleStruct_h_unnamed_24 {
-    pub unsafe fn mColor(&mut self) -> *mut nscolor {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mPaintServer(&mut self) -> *mut *mut nsIURI {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleSVGPaint_nsStyleStruct_h_unnamed_24 { }
 impl ::std::clone::Clone for nsStyleSVGPaint_nsStyleStruct_h_unnamed_24 {
     fn clone(&self) -> Self { *self }
 }
@@ -6195,16 +5976,7 @@ pub struct nsStyleClipPath_nsStyleStruct_h_unnamed_26 {
     pub mURL: __BindgenUnionField<*mut nsIURI>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleClipPath_nsStyleStruct_h_unnamed_26 {
-    pub unsafe fn mBasicShape(&mut self) -> *mut *mut nsStyleBasicShape {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mURL(&mut self) -> *mut *mut nsIURI {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleClipPath_nsStyleStruct_h_unnamed_26 { }
 impl ::std::clone::Clone for nsStyleClipPath_nsStyleStruct_h_unnamed_26 {
     fn clone(&self) -> Self { *self }
 }
@@ -6234,16 +6006,7 @@ pub struct nsStyleFilter_nsStyleStruct_h_unnamed_27 {
     pub mDropShadow: __BindgenUnionField<*mut nsCSSShadowArray>,
     pub _bindgen_data_: u64,
 }
-impl nsStyleFilter_nsStyleStruct_h_unnamed_27 {
-    pub unsafe fn mURL(&mut self) -> *mut *mut nsIURI {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-    pub unsafe fn mDropShadow(&mut self) -> *mut *mut nsCSSShadowArray {
-        let raw: *mut u8 = ::std::mem::transmute(&self._bindgen_data_);
-        ::std::mem::transmute(raw.offset(0))
-    }
-}
+impl nsStyleFilter_nsStyleStruct_h_unnamed_27 { }
 impl ::std::clone::Clone for nsStyleFilter_nsStyleStruct_h_unnamed_27 {
     fn clone(&self) -> Self { *self }
 }

--- a/ports/geckolib/gecko_bindings/tools/regen_style_structs.sh
+++ b/ports/geckolib/gecko_bindings/tools/regen_style_structs.sh
@@ -43,6 +43,7 @@ for target in debug release; do
     -o ../structs_${target}.rs                                      \
     -x c++ -std=gnu++0x                                             \
     -allow-unknown-types                                            \
+    -no-bitfield-methods                                            \
     "-I$DIST_INCLUDE" "-I$DIST_INCLUDE/nspr"                        \
     "-I$1/../nsprpub/pr/include"                                    \
     $PLATFORM_DEPENDENT_DEFINES                                     \


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This makes rust-bindgen not generate a bunch of methods that were not used, including `const fn` ones.

This helps with #11815 since `const fn` is unstable.

(Note that running `regen_style_structs.sh` without changing it made a bunch of unrelated changes to `structs_*.rs`, probably because I had a different Gecko version. I first made a commit of that, then added `-no-bitfield-methods`, regenerated, made another commit, then removed the first commit with `git rebase -i master@{u}`.)

r? @emilio 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #11815 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require new tests because they’re only removing dead code.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11827)

<!-- Reviewable:end -->
