### PR TITLE
Inline split fixes#12699

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1644,7 +1644,7 @@ impl Fragment {
             _   => return None,
         };
 
-        let mut remaining_inline_size = max_inline_size;
+        let mut remaining_inline_size = max_inline_size - self.border_padding.inline_start_end();
         let mut inline_start_range = Range::new(text_fragment_info.range.begin(), ByteIndex(0));
         let mut inline_end_range = None;
         let mut overflowing = false;

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -636,7 +636,23 @@ impl LineBreaker {
         // Push the first fragment onto the line we're working on and start off the next line with
         // the second fragment. If there's no second fragment, the next line will start off empty.
         match (inline_start_fragment, inline_end_fragment) {
-            (Some(inline_start_fragment), Some(inline_end_fragment)) => {
+            (Some(mut inline_start_fragment), Some(mut inline_end_fragment)) => {
+                inline_start_fragment.border_padding.inline_end = Au(0);
+                if let Some(ref mut inline_context) = inline_start_fragment.inline_context {
+                    for node in &mut inline_context.nodes {
+                        node.flags.remove(LAST_FRAGMENT_OF_ELEMENT);
+                    }
+                }
+                inline_start_fragment.border_box.size.inline += inline_start_fragment.border_padding.inline_start;
+
+                inline_end_fragment.border_padding.inline_start = Au(0);
+                if let Some(ref mut inline_context) = inline_end_fragment.inline_context {
+                    for node in &mut inline_context.nodes {
+                        node.flags.remove(FIRST_FRAGMENT_OF_ELEMENT);
+                    }
+                }
+                inline_end_fragment.border_box.size.inline += inline_end_fragment.border_padding.inline_end;
+
                 self.push_fragment_to_line(layout_context,
                                            inline_start_fragment,
                                            LineFlushMode::Flush);

--- a/tests/wpt/metadata-css/css21_dev/html4/c5509-ipadn-l-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/c5509-ipadn-l-001.htm.ini
@@ -1,3 +1,0 @@
-[c5509-ipadn-l-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/c5509-ipadn-l-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/c5509-ipadn-l-003.htm.ini
@@ -1,3 +1,4 @@
 [c5509-ipadn-l-003.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os == "mac": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/inlines-017.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inlines-017.htm.ini
@@ -1,3 +1,0 @@
-[inlines-017.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -816,6 +816,18 @@
             "url": "/_mozilla/css/border_collapse_simple_a.html"
           }
         ],
+        "css/border_inline_split.html": [
+          {
+            "path": "css/border_inline_split.html",
+            "references": [
+              [
+                "/_mozilla/css/border_inline_split_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/border_inline_split.html"
+          }
+        ],
         "css/border_radius_asymmetric_sizes_a.html": [
           {
             "path": "css/border_radius_asymmetric_sizes_a.html",
@@ -9956,6 +9968,18 @@
             ]
           ],
           "url": "/_mozilla/css/border_collapse_simple_a.html"
+        }
+      ],
+      "css/border_inline_split.html": [
+        {
+          "path": "css/border_inline_split.html",
+          "references": [
+            [
+              "/_mozilla/css/border_inline_split_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/border_inline_split.html"
         }
       ],
       "css/border_radius_asymmetric_sizes_a.html": [

--- a/tests/wpt/mozilla/tests/css/border_inline_split.html
+++ b/tests/wpt/mozilla/tests/css/border_inline_split.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html><head>
+<link rel=match href=border_inline_split_ref.html>
+<meta content="ahem dom" name="flags">
+<style>
+    div {
+        font: 20px/1 Ahem;
+        width: 7em;
+    }
+    span {
+        border-left: yellow solid 0.5em;
+        border-right: yellow solid 0.5em;
+    }
+</style>
+</head>
+<body>
+    <div>
+        <span>Very long |</span>
+    </div>
+</body></html>

--- a/tests/wpt/mozilla/tests/css/border_inline_split_ref.html
+++ b/tests/wpt/mozilla/tests/css/border_inline_split_ref.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html><head>
+<meta content="ahem dom" name="flags">
+<style>
+    span {
+        font: 20px/1 Ahem;
+        border-left: yellow solid 0.5em;
+        border-right: yellow solid 0.5em;
+    }
+</style>
+</head>
+<body>
+    <span>Very <br>long |</span>
+</body></html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fix fragment splitting algorithm to set FIRST/LAST_FRAGMENT_OF_ELEMENT flag correctly, account for border_padding for border_box and set zero border_padding between for new fragments.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12699 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12760)

<!-- Reviewable:end -->
