### PR TITLE
Fix the Dromaeo test runner

### DIFF
--- a/tests/dromaeo/run_dromaeo.py
+++ b/tests/dromaeo/run_dromaeo.py
@@ -19,7 +19,7 @@ TEST_SERVER_PORT = 8192
 
 # Run servo and print / parse the results for a specific Dromaeo module.
 def run_servo(servo_exe, tests):
-    url = "http://localhost:{0}/dromaeo/web/?{1}&automated&post_json".format(TEST_SERVER_PORT, tests)
+    url = "http://localhost:{0}/dromaeo/web/index.html?{1}&automated&post_json".format(TEST_SERVER_PORT, tests)
     args = [servo_exe, url, "-z", "-f"]
     return subprocess.Popen(args)
 


### PR DESCRIPTION
Fix the automated Dromaeo test runner. Without this change, it sits spinning at 100% CPU usage after completing all the tests.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11843 (github issue number if applicable).
- [X] These changes do not require tests because we don't run the Dromaeo tests in automation.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11844)

<!-- Reviewable:end -->
