### PR TITLE
Support sequences of sequences in generated bindings.

### DIFF
--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use dom::bindings::codegen::Bindings::TestBindingBinding;
 use dom::bindings::codegen::Bindings::TestBindingBinding::{TestBindingMethods, TestDictionary};
 use dom::bindings::codegen::Bindings::TestBindingBinding::{TestDictionaryDefaults, TestEnum};
-use dom::bindings::codegen::UnionTypes::{BlobOrBoolean, BlobOrBlobSequence};
+use dom::bindings::codegen::UnionTypes::{BlobOrBoolean, BlobOrBlobSequence, LongOrLongSequenceSequence};
 use dom::bindings::codegen::UnionTypes::{BlobOrString, BlobOrUnsignedLong, EventOrString};
 use dom::bindings::codegen::UnionTypes::{EventOrUSVString, HTMLElementOrLong};
 use dom::bindings::codegen::UnionTypes::{HTMLElementOrUnsignedLongOrStringOrBoolean, LongSequenceOrBoolean};
@@ -571,6 +571,17 @@ impl TestBindingMethods for TestBinding {
     fn FuncControlledAttributeEnabled(&self) -> bool { false }
     fn FuncControlledMethodDisabled(&self) {}
     fn FuncControlledMethodEnabled(&self) {}
+
+    fn PassSequenceSequence(&self, _seq: Vec<Vec<i32>>) {}
+    fn ReturnSequenceSequence(&self) -> Vec<Vec<i32>> { vec![] }
+    fn PassUnionSequenceSequence(&self, seq: LongOrLongSequenceSequence) {
+        match seq {
+            LongOrLongSequenceSequence::Long(_) => (),
+            LongOrLongSequenceSequence::LongSequenceSequence(seq) => {
+                let _seq: Vec<Vec<i32>> = seq;
+            }
+        }
+    }
 
     #[allow(unsafe_code)]
     fn CrashHard(&self) {

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -409,6 +409,10 @@ interface TestBinding {
   void passVariadicAny(any... args);
   void passVariadicObject(object... args);
 
+  void passSequenceSequence(sequence<sequence<long>> seq);
+  sequence<sequence<long>> returnSequenceSequence();
+  void passUnionSequenceSequence((long or sequence<sequence<long>>) seq);
+
   static attribute boolean booleanAttributeStatic;
   static void receiveVoidStatic();
   boolean BooleanMozPreference(DOMString pref_name);


### PR DESCRIPTION
This fixes a blocker for #11897. `unroll` recursively gets the inner type of any sequence type encountered, so it's inappropriate for codegen that only wants the immediate inner type. However, if a type identifies as a sequence and is nullable, we need to reach through the nullable wrapper first. Gecko does very similar things.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12528 (github issue number if applicable).
- [X] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12541)

<!-- Reviewable:end -->
