### PR TITLE
[tidy] prevent duplicate json keys

### DIFF
--- a/python/tidy/servo_tidy_tests/duplicate_key.json
+++ b/python/tidy/servo_tidy_tests/duplicate_key.json
@@ -1,0 +1,7 @@
+{
+    "key": "value",
+    "other_key": {
+        "the_duplicated_key": 1,
+        "the_duplicated_key": 2
+    }
+}

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -109,6 +109,11 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('Invalid control character at: line 3 column 40 (char 61)', errors.next()[2])
         self.assertNoMoreErrors(errors)
 
+    def test_json_with_duplicate_key(self):
+        errors = tidy.collect_errors_for_files(iterFile('duplicate_key.json'), [tidy.check_json], [], print_text=False)
+        self.assertEqual('Duplicated Key (the_duplicated_key)', errors.next()[2])
+        self.assertNoMoreErrors(errors)
+
     def test_lock(self):
         errors = tidy.collect_errors_for_files(iterFile('duplicated_package.lock'), [tidy.check_lock], [], print_text=False)
         msg = """duplicate versions for package "test"


### PR DESCRIPTION
Throws a tidy error when duplicated keys are present.
![screenshot from 2016-07-07 16-54-17](https://cloud.githubusercontent.com/assets/557689/16658260/fd19cece-4465-11e6-89b1-a79296ba6a72.png)

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12283 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12318)

<!-- Reviewable:end -->
