### PR TITLE
Treat flex flow as block in float calculation

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -588,7 +588,7 @@ impl FlowClass {
         match self {
             FlowClass::Block | FlowClass::ListItem | FlowClass::Table | FlowClass::TableRowGroup |
             FlowClass::TableRow | FlowClass::TableCaption | FlowClass::TableCell |
-            FlowClass::TableWrapper => true,
+            FlowClass::TableWrapper | FlowClass::Flex => true,
             _ => false,
         }
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is on of my pull requests that implement basic flexible box layout.
Currently call `is_block_like()` on flex flow returns false. This would fix some errors in tests, for example 'flexbox-justify-content-horiz-001b.htm'.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because flexbox is not implemented yet.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12371)

<!-- Reviewable:end -->
