### PR TITLE
Support 'flex' and 'flex-flow' shorthand properties

### DIFF
--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -308,6 +308,9 @@ partial interface CSSStyleDeclaration {
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString transitionDelay;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString transition-delay;
 
+  [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flex;
+  [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flexFlow;
+  [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flex-flow;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flexDirection;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flex-direction;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString flexWrap;

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -129,6 +129,7 @@ pub mod shorthands {
     <%include file="/shorthand/margin.mako.rs" />
     <%include file="/shorthand/outline.mako.rs" />
     <%include file="/shorthand/padding.mako.rs" />
+    <%include file="/shorthand/position.mako.rs" />
     <%include file="/shorthand/text.mako.rs" />
 }
 

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+<%namespace name="helpers" file="/helpers.mako.rs" />
+
+<%helpers:shorthand name="flex-flow" sub_properties="flex-direction flex-wrap"
+                                     experimental="True">
+    use properties::longhands::{flex_direction, flex_wrap};
+
+    let mut direction = None;
+    let mut wrap = None;
+    let mut any = false;
+    loop {
+        if direction.is_none() {
+            if let Ok(value) = input.try(|input| flex_direction::parse(context, input)) {
+                direction = Some(value);
+                any = true;
+                continue
+            }
+        }
+        if wrap.is_none() {
+            if let Ok(value) = input.try(|input| flex_wrap::parse(context, input)) {
+                wrap = Some(value);
+                any = true;
+                continue
+            }
+        }
+        break
+    }
+
+    if any {
+        Ok(Longhands {
+            flex_direction: direction,
+            flex_wrap: wrap,
+        })
+    } else {
+        Err(())
+    }
+</%helpers:shorthand>
+
+<%helpers:shorthand name="flex" sub_properties="flex-grow flex-shrink flex-basis"
+                                experimental="True">
+    use app_units::Au;
+    use values::specified::{Number, Length, LengthOrPercentageOrAutoOrContent};
+
+    pub fn parse_flexibility(input: &mut Parser)
+                             -> Result<(Option<Number>, Option<Number>),()> {
+        let grow = Some(try!(Number::parse_non_negative(input)));
+        let shrink = input.try(Number::parse_non_negative).ok();
+        Ok((grow, shrink))
+    }
+
+    let mut grow = None;
+    let mut shrink = None;
+    let mut basis = None;
+    let mut any = false;
+
+    if input.try(|input| input.expect_ident_matching("none")).is_ok() {
+        return Ok(Longhands {
+            flex_grow: Some(Number(0.0)),
+            flex_shrink: Some(Number(0.0)),
+            flex_basis: Some(LengthOrPercentageOrAutoOrContent::Auto)
+        })
+    }
+    loop {
+        if grow.is_none() {
+            if let Ok((flex_grow, flex_shrink)) = input.try(parse_flexibility) {
+                grow = flex_grow;
+                shrink = flex_shrink;
+                any = true;
+                continue
+            }
+        }
+        if basis.is_none() {
+            if let Ok(value) = input.try(LengthOrPercentageOrAutoOrContent::parse) {
+                basis = Some(value);
+                any = true;
+                continue
+            }
+        }
+        break
+    }
+    if any {
+        if grow == None {
+            grow = Some(Number(1.0));
+        }
+        if shrink == None && basis == None {
+            basis = Some(LengthOrPercentageOrAutoOrContent::Length(Length::Absolute(Au(0))));
+        }
+        if shrink == None {
+            shrink = Some(Number(1.0));
+        }
+        if basis == None {
+            basis = Some(LengthOrPercentageOrAutoOrContent::Auto);
+        }
+        Ok(Longhands {
+            flex_grow: grow,
+            flex_shrink: shrink,
+            flex_basis: basis,
+        })
+    } else {
+        Err(())
+    }
+</%helpers:shorthand>

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -4,49 +4,47 @@
 
 <%namespace name="helpers" file="/helpers.mako.rs" />
 
+// https://drafts.csswg.org/css-flexbox/#flex-flow-property
 <%helpers:shorthand name="flex-flow" sub_properties="flex-direction flex-wrap"
                                      experimental="True">
     use properties::longhands::{flex_direction, flex_wrap};
 
     let mut direction = None;
     let mut wrap = None;
-    let mut any = false;
     loop {
         if direction.is_none() {
             if let Ok(value) = input.try(|input| flex_direction::parse(context, input)) {
                 direction = Some(value);
-                any = true;
                 continue
             }
         }
         if wrap.is_none() {
             if let Ok(value) = input.try(|input| flex_wrap::parse(context, input)) {
                 wrap = Some(value);
-                any = true;
                 continue
             }
         }
         break
     }
 
-    if any {
-        Ok(Longhands {
-            flex_direction: direction,
-            flex_wrap: wrap,
-        })
-    } else {
-        Err(())
+    if direction.is_none() && wrap.is_none() {
+        return Err(())
     }
+    Ok(Longhands {
+        flex_direction: direction,
+        flex_wrap: wrap,
+    })
 </%helpers:shorthand>
 
+// https://drafts.csswg.org/css-flexbox/#flex-property
 <%helpers:shorthand name="flex" sub_properties="flex-grow flex-shrink flex-basis"
                                 experimental="True">
     use app_units::Au;
     use values::specified::{Number, Length, LengthOrPercentageOrAutoOrContent};
 
     pub fn parse_flexibility(input: &mut Parser)
-                             -> Result<(Option<Number>, Option<Number>),()> {
-        let grow = Some(try!(Number::parse_non_negative(input)));
+                             -> Result<(Number, Option<Number>),()> {
+        let grow = try!(Number::parse_non_negative(input));
         let shrink = input.try(Number::parse_non_negative).ok();
         Ok((grow, shrink))
     }
@@ -54,7 +52,6 @@
     let mut grow = None;
     let mut shrink = None;
     let mut basis = None;
-    let mut any = false;
 
     if input.try(|input| input.expect_ident_matching("none")).is_ok() {
         return Ok(Longhands {
@@ -66,40 +63,26 @@
     loop {
         if grow.is_none() {
             if let Ok((flex_grow, flex_shrink)) = input.try(parse_flexibility) {
-                grow = flex_grow;
+                grow = Some(flex_grow);
                 shrink = flex_shrink;
-                any = true;
                 continue
             }
         }
         if basis.is_none() {
             if let Ok(value) = input.try(LengthOrPercentageOrAutoOrContent::parse) {
                 basis = Some(value);
-                any = true;
                 continue
             }
         }
         break
     }
-    if any {
-        if grow == None {
-            grow = Some(Number(1.0));
-        }
-        if shrink == None && basis == None {
-            basis = Some(LengthOrPercentageOrAutoOrContent::Length(Length::Absolute(Au(0))));
-        }
-        if shrink == None {
-            shrink = Some(Number(1.0));
-        }
-        if basis == None {
-            basis = Some(LengthOrPercentageOrAutoOrContent::Auto);
-        }
-        Ok(Longhands {
-            flex_grow: grow,
-            flex_shrink: shrink,
-            flex_basis: basis,
-        })
-    } else {
-        Err(())
+
+    if grow.is_none() && basis.is_none() {
+        return Err(())
     }
+    Ok(Longhands {
+        flex_grow: grow.or(Some(Number(1.0))),
+        flex_shrink: shrink.or(Some(Number(1.0))),
+        flex_basis: basis.or(Some(LengthOrPercentageOrAutoOrContent::Length(Length::Absolute(Au(0)))))
+    })
 </%helpers:shorthand>

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/__dir__.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/__dir__.ini
@@ -1,4 +1,5 @@
 prefs: ["layout.flex.enabled:true",
+        "layout.flex-flow.enabled:true",
         "layout.flex-direction.enabled:true",
         "layout.flex-wrap.enabled:true",
         "layout.flex-grow.enabled:true",

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/css-flexbox-column-reverse.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/css-flexbox-column-reverse.htm.ini
@@ -1,0 +1,3 @@
+[css-flexbox-column-reverse.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-nowrap.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-nowrap.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-column-nowrap.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: column nowrap]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-reverse-nowrap.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-reverse-nowrap.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-column-reverse-nowrap.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: column-reverse nowrap]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-reverse-wrap.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-reverse-wrap.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-column-reverse-wrap.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: column-reverse wrap]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-reverse.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-reverse.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-column-reverse.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: column-reverse]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-wrap-reverse.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-wrap-reverse.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-column-wrap-reverse.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: column wrap-reverse]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-wrap.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column-wrap.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-column-wrap.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: column wrap]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-column.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-column.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: column]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-reverse-nowrap.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-reverse-nowrap.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-row-reverse-nowrap.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: row-reverse nowrap]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-reverse-wrap-reverse.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-reverse-wrap-reverse.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-row-reverse-wrap-reverse.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: row-reverse wrap-reverse]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-reverse-wrap.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-reverse-wrap.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-row-reverse-wrap.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: row-reverse wrap]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-reverse.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-reverse.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-row-reverse.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: row-reverse]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-wrap-reverse.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-wrap-reverse.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-row-wrap-reverse.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: row wrap-reverse]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-wrap.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-row-wrap.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-row-wrap.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: row wrap]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-wrap.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-flow-wrap.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-flow-wrap.htm]
-  type: testharness
-  [flexbox | computed style | flex-flow: wrap]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-shorthand-auto.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-shorthand-auto.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-shorthand-auto.htm]
-  type: testharness
-  [flexbox | computed style | flex: auto]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-shorthand-none.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-shorthand-none.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-shorthand-none.htm]
-  type: testharness
-  [flexbox | computed style | flex: auto]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-shorthand-number.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-shorthand-number.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-shorthand-number.htm]
-  type: testharness
-  [flexbox | computed style | flex: number]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-shorthand.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-shorthand.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_flex-shorthand.htm]
-  type: testharness
-  [flexbox | computed style | flex: invalid]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/percentage-heights-000.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/percentage-heights-000.htm.ini
@@ -9,9 +9,6 @@
   [.flexbox 3]
     expected: FAIL
 
-  [.flexbox 4]
-    expected: FAIL
-
   [.flexbox 5]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Support the `flex` and `flex-flow` shorthand properties in
servo. Currently they are marked as experimental, so they are added to
`__dir__.ini`.
Thanks SimonSapin and jdm for help :)

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11948)

<!-- Reviewable:end -->
