### PR TITLE
Take selection direction into account when setting selection

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -651,8 +651,17 @@ impl<T: ClipboardProvider> TextInput<T> {
             start = end;
         }
 
-        self.selection_begin = Some(self.get_text_point_for_absolute_point(start));
-        self.edit_point = self.get_text_point_for_absolute_point(end);
+        match self.selection_direction {
+            SelectionDirection::None |
+            SelectionDirection::Forward => {
+                self.selection_begin = Some(self.get_text_point_for_absolute_point(start));
+                self.edit_point = self.get_text_point_for_absolute_point(end);
+            },
+            SelectionDirection::Backward => {
+                self.selection_begin = Some(self.get_text_point_for_absolute_point(end));
+                self.edit_point = self.get_text_point_for_absolute_point(start);
+            }
+        }
         self.assert_ok_selection();
     }
 

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -458,3 +458,26 @@ fn test_textinput_cursor_position_correct_after_clearing_selection() {
     assert_eq!(textinput.edit_point.index, 0);
     assert_eq!(textinput.edit_point.line, 0);
 }
+
+
+#[test]
+fn test_textinput_set_selection_with_direction() {
+    let mut textinput = text_input(Lines::Single, "abcdef");
+    textinput.selection_direction = SelectionDirection::Forward;
+    textinput.set_selection_range(2, 6);
+    assert_eq!(textinput.edit_point.line, 0);
+    assert_eq!(textinput.edit_point.index, 6);
+
+    assert!(textinput.selection_begin.is_some());
+    assert_eq!(textinput.selection_begin.unwrap().line, 0);
+    assert_eq!(textinput.selection_begin.unwrap().index, 2);
+
+    textinput.selection_direction = SelectionDirection::Backward;
+    textinput.set_selection_range(2, 6);
+    assert_eq!(textinput.edit_point.line, 0);
+    assert_eq!(textinput.edit_point.index, 2);
+
+    assert!(textinput.selection_begin.is_some());
+    assert_eq!(textinput.selection_begin.unwrap().line, 0);
+    assert_eq!(textinput.selection_begin.unwrap().index, 6);
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

r? @asajeffrey 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12300 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12301)

<!-- Reviewable:end -->
