### PR TITLE
Refactor Bluetooth error handling

### DIFF
--- a/components/net_traits/bluetooth_thread.rs
+++ b/components/net_traits/bluetooth_thread.rs
@@ -1,8 +1,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use bluetooth_scanfilter::RequestDeviceoptions;
 use ipc_channel::ipc::IpcSender;
+
+#[derive(Deserialize, Serialize)]
+pub enum BluetoothError {
+    Type(String),
+    Network,
+    NotFound,
+    NotSupported,
+    Security,
+}
 
 #[derive(Deserialize, Serialize)]
 pub struct BluetoothDeviceMsg {
@@ -51,7 +61,7 @@ pub type BluetoothCharacteristicsMsg = Vec<BluetoothCharacteristicMsg>;
 
 pub type BluetoothDescriptorsMsg = Vec<BluetoothDescriptorMsg>;
 
-pub type BluetoothResult<T> = Result<T, String>;
+pub type BluetoothResult<T> = Result<T, BluetoothError>;
 
 #[derive(Deserialize, Serialize)]
 pub enum BluetoothMethodMsg {

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -12,7 +12,7 @@ use dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding::
     BluetoothRemoteGATTCharacteristicMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding::BluetoothRemoteGATTServiceMethods;
-use dom::bindings::error::Error::{InvalidModification, Network, NotSupported, Security, Type};
+use dom::bindings::error::Error::{self, InvalidModification, Network, NotSupported, Security};
 use dom::bindings::error::{Fallible, ErrorResult};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, MutHeap, Root};
@@ -115,7 +115,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
                                                       descriptor.instance_id))
             },
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -147,7 +147,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
                                  .collect())
             },
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -177,7 +177,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
                 ByteString::new(val)
             },
             Err(error) => {
-                return Err(Type(error))
+                return Err(Error::from(error))
             },
         };
         *self.value.borrow_mut() = Some(value.clone());
@@ -202,7 +202,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         match result {
             Ok(_) => Ok(()),
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -11,7 +11,7 @@ use dom::bindings::codegen::Bindings::BluetoothRemoteGATTDescriptorBinding;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTDescriptorBinding::BluetoothRemoteGATTDescriptorMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding::BluetoothRemoteGATTServiceMethods;
-use dom::bindings::error::Error::{InvalidModification, Network, Security, Type};
+use dom::bindings::error::Error::{self, InvalidModification, Network, Security};
 use dom::bindings::error::{Fallible, ErrorResult};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, MutHeap, Root};
@@ -101,7 +101,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
                 ByteString::new(val)
             },
             Err(error) => {
-                return Err(Type(error))
+                return Err(Error::from(error))
             },
         };
         *self.value.borrow_mut() = Some(value.clone());
@@ -126,7 +126,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         match result {
             Ok(_) => Ok(()),
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -6,7 +6,7 @@ use bluetooth_blacklist::{Blacklist, uuid_is_blacklisted};
 use dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
-use dom::bindings::error::Error::{Security, Type};
+use dom::bindings::error::Error::{self, Security};
 use dom::bindings::error::{Fallible, ErrorResult};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, MutHeap, Root};
@@ -72,7 +72,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
                 Ok(Root::from_ref(self))
             },
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -89,7 +89,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
                 Ok(())
             },
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -113,7 +113,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
                                                    service.instance_id))
             },
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -146,7 +146,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
                               .collect())
             },
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }

--- a/components/script/dom/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetoothremotegattservice.rs
@@ -5,7 +5,7 @@
 use bluetooth_blacklist::{Blacklist, uuid_is_blacklisted};
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding::BluetoothRemoteGATTServiceMethods;
-use dom::bindings::error::Error::{Security, Type};
+use dom::bindings::error::Error::{self, Security};
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, MutHeap, Root};
@@ -115,7 +115,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                                                           characteristic.instance_id))
             },
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -160,7 +160,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                 Ok(characteristics)
             },
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -188,7 +188,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                                                    service.instance_id))
             },
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }
@@ -223,7 +223,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                               .collect())
             },
             Err(error) => {
-                Err(Type(error))
+                Err(Error::from(error))
             },
         }
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Replace the error messages with an enum in `net/bluetooth_thread.rs`. Rename `bluetooth_blacklist.rs` to `bluetooth_utils.rs` and put the error conversion in it.
With this the returned errors in DOM classes follow the specification.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because  there is no Web Bluetooth test API implementation yet.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12538)

<!-- Reviewable:end -->
