### PR TITLE
Build failing because of unspecified dependency for html5lib

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,6 +3,7 @@ mach == 0.6.0
 mozdebug == 0.1
 mozinfo == 0.8
 mozlog == 3.0
+setuptools == 18.5
 toml == 0.9.1
 
 # For Python linting


### PR DESCRIPTION
Trying to simply build `servo`, I've reached a very early error.  I cloned the `servo` repo, installed the dependencies specified on the [README](https://github.com/servo/servo#prerequisites).  I'm running on a Debian Jessie [`Linux my machine 3.16.0-4-amd64 #1 SMP Debian 3.16.7-ckt25-2+deb8u3 (2016-07-02) x86_64 GNU/Linux`].

Then I run.

```
./mach build --dev
```

I only get the following message.

```
Pip failed to execute properly:
```

Looking in already existing issues, the only one I could find is #12062 which is about missing space on hard drive but this doesn't seem to be my problem.

I've looked more into the problem and found that pip was having problem.  Here is the error message.

```
  Downloading from URL https://pypi.python.org/packages/17/ee/99e69cdcefc354e0c18ff2cc60aeeb5bfcc2e33f051bf0cc5526d790c445/html5lib-0.999999999.tar.gz#md5=8578e4e3a341436cb9743a9e4a299239 (from https://pypi.python.org/simple/html5lib/)
  Running setup.py (path:/tmp/pip-build-mFVe16/html5lib/setup.py) egg_info for package html5lib
    html5lib requires setuptools version 18.5 or above; please upgrade before installing (you have 5.5.1)
    Complete output from command python setup.py egg_info:



----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /tmp/pip-build-mFVe16/html5lib
Exception information:
Traceback (most recent call last):
  File "/home/woshilapin/Projects/woshilapin/servo/python/_virtualenv/local/lib/python2.7/site-packages/pip/basecommand.py", line 122, in main
    status = self.run(options, args)
  File "/home/woshilapin/Projects/woshilapin/servo/python/_virtualenv/local/lib/python2.7/site-packages/pip/commands/install.py", line 290, in run
    requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
  File "/home/woshilapin/Projects/woshilapin/servo/python/_virtualenv/local/lib/python2.7/site-packages/pip/req.py", line 1230, in prepare_files
    req_to_install.run_egg_info()
  File "/home/woshilapin/Projects/woshilapin/servo/python/_virtualenv/local/lib/python2.7/site-packages/pip/req.py", line 326, in run_egg_info
    command_desc='python setup.py egg_info')
  File "/home/woshilapin/Projects/woshilapin/servo/python/_virtualenv/local/lib/python2.7/site-packages/pip/util.py", line 716, in call_subprocess
    % (command_desc, proc.returncode, cwd))
InstallationError: Command python setup.py egg_info failed with error code 1 in /tmp/pip-build-mFVe16/html5lib
```

I found that adding the following line in the file `python/requirements.txt` seems to solve the problem (I've build `servo` without errors and `./mach test-tidy` pass too).

```
setuptools >= 18.5
```

Since I'm very new to `servo`, I didn't propose a Pull Request because I'm not sure this is right way of fixing it or maybe I'm doing something wrong.  But I'd be happy to create the Pull Request if that's a valuable solution.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12480)

<!-- Reviewable:end -->
