### PR TITLE
Check if the return value's type is supported in binding codegen

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1305,7 +1305,7 @@ def getRetvalDeclarationForType(returnType, descriptorProvider):
     # https://github.com/servo/servo/issues/6307
     if returnType.isAny():
         return CGGeneric("JSVal")
-    if returnType.isObject() or returnType.isSpiderMonkeyInterface():
+    if returnType.isObject():
         return CGGeneric("*mut JSObject")
     if returnType.isSequence():
         result = getRetvalDeclarationForType(innerSequenceType(returnType), descriptorProvider)

--- a/components/script/dom/webidls/Crypto.webidl
+++ b/components/script/dom/webidls/Crypto.webidl
@@ -20,5 +20,5 @@ interface Crypto {
   //readonly attribute SubtleCrypto subtle;
   //ArrayBufferView getRandomValues(ArrayBufferView array);
   [Throws]
-  ArrayBufferView getRandomValues(object array);
+  object getRandomValues(object array);
 };

--- a/components/script/dom/webidls/ImageData.webidl
+++ b/components/script/dom/webidls/ImageData.webidl
@@ -18,5 +18,6 @@ interface ImageData {
   //[Constant]
   readonly attribute unsigned long height;
   //[Constant, StoreInSlot]
-  readonly attribute Uint8ClampedArray data;
+  // readonly attribute Uint8ClampedArray data;
+  readonly attribute object data;
 };

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -111,7 +111,8 @@ interface TestBinding {
            attribute (Blob or boolean) union7Attribute;
            attribute (Blob or unsigned long) union8Attribute;
            attribute (ByteString or long) union9Attribute;
-  readonly attribute Uint8ClampedArray arrayAttribute;
+  // readonly attribute Uint8ClampedArray arrayAttribute;
+  readonly attribute object arrayAttribute;
            attribute any anyAttribute;
            attribute object objectAttribute;
 

--- a/components/script/dom/webidls/TextEncoder.webidl
+++ b/components/script/dom/webidls/TextEncoder.webidl
@@ -7,5 +7,6 @@
 interface TextEncoder {
    readonly attribute DOMString encoding;
    [NewObject]
-   Uint8Array encode(optional USVString input = "");
+   // Uint8Array encode(optional USVString input = "");
+   object encode(optional USVString input = "");
 };


### PR DESCRIPTION
Motivation: before this change, the return type in IDL getter can be `ArrayBufferView`, which is confusing, since the binding is not implemented at all.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12735)

<!-- Reviewable:end -->
