### PR TITLE
 	layout: Make the stacking context take into account the children transform when calculating overflow areas.

### DIFF
--- a/components/gfx/paint_thread.rs
+++ b/components/gfx/paint_thread.rs
@@ -254,7 +254,7 @@ impl LayerCreator {
                                           parent_origin: &Point2D<Au>,
                                           transform: &Matrix4D<f32>,
                                           perspective: &Matrix4D<f32>) {
-        for kid in stacking_context.children.iter() {
+        for kid in stacking_context.children() {
             while let Some(item) = traversal.advance(stacking_context) {
                 self.create_layers_for_item(item,
                                             parent_origin,

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1729,7 +1729,7 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
                 }
             }
 
-            contexts[stacking_context_index].children = floating;
+            contexts[stacking_context_index].set_children(floating);
             return stacking_context_id;
         }
 
@@ -1745,14 +1745,14 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
                 &self.base,
                 scroll_policy,
                 StackingContextCreationMode::InnerScrollWrapper);
-            inner_stacking_context.children = child_contexts;
+            inner_stacking_context.set_children(child_contexts);
 
             let mut outer_stacking_context = self.fragment.create_stacking_context(
                 stacking_context_id,
                 &self.base,
                 scroll_policy,
                 StackingContextCreationMode::OuterScrollWrapper);
-            outer_stacking_context.children.push(inner_stacking_context);
+            outer_stacking_context.add_child(inner_stacking_context);
             outer_stacking_context
         } else {
             let mut stacking_context = self.fragment.create_stacking_context(
@@ -1760,7 +1760,7 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
                 &self.base,
                 scroll_policy,
                 StackingContextCreationMode::Normal);
-            stacking_context.children = child_contexts;
+            stacking_context.set_children(child_contexts);
             stacking_context
         };
 

--- a/components/layout/sequential.rs
+++ b/components/layout/sequential.rs
@@ -84,8 +84,10 @@ pub fn build_display_list_for_subtree(root: &mut FlowRef,
     let flow_root = flow_ref::deref_mut(root);
     let layout_context = LayoutContext::new(shared_layout_context);
     flow_root.traverse_preorder(&ComputeAbsolutePositions { layout_context: &layout_context });
+    let mut children = vec![];
     flow_root.collect_stacking_contexts(root_stacking_context.id,
-                                        &mut root_stacking_context.children);
+                                        &mut children);
+    root_stacking_context.add_children(children);
     let mut build_display_list = BuildDisplayList {
         state: DisplayListBuildState::new(&layout_context,
                                           flow::base(&*flow_root).stacking_context_id),

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -260,7 +260,7 @@ impl WebRenderStackingContextConverter for StackingContext {
                                          builder: &mut webrender_traits::DisplayListBuilder,
                                          frame_builder: &mut WebRenderFrameBuilder,
                                          _force_positioned_stacking_level: bool) {
-        for child in self.children.iter() {
+        for child in self.children() {
             while let Some(item) = traversal.advance(self) {
                 item.convert_to_webrender(builder, frame_builder);
             }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -3960,6 +3960,30 @@
             "url": "/_mozilla/css/overflow_simple_a.html"
           }
         ],
+        "css/overflow_transformed_sc.html": [
+          {
+            "path": "css/overflow_transformed_sc.html",
+            "references": [
+              [
+                "/_mozilla/css/overflow_transformed_sc_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/overflow_transformed_sc.html"
+          }
+        ],
+        "css/overflow_transformed_sc_rotate.html": [
+          {
+            "path": "css/overflow_transformed_sc_rotate.html",
+            "references": [
+              [
+                "/_mozilla/css/overflow_transformed_sc_rotate_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/overflow_transformed_sc_rotate.html"
+          }
+        ],
         "css/overflow_wrap_a.html": [
           {
             "path": "css/overflow_wrap_a.html",
@@ -13190,6 +13214,30 @@
             ]
           ],
           "url": "/_mozilla/css/overflow_simple_a.html"
+        }
+      ],
+      "css/overflow_transformed_sc.html": [
+        {
+          "path": "css/overflow_transformed_sc.html",
+          "references": [
+            [
+              "/_mozilla/css/overflow_transformed_sc_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/overflow_transformed_sc.html"
+        }
+      ],
+      "css/overflow_transformed_sc_rotate.html": [
+        {
+          "path": "css/overflow_transformed_sc_rotate.html",
+          "references": [
+            [
+              "/_mozilla/css/overflow_transformed_sc_rotate_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/overflow_transformed_sc_rotate.html"
         }
       ],
       "css/overflow_wrap_a.html": [

--- a/tests/wpt/mozilla/tests/css/overflow_transformed_sc.html
+++ b/tests/wpt/mozilla/tests/css/overflow_transformed_sc.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Inner stacking contexts' transforms are taken into account for overflow computation</title>
+<link rel="match" href="overflow_transformed_sc_ref.html">
+<style>
+  .outer-sc {
+    transform: translate(-50px, -50px);
+    position: absolute;
+    width: 250px;
+    height: 250px;
+    top: 50px;
+    left: 50px;
+    background: blue;
+  }
+
+  .inner-sc {
+    position: absolute;
+    width: 250px;
+    height: 250px;
+    top: 0;
+    left: 0;
+    transform: translate(250px, 250px);
+    background: green;
+  }
+
+  html, body { margin: 0; padding: 0; }
+</style>
+<div class="outer-sc">
+  <div class="inner-sc">
+  </div>
+</div>

--- a/tests/wpt/mozilla/tests/css/overflow_transformed_sc_ref.html
+++ b/tests/wpt/mozilla/tests/css/overflow_transformed_sc_ref.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS test reference</title>
+<style>
+  .outer-sc {
+    position: absolute;
+    width: 250px;
+    height: 250px;
+    top: 0;
+    left: 0;
+    background: blue;
+  }
+
+  .inner-sc {
+    position: absolute;
+    width: 250px;
+    height: 250px;
+    top: 250px;
+    left: 250px;
+    background: green;
+  }
+
+  html, body { margin: 0; padding: 0; }
+</style>
+<div class="outer-sc">
+  <div class="inner-sc">
+  </div>
+</div>

--- a/tests/wpt/mozilla/tests/css/overflow_transformed_sc_rotate.html
+++ b/tests/wpt/mozilla/tests/css/overflow_transformed_sc_rotate.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Inner stacking contexts' transforms are taken into account for overflow computation</title>
+<link rel="match" href="overflow_transformed_sc_rotate_ref.html">
+<style>
+  .outer-sc {
+    transform: translate(-50px, -50px);
+    position: absolute;
+    width: 250px;
+    height: 250px;
+    top: 50px;
+    left: 50px;
+    background: blue;
+  }
+
+  .inner-sc {
+    position: absolute;
+    width: 250px;
+    height: 250px;
+    top: 0;
+    left: 0;
+    transform: translate(250px, 250px) rotate(45deg);
+    background: green;
+  }
+
+  html, body { margin: 0; padding: 0; }
+</style>
+<div class="outer-sc">
+  <div class="inner-sc">
+  </div>
+</div>

--- a/tests/wpt/mozilla/tests/css/overflow_transformed_sc_rotate_ref.html
+++ b/tests/wpt/mozilla/tests/css/overflow_transformed_sc_rotate_ref.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS test reference.</title>
+<style>
+  .outer-sc {
+    transform: translate(-50px, -50px);
+    position: absolute;
+    width: 250px;
+    height: 250px;
+    top: 50px;
+    left: 50px;
+    background: blue;
+  }
+
+  .inner-sc {
+    position: absolute;
+    width: 250px;
+    height: 250px;
+    top: 0;
+    left: 0;
+    transform: translate(250px, 250px) rotate(45deg);
+    background: green;
+  }
+
+  html, body { margin: 0; padding: 0; }
+</style>
+<div class="outer-sc">
+</div>
+<div class="inner-sc">
+</div>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is a potential fix for #12842. I have done only the math to handle simple transforms because it's three AM, but I'd like @pcwalton to verify my approach, or suggest an alternative.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partially fix #12842 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12843)

<!-- Reviewable:end -->
