### PR TITLE
Pull UrlExtraData up to values.rs.

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -914,16 +914,9 @@ ${helpers.single_keyword("-moz-appearance",
     use gecko_bindings::ptr::{GeckoArcPrincipal, GeckoArcURI};
     use std::fmt::{self, Write};
     use url::Url;
+    use values::specified::UrlExtraData;
     use values::computed::ComputedValueAsSpecified;
     use values::NoViewportPercentage;
-
-    #[derive(PartialEq, Clone, Debug)]
-    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    pub struct UrlExtraData {
-        pub base: GeckoArcURI,
-        pub referrer: GeckoArcURI,
-        pub principal: GeckoArcPrincipal,
-    }
 
     #[derive(PartialEq, Clone, Debug)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -98,6 +98,8 @@ pub mod specified {
     use app_units::Au;
     use cssparser::{self, Parser, ToCss, Token};
     use euclid::size::Size2D;
+    #[cfg(feature = "gecko")]
+    use gecko_bindings::ptr::{GeckoArcPrincipal, GeckoArcURI};
     use parser::ParserContext;
     use std::ascii::AsciiExt;
     use std::cmp;
@@ -1315,6 +1317,17 @@ pub mod specified {
                  _ => Err(())
             }
         }
+    }
+
+    #[derive(PartialEq, Clone, Debug)]
+    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+    pub struct UrlExtraData {
+        #[cfg(feature = "gecko")]
+        pub base: GeckoArcURI,
+        #[cfg(feature = "gecko")]
+        pub referrer: GeckoArcURI,
+        #[cfg(feature = "gecko")]
+        pub principal: GeckoArcPrincipal,
     }
 
     /// Specified values for an image according to CSS-IMAGES.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Move `UrlExtraData` out of the `-moz-binding` mod, since it'll be needed for other properties that take `url()` values.

r? @Manishearth 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's just some code shuffling

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12646)

<!-- Reviewable:end -->
