### PR TITLE
Document Windows installation hacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Download Python for Windows [here](https://www.python.org/downloads/release/pyth
 required for the SpiderMonkey build on Windows.
 
 Install MSYS2 from [here](https://msys2.github.io/). After you have done so, open an MSYS shell
-window and update the core libraries and install new packages:
+window and update the core libraries and install new packages. The extra step at the end is to
+downgrate GCC to 5.4, as the GCC6 versions in mingw currently fail to compile some of our
+dependencies. We are upgrading to a gcc-free build on Windows as soon as possible:
 
 ```sh
 pacman -Su
@@ -88,6 +90,11 @@ pacman -Sy git mingw-w64-x86_64-toolchain mingw-w64-x86_64-freetype \
     mingw-w64-x86_64-icu mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates \
     mingw-w64-x86_64-expat mingw-w64-x86_64-cmake tar diffutils patch \
     patchutils make python2-setuptools
+export GCC_URL=http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc
+export GCC_EXT=5.4.0-1-any.pkg.tar.xz
+pacman -U --noconfirm $GCC_URL-$GCC_EXT $GCC_URL-ada-$GCC_EXT \
+    $GCC_URL-fortran-$GCC_EXT $GCC_URL-libgfortran-$GCC_EXT $GCC_URL-libs-$GCC_EXT \
+    $GCC_URL-objc-$GCC_EXT
 easy_install-2.7 pip virtualenv
 ```
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is based on the awesome work by @UK992 in #12573.

Basically, it downgrades GCC on Windows to 5.4 within the mingw environment. This is a stopgap until #11756 is completed and we no longer need mingw.

Fixes #12512

r? @metajack 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12578)

<!-- Reviewable:end -->
