### PR TITLE
Enable wpt WebGL tests on Linux

### DIFF
--- a/tests/wpt/metadata/webgl/conformance-1.0.3/__dir__.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/__dir__.ini
@@ -1,2 +1,0 @@
-disabled:
-  if os == "linux": https://github.com/servo/servo/issues/9331

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-bindAttribLocation-aliasing.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-bindAttribLocation-aliasing.html.ini
@@ -1,0 +1,770 @@
+[gl-bindAttribLocation-aliasing.html]
+  type: testharness
+  [WebGL test #1: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #2: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #3: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #4: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #5: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #6: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #7: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #8: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #9: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #10: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #11: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #12: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #13: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #14: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #15: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #16: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #18: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #19: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #20: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #21: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #22: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #23: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #24: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #25: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #26: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #27: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #28: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #29: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #30: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #31: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #32: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #33: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #35: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #36: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #37: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #38: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #39: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #40: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #41: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #42: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #43: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #44: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #45: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #46: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #47: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #48: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #49: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #50: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #52: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #53: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #54: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #55: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #56: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #57: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #58: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #59: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #60: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #61: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #62: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #63: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #64: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #65: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #66: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #67: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #69: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #70: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #71: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #72: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #73: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #74: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #75: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #76: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #77: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #78: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #79: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #80: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #81: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #82: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #83: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #84: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #86: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #87: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #88: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #89: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #90: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #91: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #92: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #93: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #94: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #95: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #96: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #97: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #98: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #99: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #100: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #101: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #103: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #104: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #105: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #106: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #107: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #108: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #109: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #110: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #111: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #112: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #113: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #114: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #115: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #116: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #117: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #118: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #120: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #121: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #122: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #123: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #124: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #125: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #126: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #127: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #128: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #129: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #130: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #131: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #132: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #133: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #134: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #135: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #137: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #138: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #139: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #140: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #141: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #142: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #143: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #144: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #145: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #146: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #147: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #148: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #149: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #150: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #151: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #152: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #154: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #155: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #156: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #157: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #158: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #159: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #160: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #161: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #162: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #163: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #164: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #165: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #166: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #167: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #168: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #169: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #171: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #172: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #173: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #174: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #175: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #176: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #177: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #178: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #179: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #180: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #181: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #182: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #183: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #184: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #185: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #186: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #188: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #189: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #190: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #191: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #192: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #193: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #194: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #195: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #196: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #197: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #198: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #199: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #200: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #201: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #202: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #203: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #205: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #206: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #207: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #208: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #209: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #210: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #211: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #212: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #213: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #214: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #215: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #216: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #217: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #218: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #219: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #220: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #222: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #223: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #224: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #225: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #226: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #227: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #228: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #229: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #230: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #231: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #232: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #233: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #234: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #235: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #236: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #237: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #239: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #240: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #241: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #242: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #243: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #244: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #245: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #246: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #247: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #248: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #249: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #250: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #251: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #252: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #253: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #254: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+
+  [WebGL test #256: Link should fail when both types are aliased to location 0]
+    expected: FAIL
+
+  [WebGL test #257: Link should fail when both types are aliased to location 1]
+    expected: FAIL
+
+  [WebGL test #258: Link should fail when both types are aliased to location 2]
+    expected: FAIL
+
+  [WebGL test #259: Link should fail when both types are aliased to location 3]
+    expected: FAIL
+
+  [WebGL test #260: Link should fail when both types are aliased to location 4]
+    expected: FAIL
+
+  [WebGL test #261: Link should fail when both types are aliased to location 5]
+    expected: FAIL
+
+  [WebGL test #262: Link should fail when both types are aliased to location 6]
+    expected: FAIL
+
+  [WebGL test #263: Link should fail when both types are aliased to location 7]
+    expected: FAIL
+
+  [WebGL test #264: Link should fail when both types are aliased to location 8]
+    expected: FAIL
+
+  [WebGL test #265: Link should fail when both types are aliased to location 9]
+    expected: FAIL
+
+  [WebGL test #266: Link should fail when both types are aliased to location 10]
+    expected: FAIL
+
+  [WebGL test #267: Link should fail when both types are aliased to location 11]
+    expected: FAIL
+
+  [WebGL test #268: Link should fail when both types are aliased to location 12]
+    expected: FAIL
+
+  [WebGL test #269: Link should fail when both types are aliased to location 13]
+    expected: FAIL
+
+  [WebGL test #270: Link should fail when both types are aliased to location 14]
+    expected: FAIL
+
+  [WebGL test #271: Link should fail when both types are aliased to location 15]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-bindAttribLocation-matrix.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-bindAttribLocation-matrix.html.ini
@@ -1,0 +1,347 @@
+[gl-bindAttribLocation-matrix.html]
+  type: testharness
+  [WebGL test #1: Matrix with location 0 and vector with location 0 should not link.]
+    expected: FAIL
+
+  [WebGL test #2: Matrix with location 0 and vector with location 1 should not link.]
+    expected: FAIL
+
+  [WebGL test #4: Matrix with location 1 and vector with location 1 should not link.]
+    expected: FAIL
+
+  [WebGL test #5: Matrix with location 1 and vector with location 2 should not link.]
+    expected: FAIL
+
+  [WebGL test #7: Matrix with location 2 and vector with location 2 should not link.]
+    expected: FAIL
+
+  [WebGL test #8: Matrix with location 2 and vector with location 3 should not link.]
+    expected: FAIL
+
+  [WebGL test #10: Matrix with location 3 and vector with location 3 should not link.]
+    expected: FAIL
+
+  [WebGL test #11: Matrix with location 3 and vector with location 4 should not link.]
+    expected: FAIL
+
+  [WebGL test #13: Matrix with location 4 and vector with location 4 should not link.]
+    expected: FAIL
+
+  [WebGL test #14: Matrix with location 4 and vector with location 5 should not link.]
+    expected: FAIL
+
+  [WebGL test #16: Matrix with location 5 and vector with location 5 should not link.]
+    expected: FAIL
+
+  [WebGL test #17: Matrix with location 5 and vector with location 6 should not link.]
+    expected: FAIL
+
+  [WebGL test #19: Matrix with location 6 and vector with location 6 should not link.]
+    expected: FAIL
+
+  [WebGL test #20: Matrix with location 6 and vector with location 7 should not link.]
+    expected: FAIL
+
+  [WebGL test #22: Matrix with location 7 and vector with location 7 should not link.]
+    expected: FAIL
+
+  [WebGL test #23: Matrix with location 7 and vector with location 8 should not link.]
+    expected: FAIL
+
+  [WebGL test #25: Matrix with location 8 and vector with location 8 should not link.]
+    expected: FAIL
+
+  [WebGL test #26: Matrix with location 8 and vector with location 9 should not link.]
+    expected: FAIL
+
+  [WebGL test #28: Matrix with location 9 and vector with location 9 should not link.]
+    expected: FAIL
+
+  [WebGL test #29: Matrix with location 9 and vector with location 10 should not link.]
+    expected: FAIL
+
+  [WebGL test #31: Matrix with location 10 and vector with location 10 should not link.]
+    expected: FAIL
+
+  [WebGL test #32: Matrix with location 10 and vector with location 11 should not link.]
+    expected: FAIL
+
+  [WebGL test #34: Matrix with location 11 and vector with location 11 should not link.]
+    expected: FAIL
+
+  [WebGL test #35: Matrix with location 11 and vector with location 12 should not link.]
+    expected: FAIL
+
+  [WebGL test #37: Matrix with location 12 and vector with location 12 should not link.]
+    expected: FAIL
+
+  [WebGL test #38: Matrix with location 12 and vector with location 13 should not link.]
+    expected: FAIL
+
+  [WebGL test #40: Matrix with location 13 and vector with location 13 should not link.]
+    expected: FAIL
+
+  [WebGL test #41: Matrix with location 13 and vector with location 14 should not link.]
+    expected: FAIL
+
+  [WebGL test #43: Matrix with location 0 and vector with location 0 should not link.]
+    expected: FAIL
+
+  [WebGL test #44: Matrix with location 0 and vector with location 1 should not link.]
+    expected: FAIL
+
+  [WebGL test #45: Matrix with location 0 and vector with location 2 should not link.]
+    expected: FAIL
+
+  [WebGL test #47: Matrix with location 1 and vector with location 1 should not link.]
+    expected: FAIL
+
+  [WebGL test #48: Matrix with location 1 and vector with location 2 should not link.]
+    expected: FAIL
+
+  [WebGL test #49: Matrix with location 1 and vector with location 3 should not link.]
+    expected: FAIL
+
+  [WebGL test #51: Matrix with location 2 and vector with location 2 should not link.]
+    expected: FAIL
+
+  [WebGL test #52: Matrix with location 2 and vector with location 3 should not link.]
+    expected: FAIL
+
+  [WebGL test #53: Matrix with location 2 and vector with location 4 should not link.]
+    expected: FAIL
+
+  [WebGL test #55: Matrix with location 3 and vector with location 3 should not link.]
+    expected: FAIL
+
+  [WebGL test #56: Matrix with location 3 and vector with location 4 should not link.]
+    expected: FAIL
+
+  [WebGL test #57: Matrix with location 3 and vector with location 5 should not link.]
+    expected: FAIL
+
+  [WebGL test #59: Matrix with location 4 and vector with location 4 should not link.]
+    expected: FAIL
+
+  [WebGL test #60: Matrix with location 4 and vector with location 5 should not link.]
+    expected: FAIL
+
+  [WebGL test #61: Matrix with location 4 and vector with location 6 should not link.]
+    expected: FAIL
+
+  [WebGL test #63: Matrix with location 5 and vector with location 5 should not link.]
+    expected: FAIL
+
+  [WebGL test #64: Matrix with location 5 and vector with location 6 should not link.]
+    expected: FAIL
+
+  [WebGL test #65: Matrix with location 5 and vector with location 7 should not link.]
+    expected: FAIL
+
+  [WebGL test #67: Matrix with location 6 and vector with location 6 should not link.]
+    expected: FAIL
+
+  [WebGL test #68: Matrix with location 6 and vector with location 7 should not link.]
+    expected: FAIL
+
+  [WebGL test #69: Matrix with location 6 and vector with location 8 should not link.]
+    expected: FAIL
+
+  [WebGL test #71: Matrix with location 7 and vector with location 7 should not link.]
+    expected: FAIL
+
+  [WebGL test #72: Matrix with location 7 and vector with location 8 should not link.]
+    expected: FAIL
+
+  [WebGL test #73: Matrix with location 7 and vector with location 9 should not link.]
+    expected: FAIL
+
+  [WebGL test #75: Matrix with location 8 and vector with location 8 should not link.]
+    expected: FAIL
+
+  [WebGL test #76: Matrix with location 8 and vector with location 9 should not link.]
+    expected: FAIL
+
+  [WebGL test #77: Matrix with location 8 and vector with location 10 should not link.]
+    expected: FAIL
+
+  [WebGL test #79: Matrix with location 9 and vector with location 9 should not link.]
+    expected: FAIL
+
+  [WebGL test #80: Matrix with location 9 and vector with location 10 should not link.]
+    expected: FAIL
+
+  [WebGL test #81: Matrix with location 9 and vector with location 11 should not link.]
+    expected: FAIL
+
+  [WebGL test #83: Matrix with location 10 and vector with location 10 should not link.]
+    expected: FAIL
+
+  [WebGL test #84: Matrix with location 10 and vector with location 11 should not link.]
+    expected: FAIL
+
+  [WebGL test #85: Matrix with location 10 and vector with location 12 should not link.]
+    expected: FAIL
+
+  [WebGL test #87: Matrix with location 11 and vector with location 11 should not link.]
+    expected: FAIL
+
+  [WebGL test #88: Matrix with location 11 and vector with location 12 should not link.]
+    expected: FAIL
+
+  [WebGL test #89: Matrix with location 11 and vector with location 13 should not link.]
+    expected: FAIL
+
+  [WebGL test #91: Matrix with location 12 and vector with location 12 should not link.]
+    expected: FAIL
+
+  [WebGL test #92: Matrix with location 12 and vector with location 13 should not link.]
+    expected: FAIL
+
+  [WebGL test #93: Matrix with location 12 and vector with location 14 should not link.]
+    expected: FAIL
+
+  [WebGL test #95: Matrix with location 0 and vector with location 0 should not link.]
+    expected: FAIL
+
+  [WebGL test #96: Matrix with location 0 and vector with location 1 should not link.]
+    expected: FAIL
+
+  [WebGL test #97: Matrix with location 0 and vector with location 2 should not link.]
+    expected: FAIL
+
+  [WebGL test #98: Matrix with location 0 and vector with location 3 should not link.]
+    expected: FAIL
+
+  [WebGL test #100: Matrix with location 1 and vector with location 1 should not link.]
+    expected: FAIL
+
+  [WebGL test #101: Matrix with location 1 and vector with location 2 should not link.]
+    expected: FAIL
+
+  [WebGL test #102: Matrix with location 1 and vector with location 3 should not link.]
+    expected: FAIL
+
+  [WebGL test #103: Matrix with location 1 and vector with location 4 should not link.]
+    expected: FAIL
+
+  [WebGL test #105: Matrix with location 2 and vector with location 2 should not link.]
+    expected: FAIL
+
+  [WebGL test #106: Matrix with location 2 and vector with location 3 should not link.]
+    expected: FAIL
+
+  [WebGL test #107: Matrix with location 2 and vector with location 4 should not link.]
+    expected: FAIL
+
+  [WebGL test #108: Matrix with location 2 and vector with location 5 should not link.]
+    expected: FAIL
+
+  [WebGL test #110: Matrix with location 3 and vector with location 3 should not link.]
+    expected: FAIL
+
+  [WebGL test #111: Matrix with location 3 and vector with location 4 should not link.]
+    expected: FAIL
+
+  [WebGL test #112: Matrix with location 3 and vector with location 5 should not link.]
+    expected: FAIL
+
+  [WebGL test #113: Matrix with location 3 and vector with location 6 should not link.]
+    expected: FAIL
+
+  [WebGL test #115: Matrix with location 4 and vector with location 4 should not link.]
+    expected: FAIL
+
+  [WebGL test #116: Matrix with location 4 and vector with location 5 should not link.]
+    expected: FAIL
+
+  [WebGL test #117: Matrix with location 4 and vector with location 6 should not link.]
+    expected: FAIL
+
+  [WebGL test #118: Matrix with location 4 and vector with location 7 should not link.]
+    expected: FAIL
+
+  [WebGL test #120: Matrix with location 5 and vector with location 5 should not link.]
+    expected: FAIL
+
+  [WebGL test #121: Matrix with location 5 and vector with location 6 should not link.]
+    expected: FAIL
+
+  [WebGL test #122: Matrix with location 5 and vector with location 7 should not link.]
+    expected: FAIL
+
+  [WebGL test #123: Matrix with location 5 and vector with location 8 should not link.]
+    expected: FAIL
+
+  [WebGL test #125: Matrix with location 6 and vector with location 6 should not link.]
+    expected: FAIL
+
+  [WebGL test #126: Matrix with location 6 and vector with location 7 should not link.]
+    expected: FAIL
+
+  [WebGL test #127: Matrix with location 6 and vector with location 8 should not link.]
+    expected: FAIL
+
+  [WebGL test #128: Matrix with location 6 and vector with location 9 should not link.]
+    expected: FAIL
+
+  [WebGL test #130: Matrix with location 7 and vector with location 7 should not link.]
+    expected: FAIL
+
+  [WebGL test #131: Matrix with location 7 and vector with location 8 should not link.]
+    expected: FAIL
+
+  [WebGL test #132: Matrix with location 7 and vector with location 9 should not link.]
+    expected: FAIL
+
+  [WebGL test #133: Matrix with location 7 and vector with location 10 should not link.]
+    expected: FAIL
+
+  [WebGL test #135: Matrix with location 8 and vector with location 8 should not link.]
+    expected: FAIL
+
+  [WebGL test #136: Matrix with location 8 and vector with location 9 should not link.]
+    expected: FAIL
+
+  [WebGL test #137: Matrix with location 8 and vector with location 10 should not link.]
+    expected: FAIL
+
+  [WebGL test #138: Matrix with location 8 and vector with location 11 should not link.]
+    expected: FAIL
+
+  [WebGL test #140: Matrix with location 9 and vector with location 9 should not link.]
+    expected: FAIL
+
+  [WebGL test #141: Matrix with location 9 and vector with location 10 should not link.]
+    expected: FAIL
+
+  [WebGL test #142: Matrix with location 9 and vector with location 11 should not link.]
+    expected: FAIL
+
+  [WebGL test #143: Matrix with location 9 and vector with location 12 should not link.]
+    expected: FAIL
+
+  [WebGL test #145: Matrix with location 10 and vector with location 10 should not link.]
+    expected: FAIL
+
+  [WebGL test #146: Matrix with location 10 and vector with location 11 should not link.]
+    expected: FAIL
+
+  [WebGL test #147: Matrix with location 10 and vector with location 12 should not link.]
+    expected: FAIL
+
+  [WebGL test #148: Matrix with location 10 and vector with location 13 should not link.]
+    expected: FAIL
+
+  [WebGL test #150: Matrix with location 11 and vector with location 11 should not link.]
+    expected: FAIL
+
+  [WebGL test #151: Matrix with location 11 and vector with location 12 should not link.]
+    expected: FAIL
+
+  [WebGL test #152: Matrix with location 11 and vector with location 13 should not link.]
+    expected: FAIL
+
+  [WebGL test #153: Matrix with location 11 and vector with location 14 should not link.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/object-deletion-behaviour.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/object-deletion-behaviour.html.ini
@@ -1,7 +1,7 @@
 [object-deletion-behaviour.html]
   type: testharness
   expected:
-    if os == "linux": TIMEOUT
+    if os == "linux": CRASH
   [WebGL test #9: gl.isShader(vertexShader) should be true. Threw exception TypeError: gl.isShader is not a function]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/readPixelsBadArgs.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/readPixelsBadArgs.html.ini
@@ -1,6 +1,6 @@
 [readPixelsBadArgs.html]
   type: testharness
-  expected: TIMEOUT
+  expected: CRASH
   [WebGL test #0: testReadPixels]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/reading/read-pixels-pack-alignment.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/reading/read-pixels-pack-alignment.html.ini
@@ -1,6 +1,6 @@
 [read-pixels-pack-alignment.html]
   type: testharness
-  expected: TIMEOUT
+  expected: CRASH
   [WebGL test #3: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/state/gl-geterror.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/state/gl-geterror.html.ini
@@ -2,6 +2,7 @@
   type: testharness
   expected:
     if os == "mac": CRASH
+    if os == "linux": CRASH
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgb565.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgb565.html.ini
@@ -1,5 +1,7 @@
 [tex-image-and-sub-image-2d-with-canvas-rgb565.html]
   type: testharness
+  disabled:
+    if os == "linux": https://github.com/servo/servo/issues/12864
   [WebGL test #0: at (0, 16) expected: 255,0,0 was 255,227,0]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba4444.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba4444.html.ini
@@ -1,5 +1,7 @@
 [tex-image-and-sub-image-2d-with-canvas-rgba4444.html]
   type: testharness
+  disabled:
+    if os == "linux": https://github.com/servo/servo/issues/12864
   [WebGL test #0: at (0, 16) expected: 255,0,0 was 255,255,0]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba5551.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba5551.html.ini
@@ -1,5 +1,7 @@
 [tex-image-and-sub-image-2d-with-canvas-rgba5551.html]
   type: testharness
+  disabled:
+    if os == "linux": https://github.com/servo/servo/issues/12864
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-canvas.html.ini
@@ -1,5 +1,7 @@
 [tex-image-and-sub-image-2d-with-canvas.html]
   type: testharness
+  disabled:
+    if os == "linux": https://github.com/servo/servo/issues/12864
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-rgba4444.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-image-rgba4444.html.ini
@@ -1,4 +1,6 @@
 [tex-image-and-sub-image-2d-with-image-rgba4444.html]
+  disabled:
+    if os == "linux": https://github.com/servo/servo/pull/12858
   type: testharness
   [WebGL test #0: Unable to fetch WebGL rendering context for Canvas]
     expected: FAIL

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565.html.ini
@@ -1,5 +1,7 @@
 [tex-image-and-sub-image-2d-with-webgl-canvas-rgb565.html]
   type: testharness
+  disabled:
+    if os == "linux": https://github.com/servo/servo/issues/12864
   [WebGL test #0: at (0, 0) expected: 255,0,0 was 255,227,0]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4444.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4444.html.ini
@@ -1,5 +1,7 @@
 [tex-image-and-sub-image-2d-with-webgl-canvas-rgba4444.html]
   type: testharness
+  disabled:
+    if os == "linux": https://github.com/servo/servo/issues/12864
   [WebGL test #0: at (0, 0) expected: 255,0,0 was 255,255,0]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgba5551.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas-rgba5551.html.ini
@@ -1,5 +1,7 @@
 [tex-image-and-sub-image-2d-with-webgl-canvas-rgba5551.html]
   type: testharness
+  disabled:
+    if os == "linux": https://github.com/servo/servo/issues/12864
   [WebGL test #0: at (0, 0) expected: 255,0,0 was 255,231,0]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-webgl-canvas.html.ini
@@ -1,5 +1,7 @@
 [tex-image-and-sub-image-2d-with-webgl-canvas.html]
   type: testharness
+  disabled:
+    if os == "linux": https://github.com/servo/servo/issues/12864
   [WebGL test #0: at (0, 0) expected: 255,0,0 was 0,255,0]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-npot-video.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-npot-video.html.ini
@@ -1,5 +1,5 @@
 [texture-npot-video.html]
   type: testharness
   expected:
-    if os == "linux": CRASH
+    if os == "linux": TIMEOUT
     if os == "mac": TIMEOUT

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-npot.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-npot.html.ini
@@ -30,6 +30,13 @@
   [WebGL test #64: at (0, 0) expected: 0,0,0,255 was 0,192,128,255]
     expected: FAIL
 
+  [WebGL test #72: at (0, 0) expected: 0,192,128,255 was 0,0,0,255]
+    expected:
+      if os == "linux": FAIL
+
   [WebGL test #76: at (0, 0) expected: 0,0,0,255 was 0,192,128,255]
     expected: FAIL
 
+  [WebGL test #84: at (0, 0) expected: 0,192,128,255 was 0,0,0,255]
+    expected:
+      if os == "linux": FAIL

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/uniform-default-values.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/uniform-default-values.html.ini
@@ -1,5 +1,5 @@
 [uniform-default-values.html]
   type: testharness
   expected:
-    if os == "linux": CRASH
+    if os == "linux": TIMEOUT
     if os == "mac": TIMEOUT


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Enables the WebGL tests in test-wpt on Linux.  They have been disabled since the webgl conformance tests first showed up, and it looks like they should work now.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #9331

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12858)

<!-- Reviewable:end -->
