### PR TITLE
Change servo s3 build bucket name

### DIFF
--- a/etc/ci/upload_nightly.sh
+++ b/etc/ci/upload_nightly.sh
@@ -12,7 +12,7 @@ usage() {
 
 
 upload() {
-    s3cmd put "${2}" "s3://servo-developer-preview/nightly/${1}"
+    s3cmd put "${2}" "s3://servo-builds/nightly/${1}"
 }
 
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This will allow us to push to URLs like:
http://servo-builds.s3.amazonaws.com/nightly/mac
instead of:
http://servo-developer-preview.s3.amazonaws.com/nightly/mac

We can have different directories for channels, individual releases, etc.

r? @edunham @metajack 

cc @tschneidereit 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11959)

<!-- Reviewable:end -->
