### PR TITLE
gfx: Don't create paint threads when WebRender is in use.

### DIFF
--- a/components/gfx/paint_thread.rs
+++ b/components/gfx/paint_thread.rs
@@ -567,6 +567,12 @@ impl WorkerThreadProxy {
              font_cache_thread: FontCacheThread,
              time_profiler_chan: time::ProfilerChan)
              -> Vec<WorkerThreadProxy> {
+        // Don't make any paint threads if we're using WebRender. They're just a waste of
+        // resources.
+        if opts::get().use_webrender {
+            return vec![]
+        }
+
         let thread_count = opts::get().paint_threads;
         (0..thread_count).map(|_| {
             let (from_worker_sender, from_worker_receiver) = channel();


### PR DESCRIPTION
They're unused and just waste memory and process table entries.

r? @glennw

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11918)

<!-- Reviewable:end -->
