### PR TITLE
Issue 12396 to add developer documentation to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ brew install openssl
 brew link --force openssl
 ```
 
+If you've already partially compiled servo but forgot to do this step, run ./mach clean, link openssl, and recompile.
+
 On Debian-based Linuxes:
 
 ``` sh
@@ -176,6 +178,7 @@ URL with servo).
   `INTERVAL` seconds
 - `-s SIZE` sets the tile size for painting; defaults to 512
 - `-z` disables all graphical output; useful for running JS / layout tests
+- `-z help` displays useful output to debug servo
 
 ### Keyboard Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ URL with servo).
   `INTERVAL` seconds
 - `-s SIZE` sets the tile size for painting; defaults to 512
 - `-z` disables all graphical output; useful for running JS / layout tests
-- `-z help` displays useful output to debug servo
+- `-Z help` displays useful output to debug servo
 
 ### Keyboard Shortcuts
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Just some added developer documentation that was useful for me while starting to develop servo. 

This adds the documentation about running ./mach clean with a partially built servo but before linking openssl.
## It also adds the -Z flag under command line flags for debugging help.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X ] `./mach build -d` does not report any errors
- [ X] `./mach test-tidy` does not report any errors
- [ X] These changes fix #12396  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it is a documentation update only.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12514)

<!-- Reviewable:end -->
