### PR TITLE
Don't warn about reopening a crashed Servo window on Mac

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,26 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleGetInfoString</key>
-<string>Servo</string>
-<key>CFBundleExecutable</key>
-<string>run-servo</string>
-<key>CFBundleIdentifier</key>
-<string>org.servo.Servo22</string>
-<key>CFBundleName</key>
-<string>Servo</string>
-<key>CFBundleIconFile</key>
-<string>servo.icns</string>
-<key>CFBundleShortVersionString</key>
-<string>0.0.1</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundlePackageType</key>
-<string>APPL</string>
-<key>NSHighResolutionCapable</key>
-<true/>
-<key>NSPrincipalClass</key>
-<string>NSApplication</string>
+	<key>CFBundleExecutable</key>
+	<string>run-servo</string>
+	<key>CFBundleGetInfoString</key>
+	<string>Servo</string>
+	<key>CFBundleIconFile</key>
+	<string>servo.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.servo.Servo</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Servo</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.1</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSQuitAlwaysKeepsWindows</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Mac warns about reopening an application that crashed in the last run. With Servo this is
quite often the case, so we should get rid of the dialog.

Generated by running http://stackoverflow.com/a/20291771/1198729 on the plist file directly,
and then using plutil to convert back to xml. It got prettified in the process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12267)

<!-- Reviewable:end -->
