### PR TITLE
All our Cargo.toml files should contain an MPL-2.0 license field.

### DIFF
--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -2,6 +2,7 @@
 name = "canvas"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -2,6 +2,7 @@
 name = "canvas_traits"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -2,6 +2,7 @@
 name = "compositing"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -2,6 +2,7 @@
 name = "constellation"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -2,6 +2,7 @@
 name = "devtools"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/devtools_traits/Cargo.toml
+++ b/components/devtools_traits/Cargo.toml
@@ -2,6 +2,7 @@
 name = "devtools_traits"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -3,6 +3,7 @@
 name = "gfx"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/gfx_traits/Cargo.toml
+++ b/components/gfx_traits/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gfx_traits"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -2,6 +2,7 @@
 name = "layout"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -2,6 +2,7 @@
 name = "layout_thread"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/layout_traits/Cargo.toml
+++ b/components/layout_traits/Cargo.toml
@@ -2,6 +2,7 @@
 name = "layout_traits"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/msg/Cargo.toml
+++ b/components/msg/Cargo.toml
@@ -2,6 +2,7 @@
 name = "msg"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -2,6 +2,7 @@
 name = "net"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -2,6 +2,7 @@
 name = "net_traits"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/plugins/Cargo.toml
+++ b/components/plugins/Cargo.toml
@@ -2,6 +2,7 @@
 name = "plugins"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -2,6 +2,7 @@
 name = "profile"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/profile_traits/Cargo.toml
+++ b/components/profile_traits/Cargo.toml
@@ -2,6 +2,7 @@
 name = "profile_traits"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/range/Cargo.toml
+++ b/components/range/Cargo.toml
@@ -3,6 +3,7 @@
 name = "range"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -2,6 +2,7 @@
 name = "script"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 build = "build.rs"

--- a/components/script_layout_interface/Cargo.toml
+++ b/components/script_layout_interface/Cargo.toml
@@ -2,6 +2,7 @@
 name = "script_layout_interface"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -2,6 +2,7 @@
 name = "script_traits"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -3,6 +3,7 @@
 name = "servo"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 build = "build.rs"
 publish = false
 

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -2,6 +2,7 @@
 name = "style"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 build = "build.rs"

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -2,6 +2,7 @@
 name = "style_traits"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/util/Cargo.toml
+++ b/components/util/Cargo.toml
@@ -2,6 +2,7 @@
 name = "util"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "webdriver_server"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -2,6 +2,7 @@
 name = "geckoservo"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 build = "build.rs"
 

--- a/ports/geckolib/gecko_bindings/Cargo.toml
+++ b/ports/geckolib/gecko_bindings/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gecko_bindings"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/ports/geckolib/string_cache/Cargo.toml
+++ b/ports/geckolib/string_cache/Cargo.toml
@@ -3,6 +3,7 @@ name = "string_cache"
 description = "A crate to allow using Gecko's nsIAtom as a replacement for string_cache."
 version = "0.2.20"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 publish = false
 
 [lib]

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -2,6 +2,7 @@
 name = "glutin_app"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "glutin_app"

--- a/python/tidy/servo_tidy/licenseck.py
+++ b/python/tidy/servo_tidy/licenseck.py
@@ -82,3 +82,9 @@ licenses = [
 // except according to those terms.
 """,
 ]  # noqa: Indicate to flake8 that we do not want to check indentation here
+
+# The valid licenses, in the form we'd expect to see them in a Cargo.toml file.
+licenses_toml = [
+    'license = "MPL-2.0"',
+    'license = "MIT/Apache-2.0"',
+]

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -295,9 +295,13 @@ duplicate versions for package "{package}"
 def check_toml(file_name, lines):
     if not file_name.endswith(".toml"):
         raise StopIteration
+    mpl_licensed = False
     for idx, line in enumerate(lines):
         if line.find("*") != -1:
             yield (idx + 1, "found asterisk instead of minimum version number")
+        mpl_licensed |= ('license = "MPL-2.0"' in line)
+    if not mpl_licensed:
+        yield (0, ".toml file should contain MPL-2.0 license.")
 
 
 def check_rust(file_name, lines):

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -17,7 +17,7 @@ import site
 import StringIO
 import subprocess
 import sys
-from licenseck import licenses
+from licenseck import licenses, licenses_toml
 
 # License and header checks
 EMACS_HEADER = "/* -*- Mode:"
@@ -295,13 +295,14 @@ duplicate versions for package "{package}"
 def check_toml(file_name, lines):
     if not file_name.endswith(".toml"):
         raise StopIteration
-    mpl_licensed = False
+    ok_licensed = False
     for idx, line in enumerate(lines):
         if line.find("*") != -1:
             yield (idx + 1, "found asterisk instead of minimum version number")
-        mpl_licensed |= ('license = "MPL-2.0"' in line)
-    if not mpl_licensed:
-        yield (0, ".toml file should contain MPL-2.0 license.")
+        for license in licenses_toml:
+            ok_licensed |= (license in line)
+    if not ok_licensed:
+        yield (0, ".toml file should contain a valid license.")
 
 
 def check_rust(file_name, lines):

--- a/support/android/build-apk/Cargo.toml
+++ b/support/android/build-apk/Cargo.toml
@@ -3,6 +3,7 @@
 name = "build-apk"
 version = "0.0.1"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The Servo Project Developers"]
+license = "MPL-2.0"
 
 [[bin]]
 name = "build-apk"

--- a/tests/compiletest/helper/Cargo.toml
+++ b/tests/compiletest/helper/Cargo.toml
@@ -2,6 +2,7 @@
 name = "compiletest_helper"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "compiletest_helper"

--- a/tests/compiletest/plugin/Cargo.toml
+++ b/tests/compiletest/plugin/Cargo.toml
@@ -2,6 +2,7 @@
 name = "plugin_compiletest"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "plugin_compiletest"

--- a/tests/unit/gfx/Cargo.toml
+++ b/tests/unit/gfx/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gfx_tests"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "gfx_tests"

--- a/tests/unit/layout/Cargo.toml
+++ b/tests/unit/layout/Cargo.toml
@@ -2,6 +2,7 @@
 name = "layout_tests"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "layout_tests"

--- a/tests/unit/net/Cargo.toml
+++ b/tests/unit/net/Cargo.toml
@@ -2,6 +2,7 @@
 name = "net_tests"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "net_tests"

--- a/tests/unit/net_traits/Cargo.toml
+++ b/tests/unit/net_traits/Cargo.toml
@@ -2,6 +2,7 @@
 name = "net_traits_tests"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "net_traits_tests"

--- a/tests/unit/profile/Cargo.toml
+++ b/tests/unit/profile/Cargo.toml
@@ -2,6 +2,7 @@
 name = "profile_tests"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "profile_tests"

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -2,6 +2,7 @@
 name = "script_tests"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "script_tests"

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -2,6 +2,7 @@
 name = "style_tests"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "style_tests"

--- a/tests/unit/util/Cargo.toml
+++ b/tests/unit/util/Cargo.toml
@@ -2,6 +2,7 @@
 name = "util_tests"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 [lib]
 name = "util_tests"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Added a `license = "MPL-2.0"` field to all our `Cargo.toml` files, and added a check to `test-tidy` that the license is present.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12434
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12447)

<!-- Reviewable:end -->
