### PR TITLE
[tidy] Test json parsing functionality

### DIFF
--- a/python/tidy/servo_tidy_tests/malformed_json.json
+++ b/python/tidy/servo_tidy_tests/malformed_json.json
@@ -1,0 +1,4 @@
+{
+    "key": "value",
+    "other_key": "value_with_bad_quote'
+}

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -104,6 +104,11 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('emacs file variables present', errors.next()[2])
         self.assertNoMoreErrors(errors)
 
+    def test_malformed_json(self):
+        errors = tidy.collect_errors_for_files(iterFile('malformed_json.json'), [tidy.check_json], [], print_text=False)
+        self.assertEqual('Invalid control character at: line 3 column 40 (char 61)', errors.next()[2])
+        self.assertNoMoreErrors(errors)
+
     def test_lock(self):
         errors = tidy.collect_errors_for_files(iterFile('duplicated_package.lock'), [tidy.check_lock], [], print_text=False)
         msg = """duplicate versions for package "test"


### PR DESCRIPTION
We didn't have a test for json parsing so lets start with that

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12317)

<!-- Reviewable:end -->
