### PR TITLE
Accumulate subpixels through stacking contexts

### DIFF
--- a/components/gfx/paint_context.rs
+++ b/components/gfx/paint_context.rs
@@ -53,6 +53,10 @@ pub struct PaintContext<'a> {
     pub transient_clip: Option<ClippingRegion>,
     /// A temporary hack to disable clipping optimizations on 3d layers.
     pub layer_kind: LayerKind,
+    /// The current subpixel offset, used to make pixel snapping aware of accumulated subpixels
+    /// from the StackingContext.
+    /// TODO: Eventually this should be added to all points handled by the PaintContext.
+    pub subpixel_offset: Point2D<Au>,
 }
 
 #[derive(Copy, Clone)]
@@ -1338,24 +1342,26 @@ impl<'a> PaintContext<'a> {
     pub fn draw_text(&mut self, text: &TextDisplayItem) {
         let draw_target_transform = self.draw_target.get_transform();
 
+        let origin = text.baseline_origin + self.subpixel_offset;
+
         // Optimization: Don’t set a transform matrix for upright text, and pass a start point to
         // `draw_text_into_context`.
         //
         // For sideways text, it’s easier to do the rotation such that its center (the baseline’s
         // start point) is at (0, 0) coordinates.
         let baseline_origin = match text.orientation {
-            Upright => text.baseline_origin,
+            Upright => origin,
             SidewaysLeft => {
-                let x = text.baseline_origin.x.to_f32_px();
-                let y = text.baseline_origin.y.to_f32_px();
+                let x = origin.x.to_f32_px();
+                let y = origin.y.to_f32_px();
                 self.draw_target.set_transform(&draw_target_transform.mul(&Matrix2D::new(0., -1.,
                                                                                          1., 0.,
                                                                                          x, y)));
                 Point2D::zero()
             }
             SidewaysRight => {
-                let x = text.baseline_origin.x.to_f32_px();
-                let y = text.baseline_origin.y.to_f32_px();
+                let x = origin.x.to_f32_px();
+                let y = origin.y.to_f32_px();
                 self.draw_target.set_transform(&draw_target_transform.mul(&Matrix2D::new(0., 1.,
                                                                                          -1., 0.,
                                                                                          x, y)));
@@ -1382,10 +1388,7 @@ impl<'a> PaintContext<'a> {
         // Blur, if necessary.
         self.blur_if_necessary(temporary_draw_target, text.blur_radius);
 
-        // Undo the transform, only when we did one.
-        if text.orientation != Upright {
-            self.draw_target.set_transform(&draw_target_transform)
-        }
+        self.draw_target.set_transform(&draw_target_transform)
     }
 
     /// Draws a linear gradient in the given boundaries from the given start point to the given end

--- a/components/gfx/paint_thread.rs
+++ b/components/gfx/paint_thread.rs
@@ -690,6 +690,7 @@ impl WorkerThread {
                 clip_rect: None,
                 transient_clip: None,
                 layer_kind: layer_kind,
+                subpixel_offset: Point2D::zero(),
             };
 
             // Apply the translation to paint the tile we want.

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transforms-3d-on-anonymous-block-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transforms-3d-on-anonymous-block-001.htm.ini
@@ -1,4 +1,2 @@
 [css-transforms-3d-on-anonymous-block-001.htm]
   type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-019.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-019.htm.ini
@@ -1,3 +1,4 @@
 [transform-input-019.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "linux": FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Instead of simply rounding layer origins and discarding subpixel
offsets, accumulate them by transforming them into the space of the
next child stacking context. This is an attempt to eliminate subpixel
differences that are caused by different stacking context boundaries in
reference tests.

Currently these accumulated subpixels are only used for text
positioning, but the plan is that they can be used for all drawing in
the future.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12543)

<!-- Reviewable:end -->
