### PR TITLE
Add option to record frames for playback

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -151,6 +151,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
                         enable_msaa: opts.use_msaa,
                         enable_profiler: opts.webrender_stats,
                         debug: opts.webrender_debug,
+                        enable_recording: opts.enable_recording,
                     });
                 (Some(webrender), Some(webrender_sender))
             } else {

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -167,6 +167,9 @@ pub struct Opts {
     /// Dumps the layer tree when it changes.
     pub dump_layer_tree: bool,
 
+    ///Record and write to disk each frame sent to webrender.
+    pub enable_recording: bool,
+
     /// Emits notifications when there is a relayout.
     pub relayout_event: bool,
 
@@ -243,6 +246,9 @@ pub struct DebugOptions {
     /// Print the layer tree whenever it changes.
     pub dump_layer_tree: bool,
 
+    ///Record display lists sent to webrender.
+    pub enable_recording: bool,
+
     /// Print notifications when there is a relayout.
     pub relayout_event: bool,
 
@@ -318,6 +324,7 @@ impl DebugOptions {
                 "dump-display-list" => debug_options.dump_display_list = true,
                 "dump-display-list-json" => debug_options.dump_display_list_json = true,
                 "dump-layer-tree" => debug_options.dump_layer_tree = true,
+                "record" => debug_options.enable_recording = true,
                 "relayout-event" => debug_options.relayout_event = true,
                 "profile-script-events" => debug_options.profile_script_events = true,
                 "profile-heartbeats" => debug_options.profile_heartbeats = true,
@@ -361,6 +368,7 @@ pub fn print_debug_usage(app: &str) -> ! {
     print_option("dump-display-list", "Print the display list after each layout.");
     print_option("dump-display-list-json", "Print the display list in JSON form.");
     print_option("dump-layer-tree", "Print the layer tree whenever it changes.");
+    print_option("record", "Serializes all frame data sent to webrender and writes to record folder.");
     print_option("relayout-event", "Print notifications when there is a relayout.");
     print_option("profile-script-events", "Enable profiling of script-related events.");
     print_option("profile-heartbeats", "Enable heartbeats for all thread categories.");
@@ -504,6 +512,7 @@ pub fn default_opts() -> Opts {
         dump_display_list: false,
         dump_display_list_json: false,
         dump_layer_tree: false,
+        enable_recording: false,
         relayout_event: false,
         profile_script_events: false,
         profile_heartbeats: false,
@@ -811,6 +820,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         dump_display_list: debug_options.dump_display_list,
         dump_display_list_json: debug_options.dump_display_list_json,
         dump_layer_tree: debug_options.dump_layer_tree,
+        enable_recording: debug_options.enable_recording,
         relayout_event: debug_options.relayout_event,
         disable_share_style_cache: debug_options.disable_share_style_cache,
         convert_mouse_to_touch: debug_options.convert_mouse_to_touch,


### PR DESCRIPTION
Adds a debug option, -Z record, to record webrender's display lists for debugging.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12630)

<!-- Reviewable:end -->
