### PR TITLE
Replace return_address usage for rooting with stack guards and convenience macros.

### DIFF
--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -9,14 +9,14 @@ use dom::bindings::global::global_root_from_object;
 use dom::bindings::reflector::Reflectable;
 use js::jsapi::GetGlobalForObjectCrossCompartment;
 use js::jsapi::JSAutoCompartment;
-use js::jsapi::{Heap, MutableHandleObject, RootedObject, RootedValue};
+use js::jsapi::{Heap, MutableHandleObject, RootedObject};
 use js::jsapi::{IsCallable, JSContext, JSObject, JS_WrapObject};
 use js::jsapi::{JSCompartment, JS_EnterCompartment, JS_LeaveCompartment};
 use js::jsapi::{JS_GetProperty, JS_IsExceptionPending, JS_ReportPendingException};
 use js::jsval::{JSVal, UndefinedValue};
+use js::rust::RootedGuard;
 use std::default::Default;
 use std::ffi::CString;
-use std::intrinsics::return_address;
 use std::ptr;
 use std::rc::Rc;
 
@@ -114,20 +114,20 @@ impl CallbackInterface {
     /// Returns the property with the given `name`, if it is a callable object,
     /// or an error otherwise.
     pub fn get_callable_property(&self, cx: *mut JSContext, name: &str) -> Fallible<JSVal> {
-        let mut callable = RootedValue::new(cx, UndefinedValue());
-        let obj = RootedObject::new(cx, self.callback());
+        rooted!(in(cx) let mut callable = UndefinedValue());
+        rooted!(in(cx) let obj = self.callback());
         unsafe {
             let c_name = CString::new(name).unwrap();
             if !JS_GetProperty(cx, obj.handle(), c_name.as_ptr(), callable.handle_mut()) {
                 return Err(Error::JSFailed);
             }
 
-            if !callable.ptr.is_object() || !IsCallable(callable.ptr.to_object()) {
+            if !callable.is_object() || !IsCallable(callable.to_object()) {
                 return Err(Error::Type(format!("The value of the {} property is not callable",
                                                name)));
             }
         }
-        Ok(callable.ptr)
+        Ok(callable.get())
     }
 }
 
@@ -147,11 +147,9 @@ pub fn wrap_call_this_object<T: Reflectable>(cx: *mut JSContext,
 
 /// A class that performs whatever setup we need to safely make a call while
 /// this class is on the stack. After `new` returns, the call is safe to make.
-pub struct CallSetup {
+pub struct CallSetup<'a> {
     /// The compartment for reporting exceptions.
-    /// As a RootedObject, this must be the first field in order to
-    /// determine the final address on the stack correctly.
-    exception_compartment: RootedObject,
+    exception_compartment: RootedGuard<'a, *mut JSObject>,
     /// The `JSContext` used for the call.
     cx: *mut JSContext,
     /// The compartment we were in before the call.
@@ -160,20 +158,21 @@ pub struct CallSetup {
     handling: ExceptionHandling,
 }
 
-impl CallSetup {
+impl<'a> CallSetup<'a> {
     /// Performs the setup needed to make a call.
     #[allow(unrooted_must_root)]
-    pub fn new<T: CallbackContainer>(callback: &T, handling: ExceptionHandling) -> CallSetup {
+    pub fn new<T: CallbackContainer>(exception_compartment: &'a mut RootedObject,
+                                     callback: &T,
+                                     handling: ExceptionHandling)
+                                     -> CallSetup<'a> {
         let global = unsafe { global_root_from_object(callback.callback()) };
         let cx = global.r().get_cx();
 
-        let exception_compartment = unsafe {
+        exception_compartment.ptr = unsafe {
             GetGlobalForObjectCrossCompartment(callback.callback())
         };
         CallSetup {
-            exception_compartment: RootedObject::new_with_addr(cx,
-                                                               exception_compartment,
-                                                               unsafe { return_address() }),
+            exception_compartment: RootedGuard::new(cx, exception_compartment),
             cx: cx,
             old_compartment: unsafe { JS_EnterCompartment(cx, callback.callback()) },
             handling: handling,
@@ -186,7 +185,7 @@ impl CallSetup {
     }
 }
 
-impl Drop for CallSetup {
+impl<'a> Drop for CallSetup<'a> {
     fn drop(&mut self) {
         unsafe {
             JS_LeaveCompartment(self.cx, self.old_compartment);
@@ -195,7 +194,7 @@ impl Drop for CallSetup {
                                           unsafe { JS_IsExceptionPending(self.cx) };
         if need_to_deal_with_exception {
             unsafe {
-                let _ac = JSAutoCompartment::new(self.cx, self.exception_compartment.ptr);
+                let _ac = JSAutoCompartment::new(self.cx, *self.exception_compartment);
                 JS_ReportPendingException(self.cx);
             }
         }

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2278,34 +2278,33 @@ def CreateBindingJSObject(descriptor, parent=None):
         assert not descriptor.isGlobal()
         create += """
 let handler = RegisterBindings::proxy_handlers[PrototypeList::Proxies::%s as usize];
-let private = RootedValue::new(cx, PrivateValue(raw as *const libc::c_void));
+rooted!(in(cx) let private = PrivateValue(raw as *const libc::c_void));
 let obj = NewProxyObject(cx, handler,
                          private.handle(),
-                         proto.ptr, %s.get(),
+                         proto.get(), %s.get(),
                          ptr::null_mut(), ptr::null_mut());
 assert!(!obj.is_null());
-let obj = RootedObject::new(cx, obj);\
+rooted!(in(cx) let obj = obj);\
 """ % (descriptor.name, parent)
     elif descriptor.isGlobal():
-        create += ("let obj = RootedObject::new(\n"
-                   "    cx,\n"
+        create += ("rooted!(in(cx) let obj =\n"
                    "    create_dom_global(\n"
                    "        cx,\n"
                    "        &Class.base as *const js::jsapi::Class as *const JSClass,\n"
                    "        raw as *const libc::c_void,\n"
                    "        Some(%s))\n"
                    ");\n"
-                   "assert!(!obj.ptr.is_null());" % TRACE_HOOK_NAME)
+                   "assert!(!obj.is_null());" % TRACE_HOOK_NAME)
     else:
-        create += ("let obj = RootedObject::new(cx, JS_NewObjectWithGivenProto(\n"
+        create += ("rooted!(in(cx) let obj = JS_NewObjectWithGivenProto(\n"
                    "    cx, &Class.base as *const js::jsapi::Class as *const JSClass, proto.handle()));\n"
-                   "assert!(!obj.ptr.is_null());\n"
+                   "assert!(!obj.is_null());\n"
                    "\n"
-                   "JS_SetReservedSlot(obj.ptr, DOM_OBJECT_SLOT,\n"
+                   "JS_SetReservedSlot(obj.get(), DOM_OBJECT_SLOT,\n"
                    "                   PrivateValue(raw as *const libc::c_void));")
     if descriptor.weakReferenceable:
         create += """
-JS_SetReservedSlot(obj.ptr, DOM_WEAK_SLOT, PrivateValue(ptr::null()));"""
+JS_SetReservedSlot(obj.get(), DOM_WEAK_SLOT, PrivateValue(ptr::null()));"""
     return create
 
 
@@ -2344,7 +2343,7 @@ def CopyUnforgeablePropertiesToInstance(descriptor):
     # reflector, so we can make sure we don't get confused by named getters.
     if descriptor.proxy:
         copyCode += """\
-let expando = RootedObject::new(cx, ensure_expando_object(cx, obj.handle()));
+rooted!(in(cx) let expando = ensure_expando_object(cx, obj.handle()));
 """
         obj = "expando"
     else:
@@ -2358,9 +2357,9 @@ let expando = RootedObject::new(cx, ensure_expando_object(cx, obj.handle()));
     else:
         copyFunc = "JS_InitializePropertiesFromCompatibleNativeObject"
     copyCode += """\
-let mut unforgeable_holder = RootedObject::new(cx, ptr::null_mut());
+rooted!(in(cx) let mut unforgeable_holder = ptr::null_mut());
 unforgeable_holder.handle_mut().set(
-    JS_GetReservedSlot(proto.ptr, DOM_PROTO_UNFORGEABLE_HOLDER_SLOT).to_object());
+    JS_GetReservedSlot(proto.get(), DOM_PROTO_UNFORGEABLE_HOLDER_SLOT).to_object());
 assert!(%(copyFunc)s(cx, %(obj)s.handle(), unforgeable_holder.handle()));
 """ % {'copyFunc': copyFunc, 'obj': obj}
 
@@ -2393,25 +2392,25 @@ let scope = scope.reflector().get_jsobject();
 assert!(!scope.get().is_null());
 assert!(((*JS_GetClass(scope.get())).flags & JSCLASS_IS_GLOBAL) != 0);
 
-let mut proto = RootedObject::new(cx, ptr::null_mut());
+rooted!(in(cx) let mut proto = ptr::null_mut());
 let _ac = JSAutoCompartment::new(cx, scope.get());
 GetProtoObject(cx, scope, proto.handle_mut());
-assert!(!proto.ptr.is_null());
+assert!(!proto.is_null());
 
 %(createObject)s
 
 %(copyUnforgeable)s
-(*raw).init_reflector(obj.ptr);
+(*raw).init_reflector(obj.get());
 
 Root::from_ref(&*raw)""" % {'copyUnforgeable': unforgeable, 'createObject': create})
         else:
             create = CreateBindingJSObject(self.descriptor)
             return CGGeneric("""\
 %(createObject)s
-(*raw).init_reflector(obj.ptr);
+(*raw).init_reflector(obj.get());
 
-let _ac = JSAutoCompartment::new(cx, obj.ptr);
-let mut proto = RootedObject::new(cx, ptr::null_mut());
+let _ac = JSAutoCompartment::new(cx, obj.get());
+rooted!(in(cx) let mut proto = ptr::null_mut());
 GetProtoObject(cx, obj.handle(), proto.handle_mut());
 JS_SetPrototype(cx, obj.handle(), proto.handle());
 
@@ -2525,29 +2524,29 @@ class CGCreateInterfaceObjectsMethod(CGAbstractMethod):
         if self.descriptor.interface.isCallback():
             assert not self.descriptor.interface.ctor() and self.descriptor.interface.hasConstants()
             return CGGeneric("""\
-let mut interface = RootedObject::new(cx, ptr::null_mut());
+rooted!(in(cx) let mut interface = ptr::null_mut());
 create_callback_interface_object(cx, global, sConstants, %(name)s, interface.handle_mut());
-assert!(!interface.ptr.is_null());
+assert!(!interface.is_null());
 assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
-(*cache)[PrototypeList::Constructor::%(id)s as usize] = interface.ptr;
+(*cache)[PrototypeList::Constructor::%(id)s as usize] = interface.get();
 <*mut JSObject>::post_barrier((*cache).as_mut_ptr().offset(PrototypeList::Constructor::%(id)s as isize),
                               ptr::null_mut(),
-                              interface.ptr);
+                              interface.get());
 """ % {"id": name, "name": str_to_const_array(name)})
 
         if len(self.descriptor.prototypeChain) == 1:
             if self.descriptor.interface.getExtendedAttribute("ExceptionClass"):
-                getPrototypeProto = "prototype_proto.ptr = JS_GetErrorPrototype(cx)"
+                getPrototypeProto = "prototype_proto.set(JS_GetErrorPrototype(cx))"
             else:
-                getPrototypeProto = "prototype_proto.ptr = JS_GetObjectPrototype(cx, global)"
+                getPrototypeProto = "prototype_proto.set(JS_GetObjectPrototype(cx, global))"
         else:
             getPrototypeProto = ("%s::GetProtoObject(cx, global, prototype_proto.handle_mut())" %
                                  toBindingNamespace(self.descriptor.prototypeChain[-2]))
 
         code = [CGGeneric("""\
-let mut prototype_proto = RootedObject::new(cx, ptr::null_mut());
+rooted!(in(cx) let mut prototype_proto = ptr::null_mut());
 %s;
-assert!(!prototype_proto.ptr.is_null());""" % getPrototypeProto)]
+assert!(!prototype_proto.is_null());""" % getPrototypeProto)]
 
         properties = {
             "id": name,
@@ -2561,7 +2560,7 @@ assert!(!prototype_proto.ptr.is_null());""" % getPrototypeProto)]
                 properties[arrayName] = "&[]"
 
         code.append(CGGeneric("""
-let mut prototype = RootedObject::new(cx, ptr::null_mut());
+rooted!(in(cx) let mut prototype = ptr::null_mut());
 create_interface_prototype_object(cx,
                                   prototype_proto.handle(),
                                   &PrototypeClass,
@@ -2570,12 +2569,12 @@ create_interface_prototype_object(cx,
                                   %(consts)s,
                                   %(unscopables)s,
                                   prototype.handle_mut());
-assert!(!prototype.ptr.is_null());
+assert!(!prototype.is_null());
 assert!((*cache)[PrototypeList::ID::%(id)s as usize].is_null());
-(*cache)[PrototypeList::ID::%(id)s as usize] = prototype.ptr;
+(*cache)[PrototypeList::ID::%(id)s as usize] = prototype.get();
 <*mut JSObject>::post_barrier((*cache).as_mut_ptr().offset(PrototypeList::ID::%(id)s as isize),
                               ptr::null_mut(),
-                              prototype.ptr);
+                              prototype.get());
 """ % properties))
 
         if self.descriptor.interface.hasInterfaceObject():
@@ -2587,15 +2586,15 @@ assert!((*cache)[PrototypeList::ID::%(id)s as usize].is_null());
             if self.descriptor.interface.parent:
                 parentName = toBindingNamespace(self.descriptor.getParentName())
                 code.append(CGGeneric("""
-let mut interface_proto = RootedObject::new(cx, ptr::null_mut());
+rooted!(in(cx) let mut interface_proto = ptr::null_mut());
 %s::GetConstructorObject(cx, global, interface_proto.handle_mut());""" % parentName))
             else:
                 code.append(CGGeneric("""
-let interface_proto = RootedObject::new(cx, JS_GetFunctionPrototype(cx, global));"""))
+rooted!(in(cx) let interface_proto = JS_GetFunctionPrototype(cx, global));"""))
             code.append(CGGeneric("""\
-assert!(!interface_proto.ptr.is_null());
+assert!(!interface_proto.is_null());
 
-let mut interface = RootedObject::new(cx, ptr::null_mut());
+rooted!(in(cx) let mut interface = ptr::null_mut());
 create_noncallback_interface_object(cx,
                                     global,
                                     interface_proto.handle(),
@@ -2607,14 +2606,14 @@ create_noncallback_interface_object(cx,
                                     %(name)s,
                                     %(length)s,
                                     interface.handle_mut());
-assert!(!interface.ptr.is_null());""" % properties))
+assert!(!interface.is_null());""" % properties))
             if self.descriptor.hasDescendants():
                 code.append(CGGeneric("""\
 assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
-(*cache)[PrototypeList::Constructor::%(id)s as usize] = interface.ptr;
+(*cache)[PrototypeList::Constructor::%(id)s as usize] = interface.get();
 <*mut JSObject>::post_barrier((*cache).as_mut_ptr().offset(PrototypeList::Constructor::%(id)s as isize),
                               ptr::null_mut(),
-                              interface.ptr);
+                              interface.get());
 """ % properties))
 
         constructors = self.descriptor.interface.namedConstructors
@@ -2649,15 +2648,15 @@ assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
                 holderClass = "&Class.base as *const js::jsapi::Class as *const JSClass"
                 holderProto = "prototype.handle()"
             code.append(CGGeneric("""
-let mut unforgeable_holder = RootedObject::new(cx, ptr::null_mut());
+rooted!(in(cx) let mut unforgeable_holder = ptr::null_mut());
 unforgeable_holder.handle_mut().set(
     JS_NewObjectWithoutMetadata(cx, %(holderClass)s, %(holderProto)s));
-assert!(!unforgeable_holder.ptr.is_null());
+assert!(!unforgeable_holder.is_null());
 """ % {'holderClass': holderClass, 'holderProto': holderProto}))
             code.append(InitUnforgeablePropertiesOnHolder(self.descriptor, self.properties))
             code.append(CGGeneric("""\
-JS_SetReservedSlot(prototype.ptr, DOM_PROTO_UNFORGEABLE_HOLDER_SLOT,
-                   ObjectValue(&*unforgeable_holder.ptr))"""))
+JS_SetReservedSlot(prototype.get(), DOM_PROTO_UNFORGEABLE_HOLDER_SLOT,
+                   ObjectValue(&*unforgeable_holder.get()))"""))
 
         return CGList(code, "\n")
 
@@ -2826,9 +2825,9 @@ class CGDefineDOMInterfaceMethod(CGAbstractMethod):
         return CGGeneric("""\
 assert!(!global.get().is_null());
 %s
-let mut proto = RootedObject::new(cx, ptr::null_mut());
+rooted!(in(cx) let mut proto = ptr::null_mut());
 %s(cx, global, proto.handle_mut());
-assert!(!proto.ptr.is_null());""" % (getCheck(self.descriptor), function))
+assert!(!proto.is_null());""" % (getCheck(self.descriptor), function))
 
 
 def needCx(returnType, arguments, considerTypes):
@@ -3277,15 +3276,15 @@ class CGSpecializedForwardingSetter(CGSpecializedSetter):
         assert all(ord(c) < 128 for c in attrName)
         assert all(ord(c) < 128 for c in forwardToAttrName)
         return CGGeneric("""\
-let mut v = RootedValue::new(cx, UndefinedValue());
+rooted!(in(cx) let mut v = UndefinedValue());
 if !JS_GetProperty(cx, obj, %s as *const u8 as *const libc::c_char, v.handle_mut()) {
     return false;
 }
-if !v.ptr.is_object() {
+if !v.is_object() {
     throw_type_error(cx, "Value.%s is not an object.");
     return false;
 }
-let target_obj = RootedObject::new(cx, v.ptr.to_object());
+rooted!(in(cx) let target_obj = v.to_object());
 JS_SetProperty(cx, target_obj.handle(), %s as *const u8 as *const libc::c_char, args.get(0))
 """ % (str_to_const_array(attrName), attrName, str_to_const_array(forwardToAttrName)))
 
@@ -4342,7 +4341,7 @@ class CGProxySpecialOperation(CGPerSignatureCall):
             }
             self.cgRoot.prepend(instantiateJSToNativeConversionTemplate(
                 template, templateValues, declType, argument.identifier.name))
-            self.cgRoot.prepend(CGGeneric("let value = RootedValue::new(cx, desc.get().value);"))
+            self.cgRoot.prepend(CGGeneric("rooted!(in(cx) let value = desc.value);"))
         elif operation.isGetter():
             self.cgRoot.prepend(CGGeneric("let mut found = false;"))
 
@@ -4450,7 +4449,7 @@ class CGProxyUnwrap(CGAbstractMethod):
     obj = js::UnwrapObject(obj);
 }*/
 //MOZ_ASSERT(IsProxy(obj));
-let box_ = GetProxyPrivate(*obj.ptr).to_private() as *const %s;
+let box_ = GetProxyPrivate(obj.get()).to_private() as *const %s;
 return box_;""" % self.descriptor.concreteType)
 
 
@@ -4458,7 +4457,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
     def __init__(self, descriptor):
         args = [Argument('*mut JSContext', 'cx'), Argument('HandleObject', 'proxy'),
                 Argument('HandleId', 'id'),
-                Argument('MutableHandle<PropertyDescriptor>', 'desc')]
+                Argument('MutableHandle<PropertyDescriptor>', 'desc', mutable=True)]
         CGAbstractExternMethod.__init__(self, descriptor, "getOwnPropertyDescriptor",
                                         "bool", args)
         self.descriptor = descriptor
@@ -4475,13 +4474,14 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
             attrs = "JSPROP_ENUMERATE"
             if self.descriptor.operations['IndexedSetter'] is None:
                 attrs += " | JSPROP_READONLY"
-            fillDescriptor = ("desc.get().value = result_root.ptr;\n"
-                              "fill_property_descriptor(&mut *desc.ptr, *proxy.ptr, %s);\n"
+            # FIXME(#11868) Should assign to desc.value, desc.get() is a copy.
+            fillDescriptor = ("desc.get().value = result_root.get();\n"
+                              "fill_property_descriptor(&mut desc, proxy.get(), %s);\n"
                               "return true;" % attrs)
             templateValues = {
                 'jsvalRef': 'result_root.handle_mut()',
                 'successCode': fillDescriptor,
-                'pre': 'let mut result_root = RootedValue::new(cx, UndefinedValue());'
+                'pre': 'rooted!(in(cx) let mut result_root = UndefinedValue());'
             }
             get += ("if let Some(index) = index {\n" +
                     "    let this = UnwrapProxy(proxy);\n" +
@@ -4500,13 +4500,14 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
                 attrs = " | ".join(attrs)
             else:
                 attrs = "0"
-            fillDescriptor = ("desc.get().value = result_root.ptr;\n"
-                              "fill_property_descriptor(&mut *desc.ptr, *proxy.ptr, %s);\n"
+            # FIXME(#11868) Should assign to desc.value, desc.get() is a copy.
+            fillDescriptor = ("desc.get().value = result_root.get();\n"
+                              "fill_property_descriptor(&mut desc, proxy.get(), %s);\n"
                               "return true;" % attrs)
             templateValues = {
                 'jsvalRef': 'result_root.handle_mut()',
                 'successCode': fillDescriptor,
-                'pre': 'let mut result_root = RootedValue::new(cx, UndefinedValue());'
+                'pre': 'rooted!(in(cx) let mut result_root = UndefinedValue());'
             }
             # Once we start supporting OverrideBuiltins we need to make
             # ResolveOwnProperty or EnumerateOwnProperties filter out named
@@ -4518,16 +4519,17 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
         else:
             namedGet = ""
 
+        # FIXME(#11868) Should assign to desc.obj, desc.get() is a copy.
         return get + """\
-let expando = RootedObject::new(cx, get_expando_object(proxy));
+rooted!(in(cx) let expando = get_expando_object(proxy));
 //if (!xpc::WrapperFactory::IsXrayWrapper(proxy) && (expando = GetExpandoObject(proxy))) {
-if !expando.ptr.is_null() {
+if !expando.is_null() {
     if !JS_GetPropertyDescriptorById(cx, expando.handle(), id, desc) {
         return false;
     }
-    if !desc.get().obj.is_null() {
+    if !desc.obj.is_null() {
         // Pretend the property lives on the wrapper.
-        desc.get().obj = *proxy.ptr;
+        desc.get().obj = proxy.get();
         return true;
     }
 }
@@ -4637,7 +4639,7 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
             body += dedent(
                 """
                 for i in 0..(*unwrapped_proxy).Length() {
-                    let rooted_jsid = RootedId::new(cx, int_to_jsid(i as i32));
+                    rooted!(in(cx) let rooted_jsid = int_to_jsid(i as i32));
                     AppendToAutoIdVector(props, rooted_jsid.handle().get());
                 }
                 """)
@@ -4648,9 +4650,9 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
                 for name in (*unwrapped_proxy).SupportedPropertyNames() {
                     let cstring = CString::new(name).unwrap();
                     let jsstring = JS_AtomizeAndPinString(cx, cstring.as_ptr());
-                    let rooted = RootedString::new(cx, jsstring);
+                    rooted!(in(cx) let rooted = jsstring);
                     let jsid = INTERNED_STRING_TO_JSID(cx, rooted.handle().get());
-                    let rooted_jsid = RootedId::new(cx, jsid);
+                    rooted!(in(cx) let rooted_jsid = jsid);
                     AppendToAutoIdVector(props, rooted_jsid.handle().get());
                 }
                 """)
@@ -4659,7 +4661,7 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
             """
             let expando = get_expando_object(proxy);
             if !expando.is_null() {
-                let rooted_expando = RootedObject::new(cx, expando);
+                rooted!(in(cx) let rooted_expando = expando);
                 GetPropertyKeys(cx, rooted_expando.handle(), JSITER_OWNONLY | JSITER_HIDDEN | JSITER_SYMBOLS, props);
             }
 
@@ -4693,7 +4695,7 @@ class CGDOMJSProxyHandler_getOwnEnumerablePropertyKeys(CGAbstractExternMethod):
             body += dedent(
                 """
                 for i in 0..(*unwrapped_proxy).Length() {
-                    let rooted_jsid = RootedId::new(cx, int_to_jsid(i as i32));
+                    rooted!(in(cx) let rooted_jsid = int_to_jsid(i as i32));
                     AppendToAutoIdVector(props, rooted_jsid.handle().get());
                 }
                 """)
@@ -4702,7 +4704,7 @@ class CGDOMJSProxyHandler_getOwnEnumerablePropertyKeys(CGAbstractExternMethod):
             """
             let expando = get_expando_object(proxy);
             if !expando.is_null() {
-                let rooted_expando = RootedObject::new(cx, expando);
+                rooted!(in(cx) let rooted_expando = expando);
                 GetPropertyKeys(cx, rooted_expando.handle(), JSITER_OWNONLY | JSITER_HIDDEN | JSITER_SYMBOLS, props);
             }
 
@@ -4748,8 +4750,8 @@ class CGDOMJSProxyHandler_hasOwn(CGAbstractExternMethod):
             named = ""
 
         return indexed + """\
-let expando = RootedObject::new(cx, get_expando_object(proxy));
-if !expando.ptr.is_null() {
+rooted!(in(cx) let expando = get_expando_object(proxy));
+if !expando.is_null() {
     let ok = JS_HasPropertyById(cx, expando.handle(), id, bp);
     if !ok || *bp {
         return ok;
@@ -4773,8 +4775,8 @@ class CGDOMJSProxyHandler_get(CGAbstractExternMethod):
 
     def getBody(self):
         getFromExpando = """\
-let expando = RootedObject::new(cx, get_expando_object(proxy));
-if !expando.ptr.is_null() {
+rooted!(in(cx) let expando = get_expando_object(proxy));
+if !expando.is_null() {
     let mut hasProp = false;
     if !JS_HasPropertyById(cx, expando.handle(), id, &mut hasProp) {
         return false;
@@ -4829,7 +4831,7 @@ if found {
     return true;
 }
 %s
-*vp.ptr = UndefinedValue();
+vp.set(UndefinedValue());
 return true;""" % (getIndexedOrExpando, getNamed)
 
     def definition_body(self):
@@ -5297,7 +5299,7 @@ class CGDictionary(CGThing):
             return CGGeneric("%s: %s,\n" % (name, conversion.define()))
 
         def varInsert(varName, dictionaryName):
-            insertion = ("let mut %s_js = RootedValue::new(cx, UndefinedValue());\n"
+            insertion = ("rooted!(in(cx) let mut %s_js = UndefinedValue());\n"
                          "%s.to_jsval(cx, %s_js.handle_mut());\n"
                          "set_dictionary_property(cx, obj.handle(), \"%s\", %s_js.handle()).unwrap();"
                          % (varName, varName, varName, dictionaryName, varName))
@@ -5324,13 +5326,14 @@ class CGDictionary(CGThing):
             "    }\n"
             "    pub unsafe fn new(cx: *mut JSContext, val: HandleValue) -> Result<${selfName}, ()> {\n"
             "        let object = if val.get().is_null_or_undefined() {\n"
-            "            RootedObject::new(cx, ptr::null_mut())\n"
+            "            ptr::null_mut()\n"
             "        } else if val.get().is_object() {\n"
-            "            RootedObject::new(cx, val.get().to_object())\n"
+            "            val.get().to_object()\n"
             "        } else {\n"
             "            throw_type_error(cx, \"Value not an object.\");\n"
             "            return Err(());\n"
             "        };\n"
+            "        rooted!(in(cx) let object = object);\n"
             "        Ok(${selfName} {\n"
             "${initParent}"
             "${initMembers}"
@@ -5348,9 +5351,9 @@ class CGDictionary(CGThing):
             "\n"
             "impl ToJSValConvertible for ${selfName} {\n"
             "    unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {\n"
-            "        let obj = RootedObject::new(cx, JS_NewObject(cx, ptr::null()));\n"
+            "        rooted!(in(cx) let obj = JS_NewObject(cx, ptr::null()));\n"
             "${insertMembers}"
-            "        rval.set(ObjectOrNullValue(obj.ptr))\n"
+            "        rval.set(ObjectOrNullValue(obj.get()))\n"
             "    }\n"
             "}\n").substitute({
                 "selfName": self.makeClassName(d),
@@ -5400,7 +5403,7 @@ class CGDictionary(CGThing):
 
         conversion = (
             "{\n"
-            "let mut rval = RootedValue::new(cx, UndefinedValue());\n"
+            "rooted!(in(cx) let mut rval = UndefinedValue());\n"
             "match try!(get_dictionary_property(cx, object.handle(), \"%s\", rval.handle_mut())) {\n"
             "    true => {\n"
             "%s\n"
@@ -5548,8 +5551,8 @@ class CGBindingRoot(CGThing):
             'js::jsapi::{JSNative, JSObject, JSNativeWrapper, JSPropertySpec}',
             'js::jsapi::{JSString, JSTracer, JSType, JSTypedMethodJitInfo, JSValueType}',
             'js::jsapi::{ObjectOpResult, JSJitInfo_OpType, MutableHandle, MutableHandleObject}',
-            'js::jsapi::{MutableHandleValue, PropertyDescriptor, RootedId, RootedObject}',
-            'js::jsapi::{RootedString, RootedValue, SymbolCode, jsid}',
+            'js::jsapi::{MutableHandleValue, PropertyDescriptor, RootedObject}',
+            'js::jsapi::{SymbolCode, jsid}',
             'js::jsval::JSVal',
             'js::jsval::{ObjectValue, ObjectOrNullValue, PrivateValue}',
             'js::jsval::{NullValue, UndefinedValue}',
@@ -5769,16 +5772,17 @@ class CGCallback(CGClass):
         args.insert(0, Argument(None, "&self"))
         argsWithoutThis.insert(0, Argument(None, "&self"))
 
-        setupCall = ("let s = CallSetup::new(self, aExceptionHandling);\n"
+        setupCall = ("let mut s_ec = RootedObject::new_unrooted(ptr::null_mut());\n"
+                     "let s = CallSetup::new(&mut s_ec, self, aExceptionHandling);\n"
                      "if s.get_context().is_null() {\n"
                      "    return Err(JSFailed);\n"
                      "}\n")
 
         bodyWithThis = string.Template(
             setupCall +
-            "let mut thisObjJS = RootedObject::new(s.get_context(), ptr::null_mut());\n"
+            "rooted!(in(s.get_context()) let mut thisObjJS = ptr::null_mut());\n"
             "wrap_call_this_object(s.get_context(), thisObj, thisObjJS.handle_mut());\n"
-            "if thisObjJS.ptr.is_null() {\n"
+            "if thisObjJS.is_null() {\n"
             "    return Err(JSFailed);\n"
             "}\n"
             "return ${methodName}(${callArgs});").substitute({
@@ -5787,7 +5791,7 @@ class CGCallback(CGClass):
             })
         bodyWithoutThis = string.Template(
             setupCall +
-            "let thisObjJS = RootedObject::new(s.get_context(), ptr::null_mut());"
+            "rooted!(in(s.get_context()) let thisObjJS = ptr::null_mut());"
             "return ${methodName}(${callArgs});").substitute({
                 "callArgs": ", ".join(argnamesWithoutThis),
                 "methodName": 'self.' + method.name,
@@ -6006,8 +6010,8 @@ class CallbackMember(CGNativeMember):
 
         conversion = wrapForType(
             "argv_root.handle_mut()", result=argval,
-            successCode="argv[%s] = argv_root.ptr;" % jsvalIndex,
-            pre="let mut argv_root = RootedValue::new(cx, UndefinedValue());")
+            successCode="argv[%s] = argv_root.get();" % jsvalIndex,
+            pre="rooted!(in(cx) let mut argv_root = UndefinedValue());")
         if arg.variadic:
             conversion = string.Template(
                 "for idx in 0..${arg}.len() {\n" +
@@ -6077,7 +6081,7 @@ class CallbackMethod(CallbackMember):
                                 needThisHandling)
 
     def getRvalDecl(self):
-        return "let mut rval = RootedValue::new(cx, UndefinedValue());\n"
+        return "rooted!(in(cx) let mut rval = UndefinedValue());\n"
 
     def getCall(self):
         replacements = {
@@ -6092,7 +6096,7 @@ class CallbackMethod(CallbackMember):
             replacements["argc"] = "0"
         return string.Template(
             "${getCallable}"
-            "let rootedThis = RootedObject::new(cx, ${thisObj});\n"
+            "rooted!(in(cx) let rootedThis = ${thisObj});\n"
             "let ok = JS_CallFunctionValue(\n"
             "    cx, rootedThis.handle(), callable.handle(),\n"
             "    &HandleValueArray {\n"
@@ -6116,7 +6120,7 @@ class CallCallback(CallbackMethod):
         return "aThisObj.get()"
 
     def getCallableDecl(self):
-        return "let callable = RootedValue::new(cx, ObjectValue(&*self.parent.callback()));\n"
+        return "rooted!(in(cx) let callable = ObjectValue(&*self.parent.callback()));\n"
 
 
 class CallbackOperationBase(CallbackMethod):
@@ -6141,17 +6145,17 @@ class CallbackOperationBase(CallbackMethod):
             "methodName": self.methodName
         }
         getCallableFromProp = string.Template(
-            'RootedValue::new(cx, try!(self.parent.get_callable_property(cx, "${methodName}")))'
+            'try!(self.parent.get_callable_property(cx, "${methodName}"))'
         ).substitute(replacements)
         if not self.singleOperation:
-            return 'JS::Rooted<JS::Value> callable(cx);\n' + getCallableFromProp
+            return 'rooted!(in(cx) let callable =\n' + getCallableFromProp + ');\n'
         return (
             'let isCallable = IsCallable(self.parent.callback());\n'
-            'let callable =\n' +
+            'rooted!(in(cx) let callable =\n' +
             CGIndenter(
                 CGIfElseWrapper('isCallable',
-                                CGGeneric('RootedValue::new(cx, ObjectValue(&*self.parent.callback()))'),
-                                CGGeneric(getCallableFromProp))).define() + ';\n')
+                                CGGeneric('ObjectValue(&*self.parent.callback())'),
+                                CGGeneric(getCallableFromProp))).define() + ');\n')
 
 
 class CallbackOperation(CallbackOperationBase):

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1166,23 +1166,22 @@ class CGArgumentConverter(CGThing):
                 template, variadicConversion, declType, "slot")]
 
             arg = "arg%d" % index
-
             if argument.type.isGeckoInterface():
-                vec = "RootedVec::new()"
+                init = "rooted_vec!(let mut %s)" % arg
                 innerConverter.append(CGGeneric("%s.push(JS::from_ref(&*slot));" % arg))
             else:
-                vec = "vec![]"
+                init = "let mut %s = vec![]" % arg
                 innerConverter.append(CGGeneric("%s.push(slot);" % arg))
             inner = CGIndenter(CGList(innerConverter, "\n"), 8).define()
 
             self.converter = CGGeneric("""\
-let mut %(arg)s = %(vec)s;
+%(init)s;
 if %(argc)s > %(index)s {
     %(arg)s.reserve(%(argc)s as usize - %(index)s);
     for variadicArg in %(index)s..%(argc)s {
 %(inner)s
     }
-}""" % {'arg': arg, 'argc': argc, 'index': index, 'inner': inner, 'vec': vec})
+}""" % {'arg': arg, 'argc': argc, 'index': index, 'inner': inner, 'init': init})
 
     def define(self):
         return self.converter.define()
@@ -5603,7 +5602,6 @@ class CGBindingRoot(CGThing):
             'dom::bindings::proxyhandler::{get_expando_object, get_property_descriptor}',
             'dom::bindings::num::Finite',
             'dom::bindings::str::{ByteString, DOMString, USVString}',
-            'dom::bindings::trace::RootedVec',
             'dom::bindings::weakref::{DOM_WEAK_SLOT, WeakBox, WeakReferenceable}',
             'dom::browsingcontext::BrowsingContext',
             'mem::heap_size_of_raw_self_and_children',

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -10,7 +10,7 @@ use dom::bindings::global::GlobalRef;
 use dom::domexception::{DOMErrorName, DOMException};
 use js::error::{throw_range_error, throw_type_error};
 use js::jsapi::JSAutoCompartment;
-use js::jsapi::{JSContext, JSObject, RootedValue};
+use js::jsapi::{JSContext, JSObject};
 use js::jsapi::{JS_IsExceptionPending, JS_ReportPendingException, JS_SetPendingException};
 use js::jsval::UndefinedValue;
 
@@ -115,7 +115,7 @@ pub unsafe fn throw_dom_exception(cx: *mut JSContext, global: GlobalRef, result:
 
     assert!(!JS_IsExceptionPending(cx));
     let exception = DOMException::new(global, code);
-    let mut thrown = RootedValue::new(cx, UndefinedValue());
+    rooted!(in(cx) let mut thrown = UndefinedValue());
     exception.to_jsval(cx, thrown.handle_mut());
     JS_SetPendingException(cx, thrown.handle());
 }

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -13,7 +13,7 @@ use js::glue::InvokeGetOwnPropertyDescriptor;
 use js::glue::{GetProxyHandler, SetProxyExtra};
 use js::jsapi::GetObjectProto;
 use js::jsapi::JS_GetPropertyDescriptorById;
-use js::jsapi::{Handle, HandleId, HandleObject, MutableHandle, ObjectOpResult, RootedObject};
+use js::jsapi::{Handle, HandleId, HandleObject, MutableHandle, ObjectOpResult};
 use js::jsapi::{JSContext, JSObject, JSPROP_GETTER, PropertyDescriptor};
 use js::jsapi::{JSErrNum, JS_StrictPropertyStub};
 use js::jsapi::{JS_DefinePropertyById, JS_NewObjectWithGivenProto};
@@ -36,12 +36,13 @@ pub unsafe extern "C" fn get_property_descriptor(cx: *mut JSContext,
     if !InvokeGetOwnPropertyDescriptor(handler, cx, proxy, id, desc) {
         return false;
     }
-    if !desc.get().obj.is_null() {
+    if !desc.obj.is_null() {
         return true;
     }
 
-    let mut proto = RootedObject::new(cx, ptr::null_mut());
+    rooted!(in(cx) let mut proto = ptr::null_mut());
     if !GetObjectProto(cx, proxy, proto.handle_mut()) {
+        // FIXME(#11868) Should assign to desc.obj, desc.get() is a copy.
         desc.get().obj = ptr::null_mut();
         return true;
     }
@@ -65,7 +66,7 @@ pub unsafe extern "C" fn define_property(cx: *mut JSContext,
         return true;
     }
 
-    let expando = RootedObject::new(cx, ensure_expando_object(cx, proxy));
+    rooted!(in(cx) let expando = ensure_expando_object(cx, proxy));
     JS_DefinePropertyById(cx, expando.handle(), id, desc, result)
 }
 
@@ -75,8 +76,8 @@ pub unsafe extern "C" fn delete(cx: *mut JSContext,
                                 id: HandleId,
                                 bp: *mut ObjectOpResult)
                                 -> bool {
-    let expando = RootedObject::new(cx, get_expando_object(proxy));
-    if expando.ptr.is_null() {
+    rooted!(in(cx) let expando = get_expando_object(proxy));
+    if expando.is_null() {
         (*bp).code_ = 0 /* OkCode */;
         return true;
     }

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -465,7 +465,7 @@ impl RootedTraceableSet {
 /// Roots any JSTraceable thing
 ///
 /// If you have a valid Reflectable, use Root.
-/// If you have GC things like *mut JSObject or JSVal, use jsapi::Rooted.
+/// If you have GC things like *mut JSObject or JSVal, use rooted!.
 /// If you have an arbitrary number of Reflectables to root, use RootedVec<JS<T>>
 /// If you know what you're doing, use this.
 #[derive(JSTraceable)]

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -77,8 +77,6 @@ use std::boxed::FnBox;
 use std::cell::{Cell, UnsafeCell};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{BuildHasher, Hash};
-use std::intrinsics::return_address;
-use std::iter::{FromIterator, IntoIterator};
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
@@ -466,7 +464,7 @@ impl RootedTraceableSet {
 ///
 /// If you have a valid Reflectable, use Root.
 /// If you have GC things like *mut JSObject or JSVal, use rooted!.
-/// If you have an arbitrary number of Reflectables to root, use RootedVec<JS<T>>
+/// If you have an arbitrary number of Reflectables to root, use rooted_vec!.
 /// If you know what you're doing, use this.
 #[derive(JSTraceable)]
 pub struct RootedTraceable<'a, T: 'a + JSTraceable> {
@@ -493,73 +491,73 @@ impl<'a, T: JSTraceable> Drop for RootedTraceable<'a, T> {
     }
 }
 
-/// A vector of items that are rooted for the lifetime of this struct.
+/// A vector of items to be rooted with `RootedVec`.
+/// Guaranteed to be empty when not rooted.
+/// Usage: `rooted_vec!(let mut v);` or if you have an
+/// iterator of `Root`s, `rooted_vec!(let v <- iterator);`.
 #[allow(unrooted_must_root)]
-#[no_move]
 #[derive(JSTraceable)]
 #[allow_unrooted_interior]
-pub struct RootedVec<T: JSTraceable> {
+pub struct RootableVec<T: JSTraceable> {
     v: Vec<T>,
 }
 
-
-impl<T: JSTraceable> RootedVec<T> {
-    /// Create a vector of items of type T that is rooted for
-    /// the lifetime of this struct
-    pub fn new() -> RootedVec<T> {
-        let addr = unsafe { return_address() as *const libc::c_void };
-
-        unsafe { RootedVec::new_with_destination_address(addr) }
-    }
-
-    /// Create a vector of items of type T. This constructor is specific
-    /// for RootTraceableSet.
-    pub unsafe fn new_with_destination_address(addr: *const libc::c_void) -> RootedVec<T> {
-        RootedTraceableSet::add::<RootedVec<T>>(&*(addr as *const _));
-        RootedVec::<T> {
+impl<T: JSTraceable> RootableVec<T> {
+    /// Create a vector of items of type T that can be rooted later.
+    pub fn new_unrooted() -> RootableVec<T> {
+        RootableVec {
             v: vec![],
         }
-    }
+   }
 }
 
-impl<T: JSTraceable + Reflectable> RootedVec<JS<T>> {
-    /// Obtain a safe slice of references that can't outlive that RootedVec.
-    pub fn r(&self) -> &[&T] {
-        unsafe { mem::transmute(&self.v[..]) }
-    }
+/// A vector of items that are rooted for the lifetime 'a.
+#[allow_unrooted_interior]
+pub struct RootedVec<'a, T: 'a + JSTraceable> {
+    root: &'a mut RootableVec<T>,
 }
 
-impl<T: JSTraceable> Drop for RootedVec<T> {
-    fn drop(&mut self) {
+impl<'a, T: JSTraceable + Reflectable> RootedVec<'a, JS<T>> {
+    /// Create a vector of items of type T that is rooted for
+    /// the lifetime of this struct
+    pub fn new<I: Iterator<Item = Root<T>>>(root: &'a mut RootableVec<JS<T>>, iter: I)
+                                            -> RootedVec<'a, JS<T>> {
         unsafe {
-            RootedTraceableSet::remove(self);
+            RootedTraceableSet::add(root);
+        }
+        root.v.extend(iter.map(|item| JS::from_ref(&*item)));
+        RootedVec {
+            root: root,
         }
     }
 }
 
-impl<T: JSTraceable> Deref for RootedVec<T> {
+impl<'a, T: JSTraceable + Reflectable> RootedVec<'a, JS<T>> {
+    /// Obtain a safe slice of references that can't outlive that RootedVec.
+    pub fn r(&self) -> &[&T] {
+        unsafe { mem::transmute(&self[..]) }
+    }
+}
+
+impl<'a, T: JSTraceable> Drop for RootedVec<'a, T> {
+    fn drop(&mut self) {
+        self.clear();
+        unsafe {
+            RootedTraceableSet::remove(self.root);
+        }
+    }
+}
+
+impl<'a, T: JSTraceable> Deref for RootedVec<'a, T> {
     type Target = Vec<T>;
     fn deref(&self) -> &Vec<T> {
-        &self.v
+        &self.root.v
     }
 }
 
-impl<T: JSTraceable> DerefMut for RootedVec<T> {
+impl<'a, T: JSTraceable> DerefMut for RootedVec<'a, T> {
     fn deref_mut(&mut self) -> &mut Vec<T> {
-        &mut self.v
-    }
-}
-
-impl<A: JSTraceable + Reflectable> FromIterator<Root<A>> for RootedVec<JS<A>> {
-    #[allow(moved_no_move)]
-    fn from_iter<T>(iterable: T) -> RootedVec<JS<A>>
-        where T: IntoIterator<Item = Root<A>>
-    {
-        let mut vec = unsafe {
-            RootedVec::new_with_destination_address(return_address() as *const libc::c_void)
-        };
-        vec.extend(iterable.into_iter().map(|item| JS::from_ref(&*item)));
-        vec
+        &mut self.root.v
     }
 }
 

--- a/components/script/dom/browsingcontext.rs
+++ b/components/script/dom/browsingcontext.rs
@@ -22,7 +22,7 @@ use js::jsapi::{Handle, HandleId, HandleObject, HandleValue, JSAutoCompartment};
 use js::jsapi::{JSContext, JSPROP_READONLY, JSErrNum, JSObject, PropertyDescriptor, JS_DefinePropertyById};
 use js::jsapi::{JS_ForwardGetPropertyTo, JS_ForwardSetPropertyTo, JS_GetClass, JSTracer, FreeOp};
 use js::jsapi::{JS_GetOwnPropertyDescriptorById, JS_HasPropertyById, MutableHandle};
-use js::jsapi::{MutableHandleValue, ObjectOpResult, RootedObject, RootedValue};
+use js::jsapi::{MutableHandleValue, ObjectOpResult};
 use js::jsval::{UndefinedValue, PrivateValue};
 use msg::constellation_msg::{PipelineId, SubpageId};
 use std::cell::Cell;
@@ -74,16 +74,15 @@ impl BrowsingContext {
             assert!(!parent.get().is_null());
             assert!(((*JS_GetClass(parent.get())).flags & JSCLASS_IS_GLOBAL) != 0);
             let _ac = JSAutoCompartment::new(cx, parent.get());
-            let window_proxy = RootedObject::new(cx,
-                NewWindowProxy(cx, parent, handler));
-            assert!(!window_proxy.ptr.is_null());
+            rooted!(in(cx) let window_proxy = NewWindowProxy(cx, parent, handler));
+            assert!(!window_proxy.is_null());
 
             let object = box BrowsingContext::new_inherited(frame_element, id);
 
             let raw = Box::into_raw(object);
-            SetProxyExtra(window_proxy.ptr, 0, &PrivateValue(raw as *const _));
+            SetProxyExtra(window_proxy.get(), 0, &PrivateValue(raw as *const _));
 
-            (*raw).init_reflector(window_proxy.ptr);
+            (*raw).init_reflector(window_proxy.get());
 
             Root::from_ref(&*raw)
         }
@@ -235,7 +234,7 @@ unsafe fn GetSubframeWindow(cx: *mut JSContext,
                             -> Option<Root<Window>> {
     let index = get_array_index_from_id(cx, id);
     if let Some(index) = index {
-        let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
+        rooted!(in(cx) let target = GetProxyPrivate(*proxy.ptr).to_object());
         let win = root_from_handleobject::<Window>(target.handle()).unwrap();
         let mut found = false;
         return win.IndexedGetter(index, &mut found);
@@ -248,25 +247,26 @@ unsafe fn GetSubframeWindow(cx: *mut JSContext,
 unsafe extern "C" fn getOwnPropertyDescriptor(cx: *mut JSContext,
                                               proxy: HandleObject,
                                               id: HandleId,
-                                              desc: MutableHandle<PropertyDescriptor>)
+                                              mut desc: MutableHandle<PropertyDescriptor>)
                                               -> bool {
     let window = GetSubframeWindow(cx, proxy, id);
     if let Some(window) = window {
-        let mut val = RootedValue::new(cx, UndefinedValue());
+        rooted!(in(cx) let mut val = UndefinedValue());
         window.to_jsval(cx, val.handle_mut());
-        (*desc.ptr).value = val.ptr;
-        fill_property_descriptor(&mut *desc.ptr, *proxy.ptr, JSPROP_READONLY);
+        desc.value = val.get();
+        fill_property_descriptor(&mut desc, proxy.get(), JSPROP_READONLY);
         return true;
     }
 
-    let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
+    rooted!(in(cx) let target = GetProxyPrivate(proxy.get()).to_object());
     if !JS_GetOwnPropertyDescriptorById(cx, target.handle(), id, desc) {
         return false;
     }
 
-    assert!(desc.get().obj.is_null() || desc.get().obj == target.ptr);
-    if desc.get().obj == target.ptr {
-        desc.get().obj = *proxy.ptr;
+    assert!(desc.obj.is_null() || desc.obj == target.get());
+    if desc.obj == target.get() {
+        // FIXME(#11868) Should assign to desc.obj, desc.get() is a copy.
+        desc.get().obj = proxy.get();
     }
 
     true
@@ -288,7 +288,7 @@ unsafe extern "C" fn defineProperty(cx: *mut JSContext,
         return true;
     }
 
-    let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
+    rooted!(in(cx) let target = GetProxyPrivate(*proxy.ptr).to_object());
     JS_DefinePropertyById(cx, target.handle(), id, desc, res)
 }
 
@@ -304,7 +304,7 @@ unsafe extern "C" fn has(cx: *mut JSContext,
         return true;
     }
 
-    let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
+    rooted!(in(cx) let target = GetProxyPrivate(*proxy.ptr).to_object());
     let mut found = false;
     if !JS_HasPropertyById(cx, target.handle(), id, &mut found) {
         return false;
@@ -327,7 +327,7 @@ unsafe extern "C" fn get(cx: *mut JSContext,
         return true;
     }
 
-    let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
+    rooted!(in(cx) let target = GetProxyPrivate(*proxy.ptr).to_object());
     JS_ForwardGetPropertyTo(cx, target.handle(), id, receiver, vp)
 }
 
@@ -345,7 +345,7 @@ unsafe extern "C" fn set(cx: *mut JSContext,
         return true;
     }
 
-    let target = RootedObject::new(cx, GetProxyPrivate(*proxy.ptr).to_object());
+    rooted!(in(cx) let target = GetProxyPrivate(*proxy.ptr).to_object());
     JS_ForwardSetPropertyTo(cx,
                             target.handle(),
                             id,

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -25,7 +25,7 @@ use dom::workerglobalscope::WorkerGlobalScopeInit;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::jsapi::{HandleValue, JS_SetInterruptCallback};
-use js::jsapi::{JSAutoCompartment, JSContext, RootedValue};
+use js::jsapi::{JSAutoCompartment, JSContext};
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use msg::constellation_msg::PipelineId;
@@ -290,7 +290,7 @@ impl DedicatedWorkerGlobalScope {
                 let target = self.upcast();
                 let _ac = JSAutoCompartment::new(scope.get_cx(),
                                                  scope.reflector().get_jsobject().get());
-                let mut message = RootedValue::new(scope.get_cx(), UndefinedValue());
+                rooted!(in(scope.get_cx()) let mut message = UndefinedValue());
                 data.read(GlobalRef::Worker(scope), message.handle_mut());
                 MessageEvent::dispatch_jsval(target, GlobalRef::Worker(scope), message.handle());
             },

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -28,7 +28,6 @@ use dom::bindings::num::Finite;
 use dom::bindings::refcounted::Trusted;
 use dom::bindings::reflector::{Reflectable, reflect_dom_object};
 use dom::bindings::str::{DOMString, USVString};
-use dom::bindings::trace::RootedVec;
 use dom::bindings::xmlname::XMLName::InvalidXMLName;
 use dom::bindings::xmlname::{validate_and_extract, namespace_from_domstring, xml_name_type};
 use dom::browsingcontext::BrowsingContext;
@@ -115,6 +114,7 @@ use std::cell::{Cell, Ref, RefMut};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::default::Default;
+use std::iter::once;
 use std::mem;
 use std::ptr;
 use std::rc::Rc;
@@ -1009,18 +1009,15 @@ impl Document {
             }
         }
 
-        let mut touches = RootedVec::new();
+        rooted_vec!(let mut touches);
         touches.extend(self.active_touch_points.borrow().iter().cloned());
-
-        let mut changed_touches = RootedVec::new();
-        changed_touches.push(JS::from_ref(&*touch));
-
-        let mut target_touches = RootedVec::new();
+        rooted_vec!(let mut target_touches);
         target_touches.extend(self.active_touch_points
                                   .borrow()
                                   .iter()
                                   .filter(|t| t.Target() == target)
                                   .cloned());
+        rooted_vec!(let changed_touches <- once(touch));
 
         let event = TouchEvent::new(window,
                                     DOMString::from(event_name),

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -13,7 +13,7 @@ use dom::bindings::js::{MutHeapJSVal, Root};
 use dom::bindings::reflector::reflect_dom_object;
 use dom::bindings::str::DOMString;
 use dom::event::{Event, EventBubbles, EventCancelable};
-use js::jsapi::{RootedValue, HandleValue, JSContext};
+use js::jsapi::{HandleValue, JSContext};
 use js::jsval::JSVal;
 use std::cell::Cell;
 use string_cache::Atom;
@@ -93,7 +93,7 @@ impl ErrorEvent {
 
         // Dictionaries need to be rooted
         // https://github.com/servo/servo/issues/6381
-        let error = RootedValue::new(global.get_cx(), init.error);
+        rooted!(in(global.get_cx()) let error = init.error);
         let event = ErrorEvent::new(global, Atom::from(type_),
                                 bubbles, cancelable,
                                 msg, file_name,

--- a/components/script/dom/eventdispatcher.rs
+++ b/components/script/dom/eventdispatcher.rs
@@ -9,7 +9,6 @@ use dom::bindings::global::GlobalRoot;
 use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{JS, Root, RootedReference};
 use dom::bindings::reflector::Reflectable;
-use dom::bindings::trace::RootedVec;
 use dom::document::Document;
 use dom::event::{Event, EventPhase};
 use dom::eventtarget::{CompiledEventListener, EventTarget, ListenerPhase};
@@ -128,12 +127,12 @@ pub fn dispatch_event(target: &EventTarget,
 
     // Step 3. The "invoke" algorithm is only used on `target` separately,
     // so we don't put it in the path.
-    let mut event_path: RootedVec<JS<EventTarget>> = RootedVec::new();
+    rooted_vec!(let mut event_path);
 
     // Step 4.
     if let Some(target_node) = target.downcast::<Node>() {
         for ancestor in target_node.ancestors() {
-            event_path.push(JS::from_ref(ancestor.upcast()));
+            event_path.push(JS::from_ref(ancestor.upcast::<EventTarget>()));
         }
         let top_most_ancestor_or_target =
             Root::from_ref(event_path.r().last().cloned().unwrap_or(target));

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -36,7 +36,7 @@ use dom::urlhelper::UrlHelper;
 use dom::virtualmethods::VirtualMethods;
 use dom::window::{ReflowReason, Window};
 use ipc_channel::ipc;
-use js::jsapi::{JSAutoCompartment, RootedValue, JSContext, MutableHandleValue};
+use js::jsapi::{JSAutoCompartment, JSContext, MutableHandleValue};
 use js::jsval::{UndefinedValue, NullValue};
 use msg::constellation_msg::{FrameType, LoadData, NavigationDirection, PipelineId, SubpageId};
 use net_traits::response::HttpsState;
@@ -171,7 +171,7 @@ impl HTMLIFrameElement {
             let custom_event = unsafe {
                 let cx = window.get_cx();
                 let _ac = JSAutoCompartment::new(cx, window.reflector().get_jsobject().get());
-                let mut detail = RootedValue::new(cx, UndefinedValue());
+                rooted!(in(cx) let mut detail = UndefinedValue());
                 let event_name = Atom::from(event.name());
                 self.build_mozbrowser_event_detail(event, cx, detail.handle_mut());
                 CustomEvent::new(GlobalRef::Window(window.r()),

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -30,7 +30,6 @@ use html5ever::tree_builder::NextParserState;
 use hyper::http::RawStatus;
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
-use js::jsapi::RootedValue;
 use js::jsval::UndefinedValue;
 use net_traits::{AsyncResponseListener, AsyncResponseTarget, Metadata, NetworkError};
 use network_listener::{NetworkListener, PreInvoke};
@@ -441,7 +440,7 @@ impl HTMLScriptElement {
         // Step 2.b.6.
         // TODO: Create a script...
         let window = window_from_node(self);
-        let mut rval = RootedValue::new(window.get_cx(), UndefinedValue());
+        rooted!(in(window.get_cx()) let mut rval = UndefinedValue());
         window.evaluate_script_on_global_with_result(&*source,
                                                          url.as_str(),
                                                          rval.handle_mut());

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -503,3 +503,18 @@ macro_rules! document_and_element_event_handlers(
         event_handler!(paste, GetOnpaste, SetOnpaste);
     )
 );
+
+#[macro_export]
+macro_rules! rooted_vec {
+    (let mut $name:ident) => {
+        rooted_vec!(let mut $name <- ::std::iter::empty())
+    };
+    (let $name:ident <- $iter:expr) => {
+        let mut __root = $crate::dom::bindings::trace::RootableVec::new_unrooted();
+        let $name = $crate::dom::bindings::trace::RootedVec::new(&mut __root, $iter);
+    };
+    (let mut $name:ident <- $iter:expr) => {
+        let mut __root = $crate::dom::bindings::trace::RootableVec::new_unrooted();
+        let mut $name = $crate::dom::bindings::trace::RootedVec::new(&mut __root, $iter);
+    }
+}

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -13,7 +13,7 @@ use dom::bindings::reflector::reflect_dom_object;
 use dom::bindings::str::DOMString;
 use dom::event::Event;
 use dom::eventtarget::EventTarget;
-use js::jsapi::{RootedValue, HandleValue, Heap, JSContext};
+use js::jsapi::{HandleValue, Heap, JSContext};
 use js::jsval::JSVal;
 use std::default::Default;
 use string_cache::Atom;
@@ -66,7 +66,7 @@ impl MessageEvent {
                        -> Fallible<Root<MessageEvent>> {
         // Dictionaries need to be rooted
         // https://github.com/servo/servo/issues/6381
-        let data = RootedValue::new(global.get_cx(), init.data);
+        rooted!(in(global.get_cx()) let data = init.data);
         let ev = MessageEvent::new(global, Atom::from(type_), init.parent.bubbles, init.parent.cancelable,
                                    data.handle(),
                                    init.origin.clone(), init.lastEventId.clone());

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -28,7 +28,6 @@ use dom::bindings::js::RootedReference;
 use dom::bindings::js::{JS, LayoutJS, MutNullableHeap};
 use dom::bindings::reflector::{Reflectable, reflect_dom_object};
 use dom::bindings::str::{DOMString, USVString};
-use dom::bindings::trace::RootedVec;
 use dom::bindings::xmlname::namespace_from_domstring;
 use dom::characterdata::{CharacterData, LayoutCharacterDataHelpers};
 use dom::document::{Document, DocumentSource, IsHTMLDocument};
@@ -1559,7 +1558,7 @@ impl Node {
                 parent.ranges.increase_above(parent, index, count);
             }
         }
-        let mut new_nodes = RootedVec::new();
+        rooted_vec!(let mut new_nodes);
         let new_nodes = if let NodeTypeId::DocumentFragment = node.type_id() {
             // Step 3.
             new_nodes.extend(node.children().map(|kid| JS::from_ref(&*kid)));
@@ -1603,9 +1602,9 @@ impl Node {
             Node::adopt(node, &*parent.owner_doc());
         }
         // Step 2.
-        let removed_nodes = parent.children().collect::<RootedVec<_>>();
+        rooted_vec!(let removed_nodes <- parent.children());
         // Step 3.
-        let mut added_nodes = RootedVec::new();
+        rooted_vec!(let mut added_nodes);
         let added_nodes = if let Some(node) = node.as_ref() {
             if let NodeTypeId::DocumentFragment = node.type_id() {
                 added_nodes.extend(node.children().map(|child| JS::from_ref(&*child)));
@@ -2149,7 +2148,7 @@ impl NodeMethods for Node {
         };
 
         // Step 12.
-        let mut nodes = RootedVec::new();
+        rooted_vec!(let mut nodes);
         let nodes = if node.type_id() == NodeTypeId::DocumentFragment {
             nodes.extend(node.children().map(|node| JS::from_ref(&*node)));
             nodes.r()

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -17,7 +17,7 @@ use dom::bindings::inheritance::{CharacterDataTypeId, NodeTypeId};
 use dom::bindings::js::{JS, MutHeap, Root, RootedReference};
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
 use dom::bindings::str::DOMString;
-use dom::bindings::trace::{JSTraceable, RootedVec};
+use dom::bindings::trace::JSTraceable;
 use dom::bindings::weakref::{WeakRef, WeakRefVec};
 use dom::characterdata::CharacterData;
 use dom::document::Document;
@@ -762,7 +762,7 @@ impl RangeMethods for Range {
         }
 
         // Step 4.
-        let mut contained_children: RootedVec<JS<Node>> = RootedVec::new();
+        rooted_vec!(let mut contained_children);
         let ancestor = self.CommonAncestorContainer();
 
         let mut iter = start_node.following_nodes(ancestor.r());

--- a/components/script/dom/serviceworker.rs
+++ b/components/script/dom/serviceworker.rs
@@ -20,7 +20,6 @@ use dom::eventtarget::EventTarget;
 use dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
 use dom::workerglobalscope::prepare_workerscope_init;
 use ipc_channel::ipc;
-use js::jsapi::RootedValue;
 use js::jsval::UndefinedValue;
 use script_thread::Runnable;
 use std::cell::Cell;
@@ -91,7 +90,7 @@ impl ServiceWorker {
         }
 
         let global = worker.r().global();
-        let error = RootedValue::new(global.r().get_cx(), UndefinedValue());
+        rooted!(in(global.r().get_cx()) let error = UndefinedValue());
         let errorevent = ErrorEvent::new(global.r(), atom!("error"),
                                          EventBubbles::Bubbles, EventCancelable::Cancelable,
                                          message, filename, lineno, colno, error.handle());

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -23,7 +23,7 @@ use dom::workerglobalscope::WorkerGlobalScope;
 use dom::workerglobalscope::WorkerGlobalScopeInit;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
-use js::jsapi::{JS_SetInterruptCallback, JSAutoCompartment, JSContext, RootedValue};
+use js::jsapi::{JS_SetInterruptCallback, JSAutoCompartment, JSContext};
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use msg::constellation_msg::PipelineId;
@@ -283,7 +283,7 @@ impl ServiceWorkerGlobalScope {
                 let target = self.upcast();
                 let _ac = JSAutoCompartment::new(scope.get_cx(),
                                                  scope.reflector().get_jsobject().get());
-                let mut message = RootedValue::new(scope.get_cx(), UndefinedValue());
+                rooted!(in(scope.get_cx()) let mut message = UndefinedValue());
                 data.read(GlobalRef::Worker(scope), message.handle_mut());
                 MessageEvent::dispatch_jsval(target, GlobalRef::Worker(scope), message.handle());
             },

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -33,7 +33,7 @@ use dom::webgltexture::{TexParameterValue, WebGLTexture};
 use dom::webgluniformlocation::WebGLUniformLocation;
 use euclid::size::Size2D;
 use ipc_channel::ipc::{self, IpcSender};
-use js::jsapi::{JSContext, JS_GetArrayBufferViewType, JSObject, RootedValue, Type};
+use js::jsapi::{JSContext, JS_GetArrayBufferViewType, JSObject, Type};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, JSVal, NullValue, UndefinedValue};
 use net_traits::image::base::PixelFormat;
 use net_traits::image_cache_thread::ImageResponse;
@@ -522,11 +522,11 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             WebGLParameter::Float(val) => DoubleValue(val as f64),
             WebGLParameter::FloatArray(_) => panic!("Parameter should not be float array"),
             WebGLParameter::String(val) => {
-                let mut rval = RootedValue::new(cx, UndefinedValue());
+                rooted!(in(cx) let mut rval = UndefinedValue());
                 unsafe {
                     val.to_jsval(cx, rval.handle_mut());
                 }
-                rval.ptr
+                rval.get()
             }
             WebGLParameter::Invalid => NullValue(),
         }
@@ -1267,13 +1267,13 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
     fn GetVertexAttrib(&self, cx: *mut JSContext, index: u32, pname: u32) -> JSVal {
         if index == 0 && pname == constants::CURRENT_VERTEX_ATTRIB {
-            let mut result = RootedValue::new(cx, UndefinedValue());
+            rooted!(in(cx) let mut result = UndefinedValue());
             let (x, y, z, w) = self.current_vertex_attrib_0.get();
             let attrib = vec![x, y, z, w];
             unsafe {
                 attrib.to_jsval(cx, result.handle_mut());
             }
-            return result.ptr
+            return result.get()
         }
 
         let (sender, receiver) = ipc::channel().unwrap();
@@ -1285,11 +1285,11 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             WebGLParameter::String(_) => panic!("Vertex attrib should not be string"),
             WebGLParameter::Float(_) => panic!("Vertex attrib should not be float"),
             WebGLParameter::FloatArray(val) => {
-                let mut result = RootedValue::new(cx, UndefinedValue());
+                rooted!(in(cx) let mut result = UndefinedValue());
                 unsafe {
                     val.to_jsval(cx, result.handle_mut());
                 }
-                result.ptr
+                result.get()
             }
             WebGLParameter::Invalid => NullValue(),
         }

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -23,7 +23,7 @@ use dom::eventtarget::EventTarget;
 use dom::messageevent::MessageEvent;
 use dom::urlhelper::UrlHelper;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
-use js::jsapi::{JSAutoCompartment, RootedValue};
+use js::jsapi::JSAutoCompartment;
 use js::jsapi::{JS_GetArrayBufferData, JS_NewArrayBuffer};
 use js::jsval::UndefinedValue;
 use libc::{uint32_t, uint8_t};
@@ -585,7 +585,7 @@ impl Runnable for MessageReceivedTask {
         unsafe {
             let cx = global.r().get_cx();
             let _ac = JSAutoCompartment::new(cx, ws.reflector().get_jsobject().get());
-            let mut message = RootedValue::new(cx, UndefinedValue());
+            rooted!(in(cx) let mut message = UndefinedValue());
             match self.message {
                 MessageData::Text(text) => text.to_jsval(cx, message.handle_mut()),
                 MessageData::Binary(data) => {

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -23,7 +23,7 @@ use dom::eventtarget::EventTarget;
 use dom::messageevent::MessageEvent;
 use dom::workerglobalscope::prepare_workerscope_init;
 use ipc_channel::ipc;
-use js::jsapi::{HandleValue, JSContext, RootedValue, JSAutoCompartment};
+use js::jsapi::{HandleValue, JSContext, JSAutoCompartment};
 use js::jsval::UndefinedValue;
 use script_thread::Runnable;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -115,7 +115,7 @@ impl Worker {
         let global = worker.r().global();
         let target = worker.upcast();
         let _ac = JSAutoCompartment::new(global.r().get_cx(), target.reflector().get_jsobject().get());
-        let mut message = RootedValue::new(global.r().get_cx(), UndefinedValue());
+        rooted!(in(global.r().get_cx()) let mut message = UndefinedValue());
         data.read(global.r(), message.handle_mut());
         MessageEvent::dispatch_jsval(target, global.r(), message.handle());
     }
@@ -134,7 +134,7 @@ impl Worker {
         }
 
         let global = worker.r().global();
-        let error = RootedValue::new(global.r().get_cx(), UndefinedValue());
+        rooted!(in(global.r().get_cx()) let error = UndefinedValue());
         let errorevent = ErrorEvent::new(global.r(), atom!("error"),
                                          EventBubbles::Bubbles, EventCancelable::Cancelable,
                                          message, filename, lineno, colno, error.handle());

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -21,7 +21,7 @@ use dom::workerlocation::WorkerLocation;
 use dom::workernavigator::WorkerNavigator;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
-use js::jsapi::{HandleValue, JSContext, JSRuntime, RootedValue};
+use js::jsapi::{HandleValue, JSContext, JSRuntime};
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use msg::constellation_msg::{PipelineId, ReferrerPolicy, PanicMsg};
@@ -309,7 +309,7 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
             };
         }
 
-        let mut rval = RootedValue::new(self.runtime.cx(), UndefinedValue());
+        rooted!(in(self.runtime.cx()) let mut rval = UndefinedValue());
         for url in urls {
             let (url, source) = match load_whole_resource(LoadContext::Script,
                                                           &self.resource_threads.sender(),
@@ -420,7 +420,7 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
 impl WorkerGlobalScope {
     #[allow(unsafe_code)]
     pub fn execute_script(&self, source: DOMString) {
-        let mut rval = RootedValue::new(self.runtime.cx(), UndefinedValue());
+        rooted!(in(self.runtime.cx()) let mut rval = UndefinedValue());
         match self.runtime.evaluate_script(
             self.reflector().get_jsobject(), &source, self.worker_url.as_str(), 1, rval.handle_mut()) {
             Ok(_) => (),

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -40,7 +40,7 @@ use hyper::mime::{self, Mime, Attr as MimeAttr, Value as MimeValue};
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use js::jsapi::JS_ClearPendingException;
-use js::jsapi::{JSContext, JS_ParseJSON, RootedValue};
+use js::jsapi::{JSContext, JS_ParseJSON};
 use js::jsval::{JSVal, NullValue, UndefinedValue};
 use msg::constellation_msg::{PipelineId, ReferrerPolicy};
 use net_traits::CoreResourceMsg::Fetch;
@@ -772,7 +772,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
     // https://xhr.spec.whatwg.org/#the-response-attribute
     fn Response(&self, cx: *mut JSContext) -> JSVal {
         unsafe {
-            let mut rval = RootedValue::new(cx, UndefinedValue());
+            rooted!(in(cx) let mut rval = UndefinedValue());
             match self.response_type.get() {
                 XMLHttpRequestResponseType::_empty | XMLHttpRequestResponseType::Text => {
                     let ready_state = self.ready_state.get();
@@ -809,7 +809,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
                     self.response.borrow().to_jsval(cx, rval.handle_mut());
                 }
             }
-            rval.ptr
+            rval.get()
         }
     }
 
@@ -1177,7 +1177,7 @@ impl XMLHttpRequest {
         let json_text = UTF_8.decode(&bytes, DecoderTrap::Replace).unwrap();
         let json_text: Vec<u16> = json_text.encode_utf16().collect();
         // Step 5
-        let mut rval = RootedValue::new(cx, UndefinedValue());
+        rooted!(in(cx) let mut rval = UndefinedValue());
         unsafe {
             if !JS_ParseJSON(cx,
                              json_text.as_ptr(),
@@ -1188,7 +1188,7 @@ impl XMLHttpRequest {
             }
         }
         // Step 6
-        self.response_json.set(rval.ptr);
+        self.response_json.set(rval.get());
         self.response_json.get()
     }
 

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -50,6 +50,7 @@ extern crate html5ever;
 extern crate hyper;
 extern crate image;
 extern crate ipc_channel;
+#[macro_use]
 extern crate js;
 extern crate libc;
 #[macro_use]

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -6,7 +6,7 @@
 #![feature(borrow_state)]
 #![feature(box_syntax)]
 #![feature(const_fn)]
-#![feature(core_intrinsics)]
+#![cfg_attr(debug_assertions, feature(core_intrinsics))]
 #![feature(custom_attribute)]
 #![feature(custom_derive)]
 #![feature(fnbox)]

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -58,7 +58,7 @@ use hyper::mime::{Mime, SubLevel, TopLevel};
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::glue::GetWindowProxyClass;
-use js::jsapi::{DOMProxyShadowsResult, HandleId, HandleObject, RootedValue};
+use js::jsapi::{DOMProxyShadowsResult, HandleId, HandleObject};
 use js::jsapi::{JSAutoCompartment, JSContext, JS_SetWrapObjectCallbacks};
 use js::jsapi::{JSTracer, SetWindowProxyClass};
 use js::jsval::UndefinedValue;
@@ -1747,7 +1747,7 @@ impl ScriptThread {
             // Script source is ready to be evaluated (11.)
             unsafe {
                 let _ac = JSAutoCompartment::new(self.get_cx(), window.reflector().get_jsobject().get());
-                let mut jsval = RootedValue::new(self.get_cx(), UndefinedValue());
+                rooted!(in(self.get_cx()) let mut jsval = UndefinedValue());
                 window.evaluate_js_on_global_with_result(&script_source, jsval.handle_mut());
                 let strval = DOMString::from_jsval(self.get_cx(),
                                                    jsval.handle(),

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -13,7 +13,7 @@ use dom::xmlhttprequest::XHRTimeoutCallback;
 use euclid::length::Length;
 use heapsize::HeapSizeOf;
 use ipc_channel::ipc::IpcSender;
-use js::jsapi::{HandleValue, Heap, RootedValue};
+use js::jsapi::{HandleValue, Heap};
 use js::jsval::{JSVal, UndefinedValue};
 use script_traits::{MsDuration, precise_time_ms};
 use script_traits::{TimerEvent, TimerEventId, TimerEventRequest, TimerSource};
@@ -488,7 +488,7 @@ impl JsTimerTask {
         match *&self.callback {
             InternalTimerCallback::StringTimerCallback(ref code_str) => {
                 let cx = this.global().r().get_cx();
-                let mut rval = RootedValue::new(cx, UndefinedValue());
+                rooted!(in(cx) let mut rval = UndefinedValue());
 
                 this.evaluate_js_on_global_with_result(code_str, rval.handle_mut());
             },

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -28,8 +28,7 @@ use euclid::point::Point2D;
 use euclid::rect::Rect;
 use euclid::size::Size2D;
 use ipc_channel::ipc::{self, IpcSender};
-use js::jsapi::JSContext;
-use js::jsapi::{HandleValue, RootedValue};
+use js::jsapi::{JSContext, HandleValue};
 use js::jsval::UndefinedValue;
 use msg::constellation_msg::PipelineId;
 use msg::webdriver_msg::WebDriverCookieError;
@@ -77,7 +76,7 @@ pub fn handle_execute_script(context: &BrowsingContext,
     let window = context.active_window();
     let result = unsafe {
         let cx = window.get_cx();
-        let mut rval = RootedValue::new(cx, UndefinedValue());
+        rooted!(in(cx) let mut rval = UndefinedValue());
         window.evaluate_js_on_global_with_result(&eval, rval.handle_mut());
         jsval_to_webdriver(cx, rval.handle())
     };
@@ -92,7 +91,7 @@ pub fn handle_execute_async_script(context: &BrowsingContext,
     let window = context.active_window();
     let cx = window.get_cx();
     window.set_webdriver_script_chan(Some(reply));
-    let mut rval = RootedValue::new(cx, UndefinedValue());
+    rooted!(in(cx) let mut rval = UndefinedValue());
     window.evaluate_js_on_global_with_result(&eval, rval.handle_mut());
 }
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1074,7 +1074,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.3"
-source = "git+https://github.com/servo/rust-mozjs#707bfb4ff4fe2c0abde1cc2bb87ac35ff8f40aaa"
+source = "git+https://github.com/servo/rust-mozjs#7ccfee50f407841b8cd03b6520a2b9db866ac90a"
 dependencies = [
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -983,7 +983,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.3"
-source = "git+https://github.com/servo/rust-mozjs#707bfb4ff4fe2c0abde1cc2bb87ac35ff8f40aaa"
+source = "git+https://github.com/servo/rust-mozjs#7ccfee50f407841b8cd03b6520a2b9db866ac90a"
 dependencies = [
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
The existing `Rooted` and `RootedVec` users were migrated the the following two macros:

``` rust
let x = Rooted::new(cx, value);
// Was changed to:
rooted!(in(cx) let x = value);
// Which expands to:
let mut __root = Rooted::new_unrooted(value);
let x = RootedGuard::new(cx, &mut __root);
```

``` rust
let mut v = RootedVec::new();
v.extend(iterator);
// Was changed to:
rooted_vec!(let v <- iterator);
// Which expands to:
let mut __root = RootableVec::new();
let v = RootedVec::new(&mut __root, iterator);
```

The `rooted!` macro depends on servo/rust-mozjs#272.
These APIs based on two types, a container to be rooted and a rooting guard, allow implementing both `Rooted`-style rooting and `Traceable`-based rooting in stable Rust, without abusing `return_address`.

Such macros may have been tried before, but in 1.9 their hygiene is broken, they work only since 1.10.

Sadly, `Rooted` is a FFI type and completely exposed, so I cannot prevent anyone from creating their own, although all fields but the value get overwritten by `RootedGuard::new` anyway.
`RootableVec` OTOH is _guaranteed_ to be empty when not rooted, which makes it harmless AFAICT.

By fixing rust-lang/rust#34227, this PR enables Servo to build with `-Zorbit`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix rust-lang/rust#34227
- [x] These changes do not require tests because they are not functional changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11872)

<!-- Reviewable:end -->
