### PR TITLE
Added devtools support to fetch for XHR

### DIFF
--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -43,6 +43,7 @@ pub struct NetworkEventActor {
     pub name: String,
     request: HttpRequest,
     response: HttpResponse,
+    is_xhr: bool,
 }
 
 #[derive(Serialize)]
@@ -340,7 +341,8 @@ impl NetworkEventActor {
                 headers: None,
                 status: None,
                 body: None,
-            }
+            },
+            is_xhr: false,
         }
     }
 
@@ -353,6 +355,7 @@ impl NetworkEventActor {
         self.request.timeStamp = request.timeStamp;
         self.request.connect_time = request.connect_time;
         self.request.send_time = request.send_time;
+        self.is_xhr = request.is_xhr;
     }
 
     pub fn add_response(&mut self, response: DevtoolsHttpResponse) {
@@ -369,7 +372,7 @@ impl NetworkEventActor {
             method: format!("{}", self.request.method),
             startedDateTime: format!("{}", self.request.startedDateTime.rfc3339()),
             timeStamp: self.request.timeStamp,
-            isXHR: false,
+            isXHR: self.is_xhr,
             private: false,
         }
     }

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -298,6 +298,7 @@ pub struct HttpRequest {
     pub timeStamp: i64,
     pub connect_time: u64,
     pub send_time: u64,
+    pub is_xhr: bool,
 }
 
 #[derive(Debug, PartialEq)]

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -574,7 +574,7 @@ impl CoreResourceManager {
                 return
             }
         };
-        debug!("resource_thread: loading url: {}", load_data.url);
+        debug!("loading url: {}", load_data.url);
 
         loader.call_box((load_data,
                          consumer,
@@ -593,6 +593,7 @@ impl CoreResourceManager {
             blocked_content: BLOCKED_CONTENT_RULES.clone(),
         };
         let ua = self.user_agent.clone();
+        let dc = self.devtools_chan.clone();
         spawn_named(format!("fetch thread for {}", init.url), move || {
             let request = Request::from_init(init);
             // XXXManishearth: Check origin against pipeline id (also ensure that the mode is allowed)
@@ -600,7 +601,7 @@ impl CoreResourceManager {
             // todo referrer policy?
             // todo service worker stuff
             let mut target = Some(Box::new(sender) as Box<FetchTaskTarget + Send + 'static>);
-            let context = FetchContext { state: http_state, user_agent: ua };
+            let context = FetchContext { state: http_state, user_agent: ua, devtools_chan: dc };
             fetch(Rc::new(request), &mut target, context);
         })
     }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -594,6 +594,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
             origin: self.global().r().get_url(),
             referer_url: self.referrer_url.clone(),
             referrer_policy: self.referrer_policy.clone(),
+            pipeline_id: self.pipeline_id(),
         };
 
         if bypass_cross_origin_check {

--- a/tests/unit/net/http_loader.rs
+++ b/tests/unit/net/http_loader.rs
@@ -339,7 +339,7 @@ impl HttpRequest for AssertMustHaveBodyRequest {
     }
 }
 
-fn expect_devtools_http_request(devtools_port: &Receiver<DevtoolsControlMsg>) -> DevtoolsHttpRequest {
+pub fn expect_devtools_http_request(devtools_port: &Receiver<DevtoolsControlMsg>) -> DevtoolsHttpRequest {
     match devtools_port.recv().unwrap() {
         DevtoolsControlMsg::FromChrome(
         ChromeToDevtoolsControlMsg::NetworkEvent(_, net_event)) => {
@@ -355,7 +355,7 @@ fn expect_devtools_http_request(devtools_port: &Receiver<DevtoolsControlMsg>) ->
     }
 }
 
-fn expect_devtools_http_response(devtools_port: &Receiver<DevtoolsControlMsg>) -> DevtoolsHttpResponse {
+pub fn expect_devtools_http_response(devtools_port: &Receiver<DevtoolsControlMsg>) -> DevtoolsHttpResponse {
     match devtools_port.recv().unwrap() {
         DevtoolsControlMsg::FromChrome(
             ChromeToDevtoolsControlMsg::NetworkEvent(_, net_event_response)) => {
@@ -526,6 +526,7 @@ fn test_request_and_response_data_with_network_messages() {
         timeStamp: devhttprequest.timeStamp,
         connect_time: devhttprequest.connect_time,
         send_time: devhttprequest.send_time,
+        is_xhr: false,
     };
 
     let content = "Yay!";


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Added devtools support for fetch for XHR, but devtools can't show the request in the XHR tab. I've attached a picture of an XHR request in devtools.

<img width="694" alt="screenshot 2016-07-19 11 07 55" src="https://cloud.githubusercontent.com/assets/11877868/16944480/210b0e8a-4da1-11e6-8288-48005ede33f6.png">

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11774  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because I don't know how to automate devtools testing for this

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12502)

<!-- Reviewable:end -->
