### PR TITLE
Remove unused inline_size_of_preceding_{left,right}_floats fields from BlockFlow.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -511,14 +511,6 @@ pub struct BlockFlow {
     /// The associated fragment.
     pub fragment: Fragment,
 
-    /// The sum of the inline-sizes of all logically left floats that precede this block. This is
-    /// used to speculatively lay out block formatting contexts.
-    inline_size_of_preceding_left_floats: Au,
-
-    /// The sum of the inline-sizes of all logically right floats that precede this block. This is
-    /// used to speculatively lay out block formatting contexts.
-    inline_size_of_preceding_right_floats: Au,
-
     /// Additional floating flow members.
     pub float: Option<Box<FloatedBlockInfo>>,
 
@@ -548,8 +540,6 @@ impl BlockFlow {
                 None => ForceNonfloatedFlag::ForceNonfloated,
             }),
             fragment: fragment,
-            inline_size_of_preceding_left_floats: Au(0),
-            inline_size_of_preceding_right_floats: Au(0),
             float: float_kind.map(|kind| box FloatedBlockInfo::new(kind)),
             flags: BlockFlowFlags::empty(),
         }


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12677)

<!-- Reviewable:end -->
