### PR TITLE
Upgrade mozlog package from 3.0 to 3.3.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,7 +2,7 @@ blessings == 1.6
 mach == 0.6.0
 mozdebug == 0.1
 mozinfo == 0.8
-mozlog == 3.0
+mozlog == 3.3
 setuptools == 18.5
 toml == 0.9.1
 

--- a/tests/wpt/harness/requirements.txt
+++ b/tests/wpt/harness/requirements.txt
@@ -1,4 +1,4 @@
 html5lib >= 0.99
 mozinfo >= 0.7
-mozlog >= 3.0
+mozlog >= 3.3
 mozdebug >= 0.1


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Update mozlog to 3.3 so we can have correct reftest screenshots displayed with --log-html.
The original mozlog update bugs are listed as follows:
https://bugzilla.mozilla.org/show_bug.cgi?id=1287019
https://bugzilla.mozilla.org/show_bug.cgi?id=1287480

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12401 and #12403 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this is just a PyPI package version bumping

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Update mozlog to 3.3.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12510)

<!-- Reviewable:end -->
