### PR TITLE
Reorder code in KeyframesAnimation::from_keyframes() to avoid a panic.

### DIFF
--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -154,8 +154,12 @@ fn get_animated_properties(keyframe: &Keyframe) -> Vec<TransitionProperty> {
 
 impl KeyframesAnimation {
     pub fn from_keyframes(keyframes: &[Keyframe]) -> Option<Self> {
+        if keyframes.is_empty() {
+            return None;
+        }
+
         let animated_properties = get_animated_properties(&keyframes[0]);
-        if keyframes.is_empty() || animated_properties.is_empty() {
+        if animated_properties.is_empty() {
             return None;
         }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6072,6 +6072,12 @@
         ]
       },
       "testharness": {
+        "css/empty-keyframes.html": [
+          {
+            "path": "css/empty-keyframes.html",
+            "url": "/_mozilla/css/empty-keyframes.html"
+          }
+        ],
         "css/flex-item-assign-inline-size.html": [
           {
             "path": "css/flex-item-assign-inline-size.html",

--- a/tests/wpt/mozilla/tests/css/empty-keyframes.html
+++ b/tests/wpt/mozilla/tests/css/empty-keyframes.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Empty keyframes rule</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style id=style>
+@keyframes foo {}
+</style>
+<div id=log></div>
+<script>
+test(function() {
+  // Check that it is exposed in the CSSOM.
+});
+</script>


### PR DESCRIPTION
Fixes #11999.
Fixes #12006.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12008)

<!-- Reviewable:end -->
