### PR TITLE
Add link arguments to test-unit

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -209,6 +209,9 @@ class MachCommands(CommandBase):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 
+        if sys.platform == "win32" or sys.platform == "msys":
+            env["RUSTFLAGS"] = "-C link-args=-Wl,--subsystem,windows"
+
         result = call(args, env=env, cwd=self.servo_crate())
         if result != 0:
             return result


### PR DESCRIPTION
Apply same link arguments added in https://github.com/servo/servo/pull/12605 to `test-unit`, to prevent rebuild servo.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12640)

<!-- Reviewable:end -->
