### PR TITLE
Fix input alignment test reference

### DIFF
--- a/tests/wpt/mozilla/tests/css/input_alignment_ref.html
+++ b/tests/wpt/mozilla/tests/css/input_alignment_ref.html
@@ -2,11 +2,8 @@
 <html>
 <head>
     <title>Input elements shouldn't inherit parent containers alignment</title>
-    <style>
-        div { float: left; }
-    </style>
 </head>
 <body>
-    <div><input value="test" /></div>
+    <input value="test" />
 </body>
 </html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

In #10249 I added a ref test about text alignment in input element. But we couldn't delete the `float: left;` styled div because of a bug addressed here: #10280 . But it seems fixed now and we can finally remove the floated div in the reference file. Test is still passing.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12524)

<!-- Reviewable:end -->
