### PR TITLE
Fix common OpenSSL intermittent failure on automated builders

### DIFF
--- a/tests/wpt/web-platform-tests/tools/sslutils/openssl.py
+++ b/tests/wpt/web-platform-tests/tools/sslutils/openssl.py
@@ -252,7 +252,10 @@ class OpenSSLEnvironment(object):
         with open(path("index.txt"), "w"):
             pass
         with open(path("serial"), "w") as f:
-            f.write(str(random.randint(0, 1000000)))
+            serial = str(random.randint(0, 1000000))
+            if len(serial) % 2:
+                serial = "0" + serial
+            f.write(serial)
 
         self.path = path
 


### PR DESCRIPTION
OpenSSL requires that the digits of the serial number for the generated certs contain an even number of digits. The recent change in sslutils (https://github.com/w3c/wpt-tools/commit/b388d6b14df8acc3fad070c74b435cd7aff056d1) does not fulfill this requirement. I'll be making the same PR upstream to address that, but this will get us out of the woods locally.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11858 and fix #11859
- [X] These changes do not require tests because there's no automated testing for the SSL cert generation

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11885)

<!-- Reviewable:end -->
