### PR TITLE
Print backtraces for panics, even if the constellation has closed.

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1090,7 +1090,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         if opts::get().hard_fail {
             // It's quite difficult to make Servo exit cleanly if some threads have failed.
             // Hard fail exists for test runners so we crash and that's good enough.
-            println!("Pipeline failed in hard-fail mode.  Crashing!\n{}\n{}", reason, backtrace.unwrap_or_default());
+            println!("Pipeline failed in hard-fail mode.  Crashing!");
             process::exit(1);
         }
 

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -34,10 +34,12 @@ extern crate servo;
 #[macro_use]
 extern crate sig;
 
+use backtrace::Backtrace;
 use servo::Browser;
 use servo::compositing::windowing::WindowEvent;
 use servo::util::opts::{self, ArgumentParsingResult};
 use servo::util::servo_version;
+use std::env;
 use std::panic;
 use std::process;
 use std::rc::Rc;
@@ -97,8 +99,8 @@ fn main() {
         None
     };
 
-    // TODO: once log-panics is released, this can be replaced by
-    // log_panics::init();
+    // TODO: once log-panics is released, can this be replaced by
+    // log_panics::init()?
     panic::set_hook(Box::new(|info| {
         warn!("Panic hook called.");
         let msg = match info.payload().downcast_ref::<&'static str>() {
@@ -111,10 +113,15 @@ fn main() {
         let current_thread = thread::current();
         let name = current_thread.name().unwrap_or("<unnamed>");
         if let Some(location) = info.location() {
-            error!("{} (thread {}, at {}:{})", msg, name, location.file(), location.line());
+            println!("{} (thread {}, at {}:{})", msg, name, location.file(), location.line());
         } else {
-            error!("{} (thread {})", msg, name);
+            println!("{} (thread {})", msg, name);
         }
+        if env::var("RUST_BACKTRACE").is_ok() {
+            println!("{:?}", Backtrace::new());
+        }
+
+        error!("{}", msg);
     }));
 
     setup_logging();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

At the moment, threads rely on the constellation to print out the reason for a panic, so panics that happen after the constellation closes are dropped on the floor. cc @jdm 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12626
- [X] These changes do not require tests because they are fixing panic behaviour

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12657)

<!-- Reviewable:end -->
