### PR TITLE
style: Remove the Mutex from new_animations_sender by moving it to the local StyleContext.

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -108,7 +108,7 @@ use style::parallel::WorkQueueData;
 use style::properties::ComputedValues;
 use style::refcell::RefCell;
 use style::selector_matching::USER_OR_USER_AGENT_STYLESHEETS;
-use style::servo::{Animation, SharedStyleContext, Stylesheet, Stylist};
+use style::servo::{Animation, LocalStyleContextCreationInfo, SharedStyleContext, Stylesheet, Stylist};
 use style::stylesheets::CSSRuleIteratorExt;
 use url::Url;
 use util::geometry::MAX_RECT;
@@ -488,6 +488,8 @@ impl LayoutThread {
                                    screen_size_changed: bool,
                                    goal: ReflowGoal)
                                    -> SharedLayoutContext {
+        let local_style_context_creation_data = LocalStyleContextCreationInfo::new(self.new_animations_sender.clone());
+
         SharedLayoutContext {
             style_context: SharedStyleContext {
                 viewport_size: self.viewport_size.clone(),
@@ -495,10 +497,10 @@ impl LayoutThread {
                 stylist: rw_data.stylist.clone(),
                 generation: self.generation,
                 goal: goal,
-                new_animations_sender: Mutex::new(self.new_animations_sender.clone()),
                 running_animations: self.running_animations.clone(),
                 expired_animations: self.expired_animations.clone(),
                 error_reporter: self.error_reporter.clone(),
+                local_context_creation_data: Mutex::new(local_style_context_creation_data),
             },
             image_cache_thread: self.image_cache_thread.clone(),
             image_cache_sender: Mutex::new(self.image_cache_sender.clone()),

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -10,13 +10,25 @@ use dom::OpaqueNode;
 use error_reporting::ParseErrorReporter;
 use euclid::Size2D;
 use matching::{ApplicableDeclarationsCache, StyleSharingCandidateCache};
-use properties::ComputedValues;
 use selector_impl::SelectorImplExt;
 use selector_matching::Stylist;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex, RwLock};
+
+/// This structure is used to create a local style context from a shared one.
+pub struct LocalStyleContextCreationInfo<Impl: SelectorImplExt> {
+    new_animations_sender: Sender<Animation<Impl>>,
+}
+
+impl<Impl: SelectorImplExt> LocalStyleContextCreationInfo<Impl> {
+    pub fn new(animations_sender: Sender<Animation<Impl>>) -> Self {
+        LocalStyleContextCreationInfo {
+            new_animations_sender: animations_sender,
+        }
+    }
+}
 
 pub struct SharedStyleContext<Impl: SelectorImplExt> {
     /// The current viewport size.
@@ -32,10 +44,6 @@ pub struct SharedStyleContext<Impl: SelectorImplExt> {
     /// This can be used to easily check for invalid stale data.
     pub generation: u32,
 
-    /// A channel on which new animations that have been triggered by style recalculation can be
-    /// sent.
-    pub new_animations_sender: Mutex<Sender<Animation<Impl>>>,
-
     /// Why is this reflow occurring
     pub goal: ReflowGoal,
 
@@ -47,16 +55,32 @@ pub struct SharedStyleContext<Impl: SelectorImplExt> {
 
     ///The CSS error reporter for all CSS loaded in this layout thread
     pub error_reporter: Box<ParseErrorReporter + Sync>,
+
+    /// Data needed to create the local style context from the shared one.
+    pub local_context_creation_data: Mutex<LocalStyleContextCreationInfo<Impl>>,
 }
 
-pub struct LocalStyleContext<C: ComputedValues> {
-    pub applicable_declarations_cache: RefCell<ApplicableDeclarationsCache<C>>,
-    pub style_sharing_candidate_cache: RefCell<StyleSharingCandidateCache<C>>,
+pub struct LocalStyleContext<Impl: SelectorImplExt> {
+    pub applicable_declarations_cache: RefCell<ApplicableDeclarationsCache<Impl::ComputedValues>>,
+    pub style_sharing_candidate_cache: RefCell<StyleSharingCandidateCache<Impl::ComputedValues>>,
+    /// A channel on which new animations that have been triggered by style
+    /// recalculation can be sent.
+    pub new_animations_sender: Sender<Animation<Impl>>,
+}
+
+impl<Impl: SelectorImplExt> LocalStyleContext<Impl> {
+    pub fn new(local_context_creation_data: &LocalStyleContextCreationInfo<Impl>) -> Self {
+        LocalStyleContext {
+            applicable_declarations_cache: RefCell::new(ApplicableDeclarationsCache::new()),
+            style_sharing_candidate_cache: RefCell::new(StyleSharingCandidateCache::new()),
+            new_animations_sender: local_context_creation_data.new_animations_sender.clone(),
+        }
+    }
 }
 
 pub trait StyleContext<'a, Impl: SelectorImplExt> {
     fn shared_context(&self) -> &'a SharedStyleContext<Impl>;
-    fn local_context(&self) -> &LocalStyleContext<Impl::ComputedValues>;
+    fn local_context(&self) -> &LocalStyleContext<Impl>;
 }
 
 /// Why we're doing reflow.

--- a/components/style/parallel.rs
+++ b/components/style/parallel.rs
@@ -45,7 +45,7 @@ pub fn traverse_dom<N, C>(root: N,
                           where N: TNode, C: DomTraversalContext<N> {
     run_queue_with_custom_work_data_type(queue, |queue| {
         queue.push(WorkUnit {
-            fun:  top_down_dom::<N, C>,
+            fun: top_down_dom::<N, C>,
             data: (Box::new(vec![root.to_unsafe()]), root.opaque()),
         });
     }, queue_data);

--- a/components/style/selector_impl.rs
+++ b/components/style/selector_impl.rs
@@ -65,7 +65,7 @@ pub trait ElementExt: Element {
 
 // NB: The `Clone` trait is here for convenience due to:
 // https://github.com/rust-lang/rust/issues/26925
-pub trait SelectorImplExt : SelectorImpl + Clone + Debug + Sized {
+pub trait SelectorImplExt : SelectorImpl + Clone + Debug + Sized + 'static {
     type ComputedValues: properties::ComputedValues;
 
     fn pseudo_element_cascade_type(pseudo: &Self::PseudoElement) -> PseudoElementCascadeType;

--- a/components/style/servo.rs
+++ b/components/style/servo.rs
@@ -15,4 +15,5 @@ pub type Stylesheet = stylesheets::Stylesheet<ServoSelectorImpl>;
 pub type PrivateStyleData = data::PrivateStyleData<ServoSelectorImpl, ServoComputedValues>;
 pub type Stylist = selector_matching::Stylist<ServoSelectorImpl>;
 pub type SharedStyleContext = context::SharedStyleContext<ServoSelectorImpl>;
+pub type LocalStyleContextCreationInfo = context::LocalStyleContextCreationInfo<ServoSelectorImpl>;
 pub type Animation = animation::Animation<ServoSelectorImpl>;

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -218,8 +218,7 @@ pub fn recalc_style_at<'a, N, C>(context: &'a C,
 
                 // Perform the CSS cascade.
                 unsafe {
-                    node.cascade_node(&context.shared_context(),
-                                      &context.local_context(),
+                    node.cascade_node(context,
                                       parent_opt,
                                       &applicable_declarations);
                 }

--- a/ports/geckolib/context.rs
+++ b/ports/geckolib/context.rs
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+use selector_impl::{GeckoSelectorImpl, SharedStyleContext};
+use std::cell::RefCell;
+use std::rc::Rc;
+use style::context::{LocalStyleContext, StyleContext};
+
+thread_local!(static LOCAL_CONTEXT_KEY:
+                RefCell<Option<Rc<LocalStyleContext<GeckoSelectorImpl>>>> = RefCell::new(None));
+
+// Keep this implementation in sync with the one in components/layout/context.rs.
+fn create_or_get_local_context(shared: &SharedStyleContext)
+                               -> Rc<LocalStyleContext<GeckoSelectorImpl>> {
+    LOCAL_CONTEXT_KEY.with(|r| {
+        let mut r = r.borrow_mut();
+        if let Some(context) = r.clone() {
+            if shared.screen_size_changed {
+                context.applicable_declarations_cache.borrow_mut().evict_all();
+            }
+            context
+        } else {
+            let context = Rc::new(LocalStyleContext::new(&shared.local_context_creation_data.lock().unwrap()));
+            *r = Some(context.clone());
+            context
+        }
+    })
+}
+
+pub struct StandaloneStyleContext<'a> {
+    pub shared: &'a SharedStyleContext,
+    cached_local_context: Rc<LocalStyleContext<GeckoSelectorImpl>>,
+}
+
+impl<'a> StandaloneStyleContext<'a> {
+    pub fn new(shared: &'a SharedStyleContext) -> Self {
+        let local_context = create_or_get_local_context(shared);
+        StandaloneStyleContext {
+            shared: shared,
+            cached_local_context: local_context,
+        }
+    }
+}
+
+impl<'a> StyleContext<'a, GeckoSelectorImpl> for StandaloneStyleContext<'a> {
+    fn shared_context(&self) -> &'a SharedStyleContext {
+        &self.shared
+    }
+
+    fn local_context(&self) -> &LocalStyleContext<GeckoSelectorImpl> {
+        &self.cached_local_context
+    }
+}

--- a/ports/geckolib/data.rs
+++ b/ports/geckolib/data.rs
@@ -6,7 +6,7 @@ use euclid::Size2D;
 use euclid::size::TypedSize2D;
 use gecko_bindings::bindings::RawServoStyleSet;
 use num_cpus;
-use selector_impl::{GeckoSelectorImpl, Stylist, Stylesheet, SharedStyleContext};
+use selector_impl::{Animation, SharedStyleContext, Stylist, Stylesheet};
 use std::cmp;
 use std::collections::HashMap;
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -17,8 +17,6 @@ use style::parallel::WorkQueueData;
 use util::geometry::ViewportPx;
 use util::thread_state;
 use util::workqueue::WorkQueue;
-
-pub type Animation = ::style::animation::Animation<GeckoSelectorImpl>;
 
 pub struct PerDocumentStyleData {
     /// Rule processor.

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -22,7 +22,7 @@ use std::ptr;
 use std::slice;
 use std::str::from_utf8_unchecked;
 use std::sync::{Arc, Mutex};
-use style::context::ReflowGoal;
+use style::context::{LocalStyleContextCreationInfo, ReflowGoal};
 use style::dom::{TDocument, TElement, TNode};
 use style::error_reporting::StdoutErrorReporter;
 use style::parallel;
@@ -77,7 +77,7 @@ pub extern "C" fn Servo_Initialize() -> () {
 fn restyle_subtree(node: GeckoNode, raw_data: *mut RawServoStyleSet) {
     debug_assert!(node.is_element() || node.is_text_node());
 
-    let data = unsafe { &mut *(raw_data as *mut PerDocumentStyleData) };
+    let per_doc_data = unsafe { &mut *(raw_data as *mut PerDocumentStyleData) };
 
     // Force the creation of our lazily-constructed initial computed values on
     // the main thread, since it's not safe to call elsewhere.
@@ -88,24 +88,28 @@ fn restyle_subtree(node: GeckoNode, raw_data: *mut RawServoStyleSet) {
     // along in startup than the sensible place to call Servo_Initialize.
     GeckoComputedValues::initial_values();
 
-    let _needs_dirtying = Arc::get_mut(&mut data.stylist).unwrap()
-                              .update(&data.stylesheets, data.stylesheets_changed);
-    data.stylesheets_changed = false;
+    let _needs_dirtying = Arc::get_mut(&mut per_doc_data.stylist).unwrap()
+                              .update(&per_doc_data.stylesheets,
+                                      per_doc_data.stylesheets_changed);
+    per_doc_data.stylesheets_changed = false;
+
+    let local_context_data =
+        LocalStyleContextCreationInfo::new(per_doc_data.new_animations_sender.clone());
 
     let shared_style_context = SharedStyleContext {
         viewport_size: Size2D::new(Au(0), Au(0)),
         screen_size_changed: false,
         generation: 0,
         goal: ReflowGoal::ForScriptQuery,
-        stylist: data.stylist.clone(),
-        new_animations_sender: Mutex::new(data.new_animations_sender.clone()),
-        running_animations: data.running_animations.clone(),
-        expired_animations: data.expired_animations.clone(),
+        stylist: per_doc_data.stylist.clone(),
+        running_animations: per_doc_data.running_animations.clone(),
+        expired_animations: per_doc_data.expired_animations.clone(),
         error_reporter: Box::new(StdoutErrorReporter),
+        local_context_creation_data: Mutex::new(local_context_data),
     };
 
     if node.is_dirty() || node.has_dirty_descendants() {
-        parallel::traverse_dom::<GeckoNode, RecalcStyleOnly>(node, &shared_style_context, &mut data.work_queue);
+        parallel::traverse_dom::<GeckoNode, RecalcStyleOnly>(node, &shared_style_context, &mut per_doc_data.work_queue);
     }
 }
 

--- a/ports/geckolib/lib.rs
+++ b/ports/geckolib/lib.rs
@@ -24,6 +24,7 @@ extern crate style_traits;
 extern crate url;
 extern crate util;
 
+mod context;
 mod data;
 #[allow(non_snake_case)]
 pub mod glue;

--- a/ports/geckolib/selector_impl.rs
+++ b/ports/geckolib/selector_impl.rs
@@ -12,6 +12,7 @@ pub type Stylist = style::selector_matching::Stylist<GeckoSelectorImpl>;
 pub type Stylesheet = style::stylesheets::Stylesheet<GeckoSelectorImpl>;
 pub type SharedStyleContext = style::context::SharedStyleContext<GeckoSelectorImpl>;
 pub type PrivateStyleData = style::data::PrivateStyleData<GeckoSelectorImpl, GeckoComputedValues>;
+pub type Animation = style::animation::Animation<GeckoSelectorImpl>;
 
 #[cfg(feature = "servo_features")]
 known_heap_size!(0, GeckoSelectorImpl, PseudoElement, NonTSPseudoClass);

--- a/ports/geckolib/traversal.rs
+++ b/ports/geckolib/traversal.rs
@@ -2,65 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use properties::GeckoComputedValues;
-use selector_impl::{GeckoSelectorImpl, SharedStyleContext};
-use std::cell::RefCell;
+use context::StandaloneStyleContext;
+use selector_impl::SharedStyleContext;
 use std::mem;
-use std::rc::Rc;
-use style::context::{LocalStyleContext, StyleContext};
 use style::dom::OpaqueNode;
-use style::matching::{ApplicableDeclarationsCache, StyleSharingCandidateCache};
 use style::traversal::{DomTraversalContext, recalc_style_at};
 use wrapper::GeckoNode;
-
-thread_local!(static LOCAL_CONTEXT_KEY:
-                RefCell<Option<Rc<LocalStyleContext<GeckoComputedValues>>>> = RefCell::new(None));
-
-// Keep this implementation in sync with the one in components/layout/context.rs.
-fn create_or_get_local_context(shared: &SharedStyleContext)
-                               -> Rc<LocalStyleContext<GeckoComputedValues>> {
-    LOCAL_CONTEXT_KEY.with(|r| {
-        let mut r = r.borrow_mut();
-        if let Some(context) = r.clone() {
-            if shared.screen_size_changed {
-                context.applicable_declarations_cache.borrow_mut().evict_all();
-            }
-            context
-        } else {
-            let context = Rc::new(LocalStyleContext {
-                applicable_declarations_cache: RefCell::new(ApplicableDeclarationsCache::new()),
-                style_sharing_candidate_cache: RefCell::new(StyleSharingCandidateCache::new()),
-            });
-            *r = Some(context.clone());
-            context
-        }
-    })
-}
-
-pub struct StandaloneStyleContext<'a> {
-    pub shared: &'a SharedStyleContext,
-    cached_local_context: Rc<LocalStyleContext<GeckoComputedValues>>,
-}
-
-impl<'a> StandaloneStyleContext<'a> {
-    pub fn new(shared: &'a SharedStyleContext) -> Self {
-        let local_context = create_or_get_local_context(shared);
-        StandaloneStyleContext {
-            shared: shared,
-            cached_local_context: local_context,
-        }
-    }
-}
-
-impl<'a> StyleContext<'a, GeckoSelectorImpl> for StandaloneStyleContext<'a> {
-    fn shared_context(&self) -> &'a SharedStyleContext {
-        &self.shared
-    }
-
-    fn local_context(&self) -> &LocalStyleContext<GeckoComputedValues> {
-        &self.cached_local_context
-    }
-}
 
 pub struct RecalcStyleOnly<'lc> {
     context: StandaloneStyleContext<'lc>,
@@ -73,7 +20,7 @@ impl<'lc, 'ln> DomTraversalContext<GeckoNode<'ln>> for RecalcStyleOnly<'lc> {
     fn new<'a>(shared: &'a Self::SharedContext, root: OpaqueNode) -> Self {
         // See the comment in RecalcStyleAndConstructFlows::new for an explanation of why this is
         // necessary.
-        let shared_lc: &'lc SharedStyleContext = unsafe { mem::transmute(shared) };
+        let shared_lc: &'lc Self::SharedContext = unsafe { mem::transmute(shared) };
         RecalcStyleOnly {
             context: StandaloneStyleContext::new(shared_lc),
             root: root,
@@ -90,4 +37,3 @@ impl<'lc, 'ln> DomTraversalContext<GeckoNode<'ln>> for RecalcStyleOnly<'lc> {
 
     fn process_postorder(&self, _: GeckoNode<'ln>) {}
 }
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because refactoring.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

As a follow-up, we could move all the data living under a mutex in the
SharedLayoutContext only in order to create the local context to the same place.

This should increase animation performance when there are multiple animations in
one page that happen to be on different threads.

r? @SimonSapin/@mbrubeck for the style/layout, @bholley for the geckolib changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11946)

<!-- Reviewable:end -->
