### PR TITLE
Place apis.html in the same place as css-properties.html

### DIFF
--- a/etc/ci/upload_docs.sh
+++ b/etc/ci/upload_docs.sh
@@ -16,7 +16,8 @@ cp etc/doc.servo.org/* target/doc/
 
 python components/style/properties/build.py servo html
 
-OUT_DIR="`pwd`/target/doc" make -f makefile.cargo -C components/script dom_docs
+OUT_DIR="`pwd`/target/doc/servo" make -f makefile.cargo -C components/script dom_docs
+rm -rf target/doc/servo/.cache
 
 ghp-import -n target/doc
 git push -qf "https://${TOKEN}@github.com/servo/doc.servo.org.git" gh-pages


### PR DESCRIPTION
Right now it's visible at http://doc.servo.org/apis.html, unlike http://doc.servo.org/servo/css-properties.html.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12470)

<!-- Reviewable:end -->
