### PR TITLE
Creates KeyModifiers value using empty() instead of from_bits()

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -576,7 +576,7 @@ impl Window {
     }
 
     fn glutin_mods_to_script_mods(modifiers: KeyModifiers) -> constellation_msg::KeyModifiers {
-        let mut result = constellation_msg::KeyModifiers::from_bits(0).expect("infallible");
+        let mut result = constellation_msg::KeyModifiers::empty();
         if modifiers.intersects(LEFT_SHIFT | RIGHT_SHIFT) {
             result.insert(SHIFT);
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11935 .

<!-- Either: -->
- [X] These changes do not require tests because: @jdm said so :P

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11952)

<!-- Reviewable:end -->
