### PR TITLE
Add a flag to dump the computed style values

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1187,6 +1187,10 @@ impl LayoutThread {
             self.root_flow = self.try_get_layout_root(node);
         }
 
+        if opts::get().dump_style_tree {
+            node.dump_style();
+        }
+
         // Perform post-style recalculation layout passes.
         self.perform_post_style_recalc_layout_passes(&data.reflow_info,
                                                      &mut rw_data,

--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -140,6 +140,11 @@ impl<'ln> TNode for ServoLayoutNode<'ln> {
         self.dump_indent(0);
     }
 
+    fn dump_style(self) {
+        println!("\nDOM with computed styles:");
+        self.dump_style_indent(0);
+    }
+
     fn opaque(&self) -> OpaqueNode {
         unsafe { self.get_jsmanaged().opaque() }
     }
@@ -320,9 +325,36 @@ impl<'ln> ServoLayoutNode<'ln> {
         }
     }
 
+    fn dump_style_indent(self, indent: u32) {
+        if self.is_element() {
+            let mut s = String::new();
+            for _ in 0..indent {
+                s.push_str("  ");
+            }
+            s.push_str(&self.debug_style_str());
+            println!("{}", s);
+        }
+
+        for kid in self.children() {
+            kid.dump_style_indent(indent + 1);
+        }
+    }
+
     fn debug_str(self) -> String {
         format!("{:?}: changed={} dirty={} dirty_descendants={}",
                 self.script_type_id(), self.has_changed(), self.is_dirty(), self.has_dirty_descendants())
+    }
+
+    fn debug_style_str(self) -> String {
+        if let Some(data) = self.borrow_data() {
+            if let Some(data) = data.style.as_ref() {
+                format!("{:?}: {:?}", self.script_type_id(), data)
+            } else {
+                format!("{:?}: style=None", self.script_type_id())
+            }
+        } else {
+            format!("{:?}: style_data=None", self.script_type_id())
+        }
     }
 
     /// Returns the interior of this node as a `LayoutJS`. This is highly unsafe for layout to

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -81,6 +81,8 @@ pub trait TNode : Sized + Copy + Clone {
 
     fn dump(self);
 
+    fn dump_style(self);
+
     fn traverse_preorder(self) -> TreeIterator<Self> {
         TreeIterator::new(self)
     }

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -155,6 +155,9 @@ pub struct Opts {
     /// used for testing the hardening of the constellation.
     pub random_pipeline_closure_seed: Option<usize>,
 
+    /// Dumps the DOM after restyle.
+    pub dump_style_tree: bool,
+
     /// Dumps the flow tree after a layout.
     pub dump_flow_tree: bool,
 
@@ -230,6 +233,9 @@ pub struct DebugOptions {
 
     /// Disable antialiasing of rendered text on the HTML canvas element.
     pub disable_canvas_aa: bool,
+
+    /// Print the DOM after each restyle.
+    pub dump_style_tree: bool,
 
     /// Print the flow tree after each layout.
     pub dump_flow_tree: bool,
@@ -314,6 +320,7 @@ impl DebugOptions {
                 "bubble-widths" => debug_options.bubble_widths = true,
                 "disable-text-aa" => debug_options.disable_text_aa = true,
                 "disable-canvas-aa" => debug_options.disable_text_aa = true,
+                "dump-style-tree" => debug_options.dump_style_tree = true,
                 "dump-flow-tree" => debug_options.dump_flow_tree = true,
                 "dump-display-list" => debug_options.dump_display_list = true,
                 "dump-display-list-json" => debug_options.dump_display_list_json = true,
@@ -357,6 +364,7 @@ pub fn print_debug_usage(app: &str) -> ! {
     print_option("bubble-widths", "Bubble intrinsic widths separately like other engines.");
     print_option("disable-text-aa", "Disable antialiasing of rendered text.");
     print_option("disable-canvas-aa", "Disable antialiasing on the HTML canvas element.");
+    print_option("dump-style-tree", "Print the DOM with computed styles after each restyle.");
     print_option("dump-flow-tree", "Print the flow tree after each layout.");
     print_option("dump-display-list", "Print the display list after each layout.");
     print_option("dump-display-list-json", "Print the display list in JSON form.");
@@ -500,6 +508,7 @@ pub fn default_opts() -> Opts {
         random_pipeline_closure_probability: None,
         random_pipeline_closure_seed: None,
         sandbox: false,
+        dump_style_tree: false,
         dump_flow_tree: false,
         dump_display_list: false,
         dump_display_list_json: false,
@@ -807,6 +816,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         paint_flashing: debug_options.paint_flashing,
         enable_text_antialiasing: !debug_options.disable_text_aa,
         enable_canvas_antialiasing: !debug_options.disable_canvas_aa,
+        dump_style_tree: debug_options.dump_style_tree,
         dump_flow_tree: debug_options.dump_flow_tree,
         dump_display_list: debug_options.dump_display_list,
         dump_display_list_json: debug_options.dump_display_list_json,

--- a/ports/geckolib/wrapper.rs
+++ b/ports/geckolib/wrapper.rs
@@ -162,6 +162,10 @@ impl<'ln> TNode for GeckoNode<'ln> {
         unimplemented!()
     }
 
+    fn dump_style(self) {
+        unimplemented!()
+    }
+
     fn opaque(&self) -> OpaqueNode {
         let ptr: uintptr_t = self.node as uintptr_t;
         OpaqueNode(ptr)


### PR DESCRIPTION
I used this to trace #11818 to a style bug, rather than a layout bug.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not fix any issues
- [X] These changes do not require tests because debugging

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12831)

<!-- Reviewable:end -->
