### PR TITLE
Implemented name for Runnable trait in WebSocket Runnables

### DIFF
--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -461,6 +461,8 @@ struct ConnectionEstablishedTask {
 }
 
 impl Runnable for ConnectionEstablishedTask {
+    fn name(&self) -> &'static str { "ConnectionEstablishedTask" }
+
     fn handler(self: Box<Self>) {
         let ws = self.address.root();
         let global = ws.r().global();
@@ -510,6 +512,8 @@ impl Runnable for BufferedAmountTask {
     // To be compliant with standards, we need to reset bufferedAmount only when the event loop
     // reaches step 1.  In our implementation, the bytes will already have been sent on a background
     // thread.
+    fn name(&self) -> &'static str { "BufferedAmountTask" }
+
     fn handler(self: Box<Self>) {
         let ws = self.address.root();
 
@@ -526,6 +530,8 @@ struct CloseTask {
 }
 
 impl Runnable for CloseTask {
+    fn name(&self) -> &'static str { "CloseTask" }
+
     fn handler(self: Box<Self>) {
         let ws = self.address.root();
         let ws = ws.r();
@@ -568,6 +574,8 @@ struct MessageReceivedTask {
 }
 
 impl Runnable for MessageReceivedTask {
+    fn name(&self) -> &'static str { "MessageReceivedTask" }
+
     #[allow(unsafe_code)]
     fn handler(self: Box<Self>) {
         let ws = self.address.root();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors 
- [X] `./mach test-tidy` does not report any errors 
- [X] These changes fix #12551
- [X] These changes do not require tests

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12570)

<!-- Reviewable:end -->
