### PR TITLE
compositing: Only recomposite after a scroll if layers actually moved, and fix the jerky scrolling "pops" during flings on Mac.

### DIFF
--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -185,6 +185,9 @@ pub enum Msg {
     GetScrollOffset(PipelineId, LayerId, IpcSender<Point2D<f32>>),
     /// Pipeline visibility changed
     PipelineVisibilityChanged(PipelineId, bool),
+    /// WebRender has successfully processed a scroll. The boolean specifies whether a composite is
+    /// needed.
+    NewScrollFrameReady(bool),
     /// A pipeline was shut down.
     // This message acts as a synchronization point between the constellation,
     // when it shuts down a pipeline, to the compositor; when the compositor
@@ -228,6 +231,7 @@ impl Debug for Msg {
             Msg::PipelineVisibilityChanged(..) => write!(f, "PipelineVisibilityChanged"),
             Msg::PipelineExited(..) => write!(f, "PipelineExited"),
             Msg::GetScrollOffset(..) => write!(f, "GetScrollOffset"),
+            Msg::NewScrollFrameReady(..) => write!(f, "NewScrollFrameReady"),
         }
     }
 }


### PR DESCRIPTION
See the comments in compositor.rs for more details.

Requires servo/webrender#302 and servo/webrender_traits#64.

r? @glennw

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11938)

<!-- Reviewable:end -->
