### PR TITLE
Check for Resources on case sensitive filesystem

### DIFF
--- a/components/util/resource_files.rs
+++ b/components/util/resource_files.rs
@@ -46,6 +46,12 @@ pub fn resources_dir_path() -> PathBuf {
             break;
         }
         path.pop();
+        // Check for Resources on mac when using a case sensitive filesystem.
+        path.push("Resources");
+        if path.is_dir() {
+            break;
+        }
+        path.pop();
     }
     *dir = Some(path.to_str().unwrap().to_owned());
     path


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Case where this is needed:
http://logs.glob.uno/?c=mozilla%23servo&s=1+Jul+2016&e=1+Jul+2016#c471192

Another option is to make the Resources folder on the mac .app bundle be lower case; however, it is standard to have `Resources` in a .app bundle.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12137)

<!-- Reviewable:end -->
