### PR TITLE
Print out useful SSL-related information on SSL error page.

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -158,8 +158,8 @@ fn start_sending_opt(start_chan: LoadConsumer, metadata: Metadata,
         }
         LoadConsumer::Listener(target) => {
             match network_error {
-                Some(NetworkError::SslValidation(url)) => {
-                    let error = NetworkError::SslValidation(url);
+                Some(NetworkError::SslValidation(url, reason)) => {
+                    let error = NetworkError::SslValidation(url, reason);
                     target.invoke_with_listener(ResponseAction::HeadersAvailable(Err(error)));
                 }
                 _ => target.invoke_with_listener(ResponseAction::HeadersAvailable(Ok(metadata))),

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -667,7 +667,7 @@ pub enum NetworkError {
     Internal(String),
     LoadCancelled,
     /// SSL validation error that has to be handled in the HTML parser
-    SslValidation(Url),
+    SslValidation(Url, String),
 }
 
 /// Normalize `slice`, as defined by

--- a/resources/badcert.html
+++ b/resources/badcert.html
@@ -4,5 +4,6 @@
 </head>
 <body>
     <img src="chrome://resources/badcert.jpg">
+    <p>${reason}</p>
 </body>
 </html>

--- a/resources/badcert.html
+++ b/resources/badcert.html
@@ -3,7 +3,7 @@
 <title>Certificate error</title>
 </head>
 <body>
-    <img src="chrome://resources/badcert.jpg">
+    <img src="chrome://resources/itried.jpg">
     <p>${reason}</p>
 </body>
 </html>


### PR DESCRIPTION
Make certificate error pages more useful. Attempt to identify known cases where upgrading OpenSSL would be useful.

<img width="553" alt="screen shot 2016-06-29 at 12 29 30 pm" src="https://cloud.githubusercontent.com/assets/27658/16460435/4d07d5e2-3df5-11e6-94ab-cf061c0e64cc.png">

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11932)

<!-- Reviewable:end -->
