### PR TITLE
geckolib: Support parsing style="" attributes longer than 255 characters.

### DIFF
--- a/ports/geckolib/gecko_bindings/bindings.rs
+++ b/ports/geckolib/gecko_bindings/bindings.rs
@@ -276,7 +276,7 @@ extern "C" {
     pub fn Servo_StyleSheetHasRules(sheet: *mut RawServoStyleSheet) -> bool;
     pub fn Servo_InitStyleSet() -> *mut RawServoStyleSet;
     pub fn Servo_DropStyleSet(set: *mut RawServoStyleSet);
-    pub fn Servo_ParseStyleAttribute(bytes: *const u8, length: u8,
+    pub fn Servo_ParseStyleAttribute(bytes: *const u8, length: u32,
                                      cache: *mut nsHTMLCSSStyleSheet)
      -> *mut ServoDeclarationBlock;
     pub fn Servo_DropDeclarationBlock(declarations:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This just fixes the bindings for a typo in `ServoBindings.h` in Gecko.  Corresponding Gecko bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1287383

r? @emilio 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12488)

<!-- Reviewable:end -->
