### PR TITLE
Fix unexpected freeze of flex item

### DIFF
--- a/components/layout/flex.rs
+++ b/components/layout/flex.rs
@@ -276,9 +276,8 @@ impl FlexLine {
         // https://drafts.csswg.org/css-flexbox/#resolve-flexible-lengths
         for item in items.iter_mut().filter(|i| !(i.is_strut && collapse)) {
             item.main_size = max(item.min_size, min(item.base_size, item.max_size));
-            if item.main_size != item.base_size
-                || (self.free_space > Au(0) && item.flex_grow == 0.0)
-                || (self.free_space < Au(0) && item.flex_shrink == 0.0) {
+            if (self.free_space > Au(0) && (item.flex_grow == 0.0 || item.base_size >= item.max_size)) ||
+                (self.free_space < Au(0) && (item.flex_shrink == 0.0 || item.base_size <= item.min_size)) {
                     item.is_frozen = true;
                 } else {
                     item.is_frozen = false;
@@ -311,7 +310,7 @@ impl FlexLine {
                     (item.flex_shrink * item.base_size.0 as f32 / total_scaled, item.min_size)
                 };
                 let variation = self.free_space.scale_by(factor);
-                if variation.0.abs() > (end_size - item.main_size).0.abs() {
+                if variation.0.abs() >= (end_size - item.main_size).0.abs() {
                     // Use constraint as the target main size, and freeze item.
                     total_variation += end_size - item.main_size;
                     item.main_size = end_size;

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox-flex-wrap-flexing.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox-flex-wrap-flexing.htm.ini
@@ -1,3 +1,0 @@
-[flexbox-flex-wrap-flexing.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_min-width-auto.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_min-width-auto.htm.ini
@@ -1,4 +1,5 @@
 [flexbox_computedstyle_min-width-auto.htm]
   type: testharness
-  expected: TIMEOUT
+  [flexbox | computed style | min-width: auto]
+    expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fix the currently logic that a item will freeze if it should
grow(shrink) and its basesize is less(more) than its min(max) size. This
also fix the divide by zero error when an item should shrink but it has
zero length and zero min size.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12754)

<!-- Reviewable:end -->
