### PR TITLE
Improve performance of HTMLDivElement constructor

### DIFF
--- a/components/script/dom/htmldivelement.rs
+++ b/components/script/dom/htmldivelement.rs
@@ -28,8 +28,9 @@ impl HTMLDivElement {
     pub fn new(localName: Atom,
                prefix: Option<DOMString>,
                document: &Document) -> Root<HTMLDivElement> {
-        let element = HTMLDivElement::new_inherited(localName, prefix, document);
-        Node::reflect_node(box element, document, HTMLDivElementBinding::Wrap)
+        Node::reflect_node(box HTMLDivElement::new_inherited(localName, prefix, document),
+                           document,
+                           HTMLDivElementBinding::Wrap)
     }
 }
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1082,7 +1082,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.3"
-source = "git+https://github.com/servo/rust-mozjs#7ccfee50f407841b8cd03b6520a2b9db866ac90a"
+source = "git+https://github.com/servo/rust-mozjs#3ea62135ba1316b4aa845b18cf621bf127b56211"
 dependencies = [
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -991,7 +991,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.3"
-source = "git+https://github.com/servo/rust-mozjs#7ccfee50f407841b8cd03b6520a2b9db866ac90a"
+source = "git+https://github.com/servo/rust-mozjs#3ea62135ba1316b4aa845b18cf621bf127b56211"
 dependencies = [
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
These changes address two sources of performance loss seen while profiling in #12354. #12358 and https://github.com/rust-lang/rust/issues/34727 are still the biggest offenders, however. 

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because we don't have performance tests and these are only optimizations

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12374)

<!-- Reviewable:end -->
