### PR TITLE
Add shebang to Linux runservo.sh

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -177,7 +177,7 @@ class PackageCommands(CommandBase):
                           path.join('./build/' + browserhtml_path.split('/')[-1], 'out', 'index.html')]
 
             runservo = os.open(dir_to_package + '/runservo.sh', os.O_WRONLY | os.O_CREAT, int("0755", 8))
-            os.write(runservo, "./servo " + ' '.join(servo_args))
+            os.write(runservo, "#!/usr/bin/env sh\n./servo " + ' '.join(servo_args))
             os.close(runservo)
             print("Creating tarball")
             tar_path = '/'.join(dir_to_package.split('/')[:-1]) + '/'


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Shebang is missing and therefore `./runservo.sh` does not work under some environments. 

I've chosen to use `/usr/bin/env sh` instead of `/bin/sh` or `/usr/bin/sh` to auto-select the right `sh` executable depending on the environment.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because it does not affect servo itself but rather the resulting package under some environments.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12020)

<!-- Reviewable:end -->
