### PR TITLE
Change colons to dashes in package name

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -142,8 +142,9 @@ class PackageCommands(CommandBase):
             print("Creating dmg")
             os.symlink('/Applications', dir_to_dmg + '/Applications')
             dmg_path = '/'.join(dir_to_build.split('/')[:-1]) + '/'
-            dmg_path += datetime.utcnow().replace(microsecond=0).isoformat()
-            dmg_path += "-servo-tech-demo.dmg"
+            time = datetime.utcnow().replace(microsecond=0).isoformat()
+            time = time.replace(':', '-')
+            dmg_path += time + "-servo-tech-demo.dmg"
             try:
                 subprocess.check_call(['hdiutil', 'create', '-volname', 'Servo', dmg_path, '-srcfolder', dir_to_dmg])
             except subprocess.CalledProcessError as e:
@@ -181,8 +182,9 @@ class PackageCommands(CommandBase):
             os.close(runservo)
             print("Creating tarball")
             tar_path = '/'.join(dir_to_package.split('/')[:-1]) + '/'
-            tar_path += datetime.utcnow().replace(microsecond=0).isoformat()
-            tar_path += "-servo-tech-demo.tar.gz"
+            time = datetime.utcnow().replace(microsecond=0).isoformat()
+            time = time.replace(':', "-")
+            tar_path += time + "-servo-tech-demo.tar.gz"
             with tarfile.open(tar_path, "w:gz") as tar:
                 # arcname is to add by relative rather than absolute path
                 tar.add(dir_to_package, arcname='servo/')


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Updating packaging so that packages use '-' instead of a ':'

r? @ConnorGBrewster

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] These changes fix #11984  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they are updating packaging

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12088)

<!-- Reviewable:end -->
