### PR TITLE
Attach more signals to the backtrace signal handler.

### DIFF
--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -70,7 +70,10 @@ fn install_crash_handler() {
         }
     }
 
-    signal!(Sig::SEGV, handler);
+    signal!(Sig::SEGV, handler); // handle segfaults
+    signal!(Sig::ILL, handler); // handle stack overflow and unsupported CPUs
+    signal!(Sig::IOT, handler); // handle double panics
+    signal!(Sig::BUS, handler); // handle invalid memory access
 }
 
 #[cfg(target_os = "android")]

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/readPixelsBadArgs.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/readPixelsBadArgs.html.ini
@@ -1,6 +1,6 @@
 [readPixelsBadArgs.html]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT
   [WebGL test #0: testReadPixels]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/reading/read-pixels-pack-alignment.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/reading/read-pixels-pack-alignment.html.ini
@@ -1,6 +1,6 @@
 [read-pixels-pack-alignment.html]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT
   [WebGL test #3: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/draw-arrays-out-of-bounds.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/draw-arrays-out-of-bounds.html.ini
@@ -1,3 +1,3 @@
 [draw-arrays-out-of-bounds.html]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/draw-elements-out-of-bounds.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/draw-elements-out-of-bounds.html.ini
@@ -1,3 +1,3 @@
 [draw-elements-out-of-bounds.html]
   type: testharness
-  expected: CRASH
+  expected: TIMEOUT


### PR DESCRIPTION
These changes should enable meaningful backtraces in more unusual situations where the program would otherwise exit almost silently.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12618 (github issue number if applicable).
- [X] These changes do not require tests because we can't verify the terminal output of the program in erroneous cases

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12621)

<!-- Reviewable:end -->
