### PR TITLE
Revert "Enable multiprocess and sandbox"

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -177,7 +177,7 @@ class PackageCommands(CommandBase):
             print("Writing run-servo")
             bhtml_path = path.join('${0%/*}/../Resources', browserhtml_path.split('/')[-1], 'out', 'index.html')
             runservo = os.open(dir_to_app + '/Contents/MacOS/run-servo', os.O_WRONLY | os.O_CREAT, int("0755", 8))
-            os.write(runservo, '#!/bin/bash\nexec ${0%/*}/servo -M -S ' + bhtml_path)
+            os.write(runservo, '#!/bin/bash\nexec ${0%/*}/servo ' + bhtml_path)
             os.close(runservo)
 
             print("Creating dmg")
@@ -278,7 +278,7 @@ class PackageCommands(CommandBase):
                     delete(dir_to_package + '/build/' + f)
             print("Writing runservo.sh")
             # TODO: deduplicate this arg list from post_build_commands
-            servo_args = ['-w', '-b', '-M', '-S',
+            servo_args = ['-w', '-b',
                           '--pref', 'dom.mozbrowser.enabled',
                           '--pref', 'dom.forcetouch.enabled',
                           '--pref', 'shell.builtin-key-shortcuts.enabled=false',

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -111,10 +111,6 @@ class PostBuildCommands(CommandBase):
                 # Convert to a relative path to avoid mingw -> Windows path conversions
                 browserhtml_path = path.relpath(browserhtml_path, os.getcwd())
 
-            if not is_windows():
-                # multiprocess + sandbox
-                args = args + ['-M', '-S']
-
             args = args + ['-w',
                            '--pref', 'dom.mozbrowser.enabled',
                            '--pref', 'dom.forcetouch.enabled',


### PR DESCRIPTION
Multiprocess and sandboxing still have some issues:
- https://github.com/servo/servo/issues/12791
- https://github.com/servo/servo/issues/12807

Let's disable these features for now and reenable them later: https://github.com/servo/servo/issues/12868.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12867)

<!-- Reviewable:end -->
