### PR TITLE
Handle row borders in border collapsing logic.

### DIFF
--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -245,10 +245,13 @@ impl Flow for TableRowFlow {
                                      .style()
                                      .get_inheritedtable()
                                      .border_collapse == border_collapse::T::collapse;
-        // FIXME(pcwalton): Shouldn't use `CollapsedBorder::new()` here.
-        self.preliminary_collapsed_borders.reset(CollapsedBorder::new());
+        let row_style = &*self.block_flow.fragment.style;
+        self.preliminary_collapsed_borders.reset(
+            CollapsedBorder::inline_start(&row_style,
+                                          CollapsedBorderProvenance::FromTableRow));
 
         {
+            let children_count = self.block_flow.base.children.len();
             let mut iterator = self.block_flow.base.child_iter_mut().enumerate().peekable();
             while let Some((i, kid)) = iterator.next() {
                 assert!(kid.is_table_cell());
@@ -268,6 +271,8 @@ impl Flow for TableRowFlow {
                     // Perform border collapse if necessary.
                     if collapsing_borders {
                         perform_inline_direction_border_collapse_for_row(
+                            row_style,
+                            children_count,
                             i,
                             child_table_cell,
                             &mut iterator,
@@ -829,10 +834,20 @@ pub struct BorderCollapseInfoForChildTableCell<'a> {
 /// table row. This is done eagerly here so that at least the inline inside border collapse
 /// computations can be parallelized across all the rows of the table.
 fn perform_inline_direction_border_collapse_for_row(
+        row_style: &ServoComputedValues,
+        children_count: usize,
         child_index: usize,
         child_table_cell: &mut TableCellFlow,
         iterator: &mut Peekable<Enumerate<MutFlowListIterator>>,
         preliminary_collapsed_borders: &mut CollapsedBordersForRow) {
+    // In the first cell, combine its border with the one coming from the row.
+    if child_index == 0 {
+        let first_inline_border = &mut preliminary_collapsed_borders.inline[0];
+        first_inline_border.combine(
+            &CollapsedBorder::inline_start(&*child_table_cell.block_flow.fragment.style,
+                                           CollapsedBorderProvenance::FromPreviousTableCell));
+    }
+
     let inline_collapsed_border = preliminary_collapsed_borders.inline.push_or_set(
         child_index + 1,
         CollapsedBorder::inline_end(&*child_table_cell.block_flow.fragment.style,
@@ -845,12 +860,25 @@ fn perform_inline_direction_border_collapse_for_row(
                                            CollapsedBorderProvenance::FromNextTableCell))
     };
 
-    let block_start_border =
+    // In the last cell, also take into account the border that may
+    // come from the row.
+    if child_index + 1 == children_count {
+        inline_collapsed_border.combine(
+            &CollapsedBorder::inline_end(&row_style,
+                                         CollapsedBorderProvenance::FromTableRow));
+    }
+
+    let mut block_start_border =
         CollapsedBorder::block_start(&*child_table_cell.block_flow.fragment.style,
                                      CollapsedBorderProvenance::FromNextTableCell);
+    block_start_border.combine(
+        &CollapsedBorder::block_start(row_style, CollapsedBorderProvenance::FromTableRow));
     preliminary_collapsed_borders.block_start.push_or_set(child_index, block_start_border);
-    let block_end_border =
+    let mut block_end_border =
         CollapsedBorder::block_end(&*child_table_cell.block_flow.fragment.style,
-                                   CollapsedBorderProvenance::FromPreviousTableCell);
+                                        CollapsedBorderProvenance::FromPreviousTableCell);
+    block_end_border.combine(
+        &CollapsedBorder::block_end(row_style, CollapsedBorderProvenance::FromTableRow));
+
     preliminary_collapsed_borders.block_end.push_or_set(child_index, block_end_border);
 }

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-applies-to-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-applies-to-004.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-applies-to-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-applies-to-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-color-applies-to-004.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-color-applies-to-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-bottom-width-applies-to-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-bottom-width-applies-to-004.htm.ini
@@ -1,3 +1,0 @@
-[border-bottom-width-applies-to-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-conflict-style-101.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-conflict-style-101.htm.ini
@@ -1,3 +1,0 @@
-[border-conflict-style-101.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-applies-to-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-applies-to-004.htm.ini
@@ -1,3 +1,0 @@
-[border-left-applies-to-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-color-applies-to-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-color-applies-to-004.htm.ini
@@ -1,3 +1,0 @@
-[border-left-color-applies-to-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-left-width-applies-to-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-left-width-applies-to-004.htm.ini
@@ -1,3 +1,0 @@
-[border-left-width-applies-to-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-applies-to-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-applies-to-004.htm.ini
@@ -1,3 +1,0 @@
-[border-right-applies-to-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-color-applies-to-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-color-applies-to-004.htm.ini
@@ -1,3 +1,0 @@
-[border-right-color-applies-to-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-right-width-applies-to-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-right-width-applies-to-004.htm.ini
@@ -1,3 +1,0 @@
-[border-right-width-applies-to-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/vertical-align-121.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/vertical-align-121.htm.ini
@@ -1,3 +1,0 @@
-[vertical-align-121.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -792,6 +792,18 @@
             "url": "/_mozilla/css/border_collapse_missing_cell_a.html"
           }
         ],
+        "css/border_collapse_row_a.html": [
+          {
+            "path": "css/border_collapse_row_a.html",
+            "references": [
+              [
+                "/_mozilla/css/border_collapse_row_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/border_collapse_row_a.html"
+          }
+        ],
         "css/border_collapse_rowgroup_a.html": [
           {
             "path": "css/border_collapse_rowgroup_a.html",
@@ -10100,6 +10112,18 @@
             ]
           ],
           "url": "/_mozilla/css/border_collapse_missing_cell_a.html"
+        }
+      ],
+      "css/border_collapse_row_a.html": [
+        {
+          "path": "css/border_collapse_row_a.html",
+          "references": [
+            [
+              "/_mozilla/css/border_collapse_row_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/border_collapse_row_a.html"
         }
       ],
       "css/border_collapse_rowgroup_a.html": [

--- a/tests/wpt/mozilla/tests/css/border_collapse_row_a.html
+++ b/tests/wpt/mozilla/tests/css/border_collapse_row_a.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>row border collapse test</title>
+    <link rel="match" href="border_collapse_row_ref.html">
+    <style>
+      table {
+        border-collapse: collapse;
+      }
+      td {
+        width: 64px;
+        height: 32px;
+      }
+      .tr_with_border {
+        border-top: 2px solid black;
+        border-right: 2px solid black;
+        border-bottom: 2px solid black;
+      }
+    </style>
+  </head>
+  <body>
+    <table>
+      <tr><td></td><td></td></tr>
+      <tr class="tr_with_border"><td></td><td></td></tr>
+      <tr class="tr_with_border"><td></td><td></td></tr>
+      <tr class="tr_with_border"><td></td><td></td></tr>
+      <tr class="tr_with_border"><td></td><td></td></tr>
+    </table>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/border_collapse_row_ref.html
+++ b/tests/wpt/mozilla/tests/css/border_collapse_row_ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>row border collapse test - reference</title>
+    <style>
+      table {
+        border-collapse: collapse;
+      }
+      td {
+        width: 64px;
+        height: 32px;
+      }
+      .td_left {
+        border-top: 2px solid black;
+        border-bottom: 2px solid black;
+      }
+      .td_right {
+        border-top: 2px solid black;
+        border-right: 2px solid black;
+        border-bottom: 2px solid black;
+      }
+    </style>
+  </head>
+  <body>
+    <table>
+      <tr><td></td><td></td></tr>
+      <tr><td class="td_left"></td><td class="td_right"</td></tr>
+      <tr><td class="td_left"></td><td class="td_right"</td></tr>
+      <tr><td class="td_left"></td><td class="td_right"</td></tr>
+      <tr><td class="td_left"></td><td class="td_right"</td></tr>
+    </table>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/border_collapse_simple_a.html
+++ b/tests/wpt/mozilla/tests/css/border_collapse_simple_a.html
@@ -8,6 +8,9 @@
     FIXME(pcwalton): This is currently offset by -2px in block and inline directions because we
     don't correctly handle collapsed borders when calculating `table_border_padding` in
     `table_wrapper.rs`.
+
+    FIXME(gpoesia): This test does not behave exactly like Gecko yet, because cell5's
+    height is currently 2px smaller in Servo.
 -->
 <link rel=match href=border_collapse_simple_ref.html>
 <style>
@@ -19,7 +22,7 @@ html {
 }
 body {
     /* See `FIXME` above. */
-    padding: 2px;
+    padding-top: 2px;
 }
 table {
     border-collapse: collapse;
@@ -28,14 +31,20 @@ table {
 td {
     border: 2px solid black;
     padding: 16px;
-    width: 32px;
+    width: 30px;
     height: 32px;
 }
 td.cell5 {
     border: 30px solid black;
+    width: 32px;
 }
 td.cell6 {
     border: 4px solid black;
+    width: 32px;
+}
+
+#row1 td {
+    height: 32px;
 }
 </style>
 </head>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Handle table row border when collapsing borders for a table row. The row border is combined with the cell's border using the already implemented conflict resolution logic.

This is a screenshot of the following test:

``` html
<!doctype html>
<html><body>
    <style>
      table {
        border-collapse: collapse;
      }
      tr {
        border: 1px solid black;
      }
    </style>
    <table>
      <tr><td>Lorem</td><td>Ipsum</td><td>Sit</td><td>Dolor</td></tr>
      <tr><td>Lorem</td><td>Ipsum</td><td>Sit</td><td>Dolor</td></tr>
      <tr><td>Lorem</td><td>Ipsum</td><td>Sit</td><td>Dolor</td></tr>
      <tr><td>Lorem</td><td>Ipsum</td><td>Sit</td><td>Dolor</td></tr>
    </table>
  </body>
</html>
```

<img src="https://dl.dropboxusercontent.com/u/10962672/Screenshots%20Servo/servo_tr_border_collapse.png"/>

The top border is missing, but I think that's a different bug, since it also does not show up when the border is in the cells, and not the rows. Also, when debugging the border collapsing structures, they seem ok (the top border seems to be there). I can look at that bug in a separate issue (or in this one too if you prefer).

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11527 (github issue number if applicable).

<!-- Either: -->
- [X] These changes do not require tests because I didn't find how to automatically test it (will be happy to provide a test if there's infrastructure for this kind of test already in place).

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Fixes #11527.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12437)

<!-- Reviewable:end -->
