### PR TITLE
Dispatch change event for HTMLInputElement.

### DIFF
--- a/components/script/dom/eventdispatcher.rs
+++ b/components/script/dom/eventdispatcher.rs
@@ -141,6 +141,7 @@ pub fn dispatch_event(target: &EventTarget,
                 event_path.push(JS::from_ref(document.window().upcast()));
             }
         }
+        vtable_for(target_node).before_handle_event(event);
     }
 
     // Steps 5-9. In a separate function to short-circuit various things easily.

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -82,6 +82,7 @@ pub struct HTMLInputElement {
     checked_changed: Cell<bool>,
     placeholder: DOMRefCell<DOMString>,
     value_changed: Cell<bool>,
+    value_on_focus: DOMRefCell<DOMString>,
     size: Cell<u32>,
     maxlength: Cell<i32>,
     #[ignore_heap_size_of = "#7193"]
@@ -132,6 +133,7 @@ impl HTMLInputElement {
                                                       localName, prefix, document),
             input_type: Cell::new(InputType::InputText),
             placeholder: DOMRefCell::new(DOMString::new()),
+            value_on_focus: DOMRefCell::new(DOMString::new()),
             checked_changed: Cell::new(false),
             value_changed: Cell::new(false),
             maxlength: Cell::new(DEFAULT_MAX_LENGTH),
@@ -951,8 +953,9 @@ impl VirtualMethods for HTMLInputElement {
             },
             &atom!("value") if !self.value_changed.get() => {
                 let value = mutation.new_value(attr).map(|value| (**value).to_owned());
-                self.textinput.borrow_mut().set_content(
-                    value.map_or(DOMString::new(), DOMString::from));
+                let stringValue = value.map_or(DOMString::new(), DOMString::from);
+                self.textinput.borrow_mut().set_content(stringValue.clone());
+                *self.value_on_focus.borrow_mut() = stringValue;
                 self.update_placeholder_shown_state();
             },
             &atom!("name") if self.input_type.get() == InputType::InputRadio => {
@@ -1025,6 +1028,24 @@ impl VirtualMethods for HTMLInputElement {
             el.check_ancestors_disabled_state_for_form_control();
         } else {
             el.check_disabled_attribute();
+        }
+    }
+
+    fn before_handle_event(&self, event: &Event) {
+        if let Some(s) = self.super_type() {
+            s.before_handle_event(event);
+        }
+
+        if event.type_() == Atom::from("blur") {
+            if *self.value_on_focus.borrow() == self.Value() {
+                return;
+            }
+
+            *self.value_on_focus.borrow_mut() = self.Value();
+            let target = self.upcast::<EventTarget>();
+            target.fire_event("change",
+                              EventBubbles::Bubbles,
+                              EventCancelable::NotCancelable);
         }
     }
 

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -99,6 +99,13 @@ pub trait VirtualMethods {
         }
     }
 
+    /// Called before an event dispatch.
+    fn before_handle_event(&self, event: &Event) {
+        if let Some(ref s) = self.super_type() {
+            s.before_handle_event(event);
+        }
+    }
+
     /// Called during event dispatch after the bubbling phase completes.
     fn handle_event(&self, event: &Event) {
         if let Some(s) = self.super_type() {


### PR DESCRIPTION
I took a stab at #9575. This is my first pull request on servo so please bear with me :-).

I added a new virtual function `before_handle_event` which is a little more generic than needed but it looks like it will be needed for other things? At least judging by Gecko's codebase. Please let me know if you'd rather have a method just for blur.

I'm not quite sure why I couldn't use atom!("blur") instead of Atom::from("blur").

If this is the right direction I can write tests for this change (probably importing them if there aren't any already).

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #9575 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12475)

<!-- Reviewable:end -->
