### PR TITLE
Clean up task sources and make all tasks cancellable

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1488,11 +1488,12 @@ impl Document {
 
         update_with_current_time_ms(&self.dom_content_loaded_event_start);
 
-        self.window().dom_manipulation_task_source().queue_event(self.upcast(), atom!("DOMContentLoaded"),
-            EventBubbles::Bubbles, EventCancelable::NotCancelable);
-        self.window().reflow(ReflowGoal::ForDisplay,
-                             ReflowQueryType::NoQuery,
-                             ReflowReason::DOMContentLoaded);
+        let window = self.window();
+        window.dom_manipulation_task_source().queue_event(self.upcast(), atom!("DOMContentLoaded"),
+            EventBubbles::Bubbles, EventCancelable::NotCancelable, window);
+        window.reflow(ReflowGoal::ForDisplay,
+                      ReflowQueryType::NoQuery,
+                      ReflowReason::DOMContentLoaded);
 
         update_with_current_time_ms(&self.dom_content_loaded_event_end);
     }

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -73,7 +73,7 @@ impl VirtualMethods for HTMLDetailsElement {
             let window = window_from_node(self);
             let task_source = window.dom_manipulation_task_source();
             let details = Trusted::new(self);
-            let runnable = DetailsNotificationRunnable {
+            let runnable = box DetailsNotificationRunnable {
                 element: details,
                 toggle_number: counter
             };

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -19,7 +19,6 @@ use script_thread::Runnable;
 use std::cell::Cell;
 use string_cache::Atom;
 use task_source::TaskSource;
-use task_source::dom_manipulation::DOMManipulationTask;
 
 #[dom_struct]
 pub struct HTMLDetailsElement {
@@ -72,14 +71,13 @@ impl VirtualMethods for HTMLDetailsElement {
             self.toggle_counter.set(counter);
 
             let window = window_from_node(self);
-            let window = window.r();
             let task_source = window.dom_manipulation_task_source();
             let details = Trusted::new(self);
-            let runnable = box DetailsNotificationRunnable {
+            let runnable = DetailsNotificationRunnable {
                 element: details,
                 toggle_number: counter
             };
-            let _ = task_source.queue(DOMManipulationTask(runnable));
+            let _ = task_source.queue(runnable, window.r());
         }
     }
 }

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -79,7 +79,7 @@ impl VirtualMethods for HTMLDetailsElement {
                 element: details,
                 toggle_number: counter
             };
-            let _ = task_source.queue(DOMManipulationTask::Runnable(runnable));
+            let _ = task_source.queue(DOMManipulationTask(runnable));
         }
     }
 }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -53,7 +53,6 @@ use string_cache::Atom;
 use style::attr::AttrValue;
 use style::str::split_html_space_chars;
 use task_source::TaskSource;
-use task_source::dom_manipulation::DOMManipulationTask;
 use url::form_urlencoded;
 
 #[derive(JSTraceable, PartialEq, Clone, Copy, HeapSizeOf)]
@@ -475,7 +474,7 @@ impl HTMLFormElement {
         self.generation_id.set(GenerationId(prev_id + 1));
 
         // Step 2
-        let nav = box PlannedNavigation {
+        let nav = PlannedNavigation {
             load_data: load_data,
             pipeline_id: window.pipeline(),
             script_chan: window.main_thread_script_chan().clone(),
@@ -484,7 +483,7 @@ impl HTMLFormElement {
         };
 
         // Step 3
-        window.dom_manipulation_task_source().queue(DOMManipulationTask(nav)).unwrap();
+        window.dom_manipulation_task_source().queue(nav, window).unwrap();
     }
 
     /// Interactively validate the constraints of form elements

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -484,7 +484,7 @@ impl HTMLFormElement {
         };
 
         // Step 3
-        window.dom_manipulation_task_source().queue(DOMManipulationTask::Runnable(nav)).unwrap();
+        window.dom_manipulation_task_source().queue(DOMManipulationTask(nav)).unwrap();
     }
 
     /// Interactively validate the constraints of form elements

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -474,7 +474,7 @@ impl HTMLFormElement {
         self.generation_id.set(GenerationId(prev_id + 1));
 
         // Step 2
-        let nav = PlannedNavigation {
+        let nav = box PlannedNavigation {
             load_data: load_data,
             pipeline_id: window.pipeline(),
             script_chan: window.main_thread_script_chan().clone(),

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -140,7 +140,7 @@ impl HTMLImageElement {
                         // Return the image via a message to the script thread, which marks the element
                         // as dirty and triggers a reflow.
                         let image_response = message.to().unwrap();
-                        let runnable = ImageResponseHandlerRunnable::new(
+                        let runnable = box ImageResponseHandlerRunnable::new(
                             trusted_node.clone(), image_response);
                         let runnable = wrapper.wrap_runnable(runnable);
                         let _ = script_chan.send(CommonScriptMsg::RunnableMsg(
@@ -179,7 +179,7 @@ impl HTMLImageElement {
                         }
                     }
 
-                    let runnable = ImgParseErrorRunnable {
+                    let runnable = box ImgParseErrorRunnable {
                         img: Trusted::new(self),
                         src: src.into(),
                     };

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -32,7 +32,6 @@ use std::sync::Arc;
 use string_cache::Atom;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use task_source::TaskSource;
-use task_source::dom_manipulation::DOMManipulationTask;
 use url::Url;
 
 #[derive(JSTraceable, HeapSizeOf)]
@@ -180,12 +179,12 @@ impl HTMLImageElement {
                         }
                     }
 
-                    let runnable = Box::new(ImgParseErrorRunnable {
+                    let runnable = ImgParseErrorRunnable {
                         img: Trusted::new(self),
                         src: src.into(),
-                    });
+                    };
                     let task = window.dom_manipulation_task_source();
-                    let _ = task.queue(DOMManipulationTask(runnable));
+                    let _ = task.queue(runnable, window);
                 }
             }
         }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -185,7 +185,7 @@ impl HTMLImageElement {
                         src: src.into(),
                     });
                     let task = window.dom_manipulation_task_source();
-                    let _ = task.queue(DOMManipulationTask::Runnable(runnable));
+                    let _ = task.queue(DOMManipulationTask(runnable));
                 }
             }
         }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -576,7 +576,8 @@ impl HTMLInputElementMethods for HTMLInputElement {
             &self.upcast(),
             atom!("select"),
             EventBubbles::Bubbles,
-            EventCancelable::NotCancelable);
+            EventCancelable::NotCancelable,
+            window.r());
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
     }
 
@@ -1061,7 +1062,8 @@ impl VirtualMethods for HTMLInputElement {
                                     &self.upcast(),
                                     atom!("input"),
                                     EventBubbles::Bubbles,
-                                    EventCancelable::NotCancelable);
+                                    EventCancelable::NotCancelable,
+                                    window.r());
                             }
 
                             self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -33,7 +33,6 @@ use std::cell::Cell;
 use std::sync::{Arc, Mutex};
 use string_cache::Atom;
 use task_source::TaskSource;
-use task_source::dom_manipulation::DOMManipulationTask;
 use time::{self, Timespec, Duration};
 use url::Url;
 
@@ -242,7 +241,7 @@ impl HTMLMediaElement {
             elem: Trusted::new(self),
         };
         let win = window_from_node(self);
-        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask(box task));
+        let _ = win.dom_manipulation_task_source().queue(task, win.r());
     }
 
     // https://html.spec.whatwg.org/multipage/#internal-pause-steps step 2.2
@@ -266,13 +265,13 @@ impl HTMLMediaElement {
             elem: Trusted::new(self),
         };
         let win = window_from_node(self);
-        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask(box task));
+        let _ = win.dom_manipulation_task_source().queue(task, win.r());
     }
 
     fn queue_fire_simple_event(&self, type_: &'static str) {
         let win = window_from_node(self);
         let task = FireSimpleEventTask::new(self, type_);
-        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask(box task));
+        let _ = win.dom_manipulation_task_source().queue(task, win.r());
     }
 
     fn fire_simple_event(&self, type_: &str) {
@@ -498,8 +497,8 @@ impl HTMLMediaElement {
     }
 
     fn queue_dedicated_media_source_failure_steps(&self) {
-        let _ = window_from_node(self).dom_manipulation_task_source().queue(
-            DOMManipulationTask(box DedicatedMediaSourceFailureTask::new(self)));
+        let window = window_from_node(self);
+        let _ = window.dom_manipulation_task_source().queue(DedicatedMediaSourceFailureTask::new(self), window.r());
     }
 
     // https://html.spec.whatwg.org/multipage/#dedicated-media-source-failure-steps

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -242,7 +242,7 @@ impl HTMLMediaElement {
             elem: Trusted::new(self),
         };
         let win = window_from_node(self);
-        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask::Runnable(box task));
+        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask(box task));
     }
 
     // https://html.spec.whatwg.org/multipage/#internal-pause-steps step 2.2
@@ -266,13 +266,13 @@ impl HTMLMediaElement {
             elem: Trusted::new(self),
         };
         let win = window_from_node(self);
-        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask::Runnable(box task));
+        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask(box task));
     }
 
     fn queue_fire_simple_event(&self, type_: &'static str) {
         let win = window_from_node(self);
         let task = FireSimpleEventTask::new(self, type_);
-        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask::Runnable(box task));
+        let _ = win.dom_manipulation_task_source().queue(DOMManipulationTask(box task));
     }
 
     fn fire_simple_event(&self, type_: &str) {
@@ -499,7 +499,7 @@ impl HTMLMediaElement {
 
     fn queue_dedicated_media_source_failure_steps(&self) {
         let _ = window_from_node(self).dom_manipulation_task_source().queue(
-            DOMManipulationTask::Runnable(box DedicatedMediaSourceFailureTask::new(self)));
+            DOMManipulationTask(box DedicatedMediaSourceFailureTask::new(self)));
     }
 
     // https://html.spec.whatwg.org/multipage/#dedicated-media-source-failure-steps

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -237,7 +237,7 @@ impl HTMLMediaElement {
             }
         }
 
-        let task = Task {
+        let task = box Task {
             elem: Trusted::new(self),
         };
         let win = window_from_node(self);
@@ -261,7 +261,7 @@ impl HTMLMediaElement {
             }
         }
 
-        let task = Task {
+        let task = box Task {
             elem: Trusted::new(self),
         };
         let win = window_from_node(self);
@@ -270,7 +270,7 @@ impl HTMLMediaElement {
 
     fn queue_fire_simple_event(&self, type_: &'static str) {
         let win = window_from_node(self);
-        let task = FireSimpleEventTask::new(self, type_);
+        let task = box FireSimpleEventTask::new(self, type_);
         let _ = win.dom_manipulation_task_source().queue(task, win.r());
     }
 
@@ -498,7 +498,7 @@ impl HTMLMediaElement {
 
     fn queue_dedicated_media_source_failure_steps(&self) {
         let window = window_from_node(self);
-        let _ = window.dom_manipulation_task_source().queue(DedicatedMediaSourceFailureTask::new(self), window.r());
+        let _ = window.dom_manipulation_task_source().queue(box DedicatedMediaSourceFailureTask::new(self), window.r());
     }
 
     // https://html.spec.whatwg.org/multipage/#dedicated-media-source-failure-steps

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -460,12 +460,13 @@ impl HTMLScriptElement {
         if external {
             self.dispatch_load_event();
         } else {
-            window.dom_manipulation_task_source().queue_simple_event(self.upcast(), atom!("load"));
+            window.dom_manipulation_task_source().queue_simple_event(self.upcast(), atom!("load"), window.r());
         }
     }
 
     pub fn queue_error_event(&self) {
-        window_from_node(self).dom_manipulation_task_source().queue_simple_event(self.upcast(), atom!("error"));
+        let window = window_from_node(self);
+        window.dom_manipulation_task_source().queue_simple_event(self.upcast(), atom!("error"), window.r());
     }
 
     pub fn dispatch_before_script_execute_event(&self) -> bool {

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -260,7 +260,8 @@ impl HTMLTextAreaElementMethods for HTMLTextAreaElement {
             &self.upcast(),
             atom!("select"),
             EventBubbles::Bubbles,
-            EventCancelable::NotCancelable);
+            EventCancelable::NotCancelable,
+            window.r());
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
     }
 }
@@ -383,7 +384,8 @@ impl VirtualMethods for HTMLTextAreaElement {
                                 &self.upcast(),
                                 atom!("input"),
                                 EventBubbles::Bubbles,
-                                EventCancelable::NotCancelable);
+                                EventCancelable::NotCancelable,
+                                window.r());
                         }
 
                         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -19,7 +19,6 @@ use net_traits::IpcSend;
 use net_traits::storage_thread::{StorageThreadMsg, StorageType};
 use script_thread::{Runnable, ScriptThread};
 use task_source::TaskSource;
-use task_source::dom_manipulation::DOMManipulationTask;
 use url::Url;
 
 #[dom_struct]
@@ -159,10 +158,10 @@ impl Storage {
                                      new_value: Option<String>) {
         let global_root = self.global();
         let global_ref = global_root.r();
-        let task_source = global_ref.as_window().dom_manipulation_task_source();
+        let window = global_ref.as_window();
+        let task_source = window.dom_manipulation_task_source();
         let trusted_storage = Trusted::new(self);
-        task_source.queue(DOMManipulationTask(
-            box StorageEventRunnable::new(trusted_storage, key, old_value, new_value))).unwrap();
+        task_source.queue(StorageEventRunnable::new(trusted_storage, key, old_value, new_value), window).unwrap();
     }
 }
 

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -161,7 +161,7 @@ impl Storage {
         let global_ref = global_root.r();
         let task_source = global_ref.as_window().dom_manipulation_task_source();
         let trusted_storage = Trusted::new(self);
-        task_source.queue(DOMManipulationTask::Runnable(
+        task_source.queue(DOMManipulationTask(
             box StorageEventRunnable::new(trusted_storage, key, old_value, new_value))).unwrap();
     }
 }

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -161,7 +161,7 @@ impl Storage {
         let window = global_ref.as_window();
         let task_source = window.dom_manipulation_task_source();
         let trusted_storage = Trusted::new(self);
-        task_source.queue(StorageEventRunnable::new(trusted_storage, key, old_value, new_value), window).unwrap();
+        task_source.queue(box StorageEventRunnable::new(trusted_storage, key, old_value, new_value), window).unwrap();
     }
 }
 

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -19,14 +19,14 @@ pub struct NetworkListener<Listener: PreInvoke + Send + 'static> {
 
 impl<Listener: PreInvoke + Send + 'static> NetworkListener<Listener> {
     pub fn notify<A: Action<Listener> + Send + 'static>(&self, action: A) {
-        let runnable = ListenerRunnable {
+        let runnable = box ListenerRunnable {
             context: self.context.clone(),
             action: action,
         };
         let result = if let Some(ref wrapper) = self.wrapper {
             self.script_chan.send(CommonScriptMsg::RunnableMsg(NetworkEvent, wrapper.wrap_runnable(runnable)))
         } else {
-            self.script_chan.send(CommonScriptMsg::RunnableMsg(NetworkEvent, box runnable))
+            self.script_chan.send(CommonScriptMsg::RunnableMsg(NetworkEvent, runnable))
         };
         if let Err(err) = result {
             warn!("failed to deliver network data: {:?}", err);

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -23,16 +23,13 @@ impl<Listener: PreInvoke + Send + 'static> NetworkListener<Listener> {
             context: self.context.clone(),
             action: action,
         };
-        if let Some(ref wrapper) = self.wrapper {
-            if let Err(err) = self.script_chan.send(
-                CommonScriptMsg::RunnableMsg(NetworkEvent, wrapper.wrap_runnable(runnable))) {
-                warn!("failed to deliver network data: {:?}", err);
-            }
+        let result = if let Some(ref wrapper) = self.wrapper {
+            self.script_chan.send(CommonScriptMsg::RunnableMsg(NetworkEvent, wrapper.wrap_runnable(runnable)))
         } else {
-            if let Err(err) = self.script_chan.send(
-                CommonScriptMsg::RunnableMsg(NetworkEvent, box runnable)) {
-                warn!("failed to deliver network data: {:?}", err);
-            }
+            self.script_chan.send(CommonScriptMsg::RunnableMsg(NetworkEvent, box runnable))
+        };
+        if let Err(err) = result {
+            warn!("failed to deliver network data: {:?}", err);
         }
     }
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -982,7 +982,7 @@ impl ScriptThread {
             MainThreadScriptMsg::DOMManipulation(task) =>
                 task.handle_task(self),
             MainThreadScriptMsg::UserInteraction(task) =>
-                task.handle_task(),
+                task.handle_task(self),
         }
     }
 
@@ -1221,7 +1221,7 @@ impl ScriptThread {
 
         // https://html.spec.whatwg.org/multipage/#the-end step 7
         let handler = box DocumentProgressHandler::new(Trusted::new(doc));
-        self.dom_manipulation_task_source.queue(DOMManipulationTask::Runnable(handler)).unwrap();
+        self.dom_manipulation_task_source.queue(DOMManipulationTask(handler)).unwrap();
 
         self.constellation_chan.send(ConstellationMsg::LoadComplete(pipeline)).unwrap();
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -189,8 +189,14 @@ pub struct CancellableRunnable<T: Runnable + Send> {
 }
 
 impl<T: Runnable + Send> Runnable for CancellableRunnable<T> {
+    fn name(&self) -> &'static str { self.inner.name() }
+
     fn is_cancelled(&self) -> bool {
         self.cancelled.load(Ordering::SeqCst)
+    }
+
+    fn main_thread_handler(self: Box<CancellableRunnable<T>>, script_thread: &ScriptThread) {
+        self.inner.main_thread_handler(script_thread);
     }
 
     fn handler(self: Box<CancellableRunnable<T>>) {
@@ -1220,8 +1226,8 @@ impl ScriptThread {
         doc.mut_loader().inhibit_events();
 
         // https://html.spec.whatwg.org/multipage/#the-end step 7
-        let handler = box DocumentProgressHandler::new(Trusted::new(doc));
-        self.dom_manipulation_task_source.queue(DOMManipulationTask(handler)).unwrap();
+        let handler = DocumentProgressHandler::new(Trusted::new(doc));
+        self.dom_manipulation_task_source.queue(handler, doc.window()).unwrap();
 
         self.constellation_chan.send(ConstellationMsg::LoadComplete(pipeline)).unwrap();
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -174,10 +174,10 @@ pub struct RunnableWrapper {
 }
 
 impl RunnableWrapper {
-    pub fn wrap_runnable<T: Runnable + Send + 'static>(&self, runnable: T) -> Box<Runnable + Send> {
+    pub fn wrap_runnable<T: Runnable + Send + 'static>(&self, runnable: Box<T>) -> Box<Runnable + Send> {
         box CancellableRunnable {
             cancelled: self.cancelled.clone(),
-            inner: box runnable,
+            inner: runnable,
         }
     }
 }
@@ -1226,7 +1226,7 @@ impl ScriptThread {
         doc.mut_loader().inhibit_events();
 
         // https://html.spec.whatwg.org/multipage/#the-end step 7
-        let handler = DocumentProgressHandler::new(Trusted::new(doc));
+        let handler = box DocumentProgressHandler::new(Trusted::new(doc));
         self.dom_manipulation_task_source.queue(handler, doc.window()).unwrap();
 
         self.constellation_chan.send(ConstellationMsg::LoadComplete(pipeline)).unwrap();

--- a/components/script/task_source/dom_manipulation.rs
+++ b/components/script/task_source/dom_manipulation.rs
@@ -16,7 +16,7 @@ use task_source::TaskSource;
 pub struct DOMManipulationTaskSource(pub Sender<MainThreadScriptMsg>);
 
 impl TaskSource for DOMManipulationTaskSource {
-    fn queue<T: Runnable + Send + 'static>(&self, msg: T, window: &Window) -> Result<(), ()> {
+    fn queue<T: Runnable + Send + 'static>(&self, msg: Box<T>, window: &Window) -> Result<(), ()> {
         let msg = DOMManipulationTask(window.get_runnable_wrapper().wrap_runnable(msg));
         self.0.send(MainThreadScriptMsg::DOMManipulation(msg)).map_err(|_| ())
     }
@@ -30,7 +30,7 @@ impl DOMManipulationTaskSource {
                        cancelable: EventCancelable,
                        window: &Window) {
         let target = Trusted::new(target);
-        let runnable = EventRunnable {
+        let runnable = box EventRunnable {
             target: target,
             name: name,
             bubbles: bubbles,
@@ -41,7 +41,7 @@ impl DOMManipulationTaskSource {
 
     pub fn queue_simple_event(&self, target: &EventTarget, name: Atom, window: &Window) {
         let target = Trusted::new(target);
-        let runnable = SimpleEventRunnable {
+        let runnable = box SimpleEventRunnable {
             target: target,
             name: name,
         };

--- a/components/script/task_source/mod.rs
+++ b/components/script/task_source/mod.rs
@@ -13,5 +13,5 @@ use script_thread::Runnable;
 use std::result::Result;
 
 pub trait TaskSource {
-    fn queue<T: Runnable + Send + 'static>(&self, msg: T, window: &Window) -> Result<(), ()>;
+    fn queue<T: Runnable + Send + 'static>(&self, msg: Box<T>, window: &Window) -> Result<(), ()>;
 }

--- a/components/script/task_source/mod.rs
+++ b/components/script/task_source/mod.rs
@@ -8,8 +8,10 @@ pub mod history_traversal;
 pub mod networking;
 pub mod user_interaction;
 
+use dom::window::Window;
+use script_thread::Runnable;
 use std::result::Result;
 
-pub trait TaskSource<T> {
-    fn queue(&self, msg: T) -> Result<(), ()>;
+pub trait TaskSource {
+    fn queue<T: Runnable + Send + 'static>(&self, msg: T, window: &Window) -> Result<(), ()>;
 }

--- a/components/script/task_source/user_interaction.rs
+++ b/components/script/task_source/user_interaction.rs
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::refcounted::Trusted;
-use dom::event::{EventBubbles, EventCancelable};
+use dom::event::{EventBubbles, EventCancelable, EventRunnable};
 use dom::eventtarget::EventTarget;
-use script_thread::MainThreadScriptMsg;
+use script_thread::{MainThreadScriptMsg, Runnable, ScriptThread};
 use std::result::Result;
 use std::sync::mpsc::Sender;
 use string_cache::Atom;
@@ -22,30 +22,27 @@ impl TaskSource<UserInteractionTask> for UserInteractionTaskSource {
 
 impl UserInteractionTaskSource {
     pub fn queue_event(&self,
-                   target: &EventTarget,
-                   name: Atom,
-                   bubbles: EventBubbles,
-                   cancelable: EventCancelable) {
+                       target: &EventTarget,
+                       name: Atom,
+                       bubbles: EventBubbles,
+                       cancelable: EventCancelable) {
         let target = Trusted::new(target);
-        let _ = self.0.send(MainThreadScriptMsg::UserInteraction(UserInteractionTask::FireEvent(
-            target, name, bubbles, cancelable)));
+        let runnable = box EventRunnable {
+            target: target,
+            name: name,
+            bubbles: bubbles,
+            cancelable: cancelable,
+        };
+        let _ = self.queue(UserInteractionTask(runnable));
     }
 }
 
-pub enum UserInteractionTask {
-    // https://dom.spec.whatwg.org/#concept-event-fire
-    FireEvent(Trusted<EventTarget>, Atom, EventBubbles, EventCancelable),
-}
+pub struct UserInteractionTask(pub Box<Runnable + Send>);
 
 impl UserInteractionTask {
-    pub fn handle_task(self) {
-        use self::UserInteractionTask::*;
-
-        match self {
-            FireEvent(element, name, bubbles, cancelable) => {
-                let target = element.root();
-                target.fire_event(&*name, bubbles, cancelable);
-            }
+    pub fn handle_task(self, script_thread: &ScriptThread) {
+        if !self.0.is_cancelled() {
+            self.0.main_thread_handler(script_thread);
         }
     }
 }

--- a/components/script/task_source/user_interaction.rs
+++ b/components/script/task_source/user_interaction.rs
@@ -5,6 +5,7 @@
 use dom::bindings::refcounted::Trusted;
 use dom::event::{EventBubbles, EventCancelable, EventRunnable};
 use dom::eventtarget::EventTarget;
+use dom::window::Window;
 use script_thread::{MainThreadScriptMsg, Runnable, ScriptThread};
 use std::result::Result;
 use std::sync::mpsc::Sender;
@@ -14,8 +15,9 @@ use task_source::TaskSource;
 #[derive(JSTraceable, Clone)]
 pub struct UserInteractionTaskSource(pub Sender<MainThreadScriptMsg>);
 
-impl TaskSource<UserInteractionTask> for UserInteractionTaskSource {
-    fn queue(&self, msg: UserInteractionTask) -> Result<(), ()> {
+impl TaskSource for UserInteractionTaskSource {
+    fn queue<T: Runnable + Send + 'static>(&self, msg: T, window: &Window) -> Result<(), ()> {
+        let msg = UserInteractionTask(window.get_runnable_wrapper().wrap_runnable(msg));
         self.0.send(MainThreadScriptMsg::UserInteraction(msg)).map_err(|_| ())
     }
 }
@@ -25,15 +27,16 @@ impl UserInteractionTaskSource {
                        target: &EventTarget,
                        name: Atom,
                        bubbles: EventBubbles,
-                       cancelable: EventCancelable) {
+                       cancelable: EventCancelable,
+                       window: &Window) {
         let target = Trusted::new(target);
-        let runnable = box EventRunnable {
+        let runnable = EventRunnable {
             target: target,
             name: name,
             bubbles: bubbles,
             cancelable: cancelable,
         };
-        let _ = self.queue(UserInteractionTask(runnable));
+        let _ = self.queue(runnable, window);
     }
 }
 

--- a/components/script/task_source/user_interaction.rs
+++ b/components/script/task_source/user_interaction.rs
@@ -16,7 +16,7 @@ use task_source::TaskSource;
 pub struct UserInteractionTaskSource(pub Sender<MainThreadScriptMsg>);
 
 impl TaskSource for UserInteractionTaskSource {
-    fn queue<T: Runnable + Send + 'static>(&self, msg: T, window: &Window) -> Result<(), ()> {
+    fn queue<T: Runnable + Send + 'static>(&self, msg: Box<T>, window: &Window) -> Result<(), ()> {
         let msg = UserInteractionTask(window.get_runnable_wrapper().wrap_runnable(msg));
         self.0.send(MainThreadScriptMsg::UserInteraction(msg)).map_err(|_| ())
     }
@@ -30,7 +30,7 @@ impl UserInteractionTaskSource {
                        cancelable: EventCancelable,
                        window: &Window) {
         let target = Trusted::new(target);
-        let runnable = EventRunnable {
+        let runnable = box EventRunnable {
             target: target,
             name: name,
             bubbles: bubbles,

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/change_parentage.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/change_parentage.html.ini
@@ -1,3 +1,0 @@
-[change_parentage.html]
-  type: testharness
-  disabled: https://github.com/servo/servo/issues/11703


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This makes it so each task is a thin wrapper over a runnable and whenever a task is queued, it is automatically wrapped by the window's `runnable_wrapper`.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix  #11703 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12404)

<!-- Reviewable:end -->
