### PR TITLE
Adds explicit mime type to upload_nightly.sh

### DIFF
--- a/etc/ci/upload_nightly.sh
+++ b/etc/ci/upload_nightly.sh
@@ -16,7 +16,8 @@ upload() {
     package_filename="$(basename "${2}")"
     local -r nightly_upload_dir="s3://servo-builds/nightly/${1}"
     local -r package_upload_path="${nightly_upload_dir}/${package_filename}"
-    s3cmd put "${2}" "${package_upload_path}"
+    s3cmd --mime-type="application/octet-stream" \
+          put "${2}" "${package_upload_path}"
     s3cmd cp "${package_upload_path}" "${nightly_upload_dir}/servo-latest.${3}"
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This changes the script to pass the `--mime-type` option to `s3cmd`, as
described [here](http://s3tools.org/usage).  The MIME type used is
`application/octet-stream`.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #12153 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this is a minimal change to the upload_nightly.sh script.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12156)

<!-- Reviewable:end -->
