### PR TITLE
Don't load stylesheets in documents without browsing contexts

### DIFF
--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -194,6 +194,10 @@ impl VirtualMethods for HTMLLinkElement {
 impl HTMLLinkElement {
     fn handle_stylesheet_url(&self, href: &str) {
         let document = document_from_node(self);
+        if document.browsing_context().is_none() {
+            return;
+        }
+
         match document.base_url().join(href) {
             Ok(url) => {
                 let element = self.upcast::<Element>();

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -36270,6 +36270,12 @@
             "path": "html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html",
             "url": "/html/browsers/browsing-the-web/navigating-across-documents/empty_fragment.html"
           }
+        ],
+        "html/semantics/document-metadata/the-link-element/document-without-browsing-context.html": [
+          {
+            "path": "html/semantics/document-metadata/the-link-element/document-without-browsing-context.html",
+            "url": "/html/semantics/document-metadata/the-link-element/document-without-browsing-context.html"
+          }
         ]
       }
     },

--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/document-without-browsing-context.html
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/document-without-browsing-context.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Documents without browsing contexts should not load stylesheets</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<body>
+<script>
+  function count(id, t) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', 'stylesheet.py?count=1&id=' + id);
+    xhr.onload = t.step_func_done(function() {
+      assert_equals(xhr.responseText, "1");
+    });
+    xhr.onerror = t.unreached_func();
+    xhr.send();
+  }
+
+  async_test(function(t) {
+    var id = token();
+    var doc = (new DOMParser()).parseFromString('<link rel="stylesheet" href="stylesheet.py?id=' + id + '"></link>', 'text/html');
+    var link = doc.querySelector('link');
+    document.head.appendChild(link);
+    t.step_timeout(function() { count(id, t) }, 500);
+  }, 'Create a document, adopt the node');
+
+  async_test(function(t) {
+    var id = token();
+    var d = document.createElement('div');
+    document.body.appendChild(d);
+    d.innerHTML = '<link rel="stylesheet" href="stylesheet.py?id=' + id + '"></link>';
+    t.step_timeout(function() { count(id, t) }, 500);
+  }, 'Create a stylesheet in innerHTML document');
+</script>
+</body>

--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet.py
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet.py
@@ -1,0 +1,9 @@
+def main(request, response):
+    try:
+        count = int(request.server.stash.take(request.GET["id"]))
+    except:
+        count = 0
+    if "count" in request.GET:
+        return str(count)
+    request.server.stash.put(request.GET["id"], str(count + 1))
+    return 'body { color: red }'


### PR DESCRIPTION
Per https://github.com/whatwg/html/issues/1495, this fixes the most commonly reported panic in nightlies by making us match what other browsers do.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12047 (github issue number if applicable).
- [X] There are tests for these changes OR

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12241)

<!-- Reviewable:end -->
