### PR TITLE
Add a keyboard shortcut (Command + Q on Mac or Control + Q on other O…

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -917,6 +917,11 @@ impl WindowMethods for Window {
                     self.event_queue.borrow_mut().push(WindowEvent::Reload);
                 }
             }
+            (CMD_OR_CONTROL, Some('q'), _) => {
+                if let Some(true) = PREFS.get("shell.builtin-key-shortcuts.enabled").as_boolean() {
+                    self.event_queue.borrow_mut().push(WindowEvent::Quit);
+                }
+            }
 
             _ => {
                 self.platform_handle_key(key, mods);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
## Added code in window.rs to enqueue the Window::Quit event when the Command/Control + Q keyboard shortcut is detected IF keyboard shortcuts are enabled.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12422 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there are no tests able to test keyboard shortcuts at the moment

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12461)

<!-- Reviewable:end -->
