### PR TITLE
Add FFmpeg install instructions for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,16 @@ If `virtualenv` does not exist, try `python-virtualenv`.
 
 On Fedora:
 
+To install FFmpeg dependency, it is required to use third-party sources. For more details on how to setup this third-party source, you may consult: http://rpmfusion.org/Configuration
+
 ``` sh
+sudo -c 'dnf install http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm http://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm'
 sudo dnf install curl freeglut-devel libtool gcc-c++ libXi-devel \
     freetype-devel mesa-libGL-devel mesa-libEGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
     fontconfig-devel cabextract ttmkfdir python python-virtualenv python-pip expat-devel \
     rpm-build openssl-devel cmake bzip2-devel libXcursor-devel libXmu-devel mesa-libOSMesa-devel \
-    dbus-devel ffmpeg-devel
-```
-
+    dbus-devel ffmpeg.x86_64 ffmpeg-devel.x86_64
+``` 
 On Arch Linux:
 
 ``` sh


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #12726 (github issue number if applicable).

I tried it on a laptop with Fedora 24, it seemed to work fine. (I ran out of memory and storage to complete the build but the dependency with the error did not fail to compile)

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12729)

<!-- Reviewable:end -->
