### PR TITLE
Union types now allow ByteString

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2077,7 +2077,7 @@ def UnionTypes(descriptors, dictionaries, callbacks, config):
         'dom::bindings::conversions::root_from_handlevalue',
         'dom::bindings::error::throw_not_in_union',
         'dom::bindings::js::Root',
-        'dom::bindings::str::{DOMString, USVString}',
+        'dom::bindings::str::{ByteString, DOMString, USVString}',
         'dom::types::*',
         'js::jsapi::JSContext',
         'js::jsapi::{HandleValue, MutableHandleValue}',
@@ -3754,6 +3754,9 @@ def getUnionTypeTemplateVars(type, descriptorProvider):
         name = str(type)
         # XXXjdm dunno about typeName here
         typeName = "/*" + type.name + "*/"
+    elif type.isByteString():
+        name = type.name
+        typeName = "ByteString"
     elif type.isDOMString():
         name = type.name
         typeName = "DOMString"

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -11,6 +11,7 @@ use dom::bindings::codegen::Bindings::TestBindingBinding::{TestBindingMethods, T
 use dom::bindings::codegen::Bindings::TestBindingBinding::{TestDictionaryDefaults, TestEnum};
 use dom::bindings::codegen::UnionTypes::{BlobOrBoolean, BlobOrBlobSequence, LongOrLongSequenceSequence};
 use dom::bindings::codegen::UnionTypes::{BlobOrString, BlobOrUnsignedLong, EventOrString};
+use dom::bindings::codegen::UnionTypes::{ByteStringOrLong, ByteStringSequenceOrLongOrString, ByteStringSequenceOrLong};
 use dom::bindings::codegen::UnionTypes::{EventOrUSVString, HTMLElementOrLong};
 use dom::bindings::codegen::UnionTypes::{HTMLElementOrUnsignedLongOrStringOrBoolean, LongSequenceOrBoolean};
 use dom::bindings::codegen::UnionTypes::{StringOrLongSequence, StringOrStringSequence, StringSequenceOrUnsignedLong};
@@ -132,6 +133,10 @@ impl TestBindingMethods for TestBinding {
         BlobOrUnsignedLong::UnsignedLong(0u32)
     }
     fn SetUnion8Attribute(&self, _: BlobOrUnsignedLong) {}
+    fn Union9Attribute(&self) -> ByteStringOrLong {
+        ByteStringOrLong::ByteString(ByteString::new(vec!()))
+    }
+    fn SetUnion9Attribute(&self, _: ByteStringOrLong) {}
     fn ArrayAttribute(&self, _: *mut JSContext) -> *mut JSObject { NullValue().to_object_or_null() }
     fn AnyAttribute(&self, _: *mut JSContext) -> JSVal { NullValue() }
     fn SetAnyAttribute(&self, _: *mut JSContext, _: HandleValue) {}
@@ -210,6 +215,10 @@ impl TestBindingMethods for TestBinding {
         Some(StringOrBoolean::Boolean(true))
     }
     fn SetUnion5AttributeNullable(&self, _: Option<StringOrBoolean>) {}
+    fn GetUnion6AttributeNullable(&self) -> Option<ByteStringOrLong> {
+        Some(ByteStringOrLong::ByteString(ByteString::new(vec!())))
+    }
+    fn SetUnion6AttributeNullable(&self, _: Option<ByteStringOrLong>) {}
     fn BinaryRenamedMethod(&self) -> () {}
     fn ReceiveVoid(&self) -> () {}
     fn ReceiveBoolean(&self) -> bool { false }
@@ -244,6 +253,10 @@ impl TestBindingMethods for TestBinding {
     fn ReceiveUnion8(&self) -> UnsignedLongOrBoolean { UnsignedLongOrBoolean::UnsignedLong(0u32) }
     fn ReceiveUnion9(&self) -> HTMLElementOrUnsignedLongOrStringOrBoolean {
         HTMLElementOrUnsignedLongOrStringOrBoolean::Boolean(true)
+    }
+    fn ReceiveUnion10(&self) -> ByteStringOrLong { ByteStringOrLong::ByteString(ByteString::new(vec!())) }
+    fn ReceiveUnion11(&self) -> ByteStringSequenceOrLongOrString {
+        ByteStringSequenceOrLongOrString::ByteStringSequence(vec!(ByteString::new(vec!())))
     }
     fn ReceiveSequence(&self) -> Vec<i32> { vec![1] }
     fn ReceiveInterfaceSequence(&self) -> Vec<Root<Blob>> {
@@ -285,6 +298,9 @@ impl TestBindingMethods for TestBinding {
     }
     fn ReceiveNullableUnion5(&self) -> Option<UnsignedLongOrBoolean> {
         Some(UnsignedLongOrBoolean::UnsignedLong(0u32))
+    }
+    fn ReceiveNullableUnion6(&self) -> Option<ByteStringOrLong> {
+        Some(ByteStringOrLong::ByteString(ByteString::new(vec!())))
     }
     fn ReceiveNullableSequence(&self) -> Option<Vec<i32>> { Some(vec![1]) }
     fn ReceiveTestDictionaryWithSuccessOnKeyword(&self) -> TestDictionary {
@@ -382,6 +398,7 @@ impl TestBindingMethods for TestBinding {
     fn PassUnion5(&self, _: StringOrBoolean) {}
     fn PassUnion6(&self, _: UnsignedLongOrBoolean) {}
     fn PassUnion7(&self, _: StringSequenceOrUnsignedLong) {}
+    fn PassUnion8(&self, _: ByteStringSequenceOrLong) {}
     fn PassAny(&self, _: *mut JSContext, _: HandleValue) {}
     fn PassObject(&self, _: *mut JSContext, _: *mut JSObject) {}
     fn PassCallbackFunction(&self, _: Rc<Function>) {}
@@ -414,6 +431,7 @@ impl TestBindingMethods for TestBinding {
     fn PassNullableUnion3(&self, _: Option<StringOrLongSequence>) {}
     fn PassNullableUnion4(&self, _: Option<LongSequenceOrBoolean>) {}
     fn PassNullableUnion5(&self, _: Option<UnsignedLongOrBoolean>) {}
+    fn PassNullableUnion6(&self, _: Option<ByteStringOrLong>) {}
     fn PassNullableCallbackFunction(&self, _: Option<Rc<Function>>) {}
     fn PassNullableCallbackInterface(&self, _: Option<Rc<EventListener>>) {}
     fn PassNullableSequence(&self, _: Option<Vec<i32>>) {}
@@ -441,6 +459,7 @@ impl TestBindingMethods for TestBinding {
     fn PassOptionalUnion3(&self, _: Option<StringOrLongSequence>) {}
     fn PassOptionalUnion4(&self, _: Option<LongSequenceOrBoolean>) {}
     fn PassOptionalUnion5(&self, _: Option<UnsignedLongOrBoolean>) {}
+    fn PassOptionalUnion6(&self, _: Option<ByteStringOrLong>) {}
     fn PassOptionalAny(&self, _: *mut JSContext, _: HandleValue) {}
     fn PassOptionalObject(&self, _: *mut JSContext, _: Option<*mut JSObject>) {}
     fn PassOptionalCallbackFunction(&self, _: Option<Rc<Function>>) {}
@@ -471,6 +490,7 @@ impl TestBindingMethods for TestBinding {
     fn PassOptionalNullableUnion3(&self, _: Option<Option<StringOrLongSequence>>) {}
     fn PassOptionalNullableUnion4(&self, _: Option<Option<LongSequenceOrBoolean>>) {}
     fn PassOptionalNullableUnion5(&self, _: Option<Option<UnsignedLongOrBoolean>>) {}
+    fn PassOptionalNullableUnion6(&self, _: Option<Option<ByteStringOrLong>>) {}
     fn PassOptionalNullableCallbackFunction(&self, _: Option<Option<Rc<Function>>>) {}
     fn PassOptionalNullableCallbackInterface(&self, _: Option<Option<Rc<EventListener>>>) {}
     fn PassOptionalNullableSequence(&self, _: Option<Option<Vec<i32>>>) {}
@@ -555,6 +575,7 @@ impl TestBindingMethods for TestBinding {
     fn PassVariadicUnion4(&self, _: Vec<BlobOrBoolean>) {}
     fn PassVariadicUnion5(&self, _: Vec<StringOrUnsignedLong>) {}
     fn PassVariadicUnion6(&self, _: Vec<UnsignedLongOrBoolean>) {}
+    fn PassVariadicUnion7(&self, _: Vec<ByteStringOrLong>) {}
     fn PassVariadicAny(&self, _: *mut JSContext, _: Vec<HandleValue>) {}
     fn PassVariadicObject(&self, _: *mut JSContext, _: Vec<*mut JSObject>) {}
     fn BooleanMozPreference(&self, pref_name: DOMString) -> bool {

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -110,6 +110,7 @@ interface TestBinding {
            attribute (unsigned long or boolean) union6Attribute;
            attribute (Blob or boolean) union7Attribute;
            attribute (Blob or unsigned long) union8Attribute;
+           attribute (ByteString or long) union9Attribute;
   readonly attribute Uint8ClampedArray arrayAttribute;
            attribute any anyAttribute;
            attribute object objectAttribute;
@@ -139,6 +140,7 @@ interface TestBinding {
            attribute (Blob or boolean)? union3AttributeNullable;
            attribute (unsigned long or boolean)? union4AttributeNullable;
            attribute (DOMString or boolean)? union5AttributeNullable;
+           attribute (ByteString or long)? union6AttributeNullable;
   [BinaryName="BinaryRenamedAttribute"] attribute DOMString attrToBinaryRename;
   [BinaryName="BinaryRenamedAttribute2"] attribute DOMString attr-to-binary-rename;
   attribute DOMString attr-to-automatically-rename;
@@ -177,6 +179,8 @@ interface TestBinding {
   (DOMString or boolean) receiveUnion7();
   (unsigned long or boolean) receiveUnion8();
   (HTMLElement or unsigned long or DOMString or boolean) receiveUnion9();
+  (ByteString or long) receiveUnion10();
+  (sequence<ByteString> or long or DOMString) receiveUnion11();
   sequence<long> receiveSequence();
   sequence<Blob> receiveInterfaceSequence();
 
@@ -204,6 +208,7 @@ interface TestBinding {
   (DOMString or sequence<long>)? receiveNullableUnion3();
   (sequence<long> or boolean)? receiveNullableUnion4();
   (unsigned long or boolean)? receiveNullableUnion5();
+  (ByteString or long)? receiveNullableUnion6();
   sequence<long>? receiveNullableSequence();
   TestDictionary receiveTestDictionaryWithSuccessOnKeyword();
   boolean dictMatchesPassedValues(TestDictionary arg);
@@ -233,6 +238,7 @@ interface TestBinding {
   void passUnion5((DOMString or boolean) data);
   void passUnion6((unsigned long or boolean) bool);
   void passUnion7((sequence<DOMString> or unsigned long) arg);
+  void passUnion8((sequence<ByteString> or long) arg);
   void passAny(any arg);
   void passObject(object arg);
   void passCallbackFunction(Function fun);
@@ -265,6 +271,7 @@ interface TestBinding {
   void passNullableUnion3((DOMString or sequence<long>)? data);
   void passNullableUnion4((sequence<long> or boolean)? bool);
   void passNullableUnion5((unsigned long or boolean)? arg);
+  void passNullableUnion6((ByteString or long)? arg);
   void passNullableCallbackFunction(Function? fun);
   void passNullableCallbackInterface(EventListener? listener);
   void passNullableSequence(sequence<long>? seq);
@@ -292,6 +299,7 @@ interface TestBinding {
   void passOptionalUnion3(optional (DOMString or sequence<long>) arg);
   void passOptionalUnion4(optional (sequence<long> or boolean) data);
   void passOptionalUnion5(optional (unsigned long or boolean) bool);
+  void passOptionalUnion6(optional (ByteString or long) arg);
   void passOptionalAny(optional any arg);
   void passOptionalObject(optional object arg);
   void passOptionalCallbackFunction(optional Function fun);
@@ -322,6 +330,7 @@ interface TestBinding {
   void passOptionalNullableUnion3(optional (DOMString or sequence<long>)? arg);
   void passOptionalNullableUnion4(optional (sequence<long> or boolean)? data);
   void passOptionalNullableUnion5(optional (unsigned long or boolean)? bool);
+  void passOptionalNullableUnion6(optional (ByteString or long)? arg);
   void passOptionalNullableCallbackFunction(optional Function? fun);
   void passOptionalNullableCallbackInterface(optional EventListener? listener);
   void passOptionalNullableSequence(optional sequence<long>? seq);
@@ -406,6 +415,7 @@ interface TestBinding {
   void passVariadicUnion4((Blob or boolean)... args);
   void passVariadicUnion5((DOMString or unsigned long)... args);
   void passVariadicUnion6((unsigned long or boolean)... args);
+  void passVariadicUnion7((ByteString or long)... args);
   void passVariadicAny(any... args);
   void passVariadicObject(object... args);
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
## This PR addresses issue #12527 to allow ByteStrings in union types.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12527  (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12546)

<!-- Reviewable:end -->
