### PR TITLE
Added test-tidy for dependent licenses.

### DIFF
--- a/python/tidy/servo_tidy/licenseck.py
+++ b/python/tidy/servo_tidy/licenseck.py
@@ -88,3 +88,38 @@ licenses_toml = [
     'license = "MPL-2.0"',
     'license = "MIT/Apache-2.0"',
 ]
+
+# The valid dependency licenses, in the form we'd expect to see them in a Cargo.toml file.
+licenses_dep_toml = [
+    # Licenses that are compatible with Servo's licensing
+    'license = "Apache-2 / MIT"',
+    'license = "Apache-2.0 / MIT"',
+    'license = "Apache-2.0"',
+    'license = "Apache-2.0/MIT"',
+    'license = "BSD-2-Clause"',
+    'license = "BSD-3-Clause"',
+    'license = "BSD-3-Clause/MIT"',
+    'license = "CC0-1.0"',
+    'license = "ISC"',
+    'license = "MIT / Apache-2.0"',
+    'license = "MIT OR Apache-2.0"',
+    'license = "MIT"',
+    'license = "MIT/Apache-2.0"',
+    'license = "MPL-2.0"',
+    'license = "Unlicense/MIT"',
+    'license = "zlib-acknowledgement"',
+    'license-file = "LICENSE-MIT"',
+    'license=  "MIT / Apache-2.0"',
+    # Whitelisted crates whose licensing has been checked manually
+    'name = "device"',
+    'name = "dylib"',
+    'name = "ipc-channel"',
+    'name = "mozjs_sys"',
+    'name = "azure"',
+    'name = "freetype"',
+    'name = "js"',
+    'name = "servo-freetype-sys"',
+    'name = "simd"',
+    'name = "webrender"',
+    'name = "webrender_traits"',
+]

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -17,7 +17,7 @@ import site
 import StringIO
 import subprocess
 import sys
-from licenseck import licenses, licenses_toml
+from licenseck import licenses, licenses_toml, licenses_dep_toml
 
 # License and header checks
 EMACS_HEADER = "/* -*- Mode:"
@@ -642,6 +642,28 @@ def check_wpt_lint_errors(files):
             yield ("WPT Lint Tool", "", "lint error(s) in Web Platform Tests: exit status {0}".format(returncode))
 
 
+def get_dep_toml_files(only_changed_files=False):
+    if not only_changed_files:
+        print '\nRunning the dependency licensing lint...'
+        for root, directories, filenames in os.walk(".cargo"):
+            for filename in filenames:
+                if filename == "Cargo.toml":
+                    yield os.path.join(root, filename)
+
+
+def check_dep_license_errors(filenames, progress=True):
+    filenames = progress_wrapper(filenames) if progress else filenames
+    for filename in filenames:
+        with open(filename, "r") as f:
+            ok_licensed = False
+            lines = f.readlines()
+            for idx, line in enumerate(lines):
+                for license_line in licenses_dep_toml:
+                    ok_licensed |= (license_line in line)
+            if not ok_licensed:
+                yield (filename, 0, "dependency should contain a valid license.")
+
+
 def get_file_list(directory, only_changed_files=False, exclude_dirs=[]):
     if only_changed_files:
         # only check the files that have been changed since the last merge
@@ -673,10 +695,12 @@ def scan(only_changed_files=False, progress=True):
     checking_functions = (check_flake8, check_lock, check_webidl_spec, check_json)
     line_checking_functions = (check_license, check_by_line, check_toml, check_rust, check_spec, check_modeline)
     errors = collect_errors_for_files(files_to_check, checking_functions, line_checking_functions)
+    # check dependecy licenses
+    dep_license_errors = check_dep_license_errors(get_dep_toml_files(only_changed_files), progress)
     # wpt lint checks
     wpt_lint_errors = check_wpt_lint_errors(get_wpt_files(only_changed_files, progress))
     # collect errors
-    errors = itertools.chain(errors, wpt_lint_errors)
+    errors = itertools.chain(errors, dep_license_errors, wpt_lint_errors)
     error = None
     for error in errors:
         print "\r\033[94m{}\033[0m:\033[93m{}\033[0m: \033[91m{}\033[0m".format(*error)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add a test-tidy lint for dependency licenses. Note that #12507 should land first.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because we don't test our lints

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12511)

<!-- Reviewable:end -->
