### PR TITLE
Temporary fix for mach test-{wpt, css} issue with wonky paths

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -354,7 +354,7 @@ class MachCommands(CommandBase):
             all_handled = True
             for test_path in requested_paths:
                 suite = self.suite_for_path(test_path)
-                if correct_suite != suite:
+                if suite is not None and correct_suite != suite:
                     all_handled = False
                     print("Warning: %s is not a %s test. Delegating to test-%s." % (test_path, correct_suite, suite))
             if all_handled:


### PR DESCRIPTION
#11604 introduced logic that checks if the test command being run is compatible with the suite to which a test belongs. The function that determines which suite a test belongs to, `suite_for_test`, currently doesn't handle special "paths" such as `SKIP_TEST` or `/FileAPI/url/url_xmlhttprequest_img.html`. This PR changes things so as not to treat this case as a mismatch and bail out.

This is just a temporary fix to get `mach test-wpt`, `mach update-manifest` etc. working properly again. A proper fix will likely involve a proper refactoring of the `suite_for_test` function.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12481
- [X] These changes have been tested to work locally

r? @ConnorGBrewster cc @jdm

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12484)

<!-- Reviewable:end -->
