### PR TITLE
Cleanups in autoarray helper

### DIFF
--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -37,12 +37,17 @@
 // and handle the empty case correctly
 <%doc>
     To be used in cases where we have a grammar like
-    "<thing> [ , <thing> ]*", but only support a single value
-    in servo
+    "<thing> [ , <thing> ]*". `gecko_only` should be set
+    to True for cases where Servo takes a single value
+    and Stylo supports vector values.
+
+    If the computed value is the same as the specified value,
+    setting computed_is_specified to True will introduce additional
+    optimizations
 </%doc>
-<%def name="gecko_autoarray_longhand(name, **kwargs)">
+<%def name="vector_longhand(name, gecko_only=False, **kwargs)">
     <%call expr="longhand(name, **kwargs)">
-        % if product == "gecko":
+        % if product == "gecko" or not gecko_only:
             use cssparser::ToCss;
             use std::fmt;
 

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -75,6 +75,8 @@
                     } else {
                         % if allow_empty:
                             try!(dest.write_str("none"));
+                        % else:
+                            error!("Found empty value for property ${name}");
                         % endif
                     }
                     for i in iter {
@@ -97,6 +99,8 @@
                     } else {
                         % if allow_empty:
                             try!(dest.write_str("none"));
+                        % else:
+                            error!("Found empty value for property ${name}");
                         % endif
                     }
                     for i in iter {

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -44,6 +44,7 @@
     Setting allow_empty to False allows for cases where the vector
     is empty. The grammar for these is usually "none | <thing> [ , <thing> ]*".
     We assume that the default/initial value is an empty vector for these.
+    `initial_value` need not be defined for these.
 </%doc>
 <%def name="vector_longhand(name, gecko_only=False, allow_empty=False, **kwargs)">
     <%call expr="longhand(name, **kwargs)">

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -16,7 +16,7 @@ use properties::longhands::line_height::computed_value::T as LineHeight;
 use properties::longhands::text_shadow::computed_value::T as TextShadowList;
 use properties::longhands::text_shadow::computed_value::TextShadow;
 use properties::longhands::box_shadow::computed_value::T as BoxShadowList;
-use properties::longhands::box_shadow::computed_value::BoxShadow;
+use properties::longhands::box_shadow::single_value::computed_value::T as BoxShadow;
 use properties::longhands::transform::computed_value::ComputedMatrix;
 use properties::longhands::transform::computed_value::ComputedOperation as TransformOperation;
 use properties::longhands::transform::computed_value::T as TransformList;

--- a/components/style/properties/longhand/background.mako.rs
+++ b/components/style/properties/longhand/background.mako.rs
@@ -10,7 +10,7 @@ ${helpers.predefined_type("background-color", "CSSColor",
     "::cssparser::Color::RGBA(::cssparser::RGBA { red: 0., green: 0., blue: 0., alpha: 0. }) /* transparent */",
     animatable=True)}
 
-<%helpers:gecko_autoarray_longhand name="background-image" animatable="False">
+<%helpers:vector_longhand gecko_only="True" name="background-image" animatable="False">
     use cssparser::ToCss;
     use std::fmt;
     use values::specified::Image;
@@ -70,7 +70,7 @@ ${helpers.predefined_type("background-color", "CSSColor",
             }
         }
     }
-</%helpers:gecko_autoarray_longhand>
+</%helpers:vector_longhand>
 
 <%helpers:longhand name="background-position" animatable="True">
         use cssparser::ToCss;


### PR DESCRIPTION
Addresses @emilio's comments from #11851
- Replace gecko_autoarray_longhand with vector_longhand, make it configurable
- Allow for empty vectors, use empty vector longhand in box-shadow

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12458)

<!-- Reviewable:end -->
