### PR TITLE
Remove fn start_sending_sniffed

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -95,14 +95,6 @@ pub fn send_error(url: Url, err: NetworkError, start_chan: LoadConsumer) {
 }
 
 /// For use by loaders in responding to a Load message that allows content sniffing.
-pub fn start_sending_sniffed(start_chan: LoadConsumer, metadata: Metadata,
-                             classifier: Arc<MimeClassifier>, partial_body: &[u8],
-                             context: LoadContext)
-                             -> ProgressSender {
-    start_sending_sniffed_opt(start_chan, metadata, classifier, partial_body, context).ok().unwrap()
-}
-
-/// For use by loaders in responding to a Load message that allows content sniffing.
 pub fn start_sending_sniffed_opt(start_chan: LoadConsumer, mut metadata: Metadata,
                                  classifier: Arc<MimeClassifier>, partial_body: &[u8],
                                  context: LoadContext)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This function was not used, but more importantly encodes the bad
practice of a raw `.unwrap()` and therefore should not be used.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes reference #12462 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are a cleanup

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12464)

<!-- Reviewable:end -->
