### PR TITLE
Make HTTP read size configurable and default to 16KB instead of 1KB.

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -89,8 +89,14 @@ pub enum ReadResult {
     EOF,
 }
 
+lazy_static! {
+    static ref BLOCK_SIZE: usize = prefs::get_pref("network.http.block-read-size")
+        .as_u64()
+        .unwrap_or(16384) as usize;
+}
+
 pub fn read_block<R: Read>(reader: &mut R) -> Result<ReadResult, ()> {
-    let mut buf = vec![0; 1024];
+    let mut buf = vec![0; *BLOCK_SIZE];
 
     match reader.read(&mut buf) {
         Ok(len) if len > 0 => {

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -55,6 +55,7 @@
   "layout.text-orientation.enabled": false,
   "layout.viewport.enabled": false,
   "layout.writing-mode.enabled": false,
+  "network.http.block-read-size": 16384,
   "network.http.redirection-limit": 20,
   "network.mime.sniff": false,
   "shell.homepage": "http://servo.org",

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-026.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-026.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-026.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-031.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-031.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-031.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-033.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-033.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-033.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-035.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-035.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-035.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-037.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-037.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-037.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-041.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-041.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-041.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-050.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-050.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-050.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-055.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-055.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-055.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-231.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-231.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-231.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-233.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-233.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-233.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-235.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-235.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-235.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-237.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-237.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-237.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-241.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-241.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-241.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-250.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-250.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-250.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-255.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-255.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-255.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-301.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-301.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-301.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-305.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-305.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-305.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-307.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-307.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-307.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-318.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-318.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-318.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-321.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-321.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-321.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-323.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-323.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-323.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-405.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-405.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-405.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-407.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-407.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-407.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-418.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-418.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-418.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-421.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-421.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-421.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-423.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-jazh-423.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-jazh-423.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-009.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-009.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-009.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-017.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-017.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-017.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-024.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-024.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-024.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-026.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-026.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-026.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-030.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-030.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-030.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-036.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-036.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-036.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-039.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-039.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-039.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-041.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-041.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-041.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-042.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-042.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-042.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-044.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-044.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-044.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-046.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-046.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-046.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-062.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-062.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-062.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-065.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-065.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-065.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-100.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-100.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-100.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-110.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-110.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-110.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-121.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-121.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-121.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-129.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-129.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-129.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-130.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-130.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-130.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-134.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-134.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-134.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-135.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-135.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-135.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-140.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-140.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-140.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-141.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-141.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-141.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-145.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-145.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-145.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-205.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/css3-text-line-break-opclns-205.htm.ini
@@ -1,3 +1,0 @@
-[css3-text-line-break-opclns-205.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
I tried to benchmark the change against google.com, reddit.com, planet.mozilla.org, and bugzilla.mozilla.org by printing `performance.timing.loadStart - performance.timing.navigationStart` to the console in the document load event. Bugzilla is the only site that showed any consistent performance improvement (2084ms -> 1492ms); Google had promising numbers as well, but could fluctuate between 100ms and 700ms based on whether some JS executed before the page load event or not. I think this is clearly an improvement, regardless of the ambiguous benchmark results.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because our WPT suite exercises the HTTP reading code

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11904)

<!-- Reviewable:end -->
