### PR TITLE
style: bailout if we find an unstyled parent node during the cascade.

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -684,8 +684,14 @@ pub trait MatchMethods : TNode {
         // enforced safe, race-free access to the parent style.
         let parent_style = match parent {
             Some(parent_node) => {
-                let parent_style = (*parent_node.borrow_data_unchecked().unwrap()).style.as_ref().unwrap();
-                Some(parent_style)
+                match parent_node.borrow_data_unchecked()
+                                 .and_then(|data| (*data).style.as_ref()) {
+                    Some(style) => Some(style),
+                    None => {
+                        warn!("Found unstyled parent on cascade_node, bailing out");
+                        return;
+                    }
+                }
             }
             None => None,
         };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is the patch I used at some point in time. Let me know if you panic here, but I certainly do not need it.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

r? @heycam

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12454)

<!-- Reviewable:end -->
