### PR TITLE
./mach throws error on poor connectivity

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -8,6 +8,7 @@
 # except according to those terms.
 
 from __future__ import print_function, unicode_literals
+from socket import error as socket_error
 
 import base64
 import json
@@ -72,6 +73,9 @@ def download(desc, src, writer, start_byte=0):
         sys.exit(1)
     except urllib2.URLError, e:
         print("Error downloading Rust compiler: %s. The failing URL was: %s" % (e.reason, src))
+        sys.exit(1)
+    except socket_error, e:
+        print("Looks like there's a connectivity issue, check your Internet connection. %s" % (e))
         sys.exit(1)
     except KeyboardInterrupt:
         writer.flush()


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Imported error from socket using `from` since it's the only thing we need.
The exception is [different ](https://docs.python.org/2/library/socket.html#socket.error) from the other exceptions as it could be a string or a tuple with error number.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12764 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests they execute before the test runner is installed. Can't test the bootstrapping code.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12900)

<!-- Reviewable:end -->
