### PR TITLE
Implement GL_FRAMEBUFFER_BINDING (and fix a VertexAttrib1fv typo)

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1788,7 +1788,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     fn VertexAttrib1fv(&self, _cx: *mut JSContext, indx: u32, data: *mut JSObject) {
         if let Some(data_vec) = array_buffer_view_to_vec_checked::<f32>(data) {
-            if data_vec.len() < 4 {
+            if data_vec.len() < 1 {
                 return self.webgl_error(InvalidOperation);
             }
             self.vertex_attrib(indx, data_vec[0], 0f32, 0f32, 1f32)

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -82,6 +82,7 @@ pub struct WebGLRenderingContext {
     #[ignore_heap_size_of = "Defined in webrender_traits"]
     last_error: Cell<Option<WebGLError>>,
     texture_unpacking_settings: Cell<TextureUnpacking>,
+    bound_framebuffer: MutNullableHeap<JS<WebGLFramebuffer>>,
     bound_texture_2d: MutNullableHeap<JS<WebGLTexture>>,
     bound_texture_cube_map: MutNullableHeap<JS<WebGLTexture>>,
     bound_buffer_array: MutNullableHeap<JS<WebGLBuffer>>,
@@ -111,6 +112,7 @@ impl WebGLRenderingContext {
                 canvas: JS::from_ref(canvas),
                 last_error: Cell::new(None),
                 texture_unpacking_settings: Cell::new(CONVERT_COLORSPACE),
+                bound_framebuffer: MutNullableHeap::new(None),
                 bound_texture_2d: MutNullableHeap::new(None),
                 bound_texture_cube_map: MutNullableHeap::new(None),
                 bound_buffer_array: MutNullableHeap::new(None),
@@ -511,6 +513,22 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
     fn GetParameter(&self, cx: *mut JSContext, parameter: u32) -> JSVal {
+        // Handle the GL_FRAMEBUFFER_BINDING without going all the way
+        // to the GL, since we would just need to map back from GL's
+        // returned ID to the WebGLFramebuffer we're tracking.
+        match parameter {
+            constants::FRAMEBUFFER_BINDING => {
+                rooted!(in(cx) let mut rval = NullValue());
+                if let Some(bound_fb) = self.bound_framebuffer.get() {
+                    unsafe {
+                        bound_fb.to_jsval(cx, rval.handle_mut());
+                    }
+                }
+                return rval.get()
+            }
+            _ => {}
+        }
+
         let (sender, receiver) = ipc::channel().unwrap();
         self.ipc_renderer
             .send(CanvasMsg::WebGL(WebGLCommand::GetParameter(parameter, sender)))
@@ -671,6 +689,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             return self.webgl_error(InvalidOperation);
         }
 
+        self.bound_framebuffer.set(framebuffer);
         if let Some(framebuffer) = framebuffer {
             framebuffer.bind(target)
         } else {
@@ -1083,6 +1102,11 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
     fn DeleteFramebuffer(&self, framebuffer: Option<&WebGLFramebuffer>) {
         if let Some(framebuffer) = framebuffer {
+            if let Some(bound_fb) = self.bound_framebuffer.get() {
+                if bound_fb.id() == framebuffer.id() {
+                    self.bound_framebuffer.set(None);
+                }
+            }
             framebuffer.delete()
         }
     }

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-disabled-vertex-attrib.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-disabled-vertex-attrib.html.ini
@@ -1,11 +1,6 @@
 [gl-disabled-vertex-attrib.html]
   type: testharness
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-
   [WebGL test #15: at (0, 0) expected: 0,255,0,255 was 255,255,255,255]
-    expected: FAIL
-
-  [WebGL test #16: getError expected: NO_ERROR. Was INVALID_ENUM : should be no errors]
-    expected: FAIL
+    expected:
+      if os == "mac": FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/copy-tex-image-2d-formats.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/copy-tex-image-2d-formats.html.ini
@@ -1,20 +1,5 @@
 [copy-tex-image-2d-formats.html]
   type: testharness
-  [WebGL test #3: getError expected: NO_ERROR. Was INVALID_ENUM : should be no errors]
-    expected: FAIL
-
-  [WebGL test #6: getError expected: NO_ERROR. Was INVALID_ENUM : should be no errors]
-    expected: FAIL
-
-  [WebGL test #9: getError expected: NO_ERROR. Was INVALID_ENUM : should be no errors]
-    expected: FAIL
-
-  [WebGL test #12: getError expected: NO_ERROR. Was INVALID_ENUM : should be no errors]
-    expected: FAIL
-
-  [WebGL test #15: getError expected: NO_ERROR. Was INVALID_ENUM : should be no errors]
-    expected: FAIL
-
   [WebGL test #16: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html.ini
@@ -36,72 +36,60 @@
   [WebGL test #11: at (8, 12) expected: 255,0,0,255 was 0,0,255,255]
     expected: FAIL
 
-  [WebGL test #12: GL error before texture upload]
-    expected: FAIL
-
-  [WebGL test #25: GL error before texture upload]
-    expected: FAIL
-
   [WebGL test #26: at (0, 0) expected: 0,0,0,255 was 255,0,0,255]
     expected: FAIL
 
-  [WebGL test #27: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
+  [WebGL test #24: at (0, 0) expected: 0,0,0,255 was 255,0,0,255]
     expected: FAIL
 
-  [WebGL test #28: at (0, 0) expected: 0,0,0,255 was 255,0,0,255]
+  [WebGL test #25: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
     expected: FAIL
 
-  [WebGL test #29: at (0, 4) expected: 255,0,0,255 was 0,0,255,255]
+  [WebGL test #27: at (0, 4) expected: 255,0,0,255 was 0,0,255,255]
     expected: FAIL
 
-  [WebGL test #30: at (8, 0) expected: 0,0,0,255 was 255,0,0,255]
+  [WebGL test #28: at (8, 0) expected: 0,0,0,255 was 255,0,0,255]
     expected: FAIL
 
-  [WebGL test #31: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
+  [WebGL test #29: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
     expected: FAIL
 
-  [WebGL test #32: at (0, 0) expected: 0,0,0,255 was 255,0,0,255]
+  [WebGL test #30: at (0, 0) expected: 0,0,0,255 was 255,0,0,255]
     expected: FAIL
 
-  [WebGL test #33: at (0, 4) expected: 255,0,0,255 was 0,0,255,255]
+  [WebGL test #31: at (0, 4) expected: 255,0,0,255 was 0,0,255,255]
     expected: FAIL
 
-  [WebGL test #34: at (8, 0) expected: 0,0,0,255 was 255,0,0,255]
+  [WebGL test #32: at (8, 0) expected: 0,0,0,255 was 255,0,0,255]
     expected: FAIL
 
-  [WebGL test #35: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
+  [WebGL test #33: at (0, 8) expected: 255,0,0,255 was 0,255,0,255]
     expected: FAIL
 
-  [WebGL test #36: at (8, 8) expected: 0,0,0,255 was 255,0,0,255]
+  [WebGL test #34: at (8, 8) expected: 0,0,0,255 was 255,0,0,255]
     expected: FAIL
 
-  [WebGL test #37: at (8, 12) expected: 255,0,0,255 was 0,0,255,255]
+  [WebGL test #35: at (8, 12) expected: 255,0,0,255 was 0,0,255,255]
     expected: FAIL
 
-  [WebGL test #38: GL error before texture upload]
+  [WebGL test #37: at (0, 8) expected: 0,0,0,255 was 0,255,0,255]
     expected: FAIL
 
-  [WebGL test #40: at (0, 8) expected: 0,0,0,255 was 0,255,0,255]
+  [WebGL test #39: at (0, 4) expected: 0,0,0,255 was 0,0,255,255]
     expected: FAIL
 
-  [WebGL test #42: at (0, 4) expected: 0,0,0,255 was 0,0,255,255]
+  [WebGL test #41: at (0, 8) expected: 0,0,0,255 was 0,255,0,255]
     expected: FAIL
 
-  [WebGL test #44: at (0, 8) expected: 0,0,0,255 was 0,255,0,255]
+  [WebGL test #43: at (0, 4) expected: 0,0,0,255 was 0,0,255,255]
     expected: FAIL
 
-  [WebGL test #46: at (0, 4) expected: 0,0,0,255 was 0,0,255,255]
+  [WebGL test #45: at (0, 8) expected: 0,0,0,255 was 0,255,0,255]
     expected: FAIL
 
-  [WebGL test #48: at (0, 8) expected: 0,0,0,255 was 0,255,0,255]
+  [WebGL test #47: at (8, 12) expected: 0,0,0,255 was 0,0,255,255]
     expected: FAIL
 
-  [WebGL test #50: at (8, 12) expected: 0,0,0,255 was 0,0,255,255]
-    expected: FAIL
-
-  [WebGL test #51: GL error before texture upload]
-    expected: FAIL
-
-  [WebGL test #52: successfullyParsed should be true. Was false.]
+  [WebGL test #48: successfullyParsed should be true. Was false.]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-npot.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-npot.html.ini
@@ -3,117 +3,33 @@
   [WebGL test #4: at (0, 0) expected: 0,0,0,255 was 192,0,128,64]
     expected: FAIL
 
-  [WebGL test #5: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
-  [WebGL test #7: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
-  [WebGL test #9: getError expected: INVALID_VALUE. Was INVALID_ENUM : copyTexImage2D with NPOT texture with level > 0 should return INVALID_VALUE.]
-    expected: FAIL
-
-  [WebGL test #12: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
   [WebGL test #14: getError expected: NO_ERROR. Was INVALID_OPERATION : gl.texImage2D with NPOT texture at level 0 should succeed]
-    expected: FAIL
-
-  [WebGL test #17: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
-  [WebGL test #19: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
     expected: FAIL
 
   [WebGL test #20: at (0, 0) expected: 192,0,128,255 was 0,0,0,255]
     expected: FAIL
 
-  [WebGL test #21: getError expected: INVALID_VALUE. Was INVALID_ENUM : copyTexImage2D with NPOT texture with level > 0 should return INVALID_VALUE.]
-    expected: FAIL
-
-  [WebGL test #24: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
   [WebGL test #26: getError expected: NO_ERROR. Was INVALID_OPERATION : gl.texImage2D with NPOT texture at level 0 should succeed]
-    expected: FAIL
-
-  [WebGL test #29: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
-  [WebGL test #31: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
     expected: FAIL
 
   [WebGL test #32: at (0, 0) expected: 192,192,192,255 was 0,0,0,255]
     expected: FAIL
 
-  [WebGL test #33: getError expected: INVALID_VALUE. Was INVALID_ENUM : copyTexImage2D with NPOT texture with level > 0 should return INVALID_VALUE.]
-    expected: FAIL
-
-  [WebGL test #36: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
   [WebGL test #38: getError expected: NO_ERROR. Was INVALID_OPERATION : gl.texImage2D with NPOT texture at level 0 should succeed]
-    expected: FAIL
-
-  [WebGL test #41: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
-  [WebGL test #43: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
     expected: FAIL
 
   [WebGL test #44: at (0, 0) expected: 0,0,0,64 was 0,0,0,255]
     expected: FAIL
 
-  [WebGL test #45: getError expected: INVALID_VALUE. Was INVALID_ENUM : copyTexImage2D with NPOT texture with level > 0 should return INVALID_VALUE.]
-    expected: FAIL
-
-  [WebGL test #48: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
   [WebGL test #50: getError expected: NO_ERROR. Was INVALID_OPERATION : gl.texImage2D with NPOT texture at level 0 should succeed]
-    expected: FAIL
-
-  [WebGL test #53: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
-  [WebGL test #55: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
     expected: FAIL
 
   [WebGL test #56: at (0, 0) expected: 192,192,192,64 was 0,0,0,255]
     expected: FAIL
 
-  [WebGL test #57: getError expected: INVALID_VALUE. Was INVALID_ENUM : copyTexImage2D with NPOT texture with level > 0 should return INVALID_VALUE.]
-    expected: FAIL
-
-  [WebGL test #60: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
   [WebGL test #64: at (0, 0) expected: 0,0,0,255 was 0,192,128,255]
     expected: FAIL
 
-  [WebGL test #65: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from draw.]
-    expected: FAIL
-
-  [WebGL test #67: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
-  [WebGL test #69: getError expected: NO_ERROR. Was INVALID_ENUM : gl.texImage2D with POT texture at level 0 should succeed]
-    expected: FAIL
-
-  [WebGL test #71: getError expected: NO_ERROR. Was INVALID_ENUM : gl.generateMipmap with POT texture should return succeed]
-    expected: FAIL
-
   [WebGL test #76: at (0, 0) expected: 0,0,0,255 was 0,192,128,255]
-    expected: FAIL
-
-  [WebGL test #77: getError returned INVALID_ENUM. Possibly Chromium bug where texture unit is set to 0 instead of GL_TEXTURE0.]
-    expected: FAIL
-
-  [WebGL test #79: getError expected: NO_ERROR. Was INVALID_ENUM : Should be no errors from setup.]
-    expected: FAIL
-
-  [WebGL test #81: getError expected: NO_ERROR. Was INVALID_ENUM : gl.texImage2D with POT texture at level 0 should succeed]
-    expected: FAIL
-
-  [WebGL test #83: getError expected: NO_ERROR. Was INVALID_ENUM : gl.generateMipmap with POT texture should return succeed]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR fixes many webgl conformance test failures due to missing support for a getParameter() call in the webgl test utils.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12852

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12857)

<!-- Reviewable:end -->
