### PR TITLE
dom: getElementsFromPoint does the hit testing on viewport coordinates.

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -147,7 +147,9 @@ impl LayoutRPC for LayoutRPCImpl {
             let result = match rw_data.display_list {
                 None => panic!("Tried to hit test without a DisplayList"),
                 Some(ref display_list) => {
-                    display_list.hit_test(&page_point, &client_point, &rw_data.stacking_context_scroll_offsets)
+                    display_list.hit_test(&page_point,
+                                          &client_point,
+                                          &rw_data.stacking_context_scroll_offsets)
                 }
             };
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1583,12 +1583,12 @@ impl Document {
         self.browsing_context.is_none() || !url_has_network_scheme(&self.url)
     }
 
-    pub fn nodes_from_point(&self, page_point: &Point2D<f32>) -> Vec<UntrustedNodeAddress> {
-        let client_point =
-            Point2D::new(page_point.x - self.window.PageXOffset() as f32,
-                         page_point.y - self.window.PageYOffset() as f32);
+    pub fn nodes_from_point(&self, client_point: &Point2D<f32>) -> Vec<UntrustedNodeAddress> {
+        let page_point =
+            Point2D::new(client_point.x + self.window.PageXOffset() as f32,
+                         client_point.y + self.window.PageYOffset() as f32);
 
-        self.window.layout().nodes_from_point(*page_point, client_point)
+        self.window.layout().nodes_from_point(page_point, *client_point)
     }
 }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6624,6 +6624,12 @@
             "url": "/_mozilla/mozilla/global.html"
           }
         ],
+        "mozilla/hit_test_pos_fixed.html": [
+          {
+            "path": "mozilla/hit_test_pos_fixed.html",
+            "url": "/_mozilla/mozilla/hit_test_pos_fixed.html"
+          }
+        ],
         "mozilla/htmlcollection.html": [
           {
             "path": "mozilla/htmlcollection.html",

--- a/tests/wpt/mozilla/tests/mozilla/hit_test_pos_fixed.html
+++ b/tests/wpt/mozilla/tests/mozilla/hit_test_pos_fixed.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Hit-test of an element with position: fixed should discard scroll offset</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+html, body { margin: 0; padding: 0; }
+.hitme {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100px;
+  height: 100px;
+  background: blue;
+}
+
+.hitme:hover { background: green }
+
+.container {
+  width: 100%;
+  background: red;
+  /* Ensure we can scroll */
+  height: 2000px;
+  /* FIXME: Uncomment when servo supports this properly
+  height: calc(100vh + 200px); */
+}
+</style>
+<div class="container">
+  <div class="hitme"></div>
+</div>
+<script>
+async_test(function(t) {
+  window.onload = t.step_func(function() {
+    window.scrollTo(0, 200);
+    var elements = document.elementsFromPoint(10, 10);
+    assert_true(elements.length > 0, "Should be elements");
+    assert_true(elements[0].className == "hitme",
+                "should be able to hit the fixed-positioned element");
+    t.done();
+  });
+});
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

We got this wrong (I think it wasn't my fault actually), I was just writing a test for #12777 when I found this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12813)

<!-- Reviewable:end -->
