### PR TITLE
Implement file reading task source

### DIFF
--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -26,6 +26,7 @@ use script_runtime::{CommonScriptMsg, ScriptChan, ScriptPort};
 use script_thread::{MainThreadScriptChan, ScriptThread, RunnableWrapper};
 use script_traits::{MsDuration, ScriptMsg as ConstellationMsg, TimerEventRequest};
 use task_source::dom_manipulation::DOMManipulationTaskSource;
+use task_source::file_reading::FileReadingTaskSource;
 use timers::{OneshotTimerCallback, OneshotTimerHandle};
 use url::Url;
 
@@ -219,10 +220,10 @@ impl<'a> GlobalRef<'a> {
 
     /// `ScriptChan` used to send messages to the event loop of this global's
     /// thread.
-    pub fn file_reading_task_source(&self) -> Box<ScriptChan + Send> {
+    pub fn file_reading_task_source(&self) -> FileReadingTaskSource {
         match *self {
             GlobalRef::Window(ref window) => window.file_reading_task_source(),
-            GlobalRef::Worker(ref worker) => worker.script_chan(),
+            GlobalRef::Worker(ref worker) => worker.file_reading_task_source(),
         }
     }
 

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -23,7 +23,7 @@ use net_traits::filemanager_thread::FileManagerThreadMsg;
 use net_traits::{ResourceThreads, CoreResourceThread, RequestSource, IpcSend};
 use profile_traits::{mem, time};
 use script_runtime::{CommonScriptMsg, ScriptChan, ScriptPort};
-use script_thread::{MainThreadScriptChan, ScriptThread};
+use script_thread::{MainThreadScriptChan, ScriptThread, RunnableWrapper};
 use script_traits::{MsDuration, ScriptMsg as ConstellationMsg, TimerEventRequest};
 use task_source::dom_manipulation::DOMManipulationTaskSource;
 use timers::{OneshotTimerCallback, OneshotTimerHandle};
@@ -295,6 +295,15 @@ impl<'a> GlobalRef<'a> {
         match *self {
             GlobalRef::Window(ref window) => window.panic_chan(),
             GlobalRef::Worker(ref worker) => worker.panic_chan(),
+        }
+    }
+
+    /// Returns a wrapper for runnables to ensure they are cancelled if the global
+    /// is being destroyed.
+    pub fn get_runnable_wrapper(&self) -> RunnableWrapper {
+        match *self {
+            GlobalRef::Window(ref window) => window.get_runnable_wrapper(),
+            GlobalRef::Worker(ref worker) => worker.get_runnable_wrapper(),
         }
     }
 }

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -5,6 +5,7 @@
 use dom::attr::Attr;
 use dom::bindings::codegen::Bindings::HTMLDetailsElementBinding;
 use dom::bindings::codegen::Bindings::HTMLDetailsElementBinding::HTMLDetailsElementMethods;
+use dom::bindings::global::GlobalRef;
 use dom::bindings::inheritance::Castable;
 use dom::bindings::js::Root;
 use dom::bindings::refcounted::Trusted;
@@ -78,7 +79,7 @@ impl VirtualMethods for HTMLDetailsElement {
                 element: details,
                 toggle_number: counter
             };
-            let _ = task_source.queue(runnable, window.r());
+            let _ = task_source.queue(runnable, GlobalRef::Window(&window));
         }
     }
 }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -12,6 +12,7 @@ use dom::bindings::codegen::Bindings::HTMLFormElementBinding::HTMLFormElementMet
 use dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding::HTMLTextAreaElementMethods;
 use dom::bindings::conversions::DerivedFrom;
+use dom::bindings::global::GlobalRef;
 use dom::bindings::inheritance::{Castable, ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use dom::bindings::js::{JS, MutNullableHeap, Root};
 use dom::bindings::refcounted::Trusted;
@@ -484,7 +485,7 @@ impl HTMLFormElement {
         };
 
         // Step 3
-        window.dom_manipulation_task_source().queue(nav, window).unwrap();
+        window.dom_manipulation_task_source().queue(nav, GlobalRef::Window(window)).unwrap();
     }
 
     /// Interactively validate the constraints of form elements

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -184,7 +184,7 @@ impl HTMLImageElement {
                         src: src.into(),
                     };
                     let task = window.dom_manipulation_task_source();
-                    let _ = task.queue(runnable, window);
+                    let _ = task.queue(runnable, GlobalRef::Window(window));
                 }
             }
         }

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -241,7 +241,7 @@ impl HTMLMediaElement {
             elem: Trusted::new(self),
         };
         let win = window_from_node(self);
-        let _ = win.dom_manipulation_task_source().queue(task, win.r());
+        let _ = win.dom_manipulation_task_source().queue(task, GlobalRef::Window(&win));
     }
 
     // https://html.spec.whatwg.org/multipage/#internal-pause-steps step 2.2
@@ -265,13 +265,13 @@ impl HTMLMediaElement {
             elem: Trusted::new(self),
         };
         let win = window_from_node(self);
-        let _ = win.dom_manipulation_task_source().queue(task, win.r());
+        let _ = win.dom_manipulation_task_source().queue(task, GlobalRef::Window(&win));
     }
 
     fn queue_fire_simple_event(&self, type_: &'static str) {
         let win = window_from_node(self);
         let task = box FireSimpleEventTask::new(self, type_);
-        let _ = win.dom_manipulation_task_source().queue(task, win.r());
+        let _ = win.dom_manipulation_task_source().queue(task, GlobalRef::Window(&win));
     }
 
     fn fire_simple_event(&self, type_: &str) {
@@ -498,7 +498,8 @@ impl HTMLMediaElement {
 
     fn queue_dedicated_media_source_failure_steps(&self) {
         let window = window_from_node(self);
-        let _ = window.dom_manipulation_task_source().queue(box DedicatedMediaSourceFailureTask::new(self), window.r());
+        let _ = window.dom_manipulation_task_source().queue(box DedicatedMediaSourceFailureTask::new(self),
+                                                            GlobalRef::Window(&window));
     }
 
     // https://html.spec.whatwg.org/multipage/#dedicated-media-source-failure-steps

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -161,7 +161,8 @@ impl Storage {
         let window = global_ref.as_window();
         let task_source = window.dom_manipulation_task_source();
         let trusted_storage = Trusted::new(self);
-        task_source.queue(box StorageEventRunnable::new(trusted_storage, key, old_value, new_value), window).unwrap();
+        task_source.queue(box StorageEventRunnable::new(trusted_storage, key, old_value, new_value),
+                          global_ref).unwrap();
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -302,7 +302,7 @@ impl Window {
         self.history_traversal_task_source.clone()
     }
 
-    pub fn file_reading_task_source(&self) -> Box<ScriptChan + Send> {
+    pub fn file_reading_task_source(&self) -> FileReadingTaskSource {
         self.file_reading_task_source.clone()
     }
 

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -39,6 +39,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::Receiver;
+use task_source::file_reading::FileReadingTaskSource;
 use timers::{IsInterval, OneshotTimerCallback, OneshotTimerHandle, OneshotTimers, TimerCallback};
 use url::Url;
 
@@ -458,6 +459,10 @@ impl WorkerGlobalScope {
         } else {
             panic!("need to implement a sender for SharedWorker")
         }
+    }
+
+    pub fn file_reading_task_source(&self) -> FileReadingTaskSource {
+        FileReadingTaskSource(self.script_chan())
     }
 
     pub fn pipeline(&self) -> PipelineId {

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -29,6 +29,7 @@ use net_traits::{LoadContext, ResourceThreads, load_whole_resource};
 use net_traits::{RequestSource, LoadOrigin, CustomResponseSender, IpcSend};
 use profile_traits::{mem, time};
 use script_runtime::{CommonScriptMsg, ScriptChan, ScriptPort, maybe_take_panic_result};
+use script_thread::RunnableWrapper;
 use script_traits::ScriptMsg as ConstellationMsg;
 use script_traits::{MsDuration, TimerEvent, TimerEventId, TimerEventRequest, TimerSource};
 use std::cell::Cell;
@@ -267,6 +268,12 @@ impl WorkerGlobalScope {
 
     pub fn panic_chan(&self) -> &IpcSender<PanicMsg> {
         &self.panic_chan
+    }
+
+    pub fn get_runnable_wrapper(&self) -> RunnableWrapper {
+        RunnableWrapper {
+            cancelled: self.closing.clone(),
+        }
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -575,6 +575,8 @@ impl ScriptThread {
         // Ask the router to proxy IPC messages from the control port to us.
         let control_port = ROUTER.route_ipc_receiver_to_new_mpsc_receiver(state.control_port);
 
+        let boxed_script_sender = MainThreadScriptChan(chan.clone()).clone();
+
         ScriptThread {
             browsing_context: MutNullableHeap::new(None),
             incomplete_loads: DOMRefCell::new(vec!()),
@@ -595,8 +597,8 @@ impl ScriptThread {
             dom_manipulation_task_source: DOMManipulationTaskSource(chan.clone()),
             user_interaction_task_source: UserInteractionTaskSource(chan.clone()),
             networking_task_source: NetworkingTaskSource(chan.clone()),
-            history_traversal_task_source: HistoryTraversalTaskSource(chan.clone()),
-            file_reading_task_source: FileReadingTaskSource(chan),
+            history_traversal_task_source: HistoryTraversalTaskSource(chan),
+            file_reading_task_source: FileReadingTaskSource(boxed_script_sender),
 
             control_chan: state.control_chan,
             control_port: control_port,
@@ -1585,7 +1587,6 @@ impl ScriptThread {
         let UserInteractionTaskSource(ref user_sender) = self.user_interaction_task_source;
         let NetworkingTaskSource(ref network_sender) = self.networking_task_source;
         let HistoryTraversalTaskSource(ref history_sender) = self.history_traversal_task_source;
-        let FileReadingTaskSource(ref file_sender) = self.file_reading_task_source;
 
         let (ipc_timer_event_chan, ipc_timer_event_port) = ipc::channel().unwrap();
         ROUTER.route_ipc_receiver_to_mpsc_sender(ipc_timer_event_port,
@@ -1598,7 +1599,7 @@ impl ScriptThread {
                                  UserInteractionTaskSource(user_sender.clone()),
                                  NetworkingTaskSource(network_sender.clone()),
                                  HistoryTraversalTaskSource(history_sender.clone()),
-                                 FileReadingTaskSource(file_sender.clone()),
+                                 self.file_reading_task_source.clone(),
                                  self.image_cache_channel.clone(),
                                  self.custom_message_chan.clone(),
                                  self.image_cache_thread.clone(),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1227,7 +1227,7 @@ impl ScriptThread {
 
         // https://html.spec.whatwg.org/multipage/#the-end step 7
         let handler = box DocumentProgressHandler::new(Trusted::new(doc));
-        self.dom_manipulation_task_source.queue(handler, doc.window()).unwrap();
+        self.dom_manipulation_task_source.queue(handler, GlobalRef::Window(doc.window())).unwrap();
 
         self.constellation_chan.send(ConstellationMsg::LoadComplete(pipeline)).unwrap();
     }

--- a/components/script/task_source/file_reading.rs
+++ b/components/script/task_source/file_reading.rs
@@ -2,19 +2,72 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use script_runtime::{CommonScriptMsg, ScriptChan};
-use script_thread::MainThreadScriptMsg;
-use std::sync::mpsc::Sender;
+use dom::domexception::DOMErrorName;
+use dom::filereader::{FileReader, TrustedFileReader, GenerationId, ReadMetaData};
+use script_runtime::{CommonScriptMsg, ScriptThreadEventCategory, ScriptChan};
+use script_thread::{Runnable, RunnableWrapper};
+use std::sync::Arc;
+use task_source::TaskSource;
 
 #[derive(JSTraceable)]
-pub struct FileReadingTaskSource(pub Sender<MainThreadScriptMsg>);
+pub struct FileReadingTaskSource(pub Box<ScriptChan + Send + 'static>);
 
-impl ScriptChan for FileReadingTaskSource {
-    fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
-        self.0.send(MainThreadScriptMsg::Common(msg)).map_err(|_| ())
+impl Clone for FileReadingTaskSource {
+    fn clone(&self) -> FileReadingTaskSource {
+        FileReadingTaskSource(self.0.clone())
     }
+}
 
-    fn clone(&self) -> Box<ScriptChan + Send> {
-        box FileReadingTaskSource((&self.0).clone())
+impl TaskSource for FileReadingTaskSource {
+    fn queue_with_wrapper<T>(&self,
+                             msg: Box<T>,
+                             wrapper: &RunnableWrapper)
+                             -> Result<(), ()>
+                             where T: Runnable + Send + 'static {
+        self.0.send(CommonScriptMsg::RunnableMsg(ScriptThreadEventCategory::FileRead,
+                                                 wrapper.wrap_runnable(msg)))
+    }
+}
+
+pub struct FileReadingRunnable {
+    task: FileReadingTask,
+}
+
+impl FileReadingRunnable {
+    pub fn new(task: FileReadingTask) -> Box<FileReadingRunnable> {
+        box FileReadingRunnable {
+            task: task
+        }
+    }
+}
+
+impl Runnable for FileReadingRunnable {
+    fn handler(self: Box<FileReadingRunnable>) {
+        self.task.handle_task();
+    }
+}
+
+#[allow(dead_code)]
+pub enum FileReadingTask {
+    ProcessRead(TrustedFileReader, GenerationId),
+    ProcessReadData(TrustedFileReader, GenerationId),
+    ProcessReadError(TrustedFileReader, GenerationId, DOMErrorName),
+    ProcessReadEOF(TrustedFileReader, GenerationId, ReadMetaData, Arc<Vec<u8>>),
+}
+
+impl FileReadingTask {
+    pub fn handle_task(self) {
+        use self::FileReadingTask::*;
+
+        match self {
+            ProcessRead(reader, gen_id) =>
+                FileReader::process_read(reader, gen_id),
+            ProcessReadData(reader, gen_id) =>
+                FileReader::process_read_data(reader, gen_id),
+            ProcessReadError(reader, gen_id, error) =>
+                FileReader::process_read_error(reader, gen_id, error),
+            ProcessReadEOF(reader, gen_id, metadata, blob_contents) =>
+                FileReader::process_read_eof(reader, gen_id, metadata, blob_contents),
+        }
     }
 }

--- a/components/script/task_source/mod.rs
+++ b/components/script/task_source/mod.rs
@@ -8,10 +8,17 @@ pub mod history_traversal;
 pub mod networking;
 pub mod user_interaction;
 
-use dom::window::Window;
-use script_thread::Runnable;
+use dom::bindings::global::GlobalRef;
+use script_thread::{Runnable, RunnableWrapper};
 use std::result::Result;
 
 pub trait TaskSource {
-    fn queue<T: Runnable + Send + 'static>(&self, msg: Box<T>, window: &Window) -> Result<(), ()>;
+    fn queue_with_wrapper<T>(&self,
+                             msg: Box<T>,
+                             wrapper: &RunnableWrapper)
+                             -> Result<(), ()>
+                             where T: Runnable + Send + 'static;
+    fn queue<T: Runnable + Send + 'static>(&self, msg: Box<T>, global: GlobalRef) -> Result<(), ()> {
+        self.queue_with_wrapper(msg, &global.get_runnable_wrapper())
+    }
 }

--- a/components/script/task_source/user_interaction.rs
+++ b/components/script/task_source/user_interaction.rs
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::global::GlobalRef;
 use dom::bindings::refcounted::Trusted;
 use dom::event::{EventBubbles, EventCancelable, EventRunnable};
 use dom::eventtarget::EventTarget;
 use dom::window::Window;
-use script_thread::{MainThreadScriptMsg, Runnable, ScriptThread};
+use script_thread::{MainThreadScriptMsg, Runnable, RunnableWrapper, ScriptThread};
 use std::result::Result;
 use std::sync::mpsc::Sender;
 use string_cache::Atom;
@@ -16,8 +17,12 @@ use task_source::TaskSource;
 pub struct UserInteractionTaskSource(pub Sender<MainThreadScriptMsg>);
 
 impl TaskSource for UserInteractionTaskSource {
-    fn queue<T: Runnable + Send + 'static>(&self, msg: Box<T>, window: &Window) -> Result<(), ()> {
-        let msg = UserInteractionTask(window.get_runnable_wrapper().wrap_runnable(msg));
+    fn queue_with_wrapper<T>(&self,
+                             msg: Box<T>,
+                             wrapper: &RunnableWrapper)
+                             -> Result<(), ()>
+                             where T: Runnable + Send + 'static {
+        let msg = UserInteractionTask(wrapper.wrap_runnable(msg));
         self.0.send(MainThreadScriptMsg::UserInteraction(msg)).map_err(|_| ())
     }
 }
@@ -36,7 +41,7 @@ impl UserInteractionTaskSource {
             bubbles: bubbles,
             cancelable: cancelable,
         };
-        let _ = self.queue(runnable, window);
+        let _ = self.queue(runnable, GlobalRef::Window(window));
     }
 }
 


### PR DESCRIPTION
Implement the task source API for the File Reader task source, enabling using task sources from non-main threads.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix (partially) #7959 (github issue number if applicable).
- [X] These changes do not require tests because they're refactoring existing code

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12448)

<!-- Reviewable:end -->
