### PR TITLE
WebDriver: Fix POST /session/:session_id/elements to return multiple

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -561,8 +561,8 @@ impl Handler {
         }
 
         let (sender, receiver) = ipc::channel().unwrap();
-        try!(self.frame_script_command(WebDriverScriptCommand::FindElementCSS(parameters.value.clone(),
-                                                                              sender)));
+        try!(self.frame_script_command(WebDriverScriptCommand::FindElementsCSS(parameters.value.clone(),
+                                                                               sender)));
         match receiver.recv().unwrap() {
             Ok(value) => {
                 let resp_value: Vec<Json> = value.into_iter().map(


### PR DESCRIPTION
Very unfamiliar with rust, but I'm trying to test servo with my Perl WebDriver module ( https://metacpan.org/pod/WebDriver::Tiny ) and fix any issues I come across. I hope to make my next commit implement find with the location strategy of link text.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because I don't believe there are WebDriver tests, I'd love to be wrong and pointed in the right direction though :-P

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12218)

<!-- Reviewable:end -->
