### PR TITLE
Update readme to tell users how to overcome compile error on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ brew install openssl
 brew link --force openssl
 ```
 
+If you get this error:
+``` sh
+"Couldn't find libavformat", do the following:
+
+brew uninstall ffmpeg
+brew install ffmpeg --build-from-source
+./mach clean
+./mach build
+```
+
 If you've already partially compiled servo but forgot to do this step, run ./mach clean, link openssl, and recompile.
 
 On Debian-based Linuxes:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
## Just updates the README.md on how to get libavformat to link correctly on OS X for some systems.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ X] `./mach build -d` does not report any errors
- [ X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ X] These changes do not require tests because it's a readme.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12740)

<!-- Reviewable:end -->
