### PR TITLE
Allow running WPT in Firefox

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -135,6 +135,7 @@ def _activate_virtualenv(topdir):
     requirements_paths = [
         os.path.join("python", "requirements.txt"),
         os.path.join("tests", "wpt", "harness", "requirements.txt"),
+        os.path.join("tests", "wpt", "harness", "requirements_firefox.txt"),
         os.path.join("tests", "wpt", "harness", "requirements_servo.txt"),
     ]
     for req_rel_path in requirements_paths:

--- a/tests/wpt/README.md
+++ b/tests/wpt/README.md
@@ -77,6 +77,18 @@ first adding the following to the system's hosts file:
 and then running `python serve` from `tests/wpt/web-platform-tests`.
 Then navigate Servo to `http://web-platform.test:8000/path/to/test`.
 
+Running the tests in Firefox
+----------------------------
+
+When working with tests, you may want to compare Servo's result with Firefox.
+You can supply `--product firefox` along with the path to a Firefox binary (as
+well as few more odds and ends) to run tests in Firefox from your Servo
+checkout:
+
+    GECKO="$HOME/projects/mozilla/gecko"
+    GECKO_BINS="$GECKO/obj-firefox-release-artifact/dist/Nightly.app/Contents/MacOS"
+    ./mach test-wpt dom --product firefox --binary $GECKO_BINS/firefox --certutil-binary $GECKO_BINS/certutil --prefs-root $GECKO/testing/profiles
+
 Updating test expectations
 ==========================
 
@@ -191,5 +203,4 @@ MANIFEST.json can be regenerated automatically with the mach command `update-man
 
 This is equivalent to running
 
-    ./mach test-wpt --manifest-update SKIP_TESTS 
-
+    ./mach test-wpt --manifest-update SKIP_TESTS

--- a/tests/wpt/config.ini
+++ b/tests/wpt/config.ini
@@ -1,6 +1,7 @@
 [products]
 servo =
 servodriver =
+firefox =
 
 [web-platform-tests]
 remote_url = https://github.com/w3c/web-platform-tests.git


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

When working with WPT tests, I find it convenient to compare the results of different browsers / engines. By installing a few more Python packages, we can easily test against Firefox from a Servo checkout.

As noted in the updated README.md, this change allows you to check WPT tests in Firefox by adding `--product firefox` to the `./mach test-wpt` command.

r? @jgraham 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because only the set of test harness packages is changed

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12547)

<!-- Reviewable:end -->
