### PR TITLE
Overwrite the last servo-latest.ext with current file

### DIFF
--- a/etc/ci/upload_nightly.sh
+++ b/etc/ci/upload_nightly.sh
@@ -13,6 +13,7 @@ usage() {
 
 upload() {
     s3cmd put "${2}" "s3://servo-builds/nightly/${1}/"
+    s3cmd put "${2}" "s3://servo-builds/nightly/${1}/servo-latest${3}"
 }
 
 
@@ -22,17 +23,21 @@ main() {
         return 1
     fi
 
-    local platform package
+    local platform package ext
     platform="${1}"
 
     if [[ "${platform}" == "android" ]]; then
         package=target/arm-linux-androideabi/release/*.apk
+        ext=".apk"
     elif [[ "${platform}" == "linux" ]]; then
         package=target/*.tar.gz
+        ext=".tar.gz"
     elif [[ "${platform}" == "mac" ]]; then
         package=target/*.dmg
+        ext=".dmg"
     elif [[ "${platform}" == "windows" ]]; then
         package=target/*.tar.gz
+        ext=".tar.gz"
     else
         usage >&2
         return 1
@@ -41,7 +46,7 @@ main() {
     # Lack of quotes on package allows glob expansion
     # Note that this is not robust in the case of embedded spaces
     # TODO(aneeshusa): make this glob robust using e.g. arrays or Python
-    upload "${platform}" ${package}
+    upload "${platform}" ${package} ${ext}
 }
 
 main "$@"


### PR DESCRIPTION
So we kinda changed the naming scheme at the last minute and this PR will make it so we actually upload packages to the location (servo-latest.ext) that we're telling people to download them from. 

If none of this makes any sense, please ping me in the morning and I'll fix it all up and be mildly embarrassed :)

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors 
  /etc/ci is unrelated to the build
- [ ] `./mach test-tidy` does not report any errors 
  It's all mad about some wpt stuff I never touched
- [ ] These changes fix #__ (github issue number if applicable). 
  IRC conversation

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because I hope someone fluent in bash takes a look and tells me if they're bad

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/11989)

<!-- Reviewable:end -->
