### PR TITLE
Fix missing namespace in Windows manifest

### DIFF
--- a/components/servo/servo.exe.manifest
+++ b/components/servo/servo.exe.manifest
@@ -6,7 +6,7 @@
                     name="servo.Servo"
                     version="0.1.0.0"/>
 
-  <compatibility>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/> <!-- Windows 7 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/> <!-- Windows 8 -->


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they must be manually tested

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

The <compatibility> tag must be in the right namespace, or Windows 7
throws an error.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12627)

<!-- Reviewable:end -->
