### PR TITLE
Update mac prerequisites for libavformat requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Visit the [Servo Project page](https://servo.org/) for news and guides.
 On OS X (homebrew):
 
 ``` sh
-brew install automake pkg-config python cmake
+brew install automake pkg-config python cmake ffmpeg
 pip install virtualenv
 ```
 
 On OS X (MacPorts):
 
 ``` sh
-sudo port install python27 py27-virtualenv cmake
+sudo port install python27 py27-virtualenv cmake ffmpeg
 ```
 
 On OS X 10.11 (El Capitan), you also have to install openssl:


### PR DESCRIPTION
These were missed in #12186.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12734)

<!-- Reviewable:end -->
