### PR TITLE
Add ability to WPT-test file uploads and fetches, fixes #12322

### DIFF
--- a/components/net_traits/filemanager_thread.rs
+++ b/components/net_traits/filemanager_thread.rs
@@ -118,10 +118,10 @@ pub struct FilterPattern(pub String);
 #[derive(Deserialize, Serialize)]
 pub enum FileManagerThreadMsg {
     /// Select a single file, return triple (FileID, FileName, lastModified)
-    SelectFile(Vec<FilterPattern>, IpcSender<FileManagerResult<SelectedFile>>, FileOrigin),
+    SelectFile(Vec<FilterPattern>, IpcSender<FileManagerResult<SelectedFile>>, FileOrigin, Option<String>),
 
     /// Select multiple files, return a vector of triples
-    SelectFiles(Vec<FilterPattern>, IpcSender<FileManagerResult<Vec<SelectedFile>>>, FileOrigin),
+    SelectFiles(Vec<FilterPattern>, IpcSender<FileManagerResult<Vec<SelectedFile>>>, FileOrigin, Option<Vec<String>>),
 
     /// Read file, return the bytes
     ReadFile(IpcSender<FileManagerResult<Vec<u8>>>, SelectedFileId, FileOrigin),

--- a/components/script/dom/webidls/HTMLInputElement.webidl
+++ b/components/script/dom/webidls/HTMLInputElement.webidl
@@ -70,6 +70,11 @@ interface HTMLInputElement : HTMLElement {
   void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 
   // also has obsolete members
+
+  // Select with file-system paths for testing purpose
+  [Pref="dom.testing.htmlinputelement.select_files.enabled"]
+  void selectFiles(sequence<DOMString> path);
+
 };
 
 // https://html.spec.whatwg.org/multipage/#HTMLInputElement-partial

--- a/tests/unit/net/filemanager_thread.rs
+++ b/tests/unit/net/filemanager_thread.rs
@@ -40,7 +40,7 @@ fn test_filemanager() {
     {
         // Try to select a dummy file "tests/unit/net/test.txt"
         let (tx, rx) = ipc::channel().unwrap();
-        chan.send(FileManagerThreadMsg::SelectFile(patterns.clone(), tx, origin.clone())).unwrap();
+        chan.send(FileManagerThreadMsg::SelectFile(patterns.clone(), tx, origin.clone(), None)).unwrap();
         let selected = rx.recv().expect("Broken channel")
                                 .expect("The file manager failed to find test.txt");
 
@@ -88,7 +88,7 @@ fn test_filemanager() {
 
     {
         let (tx, rx) = ipc::channel().unwrap();
-        let _ = chan.send(FileManagerThreadMsg::SelectFile(patterns.clone(), tx, origin.clone()));
+        let _ = chan.send(FileManagerThreadMsg::SelectFile(patterns.clone(), tx, origin.clone(), None));
 
         assert!(rx.try_recv().is_err(), "The thread should not respond normally after exited");
     }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6456,6 +6456,12 @@
             "url": "/_mozilla/mozilla/event_listener.html"
           }
         ],
+        "mozilla/file_upload.html": [
+          {
+            "path": "mozilla/file_upload.html",
+            "url": "/_mozilla/mozilla/file_upload.html"
+          }
+        ],
         "mozilla/focus_blur.html": [
           {
             "path": "mozilla/focus_blur.html",

--- a/tests/wpt/mozilla/meta/mozilla/file_upload.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/file_upload.html.ini
@@ -1,0 +1,3 @@
+[file_upload.html]
+  type: testharness
+  prefs: [dom.testing.htmlinputelement.select_files.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/file_upload.html
+++ b/tests/wpt/mozilla/tests/mozilla/file_upload.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test of uploading a file through input element</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body><input id="file-input" type="file"></body>
+
+<script>
+
+async_test(function() {
+  var e = document.getElementById("file-input");
+
+  assert_true(e.selectFiles != undefined, "selectFiles is not defined")
+
+  e.selectFiles(["./tests/wpt/mozilla/tests/mozilla/test.txt"]);
+
+  assert_true(e.files.length > 0, "test.txt is not selected");
+
+  var reader = new FileReader;
+
+  reader.onloadend = this.step_func(function(evt) {
+    assert_equals(evt.target.result, "hello, servo\n");
+
+    this.done();
+  });
+
+  reader.readAsText(e.files[0]);
+
+}, "Select a file");
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/test.txt
+++ b/tests/wpt/mozilla/tests/mozilla/test.txt
@@ -1,0 +1,1 @@
+hello, servo


### PR DESCRIPTION
Using `inputElem.selectFiles(["path1", "path2"])` in JavaScript with pref `dom.htmlinputelement.select_files.enabled` = `true` will simulate the effect of `inputElem.click()`.

See #12322  for more, also related to #12343, #11131.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12344)

<!-- Reviewable:end -->
