### PR TITLE
[prefs] deal with duplduplicated keys

### DIFF
--- a/components/util/prefs.rs
+++ b/components/util/prefs.rs
@@ -156,11 +156,16 @@ pub fn read_prefs_from_file<T>(mut file: T)
     let mut prefs = HashMap::new();
     if let Json::Object(obj) = json {
         for (name, value) in obj.into_iter() {
-            match Pref::from_json(value) {
-                Ok(x) => {
-                    prefs.insert(name, x);
-                },
-                Err(_) => println!("Ignoring non-boolean/string/i64 preference value for {:?}", name),
+            if prefs.contains_key(&name) {
+                println!("Ignoring redeclaration for pref {:?}", name);
+                continue;
+            } else {
+                match Pref::from_json(value) {
+                    Ok(x) => {
+                        prefs.insert(name, x);
+                    },
+                    Err(_) => println!("Ignoring non-boolean/string/i64 preference value for {:?}", name),
+                }
             }
         }
     }

--- a/tests/unit/util/prefs.rs
+++ b/tests/unit/util/prefs.rs
@@ -73,3 +73,15 @@ fn test_default_config_dir_create_read_write() {
 
     fs::remove_file(&json_path).unwrap();
 }
+
+#[test]
+fn test_handles_duplicated_prefs_key() {
+  let json_str = "{\
+  \"layout.writing-mode.enabled\": true,\
+  \"layout.writing-mode.enabled\": false\
+}";
+
+    let prefs = read_prefs_from_file(json_str.as_bytes());
+    let prefs = prefs.unwrap();
+    assert_eq!(prefs.len(), 1);
+}


### PR DESCRIPTION
Follow up to #12283 - prints a message if we detect duplicate keys. Any recommendations for better handling? Whats the normal way to do error logging?

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12347)

<!-- Reviewable:end -->
