### PR TITLE
Add name method for Runnable trait in DedicatedMediaSourceFailureTask…

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -777,6 +777,8 @@ impl DedicatedMediaSourceFailureTask {
 }
 
 impl Runnable for DedicatedMediaSourceFailureTask {
+    fn name(&self) -> &'static str { "DedicatedMediaSourceFailureTask" }
+
     fn handler(self: Box<DedicatedMediaSourceFailureTask>) {
         self.elem.root().dedicated_media_source_failure();
     }

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -759,6 +759,8 @@ impl ResourceSelectionTask {
 }
 
 impl Runnable for ResourceSelectionTask {
+    fn name(&self) -> &'static str { "ResourceSelectionTask" }
+
     fn handler(self: Box<ResourceSelectionTask>) {
         self.elem.root().resource_selection_algorithm_sync(self.base_url);
     }


### PR DESCRIPTION
Add name method for Runnable trait in DedicatedMediaSourceFailureTask.
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12349.
- [X] These changes do not require tests because it is says so in the issue description.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12360)

<!-- Reviewable:end -->
