### PR TITLE
Fix flag compose in runservo.sh

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -229,7 +229,7 @@ class PackageCommands(CommandBase):
                     delete(dir_to_package + '/build/' + f)
             print("Writing runservo.sh")
             # TODO: deduplicate this arg list from post_build_commands
-            servo_args = ['-w', '-b', '-M', '-S'
+            servo_args = ['-w', '-b', '-M', '-S',
                           '--pref', 'dom.mozbrowser.enabled',
                           '--pref', 'dom.forcetouch.enabled',
                           '--pref', 'shell.builtin-key-shortcuts.enabled=false',


### PR DESCRIPTION
This fixes following error when running runservo.sh:

$ ./runservo.sh 
Unrecognized option: '-'.
$

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

s/-S--pref/-S --pref/

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12755)

<!-- Reviewable:end -->
