### PR TITLE
Special-case setting location.hash to the empty string

### DIFF
--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -66,7 +66,10 @@ impl LocationMethods for Location {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-location-hash
-    fn SetHash(&self, value: USVString) {
+    fn SetHash(&self, mut value: USVString) {
+        if value.0.is_empty() {
+            value = USVString("#".to_owned());
+        }
         self.set_url_component(value, UrlHelper::SetHash);
     }
 

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -36263,7 +36263,16 @@
   "local_changes": {
     "deleted": [],
     "deleted_reftests": {},
-    "items": {},
+    "items": {
+      "testharness": {
+        "html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html": [
+          {
+            "path": "html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html",
+            "url": "/html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html"
+          }
+        ]
+      }
+    },
     "reftest_nodes": {}
   },
   "reftest_nodes": {

--- a/tests/wpt/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html
+++ b/tests/wpt/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Navigating to the same URL with an empty fragment aborts the navigation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe src="empty_fragment_iframe.html"></iframe>
+<script>
+// If the navigation were not aborted, we would expect multiple load events
+// as the page continually reloads itself.
+async_test(function(t) {
+  var count = 0;
+  var iframe = document.querySelector('iframe');
+  iframe.onload = t.step_func(function() {
+    count++;
+  });
+  window.child_succeeded = t.step_func_done(function() {
+    assert_equals(count, 1);
+  });
+});
+</script>

--- a/tests/wpt/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/empty_fragment_iframe.html
+++ b/tests/wpt/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/empty_fragment_iframe.html
@@ -1,0 +1,11 @@
+<script>
+var timeout;
+onload = function() {
+  location.hash = "";
+  timeout = setTimeout(function() { parent.child_succeeded() }, 2000);
+};
+
+onbeforeunload = function() {
+  clearTimeout(timeout);
+}
+</script>


### PR DESCRIPTION
This avoids endless redirect loops on facebook and makes us compliant with https://github.com/whatwg/html/pull/1318.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #10952
- [X] There are tests for these changes OR

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11934)

<!-- Reviewable:end -->
