### PR TITLE
Put Blob URL online

### DIFF
--- a/components/net_traits/blob_url_store.rs
+++ b/components/net_traits/blob_url_store.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use filemanager_thread::FileOrigin;
 use std::str::FromStr;
 use url::Url;
 use uuid::Uuid;
@@ -20,7 +21,7 @@ pub enum BlobURLStoreError {
 }
 
 /// Standalone blob buffer object
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BlobBuf {
     pub filename: Option<String>,
     /// MIME type string
@@ -33,13 +34,25 @@ pub struct BlobBuf {
 
 /// Parse URL as Blob URL scheme's definition
 /// https://w3c.github.io/FileAPI/#DefinitionOfScheme
-pub fn parse_blob_url(url: &Url) -> Option<(Uuid, Option<&str>)> {
-    url.path_segments().and_then(|mut segments| {
-        let id_str = match (segments.next(), segments.next()) {
-            (Some(s), None) => s,
-            _ => return None,
-        };
+pub fn parse_blob_url(url: &Url) -> Result<(Uuid, FileOrigin, Option<String>), ()> {
+    let url_inner = try!(Url::parse(url.path()).map_err(|_| ()));
+    let fragment = url_inner.fragment().map(|s| s.to_string());
+    let mut segs = try!(url_inner.path_segments().ok_or(()));
+    let id = try!(segs.nth(0).ok_or(()));
+    let id = try!(Uuid::from_str(id).map_err(|_| ()));
+    Ok((id, get_blob_origin(&url_inner), fragment))
+}
 
-        Uuid::from_str(id_str).map(|id| (id, url.fragment())).ok()
-    })
+/// Given an URL, returning the Origin that a Blob created under this
+/// URL should have.
+/// HACK(izgzhen): Not well-specified on spec, and it is a bit a hack
+/// both due to ambiguity of spec and that we have to serialization the
+/// Origin here.
+pub fn get_blob_origin(url: &Url) -> FileOrigin {
+    if url.scheme() == "file" {
+        // NOTE: by default this is "null" (Opaque), which is not ideal
+        "file://".to_string()
+    } else {
+        url.origin().unicode_serialization()
+    }
 }

--- a/components/net_traits/filemanager_thread.rs
+++ b/components/net_traits/filemanager_thread.rs
@@ -8,7 +8,6 @@ use num_traits::ToPrimitive;
 use std::cmp::{max, min};
 use std::ops::Range;
 use std::path::PathBuf;
-use super::{LoadConsumer, LoadData};
 
 // HACK: Not really process-safe now, we should send Origin
 //       directly instead of this in future, blocked on #11722
@@ -128,15 +127,13 @@ pub enum FileManagerThreadMsg {
     /// Select multiple files, return a vector of triples
     SelectFiles(Vec<FilterPattern>, IpcSender<FileManagerResult<Vec<SelectedFile>>>, FileOrigin, Option<Vec<String>>),
 
-    /// Read file, return the bytes
-    ReadFile(IpcSender<FileManagerResult<Vec<u8>>>, SelectedFileId, FileOrigin),
-
-    /// Load resource by Blob URL
-    LoadBlob(LoadData, LoadConsumer),
+    /// Read file by FileID, optionally check URL validity based on
+    /// third flag, return the blob buffer object
+    ReadFile(IpcSender<FileManagerResult<BlobBuf>>, SelectedFileId, bool, FileOrigin),
 
     /// Add an entry as promoted memory-based blob and send back the associated FileID
-    /// as part of a valid Blob URL
-    PromoteMemory(BlobBuf, IpcSender<Result<SelectedFileId, BlobURLStoreError>>, FileOrigin),
+    /// as part of a valid/invalid Blob URL depending on the second bool flag
+    PromoteMemory(BlobBuf, bool, IpcSender<Result<SelectedFileId, BlobURLStoreError>>, FileOrigin),
 
     /// Add a sliced entry pointing to the parent FileID, and send back the associated FileID
     /// as part of a valid Blob URL

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -368,6 +368,12 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
                 // Step 11 - abort existing requests
                 self.terminate_ongoing_fetch();
 
+                // TODO(izgzhen): In the WPT test: FileAPI/blob/Blob-XHR-revoke.html,
+                // the xhr.open(url) is expected to hold a reference to the URL,
+                // thus renders following revocations invalid. Though we won't
+                // implement this for now, if ever needed, we should check blob
+                // scheme and trigger corresponding actions here.
+
                 // Step 12
                 *self.request_method.borrow_mut() = parsed_method;
                 *self.request_url.borrow_mut() = Some(parsed_url);

--- a/tests/unit/net/filemanager_thread.rs
+++ b/tests/unit/net/filemanager_thread.rs
@@ -52,12 +52,12 @@ fn test_filemanager() {
         // Test by reading, expecting same content
         {
             let (tx2, rx2) = ipc::channel().unwrap();
-            chan.send(FileManagerThreadMsg::ReadFile(tx2, selected.id.clone(), origin.clone())).unwrap();
+            chan.send(FileManagerThreadMsg::ReadFile(tx2, selected.id.clone(), false, origin.clone())).unwrap();
 
             let msg = rx2.recv().expect("Broken channel");
 
-            let vec = msg.expect("File manager reading failure is unexpected");
-            assert_eq!(test_file_content, vec, "Read content differs");
+            let blob_buf = msg.expect("File manager reading failure is unexpected");
+            assert_eq!(test_file_content, blob_buf.bytes, "Read content differs");
         }
 
         // Delete the id
@@ -72,7 +72,7 @@ fn test_filemanager() {
         // Test by reading again, expecting read error because we invalidated the id
         {
             let (tx2, rx2) = ipc::channel().unwrap();
-            chan.send(FileManagerThreadMsg::ReadFile(tx2, selected.id.clone(), origin.clone())).unwrap();
+            chan.send(FileManagerThreadMsg::ReadFile(tx2, selected.id.clone(), false, origin.clone())).unwrap();
 
             let msg = rx2.recv().expect("Broken channel");
 

--- a/tests/wpt/metadata/FileAPI/url/url_xmlhttprequest_img.html.ini
+++ b/tests/wpt/metadata/FileAPI/url/url_xmlhttprequest_img.html.ini
@@ -1,5 +1,0 @@
-[url_xmlhttprequest_img.html]
-  type: reftest
-  reftype: ==
-  refurl: /FileAPI/url/url_xmlhttprequest_img-ref.html
-  expected: FAIL

--- a/tests/wpt/metadata/workers/constructors/Worker/Blob-url.html.ini
+++ b/tests/wpt/metadata/workers/constructors/Worker/Blob-url.html.ini
@@ -1,6 +1,0 @@
-[Blob-url.html]
-  type: testharness
-  expected: TIMEOUT
-  [Worker supports Blob url]
-    expected: TIMEOUT
-

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5782,6 +5782,18 @@
             "url": "/_mozilla/css/word_break_a.html"
           }
         ],
+        "mozilla/blob_url_upload.html": [
+          {
+            "path": "mozilla/blob_url_upload.html",
+            "references": [
+              [
+                "/_mozilla/mozilla/blob_url_upload_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/mozilla/blob_url_upload.html"
+          }
+        ],
         "mozilla/canvas/drawimage_html_image_1.html": [
           {
             "path": "mozilla/canvas/drawimage_html_image_1.html",
@@ -14850,6 +14862,18 @@
             ]
           ],
           "url": "/_mozilla/css/word_break_a.html"
+        }
+      ],
+      "mozilla/blob_url_upload.html": [
+        {
+          "path": "mozilla/blob_url_upload.html",
+          "references": [
+            [
+              "/_mozilla/mozilla/blob_url_upload_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/mozilla/blob_url_upload.html"
         }
       ],
       "mozilla/canvas/drawimage_html_image_1.html": [

--- a/tests/wpt/mozilla/meta/mozilla/blob_url_upload.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/blob_url_upload.html.ini
@@ -1,0 +1,3 @@
+[blob_url_upload.html]
+  type: reftest
+  prefs: [dom.testing.htmlinputelement.select_files.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/blob_url_upload.html
+++ b/tests/wpt/mozilla/tests/mozilla/blob_url_upload.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Blob URL with File Upload</title>
+<link rel="match" href="blob_url_upload_ref.html">
+<body>
+    <img src="" id="image">
+    <input type="file" id="file-input"">
+</body>
+<script type="text/javascript">
+    var image = document.getElementById("image");
+
+    var inputElem = document.getElementById("file-input");
+
+    inputElem.selectFiles(["./tests/wpt/mozilla/tests/mozilla/test.jpg"]);
+
+    var f = inputElem.files[0];
+
+    var url = URL.createObjectURL(f);
+
+    image.src = url;
+
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/blob_url_upload_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/blob_url_upload_ref.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Reference: Blob URL with File Upload</title>
+<body>
+    <img src="test.jpg" id="image">
+    <input type="file" id="file-input"">
+</body>


### PR DESCRIPTION
This PR connects the resource requests with file manager thread, including:
- `script_thread` load request
- `image_cache_thread` load request
- XHR load request (the responding part code yet not implemented due to unfamiliarity with fetch standard, but the infra is here)

One notable change is the introduction of "long-live validity", to handle the case specified in WPT test FileAPI/blob/Blob-XHR-revoke.html.

r? @Manishearth 

<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #10539
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12440)

<!-- Reviewable:end -->
