### PR TITLE
Correct negative margins in centered table cells

### DIFF
--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -80,8 +80,12 @@ impl TableCellFlow {
         if !flow::base(self).restyle_damage.contains(REFLOW) {
             return;
         }
+        // Note to the reader: this code has been tested with negative margins.
+        // We end up with a "end" that's before the "start," but the math still works out.
         let first_start = flow::base(self).children.front().map(|kid| {
+            let kid_base = flow::base(kid);
             flow::base(kid).position.start.b
+                - kid_base.collapsible_margins.block_start_margin_for_noncollapsible_context()
         });
         if let Some(mut first_start) = first_start {
             let mut last_end = first_start;

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -4960,6 +4960,18 @@
             "url": "/_mozilla/css/table_specified_width_a.html"
           }
         ],
+        "css/table_vertical_align_margin_padding.html": [
+          {
+            "path": "css/table_vertical_align_margin_padding.html",
+            "references": [
+              [
+                "/_mozilla/css/table_vertical_align_margin_padding_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/table_vertical_align_margin_padding.html"
+          }
+        ],
         "css/table_width_attribute_a.html": [
           {
             "path": "css/table_width_attribute_a.html",
@@ -12090,6 +12102,18 @@
             ]
           ],
           "url": "/_mozilla/css/table_specified_width_a.html"
+        }
+      ],
+      "css/table_vertical_align_margin_padding.html": [
+        {
+          "path": "css/table_vertical_align_margin_padding.html",
+          "references": [
+            [
+              "/_mozilla/css/table_vertical_align_margin_padding_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/table_vertical_align_margin_padding.html"
         }
       ],
       "css/table_width_attribute_a.html": [

--- a/tests/wpt/mozilla/tests/css/table_vertical_align_margin_padding.html
+++ b/tests/wpt/mozilla/tests/css/table_vertical_align_margin_padding.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Negative margins in a table with middle alignment</title>
+<link rel="match" href="table_vertical_align_margin_padding_ref.html">
+<style>table,tr,td{margin:0;padding:0;vertical-align:middle}</style>
+<h1>Test passes if there is a single green box</h1>
+<table><tr><td style="background:red">
+<div style="margin:-40px;padding:40px"><div style="background:green;width:40px;height:40px"></div></div>
+</td></tr></table>

--- a/tests/wpt/mozilla/tests/css/table_vertical_align_margin_padding_ref.html
+++ b/tests/wpt/mozilla/tests/css/table_vertical_align_margin_padding_ref.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Negative margins in table reference</title>
+<Style>table,tr,td{margin:0;padding:0;vertical-align:middle}</style>
+<h1>Test passes if there is a single green box</h1>
+<table><tr><td style="background:red">
+<div style="background:green;width:40px;height:40px"></div>
+</td></tr></table>
+


### PR DESCRIPTION
Fixes the cell-filling links on @AelitaBot [queue viewer page](http://ec2-52-26-55-30.us-west-2.compute.amazonaws.com/).

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] Couldn't find an applicable issue, and by the time I reduced the test case I'd already found the bug
- [X] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12293)

<!-- Reviewable:end -->
