### PR TITLE
put run script in the right folder for packaging

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -174,7 +174,7 @@ class PackageCommands(CommandBase):
                           '--pref', 'shell.builtin-key-shortcuts.enabled=false',
                           path.join(browserhtml_path, 'out', 'index.html')]
 
-            runservo = os.open(dir_to_package + 'runservo.sh', os.O_WRONLY | os.O_CREAT, int("0755", 8))
+            runservo = os.open(dir_to_package + '/runservo.sh', os.O_WRONLY | os.O_CREAT, int("0755", 8))
             os.write(runservo, "./servo " + ' '.join(servo_args))
             os.close(runservo)
             print("Creating tarball")


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Puts run servo script in the proper folder for packaging

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11944 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because fixing packaging script

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11975)

<!-- Reviewable:end -->
