### PR TITLE
Fix PaintContext page_rect due to display list origin

### DIFF
--- a/components/gfx/paint_thread.rs
+++ b/components/gfx/paint_thread.rs
@@ -685,7 +685,7 @@ impl WorkerThread {
             let mut paint_context = PaintContext {
                 draw_target: draw_target.clone(),
                 font_context: &mut self.font_context,
-                page_rect: Rect::from_untyped(&tile.page_rect),
+                page_rect: Rect::from_untyped(&tile.page_rect.translate(&paint_layer.display_list_origin)),
                 screen_rect: Rect::from_untyped(&tile.screen_rect),
                 clip_rect: None,
                 transient_clip: None,

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1032,6 +1032,18 @@
             "url": "/_mozilla/css/box_shadow_blur_a.html"
           }
         ],
+        "css/box_shadow_blur_fixed.html": [
+          {
+            "path": "css/box_shadow_blur_fixed.html",
+            "references": [
+              [
+                "/_mozilla/css/box_shadow_blur_fixed_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/box_shadow_blur_fixed.html"
+          }
+        ],
         "css/box_shadow_border_box_a.html": [
           {
             "path": "css/box_shadow_border_box_a.html",
@@ -10100,6 +10112,18 @@
             ]
           ],
           "url": "/_mozilla/css/box_shadow_blur_a.html"
+        }
+      ],
+      "css/box_shadow_blur_fixed.html": [
+        {
+          "path": "css/box_shadow_blur_fixed.html",
+          "references": [
+            [
+              "/_mozilla/css/box_shadow_blur_fixed_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/box_shadow_blur_fixed.html"
         }
       ],
       "css/box_shadow_border_box_a.html": [

--- a/tests/wpt/mozilla/tests/css/box_shadow_blur_fixed.html
+++ b/tests/wpt/mozilla/tests/css/box_shadow_blur_fixed.html
@@ -1,0 +1,24 @@
+<head>
+    <link rel='match' href='box_shadow_blur_fixed_ref.html'>
+    <style>
+        #div_outer {
+            width: 100%;
+            position: fixed;
+            top: 100px;
+            left: 0;
+        }
+
+        #div_inner {
+            background: lightgrey;
+            height: 40px;
+            box-shadow: 0 0 30px 30px darkblue;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="div_outer">
+        <div id="div_inner">
+        </div>
+    </div>
+</body>

--- a/tests/wpt/mozilla/tests/css/box_shadow_blur_fixed_ref.html
+++ b/tests/wpt/mozilla/tests/css/box_shadow_blur_fixed_ref.html
@@ -1,0 +1,23 @@
+<head>
+    <style>
+        #div_outer {
+            width: 100%;
+            position: absolute;
+            top: 100px;
+            left: 0;
+        }
+
+        #div_inner {
+            background: lightgrey;
+            height: 40px;
+            box-shadow: 0 0 30px 30px darkblue;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="div_outer">
+        <div id="div_inner">
+        </div>
+    </div>
+</body>


### PR DESCRIPTION
Fix PaintContext page_rect due to non zero display list origin.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11662 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11850)

<!-- Reviewable:end -->
