### PR TITLE
Add FFI glue for Gecko to implement 1-arg CSS.supports() with stylo.

### DIFF
--- a/ports/geckolib/gecko_bindings/bindings.rs
+++ b/ports/geckolib/gecko_bindings/bindings.rs
@@ -288,6 +288,8 @@ extern "C" {
                                                   *mut ServoDeclarationBlock);
     pub fn Servo_ClearDeclarationBlockCachePointer(declarations:
                                                        *mut ServoDeclarationBlock);
+    pub fn Servo_CSSSupports(property: *const u8, property_length: u32,
+                             value: *const u8, value_length: u32) -> bool;
     pub fn Servo_GetComputedValues(node: *mut RawGeckoNode)
      -> *mut ServoComputedValues;
     pub fn Servo_GetComputedValuesForAnonymousBox(parentStyleOrNull:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This adds an FFI function for Gecko to call to implement the 1-arg version of `CSS.supports()`.  This will be useful for producing an automated analysis of CSS properties we lack support for in geckolib.  Corresponding Gecko bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1287382

r? @emilio 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this is a geckolib-only change, and we don't have testing for that yet :(

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12487)

<!-- Reviewable:end -->
