### PR TITLE
use ** instead of * in manifest changed script

### DIFF
--- a/etc/ci/manifest_changed.sh
+++ b/etc/ci/manifest_changed.sh
@@ -12,6 +12,6 @@ set -o pipefail
 # Adding "--binary=" to skip looking for a compiled servo binary.
 ./mach test-wpt --manifest-update --binary= SKIP_TESTS > /dev/null
 
-diff="$(git diff -- tests/*/MANIFEST.json)"
+diff="$(git diff -- tests/**/MANIFEST.json)"
 echo "$diff"
 [[ ! $diff ]]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

A single star will only look in the current directory, a double star is recursive:

```
➜  servo git:(master) ✗ ls tests/**/MANIFEST.json
tests/wpt/metadata-css/MANIFEST.json tests/wpt/metadata/MANIFEST.json     tests/wpt/mozilla/meta/MANIFEST.json
➜  servo git:(master) ✗ ls tests/*/MANIFEST.json
zsh: no matches found: tests/*/MANIFEST.json
```

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because fixing `manifest_changed.sh`

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11879)

<!-- Reviewable:end -->
