### PR TITLE
Improve tidy's license validation logic

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,4 +14,7 @@ pyflakes == 0.8.1
 # For test-webidl
 ply == 3.8
 
+# For Cross-platform colored terminal text
+colorama == 0.3.7
+
 -e python/tidy

--- a/python/tidy/HISTORY.rst
+++ b/python/tidy/HISTORY.rst
@@ -1,6 +1,17 @@
 Release History
 ---------------
 
+0.1.0 (2016-08-09)
+++++++++++++++++++
+
+- Improve license checking to disregard comments and line breaks
+- License checking verifies that COPYRIGHT is specified when apache2 is used
+
+0.0.3 (2016-04-19)
+++++++++++++++++++
+
+- Add alternate wording of apache2 license
+
 0.0.2 (2016-04-17)
 ++++++++++++++++++
 - Cleanup Tidy to work on external deps

--- a/python/tidy/servo_tidy/licenseck.py
+++ b/python/tidy/servo_tidy/licenseck.py
@@ -7,97 +7,29 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+# when wrapped to 80 chars, the longest license is 10 lines.
+# TODO actually grab whatever commented block is before the second blank line
+# of the file instead of hard-coding this.
+MAX_LICENSE_LINESPAN = 12
 
-# These licenses are valid for use in Servo
-licenses = [
+MPL = """\
+This Source Code Form is subject to the terms of the Mozilla Public \
+License, v. 2.0. If a copy of the MPL was not distributed with this \
+file, You can obtain one at http://mozilla.org/MPL/2.0/.\
+"""
 
-"""\
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-""",
+APACHE = """\
+Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or \
+http://www.apache.org/licenses/LICENSE-2.0> or the MIT license \
+<LICENSE-MIT or http://opensource.org/licenses/MIT>, at your \
+option. This file may not be copied, modified, or distributed \
+except according to those terms.\
+"""
 
-"""\
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-""",
-
-"""\
-#!/usr/bin/env bash
-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-""",
-
-"""\
-#!/usr/bin/env python
-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-""",
-
-"""\
-#!/usr/bin/env python3
-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-""",
-
-"""\
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-""",
-
-"""\
-// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-""",
-
-"""\
-# Copyright 2013 The Servo Project Developers. See the COPYRIGHT
-# file at the top-level directory of this distribution.
-#
-# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-# option. This file may not be copied, modified, or distributed
-# except according to those terms.
-""",
-
-"""\
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-""",
-
-"""\
-// Copyright 2012-2014 The Rust Project Developers.
-// See http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-""",
-]  # noqa: Indicate to flake8 that we do not want to check indentation here
+COPYRIGHT = [
+    "See the COPYRIGHT file at the top-level directory of this distribution",
+    "See http://rust-lang.org/COPYRIGHT",
+]
 
 # The valid licenses, in the form we'd expect to see them in a Cargo.toml file.
 licenses_toml = [

--- a/python/tidy/servo_tidy/licenseck.py
+++ b/python/tidy/servo_tidy/licenseck.py
@@ -7,11 +7,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-# when wrapped to 80 chars, the longest license is 10 lines.
-# TODO actually grab whatever commented block is before the second blank line
-# of the file instead of hard-coding this.
-MAX_LICENSE_LINESPAN = 12
-
 MPL = """\
 This Source Code Form is subject to the terms of the Mozilla Public \
 License, v. 2.0. If a copy of the MPL was not distributed with this \

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -18,6 +18,7 @@ import StringIO
 import subprocess
 import sys
 from licenseck import MPL, APACHE, COPYRIGHT, licenses_toml, licenses_dep_toml
+import colorama
 
 COMMENTS = ["// ", "# ", " *", "/* "]
 
@@ -785,8 +786,10 @@ def scan(only_changed_files=False, progress=True):
     errors = itertools.chain(errors, dep_license_errors, wpt_lint_errors)
     error = None
     for error in errors:
+        colorama.init()
         print "\r\033[94m{}\033[0m:\033[93m{}\033[0m: \033[91m{}\033[0m".format(*error)
     print
     if error is None:
+        colorama.init()
         print "\033[92mtidy reported no errors.\033[0m"
     return int(error is not None)

--- a/python/tidy/servo_tidy_tests/apache2_license.rs
+++ b/python/tidy/servo_tidy_tests/apache2_license.rs
@@ -1,0 +1,5 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.

--- a/python/tidy/servo_tidy_tests/shebang_license.py
+++ b/python/tidy/servo_tidy_tests/shebang_license.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -58,6 +58,10 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('script should use `[[` instead of `[` for conditional testing', errors.next()[2])
         self.assertNoMoreErrors(errors)
 
+    def test_apache2_incomplete(self):
+        errors = tidy.collect_errors_for_files(iterFile('apache2_license.rs'), [], [tidy.check_license])
+        self.assertEqual('incorrect license', errors.next()[2])
+
     def test_rust(self):
         errors = tidy.collect_errors_for_files(iterFile('rust_tidy.rs'), [], [tidy.check_rust], print_text=False)
         self.assertEqual('use statement spans multiple lines', errors.next()[2])

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -48,6 +48,11 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('incorrect license', errors.next()[2])
         self.assertNoMoreErrors(errors)
 
+    def test_shebang_license(self):
+        errors = tidy.collect_errors_for_files(iterFile('shebang_license.py'), [], [tidy.check_license], print_text=False)
+        self.assertEqual('missing blank line after shebang', errors.next()[2])
+        self.assertNoMoreErrors(errors)
+
     def test_shell(self):
         errors = tidy.collect_errors_for_files(iterFile('shell_tidy.sh'), [], [tidy.check_shell], print_text=False)
         self.assertEqual('script does not have shebang "#!/usr/bin/env bash"', errors.next()[2])

--- a/python/tidy/setup.py
+++ b/python/tidy/setup.py
@@ -16,6 +16,7 @@ VERSION = '0.1.0'
 install_requires = [
     "flake8==2.4.1",
     "toml==0.9.1",
+    "colorama==0.3.7",
 ]
 
 here = os.path.dirname(os.path.abspath(__file__))

--- a/python/tidy/setup.py
+++ b/python/tidy/setup.py
@@ -11,7 +11,7 @@ import os
 from setuptools import setup, find_packages
 
 
-VERSION = '0.0.3'
+VERSION = '0.1.0'
 
 install_requires = [
     "flake8==2.4.1",
@@ -51,7 +51,7 @@ if __name__ == '__main__':
         zip_safe=False,
         entry_points={
             'console_scripts': [
-                'servo-tidy=servo_tidy.tidy:scan'
+                'servo-tidy=servo_tidy.tidy:scan',
             ],
         },
     )

--- a/support/rust-task_info/Cargo.toml
+++ b/support/rust-task_info/Cargo.toml
@@ -3,6 +3,7 @@
 name = "task_info"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
 
 build = "build.rs"
 


### PR DESCRIPTION
Rebased and fixed https://github.com/servo/servo/pull/10721, which is inactive for months.
Fixes https://github.com/servo/servo/issues/10716

r? @larsbergstrom or @edunham

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12781)

<!-- Reviewable:end -->
