### PR TITLE
Fix preference name

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -90,7 +90,7 @@ class PackageCommands(CommandBase):
             servo_args = ['-w', '-b',
                           '--pref', 'dom.mozbrowser.enabled',
                           '--pref', 'dom.forcetouch.enabled',
-                          '--pref', 'shell.builtin-key-shortcuts=false',
+                          '--pref', 'shell.builtin-key-shortcuts.enabled=false',
                           path.join(browserhtml_path, 'out', 'index.html')]
 
             runservo = os.open(dir_to_package + 'runservo.sh', os.O_WRONLY | os.O_CREAT, int("0755", 8))

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -114,7 +114,7 @@ class PostBuildCommands(CommandBase):
             args = args + ['-w',
                            '--pref', 'dom.mozbrowser.enabled',
                            '--pref', 'dom.forcetouch.enabled',
-                           '--pref', 'shell.builtin-key-shortcuts=false',
+                           '--pref', 'shell.builtin-key-shortcuts.enabled=false',
                            path.join(browserhtml_path, 'out', 'index.html')]
 
         # Borrowed and modified from:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because not testable

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Follow up of https://github.com/servo/servo/pull/11735. `.enabled` is missing in the python scripts.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11849)

<!-- Reviewable:end -->
