### PR TITLE
Fix absolute-flow's auto positioning

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -806,11 +806,14 @@ impl BlockFlow {
             for (child_index, kid) in self.base.child_iter_mut().enumerate() {
                 if flow::base(kid).flags.contains(IS_ABSOLUTELY_POSITIONED) {
                     // Assume that the *hypothetical box* for an absolute flow starts immediately
-                    // after the block-end border edge of the previous flow.
+                    // after the margin-end border edge of the previous flow.
                     if flow::base(kid).flags.contains(BLOCK_POSITION_IS_STATIC) {
+                        let previous_bottom_margin = margin_collapse_info.current_float_ceiling();
+
                         flow::mut_base(kid).position.start.b = cur_b +
                             flow::base(kid).collapsible_margins
-                                           .block_start_margin_for_noncollapsible_context()
+                                           .block_start_margin_for_noncollapsible_context() +
+                            previous_bottom_margin
                     }
                     kid.place_float_if_applicable();
                     if !flow::base(kid).flags.is_float() {

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-origin-002.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-origin-002.htm.ini
@@ -1,3 +1,0 @@
-[background-origin-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-origin-003.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-origin-003.htm.ini
@@ -1,3 +1,0 @@
-[background-origin-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-origin-004.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-origin-004.htm.ini
@@ -1,3 +1,0 @@
-[background-origin-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-origin-005.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-origin-005.htm.ini
@@ -1,3 +1,0 @@
-[background-origin-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-origin-008.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-origin-008.htm.ini
@@ -1,3 +1,0 @@
-[background-origin-008.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-aspect-ratio-img-column-001.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-aspect-ratio-img-column-001.htm.ini
@@ -1,3 +1,0 @@
-[flex-aspect-ratio-img-column-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-aspect-ratio-img-column-002.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-aspect-ratio-img-column-002.htm.ini
@@ -1,3 +1,0 @@
-[flex-aspect-ratio-img-column-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-aspect-ratio-img-row-001.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-aspect-ratio-img-row-001.htm.ini
@@ -1,3 +1,0 @@
-[flex-aspect-ratio-img-row-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-aspect-ratio-img-row-002.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-aspect-ratio-img-row-002.htm.ini
@@ -1,3 +1,0 @@
-[flex-aspect-ratio-img-row-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-001.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-001.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-height-flex-items-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-002.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-002.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-height-flex-items-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-004.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-004.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-height-flex-items-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-005.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-005.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-height-flex-items-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-006.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-006.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-height-flex-items-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-007.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-007.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-height-flex-items-007.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-008.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-height-flex-items-008.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-height-flex-items-008.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-width-flex-items-004.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-width-flex-items-004.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-width-flex-items-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-width-flex-items-005.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-width-flex-items-005.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-width-flex-items-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-width-flex-items-006.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-width-flex-items-006.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-width-flex-items-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-width-flex-items-007.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-width-flex-items-007.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-width-flex-items-007.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-width-flex-items-008.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-minimum-width-flex-items-008.htm.ini
@@ -1,3 +1,0 @@
-[flex-minimum-width-flex-items-008.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-001.htm.ini
@@ -1,3 +1,0 @@
-[perspective-origin-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-002.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-002.htm.ini
@@ -1,3 +1,0 @@
-[perspective-origin-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-003.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-003.htm.ini
@@ -1,3 +1,0 @@
-[perspective-origin-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-004.htm.ini
@@ -1,3 +1,0 @@
-[perspective-origin-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-005.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-005.htm.ini
@@ -1,3 +1,0 @@
-[perspective-origin-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-006.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/perspective-origin-006.htm.ini
@@ -1,3 +1,0 @@
-[perspective-origin-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/scalex.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/scalex.htm.ini
@@ -1,3 +1,0 @@
-[scalex.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/absolute-non-replaced-width-025.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/absolute-non-replaced-width-025.htm.ini
@@ -1,3 +1,0 @@
-[absolute-non-replaced-width-025.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/absolute-non-replaced-width-026.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/absolute-non-replaced-width-026.htm.ini
@@ -1,3 +1,0 @@
-[absolute-non-replaced-width-026.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-001.htm.ini
@@ -1,3 +1,0 @@
-[abspos-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-009.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-009.htm.ini
@@ -1,3 +1,0 @@
-[abspos-009.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/anonymous-boxes-001a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/anonymous-boxes-001a.htm.ini
@@ -1,3 +1,0 @@
-[anonymous-boxes-001a.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/block-formatting-context-height-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/block-formatting-context-height-001.htm.ini
@@ -1,3 +1,0 @@
-[block-formatting-context-height-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/block-formatting-context-height-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/block-formatting-context-height-002.htm.ini
@@ -1,3 +1,0 @@
-[block-formatting-context-height-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/block-formatting-context-height-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/block-formatting-context-height-003.htm.ini
@@ -1,3 +1,0 @@
-[block-formatting-context-height-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/block-formatting-contexts-009.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/block-formatting-contexts-009.htm.ini
@@ -1,3 +1,0 @@
-[block-formatting-contexts-009.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/blocks-021.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/blocks-021.htm.ini
@@ -1,3 +1,0 @@
-[blocks-021.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/clip-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/clip-001.htm.ini
@@ -1,3 +1,0 @@
-[clip-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/containing-block-019.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/containing-block-019.htm.ini
@@ -1,3 +1,0 @@
-[containing-block-019.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/containing-block-021.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/containing-block-021.htm.ini
@@ -1,3 +1,0 @@
-[containing-block-021.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/height-table-cell-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/height-table-cell-001.htm.ini
@@ -1,3 +1,0 @@
-[height-table-cell-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001.htm.ini
@@ -1,3 +1,0 @@
-[height-width-inline-table-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001a.htm.ini
@@ -1,3 +1,0 @@
-[height-width-inline-table-001a.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001b.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001b.htm.ini
@@ -1,3 +1,0 @@
-[height-width-inline-table-001b.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001c.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001c.htm.ini
@@ -1,3 +1,0 @@
-[height-width-inline-table-001c.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001d.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001d.htm.ini
@@ -1,3 +1,0 @@
-[height-width-inline-table-001d.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001e.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/height-width-inline-table-001e.htm.ini
@@ -1,3 +1,0 @@
-[height-width-inline-table-001e.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/height-width-table-001b.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/height-width-table-001b.htm.ini
@@ -1,3 +1,0 @@
-[height-width-table-001b.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/inline-replaced-height-010.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inline-replaced-height-010.htm.ini
@@ -1,3 +1,0 @@
-[inline-replaced-height-010.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/inline-replaced-height-011.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inline-replaced-height-011.htm.ini
@@ -1,3 +1,0 @@
-[inline-replaced-height-011.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/inline-replaced-width-016.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inline-replaced-width-016.htm.ini
@@ -1,3 +1,0 @@
-[inline-replaced-width-016.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/inline-replaced-width-017.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inline-replaced-width-017.htm.ini
@@ -1,3 +1,0 @@
-[inline-replaced-width-017.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/left-applies-to-013.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/left-applies-to-013.htm.ini
@@ -1,3 +1,0 @@
-[left-applies-to-013.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/left-applies-to-014.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/left-applies-to-014.htm.ini
@@ -1,3 +1,0 @@
-[left-applies-to-014.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/left-offset-percentage-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/left-offset-percentage-002.htm.ini
@@ -1,3 +1,0 @@
-[left-offset-percentage-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/left-offset-position-fixed-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/left-offset-position-fixed-001.htm.ini
@@ -1,0 +1,3 @@
+[left-offset-position-fixed-001.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-001.htm.ini
@@ -1,3 +1,0 @@
-[margin-applies-to-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-002.htm.ini
@@ -1,3 +1,0 @@
-[margin-applies-to-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-003.htm.ini
@@ -1,3 +1,0 @@
-[margin-applies-to-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-004.htm.ini
@@ -1,3 +1,0 @@
-[margin-applies-to-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-005.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-005.htm.ini
@@ -1,3 +1,0 @@
-[margin-applies-to-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-006.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-006.htm.ini
@@ -1,3 +1,0 @@
-[margin-applies-to-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-007.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-007.htm.ini
@@ -1,3 +1,0 @@
-[margin-applies-to-007.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-009.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-009.htm.ini
@@ -1,3 +1,0 @@
-[margin-applies-to-009.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-015.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-applies-to-015.htm.ini
@@ -1,3 +1,0 @@
-[margin-applies-to-015.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-039.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-039.htm.ini
@@ -1,3 +1,0 @@
-[margin-collapse-039.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-040.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-040.htm.ini
@@ -1,3 +1,0 @@
-[margin-collapse-040.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-041.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-041.htm.ini
@@ -1,3 +1,0 @@
-[margin-collapse-041.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-102.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-collapse-102.htm.ini
@@ -1,3 +1,0 @@
-[margin-collapse-102.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/max-width-105.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/max-width-105.htm.ini
@@ -1,3 +1,0 @@
-[max-width-105.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/max-width-107.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/max-width-107.htm.ini
@@ -1,3 +1,0 @@
-[max-width-107.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/position-relative-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/position-relative-004.htm.ini
@@ -1,3 +1,0 @@
-[position-relative-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/position-relative-005.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/position-relative-005.htm.ini
@@ -1,3 +1,0 @@
-[position-relative-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/position-relative-014.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/position-relative-014.htm.ini
@@ -1,3 +1,0 @@
-[position-relative-014.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/position-relative-019.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/position-relative-019.htm.ini
@@ -1,3 +1,0 @@
-[position-relative-019.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/right-applies-to-013.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/right-applies-to-013.htm.ini
@@ -1,3 +1,0 @@
-[right-applies-to-013.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/right-applies-to-014.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/right-applies-to-014.htm.ini
@@ -1,3 +1,0 @@
-[right-applies-to-014.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/separated-border-model-003a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/separated-border-model-003a.htm.ini
@@ -1,3 +1,0 @@
-[separated-border-model-003a.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/separated-border-model-004a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/separated-border-model-004a.htm.ini
@@ -1,3 +1,0 @@
-[separated-border-model-004a.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/separated-border-model-004c.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/separated-border-model-004c.htm.ini
@@ -1,3 +1,0 @@
-[separated-border-model-004c.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-height-algorithm-008a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-height-algorithm-008a.htm.ini
@@ -1,3 +1,0 @@
-[table-height-algorithm-008a.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-height-algorithm-008b.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-height-algorithm-008b.htm.ini
@@ -1,3 +1,0 @@
-[table-height-algorithm-008b.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-height-algorithm-008c.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-height-algorithm-008c.htm.ini
@@ -1,3 +1,0 @@
-[table-height-algorithm-008c.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/top-offset-percentage-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/top-offset-percentage-002.htm.ini
@@ -1,3 +1,0 @@
-[top-offset-percentage-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/z-index-015.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/z-index-015.htm.ini
@@ -1,3 +1,0 @@
-[z-index-015.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/z-index-016.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/z-index-016.htm.ini
@@ -1,3 +1,0 @@
-[z-index-016.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/z-index-017.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/z-index-017.htm.ini
@@ -1,3 +1,0 @@
-[z-index-017.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/z-index-018.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/z-index-018.htm.ini
@@ -1,3 +1,0 @@
-[z-index-018.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/z-index-019.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/z-index-019.htm.ini
@@ -1,3 +1,0 @@
-[z-index-019.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-001.htm.ini
@@ -1,3 +1,0 @@
-[z-index-abspos-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-002.htm.ini
@@ -1,3 +1,0 @@
-[z-index-abspos-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-003.htm.ini
@@ -1,3 +1,0 @@
-[z-index-abspos-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-004.htm.ini
@@ -1,3 +1,0 @@
-[z-index-abspos-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-005.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-005.htm.ini
@@ -1,3 +1,0 @@
-[z-index-abspos-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-007.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/z-index-abspos-007.htm.ini
@@ -1,3 +1,0 @@
-[z-index-abspos-007.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

If an absolute positioned flow has no top, bottom, left, right property, its hypothetical box position should be the margin-end of its previous sibling, not the border-end.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #12676 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12873)

<!-- Reviewable:end -->
