### PR TITLE
Hoist retrieval of layout_threads from opts into Constellation

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -160,6 +160,7 @@ impl Pipeline {
                     pipeline_port: pipeline_port,
                     layout_to_constellation_chan: state.layout_to_constellation_chan.clone(),
                     content_process_shutdown_chan: layout_content_process_shutdown_chan.clone(),
+                    layout_threads: opts::get().layout_threads,
                 };
 
                 if let Err(e) = script_chan.send(ConstellationControlMsg::AttachLayout(new_layout_info)) {
@@ -470,7 +471,8 @@ impl UnprivilegedPipelineContent {
                     self.time_profiler_chan,
                     self.mem_profiler_chan,
                     self.layout_content_process_shutdown_chan,
-                    self.webrender_api_sender);
+                    self.webrender_api_sender,
+                    opts::get().layout_threads);
 
         if wait_for_completion {
             let _ = self.script_content_process_shutdown_port.recv();

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -48,5 +48,6 @@ pub trait LayoutThreadFactory {
               time_profiler_chan: time::ProfilerChan,
               mem_profiler_chan: mem::ProfilerChan,
               content_process_shutdown_chan: IpcSender<()>,
-              webrender_api_sender: Option<webrender_traits::RenderApiSender>);
+              webrender_api_sender: Option<webrender_traits::RenderApiSender>,
+              layout_threads: usize);
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1142,6 +1142,7 @@ impl ScriptThread {
             pipeline_port,
             layout_to_constellation_chan,
             content_process_shutdown_chan,
+            layout_threads,
         } = new_layout_info;
 
         let layout_pair = channel();
@@ -1158,6 +1159,7 @@ impl ScriptThread {
             script_chan: self.control_chan.clone(),
             image_cache_thread: self.image_cache_thread.clone(),
             content_process_shutdown_chan: content_process_shutdown_chan,
+            layout_threads: layout_threads,
         };
 
         let context = self.root_browsing_context();

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -149,4 +149,5 @@ pub struct NewLayoutThreadInfo {
     pub image_cache_thread: ImageCacheThread,
     pub paint_chan: OptionalOpaqueIpcSender,
     pub content_process_shutdown_chan: IpcSender<()>,
+    pub layout_threads: usize,
 }

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -146,6 +146,8 @@ pub struct NewLayoutInfo {
     pub layout_to_constellation_chan: IpcSender<LayoutMsg>,
     /// A shutdown channel so that layout can tell the content process to shut down when it's done.
     pub content_process_shutdown_chan: IpcSender<()>,
+    /// Number of threads to use for layout.
+    pub layout_threads: usize,
 }
 
 /// Messages sent from the constellation or layout to the script thread.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This makes the lower-level crates less dependent on `util::opts`.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because refactoring only

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12560)

<!-- Reviewable:end -->
