### PR TITLE
Let textarea wrap lines

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -29,7 +29,6 @@ use gfx::display_list::{LayeredItem, LayerInfo, LineDisplayItem, OpaqueNode};
 use gfx::display_list::{SolidColorDisplayItem, StackingContext, StackingContextType};
 use gfx::display_list::{TextDisplayItem, TextOrientation, WebRenderImageInfo};
 use gfx::paint_thread::THREAD_TINT_COLORS;
-use gfx::text::glyph::ByteIndex;
 use gfx_traits::{color, ScrollPolicy, StackingContextId};
 use inline::{FIRST_FRAGMENT_OF_ELEMENT, InlineFlow, LAST_FRAGMENT_OF_ELEMENT};
 use ipc_channel::ipc;
@@ -970,7 +969,8 @@ impl FragmentDisplayListBuilding for Fragment {
             Some(insertion_point_index) => insertion_point_index,
             None => return,
         };
-        let range = Range::new(ByteIndex(0), insertion_point_index);
+        let range = Range::new(scanned_text_fragment_info.range.begin(),
+                               insertion_point_index - scanned_text_fragment_info.range.begin());
         let advance = scanned_text_fragment_info.run.advance_for_range(&range);
 
         let insertion_point_bounds;

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2130,10 +2130,6 @@ pub fn modify_style_for_input_text(style: &mut Arc<ServoComputedValues>) {
     margin_style.margin_right = computed::LengthOrPercentageOrAuto::Length(Au(0));
     margin_style.margin_bottom = computed::LengthOrPercentageOrAuto::Length(Au(0));
     margin_style.margin_left = computed::LengthOrPercentageOrAuto::Length(Au(0));
-
-    // whitespace inside text input should not be collapsed
-    let inherited_text = Arc::make_mut(&mut style.inheritedtext);
-    inherited_text.white_space = longhands::white_space::computed_value::T::pre;
 }
 
 /// Adjusts the `clip` property so that an inline absolute hypothetical fragment doesn't clip its

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -9,7 +9,7 @@ input {
   color: black;
   font-family: sans-serif;
   font-size: 0.8333em;
-  white-space: nowrap;
+  white-space: pre;
   text-align: left;
   line-height: 1.8;
 }
@@ -24,7 +24,7 @@ textarea {
   color: black;
   font-family: sans-serif;
   font-size: 0.8333em;
-  white-space: pre;
+  white-space: pre-wrap;
 }
 
 input::selection,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
1. Change textarea's style from white-space: pre to white-space: pre-wrap.
2. Display insertion point when a line is wrapped.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #10053 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12388)

<!-- Reviewable:end -->
