### PR TITLE
Bail out gracefully on malformed kern table headers.

### DIFF
--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -113,11 +113,14 @@ impl FontHandle {
                     let pair_data_start = subtable_start + FORMAT_0_HEADER_LEN;
 
                     result.pair_data_range = pair_data_start..end;
+                    if result.pair_data_range.len() != n_pairs * KERN_PAIR_LEN {
+                        debug!("Bad data in kern header. Disable fast path.");
+                        return None;
+                    }
+
                     let pt_per_font_unit = self.ctfont.pt_size() as f64 /
                                            self.ctfont.units_per_em() as f64;
                     result.px_per_font_unit = pt_to_px(pt_per_font_unit);
-
-                    debug_assert_eq!(n_pairs * KERN_PAIR_LEN, result.pair_data_range.len());
                 }
                 start = end;
             }


### PR DESCRIPTION
This changes a debug assert to a debug log and early return.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #12081 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because I'm just removing an assertion

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12291)

<!-- Reviewable:end -->
