### PR TITLE
Missing steps of Characteristic's readValue, writeValue functions

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -57,6 +57,8 @@ pub enum Error {
     QuotaExceeded,
     /// TypeMismatchError DOMException
     TypeMismatch,
+    /// InvalidModificationError DOMException
+    InvalidModification,
 
     /// TypeError JavaScript Error
     Type(String),
@@ -97,6 +99,7 @@ pub unsafe fn throw_dom_exception(cx: *mut JSContext, global: GlobalRef, result:
         Error::NoModificationAllowed => DOMErrorName::NoModificationAllowedError,
         Error::QuotaExceeded => DOMErrorName::QuotaExceededError,
         Error::TypeMismatch => DOMErrorName::TypeMismatchError,
+        Error::InvalidModification => DOMErrorName::InvalidModificationError,
         Error::Type(message) => {
             assert!(!JS_IsExceptionPending(cx));
             throw_type_error(cx, &message);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add a check for the read property of the characteristic as described in https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-readvalue (Step 4.1)
Add two missing steps to characteristic's WriteValue function. https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-writevalue (Step 4 and 5)

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because, there are no Web Bluetooth test API implementation yet.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12261)

<!-- Reviewable:end -->
