### PR TITLE
Fix iter_arith warning when running ./mach build-cef

### DIFF
--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -6,7 +6,6 @@
 #![feature(box_syntax)]
 #![feature(core_intrinsics)]
 #![feature(filling_drop)]
-#![feature(iter_arith)]
 #![feature(link_args)]
 #![feature(plugin)]
 #![feature(unicode)]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #12855 (github issue number if applicable).
- [x] There are tests for these changes (./mach build-cef)

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12860)

<!-- Reviewable:end -->
