### PR TITLE
Fix font metrics and switch to windows subsystem

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -236,6 +236,9 @@ class MachCommands(CommandBase):
 
         cargo_binary = "cargo" + BIN_SUFFIX
 
+        if sys.platform == "win32" or sys.platform == "msys":
+            env["RUSTFLAGS"] = "-C link-args=-Wl,--subsystem,windows"
+
         status = call(
             [cargo_binary, "build"] + opts,
             env=env, cwd=self.servo_crate(), verbose=verbose)

--- a/support/windows/fonts.conf
+++ b/support/windows/fonts.conf
@@ -38,7 +38,740 @@
 		</edit>
 	</match>
 
+
+
 <!-- Font cache directory list -->
 
-	<cachedir>~/.fontconfig</cachedir>
+<cachedir>~/.fontconfig</cachedir>
+
+
+
+
+<!--
+  Mark common families with their generics so we'll get
+  something reasonable
+-->
+
+<!--
+  Serif faces
+ -->
+	<alias>
+		<family>Nazli</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Lotoos</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Mitra</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Ferdosi</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Badr</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Zar</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Titr</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Jadid</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Kochi Mincho</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>AR PL SungtiL GB</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>AR PL Mingti2L Big5</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>ＭＳ 明朝</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>NanumMyeongjo</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>UnBatang</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Baekmuk Batang</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>MgOpen Canonica</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Sazanami Mincho</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>AR PL ZenKai Uni</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>ZYSong18030</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>FreeSerif</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>SimSun</family>
+		<default><family>serif</family></default>
+	</alias>
+<!--
+  Sans-serif faces
+ -->
+	<alias>
+		<family>Arshia</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Elham</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Farnaz</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Nasim</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Sina</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Roya</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Koodak</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Terafik</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Kochi Gothic</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>AR PL KaitiM GB</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>AR PL KaitiM Big5</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>ＭＳ ゴシック</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>NanumGothic</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>UnDotum</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Baekmuk Dotum</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>MgOpen Modata</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Sazanami Gothic</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>AR PL ShanHeiSun Uni</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>ZYSong18030</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>FreeSans</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+<!--
+  Monospace faces
+ -->
+	<alias>
+		<family>NSimSun</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>ZYSong18030</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>NanumGothicCoding</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>FreeMono</family>
+		<default><family>monospace</family></default>
+	</alias>
+
+<!--
+  Fantasy faces
+ -->
+	<alias>
+		<family>Homa</family>
+		<default><family>fantasy</family></default>
+	</alias>
+	<alias>
+		<family>Kamran</family>
+		<default><family>fantasy</family></default>
+	</alias>
+	<alias>
+		<family>Fantezi</family>
+		<default><family>fantasy</family></default>
+	</alias>
+	<alias>
+		<family>Tabassom</family>
+		<default><family>fantasy</family></default>
+	</alias>
+
+<!--
+  Cursive faces
+ -->
+	<alias>
+		<family>IranNastaliq</family>
+		<default><family>cursive</family></default>
+	</alias>
+	<alias>
+		<family>Nafees Nastaleeq</family>
+		<default><family>cursive</family></default>
+	</alias>
+
+<!--
+  Mark common families with their generics so we'll get
+  something reasonable
+-->
+
+<!--
+  Serif faces
+ -->
+	<alias>
+		<family>Bitstream Vera Serif</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>DejaVu Serif</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Liberation Serif</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Times New Roman</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Times</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Nimbus Roman No9 L</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Nimbus Roman</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Luxi Serif</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Thorndale AMT</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Thorndale</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Georgia</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Garamond</family>
+		<default><family>serif</family></default>
+	</alias>
+	<alias>
+		<family>Palatino Linotype</family>
+		<default><family>serif</family></default>
+	</alias>
+<!--
+  Sans-serif faces
+ -->
+	<alias>
+		<family>Bitstream Vera Sans</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>DejaVu Sans</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Liberation Sans</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Arial</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Helvetica</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Verdana</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Albany AMT</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Albany</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Nimbus Sans L</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Nimbus Sans</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Luxi Sans</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+	<alias>
+		<family>Trebuchet MS</family>
+		<default><family>sans-serif</family></default>
+	</alias>
+<!--
+  Monospace faces
+ -->
+ 	<alias>
+		<family>Bitstream Vera Sans Mono</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>DejaVu Sans Mono</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>Liberation Mono</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>Inconsolata</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>Courier New</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>Courier</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>Andale Mono</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>Luxi Mono</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>Cumberland AMT</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>Cumberland</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>Nimbus Mono L</family>
+		<default><family>monospace</family></default>
+	</alias>
+	<alias>
+		<family>Nimbus Mono</family>
+		<default><family>monospace</family></default>
+	</alias>
+<!--
+  Fantasy faces
+ -->
+ 	<alias>
+		<family>Impact</family>
+		<default><family>fantasy</family></default>
+	</alias>
+	<alias>
+		<family>Copperplate Gothic Std</family>
+		<default><family>fantasy</family></default>
+	</alias>
+	<alias>
+		<family>Cooper Std</family>
+		<default><family>fantasy</family></default>
+	</alias>
+	<alias>
+		<family>Bauhaus Std</family>
+		<default><family>fantasy</family></default>
+	</alias>
+<!--
+  Cursive faces
+  -->
+	<alias>
+		<family>ITC Zapf Chancery Std</family>
+		<default><family>cursive</family></default>
+	</alias>
+	<alias>
+		<family>Zapfino</family>
+		<default><family>cursive</family></default>
+	</alias>
+	<alias>
+		<family>Comic Sans MS</family>
+		<default><family>cursive</family></default>
+	</alias>
+
+<!--
+  If the font still has no generic name, add sans-serif
+ -->
+	<match target="pattern">
+		<test qual="all" name="family" compare="not_eq">
+			<string>sans-serif</string>
+		</test>
+		<test qual="all" name="family" compare="not_eq">
+			<string>serif</string>
+		</test>
+		<test qual="all" name="family" compare="not_eq">
+			<string>monospace</string>
+		</test>
+		<edit name="family" mode="append_last">
+			<string>sans-serif</string>
+		</edit>
+	</match>
+	<alias>
+		<family>serif</family>
+		<prefer>
+			<family>Bitstream Vera Serif</family>
+			<family>DejaVu Serif</family>
+			<family>Times New Roman</family>
+			<family>Thorndale AMT</family>
+			<family>Luxi Serif</family>
+			<family>Nimbus Roman No9 L</family>
+			<family>Nimbus Roman</family>
+			<family>Times</family>
+		</prefer>
+	</alias>
+	<alias>
+		<family>sans-serif</family>
+		<prefer>
+			<family>Bitstream Vera Sans</family>
+			<family>DejaVu Sans</family>
+			<family>Verdana</family>
+			<family>Arial</family>
+			<family>Albany AMT</family>
+			<family>Luxi Sans</family>
+			<family>Nimbus Sans L</family>
+			<family>Nimbus Sans</family>
+			<family>Helvetica</family>
+			<family>Lucida Sans Unicode</family>
+			<family>BPG Glaho International</family> <!-- lat,cyr,arab,geor -->
+			<family>Tahoma</family> <!-- lat,cyr,greek,heb,arab,thai -->
+		</prefer>
+	</alias>
+	<alias>
+		<family>monospace</family>
+		<prefer>
+			<family>Bitstream Vera Sans Mono</family>
+			<family>DejaVu Sans Mono</family>
+			<family>Inconsolata</family>
+			<family>Andale Mono</family>
+			<family>Courier New</family>
+			<family>Cumberland AMT</family>
+			<family>Luxi Mono</family>
+			<family>Nimbus Mono L</family>
+			<family>Nimbus Mono</family>
+			<family>Courier</family>
+		</prefer>
+	</alias>
+<!--
+  Fantasy faces
+ -->
+ 	<alias>
+		<family>fantasy</family>
+		<prefer>
+			<family>Impact</family>
+			<family>Copperplate Gothic Std</family>
+			<family>Cooper Std</family>
+			<family>Bauhaus Std</family>
+		</prefer>
+	</alias>
+<!--
+  Cursive faces
+  -->
+	<alias>
+		<family>cursive</family>
+		<prefer>
+			<family>ITC Zapf Chancery Std</family>
+			<family>Zapfino</family>
+			<family>Comic Sans MS</family>
+		</prefer>
+	</alias>
+
+	<alias>
+		<family>serif</family>
+		<prefer>
+			<family>Artsounk</family> <!-- armenian -->
+			<family>BPG UTF8 M</family> <!-- georgian -->
+			<family>Kinnari</family> <!-- thai -->
+			<family>Norasi</family> <!-- thai -->
+			<family>Frank Ruehl</family> <!-- hebrew -->
+			<family>Dror</family>  <!-- hebrew -->
+			<family>JG LaoTimes</family>  <!-- lao -->
+			<family>Saysettha Unicode</family>  <!-- lao -->
+			<family>Pigiarniq</family> <!-- canadian syllabics -->
+			<family>B Davat</family> <!-- arabic (fa) -->
+			<family>B Compset</family>  <!-- arabic (fa) -->
+			<family>Kacst-Qr</family> <!-- arabic (ar) -->
+			<family>Urdu Nastaliq Unicode</family> <!-- arabic (ur) -->
+			<family>Raghindi</family> <!-- devanagari -->
+			<family>Mukti Narrow</family> <!-- bengali -->
+			<family>malayalam</family> <!-- malayalam -->
+			<family>Sampige</family> <!-- kannada -->
+			<family>padmaa</family> <!-- gujarati -->
+			<family>Hapax Berbère</family> <!-- tifinagh -->
+			<family>MS Mincho</family> <!-- han (ja) -->
+			<family>SimSun</family> <!-- han (zh-cn,zh-tw) -->
+			<family>PMingLiu</family> <!-- han (zh-tw) -->
+			<family>WenQuanYi Zen Hei</family> <!-- han (zh-cn,zh-tw) -->
+			<family>WenQuanYi Bitmap Song</family> <!-- han (zh-cn,zh-tw) -->
+			<family>AR PL ShanHeiSun Uni</family> <!-- han (ja,zh-cn,zh-tw) -->
+			<family>AR PL New Sung</family> <!-- han (zh-cn,zh-tw) -->
+			<family>ZYSong18030</family> <!-- han (zh-cn,zh-tw) -->
+			<family>HanyiSong</family> <!-- han (zh-cn,zh-tw) -->
+			<family>MgOpen Canonica</family>
+			<family>Sazanami Mincho</family>
+			<family>IPAMonaMincho</family>
+			<family>IPAMincho</family>
+			<family>Kochi Mincho</family>
+			<family>AR PL SungtiL GB</family>
+			<family>AR PL Mingti2L Big5</family>
+ 			<family>AR PL Zenkai Uni</family>
+			<family>ＭＳ 明朝</family>
+ 			<family>ZYSong18030</family>
+			<family>NanumMyeongjo</family> <!-- hangul (ko) -->
+			<family>UnBatang</family> <!-- hangul (ko) -->
+			<family>Baekmuk Batang</family> <!-- hangul (ko) -->
+ 			<family>KacstQura</family>
+ 			<family>Frank Ruehl CLM</family>
+			<family>Lohit Bengali</family>
+ 			<family>Lohit Gujarati</family>
+ 			<family>Lohit Hindi</family>
+			<family>Lohit Marathi</family>
+			<family>Lohit Maithili</family>
+			<family>Lohit Kashmiri</family>
+			<family>Lohit Konkani</family>
+			<family>Lohit Nepali</family>
+			<family>Lohit Sindhi</family>
+ 			<family>Lohit Punjabi</family>
+ 			<family>Lohit Tamil</family>
+			<family>Meera</family>
+			<family>Lohit Malayalam</family>
+ 			<family>Lohit Kannada</family>
+ 			<family>Lohit Telugu</family>
+ 			<family>Lohit Oriya</family>
+ 			<family>LKLUG</family>
+		</prefer>
+	</alias>
+	<alias>
+		<family>sans-serif</family>
+		<prefer>
+			<family>Nachlieli</family> <!-- hebrew -->
+			<family>Lucida Sans Unicode</family>
+			<family>Yudit Unicode</family>
+			<family>Kerkis</family> <!-- greek -->
+			<family>ArmNet Helvetica</family> <!-- armenian -->
+			<family>Artsounk</family> <!-- armenian -->
+			<family>BPG UTF8 M</family> <!-- georgian -->
+			<family>Waree</family> <!-- thai -->
+			<family>Loma</family> <!-- thai -->
+			<family>Garuda</family> <!-- thai -->
+			<family>Umpush</family> <!-- thai -->
+			<family>Saysettha Unicode</family> <!-- lao? -->
+			<family>JG Lao Old Arial</family> <!-- lao -->
+			<family>GF Zemen Unicode</family> <!-- ethiopic -->
+			<family>Pigiarniq</family> <!-- canadian syllabics -->
+			<family>B Davat</family> <!-- arabic (fa) -->
+			<family>B Compset</family> <!-- arabic (fa) -->
+			<family>Kacst-Qr</family> <!-- arabic (ar) -->
+			<family>Urdu Nastaliq Unicode</family> <!-- arabic (ur) -->
+			<family>Raghindi</family> <!-- devanagari -->
+			<family>Mukti Narrow</family> <!-- bengali -->
+			<family>malayalam</family> <!-- malayalam -->
+			<family>Sampige</family> <!-- kannada -->
+			<family>padmaa</family> <!-- gujarati -->
+			<family>Hapax Berbère</family> <!-- tifinagh -->
+			<family>MS Gothic</family> <!-- han (ja) -->
+			<family>UmePlus P Gothic</family> <!-- han (ja) -->
+			<!-- chinese fonts are actually serifed -->
+			<family>SimSun</family> <!-- han (zh-cn,zh-tw) -->
+			<family>PMingLiu</family> <!-- han (zh-tw) -->
+			<family>WenQuanYi Zen Hei</family> <!-- han (zh-cn,zh-tw) -->
+			<family>WenQuanYi Bitmap Song</family> <!-- han (zh-cn,zh-tw) -->
+			<family>AR PL ShanHeiSun Uni</family> <!--han (ja,zh-cn,zh-tw) -->
+			<family>AR PL New Sung</family> <!-- han (zh-cn,zh-tw) -->
+			<family>MgOpen Modata</family>
+			<family>VL Gothic</family>
+			<family>IPAMonaGothic</family>
+			<family>IPAGothic</family>
+			<family>Sazanami Gothic</family>
+			<family>Kochi Gothic</family>
+			<family>AR PL KaitiM GB</family>
+			<family>AR PL KaitiM Big5</family>
+ 			<family>AR PL ShanHeiSun Uni</family>
+ 			<family>AR PL SungtiL GB</family>
+ 			<family>AR PL Mingti2L Big5</family>
+			<family>ＭＳ ゴシック</family>
+			<family>ZYSong18030</family> <!-- han (zh-cn,zh-tw) -->
+			<family>TSCu_Paranar</family> <!-- tamil -->
+			<family>NanumGothic</family> <!-- hangul (ko) -->
+			<family>UnDotum</family> <!-- hangul (ko) -->
+			<family>Baekmuk Dotum</family> <!-- hangul (ko) -->
+ 			<family>Baekmuk Gulim</family> <!-- hangul (ko) -->
+ 			<family>KacstQura</family>
+			<family>Lohit Bengali</family>
+ 			<family>Lohit Gujarati</family>
+ 			<family>Lohit Hindi</family>
+			<family>Lohit Marathi</family>
+			<family>Lohit Maithili</family>
+			<family>Lohit Kashmiri</family>
+			<family>Lohit Konkani</family>
+			<family>Lohit Nepali</family>
+			<family>Lohit Sindhi</family>
+ 			<family>Lohit Punjabi</family>
+ 			<family>Lohit Tamil</family>
+			<family>Meera</family>
+ 			<family>Lohit Malayalam</family>
+ 			<family>Lohit Kannada</family>
+ 			<family>Lohit Telugu</family>
+ 			<family>Lohit Oriya</family>
+ 			<family>LKLUG</family>
+		</prefer>
+	</alias>
+	<alias>
+		<family>monospace</family>
+		<prefer>
+			<family>Miriam Mono</family> <!-- hebrew -->
+			<family>VL Gothic</family>
+			<family>IPAMonaGothic</family>
+			<family>IPAGothic</family>
+			<family>Sazanami Gothic</family>
+			<family>Kochi Gothic</family>
+			<family>AR PL KaitiM GB</family>
+			<family>MS Gothic</family> <!-- han (ja) -->
+			<family>UmePlus Gothic</family> <!-- han (ja) -->
+			<family>NSimSun</family> <!-- han (zh-cn,zh-tw) -->
+			<family>MingLiu</family> <!-- han (zh-tw) -->
+			<family>AR PL ShanHeiSun Uni</family> <!-- han (ja,zh-cn,zh-tw) -->
+			<family>AR PL New Sung Mono</family> <!-- han (zh-cn,zh-tw) -->
+			<family>HanyiSong</family> <!-- han (zh-cn) -->
+			<family>AR PL SungtiL GB</family>
+			<family>AR PL Mingti2L Big5</family>
+			<family>ZYSong18030</family> <!-- han (zh-cn,zh-tw) -->
+			<family>NanumGothicCoding</family> <!-- hangul (ko) -->
+			<family>NanumGothic</family> <!-- hangul (ko) -->
+			<family>UnDotum</family> <!-- hangul (ko) -->
+			<family>Baekmuk Dotum</family> <!-- hangul (ko) -->
+			<family>Baekmuk Gulim</family> <!-- hangul (ko) -->
+			<family>TlwgTypo</family> <!-- thai -->
+			<family>TlwgTypist</family> <!-- thai -->
+			<family>TlwgTypewriter</family> <!-- thai -->
+			<family>TlwgMono</family> <!-- thai -->
+			<family>Hasida</family> <!-- hebrew -->
+			<family>Mitra Mono</family> <!-- bengali -->
+			<family>GF Zemen Unicode</family> <!-- ethiopic -->
+			<family>Hapax Berbère</family> <!-- tifinagh -->
+			<family>Lohit Bengali</family>
+			<family>Lohit Gujarati</family>
+			<family>Lohit Hindi</family>
+			<family>Lohit Marathi</family>
+			<family>Lohit Maithili</family>
+			<family>Lohit Kashmiri</family>
+			<family>Lohit Konkani</family>
+			<family>Lohit Nepali</family>
+			<family>Lohit Sindhi</family>
+			<family>Lohit Punjabi</family>
+			<family>Lohit Tamil</family>
+			<family>Meera</family>
+			<family>Lohit Malayalam</family>
+			<family>Lohit Kannada</family>
+			<family>Lohit Telugu</family>
+			<family>Lohit Oriya</family>
+			<family>LKLUG</family>
+		</prefer>
+	</alias>
+	<alias>
+		<family>serif</family>
+		<prefer>
+			<family>FreeSerif</family>
+			<family>Code2000</family>
+			<family>Code2001</family> <!-- plane1 and beyond -->
+		</prefer>
+	</alias>
+	<alias>
+		<family>sans-serif</family>
+		<prefer>
+			<family>FreeSans</family>
+			<family>Arial Unicode MS</family>
+			<family>Arial Unicode</family>
+			<family>Code2000</family> <!-- almost everything; serif actually -->
+			<family>Code2001</family> <!-- plane1 and beyond -->
+		</prefer>
+	</alias>
+	<alias>
+		<family>monospace</family>
+		<prefer>
+			<family>FreeMono</family>
+		</prefer>
+	</alias>
+
 </fontconfig>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] These changes do not require tests because they must be manually tested

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Currently fonts are using incorrect metrics and the app uses the console
subsystem. This patch adds aliases so that font metrics are found and
instructs the linker to use the windows subsystem.

NOTE: This is not yet ready to merge. The RUSTFLAGS isn't getting set right.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12605)

<!-- Reviewable:end -->
