### PR TITLE
Fix Blob type-string

### DIFF
--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -17,7 +17,6 @@ use ipc_channel::ipc;
 use net_traits::IpcSend;
 use net_traits::blob_url_store::BlobBuf;
 use net_traits::filemanager_thread::{FileManagerThreadMsg, SelectedFileId, RelativePos};
-use std::ascii::AsciiExt;
 use std::cell::Cell;
 use std::ops::Index;
 use std::path::PathBuf;
@@ -86,7 +85,9 @@ impl Blob {
         Blob {
             reflector_: Reflector::new(),
             blob_impl: DOMRefCell::new(blob_impl),
-            typeString: typeString,
+            // NOTE: Guarding the format correctness here,
+            // https://w3c.github.io/FileAPI/#dfn-type
+            typeString: normalize_type_string(&typeString),
             isClosed_: Cell::new(false),
         }
     }
@@ -135,7 +136,7 @@ impl Blob {
             }
         };
 
-        Ok(Blob::new(global, BlobImpl::new_from_bytes(bytes), blobPropertyBag.get_typestring()))
+        Ok(Blob::new(global, BlobImpl::new_from_bytes(bytes), blobPropertyBag.type_.to_string()))
     }
 
     /// Get a slice to inner data, this might incur synchronous read and caching
@@ -332,20 +333,8 @@ impl BlobMethods for Blob {
              end: Option<i64>,
              contentType: Option<DOMString>)
              -> Root<Blob> {
-        let relativeContentType = match contentType {
-            None => DOMString::new(),
-            Some(mut str) => {
-                if is_ascii_printable(&str) {
-                    str.make_ascii_lowercase();
-                    str
-                } else {
-                    DOMString::new()
-                }
-            }
-        };
-
         let rel_pos = RelativePos::from_opts(start, end);
-        Blob::new_sliced(self, rel_pos, relativeContentType)
+        Blob::new_sliced(self, rel_pos, contentType.unwrap_or(DOMString::from("")))
     }
 
     // https://w3c.github.io/FileAPI/#dfn-isClosed
@@ -368,15 +357,20 @@ impl BlobMethods for Blob {
     }
 }
 
-impl BlobBinding::BlobPropertyBag {
-    /// Get the normalized inner type string
-    /// https://w3c.github.io/FileAPI/#dfn-type
-    pub fn get_typestring(&self) -> String {
-        if is_ascii_printable(&self.type_) {
-            self.type_.to_lowercase()
-        } else {
-            "".to_string()
-        }
+/// Get the normalized, MIME-parsable type string
+/// https://w3c.github.io/FileAPI/#dfn-type
+/// XXX: We will relax the restriction here,
+/// since the spec has some problem over this part.
+/// see https://github.com/w3c/FileAPI/issues/43
+fn normalize_type_string(s: &str) -> String {
+    if is_ascii_printable(s) {
+        let s_lower = s.to_lowercase();
+        // match s_lower.parse() as Result<Mime, ()> {
+            // Ok(_) => s_lower,
+            // Err(_) => "".to_string()
+        s_lower
+    } else {
+        "".to_string()
     }
 }
 

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -55,7 +55,7 @@ impl File {
         let global = GlobalRef::Window(window);
 
         File::new(global, BlobImpl::new_from_file(selected.id, selected.filename, selected.size),
-                  name, Some(selected.modified as i64), "")
+                  name, Some(selected.modified as i64), &selected.type_string)
     }
 
     // https://w3c.github.io/FileAPI/#file-constructor
@@ -70,10 +70,10 @@ impl File {
         };
 
         let ref blobPropertyBag = filePropertyBag.parent;
-        let typeString = blobPropertyBag.get_typestring();
+        let ref typeString = blobPropertyBag.type_;
 
         let modified = filePropertyBag.lastModified;
-        Ok(File::new(global, BlobImpl::new_from_bytes(bytes), filename, modified, &typeString))
+        Ok(File::new(global, BlobImpl::new_from_bytes(bytes), filename, modified, typeString))
     }
 
     pub fn name(&self) -> &DOMString {


### PR DESCRIPTION
Use a final construction guard over type-string format; and other minor related cleanups

r? @Manishearth 

<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12400)

<!-- Reviewable:end -->
