### PR TITLE
Remove #[serde(bound = "")] attributes

### DIFF
--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -74,7 +74,6 @@ pub enum FromLayoutMsg {
 }
 
 #[derive(Clone, Deserialize, Serialize)]
-#[serde(bound = "")] // Prevent serde from generating cyclic bounds.
 pub enum Canvas2dMsg {
     Arc(Point2D<f32>, f32, f32, f32, bool),
     ArcTo(Point2D<f32>, Point2D<f32>, f32),

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -791,7 +791,6 @@ impl fmt::Debug for StackingContext {
 
 /// One drawing command in the list.
 #[derive(Clone, Deserialize, HeapSizeOf, Serialize)]
-#[serde(bound = "")] // Prevent serde from generating cyclic bounds.
 pub enum DisplayItem {
     SolidColorClass(Box<SolidColorDisplayItem>),
     TextClass(Box<TextDisplayItem>),

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -59,7 +59,6 @@ pub enum LogEntry {
 
 /// Messages from the script to the constellation.
 #[derive(Deserialize, Serialize)]
-#[serde(bound = "")] // Prevent serde from generating cyclic bounds.
 pub enum ScriptMsg {
     /// Indicates whether this pipeline is currently running animations.
     ChangeRunningAnimationsState(PipelineId, AnimationState),


### PR DESCRIPTION
These were fixed in serde_codegen 0.8.0 by serde-rs/serde#456.

cc @nox
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because: the generated code continues to compile

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12834)

<!-- Reviewable:end -->
