### PR TITLE
Simplify and extend trans-stacking-context subpixel accumulation

### DIFF
--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-017.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-017.htm.ini
@@ -1,4 +1,0 @@
-[transform-input-017.htm]
-  type: reftest
-  expected: FAIL
-  bug: https://github.com/servo/servo/issues/10881

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-018.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-018.htm.ini
@@ -1,4 +1,0 @@
-[transform-input-018.htm]
-  type: reftest
-  expected: FAIL
-  bug: https://github.com/servo/servo/issues/10881

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-019.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-019.htm.ini
@@ -1,4 +1,0 @@
-[transform-input-019.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #10881 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [x] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Simplify the situations in which subpixels are accumulated, so that it
is only done for translation or identity transformation matrices. Also,
apply accumulated subpixels to more operations in PaintContext. This
fixes several pre-existing reftests and hopefully will eliminate
off-by-one errors in flaky reftests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12742)

<!-- Reviewable:end -->
