### PR TITLE
Fire load event for external stylesheets, enforce Content-Type checks

### DIFF
--- a/tests/wpt/metadata-css/css21_dev/html4/content-type-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/content-type-001.htm.ini
@@ -1,3 +1,0 @@
-[content-type-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/link-load-event.html
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/link-load-event.html
@@ -10,12 +10,9 @@ var t = async_test("Check if the stylesheet's load event blocks the document loa
 document.getElementById('style_test').onload = t.step_func(function() {
   saw_link_onload = true;
 });
-window.addEventListener('load', function() {
-  t.step_func(function() {
-    assert_true(saw_link_onload);
-  });
-  t.done();
-}, false);
+window.addEventListener('load', t.step_func_done(function() {
+  assert_true(saw_link_onload);
+}));
 </script>
 </head>
 </html>

--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/link-style-error-01.html
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/link-style-error-01.html
@@ -40,6 +40,7 @@ tText.step(function() {
     assert_true(true, "Got error event for 404 error.")
     tText.done()
   })
+  elt.onload = tText.unreached_func("load event should not be fired");
   elt.rel = "stylesheet";
   elt.href = "../../../../../common/css-red.txt";
   document.getElementsByTagName("head")[0].appendChild(elt);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fire load event for external stylesheets

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #11912,  #11910

<!-- Either: -->
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11919)

<!-- Reviewable:end -->
