### PR TITLE
Update bindings generator to support default ByteString values in a dictionary

### DIFF
--- a/components/script/dom/bindings/codegen/parser/WebIDL.py
+++ b/components/script/dom/bindings/codegen/parser/WebIDL.py
@@ -3391,6 +3391,11 @@ class IDLValue(IDLObject):
             # extra normalization step.
             assert self.type.isDOMString()
             return self
+        elif self.type.isString() and type.isByteString():
+            # Allow ByteStrings to use default value just like
+            # DOMString.  No coercion is required here.
+            assert self.type.isDOMString()
+            return self
         raise WebIDLError("Cannot coerce type %s to type %s." %
                           (self.type, type), [location])
 
@@ -5758,6 +5763,14 @@ class Parser(Tokenizer):
         location = self.getLocation(p, 1)
         booleanType = BuiltinTypes[IDLBuiltinType.Types.boolean]
         p[0] = IDLValue(location, booleanType, p[1])
+
+    def p_ConstValueByteString(self, p):
+        """
+            ConstValue : BYTESTRING
+        """
+        location = self.getLocation(p, 1)
+        bytestringType = BuiltinTypes[IDLBuiltinType.Types.bytestring]
+        p[0] = IDLValue(location, bytestringType, p[1])
 
     def p_ConstValueInteger(self, p):
         """

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -312,6 +312,7 @@ impl TestBindingMethods for TestBinding {
                 UnrestrictedDoubleValue: 0.0,
                 anyValue: NullValue(),
                 booleanValue: false,
+                bytestringValue: ByteString::new(vec![]),
                 byteValue: 0,
                 doubleValue: Finite::new(1.0).unwrap(),
                 enumValue: TestEnum::Foo,
@@ -319,6 +320,7 @@ impl TestBindingMethods for TestBinding {
                 longLongValue: 54,
                 longValue: 12,
                 nullableBooleanValue: None,
+                nullableBytestringValue: None,
                 nullableByteValue: None,
                 nullableDoubleValue: None,
                 nullableFloatValue: None,
@@ -506,6 +508,7 @@ impl TestBindingMethods for TestBinding {
     fn PassOptionalUnsignedLongLongWithDefault(&self, _: u64) {}
     fn PassOptionalStringWithDefault(&self, _: DOMString) {}
     fn PassOptionalUsvstringWithDefault(&self, _: USVString) {}
+    fn PassOptionalBytestringWithDefault(&self, _: ByteString) {}
     fn PassOptionalEnumWithDefault(&self, _: TestEnum) {}
 
     fn PassOptionalNullableBooleanWithDefault(&self, _: Option<bool>) {}

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -53,6 +53,7 @@ dictionary TestDictionaryDefaults {
   float floatValue = 7.0;
   unrestricted double UnrestrictedDoubleValue = 7.0;
   double doubleValue = 7.0;
+  ByteString bytestringValue = "foo";
   DOMString stringValue = "foo";
   USVString usvstringValue = "foo";
   TestEnum enumValue = "bar";
@@ -71,6 +72,7 @@ dictionary TestDictionaryDefaults {
   float? nullableFloatValue = 7.0;
   unrestricted double? nullableUnrestrictedDoubleValue = 7.0;
   double? nullableDoubleValue = 7.0;
+  ByteString? nullableBytestringValue = "foo";
   DOMString? nullableStringValue = "foo";
   USVString? nullableUsvstringValue = "foo";
   // TestEnum? nullableEnumValue = "bar";
@@ -344,6 +346,7 @@ interface TestBinding {
   void passOptionalUnsignedLongWithDefault(optional unsigned long arg = 6);
   void passOptionalLongLongWithDefault(optional long long arg = -12);
   void passOptionalUnsignedLongLongWithDefault(optional unsigned long long arg = 17);
+  void passOptionalBytestringWithDefault(optional ByteString arg = "x");
   void passOptionalStringWithDefault(optional DOMString arg = "x");
   void passOptionalUsvstringWithDefault(optional USVString arg = "x");
   void passOptionalEnumWithDefault(optional TestEnum arg = "foo");


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Update bindings generator to support default ByteString values in a dictionary.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12737 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12790)

<!-- Reviewable:end -->
