### PR TITLE
Headers API constructor and methods

### DIFF
--- a/components/script/dom/webidls/Headers.webidl
+++ b/components/script/dom/webidls/Headers.webidl
@@ -4,19 +4,21 @@
 
 // https://fetch.spec.whatwg.org/#headers-class
 
-/* typedef (Headers or sequence<sequence<ByteString>>) HeadersInit; */
+// TODO support OpenEndedDictionary<ByteString>
+typedef (Headers or sequence<sequence<ByteString>>) HeadersInit;
 
-/* [Constructor(optional HeadersInit init),*/
- [Exposed=(Window,Worker)]
-
+[Constructor(optional HeadersInit init),
+ Exposed=(Window,Worker)]
 interface Headers {
   [Throws]
   void append(ByteString name, ByteString value);
+  [Throws]
+  void delete(ByteString name);
+  [Throws]
+  ByteString? get(ByteString name);
+  [Throws]
+  boolean has(ByteString name);
+  [Throws]
+  void set(ByteString name, ByteString value);
+  // iterable<ByteString, ByteString>; // TODO see issue #12628
 };
-
-/* void delete(ByteString name);
- * ByteString? get(ByteString name);
- * boolean has(ByteString name);
- * void set(ByteString name, ByteString value);
- * iterable<ByteString, ByteString>;
- * }; */

--- a/tests/wpt/metadata/fetch/api/headers/headers-basic.html.ini
+++ b/tests/wpt/metadata/fetch/api/headers/headers-basic.html.ini
@@ -1,11 +1,5 @@
 [headers-basic.html]
   type: testharness
-  [Create headers from no parameter]
-    expected: FAIL
-
-  [Create headers from undefined parameter]
-    expected: FAIL
-
   [Create headers from empty object]
     expected: FAIL
 
@@ -15,7 +9,7 @@
   [Create headers with OpenEndedDictionary]
     expected: FAIL
 
-  [Create headers whith existing headers]
+  [Create headers with existing headers]
     expected: FAIL
 
   [Check append method]
@@ -47,4 +41,3 @@
 
   [Check forEach method]
     expected: FAIL
-

--- a/tests/wpt/metadata/fetch/api/headers/headers-errors.html.ini
+++ b/tests/wpt/metadata/fetch/api/headers/headers-errors.html.ini
@@ -1,44 +1,7 @@
 [headers-errors.html]
   type: testharness
-  [Check headers get with an invalid name invalidĀ]
-    expected: FAIL
-
-  [Check headers get with an invalid name [object Object\]]
-    expected: FAIL
-
-  [Check headers delete with an invalid name invalidĀ]
-    expected: FAIL
-
-  [Check headers delete with an invalid name [object Object\]]
-    expected: FAIL
-
-  [Check headers has with an invalid name invalidĀ]
-    expected: FAIL
-
-  [Check headers has with an invalid name [object Object\]]
-    expected: FAIL
-
-  [Check headers set with an invalid name invalidĀ]
-    expected: FAIL
-
-  [Check headers set with an invalid name [object Object\]]
-    expected: FAIL
-
-  [Check headers set with an invalid value invalidĀ]
-    expected: FAIL
-
-  [Check headers append with an invalid name invalidĀ]
-    expected: FAIL
-
-  [Check headers append with an invalid name [object Object\]]
-    expected: FAIL
-
-  [Check headers append with an invalid value invalidĀ]
-    expected: FAIL
-
   [Headers forEach throws if argument is not callable]
     expected: FAIL
 
   [Headers forEach loop should stop if callback is throwing exception]
     expected: FAIL
-

--- a/tests/wpt/metadata/fetch/api/headers/headers-structure.html.ini
+++ b/tests/wpt/metadata/fetch/api/headers/headers-structure.html.ini
@@ -1,3 +1,11 @@
 [headers-structure.html]
   type: testharness
-  expected: TIMEOUT
+  expected: OK
+  [Headers has entries method]
+    expected: FAIL
+
+  [Headers has keys method]
+    expected: FAIL
+
+  [Headers has values method]
+    expected: FAIL

--- a/tests/wpt/web-platform-tests/fetch/api/headers/headers-basic.html
+++ b/tests/wpt/web-platform-tests/fetch/api/headers/headers-basic.html
@@ -66,7 +66,7 @@
           assert_equals(headers2.get(name), String(headerDict[name]),
             "name: " + name + " has value: " + headerDict[name]);
         }
-      }, "Create headers whith existing headers");
+      }, "Create headers with existing headers");
 
       test(function() {
         var headers = new Headers();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR fills out the constructor and the delete, get, has, and set methods for the Headers API. Addresses issue #11897 .

The PR also rewrites the append method to support `hyper::header::Headers`'s HashMap `insert` method, which overwrites entries instead of appending.  
As a result of this, for a given header name there is at most one value in the inner "header list"/HashMap. Multiple values for the same name are comma-delimited.

There are still a few TODOs:
- Support `OpenEndedDictionary<ByteString>`  as a possible `HeadersInit` value. [OpenEndedDictionary<T> is a future IDL construct.](https://fetch.spec.whatwg.org/#headers-class)
- Support `iterable<ByteString, ByteString>`. Related issue: #12628 
- Values are comma-delimited, except for values with the name `set-cookie`, which are newline-delimited. This is because values for `set-cookie` are [allowed to contain](https://tools.ietf.org/html/rfc7230#section-3.2.2) inner commas. This violates the [spec](https://fetch.spec.whatwg.org/#concept-header-value-combined).
- The TODOs from PR #12467 regarding value parsing also still need to be resolved.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because tests for the Headers API already exists, but this commit does not implement the interface fully. The tests will fail.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12634)

<!-- Reviewable:end -->
