### PR TITLE
Add a script to upload nightly packages to S3

### DIFF
--- a/etc/ci/upload_nightly.sh
+++ b/etc/ci/upload_nightly.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+shopt -s failglob
+
+
+usage() {
+    printf "usage: ${0} android|linux|mac|windows\n"
+}
+
+
+upload() {
+    s3cmd put "${2}" "s3://servo-developer-preview/nightly/${1}"
+}
+
+
+main() {
+    if [[ "$#" != 1 ]]; then
+        usage >&2
+        return 1
+    fi
+
+    local platform package
+    platform="${1}"
+
+    if [[ "${platform}" == "android" ]]; then
+        package=target/arm-linux-androideabi/release/*.apk
+    elif [[ "${platform}" == "linux" ]]; then
+        package=target/*.tar.gz
+    elif [[ "${platform}" == "mac" ]]; then
+        package=target/*.dmg
+    elif [[ "${platform}" == "windows" ]]; then
+        package=target/*.tar.gz
+    else
+        usage >&2
+        return 1
+    fi
+
+    # Lack of quotes on package allows glob expansion
+    # Note that this is not robust in the case of embedded spaces
+    # TODO(aneeshusa): make this glob robust using e.g. arrays or Python
+    upload "${platform}" ${package}
+}
+
+main "$@"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The nightly package name includes the date, and so we use a glob to
locate the package file without hard coding a value. However, globbing
will not work with our Buildbot steps setup because we perform word
splitting ourselves and pass an array to Buildbot, which will directly
exec the array instead of passing it to the shell, meaning globbing
does not occur. Instead, add a script to the servo repo where we can
use globbing, and use `shopt -s failglob` to guard against bad globs.

cc @larsbergstrom @edunham 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes are needed for #9921  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because will be tested by buildbot

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11943)

<!-- Reviewable:end -->
