### PR TITLE
Avoid many uses of unwrap in font_cache_thread.rs

### DIFF
--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -165,11 +165,11 @@ impl FontCache {
             match msg {
                 Command::GetFontTemplate(family, descriptor, result) => {
                     let maybe_font_template = self.find_font_template(&family, &descriptor);
-                    result.send(Reply::GetFontTemplateReply(maybe_font_template)).unwrap();
+                    let _ = result.send(Reply::GetFontTemplateReply(maybe_font_template));
                 }
                 Command::GetLastResortFontTemplate(descriptor, result) => {
                     let font_template = self.last_resort_font_template(&descriptor);
-                    result.send(Reply::GetFontTemplateReply(Some(font_template))).unwrap();
+                    let _ = result.send(Reply::GetFontTemplateReply(Some(font_template)));
                 }
                 Command::AddWebFont(family_name, sources, result) => {
                     self.handle_add_web_font(family_name, sources, result);
@@ -180,7 +180,7 @@ impl FontCache {
                     drop(result.send(()));
                 }
                 Command::Exit(result) => {
-                    result.send(()).unwrap();
+                    let _ = result.send(());
                     break;
                 }
             }


### PR DESCRIPTION
Replaced `result.send(...blah...).unwrap()` with `let _ = result.send(...blah...);` in `components/gfx/font_cache_thread.rs`
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12188 
- [X] These changes do not require tests because @jdm said if it compiles it's good enough

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12237)

<!-- Reviewable:end -->
