### PR TITLE
Avoid stalled pages containing unreachable stylesheets

### DIFF
--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/link-style-error-01.html
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/link-style-error-01.html
@@ -7,17 +7,32 @@
 <div id="log"></div>
 <div id="test">
 <script>
-//var t404 = async_test("Should get an error event for a 404 error.")
-//t404.step(function() {
-//  var elt = document.createElement("link");
-//  elt.onerror = t404.step_func(function() {
-//    assert_true(true, "Got error event for 404 error.")
-//    t404.done()
-//  })
-//  elt.rel = "stylesheet";
-//  elt.href = 404 error;
-//  document.getElementsByTagName("head")[0].appendChild(elt);
-//})
+var t404 = async_test("Should get an error event for a 404 error.")
+t404.step(function() {
+  var elt = document.createElement("link");
+  elt.onerror = t404.step_func(function() {
+    assert_true(true, "Got error event for 404 error.")
+    t404.step_timeout(function() { t404.done() }, 0);
+  })
+  elt.onload = t404.unreached_func("load event should not be fired");
+  elt.rel = "stylesheet";
+  elt.href = "nonexistent_stylesheet.css";
+  document.getElementsByTagName("head")[0].appendChild(elt);
+})
+
+var tUnsupported = async_test("Should get an error event for an unsupported URL.")
+tUnsupported.step(function() {
+  var elt = document.createElement("link");
+  elt.onerror = tUnsupported.step_func(function() {
+    assert_true(true, "Got error event for unsupported URL.")
+    tUnsupported.step_timeout(function() { tUnsupported.done() }, 0);
+  })
+  elt.onload = tUnsupported.unreached_func("load event should not be fired");
+  elt.rel = "stylesheet";
+  elt.href = "nonexistent:stylesheet.css";
+  document.getElementsByTagName("head")[0].appendChild(elt);
+})
+
 var tText = async_test("Should get an error event for a text/plain response.")
 tText.step(function() {
   var elt = document.createElement("link");


### PR DESCRIPTION
This hits some of the pages in the performance testsuite, and leads to a poor user experience since the document load event is never dispatched and the page never finishes parsing.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11535 (github issue number if applicable).
- [X] There are tests for these changes OR

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11913)

<!-- Reviewable:end -->
