### PR TITLE
Replace residual C code with Rust in codegen

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -6046,7 +6046,7 @@ class CallbackMember(CGNativeMember):
             # It's been done for us already
             return ""
         return (
-            "CallSetup s(CallbackPreserveColor(), aRv, aExceptionHandling);\n"
+            "let s = CallSetup(CallbackPreserveColor(), aRv, aExceptionHandling);\n"
             "JSContext* cx = s.get_context();\n"
             "if (!cx) {\n"
             "    return Err(JSFailed);\n"


### PR DESCRIPTION
Found this compile error yesterday when trying out unholy hacks in the bindings code.
We don't actually use this code path for now.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12407)

<!-- Reviewable:end -->
