### PR TITLE
Wrap hyper::header::Headers in Rc

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -29,6 +29,7 @@ use net_traits::request::{Type, Origin, Window};
 use net_traits::response::{HttpsState, TerminationReason};
 use net_traits::response::{Response, ResponseBody, ResponseType};
 use resource_thread::CancellationListener;
+use std::cell::RefCell;
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::Read;
@@ -393,7 +394,7 @@ fn basic_fetch(request: Rc<Request>, cache: &mut CORSCache,
             let mut response = Response::new();
             // https://github.com/whatwg/fetch/issues/312
             response.url = Some(url);
-            response.headers.set(ContentType(mime!(Text / Html; Charset = Utf8)));
+            response.headers.borrow_mut().set(ContentType(mime!(Text / Html; Charset = Utf8)));
             *response.body.lock().unwrap() = ResponseBody::Done(vec![]);
             response
         },
@@ -410,7 +411,7 @@ fn basic_fetch(request: Rc<Request>, cache: &mut CORSCache,
                         // https://github.com/whatwg/fetch/issues/312
                         response.url = Some(url.clone());
                         *response.body.lock().unwrap() = ResponseBody::Done(bytes);
-                        response.headers.set(ContentType(mime));
+                        response.headers.borrow_mut().set(ContentType(mime));
                         response
                     },
                     Err(_) => Response::network_error()
@@ -433,7 +434,7 @@ fn basic_fetch(request: Rc<Request>, cache: &mut CORSCache,
                             // https://github.com/whatwg/fetch/issues/312
                             response.url = Some(url.clone());
                             *response.body.lock().unwrap() = ResponseBody::Done(bytes);
-                            response.headers.set(ContentType(mime));
+                            response.headers.borrow_mut().set(ContentType(mime));
                             response
                         })
                     },
@@ -638,12 +639,12 @@ fn http_redirect_fetch(request: Rc<Request>,
     // Step 3
     // this step is done early, because querying if Location exists says
     // if it is None or Some, making it easy to seperate from the retrieval failure case
-    if !response.actual_response().headers.has::<Location>() {
+    if !response.actual_response().headers.borrow().has::<Location>() {
         return Rc::try_unwrap(response).ok().unwrap();
     }
 
     // Step 2
-    let location = match response.actual_response().headers.get::<Location>() {
+    let location = match response.actual_response().headers.borrow_mut().get::<Location>() {
         Some(&Location(ref location)) => location.clone(),
         // Step 4
         _ => return Response::network_error()
@@ -971,7 +972,7 @@ fn http_network_fetch(request: Rc<Request>,
             response.url = Some(url.clone());
             response.status = Some(res.response.status);
             response.raw_status = Some(res.response.status_raw().clone());
-            response.headers = res.response.headers.clone();
+            response.headers = Rc::new(RefCell::new(res.response.headers.clone()));
 
             let res_body = response.body.clone();
 
@@ -1065,7 +1066,7 @@ fn http_network_fetch(request: Rc<Request>,
     // TODO when https://bugzilla.mozilla.org/show_bug.cgi?id=1030660
     // is resolved, this step will become uneccesary
     // TODO this step
-    if let Some(encoding) = response.headers.get::<ContentEncoding>() {
+    if let Some(encoding) = response.headers.borrow().get::<ContentEncoding>() {
         if encoding.contains(&Encoding::Gzip) {
         }
 
@@ -1136,8 +1137,8 @@ fn cors_preflight_fetch(request: Rc<Request>, cache: &mut CORSCache,
     if cors_check(request.clone(), &response).is_ok() &&
        response.status.map_or(false, |status| status.is_success()) {
         // Substep 1
-        let mut methods = if response.headers.has::<AccessControlAllowMethods>() {
-            match response.headers.get::<AccessControlAllowMethods>() {
+        let mut methods = if response.headers.borrow().has::<AccessControlAllowMethods>() {
+            match response.headers.borrow().get::<AccessControlAllowMethods>() {
                 Some(&AccessControlAllowMethods(ref m)) => m.clone(),
                 // Substep 3
                 None => return Response::network_error()
@@ -1147,8 +1148,8 @@ fn cors_preflight_fetch(request: Rc<Request>, cache: &mut CORSCache,
         };
 
         // Substep 2
-        let header_names = if response.headers.has::<AccessControlAllowHeaders>() {
-            match response.headers.get::<AccessControlAllowHeaders>() {
+        let header_names = if response.headers.borrow().has::<AccessControlAllowHeaders>() {
+            match response.headers.borrow().get::<AccessControlAllowHeaders>() {
                 Some(&AccessControlAllowHeaders(ref hn)) => hn.clone(),
                 // Substep 3
                 None => return Response::network_error()
@@ -1180,7 +1181,7 @@ fn cors_preflight_fetch(request: Rc<Request>, cache: &mut CORSCache,
         }
 
         // Substep 7, 8
-        let max_age = response.headers.get::<AccessControlMaxAge>().map(|acma| acma.0).unwrap_or(0);
+        let max_age = response.headers.borrow().get::<AccessControlMaxAge>().map(|acma| acma.0).unwrap_or(0);
 
         // TODO: Substep 9 - Need to define what an imposed limit on max-age is
 
@@ -1205,7 +1206,7 @@ fn cors_preflight_fetch(request: Rc<Request>, cache: &mut CORSCache,
 /// [CORS check](https://fetch.spec.whatwg.org#concept-cors-check)
 fn cors_check(request: Rc<Request>, response: &Response) -> Result<(), ()> {
     // Step 1
-    let origin = response.headers.get::<AccessControlAllowOrigin>().cloned();
+    let origin = response.headers.borrow().get::<AccessControlAllowOrigin>().cloned();
 
     // Step 2
     let origin = try!(origin.ok_or(()));

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -33,6 +33,7 @@ use net_traits::request::RequestMode as NetTraitsRequestMode;
 use net_traits::request::Type as NetTraitsRequestType;
 use net_traits::request::{Origin, Window};
 use std::cell::Cell;
+use std::rc::Rc;
 use url::Url;
 
 #[dom_struct]
@@ -147,7 +148,7 @@ impl Request {
                                           temporary_request.current_url(),
                                           false);
         request.method = temporary_request.method;
-        request.headers = temporary_request.headers.clone();
+        request.headers = Rc::new((*temporary_request.headers).clone());
         request.unsafe_request = true;
         request.window.set(window);
         // TODO: `entry settings object` is not implemented in Servo yet.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR modifies instances of `hyper::header::Headers` in the following three structs. Instances of `RefCell<hyper::header::Headers>` or `DOMRefCell<hyper::header::Headers>` are now `Rc<RefCell<hyper::header::Headers>>`:
- `net_traits::request::Request`
- `net_traits::response::Response`
- `dom::headers::Headers`

This is useful for `dom::response::Response`, for which [the spec](https://fetch.spec.whatwg.org/#response-class) says:

> A Response object also has an associated Headers object which is itself associated with response's header list.

The use of `Rc` means that (in `dom::response::Response`) the same enclosed `hyper::header::Headers` object can now be referenced and manipulated through both `net_traits::request::Response` and `dom::headers::Headers`. 

Similar advantage for `dom::request::Request`.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there are existing web platform tests.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12884)

<!-- Reviewable:end -->
