### PR TITLE
Improve page load error information

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1143,7 +1143,7 @@ fn is_cert_verify_error(error: &OpensslError) -> bool {
     match error {
         &OpensslError::UnknownError { ref library, ref function, ref reason } => {
             library == "SSL routines" &&
-            function == "SSL3_GET_SERVER_CERTIFICATE" &&
+            function.to_uppercase() == "SSL3_GET_SERVER_CERTIFICATE" &&
             reason == "certificate verify failed"
         }
     }

--- a/resources/neterror.html
+++ b/resources/neterror.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+  <title>Error loading page</title>
+</head>
+<body>
+  <p>Could not load the requested page: ${reason}</p>
+</body>
+</html>


### PR DESCRIPTION
Fixes #8640.

This commit adds a neterror page that displays really really basic
information about what went wrong with your request, which is an
improvement over the current state of blank page.

It also fixes the problem of certificate validation errors not
triggering the cert error page, since for some reason the function
string seems to have turned lowercase.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #8640.
- [x] These changes do not require tests because I'm not sure how to test this, suggestions welcome!

r?@jdm

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12539)

<!-- Reviewable:end -->
