### PR TITLE
Snap text baseline to nearest pixel before positioning glyphs

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1558,11 +1558,14 @@ impl FragmentDisplayListBuilding for Fragment {
         let container_size = Size2D::zero();
         let metrics = &text_fragment.run.font_metrics;
         let stacking_relative_content_box = stacking_relative_content_box.translate(&offset);
-        let baseline_origin = stacking_relative_content_box.origin +
+        let mut baseline_origin = stacking_relative_content_box.origin +
             LogicalPoint::new(self.style.writing_mode,
                               Au(0),
                               metrics.ascent).to_physical(self.style.writing_mode,
                                                           container_size);
+        // Snap the baseline origin to a pixel boundary.
+        baseline_origin.x = Au::from_px(baseline_origin.x.to_nearest_px());
+        baseline_origin.y = Au::from_px(baseline_origin.y.to_nearest_px());
 
         // Create the text display item.
         let base = state.create_base_display_item(&stacking_relative_content_box,

--- a/tests/wpt/mozilla/meta/css/pixel_snapping_glyphs.html.ini
+++ b/tests/wpt/mozilla/meta/css/pixel_snapping_glyphs.html.ini
@@ -1,4 +1,0 @@
-[pixel_snapping_glyphs.html]
-  type: reftest
-  expected:
-    if os == "mac": FAIL


### PR DESCRIPTION
Fixes a test failure on Mac caused by sub-pixel-positioned glyphs being rounded in different directions depending on the baseline offset. r? @pcwalton

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12270)

<!-- Reviewable:end -->
