### PR TITLE
Remove expected-crash state of many WebGL tests on Linux.

### DIFF
--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-sub-image-2d-bad-args.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-sub-image-2d-bad-args.html.ini
@@ -1,7 +1,5 @@
 [tex-sub-image-2d-bad-args.html]
   type: testharness
-  expected:
-    if os == "linux": CRASH
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-complete.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-complete.html.ini
@@ -1,7 +1,5 @@
 [texture-complete.html]
   type: testharness
-  expected:
-    if os == "linux": CRASH
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-sub-image-cube-maps.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-sub-image-cube-maps.html.ini
@@ -1,7 +1,5 @@
 [texture-sub-image-cube-maps.html]
   type: testharness
-  expected:
-    if os == "linux": CRASH
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-transparent-pixels-initialized.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-transparent-pixels-initialized.html.ini
@@ -1,4 +1,0 @@
-[texture-transparent-pixels-initialized.html]
-  type: testharness
-  expected:
-    if os == "linux": CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-upload-cube-maps.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-upload-cube-maps.html.ini
@@ -1,7 +1,5 @@
 [texture-upload-cube-maps.html]
   type: testharness
-  expected:
-    if os == "linux": CRASH
   [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/typedarrays/data-view-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/typedarrays/data-view-test.html.ini
@@ -1,4 +1,0 @@
-[data-view-test.html]
-  type: testharness
-  expected:
-    if os == "linux": CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/null-uniform-location.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/null-uniform-location.html.ini
@@ -1,7 +1,5 @@
 [null-uniform-location.html]
   type: testharness
-  expected:
-    if os == "linux": CRASH
   [WebGL test #6: callUniformFunction('uniform1i') should be undefined. Threw exception TypeError: func is undefined]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/uniform-location.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/uniform-location.html.ini
@@ -1,7 +1,5 @@
 [uniform-location.html]
   type: testharness
-  expected:
-    if os == "linux": CRASH
   [WebGL test #1: contextA.uniformMatrix4fv(locationA, false, mat) threw exception TypeError: contextA.uniformMatrix4fv is not a function]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/uniform-values-per-program.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/uniform-values-per-program.html.ini
@@ -1,7 +1,5 @@
 [uniform-values-per-program.html]
   type: testharness
-  expected:
-    if os == "linux": CRASH
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Clear the expected-crash state on some webgl tests on linux, to reduce the diff necessary when enabling webgl testing on Linux again.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the changes are to test expectations.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

These tests are still all skipped currently (see #9331), but with
skipping removed, these didn't crash with Mesa 12.1 on Haswell
(Intel).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12793)

<!-- Reviewable:end -->
