### PR TITLE
Fix installation location for downloaded std packages

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -211,7 +211,7 @@ class MachCommands(CommandBase):
                                       "rust-std%s%s-%s" % (nightly_suffix, stable_version, target_triple),
                                       "rust-std-%s" % target_triple, "lib", "rustlib", target_triple),
                             path.join(install_dir,
-                                      "rustc%s%s-%s" % (nightly_suffix, stable_version, host_triple),
+                                      "rustc%s%s-%s" % (nightly_suffix, stable_version, host_triple()),
                                       "rustc", "lib", "rustlib", target_triple))
             shutil.rmtree(path.join(install_dir,
                           "rust-std%s%s-%s" % (nightly_suffix, stable_version, target_triple)))


### PR DESCRIPTION
Fixes a "can't find crate for `std`" error in mach build. Regression from #11945. r? @larsbergstrom

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12271)

<!-- Reviewable:end -->
