### PR TITLE
./mach has a formatting error

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -70,7 +70,7 @@ def download(desc, src, writer, start_byte=0):
                   "Please see https://github.com/servo/servo/#prerequisites")
         sys.exit(1)
     except urllib2.URLError, e:
-        print("Error downloading Rust compiler: " + str(e.reason) + ". The failing URL was: " + src)
+        print("Error downloading Rust compiler: %s. The failing URL was: %s" % (e.reason, src))
         sys.exit(1)
     except KeyboardInterrupt:
         writer.flush()

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -37,9 +37,10 @@ def download(desc, src, writer, start_byte=0):
     dumb = (os.environ.get("TERM") == "dumb") or (not sys.stdout.isatty())
 
     try:
+        req = urllib2.Request(src)
         if start_byte:
-            src = urllib2.Request(src, headers={'Range': 'bytes={}-'.format(start_byte)})
-        resp = urllib2.urlopen(src)
+            req = urllib2.Request(src, headers={'Range': 'bytes={}-'.format(start_byte)})
+        resp = urllib2.urlopen(req)
 
         fsize = None
         if resp.info().getheader('Content-Length'):


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fix for #12766. Couldn't reproduce the exact error.

I explicitly raised urllib2.URLError to get to the print and then tried using many different variable types for e.reason and src but it still didn't throw a coercion error.

So, as @Wafflespeanut said, 

> Instead of appending, we can format the values, which (I'm pretty sure) will fix this error.

which is what i've done.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12766, hopefully.

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests they execute before the test runner is installed. Can't test the bootstraping code.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12870)

<!-- Reviewable:end -->
