### PR TITLE
Support generating bindings for MSVC

### DIFF
--- a/ports/geckolib/gecko_bindings/tools/regen.py
+++ b/ports/geckolib/gecko_bindings/tools/regen.py
@@ -284,10 +284,11 @@ def build(objdir, target_name, kind_name=None,
         print("[RUSTC]... ", end='')
         sys.stdout.flush()
 
-        tests_file = tempfile.NamedTemporaryFile()
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            test_file = f.name
         output = None
         try:
-            rustc_command = ["rustc", output_filename, "--test", "-o", tests_file.name]
+            rustc_command = ["rustc", output_filename, "--test", "-o", test_file]
             output = subprocess.check_output(rustc_command, stderr=subprocess.STDOUT)
             output = output.decode('utf8')
         except subprocess.CalledProcessError as e:
@@ -299,17 +300,17 @@ def build(objdir, target_name, kind_name=None,
         if verbose:
             print(output)
 
-        tests_file.file.close()
         print("[RUSTC_TEST]... ", end='')
         sys.stdout.flush()
 
         try:
-            output = subprocess.check_output([tests_file.name], stderr=subprocess.STDOUT)
+            output = subprocess.check_output([test_file], stderr=subprocess.STDOUT)
             output = output.decode('utf8')
         except subprocess.CalledProcessError as e:
             print("tests failed: ", e.output.decode('utf8'))
             return 1
 
+        os.remove(test_file)
         print("OK")
 
         # TODO: this -3 is hacky as heck

--- a/ports/geckolib/gecko_bindings/tools/regen.py
+++ b/ports/geckolib/gecko_bindings/tools/regen.py
@@ -376,7 +376,7 @@ def builds_for(target_name, kind):
 
 def main():
     parser = argparse.ArgumentParser(description=DESCRIPTION)
-    parser.add_argument('--target',
+    parser.add_argument('--target', default="all",
                         help='The target to build, either "structs" or "bindings"')
     parser.add_argument('--kind',
                         help='Kind of build')
@@ -398,7 +398,7 @@ def main():
         print("\"{}\" doesn't seem to be a directory".format(args.objdir))
         return 1
 
-    if args.target != COMMON_BUILD_KEY and args.target != "all" and args.target not in COMPILATION_TARGETS:
+    if (args.target != "all" and args.target not in COMPILATION_TARGETS) or args.target == COMMON_BUILD_KEY:
         print("{} is not a valid compilation target.".format(args.target))
         print("Valid compilation targets are:")
         for target in COMPILATION_TARGETS.keys():

--- a/ports/geckolib/gecko_bindings/tools/regen.py
+++ b/ports/geckolib/gecko_bindings/tools/regen.py
@@ -126,6 +126,9 @@ COMPILATION_TARGETS = {
             "nsMainThreadPtrHolder", "nscolor", "nsFont", "FontFamilyList",
             "FontFamilyType", "nsIAtom",
         ],
+        "void_types": [
+            "nsINode", "nsIDocument", "nsIPrincipal", "nsIURI",
+        ]
     }
 }
 

--- a/ports/geckolib/gecko_bindings/tools/regen.py
+++ b/ports/geckolib/gecko_bindings/tools/regen.py
@@ -125,9 +125,6 @@ COMPILATION_TARGETS = {
             "nsMainThreadPtrHolder", "nscolor", "nsFont", "FontFamilyList",
             "FontFamilyType", "nsIAtom",
         ],
-        "void_types": [
-            "nsINode", "nsIDocument", "nsIPrincipal", "nsIURI",
-        ]
     }
 }
 
@@ -178,7 +175,13 @@ def build(objdir, target_name, kind_name=None,
             (kind_name in current_target["build_kinds"]))
 
     if bindgen is None:
-        bindgen = "{}/rust-bindgen/target/debug/bindgen".format(TOOLS_DIR)
+        bindgen = os.path.join(TOOLS_DIR, "rust-bindgen")
+
+    if os.path.isdir(bindgen):
+        bindgen = ["cargo", "run", "--manifest-path",
+                   os.path.join(bindgen, "Cargo.toml"), "--"]
+    else:
+        bindgen = [bindgen]
 
     if output_filename is None:
         filename = "{}.rs".format(target_name)
@@ -266,7 +269,7 @@ def build(objdir, target_name, kind_name=None,
     assert len(current_target["files"]) == 1
     flags.append(current_target["files"][0].format(objdir))
 
-    flags.insert(0, bindgen)
+    flags = bindgen + flags
     output = None
     try:
         output = subprocess.check_output(flags, stderr=subprocess.STDOUT)

--- a/ports/geckolib/gecko_bindings/tools/regen.py
+++ b/ports/geckolib/gecko_bindings/tools/regen.py
@@ -135,11 +135,13 @@ def platform_dependent_defines():
     if os.name == "posix":
         ret.append("-DOS_POSIX=1")
 
-    ret.append({
-        "Linux": "-DOS_LINUX=1",
-        "Darwin": "-DOS_MACOSX=1",
-        # TODO: Windows?
-    }[platform.system()])
+    system = platform.system()
+    if system == "Linux":
+        ret.append("-DOS_LINUX=1")
+    elif system == "Darwin":
+        ret.append("-DOS_MACOSX=1")
+    else:
+        raise Exception("Unknown platform")
 
     return ret
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This pull request includes several patches to the binding generating script to make it work with MSVC. The generated files are not updated because they may not be compatible with other platforms which the majority of developers are working on.

Only `regen.py` is modified. The two `.sh` files are not. Those files are very platform-specific and I don't think it's worth to make them work on Windows at all, and my hope is that we can get rid of those files and only use `regen.py`. I imagine the only left steps to get there are:
1. make clang version detectable via `bindgen` so that we get reliable clang version without needing to duplicate the library searching work (which has already been done in `clang-sys`)
2. checkout the git repo inside the python script and run `cargo build` there

BTW, it seems to me nightly Rust is not required to build `bindgen`, and thus we can probably get rid of the `multirust` detection. (Even if we need that, I think we should prefer `rustup` and optionally fallback to `multirust`. I know `rustup` is not yet available on Homebrew, though...)

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it is a change to binding generating script

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

r? @emilio

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12498)

<!-- Reviewable:end -->
