### PR TITLE
Use explicit height of inline-block fragments

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2005,9 +2005,10 @@ impl Fragment {
                 // See CSS 2.1 § 10.8.1.
                 let flow = &info.flow_ref;
                 let block_flow = flow.as_block();
+                let is_auto = self.style.get_position().height == LengthOrPercentageOrAuto::Auto;
                 let baseline_offset = match flow.baseline_offset_of_last_line_box_in_flow() {
-                    Some(baseline_offset) => baseline_offset,
-                    None => block_flow.fragment.border_box.size.block,
+                    Some(baseline_offset) if is_auto => baseline_offset,
+                    _ => block_flow.fragment.border_box.size.block,
                 };
                 let start_margin = block_flow.fragment.margin.block_start;
                 let end_margin = block_flow.fragment.margin.block_end;

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5272,6 +5272,18 @@
             "url": "/_mozilla/css/text_transform_uppercase_a.html"
           }
         ],
+        "css/textarea_space_calculation.html": [
+          {
+            "path": "css/textarea_space_calculation.html",
+            "references": [
+              [
+                "/_mozilla/css/textarea_space_calculation-ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/textarea_space_calculation.html"
+          }
+        ],
         "css/transform_3d.html": [
           {
             "path": "css/transform_3d.html",
@@ -14388,6 +14400,18 @@
             ]
           ],
           "url": "/_mozilla/css/text_transform_uppercase_a.html"
+        }
+      ],
+      "css/textarea_space_calculation.html": [
+        {
+          "path": "css/textarea_space_calculation.html",
+          "references": [
+            [
+              "/_mozilla/css/textarea_space_calculation-ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/textarea_space_calculation.html"
         }
       ],
       "css/transform_3d.html": [

--- a/tests/wpt/mozilla/tests/css/textarea_space_calculation-ref.html
+++ b/tests/wpt/mozilla/tests/css/textarea_space_calculation-ref.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>REFERENCE: textarea does not take up more space than it takes up</title>
+<style>
+textarea{height:2em;width:2em}
+div{width:2em;font-size:12px;line-height:3px}
+</style>
+<h1>To pass, no red should be visible</h1>
+<div>
+<textarea>
+1
+2
+3
+4
+5
+6
+8
+9
+</textarea>
+</div>

--- a/tests/wpt/mozilla/tests/css/textarea_space_calculation.html
+++ b/tests/wpt/mozilla/tests/css/textarea_space_calculation.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>textarea does not take up more space than it takes up</title>
+<link rel="match" href="textarea_space_calculation-ref.html">
+<style>
+textarea{height:2em;width:2em}
+div{background:red;width:2em;font-size:12px;line-height:3px}
+</style>
+<h1>To pass, no red should be visible</h1>
+<div>
+<textarea>
+1
+2
+3
+4
+5
+6
+8
+9
+</textarea>
+</div>


### PR DESCRIPTION
When an explicit height is used for inline-block fragments, the line spacing algorithm should use that for the height above the baseline, instead of the intrinsic one.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12492 (github issue number if applicable).
- [X] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12642)

<!-- Reviewable:end -->
