### PR TITLE
reftest harness: Honour --binary-arg

### DIFF
--- a/tests/wpt/harness/wptrunner/executors/executorservo.py
+++ b/tests/wpt/harness/wptrunner/executors/executorservo.py
@@ -205,7 +205,7 @@ class ServoRefTestExecutor(ProcessTestExecutor):
                 self.binary,
                 [render_arg(self.browser.render_backend), "--hard-fail", "--exit",
                  "-u", "Servo/wptrunner", "-Z", "disable-text-aa,load-webfonts-synchronously,replace-surrogates",
-                 "--output=%s" % output_path, full_url],
+                 "--output=%s" % output_path, full_url] + self.browser.binary_args,
                 self.debug_info)
 
             for stylesheet in self.browser.user_stylesheets:


### PR DESCRIPTION
This allows for running `test-css` with `-w`, for example.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12658)

<!-- Reviewable:end -->
