### PR TITLE
brew package

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -26,6 +26,8 @@ mac-nightly:
   - ./mach build --release
   - ./mach package --release
   - ./etc/ci/upload_nightly.sh mac
+  - ./etc/ci/upload_nightly.sh macbrew
+  - ./etc/ci/update_brew.sh
 
 linux-dev:
   - ./mach test-tidy --no-progress --all

--- a/etc/ci/servo-binary-formula.rb.in
+++ b/etc/ci/servo-binary-formula.rb.in
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class ServoBin < Formula
+  desc "Servo, the Parallel Browser Engine Project (binary version)"
+  homepage "http://servo.org"
+  url "PACKAGEURL"
+  version "VERSION"
+  sha256 "SHA"
+
+  bottle :unneeded
+
+  def install
+    prefix.install "bin", "libexec", "resources"
+  end
+
+  test do
+    system bin/"servo", "-o", "/dev/null", "-x", "http://example.com"
+  end
+end

--- a/etc/ci/update_brew.sh
+++ b/etc/ci/update_brew.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPTDIR=${PWD}/$(dirname ${0})
+cd "${SCRIPTDIR}/../.."
+
+PACKAGEPATH=$(ls -t target/brew/servo-????-??-??.tar.gz | head -n 1)
+PACKAGENAME=$(basename ${PACKAGEPATH})
+REGEX="s/servo-.*\([0-9]\{4\}\)-\([0-9]\{2\}\)-\([0-9]\{2\}\).tar.gz/\1.\2.\3/p"
+VERSION=$(echo ${PACKAGENAME}| sed -n "${REGEX}")
+SHA=$(shasum -a 256 ${PACKAGEPATH} | sed -e 's/ .*//')
+GIT="https://${TOKEN}@github.com/servo/homebrew-servo.git"
+
+# See upload_nightly.sh
+PACKAGEURL="https://download.servo.org/nightly/macbrew/${PACKAGENAME}"
+
+if [[ -z ${VERSION} ]]; then
+  echo "Package doesn't havent the right format: ${PACKAGENAME}"
+  exit 1
+fi
+
+TMP_DIR=$(mktemp -d -t homebrew-servo)
+cd ${TMP_DIR}
+echo ${TMP_DIR}
+
+echo "Cloning"
+git clone ${GIT}
+cd homebrew-servo
+
+# Not using "/" as it's used in PACKAGEURL
+cat ${SCRIPTDIR}/servo-binary-formula.rb.in | sed \
+  "s|PACKAGEURL|${PACKAGEURL}|g
+   s|SHA|${SHA}|g
+   s|VERSION|${VERSION}|g" > Formula/servo-bin.rb
+
+git add ./Formula/servo-bin.rb
+git commit -m "Version bump: ${VERSION}"
+
+git push -q ${GIT} master
+rm -rf ${TMP_DIR}

--- a/etc/ci/upload_nightly.sh
+++ b/etc/ci/upload_nightly.sh
@@ -11,7 +11,7 @@ shopt -s failglob
 
 
 usage() {
-    printf "usage: ${0} android|linux|mac|windows\n"
+    printf "usage: ${0} android|linux|mac|macbrew|windows\n"
 }
 
 
@@ -44,6 +44,9 @@ main() {
     elif [[ "${platform}" == "mac" ]]; then
         extension=dmg
         package=target/*."${extension}"
+    elif [[ "${platform}" == "macbrew" ]]; then
+        extension=tar.gz
+        package=target/brew/*."${extension}"
     elif [[ "${platform}" == "windows" ]]; then
         extension=msi
         package=target/release/msi/*.msi


### PR DESCRIPTION
Addressed #12600

This is just a WIP PR to see if this approach is right.

The same way night builds are uploaded every day, we'd like to offer a brew binary package as well.

Step 1 is to package a tarball along the dmg. This is done in `package_commands.py`.
Step 2 is to upload the package. Done is `update_brew.sh`.
Step 3 is to update the brew Formula. [servo-bin.rb](https://github.com/paulrouget/homebrew-servo/blob/master/servo-bin.rb.in) is updated in `update_brew.sh`.
Step 4 is to trigger `update_brew.sh` along `update_nightly.sh`. https://github.com/servo/saltfs/blob/master/buildbot/master/files/config/steps.yml

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12688)

<!-- Reviewable:end -->
