### PR TITLE
Enable codegen_units in dev builds

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -24,6 +24,9 @@ max_log_level = ["log/release_max_level_info"]
 webdriver = ["webdriver_server"]
 energy-profiling = ["profile_traits/energy-profiling"]
 
+[profile.dev]
+codegen-units = 4
+
 [profile.release]
 opt-level = 3
 # Uncomment to profile on Linux:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

r? @metajack 

This re-enables the use of `codegen-units` on dev builds, which should be fine because dev's perf is already atrocious anyway. The difference on my i7 iMac:
full build goes from 6m 30s to 6m
rebuild of just the script crate goes from 3m25s to 2m45s

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12297)

<!-- Reviewable:end -->
