### PR TITLE
WebBluetooth writeValue new Step

### DIFF
--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -195,6 +195,12 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         if !self.Service().Device().Gatt().Connected() {
             return Err(Network)
         }
+
+        if !(self.Properties().Write() ||
+             self.Properties().WriteWithoutResponse() ||
+             self.Properties().AuthenticatedSignedWrites()) {
+            return Err(NotSupported)
+        }
         let (sender, receiver) = ipc::channel().unwrap();
         self.get_bluetooth_thread().send(
             BluetoothMethodMsg::WriteValue(self.get_instance_id(), value, sender)).unwrap();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

There is a new step in the writeValue function of the BluetoothRemoteGATTCharacteristic:
https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-writevalue
Step 6.1

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because, there is no WebBluetooth test API implementation yet.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12603)

<!-- Reviewable:end -->
