### PR TITLE
account for sign in double parsing

### DIFF
--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -92,17 +92,17 @@ pub fn parse_double(string: &str) -> Result<f64, ()> {
     let trimmed = string.trim_matches(HTML_SPACE_CHARACTERS);
     let mut input = trimmed.chars().peekable();
 
-    let (value, divisor) = match input.peek() {
+    let (value, divisor, chars_skipped) = match input.peek() {
         None => return Err(()),
         Some(&'-') => {
             input.next();
-            (-1f64, -1f64)
+            (-1f64, -1f64, 1)
         }
         Some(&'+') => {
             input.next();
-            (1f64, 1f64)
+            (1f64, 1f64, 1)
         }
-        _ => (1f64, 1f64)
+        _ => (1f64, 1f64, 0)
     };
 
     let (value, value_digits) = if let Some(&'.') = input.peek() {
@@ -112,11 +112,11 @@ pub fn parse_double(string: &str) -> Result<f64, ()> {
         (value * read_val.and_then(|result| result.to_f64()).unwrap_or(1f64), read_digits)
     };
 
-    let input = trimmed.chars().skip(value_digits).peekable();
+    let input = trimmed.chars().skip(value_digits + chars_skipped).peekable();
 
     let (mut value, fraction_digits) = read_fraction(input, divisor, value);
 
-    let input = trimmed.chars().skip(value_digits + fraction_digits).peekable();
+    let input = trimmed.chars().skip(value_digits + chars_skipped + fraction_digits).peekable();
 
     if let Some(exp) = read_exponent(input) {
         value *= 10f64.powi(exp)

--- a/tests/unit/style/attr.rs
+++ b/tests/unit/style/attr.rs
@@ -15,6 +15,24 @@ fn test_parse_double() {
 }
 
 #[test]
+fn test_parse_double_negative_prefix() {
+    let value = String::from("-5.6");
+    match AttrValue::from_double(value, 0.0) {
+        AttrValue::Double(_, num) => assert_eq!(num, -5.6f64),
+        _ => panic!("expected a double value")
+    }
+}
+
+#[test]
+fn test_parse_double_positive_prefix() {
+    let value = String::from("+5.6");
+    match AttrValue::from_double(value, 0.0) {
+        AttrValue::Double(_, num) => assert_eq!(num, 5.6f64),
+        _ => panic!("expected a double value")
+    }
+}
+
+#[test]
 fn test_from_limited_i32_should_be_default_when_less_than_0() {
     let value = String::from("-1");
     match AttrValue::from_limited_i32(value, 0) {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

account for sign in double parsing inside styles attr.rs

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

When sign was present during double parsing correctly jump forward the
extra character when parsing fraction and exponent.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12632)

<!-- Reviewable:end -->
