### PR TITLE
layout: Clear non-inherited properties on anonymous block

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -1304,6 +1304,9 @@ impl<'a> ImmutableFlowUtils for &'a Flow {
                 Arc::new(TableCellFlow::from_node_fragment_and_visibility_flag(node, fragment, !hide))
             },
             FlowClass::Flex => {
+                properties::modify_style_for_anonymous_flow(
+                    &mut style,
+                    display::T::block);
                 let fragment =
                     Fragment::from_opaque_node_and_style(node.opaque(),
                                                          PseudoElementType::Normal,

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1972,6 +1972,47 @@ pub fn cascade<C: ComputedValues>(
     (style, cacheable)
 }
 
+pub fn modify_style_for_anonymous_flow(style: &mut Arc<ServoComputedValues>,
+                                      new_display_value: longhands::display::computed_value::T) {
+    // The 'align-self' property needs some special treatment since
+    // its value depends on the 'align-items' value of its parent.
+    % if "align-items" in data.longhands_by_name:
+        use computed_values::align_self::T as align_self;
+        use computed_values::align_items::T as align_items;
+        let self_align =
+            match style.position.align_items {
+                align_items::stretch => align_self::stretch,
+                align_items::baseline => align_self::baseline,
+                align_items::flex_start => align_self::flex_start,
+                align_items::flex_end => align_self::flex_end,
+                align_items::center => align_self::center,
+            };
+    % endif
+    let inital_values = &*INITIAL_SERVO_VALUES;
+    let mut style = Arc::make_mut(style);
+    % for style_struct in data.active_style_structs():
+    % if not style_struct.inherited:
+        style.${style_struct.ident} = inital_values.clone_${style_struct.trait_name_lower}();
+    % endif
+    % endfor
+    % if "align-items" in data.longhands_by_name:
+       let position = Arc::make_mut(&mut style.position);
+       position.align_self = self_align;
+    % endif
+    if new_display_value != longhands::display::computed_value::T::inline {
+        let new_box = Arc::make_mut(&mut style.box_);
+        new_box.display = new_display_value;
+    }
+    let border = Arc::make_mut(&mut style.border);
+    % for side in ["top", "right", "bottom", "left"]:
+        // Like calling to_computed_value, which wouldn't type check.
+        border.border_${side}_width = Au(0);
+    % endfor
+    // Initial value of outline-style is always none for anonymous box.
+    let outline = Arc::make_mut(&mut style.outline);
+    outline.outline_width = Au(0);
+}
+
 /// Alters the given style to accommodate replaced content. This is called in flow construction. It
 /// handles cases like `<div style="position: absolute">foo bar baz</div>` (in which `foo`, `bar`,
 /// and `baz` must not be absolutely-positioned) and cases like `<sup>Foo</sup>` (in which the

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_generated-flex.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_generated-flex.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_generated-flex.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is one of my pull requests that imlement basic flexible box layout.
This pull request adds a `modify_style_for_anonymous_flow()` function to use initial values for non-inherited properties and parent values for inherited properties as the flow style. It also set border and outline to zero and set the display property from the parameter. This function may also be reused to modify style of anonymous table object in the future.
Part of code comes from `cascade_anonymous()` from @SimonSapin .

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because flexbox is not implemented yet.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12382)

<!-- Reviewable:end -->
