### PR TITLE
Fix Issue 12343: Add pref-gated methods and test for activatable element

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2087,6 +2087,27 @@ impl ElementMethods for Element {
         // Step 4.
         self.insert_adjacent(position, fragment.upcast()).map(|_| ())
     }
+
+    // check-tidy: no specs after this line
+    fn EnterFormalActivationState(&self) -> ErrorResult {
+        match self.as_maybe_activatable() {
+            Some(a) => {
+                a.enter_formal_activation_state();
+                return Ok(());
+            },
+            None => return Err(Error::NotSupported)
+        }
+    }
+
+    fn ExitFormalActivationState(&self) -> ErrorResult {
+        match self.as_maybe_activatable() {
+            Some(a) => {
+                a.exit_formal_activation_state();
+                return Ok(());
+            },
+            None => return Err(Error::NotSupported)
+        }
+    }
 }
 
 pub fn fragment_affecting_attributes() -> [Atom; 3] {

--- a/components/script/dom/webidls/ActivatableElement.webidl
+++ b/components/script/dom/webidls/ActivatableElement.webidl
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Interface for testing element activation
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+[Exposed=(Window,Worker), NoInterfaceObject]
+interface ActivatableElement {
+  [Throws, Pref="dom.testing.element.activation.enabled"]
+  void enterFormalActivationState();
+
+  [Throws, Pref="dom.testing.element.activation.enabled"]
+  void exitFormalActivationState();
+};

--- a/components/script/dom/webidls/Element.webidl
+++ b/components/script/dom/webidls/Element.webidl
@@ -122,3 +122,4 @@ partial interface Element {
 Element implements ChildNode;
 Element implements NonDocumentTypeChildNode;
 Element implements ParentNode;
+Element implements ActivatableElement;

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6270,6 +6270,12 @@
             "url": "/_mozilla/mozilla/MouseEvent.html"
           }
         ],
+        "mozilla/activation.html": [
+          {
+            "path": "mozilla/activation.html",
+            "url": "/_mozilla/mozilla/activation.html"
+          }
+        ],
         "mozilla/bad_cert_detected.html": [
           {
             "path": "mozilla/bad_cert_detected.html",

--- a/tests/wpt/mozilla/meta/mozilla/activation.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/activation.html.ini
@@ -1,0 +1,3 @@
+[activation.html]
+  type: testharness
+  prefs: [dom.testing.element.activation.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/activation.html
+++ b/tests/wpt/mozilla/tests/mozilla/activation.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf=8">
+    <title>Test of activation state</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <a id="anchor" href="#foo">anchor</a>
+    <button id="button">button</button>
+    <label id="label">Label</label>
+    <input type="submit" id="input" />
+
+    <span id="foo">foo</span>
+  </body>
+
+  <script>
+    function test_activation_state(element, selector) {
+      return function () {
+        element.enterFormalActivationState();
+        var active = document.querySelector(selector);
+        assert_true(active.id == element.id, selector + " was active");
+        element.exitFormalActivationState();
+      }
+    }
+
+    test(
+      test_activation_state(document.getElementById("anchor"), "a:active"),
+      "Activate anchor");
+
+    test(
+      test_activation_state(document.getElementById("button"), "button:active"),
+      "Activate button");
+
+    test(
+      test_activation_state(document.getElementById("label"), "label:active"),
+      "Activate label");
+
+    test(
+      test_activation_state(document.getElementById("input"), "input:active"),
+      "Activate input");
+
+    test(function () {
+      assert_throws(null, function () {
+        var foo = document.getElementById("foo");
+        foo.enterFormalActivationState();
+      });
+    }, "Activation invalid for span");
+  </script>
+</html>
+


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add methods to activatable elements; gated by a preference, for use in servo-specific WPT tests.

I cargo-culted over the "redundant check" from #12322, I don't really understand the possible exploit.

Obvious flaw is the copypasta for each element. I understand that the webidl codegen will produce a trait for ActivatableElement, but I can't see how I can provide a default implementation for this? I guess otherwise could be an improvement to have each element just delegate to an Enter.../Exit... method on the Activatable trait? 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12343 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

…states

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12703)

<!-- Reviewable:end -->
