### PR TITLE
Switch the default renderer to WebRender

### DIFF
--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -504,7 +504,7 @@ pub fn default_opts() -> Opts {
         exit_after_load: false,
         no_native_titlebar: false,
         enable_vsync: true,
-        use_webrender: false,
+        use_webrender: true,
         webrender_stats: false,
         use_msaa: false,
         render_api: DEFAULT_RENDER_API,
@@ -518,7 +518,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     let (app_name, args) = args.split_first().unwrap();
 
     let mut opts = Options::new();
-    opts.optflag("c", "cpu", "CPU painting (default)");
+    opts.optflag("c", "cpu", "CPU painting");
     opts.optflag("g", "gpu", "GPU painting");
     opts.optopt("o", "output", "Output file", "output.png");
     opts.optopt("s", "size", "Size of tiles", "512");
@@ -564,7 +564,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     opts.optmulti("", "pref",
                   "A preference to set to enable", "dom.mozbrowser.enabled");
     opts.optflag("b", "no-native-titlebar", "Do not use native titlebar");
-    opts.optflag("w", "webrender", "Use webrender backend");
+    opts.optflag("w", "webrender", "Use webrender backend (default)");
     opts.optopt("G", "graphics", "Select graphics backend (gl or es2)", "gl");
     opts.optopt("", "config-dir",
                     "config directory following xdg spec on linux platform", "");
@@ -747,9 +747,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         opt_match.opt_present("b") ||
         !PREFS.get("shell.native-titlebar.enabled").as_boolean().unwrap();
 
-    let use_webrender =
-        (PREFS.get("gfx.webrender.enabled").as_boolean().unwrap() || opt_match.opt_present("w")) &&
-        !opt_match.opt_present("z");
+    let use_webrender = !opt_match.opt_present("c");
 
     let render_api = match opt_match.opt_str("G") {
         Some(ref ga) if ga == "gl" => RenderApi::GL,

--- a/tests/wpt/harness/wptrunner/browsers/servo.py
+++ b/tests/wpt/harness/wptrunner/browsers/servo.py
@@ -64,7 +64,7 @@ def render_arg(render_backend):
 
 class ServoBrowser(NullBrowser):
     def __init__(self, logger, binary, debug_info=None, binary_args=None,
-                 user_stylesheets=None, render_backend="cpu"):
+                 user_stylesheets=None, render_backend="webrender"):
         NullBrowser.__init__(self, logger)
         self.binary = binary
         self.debug_info = debug_info

--- a/tests/wpt/harness/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/harness/wptrunner/browsers/servodriver.py
@@ -80,7 +80,7 @@ class ServoWebDriverBrowser(Browser):
     used_ports = set()
 
     def __init__(self, logger, binary, debug_info=None, webdriver_host="127.0.0.1",
-                 user_stylesheets=None, render_backend="cpu"):
+                 user_stylesheets=None, render_backend="webrender"):
         Browser.__init__(self, logger)
         self.binary = binary
         self.webdriver_host = webdriver_host

--- a/tests/wpt/harness/wptrunner/wptcommandline.py
+++ b/tests/wpt/harness/wptrunner/wptcommandline.py
@@ -173,7 +173,7 @@ def create_parser(product_choices=None):
                              default=[], action="append", dest="user_stylesheets",
                              help="Inject a user CSS stylesheet into every test.")
     servo_group.add_argument("--servo-backend",
-                             default="cpu", choices=["cpu", "webrender"],
+                             default="webrender", choices=["cpu", "webrender"],
                              help="Rendering backend to use with Servo.")
 
 

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-color-4.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-color-4.htm.ini
@@ -1,3 +1,3 @@
 [attachment-local-clipping-color-4.htm]
   type: reftest
-  expected: FAIL
+  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-color-5.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-color-5.htm.ini
@@ -1,3 +1,3 @@
 [attachment-local-clipping-color-5.htm]
   type: reftest
-  expected: FAIL
+  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-color-6.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-color-6.htm.ini
@@ -1,3 +1,3 @@
 [attachment-local-clipping-color-6.htm]
   type: reftest
-  expected: FAIL
+  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-image-4.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-image-4.htm.ini
@@ -1,3 +1,3 @@
 [attachment-local-clipping-image-4.htm]
   type: reftest
-  expected: FAIL
+  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-image-5.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-image-5.htm.ini
@@ -1,3 +1,3 @@
 [attachment-local-clipping-image-5.htm]
   type: reftest
-  expected: FAIL
+  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-image-6.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-image-6.htm.ini
@@ -1,3 +1,3 @@
 [attachment-local-clipping-image-6.htm]
   type: reftest
-  expected: FAIL
+  expected: TIMEOUT

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-cover.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-cover.htm.ini
@@ -1,4 +1,0 @@
-[background-size-cover.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-bottom-left-radius-010.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-bottom-left-radius-010.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-left-radius-010.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-bottom-left-radius-011.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-bottom-left-radius-011.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-left-radius-011.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-bottom-right-radius-010.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-bottom-right-radius-010.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-right-radius-010.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-bottom-right-radius-011.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-bottom-right-radius-011.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-right-radius-011.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-radius-horizontal-value-is-zero.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-radius-horizontal-value-is-zero.htm.ini
@@ -1,3 +1,0 @@
-[border-radius-horizontal-value-is-zero.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-top-left-radius-010.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-top-left-radius-010.htm.ini
@@ -1,3 +1,0 @@
-[border-top-left-radius-010.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-top-left-radius-011.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-top-left-radius-011.htm.ini
@@ -1,3 +1,0 @@
-[border-top-left-radius-011.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-top-right-radius-010.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-top-right-radius-010.htm.ini
@@ -1,3 +1,0 @@
-[border-top-right-radius-010.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-top-right-radius-011.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/border-top-right-radius-011.htm.ini
@@ -1,3 +1,0 @@
-[border-top-right-radius-011.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-color-3_dev/html4/t425-hsla-values-b.htm.ini
+++ b/tests/wpt/metadata-css/css-color-3_dev/html4/t425-hsla-values-b.htm.ini
@@ -1,3 +1,0 @@
-[t425-hsla-values-b.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-decor-3_dev/html/text-decoration-line-012.htm.ini
+++ b/tests/wpt/metadata-css/css-text-decor-3_dev/html/text-decoration-line-012.htm.ini
@@ -1,3 +1,0 @@
-[text-decoration-line-012.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-text-decor-3_dev/html/text-decoration-line-013.htm.ini
+++ b/tests/wpt/metadata-css/css-text-decor-3_dev/html/text-decoration-line-013.htm.ini
@@ -1,4 +1,0 @@
-[text-decoration-line-013.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-rotate-2d-3d-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-rotate-2d-3d-001.htm.ini
@@ -1,0 +1,3 @@
+[css-rotate-2d-3d-001.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotate3d-X-negative.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotate3d-X-negative.htm.ini
@@ -1,0 +1,3 @@
+[css-transform-3d-rotate3d-X-negative.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotate3d-X-positive.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotate3d-X-positive.htm.ini
@@ -1,0 +1,3 @@
+[css-transform-3d-rotate3d-X-positive.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotate3d-Y-negative.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotate3d-Y-negative.htm.ini
@@ -1,0 +1,3 @@
+[css-transform-3d-rotate3d-Y-negative.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotate3d-Y-positive.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotate3d-Y-positive.htm.ini
@@ -1,0 +1,3 @@
+[css-transform-3d-rotate3d-Y-positive.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotate3d-Z-negative.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotate3d-Z-negative.htm.ini
@@ -1,0 +1,3 @@
+[css-transform-3d-rotate3d-Z-negative.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotateX-negative.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotateX-negative.htm.ini
@@ -1,0 +1,3 @@
+[css-transform-3d-rotateX-negative.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotateX-positive.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotateX-positive.htm.ini
@@ -1,0 +1,3 @@
+[css-transform-3d-rotateX-positive.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotateY-negative.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotateY-negative.htm.ini
@@ -1,0 +1,3 @@
+[css-transform-3d-rotateY-negative.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotateY-positive.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotateY-positive.htm.ini
@@ -1,0 +1,3 @@
+[css-transform-3d-rotateY-positive.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotateZ-negative.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-rotateZ-negative.htm.ini
@@ -1,0 +1,3 @@
+[css-transform-3d-rotateZ-negative.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transforms-3d-on-anonymous-block-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transforms-3d-on-anonymous-block-001.htm.ini
@@ -1,4 +1,0 @@
-[css-transforms-3d-on-anonymous-block-001.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-translateZ-negative.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-translateZ-negative.htm.ini
@@ -1,3 +1,0 @@
-[perspective-translateZ-negative.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/rotate_x_45deg.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/rotate_x_45deg.htm.ini
@@ -1,3 +1,0 @@
-[rotate_x_45deg.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-3d-rotateY-stair-above-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-3d-rotateY-stair-above-001.htm.ini
@@ -1,3 +1,0 @@
-[transform-3d-rotateY-stair-above-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-applies-to-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-applies-to-001.htm.ini
@@ -1,0 +1,3 @@
+[transform-applies-to-001.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-inherit-origin-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-inherit-origin-001.htm.ini
@@ -1,0 +1,3 @@
+[transform-inherit-origin-001.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-inherit-origin-002.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-inherit-origin-002.htm.ini
@@ -1,0 +1,3 @@
+[transform-inherit-origin-002.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-017.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-017.htm.ini
@@ -1,4 +1,3 @@
 [transform-input-017.htm]
   type: reftest
-  expected: FAIL
   bug: https://github.com/servo/servo/issues/10881

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-018.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-018.htm.ini
@@ -1,4 +1,3 @@
 [transform-input-018.htm]
   type: reftest
-  expected: FAIL
   bug: https://github.com/servo/servo/issues/10881

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-007.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-007.htm.ini
@@ -1,0 +1,3 @@
+[transform-origin-007.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-008.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-008.htm.ini
@@ -1,0 +1,3 @@
+[transform-origin-008.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-009.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-009.htm.ini
@@ -1,0 +1,3 @@
+[transform-origin-009.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-010.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-010.htm.ini
@@ -1,0 +1,3 @@
+[transform-origin-010.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-012.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin-012.htm.ini
@@ -1,0 +1,3 @@
+[transform-origin-012.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-origin.htm.ini
@@ -1,0 +1,3 @@
+[transform-origin.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translate-004.htm.ini
@@ -1,0 +1,3 @@
+[transform-translate-004.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-translatex-004.htm.ini
@@ -1,0 +1,3 @@
+[transform-translatex-004.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-backface-visibility-005.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-backface-visibility-005.htm.ini
@@ -1,0 +1,3 @@
+[transform3d-backface-visibility-005.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-backface-visibility-008.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-backface-visibility-008.htm.ini
@@ -1,0 +1,3 @@
+[transform3d-backface-visibility-008.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-perspective-003.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-perspective-003.htm.ini
@@ -1,0 +1,3 @@
+[transform3d-perspective-003.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-perspective-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-perspective-004.htm.ini
@@ -1,0 +1,3 @@
+[transform3d-perspective-004.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-perspective-005.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-perspective-005.htm.ini
@@ -1,0 +1,3 @@
+[transform3d-perspective-005.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-perspective-008.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-perspective-008.htm.ini
@@ -1,0 +1,3 @@
+[transform3d-perspective-008.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-sorting-003.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-sorting-003.htm.ini
@@ -1,3 +1,0 @@
-[transform3d-sorting-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-sorting-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-sorting-004.htm.ini
@@ -1,3 +1,0 @@
-[transform3d-sorting-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transforms-rotate-degree-90.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transforms-rotate-degree-90.htm.ini
@@ -1,0 +1,3 @@
+[transforms-rotate-degree-90.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transforms-rotate-translate-scale.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transforms-rotate-translate-scale.htm.ini
@@ -1,0 +1,3 @@
+[transforms-rotate-translate-scale.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transforms-skewX.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transforms-skewX.htm.ini
@@ -1,3 +1,0 @@
-[transforms-skewX.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transforms-skewY.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transforms-skewY.htm.ini
@@ -1,3 +1,0 @@
-[transforms-skewY.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transofrmed-rotateX-3.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transofrmed-rotateX-3.htm.ini
@@ -1,0 +1,3 @@
+[transofrmed-rotateX-3.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/ttwf-reftest-rotate.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/ttwf-reftest-rotate.htm.ini
@@ -1,0 +1,3 @@
+[ttwf-reftest-rotate.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/filters-1_dev/html/filter-containing-block-dynamic-1b.htm.ini
+++ b/tests/wpt/metadata-css/filters-1_dev/html/filter-containing-block-dynamic-1b.htm.ini
@@ -1,0 +1,3 @@
+[filter-containing-block-dynamic-1b.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/filters-1_dev/html/filter-contrast-002.htm.ini
+++ b/tests/wpt/metadata-css/filters-1_dev/html/filter-contrast-002.htm.ini
@@ -1,3 +1,0 @@
-[filter-contrast-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/filters-1_dev/html/filter-contrast-003.htm.ini
+++ b/tests/wpt/metadata-css/filters-1_dev/html/filter-contrast-003.htm.ini
@@ -1,3 +1,0 @@
-[filter-contrast-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/filters-1_dev/html/filter-grayscale-001.htm.ini
+++ b/tests/wpt/metadata-css/filters-1_dev/html/filter-grayscale-001.htm.ini
@@ -1,3 +1,0 @@
-[filter-grayscale-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/filters-1_dev/html/filter-grayscale-004.htm.ini
+++ b/tests/wpt/metadata-css/filters-1_dev/html/filter-grayscale-004.htm.ini
@@ -1,3 +1,0 @@
-[filter-grayscale-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/filters-1_dev/html/filter-invert-001-test.htm.ini
+++ b/tests/wpt/metadata-css/filters-1_dev/html/filter-invert-001-test.htm.ini
@@ -1,3 +1,0 @@
-[filter-invert-001-test.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/filters-1_dev/html/filter-invert-002-test.htm.ini
+++ b/tests/wpt/metadata-css/filters-1_dev/html/filter-invert-002-test.htm.ini
@@ -1,3 +1,0 @@
-[filter-invert-002-test.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/filters-1_dev/html/filter-saturate-001-test.htm.ini
+++ b/tests/wpt/metadata-css/filters-1_dev/html/filter-saturate-001-test.htm.ini
@@ -1,0 +1,3 @@
+[filter-saturate-001-test.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/filters-1_dev/html/filters-grayscale-001-test.htm.ini
+++ b/tests/wpt/metadata-css/filters-1_dev/html/filters-grayscale-001-test.htm.ini
@@ -1,3 +1,0 @@
-[filters-grayscale-001-test.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/filters-1_dev/html/filters-sepia-001-test.htm.ini
+++ b/tests/wpt/metadata-css/filters-1_dev/html/filters-sepia-001-test.htm.ini
@@ -1,3 +1,0 @@
-[filters-sepia-001-test.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.copy.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.copy.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.canvas.copy.html]
+  type: testharness
+  [Canvas test: 2d.composite.canvas.copy]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.destination-atop.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.destination-atop.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.canvas.destination-atop.html]
+  type: testharness
+  [Canvas test: 2d.composite.canvas.destination-atop]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.destination-over.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.destination-over.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.canvas.destination-over.html]
+  type: testharness
+  [Canvas test: 2d.composite.canvas.destination-over]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.lighter.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.lighter.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.canvas.lighter.html]
+  type: testharness
+  [Canvas test: 2d.composite.canvas.lighter]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.source-atop.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.source-atop.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.canvas.source-atop.html]
+  type: testharness
+  [Canvas test: 2d.composite.canvas.source-atop]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.source-in.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.source-in.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.canvas.source-in.html]
+  type: testharness
+  [Canvas test: 2d.composite.canvas.source-in]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.source-out.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.source-out.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.canvas.source-out.html]
+  type: testharness
+  [Canvas test: 2d.composite.canvas.source-out]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.source-over.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.source-over.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.canvas.source-over.html]
+  type: testharness
+  [Canvas test: 2d.composite.canvas.source-over]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.xor.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.canvas.xor.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.canvas.xor.html]
+  type: testharness
+  [Canvas test: 2d.composite.canvas.xor]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.copy.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.copy.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.image.copy.html]
+  type: testharness
+  [Canvas test: 2d.composite.image.copy]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.destination-atop.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.destination-atop.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.image.destination-atop.html]
+  type: testharness
+  [Canvas test: 2d.composite.image.destination-atop]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.destination-over.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.destination-over.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.image.destination-over.html]
+  type: testharness
+  [Canvas test: 2d.composite.image.destination-over]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.lighter.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.lighter.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.image.lighter.html]
+  type: testharness
+  [Canvas test: 2d.composite.image.lighter]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.source-atop.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.source-atop.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.image.source-atop.html]
+  type: testharness
+  [Canvas test: 2d.composite.image.source-atop]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.source-in.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.source-in.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.image.source-in.html]
+  type: testharness
+  [Canvas test: 2d.composite.image.source-in]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.source-out.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.source-out.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.image.source-out.html]
+  type: testharness
+  [Canvas test: 2d.composite.image.source-out]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.source-over.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.source-over.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.image.source-over.html]
+  type: testharness
+  [Canvas test: 2d.composite.image.source-over]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.xor.html.ini
+++ b/tests/wpt/metadata/2dcontext/compositing/2d.composite.image.xor.html.ini
@@ -1,0 +1,5 @@
+[2d.composite.image.xor.html]
+  type: testharness
+  [Canvas test: 2d.composite.image.xor]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.nowrap.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.nowrap.html.ini
@@ -1,0 +1,5 @@
+[2d.drawImage.nowrap.html]
+  type: testharness
+  [Stretched images do not get pixels wrapping around the edges]
+    expected: FAIL
+

--- a/tests/wpt/metadata/cssom-view/elementScroll.html.ini
+++ b/tests/wpt/metadata/cssom-view/elementScroll.html.ini
@@ -3,3 +3,15 @@
   [Element scroll maximum test]
     expected: FAIL
 
+  [Element scrollTop/Left getter/setter test]
+    expected: FAIL
+
+  [Element scroll test]
+    expected: FAIL
+
+  [Element scrollTo test]
+    expected: FAIL
+
+  [cssom-view - elementScroll]
+    expected: FAIL
+

--- a/tests/wpt/metadata/cssom-view/scrolling-no-browsing-context.html.ini
+++ b/tests/wpt/metadata/cssom-view/scrolling-no-browsing-context.html.ini
@@ -1,0 +1,5 @@
+[scrolling-no-browsing-context.html]
+  type: testharness
+  [Element get and set scrollTop, scrollLeft, scroll() and scrollTo() test]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/css/acid2_noscroll.html.ini
+++ b/tests/wpt/mozilla/meta/css/acid2_noscroll.html.ini
@@ -1,0 +1,3 @@
+[acid2_noscroll.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/border_radius_zero_sizes_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/border_radius_zero_sizes_a.html.ini
@@ -1,0 +1,3 @@
+[border_radius_zero_sizes_a.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/borders_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/borders_a.html.ini
@@ -1,0 +1,3 @@
+[borders_a.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/canvas_linear_gradient_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/canvas_linear_gradient_a.html.ini
@@ -1,0 +1,3 @@
+[canvas_linear_gradient_a.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/filter_sepia_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/filter_sepia_a.html.ini
@@ -1,0 +1,3 @@
+[filter_sepia_a.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/text_shadow_blur_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/text_shadow_blur_a.html.ini
@@ -1,0 +1,3 @@
+[text_shadow_blur_a.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/transform_3d.html.ini
+++ b/tests/wpt/mozilla/meta/css/transform_3d.html.ini
@@ -1,0 +1,3 @@
+[transform_3d.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/transform_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/transform_simple_a.html.ini
@@ -1,0 +1,3 @@
+[transform_simple_a.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/viewport_meta.html.ini
+++ b/tests/wpt/mozilla/meta/css/viewport_meta.html.ini
@@ -1,3 +1,4 @@
 prefs: [layout.viewport.enabled:true]
 [viewport_meta.html]
   type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/viewport_rule.html.ini
+++ b/tests/wpt/mozilla/meta/css/viewport_rule.html.ini
@@ -1,3 +1,4 @@
 prefs: [layout.viewport.enabled:true]
 [viewport_rule.html]
   type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/scrollTo.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/scrollTo.html.ini
@@ -1,0 +1,5 @@
+[scrollTo.html]
+  type: testharness
+  [Untitled]
+    expected: FAIL
+


### PR DESCRIPTION
@larsbergstrom I updated your PR to switch the WPT test runner to use WR, make it default on the command line, and include the differing test expectations.

I'd personally prefer we had time to fix / update some of those test expectations properly - but if you feel it's urgent enough to merge for the tech demo, we could file follow up bugs to fix up some of the differing tests / expectations.

Thoughts?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11923)

<!-- Reviewable:end -->
