### PR TITLE
Issue #12564: Fix "./mach test-tidy --self-test".

### DIFF
--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -93,6 +93,7 @@ class CheckTidiness(unittest.TestCase):
     def test_toml(self):
         errors = tidy.collect_errors_for_files(iterFile('test.toml'), [tidy.check_toml], [], print_text=False)
         self.assertEqual('found asterisk instead of minimum version number', errors.next()[2])
+        self.assertEqual('.toml file should contain a valid license.', errors.next()[2])
         self.assertNoMoreErrors(errors)
 
     def test_modeline(self):
@@ -130,11 +131,11 @@ class CheckTidiness(unittest.TestCase):
         file_list = tidy.get_file_list(base_path, only_changed_files=False,
                                        exclude_dirs=[])
         lst = list(file_list)
-        self.assertEqual([os.path.join(base_path, 'whee', 'test.rs')], lst)
+        self.assertEqual([os.path.join(base_path, 'whee', 'test.rs'), os.path.join(base_path, 'whee', 'foo', 'bar.rs')], lst)
         file_list = tidy.get_file_list(base_path, only_changed_files=False,
-                                       exclude_dirs=[os.path.join(base_path,'whee')])
+                                       exclude_dirs=[os.path.join(base_path, 'whee', 'foo')])
         lst = list(file_list)
-        self.assertEqual([], lst)
+        self.assertEqual([os.path.join(base_path, 'whee', 'test.rs')], lst)
 
 def do_tests():
     suite = unittest.TestLoader().loadTestsFromTestCase(CheckTidiness)


### PR DESCRIPTION
Fix https://github.com/servo/servo/issues/12564
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12564
- [X] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12565)

<!-- Reviewable:end -->
