### PR TITLE
Store UrlExtraData in {specified,computed}::Image::Url.

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -398,7 +398,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                                        gradient,
                                                                        style);
             }
-            Some(computed::Image::Url(ref image_url)) => {
+            Some(computed::Image::Url(ref image_url, ref _extra_data)) => {
                 self.build_display_list_for_background_image(state,
                                                              style,
                                                              display_list_section,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -347,7 +347,8 @@ impl LayoutElementHelpers for LayoutJS<Element> {
         if let Some(url) = background {
             hints.push(from_declaration(
                 PropertyDeclaration::BackgroundImage(DeclaredValue::Value(
-                    background_image::SpecifiedValue(Some(specified::Image::Url(url)))))));
+                    background_image::SpecifiedValue(Some(
+                        specified::Image::Url(url, specified::UrlExtraData { })))))));
         }
 
         let color = if let Some(this) = self.downcast::<HTMLFontElement>() {

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1097,7 +1097,7 @@ fn static_assert() {
                             Gecko_SetGradientImageValue(&mut geckoimage.mImage, gecko_gradient);
                         }
                     },
-                    Image::Url(_) => {
+                    Image::Url(..) => {
                         // let utf8_bytes = url.as_bytes();
                         // Gecko_SetUrlImageValue(&mut self.gecko.mImage.mLayers.mFirstElement,
                         //                        utf8_bytes.as_ptr() as *const _,

--- a/components/style/properties/longhand/background.mako.rs
+++ b/components/style/properties/longhand/background.mako.rs
@@ -28,7 +28,7 @@ ${helpers.predefined_type("background-color", "CSSColor",
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match self.0 {
                 None => dest.write_str("none"),
-                Some(computed::Image::Url(ref url)) => url.to_css(dest),
+                Some(computed::Image::Url(ref url, ref _extra_data)) => url.to_css(dest),
                 Some(computed::Image::LinearGradient(ref gradient)) =>
                     gradient.to_css(dest)
             }

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -914,16 +914,9 @@ ${helpers.single_keyword("-moz-appearance",
     use gecko_bindings::ptr::{GeckoArcPrincipal, GeckoArcURI};
     use std::fmt::{self, Write};
     use url::Url;
+    use values::specified::UrlExtraData;
     use values::computed::ComputedValueAsSpecified;
     use values::NoViewportPercentage;
-
-    #[derive(PartialEq, Clone, Debug)]
-    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    pub struct UrlExtraData {
-        pub base: GeckoArcURI,
-        pub referrer: GeckoArcURI,
-        pub principal: GeckoArcPrincipal,
-    }
 
     #[derive(PartialEq, Clone, Debug)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -98,6 +98,8 @@ pub mod specified {
     use app_units::Au;
     use cssparser::{self, Parser, ToCss, Token};
     use euclid::size::Size2D;
+    #[cfg(feature = "gecko")]
+    use gecko_bindings::ptr::{GeckoArcPrincipal, GeckoArcURI};
     use parser::ParserContext;
     use std::ascii::AsciiExt;
     use std::cmp;
@@ -1315,6 +1317,17 @@ pub mod specified {
                  _ => Err(())
             }
         }
+    }
+
+    #[derive(PartialEq, Clone, Debug)]
+    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+    pub struct UrlExtraData {
+        #[cfg(feature = "gecko")]
+        pub base: GeckoArcURI,
+        #[cfg(feature = "gecko")]
+        pub referrer: GeckoArcURI,
+        #[cfg(feature = "gecko")]
+        pub principal: GeckoArcPrincipal,
     }
 
     /// Specified values for an image according to CSS-IMAGES.

--- a/components/style/values.rs
+++ b/components/style/values.rs
@@ -100,7 +100,7 @@ pub mod specified {
     use euclid::size::Size2D;
     #[cfg(feature = "gecko")]
     use gecko_bindings::ptr::{GeckoArcPrincipal, GeckoArcURI};
-    use parser::ParserContext;
+    use parser::{ParserContext, ParserContextExtraData};
     use std::ascii::AsciiExt;
     use std::cmp;
     use std::f32::consts::PI;
@@ -1330,11 +1330,36 @@ pub mod specified {
         pub principal: GeckoArcPrincipal,
     }
 
+    impl UrlExtraData {
+        #[cfg(feature = "servo")]
+        pub fn make_from(content: &ParserContext) -> Option<UrlExtraData> {
+            Some(UrlExtraData { })
+        }
+
+        #[cfg(feature = "gecko")]
+        pub fn make_from(context: &ParserContext) -> Option<UrlExtraData> {
+            match context.extra_data {
+                ParserContextExtraData {
+                    base: Some(ref base),
+                    referrer: Some(ref referrer),
+                    principal: Some(ref principal),
+                } => {
+                    Some(UrlExtraData {
+                        base: base.clone(),
+                        referrer: referrer.clone(),
+                        principal: principal.clone(),
+                    })
+                },
+                _ => None,
+            }
+        }
+    }
+
     /// Specified values for an image according to CSS-IMAGES.
     #[derive(Clone, PartialEq, Debug)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum Image {
-        Url(Url),
+        Url(Url, UrlExtraData),
         LinearGradient(LinearGradient),
     }
 
@@ -1342,7 +1367,7 @@ pub mod specified {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             use values::LocalToCss;
             match *self {
-                Image::Url(ref url) => {
+                Image::Url(ref url, ref _extra_data) => {
                     url.to_css(dest)
                 }
                 Image::LinearGradient(ref gradient) => gradient.to_css(dest)
@@ -1353,7 +1378,17 @@ pub mod specified {
     impl Image {
         pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<Image, ()> {
             if let Ok(url) = input.try(|input| input.expect_url()) {
-                Ok(Image::Url(context.parse_url(&url)))
+                match UrlExtraData::make_from(context) {
+                    Some(extra_data) => {
+                        Ok(Image::Url(context.parse_url(&url), extra_data))
+                    },
+                    None => {
+                        // FIXME(heycam) should ensure we always have a principal, etc., when
+                        // parsing style attributes and re-parsing due to CSS Variables.
+                        println!("stylo: skipping declaration without ParserContextExtraData");
+                        Err(())
+                    },
+                }
             } else {
                 match_ignore_ascii_case! { try!(input.expect_function()),
                     "linear-gradient" => {
@@ -1677,7 +1712,7 @@ pub mod computed {
     use super::{CSSFloat, specified};
     use url::Url;
     pub use cssparser::Color as CSSColor;
-    pub use super::specified::{Angle, BorderStyle, Time};
+    pub use super::specified::{Angle, BorderStyle, Time, UrlExtraData};
 
     pub struct Context<'a> {
         pub is_root_element: bool,
@@ -2177,7 +2212,9 @@ pub mod computed {
         #[inline]
         fn to_computed_value(&self, context: &Context) -> Image {
             match *self {
-                specified::Image::Url(ref url) => Image::Url(url.clone()),
+                specified::Image::Url(ref url, ref extra_data) => {
+                    Image::Url(url.clone(), extra_data.clone())
+                },
                 specified::Image::LinearGradient(ref linear_gradient) => {
                     Image::LinearGradient(linear_gradient.to_computed_value(context))
                 }
@@ -2190,14 +2227,14 @@ pub mod computed {
     #[derive(Clone, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum Image {
-        Url(Url),
+        Url(Url, UrlExtraData),
         LinearGradient(LinearGradient),
     }
 
     impl fmt::Debug for Image {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match *self {
-                Image::Url(ref url) => write!(f, "url(\"{}\")", url),
+                Image::Url(ref url, ref _extra_data) => write!(f, "url(\"{}\")", url),
                 Image::LinearGradient(ref grad) => write!(f, "linear-gradient({:?})", grad),
             }
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This stores a `UrlExtraData` object in `specified::Image::Url` and `computed::Image::Url`, so that geckolib can use the base/principal to create Gecko `ImageValue`s.  (I'll do that in the followup to support background-image; want to get this in first.)

r? @Manishearth 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because existing tests should be sufficient

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12648)

<!-- Reviewable:end -->
