### PR TITLE
Build geckolib with MozillaBuild on Windows

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -332,7 +332,7 @@ class MachCommands(CommandBase):
             opts += ["--release"]
 
         env = self.build_env()
-        env["CARGO_TARGET_DIR"] = path.join(self.context.topdir, "target", "geckolib")
+        env["CARGO_TARGET_DIR"] = path.join(self.context.topdir, "target", "geckolib").encode("UTF-8")
 
         build_start = time()
         with cd(path.join("ports", "geckolib")):

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -41,7 +41,9 @@ def host_triple():
         os_type = "apple-darwin"
     elif os_type == "android":
         os_type = "linux-androideabi"
-    elif os_type == "windows" or os_type.startswith("mingw64_nt-") or os_type.startswith("cygwin_nt-"):
+    elif os_type == "windows":
+        os_type = "pc-windows-msvc"
+    elif os_type.startswith("mingw64_nt-") or os_type.startswith("cygwin_nt-"):
         os_type = "pc-windows-gnu"
     elif os_type == "freebsd":
         os_type = "unknown-freebsd"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Given #12319 removes the direct dependency of geckolib to gcc, geckolib is now compilable without gcc, and thus builds within MozillaBuild.

This changeset also changes the triple to use the MSVC backend rather than GNU for Windows . I'm not sure whether this change is necessary, but given we use MSVC to compile Gecko on Windows, I think we would eventually need this anyway. Triples for MinGW64 and Cygwin are unchanged, so that existing build targets should not be broken.

Servo itself is still not buildable with MozillaBuild. To make that work, some changes to mozjs are necessary as well.

It is probably worth some infra coverage to avoid regression.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors (on MinGW)
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it only changes build system

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

r? @bholley

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12377)

<!-- Reviewable:end -->
