### PR TITLE
Send servo version in mozbrowser error.

### DIFF
--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -49,6 +49,7 @@ use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use style::context::ReflowGoal;
 use url::Url;
 use util::prefs::mozbrowser_enabled;
+use util::servo_version;
 
 #[derive(HeapSizeOf)]
 enum SandboxAllowance {
@@ -358,6 +359,7 @@ impl MozBrowserEventDetailBuilder for HTMLIFrameElement {
                     type_: Some(DOMString::from(error_type.name())),
                     description: description.map(DOMString::from),
                     report: report.map(DOMString::from),
+                    version: Some(DOMString::from_string(servo_version().into())),
                 }.to_jsval(cx, rval);
             },
             MozBrowserEvent::SecurityChange(https_state) => {

--- a/components/script/dom/webidls/BrowserElement.webidl
+++ b/components/script/dom/webidls/BrowserElement.webidl
@@ -61,6 +61,7 @@ dictionary BrowserElementErrorEventDetail {
   DOMString type;
   DOMString description;
   DOMString report;
+  DOMString version;
 };
 
 dictionary BrowserElementLocationChangeEventDetail {

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -40,6 +40,7 @@ use servo::Browser;
 use servo::compositing::windowing::WindowEvent;
 use servo::util::opts::{self, ArgumentParsingResult};
 use servo::util::panicking::initiate_panic_hook;
+use servo::util::servo_version;
 use std::process;
 use std::rc::Rc;
 
@@ -104,7 +105,7 @@ fn main() {
     }
 
     if opts::get().is_printing_version {
-        println!("Servo {}{}", env!("CARGO_PKG_VERSION"), env!("GIT_INFO"));
+        println!("{}", servo_version());
         process::exit(0);
     }
 

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -64,3 +64,7 @@ pub fn arc_ptr_eq<T: 'static>(a: &Arc<T>, b: &Arc<T>) -> bool {
     let b: &T = &**b;
     (a as *const T) == (b as *const T)
 }
+
+pub fn servo_version() -> &'static str {
+    concat!("Servo ", env!("CARGO_PKG_VERSION"), env!("GIT_INFO"))
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Adds support for sending a version string to b.html so we can put the servo version in the auto generated issue reports.

r? @asajeffrey 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12083 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because sending servo version on mozbrwosererror for issue reporter.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12136)

<!-- Reviewable:end -->
