### PR TITLE
Partial flex implementation of flex-grow, flex-shrink and flex-basis for inline mode

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -488,6 +488,7 @@ pub enum BlockType {
     FloatNonReplaced,
     InlineBlockReplaced,
     InlineBlockNonReplaced,
+    Flex,
 }
 
 #[derive(Clone, PartialEq)]
@@ -579,6 +580,8 @@ impl BlockFlow {
             } else {
                 BlockType::InlineBlockNonReplaced
             }
+        } else if self.base.flags.is_flex() {
+            BlockType::Flex
         } else {
             if self.is_replaced_content() {
                 BlockType::Replaced
@@ -626,6 +629,12 @@ impl BlockFlow {
             }
             BlockType::InlineBlockNonReplaced => {
                 let inline_size_computer = InlineBlockNonReplaced;
+                inline_size_computer.compute_used_inline_size(self,
+                                                              shared_context,
+                                                              containing_block_inline_size);
+            }
+            BlockType::Flex => {
+                let inline_size_computer = FlexBlock;
                 inline_size_computer.compute_used_inline_size(self,
                                                               shared_context,
                                                               containing_block_inline_size);
@@ -2568,6 +2577,7 @@ pub struct FloatNonReplaced;
 pub struct FloatReplaced;
 pub struct InlineBlockNonReplaced;
 pub struct InlineBlockReplaced;
+pub struct FlexBlock;
 
 impl ISizeAndMarginsComputer for AbsoluteNonReplaced {
     /// Solve the horizontal constraint equation for absolute non-replaced elements.
@@ -3055,6 +3065,23 @@ impl ISizeAndMarginsComputer for InlineBlockReplaced {
         // For replaced block flow, the rest of the constraint solving will
         // take inline-size to be specified as the value computed here.
         MaybeAuto::Specified(fragment.content_inline_size())
+    }
+}
+
+impl ISizeAndMarginsComputer for FlexBlock {
+    /// Compute inline-start and inline-end margins and inline-size.
+    fn solve_inline_size_constraints(&self,
+                                     block: &mut BlockFlow,
+                                     input: &ISizeConstraintInput)
+                                     -> ISizeConstraintSolution {
+        let new_input = ISizeConstraintInput::new(MaybeAuto::Auto,
+               input.inline_start_margin,
+               input.inline_end_margin,
+               input.inline_start,
+               input.inline_end,
+               input.text_align,
+               input.available_inline_size);
+        self.solve_block_inline_size_constraints(block, &new_input)
     }
 }
 

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -531,7 +531,9 @@ pub struct BlockFlow {
 bitflags! {
     flags BlockFlowFlags: u8 {
         #[doc = "If this is set, then this block flow is the root flow."]
-        const IS_ROOT = 0x01,
+        const IS_ROOT = 0b0000_0001,
+        #[doc = "If this is set, then this block flow is a child of a flex flow."]
+        const IS_FLEX = 0b0000_0010,
     }
 }
 
@@ -580,7 +582,7 @@ impl BlockFlow {
             } else {
                 BlockType::InlineBlockNonReplaced
             }
-        } else if self.base.flags.is_flex() {
+        } else if self.is_flex() {
             BlockType::Flex
         } else {
             if self.is_replaced_content() {
@@ -1690,6 +1692,14 @@ impl BlockFlow {
         }
         let padding = self.fragment.style.logical_padding();
         padding.block_start.is_definitely_zero() && padding.block_end.is_definitely_zero()
+    }
+
+    pub fn mark_as_flex(&mut self) {
+        self.flags.insert(IS_FLEX)
+    }
+
+    fn is_flex(&self) -> bool {
+        self.flags.contains(IS_FLEX)
     }
 }
 

--- a/components/layout/flex.rs
+++ b/components/layout/flex.rs
@@ -14,7 +14,7 @@ use euclid::Point2D;
 use floats::FloatKind;
 use flow;
 use flow::{Flow, FlowClass, ImmutableFlowUtils, OpaqueFlow};
-use flow::{INLINE_POSITION_IS_STATIC, IS_ABSOLUTELY_POSITIONED, IS_FLEX};
+use flow::{INLINE_POSITION_IS_STATIC, IS_ABSOLUTELY_POSITIONED};
 use flow_ref::{self, FlowRef};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
 use gfx::display_list::StackingContext;
@@ -290,8 +290,11 @@ impl FlexFlow {
                 0_f32
             };
 
-            let base = flow::mut_base(flow_ref::deref_mut(&mut kid.flow));
-            base.flags.insert(IS_FLEX);
+            let flowref = flow_ref::deref_mut(&mut kid.flow);
+            if flowref.is_block_like() {
+                flowref.as_mut_block().mark_as_flex();
+            }
+            let base = flow::mut_base(flowref);
             base.block_container_inline_size = max(kid.basis + Au::from_f32_px(grow_by), Au(0));
             base.block_container_writing_mode = container_mode;
             base.block_container_explicit_block_size = block_container_explicit_block_size;

--- a/components/layout/flex.rs
+++ b/components/layout/flex.rs
@@ -14,7 +14,7 @@ use euclid::Point2D;
 use floats::FloatKind;
 use flow;
 use flow::{Flow, FlowClass, ImmutableFlowUtils, OpaqueFlow};
-use flow::{INLINE_POSITION_IS_STATIC, IS_ABSOLUTELY_POSITIONED};
+use flow::{INLINE_POSITION_IS_STATIC, IS_ABSOLUTELY_POSITIONED, IS_FLEX};
 use flow_ref::{self, FlowRef};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
 use gfx::display_list::StackingContext;
@@ -28,7 +28,8 @@ use style::computed_values::flex_direction;
 use style::logical_geometry::LogicalSize;
 use style::properties::{ComputedValues, ServoComputedValues};
 use style::servo::SharedStyleContext;
-use style::values::computed::{LengthOrPercentage, LengthOrPercentageOrAuto, LengthOrPercentageOrNone};
+use style::values::computed::LengthOrPercentageOrNone;
+use style::values::computed::{LengthOrPercentage, LengthOrPercentageOrAuto, LengthOrPercentageOrAutoOrContent};
 
 /// The size of an axis. May be a specified size, a min/max
 /// constraint, or an unlimited size
@@ -78,12 +79,14 @@ enum Mode {
 #[derive(Debug)]
 struct FlexItem {
     pub flow: FlowRef,
+    pub basis: Au,
 }
 
 impl FlexItem {
     fn new(flow: FlowRef) -> FlexItem {
         FlexItem {
-            flow: flow
+            flow: flow,
+            basis: Au(0)
         }
     }
 }
@@ -226,9 +229,6 @@ impl FlexFlow {
         }
     }
 
-    // TODO(zentner): This function should actually flex elements!
-    // Currently, this is the core of InlineFlow::propagate_assigned_inline_size_to_children() with
-    // fragment logic stripped out.
     fn inline_mode_assign_inline_sizes(&mut self,
                                        _shared_context: &SharedStyleContext,
                                        inline_start_content_edge: Au,
@@ -251,7 +251,22 @@ impl FlexFlow {
             AxisSize::Infinite => content_inline_size,
         };
 
-        let even_content_inline_size = inline_size / child_count;
+        let mut grow_count = 0_f32;
+        let mut shrink_count = 0_f32;
+        let mut grow_space_available = inline_size;
+        for kid in &mut self.items {
+            let kidbase = flow_ref::deref_mut(&mut kid.flow);
+            let base = flow::base(kidbase);
+            let css = kidbase.as_block().fragment.style.get_position();
+            grow_count = grow_count + css.flex_grow;
+            shrink_count = shrink_count + css.flex_shrink;
+            kid.basis = match css.flex_basis {
+                            LengthOrPercentageOrAutoOrContent::Length(length) => length,
+                            LengthOrPercentageOrAutoOrContent::Percentage(percent) => inline_size.scale_by(percent),
+                            _ => base.intrinsic_inline_sizes.preferred_inline_size
+                        };
+            grow_space_available = grow_space_available - kid.basis;
+        }
 
         let container_mode = self.block_flow.base.block_container_writing_mode;
         self.block_flow.base.position.size.inline = inline_size;
@@ -262,18 +277,30 @@ impl FlexFlow {
         } else {
             self.block_flow.fragment.border_box.size.inline
         };
-        for kid in &mut self.items {
-            let base = flow::mut_base(flow_ref::deref_mut(&mut kid.flow));
 
-            base.block_container_inline_size = even_content_inline_size;
+        for kid in &mut self.items {
+            let grow_by = if grow_space_available < Au(0) && shrink_count > 0_f32 {
+                // TODO shrink based on scaled_shrink_factor
+                let percent_shrink = kid.flow.as_block().fragment.style.get_position().flex_shrink / shrink_count;
+                Au::to_f32_px(grow_space_available) * percent_shrink
+            } else if grow_space_available > Au(0) && grow_count > 0_f32 {
+                let percent_grow = kid.flow.as_block().fragment.style.get_position().flex_grow / grow_count;
+                Au::to_f32_px(grow_space_available) * percent_grow
+            } else {
+                0_f32
+            };
+
+            let base = flow::mut_base(flow_ref::deref_mut(&mut kid.flow));
+            base.flags.insert(IS_FLEX);
+            base.block_container_inline_size = max(kid.basis + Au::from_f32_px(grow_by), Au(0));
             base.block_container_writing_mode = container_mode;
             base.block_container_explicit_block_size = block_container_explicit_block_size;
             if !self.is_reverse {
               base.position.start.i = inline_child_start;
-              inline_child_start = inline_child_start + even_content_inline_size;
+              inline_child_start = inline_child_start + base.block_container_inline_size;
             } else {
-              base.position.start.i = inline_child_start - base.intrinsic_inline_sizes.preferred_inline_size;
-              inline_child_start = inline_child_start - even_content_inline_size;
+              inline_child_start = inline_child_start - base.block_container_inline_size;
+              base.position.start.i = inline_child_start;
             };
         }
     }

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -679,8 +679,6 @@ bitflags! {
 
         /// Whether this flow contains any text and/or replaced fragments.
         const CONTAINS_TEXT_OR_REPLACED_FRAGMENTS = 0b0001_0000_0000_0000_0000_0000,
-
-        const IS_FLEX = 0b0010_0000_0000_0000_0000_0000,
     }
 }
 
@@ -720,11 +718,6 @@ impl FlowFlags {
     #[inline]
     pub fn clears_floats(&self) -> bool {
         self.contains(CLEARS_LEFT) || self.contains(CLEARS_RIGHT)
-    }
-
-    #[inline]
-    pub fn is_flex(&self) -> bool {
-        self.contains(IS_FLEX)
     }
 }
 

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -679,6 +679,8 @@ bitflags! {
 
         /// Whether this flow contains any text and/or replaced fragments.
         const CONTAINS_TEXT_OR_REPLACED_FRAGMENTS = 0b0001_0000_0000_0000_0000_0000,
+
+        const IS_FLEX = 0b0010_0000_0000_0000_0000_0000,
     }
 }
 
@@ -718,6 +720,11 @@ impl FlowFlags {
     #[inline]
     pub fn clears_floats(&self) -> bool {
         self.contains(CLEARS_LEFT) || self.contains(CLEARS_RIGHT)
+    }
+
+    #[inline]
+    pub fn is_flex(&self) -> bool {
+        self.contains(IS_FLEX)
     }
 }
 

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-001.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-001.htm.ini
@@ -1,3 +1,0 @@
-[align-content-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-002.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-002.htm.ini
@@ -1,3 +1,0 @@
-[align-content-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-003.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-003.htm.ini
@@ -1,3 +1,0 @@
-[align-content-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-004.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-004.htm.ini
@@ -1,3 +1,0 @@
-[align-content-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-005.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-005.htm.ini
@@ -1,3 +1,0 @@
-[align-content-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-006.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/align-content-006.htm.ini
@@ -1,3 +1,0 @@
-[align-content-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-003.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-003.htm.ini
@@ -1,3 +1,0 @@
-[flex-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-001.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-001.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-002.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-002.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-003.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-003.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-004.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-004.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-005.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-005.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-006.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-006.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-008.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-basis-008.htm.ini
@@ -1,3 +1,0 @@
-[flex-basis-008.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-flow-001.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-flow-001.htm.ini
@@ -1,3 +1,0 @@
-[flex-flow-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-flow-004.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-flow-004.htm.ini
@@ -1,3 +1,0 @@
-[flex-flow-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-grow-002.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-grow-002.htm.ini
@@ -1,3 +1,0 @@
-[flex-grow-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-grow-003.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-grow-003.htm.ini
@@ -1,3 +1,0 @@
-[flex-grow-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-grow-005.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-grow-005.htm.ini
@@ -1,3 +1,0 @@
-[flex-grow-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-grow-006.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-grow-006.htm.ini
@@ -1,3 +1,0 @@
-[flex-grow-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-001.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-001.htm.ini
@@ -1,3 +1,0 @@
-[flex-shrink-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-002.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-002.htm.ini
@@ -1,3 +1,0 @@
-[flex-shrink-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-003.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-003.htm.ini
@@ -1,3 +1,0 @@
-[flex-shrink-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-004.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-004.htm.ini
@@ -1,3 +1,0 @@
-[flex-shrink-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-005.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-005.htm.ini
@@ -1,3 +1,0 @@
-[flex-shrink-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-006.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-006.htm.ini
@@ -1,3 +1,0 @@
-[flex-shrink-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-007.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-shrink-007.htm.ini
@@ -1,3 +1,0 @@
-[flex-shrink-007.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox-anonymous-items-001.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox-anonymous-items-001.htm.ini
@@ -1,3 +1,0 @@
-[flexbox-anonymous-items-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox-flex-wrap-default.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox-flex-wrap-default.htm.ini
@@ -1,3 +1,0 @@
-[flexbox-flex-wrap-default.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox-flex-wrap-nowrap.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox-flex-wrap-nowrap.htm.ini
@@ -1,3 +1,0 @@
-[flexbox-flex-wrap-nowrap.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_align-items-stretch-writing-modes.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_align-items-stretch-writing-modes.htm.ini
@@ -1,0 +1,3 @@
+[flexbox_align-items-stretch-writing-modes.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_direction-row-reverse.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_direction-row-reverse.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_direction-row-reverse.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/justify-content-002.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/justify-content-002.htm.ini
@@ -1,3 +1,0 @@
-[justify-content-002.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Implemented flex-grow, flex-shrink, and flex-basis for the case where flex-direction is row or row-reverse. Prior to this change elements would not actually flex.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12191

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12298)

<!-- Reviewable:end -->
