### PR TITLE
Consolidate runnable variants on DOMManipulationTask into a single Runnable variant.

### DIFF
--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -79,7 +79,7 @@ impl VirtualMethods for HTMLDetailsElement {
                 element: details,
                 toggle_number: counter
             };
-            let _ = task_source.queue(DOMManipulationTask::FireToggleEvent(runnable));
+            let _ = task_source.queue(DOMManipulationTask::Runnable(runnable));
         }
     }
 }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -484,8 +484,7 @@ impl HTMLFormElement {
         };
 
         // Step 3
-        window.dom_manipulation_task_source().queue(
-            DOMManipulationTask::PlannedNavigation(nav)).unwrap();
+        window.dom_manipulation_task_source().queue(DOMManipulationTask::Runnable(nav)).unwrap();
     }
 
     /// Interactively validate the constraints of form elements

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -183,7 +183,7 @@ impl HTMLImageElement {
                         src: src.into(),
                     });
                     let task = window.dom_manipulation_task_source();
-                    let _ = task.queue(DOMManipulationTask::Miscellaneous(runnable));
+                    let _ = task.queue(DOMManipulationTask::Runnable(runnable));
                 }
             }
         }

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -242,7 +242,7 @@ impl HTMLMediaElement {
             elem: Trusted::new(self),
         };
         let win = window_from_node(self);
-        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask::MediaTask(box task));
+        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask::Runnable(box task));
     }
 
     // https://html.spec.whatwg.org/multipage/#internal-pause-steps step 2.2
@@ -266,13 +266,13 @@ impl HTMLMediaElement {
             elem: Trusted::new(self),
         };
         let win = window_from_node(self);
-        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask::MediaTask(box task));
+        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask::Runnable(box task));
     }
 
     fn queue_fire_simple_event(&self, type_: &'static str) {
         let win = window_from_node(self);
         let task = FireSimpleEventTask::new(self, type_);
-        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask::MediaTask(box task));
+        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask::Runnable(box task));
     }
 
     fn fire_simple_event(&self, type_: &str) {
@@ -497,7 +497,7 @@ impl HTMLMediaElement {
 
     fn queue_dedicated_media_source_failure_steps(&self) {
         let _ = window_from_node(self).dom_manipulation_task_source().queue(
-            DOMManipulationTask::MediaTask(box DedicatedMediaSourceFailureTask::new(self)));
+            DOMManipulationTask::Runnable(box DedicatedMediaSourceFailureTask::new(self)));
     }
 
     // https://html.spec.whatwg.org/multipage/#dedicated-media-source-failure-steps

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -17,7 +17,7 @@ use dom::urlhelper::UrlHelper;
 use ipc_channel::ipc::{self, IpcSender};
 use net_traits::IpcSend;
 use net_traits::storage_thread::{StorageThreadMsg, StorageType};
-use script_thread::{MainThreadRunnable, ScriptThread};
+use script_thread::{Runnable, ScriptThread};
 use task_source::TaskSource;
 use task_source::dom_manipulation::DOMManipulationTask;
 use url::Url;
@@ -161,7 +161,7 @@ impl Storage {
         let global_ref = global_root.r();
         let task_source = global_ref.as_window().dom_manipulation_task_source();
         let trusted_storage = Trusted::new(self);
-        task_source.queue(DOMManipulationTask::SendStorageNotification(
+        task_source.queue(DOMManipulationTask::Runnable(
             box StorageEventRunnable::new(trusted_storage, key, old_value, new_value))).unwrap();
     }
 }
@@ -180,8 +180,8 @@ impl StorageEventRunnable {
     }
 }
 
-impl MainThreadRunnable for StorageEventRunnable {
-    fn handler(self: Box<StorageEventRunnable>, script_thread: &ScriptThread) {
+impl Runnable for StorageEventRunnable {
+    fn main_thread_handler(self: Box<StorageEventRunnable>, script_thread: &ScriptThread) {
         let this = *self;
         let storage_root = this.element.root();
         let storage = storage_root.r();

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -181,6 +181,8 @@ impl StorageEventRunnable {
 }
 
 impl Runnable for StorageEventRunnable {
+    fn name(&self) -> &'static str { "StorageEventRunnable" }
+
     fn main_thread_handler(self: Box<StorageEventRunnable>, script_thread: &ScriptThread) {
         let this = *self;
         let storage_root = this.element.root();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -200,11 +200,8 @@ impl<T: Runnable + Send> Runnable for CancellableRunnable<T> {
 
 pub trait Runnable {
     fn is_cancelled(&self) -> bool { false }
-    fn handler(self: Box<Self>);
-}
-
-pub trait MainThreadRunnable {
-    fn handler(self: Box<Self>, script_thread: &ScriptThread);
+    fn handler(self: Box<Self>) {}
+    fn main_thread_handler(self: Box<Self>, _script_thread: &ScriptThread) { self.handler(); }
 }
 
 enum MixedMessage {
@@ -1223,7 +1220,7 @@ impl ScriptThread {
 
         // https://html.spec.whatwg.org/multipage/#the-end step 7
         let handler = box DocumentProgressHandler::new(Trusted::new(doc));
-        self.dom_manipulation_task_source.queue(DOMManipulationTask::DocumentProgress(handler)).unwrap();
+        self.dom_manipulation_task_source.queue(DOMManipulationTask::Runnable(handler)).unwrap();
 
         self.constellation_chan.send(ConstellationMsg::LoadComplete(pipeline)).unwrap();
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -200,6 +200,7 @@ impl<T: Runnable + Send> Runnable for CancellableRunnable<T> {
 
 pub trait Runnable {
     fn is_cancelled(&self) -> bool { false }
+    fn name(&self) -> &'static str { "generic runnable" }
     fn handler(self: Box<Self>) {}
     fn main_thread_handler(self: Box<Self>, _script_thread: &ScriptThread) { self.handler(); }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Consolidates the runnable variants on `DOMManipulationTask` into a single `Runnable` variant.
Also combines `MainThreadRunnable` into the `Runnable` trait.

I plan on filing a few E-Easy issues after this lands to implement `name` on each of the structs that implement `Runnable`.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because refactoring

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12292)

<!-- Reviewable:end -->
