### PR TITLE
Do not crash on partial calc interpolation

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -329,8 +329,8 @@ impl Interpolate for CalcLengthOrPercentage {
     #[inline]
     fn interpolate(&self, other: &Self, time: f64) -> Result<Self, ()> {
         Ok(CalcLengthOrPercentage {
-            length: try!(self.length.interpolate(&other.length, time)),
-            percentage: try!(self.percentage.interpolate(&other.percentage, time)),
+            length: self.length.interpolate(&other.length, time).ok().and_then(|x|x),
+            percentage: self.percentage.interpolate(&other.percentage, time).ok().and_then(|x|x),
         })
     }
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5320,6 +5320,18 @@
             "url": "/_mozilla/css/transition_calc.html"
           }
         ],
+        "css/transition_calc_implicit.html": [
+          {
+            "path": "css/transition_calc_implicit.html",
+            "references": [
+              [
+                "/_mozilla/css/transition_calc_implicit_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/transition_calc_implicit.html"
+          }
+        ],
         "css/translate_clip.html": [
           {
             "path": "css/translate_clip.html",
@@ -12438,6 +12450,18 @@
             ]
           ],
           "url": "/_mozilla/css/transition_calc.html"
+        }
+      ],
+      "css/transition_calc_implicit.html": [
+        {
+          "path": "css/transition_calc_implicit.html",
+          "references": [
+            [
+              "/_mozilla/css/transition_calc_implicit_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/transition_calc_implicit.html"
         }
       ],
       "css/translate_clip.html": [

--- a/tests/wpt/mozilla/tests/css/transition_calc_implicit.html
+++ b/tests/wpt/mozilla/tests/css/transition_calc_implicit.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel='match' href='transition_calc_implicit_ref.html'>
+<style>
+#inner {
+    transition: transform 0.01s;
+    height: 100px;
+    width: 100px;
+    transform: translate(1%, 1%);
+}
+.active {
+    transform: translate(0px, 1px) !important;
+}
+</style>
+<div id=inner></div>
+<script>
+requestAnimationFrame(function() {
+    var inner = document.getElementById('inner');
+    inner.className = 'active';
+    requestAnimationFrame(function() {});
+});
+</script>

--- a/tests/wpt/mozilla/tests/css/transition_calc_implicit_ref.html
+++ b/tests/wpt/mozilla/tests/css/transition_calc_implicit_ref.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html>


### PR DESCRIPTION
It should always be possible to interpolate between CalcLengthOrPercentage points.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12151 (github issue number if applicable).
- [ ] There are tests for these changes  (_I STILL NEED TO WRITE TESTS_)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12159)

<!-- Reviewable:end -->
