### PR TITLE
Implement referrer policy delivery by header

### DIFF
--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -332,7 +332,7 @@ pub enum FrameType {
 #[derive(Clone, Copy, Debug, Deserialize, HeapSizeOf, Serialize)]
 pub enum ReferrerPolicy {
     NoReferrer,
-    NoRefWhenDowngrade,
+    NoReferrerWhenDowngrade,
     Origin,
     SameOrigin,
     OriginWhenCrossOrigin,

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -155,7 +155,7 @@ fn main_fetch(request: Rc<Request>, cache: &mut CORSCache, cors_flag: bool,
 
     // Step 7
     if request.referrer_policy.get().is_none() {
-        request.referrer_policy.set(Some(ReferrerPolicy::NoRefWhenDowngrade));
+        request.referrer_policy.set(Some(ReferrerPolicy::NoReferrerWhenDowngrade));
     }
 
     // Step 8

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -425,7 +425,7 @@ fn set_default_accept_language(headers: &mut Headers) {
 }
 
 /// https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-state-no-referrer-when-downgrade
-fn no_ref_when_downgrade_header(referrer_url: Url, url: Url) -> Option<Url> {
+fn no_referrer_when_downgrade_header(referrer_url: Url, url: Url) -> Option<Url> {
     if referrer_url.scheme() == "https" && url.scheme() != "https" {
         return None;
     }
@@ -462,7 +462,8 @@ pub fn determine_request_referrer(headers: &mut Headers,
             Some(ReferrerPolicy::SameOrigin) => if cross_origin { None } else { strip_url(ref_url, false) },
             Some(ReferrerPolicy::UnsafeUrl) => strip_url(ref_url, false),
             Some(ReferrerPolicy::OriginWhenCrossOrigin) => strip_url(ref_url, cross_origin),
-            Some(ReferrerPolicy::NoRefWhenDowngrade) | None => no_ref_when_downgrade_header(ref_url, url),
+            Some(ReferrerPolicy::NoReferrerWhenDowngrade) | None =>
+                no_referrer_when_downgrade_header(ref_url, url),
         };
     }
     return None;

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1633,7 +1633,8 @@ impl Document {
                          last_modified: Option<String>,
                          source: DocumentSource,
                          doc_loader: DocumentLoader,
-                         referrer: Option<String>)
+                         referrer: Option<String>,
+                         referrer_policy: Option<ReferrerPolicy>)
                          -> Document {
         let url = url.unwrap_or_else(|| Url::parse("about:blank").unwrap());
 
@@ -1651,6 +1652,17 @@ impl Document {
             // Default to DOM standard behaviour
             Origin::opaque_identifier()
         };
+
+        // TODO: we currently default to Some(NoReferrer) instead of None (i.e. unset)
+        // for an important reason. Many of the methods by which a referrer policy is communicated
+        // are currently unimplemented, and so in such cases we may be ignoring the desired policy.
+        // If the default were left unset, then in Step 7 of the Fetch algorithm we adopt
+        // no-referrer-when-downgrade. However, since we are potentially ignoring a stricter
+        // referrer policy, this might be passing too much info. Hence, we default to the
+        // strictest policy, which is no-referrer.
+        // Once other delivery methods are implemented, make the unset case really
+        // unset (i.e. None).
+        let referrer_policy = referrer_policy.or(Some(ReferrerPolicy::NoReferrer));
 
         Document {
             node: Node::new_document_node(),
@@ -1718,9 +1730,8 @@ impl Document {
             https_state: Cell::new(HttpsState::None),
             touchpad_pressure_phase: Cell::new(TouchpadPressurePhase::BeforeClick),
             origin: origin,
-            //TODO - setting this for now so no Referer header set
-            referrer_policy: Cell::new(Some(ReferrerPolicy::NoReferrer)),
             referrer: referrer,
+            referrer_policy: Cell::new(referrer_policy),
         }
     }
 
@@ -1738,6 +1749,7 @@ impl Document {
                          None,
                          DocumentSource::NotFromParser,
                          docloader,
+                         None,
                          None))
     }
 
@@ -1749,7 +1761,8 @@ impl Document {
                last_modified: Option<String>,
                source: DocumentSource,
                doc_loader: DocumentLoader,
-               referrer: Option<String>)
+               referrer: Option<String>,
+               referrer_policy: Option<ReferrerPolicy>)
                -> Root<Document> {
         let document = reflect_dom_object(box Document::new_inherited(window,
                                                                       browsing_context,
@@ -1759,7 +1772,8 @@ impl Document {
                                                                       last_modified,
                                                                       source,
                                                                       doc_loader,
-                                                                      referrer),
+                                                                      referrer,
+                                                                      referrer_policy),
                                           GlobalRef::Window(window),
                                           DocumentBinding::Wrap);
         {
@@ -1824,6 +1838,7 @@ impl Document {
                                         None,
                                         DocumentSource::NotFromParser,
                                         DocumentLoader::new(&self.loader()),
+                                        None,
                                         None);
             new_doc.appropriate_template_contents_owner_document.set(Some(&new_doc));
             new_doc

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2863,7 +2863,7 @@ pub fn determine_policy_for_token(token: &str) -> Option<ReferrerPolicy> {
     let lower = token.to_lowercase();
     return match lower.as_ref() {
         "never" | "no-referrer" => Some(ReferrerPolicy::NoReferrer),
-        "default" | "no-referrer-when-downgrade" => Some(ReferrerPolicy::NoRefWhenDowngrade),
+        "default" | "no-referrer-when-downgrade" => Some(ReferrerPolicy::NoReferrerWhenDowngrade),
         "origin" => Some(ReferrerPolicy::Origin),
         "same-origin" => Some(ReferrerPolicy::SameOrigin),
         "origin-when-cross-origin" => Some(ReferrerPolicy::OriginWhenCrossOrigin),

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -130,6 +130,7 @@ impl DOMImplementationMethods for DOMImplementation {
                                 None,
                                 DocumentSource::NotFromParser,
                                 loader,
+                                None,
                                 None);
 
         {

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -69,6 +69,7 @@ impl DOMParserMethods for DOMParser {
                                              None,
                                              DocumentSource::FromParser,
                                              loader,
+                                             None,
                                              None);
                 parse_html(document.r(), s, url, ParseContext::Owner(None));
                 document.set_ready_state(DocumentReadyState::Complete);
@@ -84,6 +85,7 @@ impl DOMParserMethods for DOMParser {
                                              None,
                                              DocumentSource::NotFromParser,
                                              loader,
+                                             None,
                                              None);
                 parse_xml(document.r(), s, url, xml::ParseContext::Owner(None));
                 Ok(document)

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1721,7 +1721,8 @@ impl Node {
                 let document = Document::new(window, None,
                                              Some((*document.url()).clone()),
                                              is_html_doc, None,
-                                             None, DocumentSource::NotFromParser, loader, None);
+                                             None, DocumentSource::NotFromParser, loader,
+                                             None, None);
                 Root::upcast::<Node>(document)
             },
             NodeTypeId::Element(..) => {

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -42,6 +42,7 @@ impl XMLDocument {
                                               last_modified,
                                               source,
                                               doc_loader,
+                                              None,
                                               None),
         }
     }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1242,6 +1242,7 @@ impl XMLHttpRequest {
                       None,
                       DocumentSource::FromParser,
                       docloader,
+                      None,
                       None)
     }
 

--- a/components/script/parse/html.rs
+++ b/components/script/parse/html.rs
@@ -280,7 +280,7 @@ pub fn parse_html_fragment(context_node: &Node,
                                  None, None,
                                  DocumentSource::FromParser,
                                  loader,
-                                 None);
+                                 None, None);
 
     // Step 2.
     document.set_quirks_mode(context_document.quirks_mode());

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -51,8 +51,8 @@ use dom::worker::TrustedWorkerAddress;
 use euclid::Rect;
 use euclid::point::Point2D;
 use gfx_traits::LayerId;
-use hyper::header::{ContentType, HttpDate};
-use hyper::header::{Headers, LastModified};
+use hyper::header::{ContentType, Headers, HttpDate, LastModified};
+use hyper::header::{ReferrerPolicy as ReferrerPolicyHeader};
 use hyper::method::Method;
 use hyper::mime::{Mime, SubLevel, TopLevel};
 use ipc_channel::ipc::{self, IpcSender};
@@ -65,7 +65,7 @@ use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use mem::heap_size_of_self_and_children;
 use msg::constellation_msg::{FrameType, LoadData, PanicMsg, PipelineId, PipelineNamespace};
-use msg::constellation_msg::{SubpageId, WindowSizeType};
+use msg::constellation_msg::{ReferrerPolicy, SubpageId, WindowSizeType};
 use net_traits::LoadData as NetLoadData;
 use net_traits::bluetooth_thread::BluetoothMethodMsg;
 use net_traits::image_cache_thread::{ImageCacheChan, ImageCacheResult, ImageCacheThread};
@@ -1716,6 +1716,25 @@ impl ScriptThread {
             None => None,
         };
 
+        let referrer_policy = if let Some(headers) = metadata.headers {
+            headers.get::<ReferrerPolicyHeader>().map(|h| match *h {
+                ReferrerPolicyHeader::NoReferrer =>
+                    ReferrerPolicy::NoReferrer,
+                ReferrerPolicyHeader::NoReferrerWhenDowngrade =>
+                    ReferrerPolicy::NoRefWhenDowngrade,
+                ReferrerPolicyHeader::SameOrigin =>
+                    ReferrerPolicy::SameOrigin,
+                ReferrerPolicyHeader::Origin =>
+                    ReferrerPolicy::Origin,
+                ReferrerPolicyHeader::OriginWhenCrossOrigin =>
+                    ReferrerPolicy::OriginWhenCrossOrigin,
+                ReferrerPolicyHeader::UnsafeUrl =>
+                    ReferrerPolicy::UnsafeUrl,
+            })
+        } else {
+            None
+        };
+
         let document = Document::new(window.r(),
                                      Some(&browsing_context),
                                      Some(final_url.clone()),
@@ -1724,7 +1743,8 @@ impl ScriptThread {
                                      last_modified,
                                      DocumentSource::FromParser,
                                      loader,
-                                     referrer);
+                                     referrer,
+                                     referrer_policy);
         if using_new_context {
             browsing_context.init(&document);
         } else {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1721,7 +1721,7 @@ impl ScriptThread {
                 ReferrerPolicyHeader::NoReferrer =>
                     ReferrerPolicy::NoReferrer,
                 ReferrerPolicyHeader::NoReferrerWhenDowngrade =>
-                    ReferrerPolicy::NoRefWhenDowngrade,
+                    ReferrerPolicy::NoReferrerWhenDowngrade,
                 ReferrerPolicyHeader::SameOrigin =>
                     ReferrerPolicy::SameOrigin,
                 ReferrerPolicyHeader::Origin =>

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -509,7 +509,7 @@ name = "devtools"
 version = "0.0.1"
 dependencies = [
  "devtools_traits 0.0.1",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -528,7 +528,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "msg 0.0.1",
  "serde 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -981,7 +981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1379,7 +1379,7 @@ dependencies = [
  "cssparser 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "plugins 0.0.1",
  "serde 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1399,7 +1399,7 @@ dependencies = [
  "device 0.0.1 (git+https://github.com/servo/devices)",
  "devtools_traits 0.0.1",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "immeta 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1446,7 +1446,7 @@ dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "msg 0.0.1",
  "net 0.0.1",
@@ -1466,7 +1466,7 @@ dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1916,7 +1916,7 @@ dependencies = [
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "js 0.1.3 (git+https://github.com/servo/rust-mozjs)",
@@ -2560,7 +2560,7 @@ name = "webdriver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2572,7 +2572,7 @@ version = "0.0.1"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2635,7 +2635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -468,7 +468,7 @@ name = "devtools"
 version = "0.0.1"
 dependencies = [
  "devtools_traits 0.0.1",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -487,7 +487,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "msg 0.0.1",
  "serde 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -890,7 +890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1281,7 +1281,7 @@ dependencies = [
  "cssparser 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "plugins 0.0.1",
  "serde 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1301,7 +1301,7 @@ dependencies = [
  "device 0.0.1 (git+https://github.com/servo/devices)",
  "devtools_traits 0.0.1",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "immeta 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1347,7 +1347,7 @@ dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1770,7 +1770,7 @@ dependencies = [
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_plugin 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "js 0.1.3 (git+https://github.com/servo/rust-mozjs)",
@@ -2422,7 +2422,7 @@ name = "webdriver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2434,7 +2434,7 @@ version = "0.0.1"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.4.0 (git+https://github.com/servo/ipc-channel)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2497,7 +2497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/unit/net/http_loader.rs
+++ b/tests/unit/net/http_loader.rs
@@ -1732,7 +1732,7 @@ fn test_http_to_https_considered_cross_origin_for_referer_header_logic() {
 fn test_referer_set_to_ref_url_with_noreferrerwhendowngrade_policy_https_to_https() {
     let request_url = "https://mozilla.com";
     let referrer_url = "https://username:password@mozilla.com/some/path#fragment";
-    let referrer_policy = Some(ReferrerPolicy::NoRefWhenDowngrade);
+    let referrer_policy = Some(ReferrerPolicy::NoReferrerWhenDowngrade);
     let expected_referrer = "https://mozilla.com/some/path";
 
     let origin_info = LoadOriginInfo {
@@ -1747,7 +1747,7 @@ fn test_referer_set_to_ref_url_with_noreferrerwhendowngrade_policy_https_to_http
 fn test_no_referer_set_with_noreferrerwhendowngrade_policy_https_to_http() {
     let request_url = "http://mozilla.com";
     let referrer_url = "https://username:password@mozilla.com/some/path#fragment";
-    let referrer_policy = Some(ReferrerPolicy::NoRefWhenDowngrade);
+    let referrer_policy = Some(ReferrerPolicy::NoReferrerWhenDowngrade);
 
     let origin_info = LoadOriginInfo {
         referrer_url: referrer_url,
@@ -1761,7 +1761,7 @@ fn test_no_referer_set_with_noreferrerwhendowngrade_policy_https_to_http() {
 fn test_referer_set_to_ref_url_with_noreferrerwhendowngrade_policy_http_to_https() {
     let request_url = "https://mozilla.com";
     let referrer_url = "http://username:password@mozilla.com/some/path#fragment";
-    let referrer_policy = Some(ReferrerPolicy::NoRefWhenDowngrade);
+    let referrer_policy = Some(ReferrerPolicy::NoReferrerWhenDowngrade);
     let expected_referrer = "http://mozilla.com/some/path";
 
     let origin_info = LoadOriginInfo {
@@ -1776,7 +1776,7 @@ fn test_referer_set_to_ref_url_with_noreferrerwhendowngrade_policy_http_to_https
 fn test_referer_set_to_ref_url_with_noreferrerwhendowngrade_policy_http_to_http() {
     let request_url = "http://mozilla.com";
     let referrer_url = "http://username:password@mozilla.com/some/path#fragment";
-    let referrer_policy = Some(ReferrerPolicy::NoRefWhenDowngrade);
+    let referrer_policy = Some(ReferrerPolicy::NoReferrerWhenDowngrade);
     let expected_referrer = "http://mozilla.com/some/path";
 
     let origin_info = LoadOriginInfo {

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/insecure-protocol.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/insecure-protocol.keep-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[insecure-protocol.keep-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/insecure-protocol.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/insecure-protocol.no-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[insecure-protocol.no-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/insecure-protocol.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/cross-origin/http-http/xhr-request/insecure-protocol.swap-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[insecure-protocol.swap-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/insecure-protocol.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/insecure-protocol.keep-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[insecure-protocol.keep-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/insecure-protocol.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/insecure-protocol.no-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[insecure-protocol.no-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/insecure-protocol.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/no-referrer-when-downgrade/http-rp/same-origin/http-http/xhr-request/insecure-protocol.swap-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[insecure-protocol.swap-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/cross-origin.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/cross-origin.keep-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[cross-origin.keep-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/cross-origin.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/cross-origin.no-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[cross-origin.no-redirect.http.html]
-  type: testharness
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/cross-origin.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/cross-origin/http-http/xhr-request/cross-origin.swap-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[cross-origin.swap-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/same-origin-insecure.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/same-origin-insecure.keep-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[same-origin-insecure.keep-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/same-origin-insecure.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/same-origin-insecure.no-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[same-origin-insecure.no-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/same-origin-insecure.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin-when-cross-origin/http-rp/same-origin/http-http/xhr-request/same-origin-insecure.swap-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[same-origin-insecure.swap-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/generic.keep-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/generic.no-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/cross-origin/http-http/xhr-request/generic.swap-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/generic.keep-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/generic.no-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/origin/http-rp/same-origin/http-http/xhr-request/generic.swap-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is origin when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/http-rp/same-origin/http-http/xhr-request/same-origin-insecure.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/http-rp/same-origin/http-http/xhr-request/same-origin-insecure.keep-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[same-origin-insecure.keep-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/same-origin/http-rp/same-origin/http-http/xhr-request/same-origin-insecure.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/same-origin/http-rp/same-origin/http-http/xhr-request/same-origin-insecure.no-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[same-origin-insecure.no-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/generic.keep-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/generic.no-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/cross-origin/http-http/xhr-request/generic.swap-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/generic.keep-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.keep-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/generic.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/generic.no-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.no-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/unsafe-url/http-rp/same-origin/http-http/xhr-request/generic.swap-origin-redirect.http.html.ini
@@ -1,5 +1,0 @@
-[generic.swap-origin-redirect.http.html]
-  type: testharness
-  [The referrer URL is stripped-referrer when a\n                                 document served over http requires an http\n                                 sub-resource via xhr-request using the http-rp\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
-    expected: FAIL
-


### PR DESCRIPTION
Adds a new `Option<ReferrerPolicy>` field to Document and sets it appropriately in `ScriptThread::load` if a Referrer-Policy header is present.

r? @jdm

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11860
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12441)

<!-- Reviewable:end -->
