### PR TITLE
style: Do not re-expire animations.

### DIFF
--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -83,6 +83,7 @@ impl<Impl: SelectorImplExt> KeyframesAnimationState<Impl> {
     /// Returns true if the animation should keep running.
     pub fn tick(&mut self) -> bool {
         debug!("KeyframesAnimationState::tick");
+        debug_assert!(!self.expired);
 
         self.started_at += self.duration + self.delay;
         match self.running_state {
@@ -495,9 +496,9 @@ pub fn update_style_for_animation<Damage, Impl>(context: &SharedStyleContext<Imp
 where Impl: SelectorImplExt,
       Damage: TRestyleDamage<ConcreteComputedValues = Impl::ComputedValues> {
     debug!("update_style_for_animation: entering");
+    debug_assert!(!animation.is_expired());
     match *animation {
         Animation::Transition(_, start_time, ref frame, expired) => {
-            debug_assert!(!expired);
             debug!("update_style_for_animation: transition found");
             let now = time::precise_time_s();
             let mut new_style = (*style).clone();
@@ -513,7 +514,6 @@ where Impl: SelectorImplExt,
             }
         }
         Animation::Keyframes(_, ref name, ref state) => {
-            debug_assert!(!state.expired);
             debug!("update_style_for_animation: animation found: \"{}\", {:?}", name, state);
             let duration = state.duration;
             let started_at = state.started_at;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #12171 (github issue number if applicable).

<!-- Either: -->
- [x] These changes do not have tests because they depend on weird timing conditions.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

If we're restyling a page with animations and layout takes too long, we
might still have the expired animations from the last restyle, without these
being cleared out by layout on `tick_animations`.

Unfortunately it's hard (near to impossible?) to make a reduced test case for
this, since it heavily depends on the speed of the build and conditions that
only happen under heavy loads.

Mainly, it depends on how accurately the `TickAllAnimations` message is sent
from the constellation.

Thus, we can't just re-expire an animation, and we should re-check for it as a
previous animation.

Fixes #12171

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12185)

<!-- Reviewable:end -->
