### PR TITLE
Replace any errors caused by content-provided URLs by warnings.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1403,7 +1403,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                     warn!("Sending load url to constellation failed ({}).", e);
                 }
             },
-            Err(e) => error!("Parsing URL {} failed ({}).", url_string, e),
+            Err(e) => warn!("Parsing URL {} failed ({}).", url_string, e),
         }
     }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -328,7 +328,7 @@ impl HTMLScriptElement {
                 // Step 18.4-18.5.
                 let url = match base_url.join(&src) {
                     Err(_) => {
-                        error!("error parsing URL for script {}", &**src);
+                        warn!("error parsing URL for script {}", &**src);
                         self.queue_error_event();
                         return NextParserState::Continue;
                     }
@@ -414,7 +414,7 @@ impl HTMLScriptElement {
         let (source, external, url) = match load {
             // Step 2.a.
             ScriptOrigin::External(Err(e)) => {
-                error!("error loading script {:?}", e);
+                warn!("error loading script {:?}", e);
                 self.dispatch_error_event();
                 return;
             }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
#11841 makes errors generate issue reports, so anything that's content-provided should generate warnings, not errors.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because we don't test error generation

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12463)

<!-- Reviewable:end -->
