### PR TITLE
stylo: Simplify setup_bindgen.sh now that servo/rust-bindgen exists.

### DIFF
--- a/ports/geckolib/gecko_bindings/tools/setup_bindgen.sh
+++ b/ports/geckolib/gecko_bindings/tools/setup_bindgen.sh
@@ -11,7 +11,7 @@ else
 fi
 
 # Make sure we have llvm38.
-if [ ! -x "$(command -v clang++-3.8)" ]; then
+if [ ! -x "$(command -v clang-3.8)" ]; then
     echo "llmv38 must be installed. Mac users should |brew install llvm38|, Linux varies by distro."
     exit 1
 fi
@@ -27,12 +27,10 @@ fi
 
 # Don't try to clone twice.
 if [ ! -d rust-bindgen ]; then
-  git clone https://github.com/ecoal95/rust-bindgen.git
-  cd rust-bindgen
-  git checkout sm-hacks-rebase-squashed
-else
-  cd rust-bindgen
+  git clone https://github.com/servo/rust-bindgen.git
 fi
 
+cd rust-bindgen
+
 multirust override nightly
-cargo build
+cargo build --features llvm_stable


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because they are infra changes.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

The clang-3.8 instead of clang++-3.8 check is because on some Linux distros
clang++-3.8 doesn't exists, while the former does.

r? @bholley

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11925)

<!-- Reviewable:end -->
