### PR TITLE
Refactor attribute handling to avoid marshalling attributes from Gecko into Servo

### DIFF
--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -31,7 +31,7 @@ range = {path = "../range"}
 rustc-serialize = "0.3"
 script_layout_interface = {path = "../script_layout_interface"}
 script_traits = {path = "../script_traits"}
-selectors = {version = "0.6", features = ["heap_size"]}
+selectors = {version = "0.7", features = ["heap_size"]}
 serde_macros = "0.7.11"
 smallvec = "0.1"
 string_cache = {version = "0.2.20", features = ["heap_size"]}

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -28,7 +28,7 @@ pub struct RecalcStyleAndConstructFlows<'lc> {
 
 impl<'lc, N> DomTraversalContext<N> for RecalcStyleAndConstructFlows<'lc>
     where N: LayoutNode + TNode<ConcreteComputedValues=ServoComputedValues>,
-          N::ConcreteElement: ::selectors::Element<Impl=ServoSelectorImpl>
+          N::ConcreteElement: ::selectors::Element<Impl=ServoSelectorImpl, AttrString=String>
 
 {
     type SharedContext = SharedLayoutContext;

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -57,7 +57,7 @@ regex = "0.1.43"
 rustc-serialize = "0.3"
 script_layout_interface = {path = "../script_layout_interface"}
 script_traits = {path = "../script_traits"}
-selectors = {version = "0.6", features = ["heap_size"]}
+selectors = {version = "0.7", features = ["heap_size"]}
 serde = "0.7.11"
 smallvec = "0.1"
 string_cache = {version = "0.2.20", features = ["heap_size", "unstable"]}

--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -395,13 +395,6 @@ impl<'le> TElement for ServoLayoutElement<'le> {
     fn attr_equals(&self, namespace: &Namespace, attr: &Atom, val: &Atom) -> bool {
         self.get_attr(namespace, attr).map_or(false, |x| x == val)
     }
-
-    #[inline]
-    fn get_attr(&self, namespace: &Namespace, name: &Atom) -> Option<&str> {
-        unsafe {
-            (*self.element.unsafe_get()).get_attr_val_for_layout(namespace, name)
-        }
-    }
 }
 
 
@@ -410,6 +403,13 @@ impl<'le> ServoLayoutElement<'le> {
         ServoLayoutElement {
             element: el,
             chain: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn get_attr(&self, namespace: &Namespace, name: &Atom) -> Option<&str> {
+        unsafe {
+            (*self.element.unsafe_get()).get_attr_val_for_layout(namespace, name)
         }
     }
 }

--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -392,6 +392,11 @@ impl<'le> TElement for ServoLayoutElement<'le> {
     }
 
     #[inline]
+    fn attr_equals(&self, namespace: &Namespace, attr: &Atom, val: &Atom) -> bool {
+        self.get_attr(namespace, attr).map_or(false, |x| x == val)
+    }
+
+    #[inline]
     fn get_attr(&self, namespace: &Namespace, name: &Atom) -> Option<&str> {
         unsafe {
             (*self.element.unsafe_get()).get_attr_val_for_layout(namespace, name)

--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -387,6 +387,11 @@ impl<'le> TElement for ServoLayoutElement<'le> {
     }
 
     #[inline]
+    fn has_attr(&self, namespace: &Namespace, attr: &Atom) -> bool {
+        self.get_attr(namespace, attr).is_some()
+    }
+
+    #[inline]
     fn get_attr(&self, namespace: &Namespace, name: &Atom) -> Option<&str> {
         unsafe {
             (*self.element.unsafe_get()).get_attr_val_for_layout(namespace, name)

--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -392,13 +392,6 @@ impl<'le> TElement for ServoLayoutElement<'le> {
             (*self.element.unsafe_get()).get_attr_val_for_layout(namespace, name)
         }
     }
-
-    #[inline]
-    fn get_attrs(&self, name: &Atom) -> Vec<&str> {
-        unsafe {
-            (*self.element.unsafe_get()).get_attr_vals_for_layout(name)
-        }
-    }
 }
 
 
@@ -561,7 +554,10 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
                 self.get_attr(ns, name).map_or(false, |attr| test(attr))
             },
             NamespaceConstraint::Any => {
-                self.get_attrs(name).iter().any(|attr| test(*attr))
+                let attrs = unsafe {
+                    (*self.element.unsafe_get()).get_attr_vals_for_layout(name)
+                };
+                attrs.iter().any(|attr| test(*attr))
             }
         }
     }

--- a/components/script_layout_interface/Cargo.toml
+++ b/components/script_layout_interface/Cargo.toml
@@ -26,7 +26,7 @@ plugins = {path = "../plugins"}
 profile_traits = {path = "../profile_traits"}
 range = {path = "../range"}
 script_traits = {path = "../script_traits"}
-selectors = {version = "0.6", features = ["heap_size"]}
+selectors = {version = "0.7", features = ["heap_size"]}
 string_cache = {version = "0.2.20", features = ["heap_size"]}
 style = {path = "../style"}
 url = {version = "1.0.0", features = ["heap_size"]}

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -86,7 +86,7 @@ pub trait LayoutNode: TNode {
 pub trait ThreadSafeLayoutNode: Clone + Copy + Sized + PartialEq {
     type ConcreteThreadSafeLayoutElement:
         ThreadSafeLayoutElement<ConcreteThreadSafeLayoutNode = Self>
-        + ::selectors::Element<Impl=ServoSelectorImpl>;
+        + ::selectors::Element<Impl=ServoSelectorImpl, AttrString=String>;
     type ChildrenIterator: Iterator<Item = Self> + Sized;
 
     /// Creates a new `ThreadSafeLayoutNode` for the same `LayoutNode`
@@ -351,7 +351,7 @@ pub trait DangerousThreadSafeLayoutNode: ThreadSafeLayoutNode {
 }
 
 pub trait ThreadSafeLayoutElement: Clone + Copy + Sized +
-                                   ::selectors::Element<Impl=ServoSelectorImpl> +
+                                   ::selectors::Element<Impl=ServoSelectorImpl, AttrString=String> +
                                    PresentationalHintsSynthetizer {
     type ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<ConcreteThreadSafeLayoutElement = Self>;
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1159,7 +1159,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_layout_interface 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1942,7 +1942,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_layout_interface 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1978,7 +1978,7 @@ dependencies = [
  "profile_traits 0.0.1",
  "range 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2243,7 +2243,7 @@ dependencies = [
  "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2263,7 +2263,7 @@ dependencies = [
  "cssparser 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -11,7 +11,7 @@ name = "style"
 path = "lib.rs"
 
 [features]
-gecko = ["gecko_bindings"]
+gecko = ["gecko_bindings", "selectors/gecko"]
 servo = ["serde", "serde/nightly", "serde_macros", "heapsize", "heapsize_plugin",
          "style_traits/servo", "app_units/plugins", "euclid/plugins",
          "cssparser/heap_size", "cssparser/serde-serialization",
@@ -36,7 +36,7 @@ matches = "0.1"
 num-traits = "0.1.32"
 rand = "0.3"
 rustc-serialize = "0.3"
-selectors = "0.6"
+selectors = "0.7"
 serde = {version = "0.7.11", optional = true}
 serde_macros = {version = "0.7.11", optional = true}
 smallvec = "0.1"

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -208,6 +208,7 @@ pub trait TElement : Sized + Copy + Clone + ElementExt + PresentationalHintsSynt
     fn get_state(&self) -> ElementState;
 
     fn has_attr(&self, namespace: &Namespace, attr: &Atom) -> bool;
+    fn attr_equals(&self, namespace: &Namespace, attr: &Atom, value: &Atom) -> bool;
 
     fn get_attr<'a>(&'a self, namespace: &Namespace, attr: &Atom) -> Option<&'a str>;
 

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -210,8 +210,6 @@ pub trait TElement : Sized + Copy + Clone + ElementExt + PresentationalHintsSynt
     fn has_attr(&self, namespace: &Namespace, attr: &Atom) -> bool;
     fn attr_equals(&self, namespace: &Namespace, attr: &Atom, value: &Atom) -> bool;
 
-    fn get_attr<'a>(&'a self, namespace: &Namespace, attr: &Atom) -> Option<&'a str>;
-
     /// Properly marks nodes as dirty in response to restyle hints.
     fn note_restyle_hint(&self, mut hint: RestyleHint) {
         // Bail early if there's no restyling to do.

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -207,6 +207,8 @@ pub trait TElement : Sized + Copy + Clone + ElementExt + PresentationalHintsSynt
 
     fn get_state(&self) -> ElementState;
 
+    fn has_attr(&self, namespace: &Namespace, attr: &Atom) -> bool;
+
     fn get_attr<'a>(&'a self, namespace: &Namespace, attr: &Atom) -> Option<&'a str>;
 
     /// Properly marks nodes as dirty in response to restyle hints.

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -208,7 +208,6 @@ pub trait TElement : Sized + Copy + Clone + ElementExt + PresentationalHintsSynt
     fn get_state(&self) -> ElementState;
 
     fn get_attr<'a>(&'a self, namespace: &Namespace, attr: &Atom) -> Option<&'a str>;
-    fn get_attrs<'a>(&'a self, attr: &Atom) -> Vec<&'a str>;
 
     /// Properly marks nodes as dirty in response to restyle hints.
     fn note_restyle_hint(&self, mut hint: RestyleHint) {

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -38,9 +38,8 @@ fn create_common_style_affecting_attributes_from_element<E: TElement>(element: &
                     flags.insert(flag)
                 }
             }
-            CommonStyleAffectingAttributeMode::IsEqual(target_value, flag) => {
-                let atom = Atom::from(target_value); // FIXME(bholley): This goes away in the next patch.
-                if element.attr_equals(&ns!(), &attribute_info.atom, &atom) {
+            CommonStyleAffectingAttributeMode::IsEqual(ref target_value, flag) => {
+                if element.attr_equals(&ns!(), &attribute_info.atom, target_value) {
                     flags.insert(flag)
                 }
             }
@@ -298,11 +297,10 @@ impl<C: ComputedValues> StyleSharingCandidate<C> {
                         return false
                     }
                 }
-                CommonStyleAffectingAttributeMode::IsEqual(target_value, flag) => {
-                    let atom = Atom::from(target_value); // FIXME(bholley): This goes away in the next patch.
+                CommonStyleAffectingAttributeMode::IsEqual(ref target_value, flag) => {
                     let contains = self.common_style_affecting_attributes.contains(flag);
                     if element.has_attr(&ns!(), &attribute_info.atom) {
-                        if !contains || !element.attr_equals(&ns!(), &attribute_info.atom, &atom) {
+                        if !contains || !element.attr_equals(&ns!(), &attribute_info.atom, target_value) {
                             return false
                         }
                     } else if contains {

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -34,7 +34,7 @@ fn create_common_style_affecting_attributes_from_element<E: TElement>(element: &
     for attribute_info in &common_style_affecting_attributes() {
         match attribute_info.mode {
             CommonStyleAffectingAttributeMode::IsPresent(flag) => {
-                if element.get_attr(&ns!(), &attribute_info.atom).is_some() {
+                if element.has_attr(&ns!(), &attribute_info.atom) {
                     flags.insert(flag)
                 }
             }
@@ -296,7 +296,7 @@ impl<C: ComputedValues> StyleSharingCandidate<C> {
             match attribute_info.mode {
                 CommonStyleAffectingAttributeMode::IsPresent(flag) => {
                     if self.common_style_affecting_attributes.contains(flag) !=
-                            element.get_attr(&ns!(), &attribute_info.atom).is_some() {
+                            element.has_attr(&ns!(), &attribute_info.atom) {
                         return false
                     }
                 }
@@ -320,7 +320,7 @@ impl<C: ComputedValues> StyleSharingCandidate<C> {
         }
 
         for attribute_name in &rare_style_affecting_attributes() {
-            if element.get_attr(&ns!(), attribute_name).is_some() {
+            if element.has_attr(&ns!(), attribute_name) {
                 return false
             }
         }
@@ -606,7 +606,7 @@ pub trait ElementMatchMethods : TElement
         if self.style_attribute().is_some() {
             return StyleSharingResult::CannotShare
         }
-        if self.get_attr(&ns!(), &atom!("id")).is_some() {
+        if self.has_attr(&ns!(), &atom!("id")) {
             return StyleSharingResult::CannotShare
         }
 

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -39,11 +39,9 @@ fn create_common_style_affecting_attributes_from_element<E: TElement>(element: &
                 }
             }
             CommonStyleAffectingAttributeMode::IsEqual(target_value, flag) => {
-                match element.get_attr(&ns!(), &attribute_info.atom) {
-                    Some(element_value) if element_value == target_value => {
-                        flags.insert(flag)
-                    }
-                    _ => {}
+                let atom = Atom::from(target_value); // FIXME(bholley): This goes away in the next patch.
+                if element.attr_equals(&ns!(), &attribute_info.atom, &atom) {
+                    flags.insert(flag)
                 }
             }
         }
@@ -301,19 +299,14 @@ impl<C: ComputedValues> StyleSharingCandidate<C> {
                     }
                 }
                 CommonStyleAffectingAttributeMode::IsEqual(target_value, flag) => {
-                    match element.get_attr(&ns!(), &attribute_info.atom) {
-                        Some(ref element_value) if self.common_style_affecting_attributes
-                                                       .contains(flag) &&
-                                                       *element_value != target_value => {
+                    let atom = Atom::from(target_value); // FIXME(bholley): This goes away in the next patch.
+                    let contains = self.common_style_affecting_attributes.contains(flag);
+                    if element.has_attr(&ns!(), &attribute_info.atom) {
+                        if !contains || !element.attr_equals(&ns!(), &attribute_info.atom, &atom) {
                             return false
                         }
-                        Some(_) if !self.common_style_affecting_attributes.contains(flag) => {
-                            return false
-                        }
-                        None if self.common_style_affecting_attributes.contains(flag) => {
-                            return false
-                        }
-                        _ => {}
+                    } else if contains {
+                        return false
                     }
                 }
             }

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -94,8 +94,7 @@ ${helpers.single_keyword("position", "static absolute relative fixed",
 <%helpers:single_keyword_computed name="float"
                                   values="none left right"
                                   animatable="False"
-                                  need_clone="True"
-                                  gecko_ffi_name="mFloats">
+                                  need_clone="True">
     impl ToComputedValue for SpecifiedValue {
         type ComputedValue = computed_value::T;
 

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -77,11 +77,14 @@ ${helpers.single_keyword("justify-content", "flex-start flex-end center space-be
                          products="servo",
                          animatable=False)}
 
+// FIXME(heycam): Disable align-items in geckolib since we don't support the Gecko initial value
+// 'normal' yet.
 ${helpers.single_keyword("align-items", "stretch flex-start flex-end center baseline",
                          experimental=True,
                          need_clone=True,
                          gecko_constant_prefix="NS_STYLE_ALIGN",
-                         animatable=False)}
+                         animatable=False,
+                         products="servo")}
 
 ${helpers.single_keyword("align-content", "stretch flex-start flex-end center space-between space-around",
                          experimental=True,

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1921,6 +1921,7 @@ pub fn cascade<C: ComputedValues>(
         }
     }
 
+    % if "align-items" in data.longhands_by_name:
     {
         use self::style_struct_traits::Position;
         use computed_values::align_self::T as align_self;
@@ -1937,6 +1938,7 @@ pub fn cascade<C: ComputedValues>(
             style.mutate_position().set_align_self(self_align);
         }
     }
+    % endif
 
     // The initial value of border-*-width may be changed at computed value time.
     % for side in ["top", "right", "bottom", "left"]:

--- a/components/style/selector_impl.rs
+++ b/components/style/selector_impl.rs
@@ -181,6 +181,7 @@ impl NonTSPseudoClass {
 pub struct ServoSelectorImpl;
 
 impl SelectorImpl for ServoSelectorImpl {
+    type AttrString = String;
     type PseudoElement = PseudoElement;
     type NonTSPseudoClass = NonTSPseudoClass;
 
@@ -278,7 +279,7 @@ impl SelectorImplExt for ServoSelectorImpl {
     }
 }
 
-impl<E: Element<Impl=ServoSelectorImpl>> ElementExt for E {
+impl<E: Element<Impl=ServoSelectorImpl, AttrString=String>> ElementExt for E {
     fn is_link(&self) -> bool {
         self.match_non_ts_pseudo_class(NonTSPseudoClass::AnyLink)
     }

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -1068,7 +1068,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_layout_interface 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1796,7 +1796,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_layout_interface 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1832,7 +1832,7 @@ dependencies = [
  "profile_traits 0.0.1",
  "range 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2128,7 +2128,7 @@ dependencies = [
  "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
@@ -379,7 +379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "selectors"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -465,7 +465,7 @@ dependencies = [
  "num-traits 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -37,7 +37,7 @@ lazy_static = "0.2"
 libc = "0.2"
 log = {version = "0.3.5", features = ["release_max_level_info"]}
 num_cpus = "0.2.2"
-selectors = "0.6"
+selectors = "0.7"
 smallvec = "0.1"
 string_cache = {version = "0.2.20", features = ["unstable"]}
 style = {path = "../../components/style", features = ["gecko"]}

--- a/ports/geckolib/gecko_bindings/bindings.rs
+++ b/ports/geckolib/gecko_bindings/bindings.rs
@@ -169,6 +169,25 @@ extern "C" {
     pub fn Gecko_LocalName(element: *mut RawGeckoElement) -> *mut nsIAtom;
     pub fn Gecko_Namespace(element: *mut RawGeckoElement) -> *mut nsIAtom;
     pub fn Gecko_GetElementId(element: *mut RawGeckoElement) -> *mut nsIAtom;
+    pub fn Gecko_HasAttr(element: *mut RawGeckoElement, ns: *mut nsIAtom,
+                         name: *mut nsIAtom) -> bool;
+    pub fn Gecko_AttrEquals(element: *mut RawGeckoElement, ns: *mut nsIAtom,
+                            name: *mut nsIAtom, str: *mut nsIAtom,
+                            ignoreCase: bool) -> bool;
+    pub fn Gecko_AttrDashEquals(element: *mut RawGeckoElement,
+                                ns: *mut nsIAtom, name: *mut nsIAtom,
+                                str: *mut nsIAtom) -> bool;
+    pub fn Gecko_AttrIncludes(element: *mut RawGeckoElement, ns: *mut nsIAtom,
+                              name: *mut nsIAtom, str: *mut nsIAtom) -> bool;
+    pub fn Gecko_AttrHasSubstring(element: *mut RawGeckoElement,
+                                  ns: *mut nsIAtom, name: *mut nsIAtom,
+                                  str: *mut nsIAtom) -> bool;
+    pub fn Gecko_AttrHasPrefix(element: *mut RawGeckoElement,
+                               ns: *mut nsIAtom, name: *mut nsIAtom,
+                               str: *mut nsIAtom) -> bool;
+    pub fn Gecko_AttrHasSuffix(element: *mut RawGeckoElement,
+                               ns: *mut nsIAtom, name: *mut nsIAtom,
+                               str: *mut nsIAtom) -> bool;
     pub fn Gecko_ClassOrClassList(element: *mut RawGeckoElement,
                                   class_: *mut *mut nsIAtom,
                                   classList: *mut *mut *mut nsIAtom) -> u32;
@@ -182,7 +201,6 @@ extern "C" {
      -> *mut nsIAtom;
     pub fn Gecko_AddRefAtom(aAtom: *mut nsIAtom);
     pub fn Gecko_ReleaseAtom(aAtom: *mut nsIAtom);
-    pub fn Gecko_HashAtom(aAtom: *mut nsIAtom) -> u32;
     pub fn Gecko_GetAtomAsUTF16(aAtom: *mut nsIAtom, aLength: *mut u32)
      -> *const u16;
     pub fn Gecko_AtomEqualsUTF8(aAtom: *mut nsIAtom,
@@ -209,9 +227,6 @@ extern "C" {
     pub fn Gecko_CreateGradient(shape: u8, size: u8, repeating: bool,
                                 legacy_syntax: bool, stops: u32)
      -> *mut nsStyleGradient;
-    pub fn Gecko_SetGradientStop(gradient: *mut nsStyleGradient, index: u32,
-                                 location: *const nsStyleCoord,
-                                 color: nscolor, is_interpolation_hint: bool);
     pub fn Gecko_AddRefPrincipalArbitraryThread(aPtr:
                                                     *mut ThreadSafePrincipalHolder);
     pub fn Gecko_ReleasePrincipalArbitraryThread(aPtr:
@@ -282,6 +297,7 @@ extern "C" {
                                  set: *mut RawServoStyleSet);
     pub fn Servo_RestyleSubtree(node: *mut RawGeckoNode,
                                 set: *mut RawServoStyleSet);
+    pub fn Servo_StyleWorkerThreadCount() -> u32;
     pub fn Gecko_GetAttrAsUTF8(element: *mut RawGeckoElement,
                                ns: *mut nsIAtom, name: *mut nsIAtom,
                                length: *mut u32)

--- a/ports/geckolib/gecko_bindings/structs_debug.rs
+++ b/ports/geckolib/gecko_bindings/structs_debug.rs
@@ -188,8 +188,6 @@ pub const NS_ERROR_MODULE_BASE_OFFSET: ::std::os::raw::c_uint = 69;
 pub const MOZ_STRING_WITH_OBSOLETE_API: ::std::os::raw::c_uint = 1;
 pub const NSID_LENGTH: ::std::os::raw::c_uint = 39;
 pub const NS_NUMBER_OF_FLAGS_IN_REFCNT: ::std::os::raw::c_uint = 2;
-pub const _STL_PAIR_H: ::std::os::raw::c_uint = 1;
-pub const _GLIBCXX_UTILITY: ::std::os::raw::c_uint = 1;
 pub const TWIPS_PER_POINT_INT: ::std::os::raw::c_uint = 20;
 pub const POINTS_PER_INCH_INT: ::std::os::raw::c_uint = 72;
 pub const NS_FONT_VARIANT_NORMAL: ::std::os::raw::c_uint = 0;
@@ -2903,6 +2901,16 @@ pub struct pair<_T1, _T2> {
     pub first: _T1,
     pub second: _T2,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __make_pair_return_impl<_Tp> {
+    pub _phantom0: ::std::marker::PhantomData<_Tp>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __make_pair_return<_Tp> {
+    pub _phantom0: ::std::marker::PhantomData<_Tp>,
+}
 pub type Float = f32;
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -2931,12 +2939,17 @@ pub enum SurfaceFormat {
     R8G8B8X8 = 3,
     A8R8G8B8 = 4,
     X8R8G8B8 = 5,
-    R5G6B5_UINT16 = 6,
-    A8 = 7,
-    YUV = 8,
-    NV12 = 9,
-    YUV422 = 10,
-    UNKNOWN = 11,
+    R8G8B8 = 6,
+    B8G8R8 = 7,
+    R5G6B5_UINT16 = 8,
+    A8 = 9,
+    YUV = 10,
+    NV12 = 11,
+    YUV422 = 12,
+    HSV = 13,
+    Lab = 14,
+    Depth = 15,
+    UNKNOWN = 16,
 }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -3072,7 +3085,7 @@ pub enum FillRule { FILL_WINDING = 0, FILL_EVEN_ODD = 1, }
 pub enum AntialiasMode { NONE = 0, GRAY = 1, SUBPIXEL = 2, DEFAULT = 3, }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum Filter { GOOD = 0, LINEAR = 1, POINT = 2, SENTINEL = 3, }
+pub enum SamplingFilter { GOOD = 0, LINEAR = 1, POINT = 2, SENTINEL = 3, }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum PatternType {
@@ -3158,16 +3171,6 @@ pub enum SideBits {
     eSideBitsTopBottom = 5,
     eSideBitsLeftRight = 10,
     eSideBitsAll = 15,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct tuple_size<_Tp> {
-    pub _phantom0: ::std::marker::PhantomData<_Tp>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct tuple_element<_Tp> {
-    pub _phantom0: ::std::marker::PhantomData<_Tp>,
 }
 pub type nscoord = i32;
 #[repr(C)]
@@ -3269,7 +3272,7 @@ pub const eFamily_generic_count: FontFamilyType =
  * generic (e.g. serif, sans-serif), with the ability to distinguish
  * between unquoted and quoted names for serializaiton
  */
-#[repr(u32)]
+#[repr(i32)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum FontFamilyType {
     eFamily_none = 0,
@@ -3389,7 +3392,7 @@ fn bindgen_test_layout_nsFont() {
 }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum StyleBoxSizing { Content = 0, Padding = 1, Border = 2, }
+pub enum StyleBoxSizing { Content = 0, Border = 1, }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum PlaybackDirection { _BindgenOpaqueEnum = 0, }
@@ -5069,6 +5072,9 @@ pub enum nsStyleImageLayers_nsStyleStruct_h_unnamed_19 {
     maskMode = 10,
     composite = 11,
 }
+#[repr(i8)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum nsStyleImageLayers_LayerType { Background = 0, Mask = 1, }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsStyleImageLayers_Position {
@@ -5645,8 +5651,8 @@ pub struct nsStyleDisplay {
     pub mContain: u8,
     pub mAppearance: u8,
     pub mPosition: u8,
-    pub mFloats: u8,
-    pub mOriginalFloats: u8,
+    pub mFloat: u8,
+    pub mOriginalFloat: u8,
     pub mBreakType: u8,
     pub mBreakInside: u8,
     pub mBreakBefore: bool,

--- a/ports/geckolib/gecko_bindings/structs_release.rs
+++ b/ports/geckolib/gecko_bindings/structs_release.rs
@@ -188,8 +188,6 @@ pub const NS_ERROR_MODULE_BASE_OFFSET: ::std::os::raw::c_uint = 69;
 pub const MOZ_STRING_WITH_OBSOLETE_API: ::std::os::raw::c_uint = 1;
 pub const NSID_LENGTH: ::std::os::raw::c_uint = 39;
 pub const NS_NUMBER_OF_FLAGS_IN_REFCNT: ::std::os::raw::c_uint = 2;
-pub const _STL_PAIR_H: ::std::os::raw::c_uint = 1;
-pub const _GLIBCXX_UTILITY: ::std::os::raw::c_uint = 1;
 pub const TWIPS_PER_POINT_INT: ::std::os::raw::c_uint = 20;
 pub const POINTS_PER_INCH_INT: ::std::os::raw::c_uint = 72;
 pub const NS_FONT_VARIANT_NORMAL: ::std::os::raw::c_uint = 0;
@@ -2882,6 +2880,16 @@ pub struct pair<_T1, _T2> {
     pub first: _T1,
     pub second: _T2,
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __make_pair_return_impl<_Tp> {
+    pub _phantom0: ::std::marker::PhantomData<_Tp>,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __make_pair_return<_Tp> {
+    pub _phantom0: ::std::marker::PhantomData<_Tp>,
+}
 pub type Float = f32;
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -2910,12 +2918,17 @@ pub enum SurfaceFormat {
     R8G8B8X8 = 3,
     A8R8G8B8 = 4,
     X8R8G8B8 = 5,
-    R5G6B5_UINT16 = 6,
-    A8 = 7,
-    YUV = 8,
-    NV12 = 9,
-    YUV422 = 10,
-    UNKNOWN = 11,
+    R8G8B8 = 6,
+    B8G8R8 = 7,
+    R5G6B5_UINT16 = 8,
+    A8 = 9,
+    YUV = 10,
+    NV12 = 11,
+    YUV422 = 12,
+    HSV = 13,
+    Lab = 14,
+    Depth = 15,
+    UNKNOWN = 16,
 }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -3051,7 +3064,7 @@ pub enum FillRule { FILL_WINDING = 0, FILL_EVEN_ODD = 1, }
 pub enum AntialiasMode { NONE = 0, GRAY = 1, SUBPIXEL = 2, DEFAULT = 3, }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum Filter { GOOD = 0, LINEAR = 1, POINT = 2, SENTINEL = 3, }
+pub enum SamplingFilter { GOOD = 0, LINEAR = 1, POINT = 2, SENTINEL = 3, }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum PatternType {
@@ -3137,16 +3150,6 @@ pub enum SideBits {
     eSideBitsTopBottom = 5,
     eSideBitsLeftRight = 10,
     eSideBitsAll = 15,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct tuple_size<_Tp> {
-    pub _phantom0: ::std::marker::PhantomData<_Tp>,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct tuple_element<_Tp> {
-    pub _phantom0: ::std::marker::PhantomData<_Tp>,
 }
 pub type nscoord = i32;
 #[repr(C)]
@@ -3248,7 +3251,7 @@ pub const eFamily_generic_count: FontFamilyType =
  * generic (e.g. serif, sans-serif), with the ability to distinguish
  * between unquoted and quoted names for serializaiton
  */
-#[repr(u32)]
+#[repr(i32)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum FontFamilyType {
     eFamily_none = 0,
@@ -3368,7 +3371,7 @@ fn bindgen_test_layout_nsFont() {
 }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum StyleBoxSizing { Content = 0, Padding = 1, Border = 2, }
+pub enum StyleBoxSizing { Content = 0, Border = 1, }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum PlaybackDirection { _BindgenOpaqueEnum = 0, }
@@ -5047,6 +5050,9 @@ pub enum nsStyleImageLayers_nsStyleStruct_h_unnamed_19 {
     maskMode = 10,
     composite = 11,
 }
+#[repr(i8)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum nsStyleImageLayers_LayerType { Background = 0, Mask = 1, }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsStyleImageLayers_Position {
@@ -5623,8 +5629,8 @@ pub struct nsStyleDisplay {
     pub mContain: u8,
     pub mAppearance: u8,
     pub mPosition: u8,
-    pub mFloats: u8,
-    pub mOriginalFloats: u8,
+    pub mFloat: u8,
+    pub mOriginalFloat: u8,
     pub mBreakType: u8,
     pub mBreakInside: u8,
     pub mBreakBefore: bool,

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -5,7 +5,7 @@
 #![allow(unsafe_code)]
 
 use app_units::Au;
-use data::PerDocumentStyleData;
+use data::{NUM_THREADS, PerDocumentStyleData};
 use env_logger;
 use euclid::Size2D;
 use gecko_bindings::bindings::{RawGeckoDocument, RawGeckoElement, RawGeckoNode};
@@ -134,6 +134,11 @@ pub extern "C" fn Servo_RestyleDocument(doc: *mut RawGeckoDocument, raw_data: *m
         None => return,
     };
     restyle_subtree(node, raw_data);
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_StyleWorkerThreadCount() -> u32 {
+    *NUM_THREADS as u32
 }
 
 #[no_mangle]

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -29,6 +29,7 @@ use style::parallel;
 use style::parser::ParserContextExtraData;
 use style::properties::{ComputedValues, PropertyDeclarationBlock};
 use style::selector_impl::{SelectorImplExt, PseudoElementCascadeType};
+use style::sequential;
 use style::stylesheets::Origin;
 use traversal::RecalcStyleOnly;
 use url::Url;
@@ -109,7 +110,12 @@ fn restyle_subtree(node: GeckoNode, raw_data: *mut RawServoStyleSet) {
     };
 
     if node.is_dirty() || node.has_dirty_descendants() {
-        parallel::traverse_dom::<GeckoNode, RecalcStyleOnly>(node, &shared_style_context, &mut per_doc_data.work_queue);
+        if per_doc_data.num_threads == 1 {
+            sequential::traverse_dom::<GeckoNode, RecalcStyleOnly>(node, &shared_style_context);
+        } else {
+            parallel::traverse_dom::<GeckoNode, RecalcStyleOnly>(node, &shared_style_context,
+                                                                 &mut per_doc_data.work_queue);
+        }
     }
 }
 

--- a/ports/geckolib/lib.rs
+++ b/ports/geckolib/lib.rs
@@ -39,3 +39,7 @@ mod wrapper;
 pub mod properties {
     include!(concat!(env!("OUT_DIR"), "/properties.rs"));
 }
+
+// FIXME(bholley): This should probably go away once we harmonize the allocators.
+#[no_mangle]
+pub extern "C" fn je_malloc_usable_size(_: *const ::libc::c_void) -> ::libc::size_t { 0 }

--- a/ports/geckolib/selector_impl.rs
+++ b/ports/geckolib/selector_impl.rs
@@ -4,6 +4,7 @@
 
 use properties::GeckoComputedValues;
 use selectors::parser::{ParserContext, SelectorImpl};
+use string_cache::Atom;
 use style;
 use style::element_state::ElementState;
 use style::selector_impl::{PseudoElementCascadeType, SelectorImplExt};
@@ -157,6 +158,7 @@ impl NonTSPseudoClass {
 }
 
 impl SelectorImpl for GeckoSelectorImpl {
+    type AttrString = Atom;
     type PseudoElement = PseudoElement;
     type NonTSPseudoClass = NonTSPseudoClass;
     fn parse_non_ts_pseudo_class(_context: &ParserContext,

--- a/ports/geckolib/wrapper.rs
+++ b/ports/geckolib/wrapper.rs
@@ -370,6 +370,17 @@ impl<'le> TElement for GeckoElement<'le> {
     }
 
     #[inline]
+    fn attr_equals(&self, namespace: &Namespace, attr: &Atom, val: &Atom) -> bool {
+        unsafe {
+            bindings::Gecko_AttrEquals(self.element,
+                                       namespace.0.as_ptr(),
+                                       attr.as_ptr(),
+                                       val.as_ptr(),
+                                       /* ignoreCase = */ false)
+        }
+    }
+
+    #[inline]
     fn get_attr<'a>(&'a self, namespace: &Namespace, name: &Atom) -> Option<&'a str> {
         unsafe {
             let mut length: u32 = 0;

--- a/ports/geckolib/wrapper.rs
+++ b/ports/geckolib/wrapper.rs
@@ -369,11 +369,6 @@ impl<'le> TElement for GeckoElement<'le> {
             reinterpret_string(ptr, length)
         }
     }
-
-    #[inline]
-    fn get_attrs<'a>(&'a self, _name: &Atom) -> Vec<&'a str> {
-        unimplemented!()
-    }
 }
 
 impl<'le> PresentationalHintsSynthetizer for GeckoElement<'le> {
@@ -519,7 +514,9 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
                 self.get_attr(ns, name).map_or(false, |attr| test(attr))
             },
             NamespaceConstraint::Any => {
-                self.get_attrs(name).iter().any(|attr| test(*attr))
+                // We should probably pass the atom into gecko and let it match
+                // against attributes across namespaces.
+                unimplemented!()
             }
         }
     }

--- a/ports/geckolib/wrapper.rs
+++ b/ports/geckolib/wrapper.rs
@@ -361,6 +361,15 @@ impl<'le> TElement for GeckoElement<'le> {
     }
 
     #[inline]
+    fn has_attr(&self, namespace: &Namespace, attr: &Atom) -> bool {
+        unsafe {
+            bindings::Gecko_HasAttr(self.element,
+                                    namespace.0.as_ptr(),
+                                    attr.as_ptr())
+        }
+    }
+
+    #[inline]
     fn get_attr<'a>(&'a self, namespace: &Namespace, name: &Atom) -> Option<&'a str> {
         unsafe {
             let mut length: u32 = 0;

--- a/ports/geckolib/wrapper.rs
+++ b/ports/geckolib/wrapper.rs
@@ -380,16 +380,6 @@ impl<'le> TElement for GeckoElement<'le> {
                                        /* ignoreCase = */ false)
         }
     }
-
-    #[inline]
-    fn get_attr<'a>(&'a self, namespace: &Namespace, name: &Atom) -> Option<&'a str> {
-        unsafe {
-            let mut length: u32 = 0;
-            let ptr = Gecko_GetAttrAsUTF8(self.element, namespace.0.as_ptr(), name.as_ptr(),
-                                          &mut length);
-            reinterpret_string(ptr, length)
-        }
-    }
 }
 
 impl<'le> PresentationalHintsSynthetizer for GeckoElement<'le> {

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -13,7 +13,7 @@ app_units = "0.2.5"
 cssparser = {version = "0.5.4", features = ["heap_size"]}
 euclid = "0.7.1"
 rustc-serialize = "0.3"
-selectors = {version = "0.6", features = ["heap_size"]}
+selectors = {version = "0.7", features = ["heap_size"]}
 string_cache = {version = "0.2", features = ["heap_size"]}
 style = {path = "../../../components/style"}
 style_traits = {path = "../../../components/style_traits"}


### PR DESCRIPTION
This marshaling is slow, because Gecko stores attributes as UTF-16 and does not atomize them in all cases, and it turns out that the need for them in Servo is pretty minimal. With some refactoring across servo and rust-selectors we can fix this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11886)

<!-- Reviewable:end -->
