### PR TITLE
Generate multiple DOM bindings in parallel.

### DIFF
--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -2,12 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::env;
 use std::process::Command;
+use std::time::Instant;
 
 fn main() {
+    let start = Instant::now();
+    let num_jobs = env::var("NUM_JOBS").unwrap();
     assert!(Command::new("make")
-        .args(&["-f", "makefile.cargo"])
+        .args(&["-f", "makefile.cargo", "-j", &num_jobs])
         .status()
         .unwrap()
         .success());
+    println!("Binding generation completed in {}s", start.elapsed().as_secs());
 }


### PR DESCRIPTION
Reduces the time for a build after touching `CodegenRust.py` by 58s for me.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12529 (github issue number if applicable).
- [X] These changes do not require tests because it's a build performance optimization

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12559)

<!-- Reviewable:end -->
