### PR TITLE
Send logging messages even if the channel lock is poisoned.

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -342,9 +342,8 @@ impl Log for FromScriptLogger {
             let pipeline_id = PipelineId::installed();
             let thread_name = thread::current().name().map(ToOwned::to_owned);
             let msg = FromScriptMsg::LogEntry(pipeline_id, thread_name, entry);
-            if let Ok(chan) = self.constellation_chan.lock() {
-                let _ = chan.send(msg);
-            }
+            let chan = self.constellation_chan.lock().unwrap_or_else(|err| err.into_inner());
+            let _ = chan.send(msg);
         }
     }
 }
@@ -381,9 +380,8 @@ impl Log for FromCompositorLogger {
             let pipeline_id = PipelineId::installed();
             let thread_name = thread::current().name().map(ToOwned::to_owned);
             let msg = FromCompositorMsg::LogEntry(pipeline_id, thread_name, entry);
-            if let Ok(chan) = self.constellation_chan.lock() {
-                let _ = chan.send(msg);
-            }
+            let chan = self.constellation_chan.lock().unwrap_or_else(|err| err.into_inner());
+            let _ = chan.send(msg);
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Send panic and logging messages to the contellation even if the channel lock is poisoned.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12638.
- [X] These changes do not require tests because we don't have tests for panic.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12639)

<!-- Reviewable:end -->
