### PR TITLE
Implement Runnable trait name method for PauseIfNotInDocumentTask

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -801,6 +801,8 @@ impl PauseIfNotInDocumentTask {
 }
 
 impl Runnable for PauseIfNotInDocumentTask {
+    fn name(&self) -> &'static str { "PauseIfNotInDocumentTask" }
+
     fn handler(self: Box<PauseIfNotInDocumentTask>) {
         let elem = self.elem.root();
         if !elem.upcast::<Node>().is_in_doc() {


### PR DESCRIPTION
Implements #12350.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12350.

<!-- Either: -->
- [X] These changes do not require tests

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12495)

<!-- Reviewable:end -->
