### PR TITLE
Implement promise bindings

### DIFF
--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -41,7 +41,7 @@ hyper = "0.9.9"
 hyper_serde = "0.1.4"
 image = "0.10"
 ipc-channel = "0.5"
-js = {git = "https://github.com/servo/rust-mozjs"}
+js = {git = "https://github.com/servo/rust-mozjs", features = ["promises"]}
 libc = "0.2"
 log = "0.3.5"
 mime = "0.2.1"

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -14,6 +14,10 @@
 
 DOMInterfaces = {
 
+'Promise': {
+    'spiderMonkeyInterface': True,
+},
+
 'Range': {
 	'weakReferenceable': True,
 },

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -826,7 +826,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
                   rooted!(in(cx) let globalObj = CurrentGlobalOrNull(cx));
                   let promiseGlobal = global_root_from_object_maybe_wrapped(globalObj.handle().get());
 
-                  let mut valueToResolve = RootedValue::new(cx, $${val}.get());
+                  rooted!(in(cx) let mut valueToResolve = $${val}.get());
                   if !JS_WrapValue(cx, valueToResolve.handle_mut()) {
                     $*{exceptionCode}
                   }
@@ -5482,6 +5482,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'js::jsapi::JS_SetProperty',
         'js::jsapi::JS_SetReservedSlot',
         'js::jsapi::JS_SplicePrototype',
+        'js::jsapi::JS_WrapValue',
         'js::jsapi::MutableHandle',
         'js::jsapi::MutableHandleObject',
         'js::jsapi::MutableHandleValue',

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -658,7 +658,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
     # failureCode will prevent pending exceptions from being set in cases when
     # they really should be!
     if exceptionCode is None:
-        exceptionCode = "return false;"
+        exceptionCode = "return false;\n"
 
     if failureCode is None:
         failOrPropagate = "throw_type_error(cx, &error);\n%s" % exceptionCode
@@ -797,25 +797,69 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
             descriptorType = descriptor.argumentType
 
         templateBody = ""
-        if descriptor.interface.isConsequential():
-            raise TypeError("Consequential interface %s being used as an "
-                            "argument" % descriptor.interface.identifier.name)
+        isPromise = descriptor.interface.identifier.name == "Promise"
+        if isPromise:
+            # Per spec, what we're supposed to do is take the original
+            # Promise.resolve and call it with the original Promise as this
+            # value to make a Promise out of whatever value we actually have
+            # here.  The question is which global we should use.  There are
+            # a couple cases to consider:
+            #
+            # 1) Normal call to API with a Promise argument.  This is a case the
+            #    spec covers, and we should be using the current Realm's
+            #    Promise.  That means the current compartment.
+            # 2) Promise return value from a callback or callback interface.
+            #    This is in theory a case the spec covers but in practice it
+            #    really doesn't define behavior here because it doesn't define
+            #    what Realm we're in after the callback returns, which is when
+            #    the argument conversion happens.  We will use the current
+            #    compartment, which is the compartment of the callable (which
+            #    may itself be a cross-compartment wrapper itself), which makes
+            #    as much sense as anything else. In practice, such an API would
+            #    once again be providing a Promise to signal completion of an
+            #    operation, which would then not be exposed to anyone other than
+            #    our own implementation code.
+            templateBody = fill(
+                """
+                { // Scope for our JSAutoCompartment.
 
-        if failureCode is None:
-            substitutions = {
-                "sourceDescription": sourceDescription,
-                "interface": descriptor.interface.identifier.name,
-                "exceptionCode": exceptionCode,
-            }
-            unwrapFailureCode = string.Template(
-                'throw_type_error(cx, "${sourceDescription} does not '
-                'implement interface ${interface}.");\n'
-                '${exceptionCode}').substitute(substitutions)
+                  rooted!(in(cx) let globalObj = CurrentGlobalOrNull(cx));
+                  let promiseGlobal = global_root_from_object_maybe_wrapped(globalObj.handle().get());
+
+                  let mut valueToResolve = RootedValue::new(cx, $${val}.get());
+                  if !JS_WrapValue(cx, valueToResolve.handle_mut()) {
+                    $*{exceptionCode}
+                  }
+                  match Promise::Resolve(promiseGlobal.r(), cx, valueToResolve.handle()) {
+                      Ok(value) => value,
+                      Err(error) => {
+                        throw_dom_exception(cx, promiseGlobal.r(), error);
+                        $*{exceptionCode}
+                      }
+                  }
+                }
+                """,
+                exceptionCode=exceptionCode)
         else:
-            unwrapFailureCode = failureCode
+            if descriptor.interface.isConsequential():
+                raise TypeError("Consequential interface %s being used as an "
+                                "argument" % descriptor.interface.identifier.name)
 
-        templateBody = unwrapCastableObject(
-            descriptor, "${val}", unwrapFailureCode, conversionFunction)
+            if failureCode is None:
+                substitutions = {
+                    "sourceDescription": sourceDescription,
+                    "interface": descriptor.interface.identifier.name,
+                    "exceptionCode": exceptionCode,
+                }
+                unwrapFailureCode = string.Template(
+                    'throw_type_error(cx, "${sourceDescription} does not '
+                    'implement interface ${interface}.");\n'
+                    '${exceptionCode}').substitute(substitutions)
+            else:
+                unwrapFailureCode = failureCode
+
+            templateBody = unwrapCastableObject(
+                descriptor, "${val}", unwrapFailureCode, conversionFunction)
 
         declType = CGGeneric(descriptorType)
         if type.nullable():
@@ -5372,6 +5416,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'js::jsapi::AutoIdVector',
         'js::jsapi::Call',
         'js::jsapi::CallArgs',
+        'js::jsapi::CurrentGlobalOrNull',
         'js::jsapi::FreeOp',
         'js::jsapi::GetPropertyKeys',
         'js::jsapi::GetWellKnownSymbol',
@@ -5442,7 +5487,9 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'js::jsapi::MutableHandleValue',
         'js::jsapi::ObjectOpResult',
         'js::jsapi::PropertyDescriptor',
+        'js::jsapi::RootedId',
         'js::jsapi::RootedObject',
+        'js::jsapi::RootedString',
         'js::jsapi::SymbolCode',
         'js::jsapi::jsid',
         'js::jsval::JSVal',
@@ -5472,6 +5519,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'dom::bindings::constant::ConstantVal',
         'dom::bindings::global::GlobalRef',
         'dom::bindings::global::global_root_from_object',
+        'dom::bindings::global::global_root_from_object_maybe_wrapped',
         'dom::bindings::global::global_root_from_reflector',
         'dom::bindings::interface::ConstructorClassHook',
         'dom::bindings::interface::InterfaceConstructorBehavior',
@@ -5490,6 +5538,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'dom::bindings::js::JS',
         'dom::bindings::js::OptionalRootedReference',
         'dom::bindings::js::Root',
+        'dom::bindings::js::RootedRcReference',
         'dom::bindings::js::RootedReference',
         'dom::bindings::namespace::NamespaceObjectClass',
         'dom::bindings::namespace::create_namespace_object',

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -233,7 +233,8 @@ class Descriptor(DescriptorProvider):
         # them as having a concrete descendant.
         self.concrete = (not self.interface.isCallback() and
                          not self.interface.isNamespace() and
-                         not self.interface.getExtendedAttribute("Abstract"))
+                         not self.interface.getExtendedAttribute("Abstract") and
+                         not spiderMonkeyInterface)
         self.hasUnforgeableMembers = (self.concrete and
                                       any(MemberIsUnforgeable(m, self) for m in
                                           self.interface.members))

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -194,9 +194,17 @@ class Descriptor(DescriptorProvider):
 
         typeName = desc.get('nativeType', nativeTypeDefault)
 
-        # Callback types do not use JS smart pointers, so we should not use the
+        spiderMonkeyInterface = desc.get('spiderMonkeyInterface', False)
+
+        # Callback and SpiderMonkey types do not use JS smart pointers, so we should not use the
         # built-in rooting mechanisms for them.
-        if self.interface.isCallback():
+        if spiderMonkeyInterface:
+            self.needsRooting = False
+            self.returnType = 'Rc<%s>' % typeName
+            self.argumentType = '&%s' % typeName
+            self.nativeType = typeName
+            pathDefault = 'dom::types::%s' % typeName
+        elif self.interface.isCallback():
             self.needsRooting = False
             ty = 'dom::bindings::codegen::Bindings::%sBinding::%s' % (ifaceName, ifaceName)
             pathDefault = ty

--- a/components/script/dom/bindings/global.rs
+++ b/components/script/dom/bindings/global.rs
@@ -18,6 +18,7 @@ use dom::window::{self, ScriptHelpers};
 use dom::workerglobalscope::WorkerGlobalScope;
 use ipc_channel::ipc::IpcSender;
 use js::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
+use js::glue::{IsWrapper, UnwrapObject};
 use js::jsapi::{CurrentGlobalOrNull, GetGlobalForObjectCrossCompartment};
 use js::jsapi::{JSContext, JSObject, JS_GetClass, MutableHandleValue};
 use js::jsapi::HandleValue;
@@ -355,4 +356,14 @@ pub unsafe fn global_root_from_object(obj: *mut JSObject) -> GlobalRoot {
 pub unsafe fn global_root_from_context(cx: *mut JSContext) -> GlobalRoot {
     let global = CurrentGlobalOrNull(cx);
     global_root_from_global(global)
+}
+
+/// Returns the global object of the realm that the given JS object was created in,
+/// after unwrapping any wrappers.
+pub unsafe fn global_root_from_object_maybe_wrapped(mut obj: *mut JSObject) -> GlobalRoot {
+    if IsWrapper(obj) {
+        obj = UnwrapObject(obj, /* stopAtWindowProxy = */ 0);
+        assert!(!obj.is_null());
+    }
+    global_root_from_object(obj)
 }

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -43,6 +43,7 @@ use std::intrinsics::type_name;
 use std::mem;
 use std::ops::Deref;
 use std::ptr;
+use std::rc::Rc;
 use style::thread_state;
 
 /// A traced reference to a DOM object
@@ -439,11 +440,29 @@ impl<T: Reflectable> LayoutJS<T> {
     }
 }
 
+/// Get an `&T` out of a `Rc<T>`
+pub trait RootedRcReference<T> {
+    /// Obtain a safe reference to the wrapped non-JS owned value.
+    fn r(&self) -> &T;
+}
+
+impl<T: Reflectable> RootedRcReference<T> for Rc<T> {
+    fn r(&self) -> &T {
+        &*self
+    }
+}
+
 /// Get an `Option<&T>` out of an `Option<Root<T>>`
 pub trait RootedReference<T> {
     /// Obtain a safe optional reference to the wrapped JS owned-value that
     /// cannot outlive the lifetime of this root.
     fn r(&self) -> Option<&T>;
+}
+
+impl<T: Reflectable> RootedReference<T> for Option<Rc<T>> {
+    fn r(&self) -> Option<&T> {
+        self.as_ref().map(|root| &**root)
+    }
 }
 
 impl<T: Reflectable> RootedReference<T> for Option<Root<T>> {

--- a/components/script/dom/bindings/js.rs
+++ b/components/script/dom/bindings/js.rs
@@ -270,6 +270,12 @@ impl MutHeapJSVal {
         debug_assert!(thread_state::get().is_script());
         unsafe { (*self.val.get()).get() }
     }
+
+    /// Get the underlying unsafe pointer to the contained value.
+    pub unsafe fn get_unsafe(&self) -> *mut JSVal {
+        debug_assert!(thread_state::get().is_script());
+        (*self.val.get()).get_unsafe()
+    }
 }
 
 

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -36,7 +36,7 @@ use devtools_traits::CSSError;
 use devtools_traits::WorkerId;
 use dom::abstractworker::SharedRt;
 use dom::bindings::js::{JS, Root};
-use dom::bindings::refcounted::Trusted;
+use dom::bindings::refcounted::{Trusted, TrustedPromise};
 use dom::bindings::reflector::{Reflectable, Reflector};
 use dom::bindings::str::{DOMString, USVString};
 use dom::bindings::utils::WindowProxyHandler;
@@ -303,6 +303,7 @@ no_jsmanaged_fields!(Metadata);
 no_jsmanaged_fields!(NetworkError);
 no_jsmanaged_fields!(Atom, Namespace, QualName);
 no_jsmanaged_fields!(Trusted<T: Reflectable>);
+no_jsmanaged_fields!(TrustedPromise);
 no_jsmanaged_fields!(PropertyDeclarationBlock);
 no_jsmanaged_fields!(HashSet<T>);
 // These three are interdependent, if you plan to put jsmanaged data

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -156,7 +156,7 @@ impl<T: JSTraceable> JSTraceable for Rc<T> {
     }
 }
 
-impl<T: JSTraceable> JSTraceable for Box<T> {
+impl<T: JSTraceable + ?Sized> JSTraceable for Box<T> {
     fn trace(&self, trc: *mut JSTracer) {
         (**self).trace(trc)
     }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -374,6 +374,7 @@ pub mod popstateevent;
 pub mod processinginstruction;
 pub mod progressevent;
 pub mod promise;
+pub mod promisenativehandler;
 pub mod radionodelist;
 pub mod range;
 pub mod request;

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -373,6 +373,7 @@ pub mod pluginarray;
 pub mod popstateevent;
 pub mod processinginstruction;
 pub mod progressevent;
+pub mod promise;
 pub mod radionodelist;
 pub mod range;
 pub mod request;

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::error::Fallible;
+use dom::bindings::global::GlobalRef;
+use dom::bindings::reflector::{Reflectable, Reflector};
+use js::jsapi::{JSAutoCompartment, RootedObject, CallArgs, JS_GetFunctionObject, JS_NewFunction};
+use js::jsapi::{JSContext, HandleValue, HandleObject, IsPromiseObject, CallOriginalPromiseResolve};
+use js::jsapi::{MutableHandleObject, NewPromiseObject};
+use js::jsval::{JSVal, UndefinedValue};
+use std::ptr;
+use std::rc::Rc;
+
+#[dom_struct]
+pub struct Promise {
+    reflector: Reflector
+}
+
+impl Promise {
+    #[allow(unsafe_code)]
+    pub fn new(global: GlobalRef) -> Rc<Promise> {
+        let cx = global.get_cx();
+        let mut obj = RootedObject::new(cx, ptr::null_mut());
+        unsafe {
+            Promise::create_js_promise(cx, HandleObject::null(), obj.handle_mut());
+        }
+        Promise::new_with_js_promise(obj.handle())
+    }
+
+    #[allow(unsafe_code, unrooted_must_root)]
+    fn new_with_js_promise(obj: HandleObject) -> Rc<Promise> {
+        unsafe {
+            assert!(IsPromiseObject(obj));
+        }
+        let mut promise = Promise {
+            reflector: Reflector::new(),
+        };
+        promise.init_reflector(obj.get());
+        Rc::new(promise)
+    }
+
+    #[allow(unsafe_code)]
+    unsafe fn create_js_promise(cx: *mut JSContext, proto: HandleObject, mut obj: MutableHandleObject) {
+        let do_nothing_func = JS_NewFunction(cx, Some(do_nothing_promise_executor), 2, 0, ptr::null());
+        assert!(!do_nothing_func.is_null());
+        let do_nothing_obj = RootedObject::new(cx, JS_GetFunctionObject(do_nothing_func));
+        assert!(!do_nothing_obj.handle().is_null());
+        *obj = NewPromiseObject(cx, do_nothing_obj.handle(), proto);
+        assert!(!obj.is_null());
+    }
+
+    #[allow(unrooted_must_root, unsafe_code)]
+    pub fn Resolve(global: GlobalRef,
+                   cx: *mut JSContext,
+                   value: HandleValue) -> Fallible<Rc<Promise>> {
+        let _ac = JSAutoCompartment::new(cx, global.reflector().get_jsobject().get());
+        let p = unsafe {
+            RootedObject::new(cx, CallOriginalPromiseResolve(cx, value))
+        };
+        assert!(!p.handle().is_null());
+        Ok(Promise::new_with_js_promise(p.handle()))
+    }
+}
+
+#[allow(unsafe_code)]
+unsafe extern fn do_nothing_promise_executor(_cx: *mut JSContext, argc: u32, vp: *mut JSVal) -> bool {
+    let args = CallArgs::from_vp(vp, argc);
+    *args.rval() = UndefinedValue();
+    true
+}

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -78,6 +78,15 @@ impl Promise {
         Ok(Promise::new_with_js_promise(p.handle()))
     }
 
+    #[allow(unsafe_code)]
+    pub fn maybe_resolve_native<T>(&self, cx: *mut JSContext, val: &T) where T: ToJSValConvertible {
+        rooted!(in(cx) let mut v = UndefinedValue());
+        unsafe {
+            val.to_jsval(cx, m.handle_mut());
+        }
+        self.maybe_resolve(cx, v.handle());
+    }
+
     #[allow(unrooted_must_root, unsafe_code)]
     pub fn maybe_resolve(&self,
                          cx: *mut JSContext,
@@ -87,6 +96,15 @@ impl Promise {
                 JS_ClearPendingException(cx);
             }
         }
+    }
+
+    #[allow(unsafe_code)]
+    pub fn maybe_reject_native<T>(&self, cx: *mut JSContext, val: &T) where T: ToJSValConvertible {
+        rooted!(in(cx) let mut v = UndefinedValue());
+        unsafe {
+            val.to_jsval(cx, m.handle_mut());
+        }
+        self.maybe_reject(cx, v.handle());
     }
 
     #[allow(unrooted_must_root, unsafe_code)]

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -136,18 +136,16 @@ impl Promise {
     }
 
     #[allow(unsafe_code)]
-    pub fn maybe_resolve_native<T>(&self, cx: *mut JSContext, val: &T) where T: ToJSValConvertible {
+    pub fn resolve_native<T>(&self, cx: *mut JSContext, val: &T) where T: ToJSValConvertible {
         rooted!(in(cx) let mut v = UndefinedValue());
         unsafe {
             val.to_jsval(cx, v.handle_mut());
         }
-        self.maybe_resolve(cx, v.handle());
+        self.resolve(cx, v.handle());
     }
 
     #[allow(unrooted_must_root, unsafe_code)]
-    pub fn maybe_resolve(&self,
-                         cx: *mut JSContext,
-                         value: HandleValue) {
+    pub fn resolve(&self, cx: *mut JSContext, value: HandleValue) {
         unsafe {
             if !ResolvePromise(cx, self.promise_obj(), value) {
                 JS_ClearPendingException(cx);
@@ -156,25 +154,25 @@ impl Promise {
     }
 
     #[allow(unsafe_code)]
-    pub fn maybe_reject_native<T>(&self, cx: *mut JSContext, val: &T) where T: ToJSValConvertible {
+    pub fn reject_native<T>(&self, cx: *mut JSContext, val: &T) where T: ToJSValConvertible {
         rooted!(in(cx) let mut v = UndefinedValue());
         unsafe {
             val.to_jsval(cx, v.handle_mut());
         }
-        self.maybe_reject(cx, v.handle());
+        self.reject(cx, v.handle());
     }
 
     #[allow(unsafe_code)]
-    pub fn maybe_reject_error(&self, cx: *mut JSContext, error: Error) {
+    pub fn reject_error(&self, cx: *mut JSContext, error: Error) {
         rooted!(in(cx) let mut v = UndefinedValue());
         unsafe {
-            error.maybe_to_jsval(cx, self.global().r(), v.handle_mut());
+            error.to_jsval(cx, self.global().r(), v.handle_mut());
         }
-        self.maybe_reject(cx, v.handle());
+        self.reject(cx, v.handle());
     }
 
     #[allow(unrooted_must_root, unsafe_code)]
-    pub fn maybe_reject(&self,
+    pub fn reject(&self,
                         cx: *mut JSContext,
                         value: HandleValue) {
         unsafe {

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -80,6 +80,14 @@ impl Promise {
     }
 
     #[allow(unsafe_code, unrooted_must_root)]
+    pub fn duplicate(&self) -> Rc<Promise> {
+        let cx = self.global().r().get_cx();
+        unsafe {
+            Promise::new_with_js_promise(self.reflector().get_jsobject(), cx)
+        }
+    }
+
+    #[allow(unsafe_code, unrooted_must_root)]
     unsafe fn new_with_js_promise(obj: HandleObject, cx: *mut JSContext) -> Rc<Promise> {
         assert!(IsPromiseObject(obj));
         let mut promise = Promise {

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -4,6 +4,7 @@
 
 use dom::bindings::callback::CallbackContainer;
 use dom::bindings::codegen::Bindings::PromiseBinding::AnyCallback;
+use dom::bindings::conversions::root_from_object;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::reflector::{Reflectable, MutReflectable, Reflector};
@@ -82,7 +83,7 @@ impl Promise {
     pub fn maybe_resolve_native<T>(&self, cx: *mut JSContext, val: &T) where T: ToJSValConvertible {
         rooted!(in(cx) let mut v = UndefinedValue());
         unsafe {
-            val.to_jsval(cx, m.handle_mut());
+            val.to_jsval(cx, v.handle_mut());
         }
         self.maybe_resolve(cx, v.handle());
     }
@@ -102,7 +103,7 @@ impl Promise {
     pub fn maybe_reject_native<T>(&self, cx: *mut JSContext, val: &T) where T: ToJSValConvertible {
         rooted!(in(cx) let mut v = UndefinedValue());
         unsafe {
-            val.to_jsval(cx, m.handle_mut());
+            val.to_jsval(cx, v.handle_mut());
         }
         self.maybe_reject(cx, v.handle());
     }
@@ -143,6 +144,29 @@ impl Promise {
         }
         obj
     }
+
+    #[allow(unsafe_code)]
+    pub fn append_native_handler(&self, handler: &PromiseNativeHandler) {
+        let global = self.global();
+        let cx = global.r().get_cx();
+        rooted!(in(cx) let resolve_func =
+                create_native_handler_function(cx,
+                                               handler.reflector().get_jsobject(),
+                                               NativeHandlerTask::Resolve));
+
+        rooted!(in(cx) let reject_func =
+                create_native_handler_function(cx,
+                                               handler.reflector().get_jsobject(),
+                                               NativeHandlerTask::Reject));
+
+        unsafe {
+            let ok = AddPromiseReactions(cx,
+                                         self.promise_obj(),
+                                         resolve_func.handle(),
+                                         reject_func.handle());
+            assert!(ok);
+        }
+    }
 }
 
 #[allow(unsafe_code)]
@@ -150,4 +174,52 @@ unsafe extern fn do_nothing_promise_executor(_cx: *mut JSContext, argc: u32, vp:
     let args = CallArgs::from_vp(vp, argc);
     *args.rval() = UndefinedValue();
     true
+}
+
+const SLOT_NATIVEHANDLER: usize = 0;
+const SLOT_NATIVEHANDLER_TASK: usize = 1;
+
+#[derive(PartialEq)]
+enum NativeHandlerTask {
+    Resolve = 0,
+    Reject = 1,
+}
+
+#[allow(unsafe_code)]
+unsafe extern fn native_handler_callback(cx: *mut JSContext, argc: u32, vp: *mut JSVal) -> bool {
+    let args = CallArgs::from_vp(vp, argc);
+    rooted!(in(cx) let v = *GetFunctionNativeReserved(args.callee(), SLOT_NATIVEHANDLER));
+    assert!(v.get().is_object());
+
+    let handler = root_from_object::<PromiseNativeHandler>(v.to_object())
+        .ok().expect("unexpected value for native handler in promise native handler callback");
+
+    rooted!(in(cx) let v = *GetFunctionNativeReserved(args.callee(), SLOT_NATIVEHANDLER_TASK));
+    match v.to_int32() {
+        v if v == NativeHandlerTask::Resolve as i32 => handler.resolved_callback(cx, args.get(0)),
+        v if v == NativeHandlerTask::Reject as i32 => handler.rejected_callback(cx, args.get(0)),
+        _ => panic!("unexpected native handler task value"),
+    };
+
+    true
+}
+
+#[allow(unsafe_code)]
+fn create_native_handler_function(cx: *mut JSContext,
+                                  holder: HandleObject,
+                                  task: NativeHandlerTask) -> *mut JSObject {
+    unsafe {
+        let func = NewFunctionWithReserved(cx, Some(native_handler_callback), 1, 0, ptr::null());
+        assert!(!func.is_null());
+
+        rooted!(in(cx) let obj = JS_GetFunctionObject(func));
+        assert!(!obj.is_null());
+        SetFunctionNativeReserved(obj.get(),
+                                  SLOT_NATIVEHANDLER,
+                                  &ObjectValue(&**holder));
+        SetFunctionNativeReserved(obj.get(),
+                                  SLOT_NATIVEHANDLER_TASK,
+                                  &Int32Value(task as i32));
+        obj.get()
+    }
 }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -14,7 +14,7 @@
 use dom::bindings::callback::CallbackContainer;
 use dom::bindings::codegen::Bindings::PromiseBinding::AnyCallback;
 use dom::bindings::conversions::root_from_object;
-use dom::bindings::error::Fallible;
+use dom::bindings::error::{Error, Fallible};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::MutHeapJSVal;
 use dom::bindings::reflector::{Reflectable, MutReflectable, Reflector};
@@ -152,6 +152,15 @@ impl Promise {
         rooted!(in(cx) let mut v = UndefinedValue());
         unsafe {
             val.to_jsval(cx, v.handle_mut());
+        }
+        self.maybe_reject(cx, v.handle());
+    }
+
+    #[allow(unsafe_code)]
+    pub fn maybe_reject_error(&self, cx: *mut JSContext, error: Error) {
+        rooted!(in(cx) let mut v = UndefinedValue());
+        unsafe {
+            error.maybe_to_jsval(cx, self.global().r(), v.handle_mut());
         }
         self.maybe_reject(cx, v.handle());
     }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -2,26 +2,33 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::callback::CallbackContainer;
+use dom::bindings::codegen::Bindings::PromiseBinding::AnyCallback;
 use dom::bindings::error::Fallible;
 use dom::bindings::global::GlobalRef;
-use dom::bindings::reflector::{Reflectable, Reflector};
-use js::jsapi::{JSAutoCompartment, RootedObject, CallArgs, JS_GetFunctionObject, JS_NewFunction};
-use js::jsapi::{JSContext, HandleValue, HandleObject, IsPromiseObject, CallOriginalPromiseResolve};
-use js::jsapi::{MutableHandleObject, NewPromiseObject};
-use js::jsval::{JSVal, UndefinedValue};
+use dom::bindings::reflector::{Reflectable, MutReflectable, Reflector};
+use dom::promisenativehandler::PromiseNativeHandler;
+use js::conversions::ToJSValConvertible;
+use js::jsapi::{CallOriginalPromiseResolve, CallOriginalPromiseReject, CallOriginalPromiseThen};
+use js::jsapi::{JSAutoCompartment, CallArgs, JS_GetFunctionObject, JS_NewFunction};
+use js::jsapi::{JSContext, HandleValue, HandleObject, IsPromiseObject, GetFunctionNativeReserved};
+use js::jsapi::{JS_ClearPendingException, JSObject};
+use js::jsapi::{MutableHandleObject, NewPromiseObject, ResolvePromise, RejectPromise};
+use js::jsapi::{SetFunctionNativeReserved, NewFunctionWithReserved, AddPromiseReactions};
+use js::jsval::{JSVal, UndefinedValue, ObjectValue, Int32Value};
 use std::ptr;
 use std::rc::Rc;
 
 #[dom_struct]
 pub struct Promise {
-    reflector: Reflector
+    reflector: Reflector,
 }
 
 impl Promise {
     #[allow(unsafe_code)]
     pub fn new(global: GlobalRef) -> Rc<Promise> {
         let cx = global.get_cx();
-        let mut obj = RootedObject::new(cx, ptr::null_mut());
+        rooted!(in(cx) let mut obj = ptr::null_mut());
         unsafe {
             Promise::create_js_promise(cx, HandleObject::null(), obj.handle_mut());
         }
@@ -41,12 +48,13 @@ impl Promise {
     }
 
     #[allow(unsafe_code)]
-    unsafe fn create_js_promise(cx: *mut JSContext, proto: HandleObject, mut obj: MutableHandleObject) {
-        let do_nothing_func = JS_NewFunction(cx, Some(do_nothing_promise_executor), 2, 0, ptr::null());
+    unsafe fn create_js_promise(cx: *mut JSContext, proto: HandleObject, obj: MutableHandleObject) {
+        let do_nothing_func = JS_NewFunction(cx, Some(do_nothing_promise_executor), /* nargs = */ 2,
+                                             /* flags = */ 0, ptr::null());
         assert!(!do_nothing_func.is_null());
-        let do_nothing_obj = RootedObject::new(cx, JS_GetFunctionObject(do_nothing_func));
-        assert!(!do_nothing_obj.handle().is_null());
-        *obj = NewPromiseObject(cx, do_nothing_obj.handle(), proto);
+        rooted!(in(cx) let do_nothing_obj = JS_GetFunctionObject(do_nothing_func));
+        assert!(!do_nothing_obj.is_null());
+        obj.set(NewPromiseObject(cx, do_nothing_obj.handle(), proto));
         assert!(!obj.is_null());
     }
 
@@ -55,11 +63,67 @@ impl Promise {
                    cx: *mut JSContext,
                    value: HandleValue) -> Fallible<Rc<Promise>> {
         let _ac = JSAutoCompartment::new(cx, global.reflector().get_jsobject().get());
-        let p = unsafe {
-            RootedObject::new(cx, CallOriginalPromiseResolve(cx, value))
-        };
+        rooted!(in(cx) let p = unsafe { CallOriginalPromiseResolve(cx, value) });
         assert!(!p.handle().is_null());
         Ok(Promise::new_with_js_promise(p.handle()))
+    }
+
+    #[allow(unrooted_must_root, unsafe_code)]
+    pub fn Reject(global: GlobalRef,
+                  cx: *mut JSContext,
+                  value: HandleValue) -> Fallible<Rc<Promise>> {
+        let _ac = JSAutoCompartment::new(cx, global.reflector().get_jsobject().get());
+        rooted!(in(cx) let p = unsafe { CallOriginalPromiseReject(cx, value) });
+        assert!(!p.handle().is_null());
+        Ok(Promise::new_with_js_promise(p.handle()))
+    }
+
+    #[allow(unrooted_must_root, unsafe_code)]
+    pub fn maybe_resolve(&self,
+                         cx: *mut JSContext,
+                         value: HandleValue) {
+        unsafe {
+            if !ResolvePromise(cx, self.promise_obj(), value) {
+                JS_ClearPendingException(cx);
+            }
+        }
+    }
+
+    #[allow(unrooted_must_root, unsafe_code)]
+    pub fn maybe_reject(&self,
+                        cx: *mut JSContext,
+                        value: HandleValue) {
+        unsafe {
+            if !RejectPromise(cx, self.promise_obj(), value) {
+                JS_ClearPendingException(cx);
+            }
+        }
+    }
+
+    #[allow(unrooted_must_root, unsafe_code)]
+    pub fn then(&self,
+                cx: *mut JSContext,
+                _callee: HandleObject,
+                cb_resolve: AnyCallback,
+                cb_reject: AnyCallback,
+                result: MutableHandleObject) {
+        let promise = self.promise_obj();
+        rooted!(in(cx) let resolve = cb_resolve.callback());
+        rooted!(in(cx) let reject = cb_reject.callback());
+        unsafe {
+            rooted!(in(cx) let res =
+                CallOriginalPromiseThen(cx, promise, resolve.handle(), reject.handle()));
+            result.set(*res);
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn promise_obj(&self) -> HandleObject {
+        let obj = self.reflector().get_jsobject();
+        unsafe {
+            assert!(IsPromiseObject(obj));
+        }
+        obj
     }
 }
 

--- a/components/script/dom/promisenativehandler.rs
+++ b/components/script/dom/promisenativehandler.rs
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::codegen::Bindings::PromiseNativeHandlerBinding;
+use dom::bindings::global::GlobalRef;
+use dom::bindings::js::Root;
+use dom::bindings::reflector::{Reflector, reflect_dom_object};
+use dom::bindings::trace::JSTraceable;
+use heapsize::HeapSizeOf;
+use js::jsapi::{JSContext, HandleValue};
+
+pub trait Callback: JSTraceable + HeapSizeOf {
+    fn callback(&self, cx: *mut JSContext, v: HandleValue);
+}
+
+#[dom_struct]
+pub struct PromiseNativeHandler {
+    reflector: Reflector,
+    resolve: Option<Box<Callback>>,
+    reject: Option<Box<Callback>>,
+}
+
+impl PromiseNativeHandler {
+    pub fn new(global: GlobalRef,
+               resolve: Option<Box<Callback>>,
+               reject: Option<Box<Callback>>)
+               -> Root<PromiseNativeHandler> {
+        reflect_dom_object(box PromiseNativeHandler {
+            reflector: Reflector::new(),
+            resolve: resolve,
+            reject: reject,
+        }, global, PromiseNativeHandlerBinding::Wrap)
+    }
+
+    fn callback(callback: &Option<Box<Callback>>, cx: *mut JSContext, v: HandleValue) {
+        if let Some(ref callback) = *callback {
+            callback.callback(cx, v)
+        }
+    }
+
+    pub fn resolved_callback(&self, cx: *mut JSContext, v: HandleValue) {
+        PromiseNativeHandler::callback(&self.resolve, cx, v)
+    }
+
+    pub fn rejected_callback(&self, cx: *mut JSContext, v: HandleValue) {
+        PromiseNativeHandler::callback(&self.reject, cx, v)
+    }
+}

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -664,15 +664,15 @@ impl TestBindingMethods for TestBinding {
     }
 
     fn PromiseResolveNative(&self, cx: *mut JSContext, p: &Promise, v: HandleValue) {
-        p.maybe_resolve(cx, v);
+        p.resolve(cx, v);
     }
 
     fn PromiseRejectNative(&self, cx: *mut JSContext, p: &Promise, v: HandleValue) {
-        p.maybe_reject(cx, v);
+        p.reject(cx, v);
     }
 
     fn PromiseRejectWithTypeError(&self, p: &Promise, s: USVString) {
-        p.maybe_reject_error(self.global().r().get_cx(), Error::Type(s.0));
+        p.reject_error(self.global().r().get_cx(), Error::Type(s.0));
     }
 
     #[allow(unrooted_must_root)]
@@ -692,8 +692,8 @@ impl TestBindingMethods for TestBinding {
                             reject: Option<Rc<SimpleCallback>>) -> Rc<Promise> {
         let global = self.global();
         let handler = PromiseNativeHandler::new(global.r(),
-                                                resolve.map(|r| SimpleHandler::new(r)),
-                                                reject.map(|r| SimpleHandler::new(r)));
+                                                resolve.map(SimpleHandler::new),
+                                                reject.map(SimpleHandler::new));
         let p = Promise::new(global.r());
         p.append_native_handler(&handler);
         return p;
@@ -788,6 +788,6 @@ impl TestBindingCallback {
         let p = self.promise.root();
         let cx = p.global().r().get_cx();
         let _ac = JSAutoCompartment::new(cx, p.reflector().get_jsobject().get());
-        p.maybe_resolve_native(cx, &self.value);
+        p.resolve_native(cx, &self.value);
     }
 }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -20,7 +20,7 @@ use dom::bindings::codegen::UnionTypes::{EventOrUSVString, HTMLElementOrLong, Lo
 use dom::bindings::codegen::UnionTypes::{HTMLElementOrUnsignedLongOrStringOrBoolean, LongSequenceOrBoolean};
 use dom::bindings::codegen::UnionTypes::{StringOrLongSequence, StringOrStringSequence, StringSequenceOrUnsignedLong};
 use dom::bindings::codegen::UnionTypes::{StringOrUnsignedLong, StringOrBoolean, UnsignedLongOrBoolean};
-use dom::bindings::error::Fallible;
+use dom::bindings::error::{Error, Fallible};
 use dom::bindings::global::{GlobalRef, global_root_from_context};
 use dom::bindings::js::Root;
 use dom::bindings::mozmap::MozMap;
@@ -666,6 +666,10 @@ impl TestBindingMethods for TestBinding {
 
     fn PromiseRejectNative(&self, cx: *mut JSContext, p: &Promise, v: HandleValue) {
         p.maybe_reject(cx, v);
+    }
+
+    fn PromiseRejectWithTypeError(&self, p: &Promise, s: USVString) {
+        p.maybe_reject_error(self.global().r().get_cx(), Error::Type(s.0));
     }
 
     #[allow(unrooted_must_root)]

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -5,9 +5,10 @@
 // check-tidy: no specs after this line
 
 use core::nonzero::NonZero;
+use dom::bindings::callback::ExceptionHandling;
 use dom::bindings::codegen::Bindings::EventListenerBinding::EventListener;
 use dom::bindings::codegen::Bindings::FunctionBinding::Function;
-use dom::bindings::codegen::Bindings::TestBindingBinding;
+use dom::bindings::codegen::Bindings::TestBindingBinding::{self, SimpleCallback};
 use dom::bindings::codegen::Bindings::TestBindingBinding::{TestBindingMethods, TestDictionary};
 use dom::bindings::codegen::Bindings::TestBindingBinding::{TestDictionaryDefaults, TestEnum};
 use dom::bindings::codegen::UnionTypes;
@@ -20,7 +21,7 @@ use dom::bindings::codegen::UnionTypes::{HTMLElementOrUnsignedLongOrStringOrBool
 use dom::bindings::codegen::UnionTypes::{StringOrLongSequence, StringOrStringSequence, StringSequenceOrUnsignedLong};
 use dom::bindings::codegen::UnionTypes::{StringOrUnsignedLong, StringOrBoolean, UnsignedLongOrBoolean};
 use dom::bindings::error::Fallible;
-use dom::bindings::global::GlobalRef;
+use dom::bindings::global::{GlobalRef, global_root_from_context};
 use dom::bindings::js::Root;
 use dom::bindings::mozmap::MozMap;
 use dom::bindings::num::Finite;
@@ -29,6 +30,7 @@ use dom::bindings::str::{ByteString, DOMString, USVString};
 use dom::bindings::weakref::MutableWeakRef;
 use dom::blob::{Blob, BlobImpl};
 use dom::promise::Promise;
+use dom::promisenativehandler::{PromiseNativeHandler, Callback};
 use dom::url::URL;
 use js::jsapi::{HandleObject, HandleValue, JSContext, JSObject};
 use js::jsapi::{JS_NewPlainObject, JS_NewUint8ClampedArray};
@@ -649,8 +651,44 @@ impl TestBindingMethods for TestBinding {
     fn ReceiveAnyMozMap(&self) -> MozMap<JSVal> { MozMap::new() }
 
     #[allow(unrooted_must_root)]
-    fn ReturnPromise(&self) -> Rc<Promise> {
-        Promise::new(self.global().r())
+    fn ReturnResolvedPromise(&self, cx: *mut JSContext, v: HandleValue) -> Fallible<Rc<Promise>> {
+        Promise::Resolve(self.global().r(), cx, v)
+    }
+
+    #[allow(unrooted_must_root)]
+    fn ReturnRejectedPromise(&self, cx: *mut JSContext, v: HandleValue) -> Fallible<Rc<Promise>> {
+        Promise::Reject(self.global().r(), cx, v)
+    }
+
+    #[allow(unrooted_must_root)]
+    fn PromiseNativeHandler(&self,
+                            resolve: Option<Rc<SimpleCallback>>,
+                            reject: Option<Rc<SimpleCallback>>) -> Rc<Promise> {
+        let global = self.global();
+        let handler = PromiseNativeHandler::new(global.r(),
+                                                resolve.map(|r| SimpleHandler::new(r)),
+                                                reject.map(|r| SimpleHandler::new(r)));
+        let p = Promise::new(global.r());
+        p.append_native_handler(&handler);
+        return p;
+
+        #[derive(JSTraceable, HeapSizeOf)]
+        struct SimpleHandler {
+            #[ignore_heap_size_of = "Rc has unclear ownership semantics"]
+            handler: Rc<SimpleCallback>,
+        }
+        impl SimpleHandler {
+            fn new(callback: Rc<SimpleCallback>) -> Box<Callback> {
+                box SimpleHandler { handler: callback }
+            }
+        }
+        impl Callback for SimpleHandler {
+            #[allow(unsafe_code)]
+            fn callback(&self, cx: *mut JSContext, v: HandleValue) {
+                let global = unsafe { global_root_from_context(cx) };
+                let _ = self.handler.Call_(&global.r(), v, ExceptionHandling::Report);
+            }
+        }
     }
 
     #[allow(unrooted_must_root)]

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -660,6 +660,14 @@ impl TestBindingMethods for TestBinding {
         Promise::Reject(self.global().r(), cx, v)
     }
 
+    fn PromiseResolveNative(&self, cx: *mut JSContext, p: &Promise, v: HandleValue) {
+        p.maybe_resolve(cx, v);
+    }
+
+    fn PromiseRejectNative(&self, cx: *mut JSContext, p: &Promise, v: HandleValue) {
+        p.maybe_reject(cx, v);
+    }
+
     #[allow(unrooted_must_root)]
     fn PromiseNativeHandler(&self,
                             resolve: Option<Rc<SimpleCallback>>,

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -28,6 +28,7 @@ use dom::bindings::reflector::{Reflectable, Reflector, reflect_dom_object};
 use dom::bindings::str::{ByteString, DOMString, USVString};
 use dom::bindings::weakref::MutableWeakRef;
 use dom::blob::{Blob, BlobImpl};
+use dom::promise::Promise;
 use dom::url::URL;
 use js::jsapi::{HandleObject, HandleValue, JSContext, JSObject};
 use js::jsapi::{JS_NewPlainObject, JS_NewUint8ClampedArray};
@@ -646,6 +647,22 @@ impl TestBindingMethods for TestBinding {
     fn ReceiveNullableMozMapOfNullableInts(&self) -> Option<MozMap<Option<i32>>> { Some(MozMap::new()) }
     fn ReceiveMozMapOfMozMaps(&self) -> MozMap<MozMap<i32>> { MozMap::new() }
     fn ReceiveAnyMozMap(&self) -> MozMap<JSVal> { MozMap::new() }
+
+    #[allow(unrooted_must_root)]
+    fn ReturnPromise(&self) -> Rc<Promise> {
+        Promise::new(self.global().r())
+    }
+
+    #[allow(unrooted_must_root)]
+    fn PromiseAttribute(&self) -> Rc<Promise> {
+        Promise::new(self.global().r())
+    }
+
+    fn AcceptPromise(&self, _promise: &Promise) {
+    }
+
+    fn AcceptNullablePromise(&self, _promise: Option<&Promise>) {
+    }
 
     fn PassSequenceSequence(&self, _seq: Vec<Vec<i32>>) {}
     fn ReturnSequenceSequence(&self) -> Vec<Vec<i32>> { vec![] }

--- a/components/script/dom/webidls/Promise.webidl
+++ b/components/script/dom/webidls/Promise.webidl
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+
+[NoInterfaceObject]
+// Need to escape "Promise" so it's treated as an identifier.
+interface _Promise {
+};

--- a/components/script/dom/webidls/Promise.webidl
+++ b/components/script/dom/webidls/Promise.webidl
@@ -5,7 +5,12 @@
 // This interface is entirely internal to Servo, and should not be accessible to
 // web pages.
 
-[NoInterfaceObject]
+callback PromiseJobCallback = void();
+
+[TreatNonCallableAsNull]
+callback AnyCallback = any (any value);
+
+[NoInterfaceObject, Exposed=(Window,Worker)]
 // Need to escape "Promise" so it's treated as an identifier.
 interface _Promise {
 };

--- a/components/script/dom/webidls/PromiseNativeHandler.webidl
+++ b/components/script/dom/webidls/PromiseNativeHandler.webidl
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+
+// Hack to allow us to have JS owning and properly tracing/CCing/etc a
+// PromiseNativeHandler.
+[NoInterfaceObject,
+ Exposed=(Window,Worker)]
+interface PromiseNativeHandler {
+};

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -508,13 +508,19 @@ interface TestBinding {
   [Func="TestBinding::condition_satisfied"]
   const unsigned short funcControlledConstEnabled = 0;
 
-  Promise<DOMString> returnPromise();
+  [Throws]
+  Promise<any> returnResolvedPromise(any value);
+  [Throws]
+  Promise<any> returnRejectedPromise(any value);
   readonly attribute Promise<boolean> promiseAttribute;
   void acceptPromise(Promise<DOMString> string);
   void acceptNullablePromise(Promise<DOMString>? string);
+  Promise<any> promiseNativeHandler(SimpleCallback? resolve, SimpleCallback? reject);
 
   void panic();
 };
+
+callback SimpleCallback = void(any value);
 
 partial interface TestBinding {
   [Pref="dom.testable_crash.enabled"]

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -518,6 +518,7 @@ interface TestBinding {
   Promise<any> promiseNativeHandler(SimpleCallback? resolve, SimpleCallback? reject);
   void promiseResolveNative(Promise<any> p, any value);
   void promiseRejectNative(Promise<any> p, any value);
+  void promiseRejectWithTypeError(Promise<any> p, USVString message);
 
   void panic();
 };

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -519,6 +519,7 @@ interface TestBinding {
   void promiseResolveNative(Promise<any> p, any value);
   void promiseRejectNative(Promise<any> p, any value);
   void promiseRejectWithTypeError(Promise<any> p, USVString message);
+  void resolvePromiseDelayed(Promise<any> p, DOMString value, unsigned long long ms);
 
   void panic();
 };

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -516,6 +516,8 @@ interface TestBinding {
   void acceptPromise(Promise<DOMString> string);
   void acceptNullablePromise(Promise<DOMString>? string);
   Promise<any> promiseNativeHandler(SimpleCallback? resolve, SimpleCallback? reject);
+  void promiseResolveNative(Promise<any> p, any value);
+  void promiseRejectNative(Promise<any> p, any value);
 
   void panic();
 };

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -508,6 +508,11 @@ interface TestBinding {
   [Func="TestBinding::condition_satisfied"]
   const unsigned short funcControlledConstEnabled = 0;
 
+  Promise<DOMString> returnPromise();
+  readonly attribute Promise<boolean> promiseAttribute;
+  void acceptPromise(Promise<DOMString> string);
+  void acceptNullablePromise(Promise<DOMString>? string);
+
   void panic();
 };
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -22,14 +22,12 @@ use devtools_traits::{DevtoolScriptControlMsg, DevtoolsPageInfo};
 use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
 use devtools_traits::CSSError;
 use document_loader::DocumentLoader;
-use dom::bindings::callback::ExceptionHandling;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::DocumentBinding::{DocumentMethods, DocumentReadyState};
 use dom::bindings::codegen::Bindings::LocationBinding::LocationMethods;
-use dom::bindings::codegen::Bindings::PromiseBinding::PromiseJobCallback;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::conversions::{ConversionResult, FromJSValConvertible, StringificationBehavior};
-use dom::bindings::global::{GlobalRef, global_root_from_object};
+use dom::bindings::global::{GlobalRef, GlobalRoot};
 use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{JS, MutNullableHeap, Root, RootCollection};
 use dom::bindings::js::{RootCollectionPtr, RootedReference};
@@ -61,8 +59,8 @@ use hyper_serde::Serde;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::glue::GetWindowProxyClass;
-use js::jsapi::{JSAutoCompartment, JSContext, JS_SetWrapObjectCallbacks, HandleObject};
-use js::jsapi::{JSTracer, SetWindowProxyClass, SetEnqueuePromiseJobCallback};
+use js::jsapi::{JSAutoCompartment, JSContext, JS_SetWrapObjectCallbacks};
+use js::jsapi::{JSTracer, SetWindowProxyClass};
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use mem::heap_size_of_self_and_children;
@@ -79,8 +77,8 @@ use parse::xml::{self, parse_xml};
 use profile_traits::mem::{self, OpaqueSender, Report, ReportKind, ReportsChan};
 use profile_traits::time::{self, ProfilerCategory, profile};
 use script_layout_interface::message::{self, NewLayoutThreadInfo, ReflowQueryType};
-use script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory};
-use script_runtime::{ScriptPort, StackRootTLS, get_reports, new_rt_and_cx};
+use script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory, EnqueuedPromiseCallback};
+use script_runtime::{ScriptPort, StackRootTLS, get_reports, new_rt_and_cx, PromiseJobQueue};
 use script_traits::{CompositorEvent, ConstellationControlMsg, EventResult};
 use script_traits::{InitialScriptState, MouseButton, MouseEventType, MozBrowserEvent};
 use script_traits::{NewLayoutInfo, ScriptMsg as ConstellationMsg};
@@ -93,7 +91,6 @@ use std::borrow::ToOwned;
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::option::Option;
-use std::os::raw::c_void;
 use std::ptr;
 use std::rc::Rc;
 use std::result::Result;
@@ -318,18 +315,6 @@ impl OpaqueSender<CommonScriptMsg> for Sender<MainThreadScriptMsg> {
     }
 }
 
-#[allow(unsafe_code)]
-unsafe extern "C" fn enqueue_job(_cx: *mut JSContext,
-                                 job: HandleObject,
-                                 _allocation_site: HandleObject,
-                                 _data: *mut c_void) -> bool {
-    SCRIPT_THREAD_ROOT.with(|root| {
-        let script_thread = &*root.get().unwrap();
-        script_thread.enqueue_promise_job(job);
-    });
-    true
-}
-
 /// Information for an entire page. Pages are top-level browsing contexts and can contain multiple
 /// frames.
 #[derive(JSTraceable)]
@@ -410,15 +395,7 @@ pub struct ScriptThread {
 
     content_process_shutdown_chan: IpcSender<()>,
 
-    flushing_job_queue: DOMRefCell<Vec<EnqueuedPromiseCallback>>,
-    promise_job_queue: DOMRefCell<Vec<EnqueuedPromiseCallback>>,
-    pending_promise_job_runnable: Cell<bool>,
-}
-
-#[derive(JSTraceable)]
-struct EnqueuedPromiseCallback {
-    callback: Rc<PromiseJobCallback>,
-    pipeline: PipelineId,
+    promise_job_queue: PromiseJobQueue,
 }
 
 /// In the event of thread panic, all data on the stack runs its destructor. However, there
@@ -566,7 +543,6 @@ impl ScriptThread {
             JS_SetWrapObjectCallbacks(runtime.rt(),
                                       &WRAP_CALLBACKS);
             SetWindowProxyClass(runtime.rt(), GetWindowProxyClass());
-            SetEnqueuePromiseJobCallback(runtime.rt(), Some(enqueue_job), ptr::null_mut());
         }
 
         // Ask the router to proxy IPC messages from the devtools to us.
@@ -626,9 +602,7 @@ impl ScriptThread {
 
             content_process_shutdown_chan: state.content_process_shutdown_chan,
 
-            promise_job_queue: DOMRefCell::new(vec![]),
-            flushing_job_queue: DOMRefCell::new(vec![]),
-            pending_promise_job_runnable: Cell::new(false),
+            promise_job_queue: PromiseJobQueue::new(),
         }
     }
 
@@ -2205,38 +2179,31 @@ impl ScriptThread {
         }
     }
 
-    fn enqueue_promise_job(&self, job: HandleObject) {
-        let global = unsafe { global_root_from_object(job.get()) };
-        let pipeline = global.r().pipeline();
-        self.promise_job_queue.borrow_mut().push(EnqueuedPromiseCallback {
-            callback: PromiseJobCallback::new(job.get()),
-            pipeline: pipeline,
+    pub fn enqueue_promise_job(job: EnqueuedPromiseCallback, global: GlobalRef) {
+        SCRIPT_THREAD_ROOT.with(|root| {
+            let script_thread = unsafe { &*root.get().unwrap() };
+            script_thread.promise_job_queue.enqueue(job, global);
         });
-        if !self.pending_promise_job_runnable.get() {
-            self.pending_promise_job_runnable.set(true);
-            let _ = self.dom_manipulation_task_source.queue(box FlushPromiseJobs, global.r());
-        }
     }
 
-    fn flush_promise_jobs(&self) {
-        self.pending_promise_job_runnable.set(false);
-        {
-            let mut pending_queue = self.promise_job_queue.borrow_mut();
-            *self.flushing_job_queue.borrow_mut() = pending_queue.drain(..).collect();
-        }
-        for job in &*self.flushing_job_queue.borrow() {
-            if let Some(context) = self.find_child_context(job.pipeline) {
-                let _ = job.callback.Call_(&*context.active_window(), ExceptionHandling::Report);
-            }
-        }
-        self.flushing_job_queue.borrow_mut().clear();
+    pub fn flush_promise_jobs(global: GlobalRef) {
+        SCRIPT_THREAD_ROOT.with(|root| {
+            let script_thread = unsafe { &*root.get().unwrap() };
+            let _ = script_thread.dom_manipulation_task_source.queue(box FlushPromiseJobs, global);
+        })
+    }
+
+    fn do_flush_promise_jobs(&self) {
+        self.promise_job_queue.flush_promise_jobs(|id| {
+            self.find_child_context(id).map(|context| GlobalRoot::Window(context.active_window()))
+        });
     }
 }
 
 struct FlushPromiseJobs;
 impl Runnable for FlushPromiseJobs {
     fn main_thread_handler(self: Box<FlushPromiseJobs>, script_thread: &ScriptThread) {
-        script_thread.flush_promise_jobs();
+        script_thread.do_flush_promise_jobs();
     }
 }
 

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -8,6 +8,7 @@ use dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use dom::bindings::global::GlobalRef;
 use dom::bindings::reflector::Reflectable;
 use dom::bindings::str::DOMString;
+use dom::testbinding::TestBindingCallback;
 use dom::window::ScriptHelpers;
 use dom::xmlhttprequest::XHRTimeoutCallback;
 use euclid::length::Length;
@@ -68,6 +69,7 @@ struct OneshotTimer {
 pub enum OneshotTimerCallback {
     XhrTimeout(XHRTimeoutCallback),
     JsTimer(JsTimerTask),
+    TestBindingCallback(TestBindingCallback),
 }
 
 impl OneshotTimerCallback {
@@ -75,6 +77,7 @@ impl OneshotTimerCallback {
         match self {
             OneshotTimerCallback::XhrTimeout(callback) => callback.invoke(),
             OneshotTimerCallback::JsTimer(task) => task.invoke(this, js_timers),
+            OneshotTimerCallback::TestBindingCallback(callback) => callback.invoke(),
         }
     }
 }

--- a/tests/wpt/metadata/WebCryptoAPI/digest/digest.worker.js.ini
+++ b/tests/wpt/metadata/WebCryptoAPI/digest/digest.worker.js.ini
@@ -1,6 +1,242 @@
 [digest.worker]
   type: testharness
-  expected: ERROR
   [SHA-1 with empty source data]
-    expected: NOTRUN
+    expected: FAIL
+
+  [sha-1 with empty source data]
+    expected: FAIL
+
+  [Sha-1 with empty source data]
+    expected: FAIL
+
+  [SHA-1 with empty source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-256 with empty source data]
+    expected: FAIL
+
+  [sha-256 with empty source data]
+    expected: FAIL
+
+  [Sha-256 with empty source data]
+    expected: FAIL
+
+  [SHA-256 with empty source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-384 with empty source data]
+    expected: FAIL
+
+  [sha-384 with empty source data]
+    expected: FAIL
+
+  [Sha-384 with empty source data]
+    expected: FAIL
+
+  [SHA-384 with empty source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-512 with empty source data]
+    expected: FAIL
+
+  [sha-512 with empty source data]
+    expected: FAIL
+
+  [Sha-512 with empty source data]
+    expected: FAIL
+
+  [SHA-512 with empty source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-1 with short source data]
+    expected: FAIL
+
+  [sha-1 with short source data]
+    expected: FAIL
+
+  [Sha-1 with short source data]
+    expected: FAIL
+
+  [SHA-1 with short source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-256 with short source data]
+    expected: FAIL
+
+  [sha-256 with short source data]
+    expected: FAIL
+
+  [Sha-256 with short source data]
+    expected: FAIL
+
+  [SHA-256 with short source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-384 with short source data]
+    expected: FAIL
+
+  [sha-384 with short source data]
+    expected: FAIL
+
+  [Sha-384 with short source data]
+    expected: FAIL
+
+  [SHA-384 with short source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-512 with short source data]
+    expected: FAIL
+
+  [sha-512 with short source data]
+    expected: FAIL
+
+  [Sha-512 with short source data]
+    expected: FAIL
+
+  [SHA-512 with short source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-1 with medium source data]
+    expected: FAIL
+
+  [sha-1 with medium source data]
+    expected: FAIL
+
+  [Sha-1 with medium source data]
+    expected: FAIL
+
+  [SHA-1 with medium source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-256 with medium source data]
+    expected: FAIL
+
+  [sha-256 with medium source data]
+    expected: FAIL
+
+  [Sha-256 with medium source data]
+    expected: FAIL
+
+  [SHA-256 with medium source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-384 with medium source data]
+    expected: FAIL
+
+  [sha-384 with medium source data]
+    expected: FAIL
+
+  [Sha-384 with medium source data]
+    expected: FAIL
+
+  [SHA-384 with medium source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-512 with medium source data]
+    expected: FAIL
+
+  [sha-512 with medium source data]
+    expected: FAIL
+
+  [Sha-512 with medium source data]
+    expected: FAIL
+
+  [SHA-512 with medium source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-1 with long source data]
+    expected: FAIL
+
+  [sha-1 with long source data]
+    expected: FAIL
+
+  [Sha-1 with long source data]
+    expected: FAIL
+
+  [SHA-1 with long source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-256 with long source data]
+    expected: FAIL
+
+  [sha-256 with long source data]
+    expected: FAIL
+
+  [Sha-256 with long source data]
+    expected: FAIL
+
+  [SHA-256 with long source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-384 with long source data]
+    expected: FAIL
+
+  [sha-384 with long source data]
+    expected: FAIL
+
+  [Sha-384 with long source data]
+    expected: FAIL
+
+  [SHA-384 with long source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-512 with long source data]
+    expected: FAIL
+
+  [sha-512 with long source data]
+    expected: FAIL
+
+  [Sha-512 with long source data]
+    expected: FAIL
+
+  [SHA-512 with long source data and altered buffer after call]
+    expected: FAIL
+
+  [AES-GCM with empty]
+    expected: FAIL
+
+  [RSA-OAEP with empty]
+    expected: FAIL
+
+  [PBKDF2 with empty]
+    expected: FAIL
+
+  [AES-KW with empty]
+    expected: FAIL
+
+  [AES-GCM with short]
+    expected: FAIL
+
+  [RSA-OAEP with short]
+    expected: FAIL
+
+  [PBKDF2 with short]
+    expected: FAIL
+
+  [AES-KW with short]
+    expected: FAIL
+
+  [AES-GCM with medium]
+    expected: FAIL
+
+  [RSA-OAEP with medium]
+    expected: FAIL
+
+  [PBKDF2 with medium]
+    expected: FAIL
+
+  [AES-KW with medium]
+    expected: FAIL
+
+  [AES-GCM with long]
+    expected: FAIL
+
+  [RSA-OAEP with long]
+    expected: FAIL
+
+  [PBKDF2 with long]
+    expected: FAIL
+
+  [AES-KW with long]
+    expected: FAIL
 

--- a/tests/wpt/metadata/WebCryptoAPI/digest/test_digest.html.ini
+++ b/tests/wpt/metadata/WebCryptoAPI/digest/test_digest.html.ini
@@ -1,6 +1,242 @@
 [test_digest.html]
   type: testharness
-  expected: ERROR
   [SHA-1 with empty source data]
-    expected: NOTRUN
+    expected: FAIL
+
+  [sha-1 with empty source data]
+    expected: FAIL
+
+  [Sha-1 with empty source data]
+    expected: FAIL
+
+  [SHA-1 with empty source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-256 with empty source data]
+    expected: FAIL
+
+  [sha-256 with empty source data]
+    expected: FAIL
+
+  [Sha-256 with empty source data]
+    expected: FAIL
+
+  [SHA-256 with empty source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-384 with empty source data]
+    expected: FAIL
+
+  [sha-384 with empty source data]
+    expected: FAIL
+
+  [Sha-384 with empty source data]
+    expected: FAIL
+
+  [SHA-384 with empty source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-512 with empty source data]
+    expected: FAIL
+
+  [sha-512 with empty source data]
+    expected: FAIL
+
+  [Sha-512 with empty source data]
+    expected: FAIL
+
+  [SHA-512 with empty source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-1 with short source data]
+    expected: FAIL
+
+  [sha-1 with short source data]
+    expected: FAIL
+
+  [Sha-1 with short source data]
+    expected: FAIL
+
+  [SHA-1 with short source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-256 with short source data]
+    expected: FAIL
+
+  [sha-256 with short source data]
+    expected: FAIL
+
+  [Sha-256 with short source data]
+    expected: FAIL
+
+  [SHA-256 with short source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-384 with short source data]
+    expected: FAIL
+
+  [sha-384 with short source data]
+    expected: FAIL
+
+  [Sha-384 with short source data]
+    expected: FAIL
+
+  [SHA-384 with short source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-512 with short source data]
+    expected: FAIL
+
+  [sha-512 with short source data]
+    expected: FAIL
+
+  [Sha-512 with short source data]
+    expected: FAIL
+
+  [SHA-512 with short source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-1 with medium source data]
+    expected: FAIL
+
+  [sha-1 with medium source data]
+    expected: FAIL
+
+  [Sha-1 with medium source data]
+    expected: FAIL
+
+  [SHA-1 with medium source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-256 with medium source data]
+    expected: FAIL
+
+  [sha-256 with medium source data]
+    expected: FAIL
+
+  [Sha-256 with medium source data]
+    expected: FAIL
+
+  [SHA-256 with medium source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-384 with medium source data]
+    expected: FAIL
+
+  [sha-384 with medium source data]
+    expected: FAIL
+
+  [Sha-384 with medium source data]
+    expected: FAIL
+
+  [SHA-384 with medium source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-512 with medium source data]
+    expected: FAIL
+
+  [sha-512 with medium source data]
+    expected: FAIL
+
+  [Sha-512 with medium source data]
+    expected: FAIL
+
+  [SHA-512 with medium source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-1 with long source data]
+    expected: FAIL
+
+  [sha-1 with long source data]
+    expected: FAIL
+
+  [Sha-1 with long source data]
+    expected: FAIL
+
+  [SHA-1 with long source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-256 with long source data]
+    expected: FAIL
+
+  [sha-256 with long source data]
+    expected: FAIL
+
+  [Sha-256 with long source data]
+    expected: FAIL
+
+  [SHA-256 with long source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-384 with long source data]
+    expected: FAIL
+
+  [sha-384 with long source data]
+    expected: FAIL
+
+  [Sha-384 with long source data]
+    expected: FAIL
+
+  [SHA-384 with long source data and altered buffer after call]
+    expected: FAIL
+
+  [SHA-512 with long source data]
+    expected: FAIL
+
+  [sha-512 with long source data]
+    expected: FAIL
+
+  [Sha-512 with long source data]
+    expected: FAIL
+
+  [SHA-512 with long source data and altered buffer after call]
+    expected: FAIL
+
+  [AES-GCM with empty]
+    expected: FAIL
+
+  [RSA-OAEP with empty]
+    expected: FAIL
+
+  [PBKDF2 with empty]
+    expected: FAIL
+
+  [AES-KW with empty]
+    expected: FAIL
+
+  [AES-GCM with short]
+    expected: FAIL
+
+  [RSA-OAEP with short]
+    expected: FAIL
+
+  [PBKDF2 with short]
+    expected: FAIL
+
+  [AES-KW with short]
+    expected: FAIL
+
+  [AES-GCM with medium]
+    expected: FAIL
+
+  [RSA-OAEP with medium]
+    expected: FAIL
+
+  [PBKDF2 with medium]
+    expected: FAIL
+
+  [AES-KW with medium]
+    expected: FAIL
+
+  [AES-GCM with long]
+    expected: FAIL
+
+  [RSA-OAEP with long]
+    expected: FAIL
+
+  [PBKDF2 with long]
+    expected: FAIL
+
+  [AES-KW with long]
+    expected: FAIL
 

--- a/tests/wpt/metadata/WebCryptoAPI/import_export/ec_importKey.worker.js.ini
+++ b/tests/wpt/metadata/WebCryptoAPI/import_export/ec_importKey.worker.js.ini
@@ -1,6 +1,218 @@
 [ec_importKey.worker]
   type: testharness
-  expected: ERROR
   [Good parameters: P-256 bits (spki, buffer(91), {name: ECDSA, namedCurve: P-256}, true, [\])]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-256}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDSA, namedCurve: P-256}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-256}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (spki, buffer(91), {name: ECDSA, namedCurve: P-256}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-256}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDSA, namedCurve: P-256}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-256}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (spki, buffer(120), {name: ECDSA, namedCurve: P-384}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-384}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDSA, namedCurve: P-384}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-384}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (spki, buffer(120), {name: ECDSA, namedCurve: P-384}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-384}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDSA, namedCurve: P-384}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-384}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (spki, buffer(158), {name: ECDSA, namedCurve: P-521}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-521}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDSA, namedCurve: P-521}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-521}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (spki, buffer(158), {name: ECDSA, namedCurve: P-521}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-521}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDSA, namedCurve: P-521}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-521}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (spki, buffer(91), {name: ECDH, namedCurve: P-256}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-256}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (spki, buffer(91), {name: ECDH, namedCurve: P-256}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-256}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (spki, buffer(120), {name: ECDH, namedCurve: P-384}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-384}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (spki, buffer(120), {name: ECDH, namedCurve: P-384}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-384}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (spki, buffer(158), {name: ECDH, namedCurve: P-521}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-521}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (spki, buffer(158), {name: ECDH, namedCurve: P-521}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-521}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, false, [deriveBits\])]
+    expected: FAIL
 

--- a/tests/wpt/metadata/WebCryptoAPI/import_export/rsa_importKey.worker.js.ini
+++ b/tests/wpt/metadata/WebCryptoAPI/import_export/rsa_importKey.worker.js.ini
@@ -1,6 +1,1442 @@
 [rsa_importKey.worker]
   type: testharness
-  expected: ERROR
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
 

--- a/tests/wpt/metadata/WebCryptoAPI/import_export/symmetric_importKey.worker.js.ini
+++ b/tests/wpt/metadata/WebCryptoAPI/import_export/symmetric_importKey.worker.js.ini
@@ -1,6 +1,704 @@
 [symmetric_importKey.worker]
   type: testharness
-  expected: ERROR
   [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [encrypt\])]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey\])]
+    expected: FAIL
 

--- a/tests/wpt/metadata/WebCryptoAPI/import_export/test_ec_importKey.html.ini
+++ b/tests/wpt/metadata/WebCryptoAPI/import_export/test_ec_importKey.html.ini
@@ -1,6 +1,218 @@
 [test_ec_importKey.html]
   type: testharness
-  expected: ERROR
   [Good parameters: P-256 bits (spki, buffer(91), {name: ECDSA, namedCurve: P-256}, true, [\])]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-256}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDSA, namedCurve: P-256}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-256}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (spki, buffer(91), {name: ECDSA, namedCurve: P-256}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-256}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDSA, namedCurve: P-256}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-256}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (spki, buffer(120), {name: ECDSA, namedCurve: P-384}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-384}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDSA, namedCurve: P-384}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-384}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (spki, buffer(120), {name: ECDSA, namedCurve: P-384}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-384}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDSA, namedCurve: P-384}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-384}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (spki, buffer(158), {name: ECDSA, namedCurve: P-521}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-521}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDSA, namedCurve: P-521}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-521}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (spki, buffer(158), {name: ECDSA, namedCurve: P-521}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDSA, namedCurve: P-521}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDSA, namedCurve: P-521}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-521}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (spki, buffer(91), {name: ECDH, namedCurve: P-256}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-256}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (spki, buffer(91), {name: ECDH, namedCurve: P-256}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-256}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (spki, buffer(120), {name: ECDH, namedCurve: P-384}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-384}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (spki, buffer(120), {name: ECDH, namedCurve: P-384}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-384}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (spki, buffer(158), {name: ECDH, namedCurve: P-521}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-521}, true, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, true, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, true, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, true, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (spki, buffer(158), {name: ECDH, namedCurve: P-521}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-521}, false, [\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, false, [deriveBits, deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, false, [deriveBits\])]
+    expected: FAIL
 

--- a/tests/wpt/metadata/WebCryptoAPI/import_export/test_rsa_importKey.html.ini
+++ b/tests/wpt/metadata/WebCryptoAPI/import_export/test_rsa_importKey.html.ini
@@ -1,6 +1,1442 @@
 [test_rsa_importKey.html]
   type: testharness
-  expected: ERROR
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-OAEP}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey, decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-OAEP}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, true, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSASSA-PKCS1-v1_5}, false, [sign\])]
+    expected: FAIL
 

--- a/tests/wpt/metadata/WebCryptoAPI/import_export/test_symmetric_importKey.html.ini
+++ b/tests/wpt/metadata/WebCryptoAPI/import_export/test_symmetric_importKey.html.ini
@@ -1,6 +1,704 @@
 [test_symmetric_importKey.html]
   type: testharness
-  expected: ERROR
   [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [encrypt\])]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CTR, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CTR, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CTR}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128CBC, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256CBC, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-CBC}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128GCM, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, true, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, false, [encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, true, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, false, [decrypt, encrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, true, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256GCM, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-GCM}, false, [decrypt\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: A128KW, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: A192KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, true, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, false, [wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, true, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, false, [unwrapKey, wrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, true, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: A256KW, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {name: AES-KW}, false, [unwrapKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS1, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-1, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS256, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-256, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS384, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-384, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify, sign\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (jwk, {alg: HS512, k: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA, kty: oct}, {hash: SHA-512, name: HMAC}, false, [verify\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: HKDF}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 128 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 192 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey, deriveBits\])]
+    expected: FAIL
+
+  [Good parameters: 256 bits (raw, {0: 1, 1: 2, 10: 11, 11: 12, 12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18, 18: 19, 19: 20, 2: 3, 20: 21, 21: 22, 22: 23, 23: 24, 24: 25, 25: 26, 26: 27, 27: 28, 28: 29, 29: 30, 3: 4, 30: 31, 31: 32, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10}, {name: PBKDF2}, false, [deriveKey\])]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/accept-header-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/accept-header-worker.html.ini
@@ -1,6 +1,5 @@
 [accept-header-worker.html]
   type: testharness
-  expected: ERROR
   [Request through fetch should have 'accept' header with value '*/*']
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/accept-header.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/accept-header.html.ini
@@ -1,6 +1,5 @@
 [accept-header.html]
   type: testharness
-  expected: ERROR
   [Request through fetch should have 'accept' header with value '*/*']
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/integrity-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/integrity-worker.html.ini
@@ -1,6 +1,41 @@
 [integrity-worker.html]
   type: testharness
-  expected: ERROR
   [Empty string integrity]
-    expected: NOTRUN
+    expected: FAIL
+
+  [SHA-256 integrity]
+    expected: FAIL
+
+  [SHA-384 integrity]
+    expected: FAIL
+
+  [SHA-512 integrity]
+    expected: FAIL
+
+  [Invalid integrity]
+    expected: FAIL
+
+  [Multiple integrities: valid stronger than invalid]
+    expected: FAIL
+
+  [Multiple integrities: invalid stronger than valid]
+    expected: FAIL
+
+  [Multiple integrities: invalid as strong as valid]
+    expected: FAIL
+
+  [Multiple integrities: both are valid]
+    expected: FAIL
+
+  [Multiple integrities: both are invalid]
+    expected: FAIL
+
+  [CORS empty integrity]
+    expected: FAIL
+
+  [CORS SHA-512 integrity]
+    expected: FAIL
+
+  [CORS invalid integrity]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/integrity.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/integrity.html.ini
@@ -1,6 +1,41 @@
 [integrity.html]
   type: testharness
-  expected: ERROR
   [Empty string integrity]
-    expected: NOTRUN
+    expected: FAIL
+
+  [SHA-256 integrity]
+    expected: FAIL
+
+  [SHA-384 integrity]
+    expected: FAIL
+
+  [SHA-512 integrity]
+    expected: FAIL
+
+  [Invalid integrity]
+    expected: FAIL
+
+  [Multiple integrities: valid stronger than invalid]
+    expected: FAIL
+
+  [Multiple integrities: invalid stronger than valid]
+    expected: FAIL
+
+  [Multiple integrities: invalid as strong as valid]
+    expected: FAIL
+
+  [Multiple integrities: both are valid]
+    expected: FAIL
+
+  [Multiple integrities: both are invalid]
+    expected: FAIL
+
+  [CORS empty integrity]
+    expected: FAIL
+
+  [CORS SHA-512 integrity]
+    expected: FAIL
+
+  [CORS invalid integrity]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/mode-no-cors-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/mode-no-cors-worker.html.ini
@@ -1,6 +1,14 @@
 [mode-no-cors-worker.html]
   type: testharness
-  expected: ERROR
   [Fetch ../resources/top.txt with no-cors mode]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetch http://web-platform.test:8000/fetch/api/resources/top.txt with no-cors mode]
+    expected: FAIL
+
+  [Fetch https://web-platform.test:8443/fetch/api/resources/top.txt with no-cors mode]
+    expected: FAIL
+
+  [Fetch http://web-platform.test:8001/fetch/api/resources/top.txt with no-cors mode]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/mode-no-cors.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/mode-no-cors.html.ini
@@ -1,6 +1,14 @@
 [mode-no-cors.html]
   type: testharness
-  expected: ERROR
   [Fetch ../resources/top.txt with no-cors mode]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetch http://web-platform.test:8000/fetch/api/resources/top.txt with no-cors mode]
+    expected: FAIL
+
+  [Fetch https://web-platform.test:8443/fetch/api/resources/top.txt with no-cors mode]
+    expected: FAIL
+
+  [Fetch http://web-platform.test:8001/fetch/api/resources/top.txt with no-cors mode]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/mode-same-origin-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/mode-same-origin-worker.html.ini
@@ -1,6 +1,26 @@
 [mode-same-origin-worker.html]
   type: testharness
-  expected: ERROR
   [Fetch ../resources/top.txt with same-origin mode]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetch http://web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch https://web-platform.test:8443/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch http://www1.web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch /fetch/api/basic/../resources/redirect.py?location=../resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch /fetch/api/basic/../resources/redirect.py?location=http://web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch /fetch/api/basic/../resources/redirect.py?location=https://web-platform.test:8443/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch /fetch/api/basic/../resources/redirect.py?location=http://www1.web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/mode-same-origin.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/mode-same-origin.html.ini
@@ -1,6 +1,26 @@
 [mode-same-origin.html]
   type: testharness
-  expected: ERROR
   [Fetch ../resources/top.txt with same-origin mode]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetch http://web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch https://web-platform.test:8443/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch http://www1.web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch /fetch/api/basic/../resources/redirect.py?location=../resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch /fetch/api/basic/../resources/redirect.py?location=http://web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch /fetch/api/basic/../resources/redirect.py?location=https://web-platform.test:8443/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
+
+  [Fetch /fetch/api/basic/../resources/redirect.py?location=http://www1.web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/referrer-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/referrer-worker.html.ini
@@ -1,6 +1,20 @@
 [referrer-worker.html]
   type: testharness
-  expected: ERROR
   [origin-when-cross-origin policy on a same-origin URL]
-    expected: NOTRUN
+    expected: FAIL
+
+  [origin-when-cross-origin policy on a cross-origin URL]
+    expected: FAIL
+
+  [origin-when-cross-origin policy on a cross-origin URL after same-origin redirection]
+    expected: FAIL
+
+  [origin-when-cross-origin policy on a same-origin URL after cross-origin redirection]
+    expected: FAIL
+
+  [Referrer with credentials should be stripped]
+    expected: FAIL
+
+  [Referrer with fragment ID should be stripped]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/referrer.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/referrer.html.ini
@@ -1,6 +1,20 @@
 [referrer.html]
   type: testharness
-  expected: ERROR
   [origin-when-cross-origin policy on a same-origin URL]
-    expected: NOTRUN
+    expected: FAIL
+
+  [origin-when-cross-origin policy on a cross-origin URL]
+    expected: FAIL
+
+  [origin-when-cross-origin policy on a cross-origin URL after same-origin redirection]
+    expected: FAIL
+
+  [origin-when-cross-origin policy on a same-origin URL after cross-origin redirection]
+    expected: FAIL
+
+  [Referrer with credentials should be stripped]
+    expected: FAIL
+
+  [Referrer with fragment ID should be stripped]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/request-forbidden-headers-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-forbidden-headers-worker.html.ini
@@ -1,6 +1,74 @@
 [request-forbidden-headers-worker.html]
   type: testharness
-  expected: ERROR
   [Accept-Charset is a forbidden request header]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Accept-Encoding is a forbidden request header]
+    expected: FAIL
+
+  [Access-Control-Request-Headers is a forbidden request header]
+    expected: FAIL
+
+  [Access-Control-Request-Method is a forbidden request header]
+    expected: FAIL
+
+  [Connection is a forbidden request header]
+    expected: FAIL
+
+  [Content-Length is a forbidden request header]
+    expected: FAIL
+
+  [Cookie is a forbidden request header]
+    expected: FAIL
+
+  [Cookie2 is a forbidden request header]
+    expected: FAIL
+
+  [Date is a forbidden request header]
+    expected: FAIL
+
+  [DNT is a forbidden request header]
+    expected: FAIL
+
+  [Expect is a forbidden request header]
+    expected: FAIL
+
+  [Host is a forbidden request header]
+    expected: FAIL
+
+  [Keep-Alive is a forbidden request header]
+    expected: FAIL
+
+  [Origin is a forbidden request header]
+    expected: FAIL
+
+  [Referer is a forbidden request header]
+    expected: FAIL
+
+  [TE is a forbidden request header]
+    expected: FAIL
+
+  [Trailer is a forbidden request header]
+    expected: FAIL
+
+  [Transfer-Encoding is a forbidden request header]
+    expected: FAIL
+
+  [Upgrade is a forbidden request header]
+    expected: FAIL
+
+  [Via is a forbidden request header]
+    expected: FAIL
+
+  [Proxy- is a forbidden request header]
+    expected: FAIL
+
+  [Proxy-Test is a forbidden request header]
+    expected: FAIL
+
+  [Sec- is a forbidden request header]
+    expected: FAIL
+
+  [Sec-Test is a forbidden request header]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/request-forbidden-headers.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-forbidden-headers.html.ini
@@ -1,6 +1,74 @@
 [request-forbidden-headers.html]
   type: testharness
-  expected: ERROR
   [Accept-Charset is a forbidden request header]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Accept-Encoding is a forbidden request header]
+    expected: FAIL
+
+  [Access-Control-Request-Headers is a forbidden request header]
+    expected: FAIL
+
+  [Access-Control-Request-Method is a forbidden request header]
+    expected: FAIL
+
+  [Connection is a forbidden request header]
+    expected: FAIL
+
+  [Content-Length is a forbidden request header]
+    expected: FAIL
+
+  [Cookie is a forbidden request header]
+    expected: FAIL
+
+  [Cookie2 is a forbidden request header]
+    expected: FAIL
+
+  [Date is a forbidden request header]
+    expected: FAIL
+
+  [DNT is a forbidden request header]
+    expected: FAIL
+
+  [Expect is a forbidden request header]
+    expected: FAIL
+
+  [Host is a forbidden request header]
+    expected: FAIL
+
+  [Keep-Alive is a forbidden request header]
+    expected: FAIL
+
+  [Origin is a forbidden request header]
+    expected: FAIL
+
+  [Referer is a forbidden request header]
+    expected: FAIL
+
+  [TE is a forbidden request header]
+    expected: FAIL
+
+  [Trailer is a forbidden request header]
+    expected: FAIL
+
+  [Transfer-Encoding is a forbidden request header]
+    expected: FAIL
+
+  [Upgrade is a forbidden request header]
+    expected: FAIL
+
+  [Via is a forbidden request header]
+    expected: FAIL
+
+  [Proxy- is a forbidden request header]
+    expected: FAIL
+
+  [Proxy-Test is a forbidden request header]
+    expected: FAIL
+
+  [Sec- is a forbidden request header]
+    expected: FAIL
+
+  [Sec-Test is a forbidden request header]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/request-head-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-head-worker.html.ini
@@ -1,6 +1,5 @@
 [request-head-worker.html]
   type: testharness
-  expected: ERROR
   [Fetch with HEAD with body]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/request-head.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-head.html.ini
@@ -1,6 +1,5 @@
 [request-head.html]
   type: testharness
-  expected: ERROR
   [Fetch with HEAD with body]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/request-headers-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-headers-worker.html.ini
@@ -1,6 +1,53 @@
 [request-headers-worker.html]
   type: testharness
-  expected: ERROR
   [Fetch with GET]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetch with HEAD]
+    expected: FAIL
+
+  [Fetch with PUT without body]
+    expected: FAIL
+
+  [Fetch with PUT with body]
+    expected: FAIL
+
+  [Fetch with POST without body]
+    expected: FAIL
+
+  [Fetch with POST with text body]
+    expected: FAIL
+
+  [Fetch with POST with FormData body]
+    expected: FAIL
+
+  [Fetch with POST with Blob body]
+    expected: FAIL
+
+  [Fetch with POST with ArrayBuffer body]
+    expected: FAIL
+
+  [Fetch with POST with Uint8Array body]
+    expected: FAIL
+
+  [Fetch with POST with Int8Array body]
+    expected: FAIL
+
+  [Fetch with POST with Float32Array body]
+    expected: FAIL
+
+  [Fetch with POST with Float64Array body]
+    expected: FAIL
+
+  [Fetch with POST with DataView body]
+    expected: FAIL
+
+  [Fetch with POST with Blob body with mime type]
+    expected: FAIL
+
+  [Fetch with Chicken]
+    expected: FAIL
+
+  [Fetch with Chicken with body]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/request-headers.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-headers.html.ini
@@ -1,6 +1,53 @@
 [request-headers.html]
   type: testharness
-  expected: ERROR
   [Fetch with GET]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetch with HEAD]
+    expected: FAIL
+
+  [Fetch with PUT without body]
+    expected: FAIL
+
+  [Fetch with PUT with body]
+    expected: FAIL
+
+  [Fetch with POST without body]
+    expected: FAIL
+
+  [Fetch with POST with text body]
+    expected: FAIL
+
+  [Fetch with POST with FormData body]
+    expected: FAIL
+
+  [Fetch with POST with Blob body]
+    expected: FAIL
+
+  [Fetch with POST with ArrayBuffer body]
+    expected: FAIL
+
+  [Fetch with POST with Uint8Array body]
+    expected: FAIL
+
+  [Fetch with POST with Int8Array body]
+    expected: FAIL
+
+  [Fetch with POST with Float32Array body]
+    expected: FAIL
+
+  [Fetch with POST with Float64Array body]
+    expected: FAIL
+
+  [Fetch with POST with DataView body]
+    expected: FAIL
+
+  [Fetch with POST with Blob body with mime type]
+    expected: FAIL
+
+  [Fetch with Chicken]
+    expected: FAIL
+
+  [Fetch with Chicken with body]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/request-referrer.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-referrer.html.ini
@@ -1,6 +1,8 @@
 [request-referrer.html]
   type: testharness
-  expected: ERROR
   [Fetch: fetch() respects Request referrer value]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetch: fetch() respects Request referrer value 1]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/response-url-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/response-url-worker.html.ini
@@ -1,6 +1,14 @@
 [response-url-worker.html]
   type: testharness
-  expected: ERROR
   [Testing response url getter with http://web-platform.test:8000/ada]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Testing response url getter with http://web-platform.test:8000/#]
+    expected: FAIL
+
+  [Testing response url getter with http://web-platform.test:8000/#ada]
+    expected: FAIL
+
+  [Testing response url getter with http://web-platform.test:8000#ada]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/response-url.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/response-url.html.ini
@@ -1,6 +1,14 @@
 [response-url.html]
   type: testharness
-  expected: ERROR
   [Testing response url getter with http://web-platform.test:8000/ada]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Testing response url getter with http://web-platform.test:8000/#]
+    expected: FAIL
+
+  [Testing response url getter with http://web-platform.test:8000/#ada]
+    expected: FAIL
+
+  [Testing response url getter with http://web-platform.test:8000#ada]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/scheme-about-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-about-worker.html.ini
@@ -1,9 +1,23 @@
 [scheme-about-worker.html]
   type: testharness
-  expected: ERROR
   [Fetching about:blank is OK]
     expected: FAIL
 
   [Fetching about:blank (GET) is OK]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetching about:blank (PUT) is OK]
+    expected: FAIL
+
+  [Fetching about:blank (POST) is OK]
+    expected: FAIL
+
+  [Fetching about:invalid.com is KO]
+    expected: FAIL
+
+  [Fetching about:config is KO]
+    expected: FAIL
+
+  [Fetching about:unicorn is KO]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/scheme-about.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-about.html.ini
@@ -1,9 +1,23 @@
 [scheme-about.html]
   type: testharness
-  expected: ERROR
   [Fetching about:blank is OK]
     expected: FAIL
 
   [Fetching about:blank (GET) is OK]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetching about:blank (PUT) is OK]
+    expected: FAIL
+
+  [Fetching about:blank (POST) is OK]
+    expected: FAIL
+
+  [Fetching about:invalid.com is KO]
+    expected: FAIL
+
+  [Fetching about:config is KO]
+    expected: FAIL
+
+  [Fetching about:unicorn is KO]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/scheme-blob-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-blob-worker.html.ini
@@ -1,6 +1,26 @@
 [scheme-blob-worker.html]
   type: testharness
-  expected: ERROR
   [Fetching [GET\] URL.createObjectURL(blob) is OK]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetching [GET\] blob:http://www.web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching [POST\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
+
+  [Fetching [OPTIONS\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
+
+  [Fetching [HEAD\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
+
+  [Fetching [PUT\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
+
+  [Fetching [DELETE\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
+
+  [Fetching [INVALID\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/scheme-blob.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-blob.html.ini
@@ -1,6 +1,26 @@
 [scheme-blob.html]
   type: testharness
-  expected: ERROR
   [Fetching [GET\] URL.createObjectURL(blob) is OK]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetching [GET\] blob:http://www.web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching [POST\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
+
+  [Fetching [OPTIONS\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
+
+  [Fetching [HEAD\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
+
+  [Fetching [PUT\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
+
+  [Fetching [DELETE\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
+
+  [Fetching [INVALID\] URL.createObjectURL(blob) is KO]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/scheme-data-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-data-worker.html.ini
@@ -1,6 +1,26 @@
 [scheme-data-worker.html]
   type: testharness
-  expected: ERROR
   [Fetching data:,response%27s%20body is OK]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetching data:,response%27s%20body is OK (same-origin)]
+    expected: FAIL
+
+  [Fetching data:,response%27s%20body is OK (cors)]
+    expected: FAIL
+
+  [Fetching data:text/plain;base64,cmVzcG9uc2UncyBib[...\] is OK]
+    expected: FAIL
+
+  [Fetching data:image/png;base64,cmVzcG9uc2UncyBib2[...\] is OK]
+    expected: FAIL
+
+  [Fetching [GET\] data:notAdataUrl.com is KO]
+    expected: FAIL
+
+  [Fetching [POST\] data:,response%27s%20body is KO]
+    expected: FAIL
+
+  [Fetching [HEAD\] data:,response%27s%20body is KO]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/scheme-data.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-data.html.ini
@@ -1,6 +1,26 @@
 [scheme-data.html]
   type: testharness
-  expected: ERROR
   [Fetching data:,response%27s%20body is OK]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetching data:,response%27s%20body is OK (same-origin)]
+    expected: FAIL
+
+  [Fetching data:,response%27s%20body is OK (cors)]
+    expected: FAIL
+
+  [Fetching data:text/plain;base64,cmVzcG9uc2UncyBib[...\] is OK]
+    expected: FAIL
+
+  [Fetching data:image/png;base64,cmVzcG9uc2UncyBib2[...\] is OK]
+    expected: FAIL
+
+  [Fetching [GET\] data:notAdataUrl.com is KO]
+    expected: FAIL
+
+  [Fetching [POST\] data:,response%27s%20body is KO]
+    expected: FAIL
+
+  [Fetching [HEAD\] data:,response%27s%20body is KO]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/scheme-others-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-others-worker.html.ini
@@ -1,6 +1,50 @@
 [scheme-others-worker.html]
   type: testharness
-  expected: ERROR
   [Fetching aaa://web-platform.test:8000/ is KO]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetching cap://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching cid://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching dav://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching dict://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching dns://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching geo://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching im://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching imap://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching ipp://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching ldap://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching mailto://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching nfs://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching pop://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching rtsp://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching snmp://web-platform.test:8000/ is KO]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/scheme-others.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-others.html.ini
@@ -1,6 +1,50 @@
 [scheme-others.html]
   type: testharness
-  expected: ERROR
   [Fetching aaa://web-platform.test:8000/ is KO]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetching cap://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching cid://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching dav://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching dict://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching dns://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching geo://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching im://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching imap://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching ipp://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching ldap://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching mailto://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching nfs://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching pop://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching rtsp://web-platform.test:8000/ is KO]
+    expected: FAIL
+
+  [Fetching snmp://web-platform.test:8000/ is KO]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/stream-response-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/stream-response-worker.html.ini
@@ -1,6 +1,5 @@
 [stream-response-worker.html]
   type: testharness
-  expected: ERROR
   [Stream response's body]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/stream-response.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/stream-response.html.ini
@@ -1,6 +1,5 @@
 [stream-response.html]
   type: testharness
-  expected: ERROR
   [Stream response's body]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/text-utf8.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/text-utf8.html.ini
@@ -1,6 +1,62 @@
 [text-utf8.html]
   type: testharness
-  expected: ERROR
   [UTF-8 with BOM with Request.text()]
-    expected: NOTRUN
+    expected: FAIL
+
+  [UTF-8 with BOM with Response.text()]
+    expected: FAIL
+
+  [UTF-8 with BOM with fetched data (UTF-8 charset)]
+    expected: FAIL
+
+  [UTF-8 with BOM with fetched data (UTF-16 charset)]
+    expected: FAIL
+
+  [UTF-8 without BOM with Request.text()]
+    expected: FAIL
+
+  [UTF-8 without BOM with Response.text()]
+    expected: FAIL
+
+  [UTF-8 without BOM with fetched data (UTF-8 charset)]
+    expected: FAIL
+
+  [UTF-8 without BOM with fetched data (UTF-16 charset)]
+    expected: FAIL
+
+  [UTF-16BE with BOM decoded as UTF-8 with Request.text()]
+    expected: FAIL
+
+  [UTF-16BE with BOM decoded as UTF-8 with Response.text()]
+    expected: FAIL
+
+  [UTF-16BE with BOM decoded as UTF-8 with fetched data (UTF-8 charset)]
+    expected: FAIL
+
+  [UTF-16BE with BOM decoded as UTF-8 with fetched data (UTF-16 charset)]
+    expected: FAIL
+
+  [UTF-16LE with BOM decoded as UTF-8 with Request.text()]
+    expected: FAIL
+
+  [UTF-16LE with BOM decoded as UTF-8 with Response.text()]
+    expected: FAIL
+
+  [UTF-16LE with BOM decoded as UTF-8 with fetched data (UTF-8 charset)]
+    expected: FAIL
+
+  [UTF-16LE with BOM decoded as UTF-8 with fetched data (UTF-16 charset)]
+    expected: FAIL
+
+  [UTF-16 without BOM decoded as UTF-8 with Request.text()]
+    expected: FAIL
+
+  [UTF-16 without BOM decoded as UTF-8 with Response.text()]
+    expected: FAIL
+
+  [UTF-16 without BOM decoded as UTF-8 with fetched data (UTF-8 charset)]
+    expected: FAIL
+
+  [UTF-16 without BOM decoded as UTF-8 with fetched data (UTF-16 charset)]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-basic-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-basic-worker.html.ini
@@ -1,6 +1,47 @@
 [cors-basic-worker.html]
   type: testharness
-  expected: ERROR
   [Same domain different port [no-cors mode\]]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Same domain different port [server forbid CORS\]]
+    expected: FAIL
+
+  [Same domain different port [cors mode\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [no-cors mode\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [server forbid CORS\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [cors mode\]]
+    expected: FAIL
+
+  [Cross domain basic usage [no-cors mode\]]
+    expected: FAIL
+
+  [Cross domain basic usage [server forbid CORS\]]
+    expected: FAIL
+
+  [Cross domain basic usage [cors mode\]]
+    expected: FAIL
+
+  [Cross domain different port [no-cors mode\]]
+    expected: FAIL
+
+  [Cross domain different port [server forbid CORS\]]
+    expected: FAIL
+
+  [Cross domain different port [cors mode\]]
+    expected: FAIL
+
+  [Cross domain different protocol [no-cors mode\]]
+    expected: FAIL
+
+  [Cross domain different protocol [server forbid CORS\]]
+    expected: FAIL
+
+  [Cross domain different protocol [cors mode\]]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-basic.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-basic.html.ini
@@ -1,6 +1,47 @@
 [cors-basic.html]
   type: testharness
-  expected: ERROR
   [Same domain different port [no-cors mode\]]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Same domain different port [server forbid CORS\]]
+    expected: FAIL
+
+  [Same domain different port [cors mode\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [no-cors mode\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [server forbid CORS\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [cors mode\]]
+    expected: FAIL
+
+  [Cross domain basic usage [no-cors mode\]]
+    expected: FAIL
+
+  [Cross domain basic usage [server forbid CORS\]]
+    expected: FAIL
+
+  [Cross domain basic usage [cors mode\]]
+    expected: FAIL
+
+  [Cross domain different port [no-cors mode\]]
+    expected: FAIL
+
+  [Cross domain different port [server forbid CORS\]]
+    expected: FAIL
+
+  [Cross domain different port [cors mode\]]
+    expected: FAIL
+
+  [Cross domain different protocol [no-cors mode\]]
+    expected: FAIL
+
+  [Cross domain different protocol [server forbid CORS\]]
+    expected: FAIL
+
+  [Cross domain different protocol [cors mode\]]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-cookies-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-cookies-worker.html.ini
@@ -1,6 +1,20 @@
 [cors-cookies-worker.html]
   type: testharness
-  expected: ERROR
   [Omit mode: no cookie sent]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Include mode: 1 cookie]
+    expected: FAIL
+
+  [Include mode: local cookies are not sent with remote request]
+    expected: FAIL
+
+  [Include mode: remote cookies are not sent with local request]
+    expected: FAIL
+
+  [Same-origin mode: cookies are discarded in cors request]
+    expected: FAIL
+
+  [Include mode: remote cookies are not sent with other remote request]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-cookies.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-cookies.html.ini
@@ -1,6 +1,20 @@
 [cors-cookies.html]
   type: testharness
-  expected: ERROR
   [Omit mode: no cookie sent]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Include mode: 1 cookie]
+    expected: FAIL
+
+  [Include mode: local cookies are not sent with remote request]
+    expected: FAIL
+
+  [Include mode: remote cookies are not sent with local request]
+    expected: FAIL
+
+  [Same-origin mode: cookies are discarded in cors request]
+    expected: FAIL
+
+  [Include mode: remote cookies are not sent with other remote request]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-filtering-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-filtering-worker.html.ini
@@ -1,6 +1,56 @@
 [cors-filtering-worker.html]
   type: testharness
-  expected: ERROR
   [CORS filter on Cache-Control header]
-    expected: NOTRUN
+    expected: FAIL
+
+  [CORS filter on Content-Language header]
+    expected: FAIL
+
+  [CORS filter on Content-Type header]
+    expected: FAIL
+
+  [CORS filter on Expires header]
+    expected: FAIL
+
+  [CORS filter on Last-Modified header]
+    expected: FAIL
+
+  [CORS filter on Pragma header]
+    expected: FAIL
+
+  [CORS filter on Age header]
+    expected: FAIL
+
+  [CORS filter on Server header]
+    expected: FAIL
+
+  [CORS filter on Warning header]
+    expected: FAIL
+
+  [CORS filter on Content-Length header]
+    expected: FAIL
+
+  [CORS filter on Set-Cookie header]
+    expected: FAIL
+
+  [CORS filter on Set-Cookie2 header]
+    expected: FAIL
+
+  [CORS filter on Age header, header is exposed]
+    expected: FAIL
+
+  [CORS filter on Server header, header is exposed]
+    expected: FAIL
+
+  [CORS filter on Warning header, header is exposed]
+    expected: FAIL
+
+  [CORS filter on Content-Length header, header is exposed]
+    expected: FAIL
+
+  [CORS filter on Set-Cookie header, header is exposed]
+    expected: FAIL
+
+  [CORS filter on Set-Cookie2 header, header is exposed]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-filtering.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-filtering.html.ini
@@ -1,6 +1,56 @@
 [cors-filtering.html]
   type: testharness
-  expected: ERROR
   [CORS filter on Cache-Control header]
-    expected: NOTRUN
+    expected: FAIL
+
+  [CORS filter on Content-Language header]
+    expected: FAIL
+
+  [CORS filter on Content-Type header]
+    expected: FAIL
+
+  [CORS filter on Expires header]
+    expected: FAIL
+
+  [CORS filter on Last-Modified header]
+    expected: FAIL
+
+  [CORS filter on Pragma header]
+    expected: FAIL
+
+  [CORS filter on Age header]
+    expected: FAIL
+
+  [CORS filter on Server header]
+    expected: FAIL
+
+  [CORS filter on Warning header]
+    expected: FAIL
+
+  [CORS filter on Content-Length header]
+    expected: FAIL
+
+  [CORS filter on Set-Cookie header]
+    expected: FAIL
+
+  [CORS filter on Set-Cookie2 header]
+    expected: FAIL
+
+  [CORS filter on Age header, header is exposed]
+    expected: FAIL
+
+  [CORS filter on Server header, header is exposed]
+    expected: FAIL
+
+  [CORS filter on Warning header, header is exposed]
+    expected: FAIL
+
+  [CORS filter on Content-Length header, header is exposed]
+    expected: FAIL
+
+  [CORS filter on Set-Cookie header, header is exposed]
+    expected: FAIL
+
+  [CORS filter on Set-Cookie2 header, header is exposed]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-multiple-origins-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-multiple-origins-worker.html.ini
@@ -1,6 +1,20 @@
 [cors-multiple-origins-worker.html]
   type: testharness
-  expected: ERROR
   [3 origins allowed, match the 3rd (http://web-platform.test:8000)]
-    expected: NOTRUN
+    expected: FAIL
+
+  [3 origins allowed, match the 3rd ("*")]
+    expected: FAIL
+
+  [3 origins allowed, match twice (http://web-platform.test:8000)]
+    expected: FAIL
+
+  [3 origins allowed, match twice ("*")]
+    expected: FAIL
+
+  [3 origins allowed, match twice ("*" and http://web-platform.test:8000)]
+    expected: FAIL
+
+  [3 origins allowed, no match]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-multiple-origins.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-multiple-origins.html.ini
@@ -1,6 +1,20 @@
 [cors-multiple-origins.html]
   type: testharness
-  expected: ERROR
   [3 origins allowed, match the 3rd (http://web-platform.test:8000)]
-    expected: NOTRUN
+    expected: FAIL
+
+  [3 origins allowed, match the 3rd ("*")]
+    expected: FAIL
+
+  [3 origins allowed, match twice (http://web-platform.test:8000)]
+    expected: FAIL
+
+  [3 origins allowed, match twice ("*")]
+    expected: FAIL
+
+  [3 origins allowed, match twice ("*" and http://web-platform.test:8000)]
+    expected: FAIL
+
+  [3 origins allowed, no match]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-no-preflight-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-no-preflight-worker.html.ini
@@ -1,6 +1,47 @@
 [cors-no-preflight-worker.html]
   type: testharness
-  expected: ERROR
   [Cross domain basic usage [GET\]]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Same domain different port [GET\]]
+    expected: FAIL
+
+  [Cross domain different port [GET\]]
+    expected: FAIL
+
+  [Cross domain different protocol [GET\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [GET\]]
+    expected: FAIL
+
+  [Cross domain [POST\]]
+    expected: FAIL
+
+  [Cross domain [HEAD\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Accept: */*\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Accept-Language: fr\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Language: fr\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Type: application/x-www-form-urlencoded\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Type: multipart/form-data\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Type: text/plain\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Type: text/plain;charset=utf-8\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Type: Text/Plain;charset=utf-8\]]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-no-preflight.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-no-preflight.html.ini
@@ -1,6 +1,47 @@
 [cors-no-preflight.html]
   type: testharness
-  expected: ERROR
   [Cross domain basic usage [GET\]]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Same domain different port [GET\]]
+    expected: FAIL
+
+  [Cross domain different port [GET\]]
+    expected: FAIL
+
+  [Cross domain different protocol [GET\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [GET\]]
+    expected: FAIL
+
+  [Cross domain [POST\]]
+    expected: FAIL
+
+  [Cross domain [HEAD\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Accept: */*\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Accept-Language: fr\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Language: fr\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Type: application/x-www-form-urlencoded\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Type: multipart/form-data\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Type: text/plain\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Type: text/plain;charset=utf-8\]]
+    expected: FAIL
+
+  [Cross domain [GET\] [Content-Type: Text/Plain;charset=utf-8\]]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-origin-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-origin-worker.html.ini
@@ -1,6 +1,53 @@
 [cors-origin-worker.html]
   type: testharness
-  expected: ERROR
   [Cross domain different subdomain [origin OK\]]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Cross domain different subdomain [origin KO\]]
+    expected: FAIL
+
+  [Same domain different port [origin OK\]]
+    expected: FAIL
+
+  [Same domain different port [origin KO\]]
+    expected: FAIL
+
+  [Cross domain different port [origin OK\]]
+    expected: FAIL
+
+  [Cross domain different port [origin KO\]]
+    expected: FAIL
+
+  [Cross domain different protocol [origin OK\]]
+    expected: FAIL
+
+  [Cross domain different protocol [origin KO\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [origin OK\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [origin KO\]]
+    expected: FAIL
+
+  [Cross domain [POST\] [origin OK\]]
+    expected: FAIL
+
+  [Cross domain [POST\] [origin KO\]]
+    expected: FAIL
+
+  [Cross domain [HEAD\] [origin OK\]]
+    expected: FAIL
+
+  [Cross domain [HEAD\] [origin KO\]]
+    expected: FAIL
+
+  [CORS preflight [PUT\] [origin OK\]]
+    expected: FAIL
+
+  [CORS preflight [PUT\] [origin KO\]]
+    expected: FAIL
+
+  [Allowed origin: "" [origin KO\]]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-origin.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-origin.html.ini
@@ -1,6 +1,53 @@
 [cors-origin.html]
   type: testharness
-  expected: ERROR
   [Cross domain different subdomain [origin OK\]]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Cross domain different subdomain [origin KO\]]
+    expected: FAIL
+
+  [Same domain different port [origin OK\]]
+    expected: FAIL
+
+  [Same domain different port [origin KO\]]
+    expected: FAIL
+
+  [Cross domain different port [origin OK\]]
+    expected: FAIL
+
+  [Cross domain different port [origin KO\]]
+    expected: FAIL
+
+  [Cross domain different protocol [origin OK\]]
+    expected: FAIL
+
+  [Cross domain different protocol [origin KO\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [origin OK\]]
+    expected: FAIL
+
+  [Same domain different protocol different port [origin KO\]]
+    expected: FAIL
+
+  [Cross domain [POST\] [origin OK\]]
+    expected: FAIL
+
+  [Cross domain [POST\] [origin KO\]]
+    expected: FAIL
+
+  [Cross domain [HEAD\] [origin OK\]]
+    expected: FAIL
+
+  [Cross domain [HEAD\] [origin KO\]]
+    expected: FAIL
+
+  [CORS preflight [PUT\] [origin OK\]]
+    expected: FAIL
+
+  [CORS preflight [PUT\] [origin KO\]]
+    expected: FAIL
+
+  [Allowed origin: "" [origin KO\]]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-preflight-redirect-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-preflight-redirect-worker.html.ini
@@ -1,6 +1,32 @@
 [cors-preflight-redirect-worker.html]
   type: testharness
-  expected: ERROR
   [Redirection 301 on preflight failed]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirection 301 after preflight failed]
+    expected: FAIL
+
+  [Redirection 302 on preflight failed]
+    expected: FAIL
+
+  [Redirection 302 after preflight failed]
+    expected: FAIL
+
+  [Redirection 303 on preflight failed]
+    expected: FAIL
+
+  [Redirection 303 after preflight failed]
+    expected: FAIL
+
+  [Redirection 307 on preflight failed]
+    expected: FAIL
+
+  [Redirection 307 after preflight failed]
+    expected: FAIL
+
+  [Redirection 308 on preflight failed]
+    expected: FAIL
+
+  [Redirection 308 after preflight failed]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-preflight-redirect.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-preflight-redirect.html.ini
@@ -1,6 +1,32 @@
 [cors-preflight-redirect.html]
   type: testharness
-  expected: ERROR
   [Redirection 301 on preflight failed]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirection 301 after preflight failed]
+    expected: FAIL
+
+  [Redirection 302 on preflight failed]
+    expected: FAIL
+
+  [Redirection 302 after preflight failed]
+    expected: FAIL
+
+  [Redirection 303 on preflight failed]
+    expected: FAIL
+
+  [Redirection 303 after preflight failed]
+    expected: FAIL
+
+  [Redirection 307 on preflight failed]
+    expected: FAIL
+
+  [Redirection 307 after preflight failed]
+    expected: FAIL
+
+  [Redirection 308 on preflight failed]
+    expected: FAIL
+
+  [Redirection 308 after preflight failed]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-preflight-referrer-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-preflight-referrer-worker.html.ini
@@ -1,6 +1,17 @@
 [cors-preflight-referrer-worker.html]
   type: testharness
-  expected: ERROR
   [Referrer policy: no-referrer]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Referrer policy: ""]
+    expected: FAIL
+
+  [Referrer policy: origin]
+    expected: FAIL
+
+  [Referrer policy: origin-when-cross-origin]
+    expected: FAIL
+
+  [Referrer policy: unsafe-url]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-preflight-referrer.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-preflight-referrer.html.ini
@@ -1,6 +1,17 @@
 [cors-preflight-referrer.html]
   type: testharness
-  expected: ERROR
   [Referrer policy: no-referrer]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Referrer policy: ""]
+    expected: FAIL
+
+  [Referrer policy: origin]
+    expected: FAIL
+
+  [Referrer policy: origin-when-cross-origin]
+    expected: FAIL
+
+  [Referrer policy: unsafe-url]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-preflight-status-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-preflight-status-worker.html.ini
@@ -1,6 +1,83 @@
 [cors-preflight-status-worker.html]
   type: testharness
-  expected: ERROR
   [Preflight answered with status 200]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Preflight answered with status 201]
+    expected: FAIL
+
+  [Preflight answered with status 202]
+    expected: FAIL
+
+  [Preflight answered with status 203]
+    expected: FAIL
+
+  [Preflight answered with status 204]
+    expected: FAIL
+
+  [Preflight answered with status 205]
+    expected: FAIL
+
+  [Preflight answered with status 206]
+    expected: FAIL
+
+  [Preflight answered with status 300]
+    expected: FAIL
+
+  [Preflight answered with status 301]
+    expected: FAIL
+
+  [Preflight answered with status 302]
+    expected: FAIL
+
+  [Preflight answered with status 303]
+    expected: FAIL
+
+  [Preflight answered with status 304]
+    expected: FAIL
+
+  [Preflight answered with status 305]
+    expected: FAIL
+
+  [Preflight answered with status 306]
+    expected: FAIL
+
+  [Preflight answered with status 307]
+    expected: FAIL
+
+  [Preflight answered with status 308]
+    expected: FAIL
+
+  [Preflight answered with status 400]
+    expected: FAIL
+
+  [Preflight answered with status 401]
+    expected: FAIL
+
+  [Preflight answered with status 402]
+    expected: FAIL
+
+  [Preflight answered with status 403]
+    expected: FAIL
+
+  [Preflight answered with status 404]
+    expected: FAIL
+
+  [Preflight answered with status 405]
+    expected: FAIL
+
+  [Preflight answered with status 501]
+    expected: FAIL
+
+  [Preflight answered with status 502]
+    expected: FAIL
+
+  [Preflight answered with status 503]
+    expected: FAIL
+
+  [Preflight answered with status 504]
+    expected: FAIL
+
+  [Preflight answered with status 505]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-preflight-status.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-preflight-status.html.ini
@@ -1,6 +1,83 @@
 [cors-preflight-status.html]
   type: testharness
-  expected: ERROR
   [Preflight answered with status 200]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Preflight answered with status 201]
+    expected: FAIL
+
+  [Preflight answered with status 202]
+    expected: FAIL
+
+  [Preflight answered with status 203]
+    expected: FAIL
+
+  [Preflight answered with status 204]
+    expected: FAIL
+
+  [Preflight answered with status 205]
+    expected: FAIL
+
+  [Preflight answered with status 206]
+    expected: FAIL
+
+  [Preflight answered with status 300]
+    expected: FAIL
+
+  [Preflight answered with status 301]
+    expected: FAIL
+
+  [Preflight answered with status 302]
+    expected: FAIL
+
+  [Preflight answered with status 303]
+    expected: FAIL
+
+  [Preflight answered with status 304]
+    expected: FAIL
+
+  [Preflight answered with status 305]
+    expected: FAIL
+
+  [Preflight answered with status 306]
+    expected: FAIL
+
+  [Preflight answered with status 307]
+    expected: FAIL
+
+  [Preflight answered with status 308]
+    expected: FAIL
+
+  [Preflight answered with status 400]
+    expected: FAIL
+
+  [Preflight answered with status 401]
+    expected: FAIL
+
+  [Preflight answered with status 402]
+    expected: FAIL
+
+  [Preflight answered with status 403]
+    expected: FAIL
+
+  [Preflight answered with status 404]
+    expected: FAIL
+
+  [Preflight answered with status 405]
+    expected: FAIL
+
+  [Preflight answered with status 501]
+    expected: FAIL
+
+  [Preflight answered with status 502]
+    expected: FAIL
+
+  [Preflight answered with status 503]
+    expected: FAIL
+
+  [Preflight answered with status 504]
+    expected: FAIL
+
+  [Preflight answered with status 505]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-preflight-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-preflight-worker.html.ini
@@ -1,6 +1,44 @@
 [cors-preflight-worker.html]
   type: testharness
-  expected: ERROR
   [CORS [DELETE\], server allows]
-    expected: NOTRUN
+    expected: FAIL
+
+  [CORS [DELETE\], server refuses]
+    expected: FAIL
+
+  [CORS [PUT\], server allows]
+    expected: FAIL
+
+  [CORS [PUT\], server refuses]
+    expected: FAIL
+
+  [CORS [PATCH\], server allows]
+    expected: FAIL
+
+  [CORS [PATCH\], server refuses]
+    expected: FAIL
+
+  [CORS [NEW\], server allows]
+    expected: FAIL
+
+  [CORS [NEW\], server refuses]
+    expected: FAIL
+
+  [CORS [GET\] [x-test-header: allowed\], server allows]
+    expected: FAIL
+
+  [CORS [GET\] [x-test-header: refused\], server refuses]
+    expected: FAIL
+
+  [CORS [GET\] [several headers\], server allows]
+    expected: FAIL
+
+  [CORS [GET\] [several headers\], server refuses]
+    expected: FAIL
+
+  [CORS [PUT\] [several headers\], server allows]
+    expected: FAIL
+
+  [CORS [PUT\] [several headers\], server refuses]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-preflight.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-preflight.html.ini
@@ -1,6 +1,44 @@
 [cors-preflight.html]
   type: testharness
-  expected: ERROR
   [CORS [DELETE\], server allows]
-    expected: NOTRUN
+    expected: FAIL
+
+  [CORS [DELETE\], server refuses]
+    expected: FAIL
+
+  [CORS [PUT\], server allows]
+    expected: FAIL
+
+  [CORS [PUT\], server refuses]
+    expected: FAIL
+
+  [CORS [PATCH\], server allows]
+    expected: FAIL
+
+  [CORS [PATCH\], server refuses]
+    expected: FAIL
+
+  [CORS [NEW\], server allows]
+    expected: FAIL
+
+  [CORS [NEW\], server refuses]
+    expected: FAIL
+
+  [CORS [GET\] [x-test-header: allowed\], server allows]
+    expected: FAIL
+
+  [CORS [GET\] [x-test-header: refused\], server refuses]
+    expected: FAIL
+
+  [CORS [GET\] [several headers\], server allows]
+    expected: FAIL
+
+  [CORS [GET\] [several headers\], server refuses]
+    expected: FAIL
+
+  [CORS [PUT\] [several headers\], server allows]
+    expected: FAIL
+
+  [CORS [PUT\] [several headers\], server refuses]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-redirect-credentials-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-redirect-credentials-worker.html.ini
@@ -1,6 +1,182 @@
 [cors-redirect-credentials-worker.html]
   type: testharness
-  expected: ERROR
   [Redirect 301 from same origin to remote with user and password]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301 from same origin to remote with user]
+    expected: FAIL
+
+  [Redirect 301 from same origin to remote with password]
+    expected: FAIL
+
+  [Redirect 301 from remote to same origin with user and password]
+    expected: FAIL
+
+  [Redirect 301 from remote to same origin with user]
+    expected: FAIL
+
+  [Redirect 301 from remote to same origin with password]
+    expected: FAIL
+
+  [Redirect 301 from remote to same remote with user and password]
+    expected: FAIL
+
+  [Redirect 301 from remote to same remote with user]
+    expected: FAIL
+
+  [Redirect 301 from remote to same remote with password]
+    expected: FAIL
+
+  [Redirect 301 from remote to another remote with user and password]
+    expected: FAIL
+
+  [Redirect 301 from remote to another remote with user]
+    expected: FAIL
+
+  [Redirect 301 from remote to another remote with password]
+    expected: FAIL
+
+  [Redirect 302 from same origin to remote with user and password]
+    expected: FAIL
+
+  [Redirect 302 from same origin to remote with user]
+    expected: FAIL
+
+  [Redirect 302 from same origin to remote with password]
+    expected: FAIL
+
+  [Redirect 302 from remote to same origin with user and password]
+    expected: FAIL
+
+  [Redirect 302 from remote to same origin with user]
+    expected: FAIL
+
+  [Redirect 302 from remote to same origin with password]
+    expected: FAIL
+
+  [Redirect 302 from remote to same remote with user and password]
+    expected: FAIL
+
+  [Redirect 302 from remote to same remote with user]
+    expected: FAIL
+
+  [Redirect 302 from remote to same remote with password]
+    expected: FAIL
+
+  [Redirect 302 from remote to another remote with user and password]
+    expected: FAIL
+
+  [Redirect 302 from remote to another remote with user]
+    expected: FAIL
+
+  [Redirect 302 from remote to another remote with password]
+    expected: FAIL
+
+  [Redirect 303 from same origin to remote with user and password]
+    expected: FAIL
+
+  [Redirect 303 from same origin to remote with user]
+    expected: FAIL
+
+  [Redirect 303 from same origin to remote with password]
+    expected: FAIL
+
+  [Redirect 303 from remote to same origin with user and password]
+    expected: FAIL
+
+  [Redirect 303 from remote to same origin with user]
+    expected: FAIL
+
+  [Redirect 303 from remote to same origin with password]
+    expected: FAIL
+
+  [Redirect 303 from remote to same remote with user and password]
+    expected: FAIL
+
+  [Redirect 303 from remote to same remote with user]
+    expected: FAIL
+
+  [Redirect 303 from remote to same remote with password]
+    expected: FAIL
+
+  [Redirect 303 from remote to another remote with user and password]
+    expected: FAIL
+
+  [Redirect 303 from remote to another remote with user]
+    expected: FAIL
+
+  [Redirect 303 from remote to another remote with password]
+    expected: FAIL
+
+  [Redirect 307 from same origin to remote with user and password]
+    expected: FAIL
+
+  [Redirect 307 from same origin to remote with user]
+    expected: FAIL
+
+  [Redirect 307 from same origin to remote with password]
+    expected: FAIL
+
+  [Redirect 307 from remote to same origin with user and password]
+    expected: FAIL
+
+  [Redirect 307 from remote to same origin with user]
+    expected: FAIL
+
+  [Redirect 307 from remote to same origin with password]
+    expected: FAIL
+
+  [Redirect 307 from remote to same remote with user and password]
+    expected: FAIL
+
+  [Redirect 307 from remote to same remote with user]
+    expected: FAIL
+
+  [Redirect 307 from remote to same remote with password]
+    expected: FAIL
+
+  [Redirect 307 from remote to another remote with user and password]
+    expected: FAIL
+
+  [Redirect 307 from remote to another remote with user]
+    expected: FAIL
+
+  [Redirect 307 from remote to another remote with password]
+    expected: FAIL
+
+  [Redirect 308 from same origin to remote with user and password]
+    expected: FAIL
+
+  [Redirect 308 from same origin to remote with user]
+    expected: FAIL
+
+  [Redirect 308 from same origin to remote with password]
+    expected: FAIL
+
+  [Redirect 308 from remote to same origin with user and password]
+    expected: FAIL
+
+  [Redirect 308 from remote to same origin with user]
+    expected: FAIL
+
+  [Redirect 308 from remote to same origin with password]
+    expected: FAIL
+
+  [Redirect 308 from remote to same remote with user and password]
+    expected: FAIL
+
+  [Redirect 308 from remote to same remote with user]
+    expected: FAIL
+
+  [Redirect 308 from remote to same remote with password]
+    expected: FAIL
+
+  [Redirect 308 from remote to another remote with user and password]
+    expected: FAIL
+
+  [Redirect 308 from remote to another remote with user]
+    expected: FAIL
+
+  [Redirect 308 from remote to another remote with password]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-redirect-credentials.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-redirect-credentials.html.ini
@@ -1,6 +1,182 @@
 [cors-redirect-credentials.html]
   type: testharness
-  expected: ERROR
   [Redirect 301 from same origin to remote with user and password]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301 from same origin to remote with user]
+    expected: FAIL
+
+  [Redirect 301 from same origin to remote with password]
+    expected: FAIL
+
+  [Redirect 301 from remote to same origin with user and password]
+    expected: FAIL
+
+  [Redirect 301 from remote to same origin with user]
+    expected: FAIL
+
+  [Redirect 301 from remote to same origin with password]
+    expected: FAIL
+
+  [Redirect 301 from remote to same remote with user and password]
+    expected: FAIL
+
+  [Redirect 301 from remote to same remote with user]
+    expected: FAIL
+
+  [Redirect 301 from remote to same remote with password]
+    expected: FAIL
+
+  [Redirect 301 from remote to another remote with user and password]
+    expected: FAIL
+
+  [Redirect 301 from remote to another remote with user]
+    expected: FAIL
+
+  [Redirect 301 from remote to another remote with password]
+    expected: FAIL
+
+  [Redirect 302 from same origin to remote with user and password]
+    expected: FAIL
+
+  [Redirect 302 from same origin to remote with user]
+    expected: FAIL
+
+  [Redirect 302 from same origin to remote with password]
+    expected: FAIL
+
+  [Redirect 302 from remote to same origin with user and password]
+    expected: FAIL
+
+  [Redirect 302 from remote to same origin with user]
+    expected: FAIL
+
+  [Redirect 302 from remote to same origin with password]
+    expected: FAIL
+
+  [Redirect 302 from remote to same remote with user and password]
+    expected: FAIL
+
+  [Redirect 302 from remote to same remote with user]
+    expected: FAIL
+
+  [Redirect 302 from remote to same remote with password]
+    expected: FAIL
+
+  [Redirect 302 from remote to another remote with user and password]
+    expected: FAIL
+
+  [Redirect 302 from remote to another remote with user]
+    expected: FAIL
+
+  [Redirect 302 from remote to another remote with password]
+    expected: FAIL
+
+  [Redirect 303 from same origin to remote with user and password]
+    expected: FAIL
+
+  [Redirect 303 from same origin to remote with user]
+    expected: FAIL
+
+  [Redirect 303 from same origin to remote with password]
+    expected: FAIL
+
+  [Redirect 303 from remote to same origin with user and password]
+    expected: FAIL
+
+  [Redirect 303 from remote to same origin with user]
+    expected: FAIL
+
+  [Redirect 303 from remote to same origin with password]
+    expected: FAIL
+
+  [Redirect 303 from remote to same remote with user and password]
+    expected: FAIL
+
+  [Redirect 303 from remote to same remote with user]
+    expected: FAIL
+
+  [Redirect 303 from remote to same remote with password]
+    expected: FAIL
+
+  [Redirect 303 from remote to another remote with user and password]
+    expected: FAIL
+
+  [Redirect 303 from remote to another remote with user]
+    expected: FAIL
+
+  [Redirect 303 from remote to another remote with password]
+    expected: FAIL
+
+  [Redirect 307 from same origin to remote with user and password]
+    expected: FAIL
+
+  [Redirect 307 from same origin to remote with user]
+    expected: FAIL
+
+  [Redirect 307 from same origin to remote with password]
+    expected: FAIL
+
+  [Redirect 307 from remote to same origin with user and password]
+    expected: FAIL
+
+  [Redirect 307 from remote to same origin with user]
+    expected: FAIL
+
+  [Redirect 307 from remote to same origin with password]
+    expected: FAIL
+
+  [Redirect 307 from remote to same remote with user and password]
+    expected: FAIL
+
+  [Redirect 307 from remote to same remote with user]
+    expected: FAIL
+
+  [Redirect 307 from remote to same remote with password]
+    expected: FAIL
+
+  [Redirect 307 from remote to another remote with user and password]
+    expected: FAIL
+
+  [Redirect 307 from remote to another remote with user]
+    expected: FAIL
+
+  [Redirect 307 from remote to another remote with password]
+    expected: FAIL
+
+  [Redirect 308 from same origin to remote with user and password]
+    expected: FAIL
+
+  [Redirect 308 from same origin to remote with user]
+    expected: FAIL
+
+  [Redirect 308 from same origin to remote with password]
+    expected: FAIL
+
+  [Redirect 308 from remote to same origin with user and password]
+    expected: FAIL
+
+  [Redirect 308 from remote to same origin with user]
+    expected: FAIL
+
+  [Redirect 308 from remote to same origin with password]
+    expected: FAIL
+
+  [Redirect 308 from remote to same remote with user and password]
+    expected: FAIL
+
+  [Redirect 308 from remote to same remote with user]
+    expected: FAIL
+
+  [Redirect 308 from remote to same remote with password]
+    expected: FAIL
+
+  [Redirect 308 from remote to another remote with user and password]
+    expected: FAIL
+
+  [Redirect 308 from remote to another remote with user]
+    expected: FAIL
+
+  [Redirect 308 from remote to another remote with password]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-redirect-preflight-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-redirect-preflight-worker.html.ini
@@ -1,6 +1,92 @@
 [cors-redirect-preflight-worker.html]
   type: testharness
-  expected: ERROR
   [Redirect 301: same origin to cors (preflight after redirection success case)]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301: same origin to cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 301: cors to same origin (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 301: cors to same origin (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 301: cors to another cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 301: cors to another cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 302: same origin to cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 302: same origin to cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 302: cors to same origin (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 302: cors to same origin (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 302: cors to another cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 302: cors to another cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 303: same origin to cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 303: same origin to cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 303: cors to same origin (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 303: cors to same origin (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 303: cors to another cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 303: cors to another cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 307: same origin to cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 307: same origin to cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 307: cors to same origin (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 307: cors to same origin (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 307: cors to another cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 307: cors to another cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 308: same origin to cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 308: same origin to cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 308: cors to same origin (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 308: cors to same origin (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 308: cors to another cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 308: cors to another cors (preflight after redirection failure case)]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-redirect-preflight.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-redirect-preflight.html.ini
@@ -1,6 +1,92 @@
 [cors-redirect-preflight.html]
   type: testharness
-  expected: ERROR
   [Redirect 301: same origin to cors (preflight after redirection success case)]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301: same origin to cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 301: cors to same origin (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 301: cors to same origin (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 301: cors to another cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 301: cors to another cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 302: same origin to cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 302: same origin to cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 302: cors to same origin (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 302: cors to same origin (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 302: cors to another cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 302: cors to another cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 303: same origin to cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 303: same origin to cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 303: cors to same origin (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 303: cors to same origin (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 303: cors to another cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 303: cors to another cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 307: same origin to cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 307: same origin to cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 307: cors to same origin (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 307: cors to same origin (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 307: cors to another cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 307: cors to another cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 308: same origin to cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 308: same origin to cors (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 308: cors to same origin (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 308: cors to same origin (preflight after redirection failure case)]
+    expected: FAIL
+
+  [Redirect 308: cors to another cors (preflight after redirection success case)]
+    expected: FAIL
+
+  [Redirect 308: cors to another cors (preflight after redirection failure case)]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-redirect-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-redirect-worker.html.ini
@@ -1,6 +1,62 @@
 [cors-redirect-worker.html]
   type: testharness
-  expected: ERROR
   [Redirect 301: cors to same cors]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301: cors to another cors]
+    expected: FAIL
+
+  [Redirect 301: same origin to cors]
+    expected: FAIL
+
+  [Redirect 301: cors to same origin]
+    expected: FAIL
+
+  [Redirect 302: cors to same cors]
+    expected: FAIL
+
+  [Redirect 302: cors to another cors]
+    expected: FAIL
+
+  [Redirect 302: same origin to cors]
+    expected: FAIL
+
+  [Redirect 302: cors to same origin]
+    expected: FAIL
+
+  [Redirect 303: cors to same cors]
+    expected: FAIL
+
+  [Redirect 303: cors to another cors]
+    expected: FAIL
+
+  [Redirect 303: same origin to cors]
+    expected: FAIL
+
+  [Redirect 303: cors to same origin]
+    expected: FAIL
+
+  [Redirect 307: cors to same cors]
+    expected: FAIL
+
+  [Redirect 307: cors to another cors]
+    expected: FAIL
+
+  [Redirect 307: same origin to cors]
+    expected: FAIL
+
+  [Redirect 307: cors to same origin]
+    expected: FAIL
+
+  [Redirect 308: cors to same cors]
+    expected: FAIL
+
+  [Redirect 308: cors to another cors]
+    expected: FAIL
+
+  [Redirect 308: same origin to cors]
+    expected: FAIL
+
+  [Redirect 308: cors to same origin]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/cors/cors-redirect.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-redirect.html.ini
@@ -1,6 +1,62 @@
 [cors-redirect.html]
   type: testharness
-  expected: ERROR
   [Redirect 301: cors to same cors]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301: cors to another cors]
+    expected: FAIL
+
+  [Redirect 301: same origin to cors]
+    expected: FAIL
+
+  [Redirect 301: cors to same origin]
+    expected: FAIL
+
+  [Redirect 302: cors to same cors]
+    expected: FAIL
+
+  [Redirect 302: cors to another cors]
+    expected: FAIL
+
+  [Redirect 302: same origin to cors]
+    expected: FAIL
+
+  [Redirect 302: cors to same origin]
+    expected: FAIL
+
+  [Redirect 303: cors to same cors]
+    expected: FAIL
+
+  [Redirect 303: cors to another cors]
+    expected: FAIL
+
+  [Redirect 303: same origin to cors]
+    expected: FAIL
+
+  [Redirect 303: cors to same origin]
+    expected: FAIL
+
+  [Redirect 307: cors to same cors]
+    expected: FAIL
+
+  [Redirect 307: cors to another cors]
+    expected: FAIL
+
+  [Redirect 307: same origin to cors]
+    expected: FAIL
+
+  [Redirect 307: cors to same origin]
+    expected: FAIL
+
+  [Redirect 308: cors to same cors]
+    expected: FAIL
+
+  [Redirect 308: cors to another cors]
+    expected: FAIL
+
+  [Redirect 308: same origin to cors]
+    expected: FAIL
+
+  [Redirect 308: cors to same origin]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/credentials/authentication-basic-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/credentials/authentication-basic-worker.html.ini
@@ -1,6 +1,11 @@
 [authentication-basic-worker.html]
   type: testharness
-  expected: ERROR
   [User-added Authorization header with include mode]
-    expected: NOTRUN
+    expected: FAIL
+
+  [User-added Authorization header with same-origin mode]
+    expected: FAIL
+
+  [User-added Authorization header with omit mode]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/credentials/authentication-basic.html.ini
+++ b/tests/wpt/metadata/fetch/api/credentials/authentication-basic.html.ini
@@ -1,6 +1,11 @@
 [authentication-basic.html]
   type: testharness
-  expected: ERROR
   [User-added Authorization header with include mode]
-    expected: NOTRUN
+    expected: FAIL
+
+  [User-added Authorization header with same-origin mode]
+    expected: FAIL
+
+  [User-added Authorization header with omit mode]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/credentials/cookies-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/credentials/cookies-worker.html.ini
@@ -1,6 +1,23 @@
 [cookies-worker.html]
   type: testharness
-  expected: ERROR
   [Include mode: 1 cookie]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Include mode: 2 cookies]
+    expected: FAIL
+
+  [Omit mode: discard cookies]
+    expected: FAIL
+
+  [Omit mode: no cookie is stored]
+    expected: FAIL
+
+  [Omit mode: no cookie is sent]
+    expected: FAIL
+
+  [Same-origin mode: 1 cookie]
+    expected: FAIL
+
+  [Same-origin mode: 2 cookies]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/credentials/cookies.html.ini
+++ b/tests/wpt/metadata/fetch/api/credentials/cookies.html.ini
@@ -1,6 +1,23 @@
 [cookies.html]
   type: testharness
-  expected: ERROR
   [Include mode: 1 cookie]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Include mode: 2 cookies]
+    expected: FAIL
+
+  [Omit mode: discard cookies]
+    expected: FAIL
+
+  [Omit mode: no cookie is stored]
+    expected: FAIL
+
+  [Omit mode: no cookie is sent]
+    expected: FAIL
+
+  [Same-origin mode: 1 cookie]
+    expected: FAIL
+
+  [Same-origin mode: 2 cookies]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/policies/csp-blocked-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/csp-blocked-worker.html.ini
@@ -1,6 +1,5 @@
 [csp-blocked-worker.html]
   type: testharness
-  expected: ERROR
   [Fetch is blocked by CSP, got a TypeError]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/policies/csp-blocked.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/csp-blocked.html.ini
@@ -1,6 +1,5 @@
 [csp-blocked.html]
   type: testharness
-  expected: ERROR
   [Fetch is blocked by CSP, got a TypeError]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/policies/referrer-no-referrer-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/referrer-no-referrer-worker.html.ini
@@ -1,6 +1,5 @@
 [referrer-no-referrer-worker.html]
   type: testharness
-  expected: ERROR
   [Request's referrer is empty]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/policies/referrer-no-referrer.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/referrer-no-referrer.html.ini
@@ -1,6 +1,5 @@
 [referrer-no-referrer.html]
   type: testharness
-  expected: ERROR
   [Request's referrer is empty]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/policies/referrer-origin-when-cross-origin-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/referrer-origin-when-cross-origin-worker.html.ini
@@ -1,6 +1,5 @@
 [referrer-origin-when-cross-origin-worker.html]
   type: testharness
-  expected: ERROR
   [Request's referrer is origin]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/policies/referrer-origin-when-cross-origin.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/referrer-origin-when-cross-origin.html.ini
@@ -1,6 +1,5 @@
 [referrer-origin-when-cross-origin.html]
   type: testharness
-  expected: ERROR
   [Request's referrer is origin]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/policies/referrer-origin-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/referrer-origin-worker.html.ini
@@ -1,6 +1,8 @@
 [referrer-origin-worker.html]
   type: testharness
-  expected: ERROR
   [Request's referrer is origin]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Throw a TypeError referrer is not same-origin with origin]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/policies/referrer-origin.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/referrer-origin.html.ini
@@ -1,6 +1,8 @@
 [referrer-origin.html]
   type: testharness
-  expected: ERROR
   [Request's referrer is origin]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Throw a TypeError referrer is not same-origin with origin]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/policies/referrer-unsafe-url-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/referrer-unsafe-url-worker.html.ini
@@ -1,6 +1,5 @@
 [referrer-unsafe-url-worker.html]
   type: testharness
-  expected: ERROR
   [Request's referrer is the full url of current document/worker]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/policies/referrer-unsafe-url.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/referrer-unsafe-url.html.ini
@@ -1,6 +1,5 @@
 [referrer-unsafe-url.html]
   type: testharness
-  expected: ERROR
   [Request's referrer is the full url of current document/worker]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-count-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-count-worker.html.ini
@@ -1,6 +1,32 @@
 [redirect-count-worker.html]
   type: testharness
-  expected: ERROR
   [Redirect 301 20 times]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301 21 times]
+    expected: FAIL
+
+  [Redirect 302 20 times]
+    expected: FAIL
+
+  [Redirect 302 21 times]
+    expected: FAIL
+
+  [Redirect 303 20 times]
+    expected: FAIL
+
+  [Redirect 303 21 times]
+    expected: FAIL
+
+  [Redirect 307 20 times]
+    expected: FAIL
+
+  [Redirect 307 21 times]
+    expected: FAIL
+
+  [Redirect 308 20 times]
+    expected: FAIL
+
+  [Redirect 308 21 times]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-count.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-count.html.ini
@@ -1,6 +1,32 @@
 [redirect-count.html]
   type: testharness
-  expected: ERROR
   [Redirect 301 20 times]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301 21 times]
+    expected: FAIL
+
+  [Redirect 302 20 times]
+    expected: FAIL
+
+  [Redirect 302 21 times]
+    expected: FAIL
+
+  [Redirect 303 20 times]
+    expected: FAIL
+
+  [Redirect 303 21 times]
+    expected: FAIL
+
+  [Redirect 307 20 times]
+    expected: FAIL
+
+  [Redirect 307 21 times]
+    expected: FAIL
+
+  [Redirect 308 20 times]
+    expected: FAIL
+
+  [Redirect 308 21 times]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-location-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-location-worker.html.ini
@@ -1,6 +1,92 @@
 [redirect-location-worker.html]
   type: testharness
-  expected: ERROR
   [Redirect 301 in "follow" mode without location]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301 in "manual" mode without location]
+    expected: FAIL
+
+  [Redirect 301 in "follow" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 301 in "manual" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 301 in "follow" mode with data location]
+    expected: FAIL
+
+  [Redirect 301 in "manual" mode with data location]
+    expected: FAIL
+
+  [Redirect 302 in "follow" mode without location]
+    expected: FAIL
+
+  [Redirect 302 in "manual" mode without location]
+    expected: FAIL
+
+  [Redirect 302 in "follow" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 302 in "manual" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 302 in "follow" mode with data location]
+    expected: FAIL
+
+  [Redirect 302 in "manual" mode with data location]
+    expected: FAIL
+
+  [Redirect 303 in "follow" mode without location]
+    expected: FAIL
+
+  [Redirect 303 in "manual" mode without location]
+    expected: FAIL
+
+  [Redirect 303 in "follow" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 303 in "manual" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 303 in "follow" mode with data location]
+    expected: FAIL
+
+  [Redirect 303 in "manual" mode with data location]
+    expected: FAIL
+
+  [Redirect 307 in "follow" mode without location]
+    expected: FAIL
+
+  [Redirect 307 in "manual" mode without location]
+    expected: FAIL
+
+  [Redirect 307 in "follow" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 307 in "manual" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 307 in "follow" mode with data location]
+    expected: FAIL
+
+  [Redirect 307 in "manual" mode with data location]
+    expected: FAIL
+
+  [Redirect 308 in "follow" mode without location]
+    expected: FAIL
+
+  [Redirect 308 in "manual" mode without location]
+    expected: FAIL
+
+  [Redirect 308 in "follow" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 308 in "manual" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 308 in "follow" mode with data location]
+    expected: FAIL
+
+  [Redirect 308 in "manual" mode with data location]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-location.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-location.html.ini
@@ -1,6 +1,92 @@
 [redirect-location.html]
   type: testharness
-  expected: ERROR
   [Redirect 301 in "follow" mode without location]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301 in "manual" mode without location]
+    expected: FAIL
+
+  [Redirect 301 in "follow" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 301 in "manual" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 301 in "follow" mode with data location]
+    expected: FAIL
+
+  [Redirect 301 in "manual" mode with data location]
+    expected: FAIL
+
+  [Redirect 302 in "follow" mode without location]
+    expected: FAIL
+
+  [Redirect 302 in "manual" mode without location]
+    expected: FAIL
+
+  [Redirect 302 in "follow" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 302 in "manual" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 302 in "follow" mode with data location]
+    expected: FAIL
+
+  [Redirect 302 in "manual" mode with data location]
+    expected: FAIL
+
+  [Redirect 303 in "follow" mode without location]
+    expected: FAIL
+
+  [Redirect 303 in "manual" mode without location]
+    expected: FAIL
+
+  [Redirect 303 in "follow" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 303 in "manual" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 303 in "follow" mode with data location]
+    expected: FAIL
+
+  [Redirect 303 in "manual" mode with data location]
+    expected: FAIL
+
+  [Redirect 307 in "follow" mode without location]
+    expected: FAIL
+
+  [Redirect 307 in "manual" mode without location]
+    expected: FAIL
+
+  [Redirect 307 in "follow" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 307 in "manual" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 307 in "follow" mode with data location]
+    expected: FAIL
+
+  [Redirect 307 in "manual" mode with data location]
+    expected: FAIL
+
+  [Redirect 308 in "follow" mode without location]
+    expected: FAIL
+
+  [Redirect 308 in "manual" mode without location]
+    expected: FAIL
+
+  [Redirect 308 in "follow" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 308 in "manual" mode with invalid location]
+    expected: FAIL
+
+  [Redirect 308 in "follow" mode with data location]
+    expected: FAIL
+
+  [Redirect 308 in "manual" mode with data location]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-method-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-method-worker.html.ini
@@ -1,6 +1,41 @@
 [redirect-method-worker.html]
   type: testharness
-  expected: ERROR
   [Response.redirected should be false on not-redirected responses]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301 with GET]
+    expected: FAIL
+
+  [Redirect 301 with POST]
+    expected: FAIL
+
+  [Redirect 301 with HEAD]
+    expected: FAIL
+
+  [Redirect 302 with GET]
+    expected: FAIL
+
+  [Redirect 302 with POST]
+    expected: FAIL
+
+  [Redirect 302 with HEAD]
+    expected: FAIL
+
+  [Redirect 303 with GET]
+    expected: FAIL
+
+  [Redirect 303 with POST]
+    expected: FAIL
+
+  [Redirect 303 with HEAD]
+    expected: FAIL
+
+  [Redirect 307 with GET]
+    expected: FAIL
+
+  [Redirect 307 with POST]
+    expected: FAIL
+
+  [Redirect 307 with HEAD]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-method.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-method.html.ini
@@ -1,6 +1,41 @@
 [redirect-method.html]
   type: testharness
-  expected: ERROR
   [Response.redirected should be false on not-redirected responses]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301 with GET]
+    expected: FAIL
+
+  [Redirect 301 with POST]
+    expected: FAIL
+
+  [Redirect 301 with HEAD]
+    expected: FAIL
+
+  [Redirect 302 with GET]
+    expected: FAIL
+
+  [Redirect 302 with POST]
+    expected: FAIL
+
+  [Redirect 302 with HEAD]
+    expected: FAIL
+
+  [Redirect 303 with GET]
+    expected: FAIL
+
+  [Redirect 303 with POST]
+    expected: FAIL
+
+  [Redirect 303 with HEAD]
+    expected: FAIL
+
+  [Redirect 307 with GET]
+    expected: FAIL
+
+  [Redirect 307 with POST]
+    expected: FAIL
+
+  [Redirect 307 with HEAD]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-mode-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-mode-worker.html.ini
@@ -1,6 +1,47 @@
 [redirect-mode-worker.html]
   type: testharness
-  expected: ERROR
   [Redirect 301 in "error" mode ]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301 in "follow" mode ]
+    expected: FAIL
+
+  [Redirect 301 in "manual" mode ]
+    expected: FAIL
+
+  [Redirect 302 in "error" mode ]
+    expected: FAIL
+
+  [Redirect 302 in "follow" mode ]
+    expected: FAIL
+
+  [Redirect 302 in "manual" mode ]
+    expected: FAIL
+
+  [Redirect 303 in "error" mode ]
+    expected: FAIL
+
+  [Redirect 303 in "follow" mode ]
+    expected: FAIL
+
+  [Redirect 303 in "manual" mode ]
+    expected: FAIL
+
+  [Redirect 307 in "error" mode ]
+    expected: FAIL
+
+  [Redirect 307 in "follow" mode ]
+    expected: FAIL
+
+  [Redirect 307 in "manual" mode ]
+    expected: FAIL
+
+  [Redirect 308 in "error" mode ]
+    expected: FAIL
+
+  [Redirect 308 in "follow" mode ]
+    expected: FAIL
+
+  [Redirect 308 in "manual" mode ]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-mode.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-mode.html.ini
@@ -1,6 +1,47 @@
 [redirect-mode.html]
   type: testharness
-  expected: ERROR
   [Redirect 301 in "error" mode ]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Redirect 301 in "follow" mode ]
+    expected: FAIL
+
+  [Redirect 301 in "manual" mode ]
+    expected: FAIL
+
+  [Redirect 302 in "error" mode ]
+    expected: FAIL
+
+  [Redirect 302 in "follow" mode ]
+    expected: FAIL
+
+  [Redirect 302 in "manual" mode ]
+    expected: FAIL
+
+  [Redirect 303 in "error" mode ]
+    expected: FAIL
+
+  [Redirect 303 in "follow" mode ]
+    expected: FAIL
+
+  [Redirect 303 in "manual" mode ]
+    expected: FAIL
+
+  [Redirect 307 in "error" mode ]
+    expected: FAIL
+
+  [Redirect 307 in "follow" mode ]
+    expected: FAIL
+
+  [Redirect 307 in "manual" mode ]
+    expected: FAIL
+
+  [Redirect 308 in "error" mode ]
+    expected: FAIL
+
+  [Redirect 308 in "follow" mode ]
+    expected: FAIL
+
+  [Redirect 308 in "manual" mode ]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-origin-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-origin-worker.html.ini
@@ -1,6 +1,62 @@
 [redirect-origin-worker.html]
   type: testharness
-  expected: ERROR
   [Same origin to same origin redirection 301]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Same origin to other origin redirection 301]
+    expected: FAIL
+
+  [Other origin to other origin redirection 301]
+    expected: FAIL
+
+  [Other origin to same origin redirection 301]
+    expected: FAIL
+
+  [Same origin to same origin redirection 302]
+    expected: FAIL
+
+  [Same origin to other origin redirection 302]
+    expected: FAIL
+
+  [Other origin to other origin redirection 302]
+    expected: FAIL
+
+  [Other origin to same origin redirection 302]
+    expected: FAIL
+
+  [Same origin to same origin redirection 303]
+    expected: FAIL
+
+  [Same origin to other origin redirection 303]
+    expected: FAIL
+
+  [Other origin to other origin redirection 303]
+    expected: FAIL
+
+  [Other origin to same origin redirection 303]
+    expected: FAIL
+
+  [Same origin to same origin redirection 307]
+    expected: FAIL
+
+  [Same origin to other origin redirection 307]
+    expected: FAIL
+
+  [Other origin to other origin redirection 307]
+    expected: FAIL
+
+  [Other origin to same origin redirection 307]
+    expected: FAIL
+
+  [Same origin to same origin redirection 308]
+    expected: FAIL
+
+  [Same origin to other origin redirection 308]
+    expected: FAIL
+
+  [Other origin to other origin redirection 308]
+    expected: FAIL
+
+  [Other origin to same origin redirection 308]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-origin.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-origin.html.ini
@@ -1,6 +1,62 @@
 [redirect-origin.html]
   type: testharness
-  expected: ERROR
   [Same origin to same origin redirection 301]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Same origin to other origin redirection 301]
+    expected: FAIL
+
+  [Other origin to other origin redirection 301]
+    expected: FAIL
+
+  [Other origin to same origin redirection 301]
+    expected: FAIL
+
+  [Same origin to same origin redirection 302]
+    expected: FAIL
+
+  [Same origin to other origin redirection 302]
+    expected: FAIL
+
+  [Other origin to other origin redirection 302]
+    expected: FAIL
+
+  [Other origin to same origin redirection 302]
+    expected: FAIL
+
+  [Same origin to same origin redirection 303]
+    expected: FAIL
+
+  [Same origin to other origin redirection 303]
+    expected: FAIL
+
+  [Other origin to other origin redirection 303]
+    expected: FAIL
+
+  [Other origin to same origin redirection 303]
+    expected: FAIL
+
+  [Same origin to same origin redirection 307]
+    expected: FAIL
+
+  [Same origin to other origin redirection 307]
+    expected: FAIL
+
+  [Other origin to other origin redirection 307]
+    expected: FAIL
+
+  [Other origin to same origin redirection 307]
+    expected: FAIL
+
+  [Same origin to same origin redirection 308]
+    expected: FAIL
+
+  [Same origin to other origin redirection 308]
+    expected: FAIL
+
+  [Other origin to other origin redirection 308]
+    expected: FAIL
+
+  [Other origin to same origin redirection 308]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-schemes.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-schemes.html.ini
@@ -1,6 +1,20 @@
 [redirect-schemes.html]
   type: testharness
-  expected: ERROR
   [Fetch: handling different schemes in redirects]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Fetch: handling different schemes in redirects 1]
+    expected: FAIL
+
+  [Fetch: handling different schemes in redirects 2]
+    expected: FAIL
+
+  [Fetch: handling different schemes in redirects 3]
+    expected: FAIL
+
+  [Fetch: handling different schemes in redirects 4]
+    expected: FAIL
+
+  [Fetch: handling different schemes in redirects 5]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-to-dataurl-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-to-dataurl-worker.html.ini
@@ -1,6 +1,17 @@
 [redirect-to-dataurl-worker.html]
   type: testharness
-  expected: ERROR
   [Testing data URL loading after same-origin redirection (cors mode)]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Testing data URL loading after same-origin redirection (no-cors mode)]
+    expected: FAIL
+
+  [Testing data URL loading after same-origin redirection (same-origin mode)]
+    expected: FAIL
+
+  [Testing data URL loading after cross-origin redirection (cors mode)]
+    expected: FAIL
+
+  [Testing data URL loading after cross-origin redirection (no-cors mode)]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-to-dataurl.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-to-dataurl.html.ini
@@ -1,6 +1,17 @@
 [redirect-to-dataurl.html]
   type: testharness
-  expected: ERROR
   [Testing data URL loading after same-origin redirection (cors mode)]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Testing data URL loading after same-origin redirection (no-cors mode)]
+    expected: FAIL
+
+  [Testing data URL loading after same-origin redirection (same-origin mode)]
+    expected: FAIL
+
+  [Testing data URL loading after cross-origin redirection (cors mode)]
+    expected: FAIL
+
+  [Testing data URL loading after cross-origin redirection (no-cors mode)]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/request/request-cache.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-cache.html.ini
@@ -1,6 +1,248 @@
 [request-cache.html]
   type: testharness
-  expected: ERROR
   [RequestCache "default" mode checks the cache for previously cached content and goes to the network for stale responses with Etag and stale response]
-    expected: NOTRUN
+    expected: FAIL
+
+  [RequestCache "default" mode checks the cache for previously cached content and goes to the network for stale responses with date and stale response]
+    expected: FAIL
+
+  [RequestCache "default" mode checks the cache for previously cached content and avoids going to the network if a fresh response exists with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "default" mode checks the cache for previously cached content and avoids going to the network if a fresh response exists with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "no-cache" mode revalidates stale responses found in the cache with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "no-cache" mode revalidates stale responses found in the cache with date and stale response]
+    expected: FAIL
+
+  [RequestCache "no-cache" mode revalidates fresh responses found in the cache with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "no-cache" mode revalidates fresh responses found in the cache with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and avoid revalidation for stale responses with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and avoid revalidation for stale responses with date and stale response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and avoid revalidation for fresh responses with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and avoid revalidation for fresh responses with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and goes to the network if a cached response is not found with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and goes to the network if a cached response is not found with date and stale response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and goes to the network if a cached response is not found with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and goes to the network if a cached response is not found with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and goes to the network if a cached response would vary with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and goes to the network if a cached response would vary with date and stale response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and goes to the network if a cached response would vary with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "force-cache" mode checks the cache for previously cached content and goes to the network if a cached response would vary with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "force-cache" stores the response in the cache if it goes to the network with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "force-cache" stores the response in the cache if it goes to the network with date and stale response]
+    expected: FAIL
+
+  [RequestCache "force-cache" stores the response in the cache if it goes to the network with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "force-cache" stores the response in the cache if it goes to the network with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" mode checks the cache for previously cached content and avoids revalidation for stale responses with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" mode checks the cache for previously cached content and avoids revalidation for stale responses with date and stale response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" mode checks the cache for previously cached content and avoids revalidation for fresh responses with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" mode checks the cache for previously cached content and avoids revalidation for fresh responses with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" mode checks the cache for previously cached content and does not go to the network if a cached response is not found with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" mode checks the cache for previously cached content and does not go to the network if a cached response is not found with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" (with "same-origin") uses cached same-origin redirects to same-origin content with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" (with "same-origin") uses cached same-origin redirects to same-origin content with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" (with "same-origin") uses cached same-origin redirects to same-origin content with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" (with "same-origin") uses cached same-origin redirects to same-origin content with date and stale response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" (with "same-origin") does not follow redirects across origins and rejects with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" (with "same-origin") does not follow redirects across origins and rejects with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" (with "same-origin") does not follow redirects across origins and rejects with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "only-if-cached" (with "same-origin") does not follow redirects across origins and rejects with date and stale response]
+    expected: FAIL
+
+  [RequestCache "no-store" mode does not check the cache for previously cached content and goes to the network regardless with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "no-store" mode does not check the cache for previously cached content and goes to the network regardless with date and stale response]
+    expected: FAIL
+
+  [RequestCache "no-store" mode does not check the cache for previously cached content and goes to the network regardless with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "no-store" mode does not check the cache for previously cached content and goes to the network regardless with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "no-store" mode does not store the response in the cache with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "no-store" mode does not store the response in the cache with date and stale response]
+    expected: FAIL
+
+  [RequestCache "no-store" mode does not store the response in the cache with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "no-store" mode does not store the response in the cache with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Modified-Since header is treated similarly to "no-store" with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Modified-Since header is treated similarly to "no-store" with date and stale response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Modified-Since header is treated similarly to "no-store" with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Modified-Since header is treated similarly to "no-store" with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-None-Match header is treated similarly to "no-store" with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-None-Match header is treated similarly to "no-store" with date and stale response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-None-Match header is treated similarly to "no-store" with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-None-Match header is treated similarly to "no-store" with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Unmodified-Since header is treated similarly to "no-store" with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Unmodified-Since header is treated similarly to "no-store" with date and stale response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Unmodified-Since header is treated similarly to "no-store" with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Unmodified-Since header is treated similarly to "no-store" with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Match header is treated similarly to "no-store" with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Match header is treated similarly to "no-store" with date and stale response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Match header is treated similarly to "no-store" with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Match header is treated similarly to "no-store" with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Range header is treated similarly to "no-store" with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Range header is treated similarly to "no-store" with date and stale response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Range header is treated similarly to "no-store" with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "default" mode with an If-Range header is treated similarly to "no-store" with date and fresh response]
+    expected: FAIL
+
+  [Responses with the "Cache-Control: no-store" header are not stored in the cache with Etag and stale response]
+    expected: FAIL
+
+  [Responses with the "Cache-Control: no-store" header are not stored in the cache with date and stale response]
+    expected: FAIL
+
+  [Responses with the "Cache-Control: no-store" header are not stored in the cache with Etag and fresh response]
+    expected: FAIL
+
+  [Responses with the "Cache-Control: no-store" header are not stored in the cache with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does not check the cache for previously cached content and goes to the network regardless with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does not check the cache for previously cached content and goes to the network regardless with date and stale response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does not check the cache for previously cached content and goes to the network regardless with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does not check the cache for previously cached content and goes to the network regardless with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does store the response in the cache with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does store the response in the cache with date and stale response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does store the response in the cache with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does store the response in the cache with date and fresh response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does store the response in the cache even if a previous response is already stored with Etag and stale response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does store the response in the cache even if a previous response is already stored with date and stale response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does store the response in the cache even if a previous response is already stored with Etag and fresh response]
+    expected: FAIL
+
+  [RequestCache "reload" mode does store the response in the cache even if a previous response is already stored with date and fresh response]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/request/request-consume-empty.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-consume-empty.html.ini
@@ -1,6 +1,29 @@
 [request-consume-empty.html]
   type: testharness
-  expected: ERROR
   [Consume request's body as text]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Consume request's body as blob]
+    expected: FAIL
+
+  [Consume request's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume request's body as json]
+    expected: FAIL
+
+  [Consume request's body as formData]
+    expected: FAIL
+
+  [Consume empty blob request body as arrayBuffer]
+    expected: FAIL
+
+  [Consume empty text request body as arrayBuffer]
+    expected: FAIL
+
+  [Consume empty blob request body as text]
+    expected: FAIL
+
+  [Consume empty text request body as text]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/request/request-consume.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-consume.html.ini
@@ -1,9 +1,122 @@
 [request-consume.html]
   type: testharness
-  expected: ERROR
-  [Consume request's body as text]
+  [Consume String request's body as text]
     expected: FAIL
 
-  [Consume String request's body as text]
-    expected: NOTRUN
+  [Consume String request's body as blob]
+    expected: FAIL
+
+  [Consume String request's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume String request's body as json]
+    expected: FAIL
+
+  [Consume String request's body as formData]
+    expected: FAIL
+
+  [Consume blob response's body as blob]
+    expected: FAIL
+
+  [Consume blob response's body as text]
+    expected: FAIL
+
+  [Consume blob response's body as json]
+    expected: FAIL
+
+  [Consume blob response's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume JSON from text: '"null"']
+    expected: FAIL
+
+  [Consume JSON from text: '"1"']
+    expected: FAIL
+
+  [Consume JSON from text: '"true"']
+    expected: FAIL
+
+  [Consume JSON from text: '"\\"string\\""']
+    expected: FAIL
+
+  [Trying to consume bad JSON text as JSON: 'undefined']
+    expected: FAIL
+
+  [Trying to consume bad JSON text as JSON: '{']
+    expected: FAIL
+
+  [Trying to consume bad JSON text as JSON: 'a']
+    expected: FAIL
+
+  [Trying to consume bad JSON text as JSON: '[']
+    expected: FAIL
+
+  [Consume String request's body as JSON]
+    expected: FAIL
+
+  [Consume ArrayBuffer request's body as text]
+    expected: FAIL
+
+  [Consume ArrayBuffer request's body as blob]
+    expected: FAIL
+
+  [Consume ArrayBuffer request's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume ArrayBuffer request's body as JSON]
+    expected: FAIL
+
+  [Consume Uint8Array request's body as text]
+    expected: FAIL
+
+  [Consume Uint8Array request's body as blob]
+    expected: FAIL
+
+  [Consume Uint8Array request's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume Uint8Array request's body as JSON]
+    expected: FAIL
+
+  [Consume Int8Array request's body as text]
+    expected: FAIL
+
+  [Consume Int8Array request's body as blob]
+    expected: FAIL
+
+  [Consume Int8Array request's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume Int8Array request's body as JSON]
+    expected: FAIL
+
+  [Consume Float32Array request's body as text]
+    expected: FAIL
+
+  [Consume Float32Array request's body as blob]
+    expected: FAIL
+
+  [Consume Float32Array request's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume Float32Array request's body as JSON]
+    expected: FAIL
+
+  [Consume DataView request's body as text]
+    expected: FAIL
+
+  [Consume DataView request's body as blob]
+    expected: FAIL
+
+  [Consume DataView request's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume DataView request's body as JSON]
+    expected: FAIL
+
+  [Consume FormData request's body as FormData]
+    expected: FAIL
+
+  [Consume blob response's body as blob (empty blob as input)]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/request/request-headers.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-headers.html.ini
@@ -1,6 +1,5 @@
 [request-headers.html]
   type: testharness
-  expected: ERROR
   [Request should get its content-type from the body if none is provided]
     expected: FAIL
 
@@ -8,5 +7,5 @@
     expected: FAIL
 
   [Testing empty Request Content-Type header]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/request/request-init-002.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-init-002.html.ini
@@ -1,9 +1,23 @@
 [request-init-002.html]
   type: testharness
-  expected: ERROR
   [Initialize Request with headers values]
     expected: FAIL
 
   [Initialize Request's body with undefined]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Initialize Request's body with null]
+    expected: FAIL
+
+  [Initialize Request's body with application/octet-binary]
+    expected: FAIL
+
+  [Initialize Request's body with multipart/form-data]
+    expected: FAIL
+
+  [Initialize Request's body with text/plain;charset=UTF-8]
+    expected: FAIL
+
+  [Initialize Request's body with application/x-www-form-urlencoded;charset=UTF-8]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/response/response-cancel-stream.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-cancel-stream.html.ini
@@ -1,6 +1,20 @@
 [response-cancel-stream.html]
   type: testharness
-  expected: ERROR
   [Cancelling a starting blob Response stream]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Cancelling a loading blob Response stream]
+    expected: FAIL
+
+  [Cancelling a closed blob Response stream]
+    expected: FAIL
+
+  [Cancelling a starting Response stream]
+    expected: FAIL
+
+  [Cancelling a loading Response stream]
+    expected: FAIL
+
+  [Cancelling a closed Response stream]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/response/response-consume-empty.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-consume-empty.html.ini
@@ -1,6 +1,29 @@
 [response-consume-empty.html]
   type: testharness
-  expected: ERROR
   [Consume response's body as text]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Consume response's body as blob]
+    expected: FAIL
+
+  [Consume response's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume response's body as json]
+    expected: FAIL
+
+  [Consume response's body as formData]
+    expected: FAIL
+
+  [Consume empty blob response body as arrayBuffer]
+    expected: FAIL
+
+  [Consume empty text response body as arrayBuffer]
+    expected: FAIL
+
+  [Consume empty blob response body as text]
+    expected: FAIL
+
+  [Consume empty text response body as text]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/response/response-consume-stream.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-consume-stream.html.ini
@@ -1,6 +1,26 @@
 [response-consume-stream.html]
   type: testharness
-  expected: ERROR
   [Read empty text response's body as readableStream]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Read empty blob response's body as readableStream]
+    expected: FAIL
+
+  [Read blob response's body as readableStream]
+    expected: FAIL
+
+  [Read text response's body as readableStream]
+    expected: FAIL
+
+  [Read form data response's body as readableStream]
+    expected: FAIL
+
+  [Getting an error Response stream]
+    expected: FAIL
+
+  [Getting a redirect Response stream]
+    expected: FAIL
+
+  [Read array buffer response's body as readableStream]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/response/response-consume.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-consume.html.ini
@@ -1,6 +1,50 @@
 [response-consume.html]
   type: testharness
-  expected: ERROR
   [Consume response's body as text]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Consume response's body as blob]
+    expected: FAIL
+
+  [Consume response's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume response's body as json]
+    expected: FAIL
+
+  [Consume response's body as formData]
+    expected: FAIL
+
+  [Consume blob response's body as blob]
+    expected: FAIL
+
+  [Consume blob response's body as text]
+    expected: FAIL
+
+  [Consume blob response's body as json]
+    expected: FAIL
+
+  [Consume blob response's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume stream response's body as blob]
+    expected: FAIL
+
+  [Consume stream response's body as text]
+    expected: FAIL
+
+  [Consume stream response's body as json]
+    expected: FAIL
+
+  [Consume stream response's body as arrayBuffer]
+    expected: FAIL
+
+  [Consume fetched response's body as blob]
+    expected: FAIL
+
+  [Consume fetched response's body as text]
+    expected: FAIL
+
+  [Consume fetched response's body as arrayBuffer]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/response/response-init-002.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-init-002.html.ini
@@ -1,9 +1,23 @@
 [response-init-002.html]
   type: testharness
-  expected: ERROR
   [Initialize Response with headers values]
     expected: FAIL
 
   [Initialize Response's body with application/octet-binary]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Initialize Response's body with multipart/form-data]
+    expected: FAIL
+
+  [Initialize Response's body with application/x-www-form-urlencoded;charset=UTF-8]
+    expected: FAIL
+
+  [Initialize Response's body with text/plain;charset=UTF-8]
+    expected: FAIL
+
+  [Read Response's body as readableStream]
+    expected: FAIL
+
+  [Testing empty Response Content-Type header]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/response/response-stream-disturbed-1.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-stream-disturbed-1.html.ini
@@ -1,6 +1,14 @@
 [response-stream-disturbed-1.html]
   type: testharness
-  expected: ERROR
   [Getting blob after getting the Response body - not disturbed, not locked]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Getting text after getting the Response body - not disturbed, not locked]
+    expected: FAIL
+
+  [Getting json after getting the Response body - not disturbed, not locked]
+    expected: FAIL
+
+  [Getting arrayBuffer after getting the Response body - not disturbed, not locked]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/response/response-stream-disturbed-2.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-stream-disturbed-2.html.ini
@@ -1,6 +1,14 @@
 [response-stream-disturbed-2.html]
   type: testharness
-  expected: ERROR
   [Getting blob after getting a locked Response body]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Getting text after getting a locked Response body]
+    expected: FAIL
+
+  [Getting json after getting a locked Response body]
+    expected: FAIL
+
+  [Getting arrayBuffer after getting a locked Response body]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/response/response-stream-disturbed-3.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-stream-disturbed-3.html.ini
@@ -1,6 +1,14 @@
 [response-stream-disturbed-3.html]
   type: testharness
-  expected: ERROR
   [Getting blob after reading the Response body]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Getting text after reading the Response body]
+    expected: FAIL
+
+  [Getting json after reading the Response body]
+    expected: FAIL
+
+  [Getting arrayBuffer after reading the Response body]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/response/response-stream-disturbed-4.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-stream-disturbed-4.html.ini
@@ -1,6 +1,14 @@
 [response-stream-disturbed-4.html]
   type: testharness
-  expected: ERROR
   [Getting blob after cancelling the Response body]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Getting text after cancelling the Response body]
+    expected: FAIL
+
+  [Getting json after cancelling the Response body]
+    expected: FAIL
+
+  [Getting arrayBuffer after cancelling the Response body]
+    expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/response/response-stream-disturbed-5.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-stream-disturbed-5.html.ini
@@ -1,6 +1,14 @@
 [response-stream-disturbed-5.html]
   type: testharness
-  expected: ERROR
   [Getting a body reader after consuming as blob]
-    expected: NOTRUN
+    expected: FAIL
+
+  [Getting a body reader after consuming as text]
+    expected: FAIL
+
+  [Getting a body reader after consuming as json]
+    expected: FAIL
+
+  [Getting a body reader after consuming as arrayBuffer]
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/browsers/history/the-location-interface/allow_prototype_cycle_through_location.sub.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-location-interface/allow_prototype_cycle_through_location.sub.html.ini
@@ -1,9 +1,14 @@
 [allow_prototype_cycle_through_location.sub.html]
   type: testharness
-  expected: ERROR
   [same-origin, same-window location cycle]
     expected: FAIL
 
   [cross-origin location has null prototype]
-    expected: NOTRUN
+    expected: FAIL
+
+  [same-origin, different-window location cycle]
+    expected: FAIL
+
+  [cross-origin, but joined via document.domain, location cycle]
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/webappapis/scripting/event-loops/microtask_after_raf.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/event-loops/microtask_after_raf.html.ini
@@ -1,6 +1,5 @@
 [microtask_after_raf.html]
   type: testharness
-  expected: ERROR
   [Microtask execute immediately after script]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/webappapis/scripting/event-loops/microtask_after_script.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/event-loops/microtask_after_script.html.ini
@@ -1,6 +1,5 @@
 [microtask_after_script.html]
   type: testharness
-  expected: ERROR
   [Microtask immediately after script]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7176,6 +7176,12 @@
             "url": "/_mozilla/mozilla/preserve_wrapper_callback.html"
           }
         ],
+        "mozilla/promise.html": [
+          {
+            "path": "mozilla/promise.html",
+            "url": "/_mozilla/mozilla/promise.html"
+          }
+        ],
         "mozilla/prototypes.html": [
           {
             "path": "mozilla/prototypes.html",

--- a/tests/wpt/mozilla/meta/mozilla/promise.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/promise.html.ini
@@ -1,0 +1,3 @@
+[promise.html]
+  type: testharness
+  prefs: [dom.testbinding.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.js
@@ -27,6 +27,7 @@ function test_interfaces(interfaceNamesInGlobalScope) {
       "NaN",
       "Number",
       "Object",
+      "Promise",
       "Proxy",
       "RangeError",
       "ReferenceError",

--- a/tests/wpt/mozilla/tests/mozilla/promise.html
+++ b/tests/wpt/mozilla/tests/mozilla/promise.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+  promise_test(function() {
+      var t = new TestBinding;
+      return t.returnResolvedPromise('success')
+          .then(function(s) {
+              assert_equals(s, 'success');
+          });
+  }, 'Resolve callback gets argument');
+
+  promise_test(function(test) {
+      var t = new TestBinding;
+      return t.returnRejectedPromise('success')
+          .then(test.unreached_func())
+          .catch(function(s) {
+              assert_equals(s, 'success');
+          });
+  }, 'Reject callback gets argument');
+
+  promise_test(function(test) {
+      var t = new TestBinding;
+      var p = t.promiseNativeHandler(function(v) {
+          assert_equals(v, 'success');
+      }, null);
+      return Promise.resolve('success').then(p);
+  }, 'Native resolve callback gets argument');
+
+  promise_test(function(test) {
+      var t = new TestBinding;
+      var p = t.promiseNativeHandler(null, function(v) {
+          assert_equals(v, 'success');
+      });
+      p.then(test.unreached_func());
+      return Promise.resolve('success').then(p);
+  }, 'Native resolve callback gets argument');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/promise.html
+++ b/tests/wpt/mozilla/tests/mozilla/promise.html
@@ -23,18 +23,25 @@
 
   promise_test(function(test) {
       var t = new TestBinding;
+      var resolved;
       var p = t.promiseNativeHandler(function(v) {
-          assert_equals(v, 'success');
+          resolved = v;
       }, null);
-      return Promise.resolve('success').then(p);
+      t.promiseResolveNative(p, 'success');
+      return p.then(function() {
+          assert_equals(resolved, 'success')
+      });
   }, 'Native resolve callback gets argument');
 
   promise_test(function(test) {
       var t = new TestBinding;
+      var rejected;
       var p = t.promiseNativeHandler(null, function(v) {
-          assert_equals(v, 'success');
+          rejected = v;
       });
-      p.then(test.unreached_func());
-      return Promise.resolve('success').then(p);
-  }, 'Native resolve callback gets argument');
+      t.promiseRejectNative(p, 'success');
+      return p.catch(function() {
+          assert_equals(rejected, 'success')
+      });
+  }, 'Native reject callback gets argument');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/promise.html
+++ b/tests/wpt/mozilla/tests/mozilla/promise.html
@@ -23,6 +23,13 @@
 
   promise_test(function(test) {
       var t = new TestBinding;
+      var p = new Promise(function() {});
+      t.promiseRejectWithTypeError(p, "success");
+      return promise_rejects(test, new TypeError("success"), p, "TypeError should be instantiated");
+  }, 'Native code rejects with exception');
+
+  promise_test(function(test) {
+      var t = new TestBinding;
       var resolved;
       var p = t.promiseNativeHandler(function(v) {
           resolved = v;

--- a/tests/wpt/mozilla/tests/mozilla/promise.html
+++ b/tests/wpt/mozilla/tests/mozilla/promise.html
@@ -51,4 +51,17 @@
           assert_equals(rejected, 'success')
       });
   }, 'Native reject callback gets argument');
+
+  promise_test(function(test) {
+      var t = new TestBinding;
+      var resolved;
+      var p = new Promise(function() {});
+      var start = Date.now();
+      t.resolvePromiseDelayed(p, 'success', 100);
+      return p.then(function(v) {
+          var end = Date.now();
+          assert_true(end - start > 100);
+          assert_equals(v, 'success');
+      });
+  }, 'Native promise from async callback can be resolved');
 </script>


### PR DESCRIPTION
This implements support for using Promises in WebIDL, executing promise callbacks in batches (equivalent to running all enqueued jobs from a setTimeout(0)), and attaching native callbacks to promise objects. This is the combined work of myself, @dati91, and @mmatyas based on the following prior work in Gecko:
- Codegen.py
- Promise.webidl
- Promise.cpp/Promise.h
- PromiseNativeHandler.h

This does not implement microtasks per #4283. This allows us to make progress on testing code that requires the use of Promises right now; the microtasks work is more complicated, but also largely orthogonal to implement.

Requires https://github.com/servo/mozjs/pull/89, https://github.com/servo/rust-mozjs/pull/287, and https://github.com/servo/rust-mozjs/pull/294.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #4282
- [X] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12830)

<!-- Reviewable:end -->
