### PR TITLE
Clear pending pipelines on traversal

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1391,7 +1391,7 @@ impl ScriptThread {
             doc.find_iframe(old_subpage_id)
         });
 
-        frame_element.unwrap().update_subpage_id(new_subpage_id, new_pipeline_id);
+        frame_element.map(|fe| fe.update_subpage_id(new_subpage_id, new_pipeline_id));
     }
 
     /// Window was resized, but this script was not active, so don't reflow yet


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

r? @asajeffrey 
**Don't merge, Still need to add a test**

This closes any pending pipelines during a traversal, and waits to freeze the current pipeline on a navigation until the new pipeline is ready to be added to the frame tree.

I believe just doing the latter would fix the crash, I am ok with dropping the former. Let me know if you have any thoughts on that.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12784 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12788)

<!-- Reviewable:end -->
