### PR TITLE
Improve Blob.Size() speed by avoid reading content

### DIFF
--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -357,11 +357,12 @@ pub fn blob_parts_to_bytes(blobparts: Vec<BlobOrString>) -> Result<Vec<u8>, ()> 
 impl BlobMethods for Blob {
     // https://w3c.github.io/FileAPI/#dfn-size
     fn Size(&self) -> u64 {
-        // XXX: This will incur reading if file-based
-        match self.get_bytes() {
-            Ok(s) => s.len() as u64,
-            _ => 0,
-        }
+         match *self.blob_impl.borrow() {
+            BlobImpl::File(ref f) => f.size,
+            BlobImpl::Memory(ref v) => v.len() as u64,
+            BlobImpl::Sliced(ref parent, ref rel_pos) =>
+                rel_pos.to_abs_range(parent.Size() as usize).len() as u64,
+         }
     }
 
     // https://w3c.github.io/FileAPI/#dfn-type


### PR DESCRIPTION
r? @Manishearth 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12896)

<!-- Reviewable:end -->
