### PR TITLE
stylo: Improve restyling performance

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -2114,7 +2114,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 }
 
                 // Check if there are any pending frames. If so, the image is not stable yet.
-                if self.pending_subpages.len() > 0 {
+                if !self.pending_subpages.is_empty() {
                     return Err(NotReadyToPaint::PendingSubpages(self.pending_subpages.len()));
                 }
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1323,10 +1323,13 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         }
     }
 
-    fn handle_alert(&mut self, pipeline_id: PipelineId, message: String, sender: IpcSender<bool>) {
+    fn handle_alert(&mut self,
+                    pipeline_id: PipelineId,
+                    message: String,
+                    sender: IpcSender<bool>) {
         let display_alert_dialog = if PREFS.is_mozbrowser_enabled() {
             let parent_pipeline_info = self.pipelines.get(&pipeline_id).and_then(|source| source.parent_info);
-            if let Some(_) = parent_pipeline_info {
+            if parent_pipeline_info.is_some() {
                 let root_pipeline_id = self.root_frame_id
                     .and_then(|root_frame_id| self.frames.get(&root_frame_id))
                     .map(|root_frame| root_frame.current.0);

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -501,6 +501,10 @@ impl UnprivilegedPipelineContent {
                 command.env("RUST_BACKTRACE", value);
             }
 
+            if let Ok(value) = env::var("RUST_LOG") {
+                command.env("RUST_LOG", value);
+            }
+
             let profile = content_process_sandbox_profile();
             ChildProcess::Sandboxed(Sandbox::new(profile).start(&mut command)
                                     .expect("Failed to start sandboxed child process!"))
@@ -513,6 +517,10 @@ impl UnprivilegedPipelineContent {
 
             if let Ok(value) = env::var("RUST_BACKTRACE") {
                 child_process.env("RUST_BACKTRACE", value);
+            }
+
+            if let Ok(value) = env::var("RUST_LOG") {
+                child_process.env("RUST_LOG", value);
             }
 
             ChildProcess::Unsandboxed(child_process.spawn()

--- a/components/gfx/paint_thread.rs
+++ b/components/gfx/paint_thread.rs
@@ -379,8 +379,7 @@ impl<C> PaintThread<C> where C: PaintListener + Send + 'static {
                   font_cache_thread: FontCacheThread,
                   time_profiler_chan: time::ProfilerChan,
                   mem_profiler_chan: mem::ProfilerChan) {
-        thread::spawn_named(format!("PaintThread {:?}", id),
-                            move || {
+        thread::spawn_named(format!("PaintThread {:?}", id), move || {
             thread_state::initialize(thread_state::PAINT);
             PipelineId::install(id);
 
@@ -425,9 +424,9 @@ impl<C> PaintThread<C> where C: PaintListener + Send + 'static {
                 let chrome_to_paint = &self.chrome_to_paint_port;
                 select! {
                     msg = layout_to_paint.recv() =>
-                        Msg::FromLayout(msg.unwrap()),
+                        Msg::FromLayout(msg.expect("expected message from layout")),
                     msg = chrome_to_paint.recv() =>
-                        Msg::FromChrome(msg.unwrap())
+                        Msg::FromChrome(msg.expect("expected message from chrome"))
                 }
             };
 

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -77,7 +77,9 @@ impl<'lc, N> DomTraversalContext<N> for RecalcStyleAndConstructFlows<'lc>
         recalc_style_at(&self.context, self.root, node);
     }
 
-    fn process_postorder(&self, node: N) { construct_flows_at(&self.context, self.root, node); }
+    fn process_postorder(&self, node: N) {
+        construct_flows_at(&self.context, self.root, node);
+    }
 }
 
 /// A bottom-up, parallelizable traversal.
@@ -96,7 +98,7 @@ fn construct_flows_at<'a, N: LayoutNode>(context: &'a LayoutContext<'a>, root: O
 
         // Always reconstruct if incremental layout is turned off.
         let nonincremental_layout = opts::get().nonincremental_layout;
-        if nonincremental_layout || node.has_dirty_descendants() {
+        if nonincremental_layout || node.is_dirty() || node.has_dirty_descendants() {
             let mut flow_constructor = FlowConstructor::new(context);
             if nonincremental_layout || !flow_constructor.repair_if_possible(&tnode) {
                 flow_constructor.process(&tnode);

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1474,16 +1474,6 @@ impl LayoutThread {
         }
     }
 
-    unsafe fn dirty_all_nodes<N: LayoutNode>(node: N) {
-        for node in node.traverse_preorder() {
-            // TODO(cgaebel): mark nodes which are sensitive to media queries as
-            // "changed":
-            // > node.set_changed(true);
-            node.set_dirty(true);
-            node.set_dirty_descendants(true);
-        }
-    }
-
     fn reflow_all_nodes(flow: &mut Flow) {
         debug!("reflowing all nodes!");
         flow::mut_base(flow).restyle_damage.insert(REPAINT | STORE_OVERFLOW | REFLOW);

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -376,6 +376,7 @@ impl Document {
         // that workable.
         match self.GetDocumentElement() {
             Some(root) => {
+                root.upcast::<Node>().is_dirty() ||
                 root.upcast::<Node>().has_dirty_descendants() ||
                 !self.modified_elements.borrow().is_empty()
             }
@@ -1371,6 +1372,7 @@ impl Document {
     }
 
     pub fn finish_load(&self, load: LoadType) {
+        debug!("Document got finish_load: {:?}", load);
         // The parser might need the loader, so restrict the lifetime of the borrow.
         {
             let mut loader = self.loader.borrow_mut();
@@ -1396,9 +1398,9 @@ impl Document {
             // If we don't have a parser, and the reflow timer has been reset, explicitly
             // trigger a reflow.
             if let LoadType::Stylesheet(_) = load {
-                self.window().reflow(ReflowGoal::ForDisplay,
-                                     ReflowQueryType::NoQuery,
-                                     ReflowReason::StylesheetLoaded);
+                self.window.reflow(ReflowGoal::ForDisplay,
+                                   ReflowQueryType::NoQuery,
+                                   ReflowReason::StylesheetLoaded);
             }
         }
 
@@ -1487,6 +1489,8 @@ impl Document {
             return;
         }
         self.domcontentloaded_dispatched.set(true);
+        assert!(self.ReadyState() != DocumentReadyState::Complete,
+                "Complete before DOMContentLoaded?");
 
         update_with_current_time_ms(&self.dom_content_loaded_event_start);
 
@@ -1497,14 +1501,17 @@ impl Document {
                       ReflowQueryType::NoQuery,
                       ReflowReason::DOMContentLoaded);
 
+        let pipeline_id = self.window.pipeline();
+        let event = ConstellationMsg::DOMLoad(pipeline_id);
+        self.window.constellation_chan().send(event).unwrap();
+
         update_with_current_time_ms(&self.dom_content_loaded_event_end);
     }
 
     pub fn notify_constellation_load(&self) {
         let pipeline_id = self.window.pipeline();
-        let event = ConstellationMsg::DOMLoad(pipeline_id);
-        self.window.constellation_chan().send(event).unwrap();
-
+        let load_event = ConstellationMsg::LoadComplete(pipeline_id);
+        self.window.constellation_chan().send(load_event).unwrap();
     }
 
     pub fn set_current_parser(&self, script: Option<ParserRef>) {
@@ -2913,11 +2920,12 @@ impl DocumentProgressHandler {
         // http://w3c.github.io/navigation-timing/#widl-PerformanceNavigationTiming-loadEventEnd
         update_with_current_time_ms(&document.load_event_end);
 
-        document.notify_constellation_load();
 
         window.reflow(ReflowGoal::ForDisplay,
                       ReflowQueryType::NoQuery,
                       ReflowReason::DocumentLoaded);
+
+        document.notify_constellation_load();
     }
 }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1497,14 +1497,10 @@ impl Document {
         let window = self.window();
         window.dom_manipulation_task_source().queue_event(self.upcast(), atom!("DOMContentLoaded"),
             EventBubbles::Bubbles, EventCancelable::NotCancelable, window);
+
         window.reflow(ReflowGoal::ForDisplay,
                       ReflowQueryType::NoQuery,
                       ReflowReason::DOMContentLoaded);
-
-        let pipeline_id = self.window.pipeline();
-        let event = ConstellationMsg::DOMLoad(pipeline_id);
-        self.window.constellation_chan().send(event).unwrap();
-
         update_with_current_time_ms(&self.dom_content_loaded_event_end);
     }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2915,6 +2915,7 @@ impl DocumentProgressHandler {
         // http://w3c.github.io/navigation-timing/#widl-PerformanceNavigationTiming-loadEventStart
         update_with_current_time_ms(&document.load_event_start);
 
+        debug!("About to dispatch load for {:?}", document.url());
         let _ = wintarget.dispatch_event_with_target(document.upcast(), &event);
 
         // http://w3c.github.io/navigation-timing/#widl-PerformanceNavigationTiming-loadEventEnd

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -479,19 +479,7 @@ impl Node {
             return
         }
 
-        // 2. Dirty descendants.
-        fn dirty_subtree(node: &Node) {
-            // Stop if this subtree is already dirty.
-            if node.is_dirty() { return }
-
-            node.set_flag(IS_DIRTY | HAS_DIRTY_DESCENDANTS, true);
-
-            for kid in node.children() {
-                dirty_subtree(kid.r());
-            }
-        }
-
-        dirty_subtree(self);
+        self.set_flag(IS_DIRTY, true);
 
         // 4. Dirty ancestors.
         for ancestor in self.ancestors() {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -450,13 +450,15 @@ impl WindowMethods for Window {
         // Right now, just print to the console
         // Ensure that stderr doesn't trample through the alert() we use to
         // communicate test results (see executorservo.py in wptrunner).
-        let stderr = stderr();
-        let mut stderr = stderr.lock();
-        let stdout = stdout();
-        let mut stdout = stdout.lock();
-        writeln!(&mut stdout, "ALERT: {}", s).unwrap();
-        stdout.flush().unwrap();
-        stderr.flush().unwrap();
+        {
+            let stderr = stderr();
+            let mut stderr = stderr.lock();
+            let stdout = stdout();
+            let mut stdout = stdout.lock();
+            writeln!(&mut stdout, "ALERT: {}", s).unwrap();
+            stdout.flush().unwrap();
+            stderr.flush().unwrap();
+        }
 
         let (sender, receiver) = ipc::channel().unwrap();
         self.constellation_chan().send(ConstellationMsg::Alert(self.pipeline(), s.to_string(), sender)).unwrap();

--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -199,15 +199,6 @@ impl<'ln> TNode for ServoLayoutNode<'ln> {
         self.node.set_flag(DIRTY_ON_VIEWPORT_SIZE_CHANGE, true);
     }
 
-    fn set_descendants_dirty_on_viewport_size_changed(&self) {
-        for ref child in self.children() {
-            unsafe {
-                child.set_dirty_on_viewport_size_changed();
-            }
-            child.set_descendants_dirty_on_viewport_size_changed();
-        }
-    }
-
     fn can_be_fragmented(&self) -> bool {
         unsafe { self.node.get_flag(CAN_BE_FRAGMENTED) }
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1193,8 +1193,6 @@ impl ScriptThread {
         // https://html.spec.whatwg.org/multipage/#the-end step 7
         let handler = box DocumentProgressHandler::new(Trusted::new(doc));
         self.dom_manipulation_task_source.queue(handler, GlobalRef::Window(doc.window())).unwrap();
-
-        self.constellation_chan.send(ConstellationMsg::LoadComplete(pipeline)).unwrap();
     }
 
     fn collect_reports(&self, reports_chan: ReportsChan) {

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -70,10 +70,6 @@ pub enum ScriptMsg {
     CreateWebGLPaintThread(Size2D<i32>,
                            GLContextAttributes,
                            IpcSender<Result<(IpcSender<CanvasMsg>, GLLimits), String>>),
-    /// Dispatched after the DOM load event has fired on a document
-    /// Causes a `load` event to be dispatched to any enclosing frame context element
-    /// for the given pipeline.
-    DOMLoad(PipelineId),
     /// Notifies the constellation that this frame has received focus.
     Focus(PipelineId),
     /// Re-send a mouse button event that was sent to the parent window.
@@ -84,7 +80,8 @@ pub enum ScriptMsg {
     GetClipboardContents(IpcSender<String>),
     /// <head> tag finished parsing
     HeadParsed,
-    /// All pending loads are complete.
+    /// All pending loads are complete, and the `load` event for this pipeline
+    /// has been dispatched.
     LoadComplete(PipelineId),
     /// A new load has been requested.
     LoadUrl(PipelineId, LoadData),

--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -37,13 +37,13 @@ impl PrivateStyleData {
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct DomParallelInfo {
     /// The number of children that still need work done.
-    pub children_count: AtomicIsize,
+    pub children_to_process: AtomicIsize,
 }
 
 impl DomParallelInfo {
     pub fn new() -> DomParallelInfo {
         DomParallelInfo {
-            children_count: AtomicIsize::new(0),
+            children_to_process: AtomicIsize::new(0),
         }
     }
 }

--- a/components/style/parallel.rs
+++ b/components/style/parallel.rs
@@ -73,6 +73,12 @@ fn top_down_dom<N, C>(unsafe_nodes: UnsafeNodeList,
         // Possibly enqueue the children.
         let mut children_to_process = 0isize;
         for kid in node.children() {
+            // Trigger the hook pre-adding the kid to the list. This can (and in
+            // fact uses to) change the result of the should_process operation.
+            //
+            // As of right now, this hook takes care of propagating the restyle
+            // flag down the tree. In the future, more accurate behavior is
+            // probably going to be needed.
             context.pre_process_child_hook(node, kid);
             if context.should_process(kid) {
                 children_to_process += 1;

--- a/components/style/sequential.rs
+++ b/components/style/sequential.rs
@@ -9,20 +9,29 @@ use traversal::DomTraversalContext;
 
 pub fn traverse_dom<N, C>(root: N,
                           shared: &C::SharedContext)
-                          where N: TNode,
-                                C: DomTraversalContext<N> {
+    where N: TNode,
+          C: DomTraversalContext<N>
+{
     fn doit<'a, N, C>(context: &'a C, node: N)
-                      where N: TNode, C: DomTraversalContext<N> {
+        where N: TNode,
+              C: DomTraversalContext<N>
+    {
+        debug_assert!(context.should_process(node));
         context.process_preorder(node);
 
         for kid in node.children() {
-            doit::<N, C>(context, kid);
+            context.pre_process_child_hook(node, kid);
+            if context.should_process(node) {
+                doit::<N, C>(context, kid);
+            }
         }
 
         context.process_postorder(node);
     }
 
     let context = C::new(shared, root.opaque());
-    doit::<N, C>(&context, root);
+    if context.should_process(root) {
+        doit::<N, C>(&context, root);
+    }
 }
 

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -153,10 +153,24 @@ pub trait DomTraversalContext<N: TNode>  {
     ///
     /// Note that this is true unconditionally for servo, since it requires to
     /// bubble the widths bottom-up for all the DOM.
-    fn should_process(&self, _node: N) -> bool { true }
+    fn should_process(&self, node: N) -> bool {
+        node.is_dirty() || node.has_dirty_descendants()
+    }
 
     /// Do an action over the child before pushing him to the work queue.
-    fn pre_process_child_hook(&self, _parent: N, _kid: N) {}
+    ///
+    /// By default, propagate the IS_DIRTY flag down the tree.
+    #[allow(unsafe_code)]
+    fn pre_process_child_hook(&self, parent: N, kid: N) {
+        // NOTE: At this point is completely safe to modify either the parent or
+        // the child, since we have exclusive access to both of them.
+        if parent.is_dirty() {
+            unsafe {
+                kid.set_dirty(true);
+                parent.set_dirty_descendants(true);
+            }
+        }
+    }
 }
 
 /// Calculates the style for a single node.

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -268,16 +268,17 @@ pub fn recalc_style_at<'a, N, C>(context: &'a C,
     // NB: flow construction updates the bloom filter on the way up.
     put_thread_local_bloom_filter(bf, &unsafe_layout_node, context.shared_context());
 
-    // Mark the node as DIRTY_ON_VIEWPORT_SIZE_CHANGE is it uses viewport percentage units.
-    if let Some(element) = node.as_element() {
-        if let Some(ref property_declaration_block) = *element.style_attribute() {
-            if property_declaration_block.declarations().any(|d| d.0.has_viewport_percentage()) {
-                unsafe {
-                    node.set_dirty_on_viewport_size_changed();
+    // Mark the node as DIRTY_ON_VIEWPORT_SIZE_CHANGE is it uses viewport
+    // percentage units.
+    if !node.needs_dirty_on_viewport_size_changed() {
+        if let Some(element) = node.as_element() {
+            if let Some(ref property_declaration_block) = *element.style_attribute() {
+                if property_declaration_block.declarations().any(|d| d.0.has_viewport_percentage()) {
+                    unsafe {
+                        node.set_dirty_on_viewport_size_changed();
+                    }
                 }
-                node.set_descendants_dirty_on_viewport_size_changed();
             }
         }
     }
 }
-

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -148,7 +148,11 @@ pub trait DomTraversalContext<N: TNode>  {
     /// Process `node` on the way up, after its children have been processed.
     fn process_postorder(&self, node: N);
 
-    /// Returns if the node should be processed by the preorder traversal.
+    /// Returns if the node should be processed by the preorder traversal (and
+    /// then by the post-order one).
+    ///
+    /// Note that this is true unconditionally for servo, since it requires to
+    /// bubble the widths bottom-up for all the DOM.
     fn should_process(&self, _node: N) -> bool { true }
 
     /// Do an action over the child before pushing him to the work queue.

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -113,13 +113,13 @@ fn restyle_subtree(node: GeckoNode, raw_data: *mut RawServoStyleSet) {
         timer: Timer::new(),
     };
 
-    if node.is_dirty() || node.has_dirty_descendants() {
-        if per_doc_data.num_threads == 1 {
-            sequential::traverse_dom::<GeckoNode, RecalcStyleOnly>(node, &shared_style_context);
-        } else {
-            parallel::traverse_dom::<GeckoNode, RecalcStyleOnly>(node, &shared_style_context,
-                                                                 &mut per_doc_data.work_queue);
-        }
+    // We ensure this is true before calling Servo_RestyleSubtree()
+    debug_assert!(node.is_dirty() || node.has_dirty_descendants());
+    if per_doc_data.num_threads == 1 {
+        sequential::traverse_dom::<GeckoNode, RecalcStyleOnly>(node, &shared_style_context);
+    } else {
+        parallel::traverse_dom::<GeckoNode, RecalcStyleOnly>(node, &shared_style_context,
+                                                             &mut per_doc_data.work_queue);
     }
 }
 

--- a/ports/geckolib/traversal.rs
+++ b/ports/geckolib/traversal.rs
@@ -36,11 +36,13 @@ impl<'lc, 'ln> DomTraversalContext<GeckoNode<'ln>> for RecalcStyleOnly<'lc> {
         recalc_style_at(&self.context, self.root, node);
     }
 
+    fn process_postorder(&self, _: GeckoNode<'ln>) {}
+
+    /// In Gecko we use this traversal just for restyling, so we can stop once
+    /// we know there aren't more dirty nodes under ourselves.
     fn should_process(&self, node: GeckoNode<'ln>) -> bool {
         node.is_dirty() || node.has_dirty_descendants()
     }
-
-    fn process_postorder(&self, _: GeckoNode<'ln>) {}
 
     fn pre_process_child_hook(&self, parent: GeckoNode<'ln>, kid: GeckoNode<'ln>) {
         // NOTE: At this point is completely safe to modify either the parent or

--- a/ports/geckolib/traversal.rs
+++ b/ports/geckolib/traversal.rs
@@ -6,7 +6,6 @@ use context::StandaloneStyleContext;
 use std::mem;
 use style::context::SharedStyleContext;
 use style::dom::OpaqueNode;
-use style::dom::TNode;
 use style::traversal::{DomTraversalContext, recalc_style_at};
 use wrapper::GeckoNode;
 
@@ -37,21 +36,4 @@ impl<'lc, 'ln> DomTraversalContext<GeckoNode<'ln>> for RecalcStyleOnly<'lc> {
     }
 
     fn process_postorder(&self, _: GeckoNode<'ln>) {}
-
-    /// In Gecko we use this traversal just for restyling, so we can stop once
-    /// we know there aren't more dirty nodes under ourselves.
-    fn should_process(&self, node: GeckoNode<'ln>) -> bool {
-        node.is_dirty() || node.has_dirty_descendants()
-    }
-
-    fn pre_process_child_hook(&self, parent: GeckoNode<'ln>, kid: GeckoNode<'ln>) {
-        // NOTE: At this point is completely safe to modify either the parent or
-        // the child, since we have exclusive access to them.
-        if parent.is_dirty() {
-            unsafe {
-                kid.set_dirty(true);
-                parent.set_dirty_descendants(true);
-            }
-        }
-    }
 }


### PR DESCRIPTION
This commit adds hooks to the Servo style traversal to avoid traversing all the
DOM for every restyle. Additionally it changes the behavior of the dirty flag to
be propagated top down, to prevent extra overhead when an element is dirtied.

This commit doesn't aim to change the behavior on Servo just yet, since Servo does extra job when dirtying the node related with DOM revision counters that might be necessary.

CC @asajeffrey for the DOM revision counters stuff. When a node is dirty, do all its descendants really need to increment the revision counter, or is this an unintended effect? My intuition is that this is hurting performance quite a lot for servo.

r? @bholley 

<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because no geckolib tests yet.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12563)

<!-- Reviewable:end -->
