### PR TITLE
Implement postMessage for ServiceWorkers

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -738,12 +738,6 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                 // store service worker manager for communicating with it.
                 self.swmanager_chan = Some(sw_sender);
             }
-            SWManagerMsg::ConnectServiceWorker(scope_url, pipeline_id, msg_chan) => {
-                if let Some(ref parent_info) = self.pipelines.get(&pipeline_id) {
-                    let from_cons_msg = ConstellationControlMsg::ConnectServiceWorker(scope_url, msg_chan);
-                    let _ = parent_info.script_chan.send(from_cons_msg);
-                }
-            }
         }
     }
 
@@ -1005,6 +999,13 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             FromScriptMsg::RegisterServiceWorker(scope_things, scope) => {
                 debug!("constellation got store registration scope message");
                 self.handle_register_serviceworker(scope_things, scope);
+            }
+            FromScriptMsg::ForwardDOMMessage(msg_vec, scope_url) => {
+                if let Some(ref mgr) = self.swmanager_chan {
+                    let _ = mgr.send(ServiceWorkerMsg::ForwardDOMMessage(msg_vec, scope_url));
+                } else {
+                    warn!("Unable to forward DOMMessage for postMessage call");
+                }
             }
         }
     }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -738,6 +738,12 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                 // store service worker manager for communicating with it.
                 self.swmanager_chan = Some(sw_sender);
             }
+            SWManagerMsg::ConnectServiceWorker(scope_url, pipeline_id, msg_chan) => {
+                if let Some(ref parent_info) = self.pipelines.get(&pipeline_id) {
+                    let from_cons_msg = ConstellationControlMsg::ConnectServiceWorker(scope_url, msg_chan);
+                    let _ = parent_info.script_chan.send(from_cons_msg);
+                }
+            }
         }
     }
 

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -11,14 +11,15 @@ use js::jsapi::{HandleValue, MutableHandleValue};
 use js::jsapi::{JSContext, JS_ReadStructuredClone, JS_STRUCTURED_CLONE_VERSION};
 use js::jsapi::{JS_ClearPendingException, JS_WriteStructuredClone};
 use libc::size_t;
-use script_traits::DOMMessage;
 use std::ptr;
 use std::slice;
 
 /// A buffer for a structured clone.
-pub struct StructuredCloneData {
-    data: *mut u64,
-    nbytes: size_t,
+pub enum StructuredCloneData {
+    /// A non-serializable (default) variant
+    Struct(*mut u64, size_t),
+    /// A variant that can be serialized
+    Vector(Vec<u8>)
 }
 
 impl StructuredCloneData {
@@ -41,42 +42,45 @@ impl StructuredCloneData {
             }
             return Err(Error::DataClone);
         }
-        Ok(StructuredCloneData {
-            data: data,
-            nbytes: nbytes,
-        })
+        Ok(StructuredCloneData::Struct(data, nbytes))
     }
 
     /// Converts a StructuredCloneData to Vec<u8> for inter-thread sharing
-    pub fn move_to_arraybuffer(self) -> DOMMessage {
-        unsafe {
-            DOMMessage(slice::from_raw_parts(self.data as *mut u8, self.nbytes).to_vec())
-        }
-    }
-
-    /// Converts back to StructuredCloneData
-    pub fn make_structured_clone(data: DOMMessage) -> StructuredCloneData {
-        let DOMMessage(mut data) = data;
-        let nbytes = data.len();
-        let data = data.as_mut_ptr() as *mut u64;
-        StructuredCloneData {
-            data: data,
-            nbytes: nbytes
+    pub fn move_to_arraybuffer(self) -> Vec<u8> {
+        match self {
+            StructuredCloneData::Struct(data, nbytes) => {
+                unsafe {
+                    slice::from_raw_parts(data as *mut u8, nbytes).to_vec()
+                }
+            }
+            StructuredCloneData::Vector(msg) => msg
         }
     }
 
     /// Reads a structured clone.
     ///
     /// Panics if `JS_ReadStructuredClone` fails.
-    pub fn read(self, global: GlobalRef, rval: MutableHandleValue) {
+    fn read_clone(global: GlobalRef, data: *mut u64, nbytes: size_t, rval: MutableHandleValue) {
         unsafe {
             assert!(JS_ReadStructuredClone(global.get_cx(),
-                                           self.data,
-                                           self.nbytes,
+                                           data,
+                                           nbytes,
                                            JS_STRUCTURED_CLONE_VERSION,
                                            rval,
                                            ptr::null(),
                                            ptr::null_mut()));
+        }
+    }
+
+    /// Thunk for the actual `read_clone` method. Resolves proper variant for read_clone.
+    pub fn read(self, global: GlobalRef, rval: MutableHandleValue) {
+        match self {
+            StructuredCloneData::Vector(mut vec_msg) => {
+                let nbytes = vec_msg.len();
+                let data = vec_msg.as_mut_ptr() as *mut u64;
+                StructuredCloneData::read_clone(global, data, nbytes, rval);
+            }
+            StructuredCloneData::Struct(data, nbytes) => StructuredCloneData::read_clone(global, data, nbytes, rval)
         }
     }
 }

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -11,6 +11,7 @@ use js::jsapi::{HandleValue, MutableHandleValue};
 use js::jsapi::{JSContext, JS_ReadStructuredClone, JS_STRUCTURED_CLONE_VERSION};
 use js::jsapi::{JS_ClearPendingException, JS_WriteStructuredClone};
 use libc::size_t;
+use script_traits::DOMMessage;
 use std::ptr;
 use std::slice;
 
@@ -46,15 +47,18 @@ impl StructuredCloneData {
         })
     }
 
-    /// Converts a StructuredCloneData to Vec<u64>
-    pub fn move_to_arraybuffer(self) -> Vec<u64> {
+    /// Converts a StructuredCloneData to Vec<u8> for inter-thread sharing
+    pub fn move_to_arraybuffer(self) -> DOMMessage {
         unsafe {
-            slice::from_raw_parts(self.data, self.nbytes).to_vec()
+            DOMMessage(slice::from_raw_parts(self.data as *mut u8, self.nbytes).to_vec())
         }
     }
 
-    /// Converts back to StructuredCloneData using a pointer and no of bytes
-    pub fn make_structured_clone(data: *mut u64, nbytes: size_t) -> StructuredCloneData {
+    /// Converts back to StructuredCloneData
+    pub fn make_structured_clone(data: DOMMessage) -> StructuredCloneData {
+        let DOMMessage(mut data) = data;
+        let nbytes = data.len();
+        let data = data.as_mut_ptr() as *mut u64;
         StructuredCloneData {
             data: data,
             nbytes: nbytes

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -12,6 +12,7 @@ use js::jsapi::{JSContext, JS_ReadStructuredClone, JS_STRUCTURED_CLONE_VERSION};
 use js::jsapi::{JS_ClearPendingException, JS_WriteStructuredClone};
 use libc::size_t;
 use std::ptr;
+use std::slice;
 
 /// A buffer for a structured clone.
 pub struct StructuredCloneData {
@@ -43,6 +44,21 @@ impl StructuredCloneData {
             data: data,
             nbytes: nbytes,
         })
+    }
+
+    /// Converts a StructuredCloneData to Vec<u64>
+    pub fn move_to_arraybuffer(self) -> Vec<u64> {
+        unsafe {
+            slice::from_raw_parts(self.data, self.nbytes).to_vec()
+        }
+    }
+
+    /// Converts back to StructuredCloneData using a pointer and no of bytes
+    pub fn make_structured_clone(data: *mut u64, nbytes: size_t) -> StructuredCloneData {
+        StructuredCloneData {
+            data: data,
+            nbytes: nbytes
+        }
     }
 
     /// Reads a structured clone.

--- a/components/script/dom/serviceworker.rs
+++ b/components/script/dom/serviceworker.rs
@@ -6,7 +6,7 @@ use dom::abstractworker::SimpleWorkerErrorHandler;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::ServiceWorkerBinding::{ServiceWorkerMethods, ServiceWorkerState, Wrap};
-use dom::bindings::error::ErrorResult;
+use dom::bindings::error::{ErrorResult, Error};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::inheritance::Castable;
 use dom::bindings::js::Root;
@@ -15,10 +15,9 @@ use dom::bindings::reflector::reflect_dom_object;
 use dom::bindings::str::USVString;
 use dom::bindings::structuredclone::StructuredCloneData;
 use dom::eventtarget::EventTarget;
-use ipc_channel::ipc::IpcSender;
 use js::jsapi::{HandleValue, JSContext};
 use script_thread::Runnable;
-use script_traits::DOMMessage;
+use script_traits::ScriptMsg;
 use std::cell::Cell;
 use url::Url;
 
@@ -28,28 +27,29 @@ pub type TrustedServiceWorkerAddress = Trusted<ServiceWorker>;
 pub struct ServiceWorker {
     eventtarget: EventTarget,
     script_url: DOMRefCell<String>,
+    scope_url: DOMRefCell<String>,
     state: Cell<ServiceWorkerState>,
-    #[ignore_heap_size_of = "Defined in std"]
-    msg_sender: DOMRefCell<Option<IpcSender<DOMMessage>>>,
     skip_waiting: Cell<bool>
 }
 
 impl ServiceWorker {
     fn new_inherited(script_url: &str,
-                     skip_waiting: bool) -> ServiceWorker {
+                     skip_waiting: bool,
+                     scope_url: &str) -> ServiceWorker {
         ServiceWorker {
             eventtarget: EventTarget::new_inherited(),
             script_url: DOMRefCell::new(String::from(script_url)),
             state: Cell::new(ServiceWorkerState::Installing),
-            skip_waiting: Cell::new(skip_waiting),
-            msg_sender: DOMRefCell::new(None)
+            scope_url: DOMRefCell::new(String::from(scope_url)),
+            skip_waiting: Cell::new(skip_waiting)
         }
     }
 
     pub fn new(global: GlobalRef,
                 script_url: &str,
+                scope_url: &str,
                 skip_waiting: bool) -> Root<ServiceWorker> {
-        reflect_dom_object(box ServiceWorker::new_inherited(script_url, skip_waiting), global, Wrap)
+        reflect_dom_object(box ServiceWorker::new_inherited(script_url, skip_waiting, scope_url), global, Wrap)
     }
 
     pub fn dispatch_simple_error(address: TrustedServiceWorkerAddress) {
@@ -68,17 +68,12 @@ impl ServiceWorker {
 
     pub fn install_serviceworker(global: GlobalRef,
                                  script_url: Url,
+                                 scope_url: &str,
                                  skip_waiting: bool) -> Root<ServiceWorker> {
         ServiceWorker::new(global,
                            script_url.as_str(),
+                           scope_url,
                            skip_waiting)
-    }
-
-    pub fn store_sender(trusted_worker: TrustedServiceWorkerAddress, sender: IpcSender<DOMMessage>) {
-        let worker = trusted_worker.root();
-        // This channel is used for sending message from the ServiceWorker object to its
-        // corresponding ServiceWorkerGlobalScope
-        *worker.msg_sender.borrow_mut() = Some(sender);
     }
 }
 
@@ -95,13 +90,15 @@ impl ServiceWorkerMethods for ServiceWorker {
 
     // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-postmessage
     fn PostMessage(&self, cx: *mut JSContext, message: HandleValue) -> ErrorResult {
-        let data = try!(StructuredCloneData::write(cx, message));
-        let msg_vec = DOMMessage(data.move_to_arraybuffer());
-        if let Some(ref sender) = *self.msg_sender.borrow() {
-            let _ = sender.send(msg_vec);
-        } else {
-            warn!("Could not communicate message to ServiceWorkerGlobalScope");
+        // Step 1
+        if let ServiceWorkerState::Redundant = self.state.get() {
+            return Err(Error::InvalidState);
         }
+        // Step 7
+        let data = try!(StructuredCloneData::write(cx, message));
+        let msg_vec = data.move_to_arraybuffer();
+        let scope_url = Url::parse(&*self.scope_url.borrow()).unwrap();
+        let _ = self.global().r().constellation_chan().send(ScriptMsg::ForwardDOMMessage(msg_vec, scope_url));
         Ok(())
     }
 

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -95,10 +95,9 @@ impl ServiceWorkerContainerMethods for ServiceWorkerContainer {
             return Err(Error::Type("Scope URL contains forbidden characters".to_owned()));
         }
 
-        let scope_str = scope.as_str().to_owned();
         let worker_registration = ServiceWorkerRegistration::new(self.global().r(),
                                                                  script_url,
-                                                                 scope_str.clone(),
+                                                                 scope.clone(),
                                                                  self);
         ScriptThread::set_registration(scope, &*worker_registration, self.global().r().pipeline());
         Ok(worker_registration)

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -5,7 +5,6 @@
 use devtools;
 use devtools_traits::DevtoolScriptControlMsg;
 use dom::abstractworker::WorkerScriptMsg;
-use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::ServiceWorkerGlobalScopeBinding;
 use dom::bindings::codegen::Bindings::ServiceWorkerGlobalScopeBinding::ServiceWorkerGlobalScopeMethods;
@@ -14,9 +13,9 @@ use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{Root, RootCollection};
 use dom::bindings::reflector::Reflectable;
 use dom::bindings::str::DOMString;
+use dom::bindings::structuredclone::StructuredCloneData;
 use dom::eventtarget::EventTarget;
 use dom::messageevent::MessageEvent;
-use dom::serviceworker::TrustedServiceWorkerAddress;
 use dom::workerglobalscope::WorkerGlobalScope;
 use ipc_channel::ipc::{self, IpcSender, IpcReceiver};
 use ipc_channel::router::ROUTER;
@@ -26,8 +25,8 @@ use js::rust::Runtime;
 use msg::constellation_msg::PipelineId;
 use net_traits::{LoadContext, load_whole_resource, IpcSend, CustomResponseMediator};
 use rand::random;
-use script_runtime::{CommonScriptMsg, StackRootTLS, get_reports, new_rt_and_cx};
-use script_traits::{TimerEvent, WorkerGlobalScopeInit, ScopeThings, ServiceWorkerMsg};
+use script_runtime::{CommonScriptMsg, StackRootTLS, get_reports, new_rt_and_cx, ScriptChan};
+use script_traits::{TimerEvent, WorkerGlobalScopeInit, ScopeThings, ServiceWorkerMsg, DOMMessage};
 use std::sync::mpsc::{Receiver, RecvError, Select, Sender, channel};
 use std::thread;
 use std::time::Duration;
@@ -49,6 +48,27 @@ pub enum MixedMessage {
     FromServiceWorker(ServiceWorkerScriptMsg),
     FromDevtools(DevtoolScriptControlMsg),
     FromTimeoutThread(()),
+    PostMessage(DOMMessage)
+}
+
+// Required for run_with_memory_reporting
+#[derive(JSTraceable, Clone)]
+pub struct ServiceWorkerChan {
+    pub sender: Sender<ServiceWorkerScriptMsg>
+}
+
+impl ScriptChan for ServiceWorkerChan {
+    fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
+        self.sender
+            .send(ServiceWorkerScriptMsg::CommonWorker(WorkerScriptMsg::Common(msg)))
+            .map_err(|_| ())
+    }
+
+    fn clone(&self) -> Box<ScriptChan + Send> {
+        box ServiceWorkerChan {
+            sender: self.sender.clone(),
+        }
+    }
 }
 
 #[dom_struct]
@@ -61,12 +81,12 @@ pub struct ServiceWorkerGlobalScope {
     own_sender: Sender<ServiceWorkerScriptMsg>,
     #[ignore_heap_size_of = "Defined in std"]
     timer_event_port: Receiver<()>,
-    #[ignore_heap_size_of = "Trusted<T> has unclear ownership like JS<T>"]
-    worker: DOMRefCell<Option<TrustedServiceWorkerAddress>>,
     #[ignore_heap_size_of = "Defined in std"]
     swmanager_sender: IpcSender<ServiceWorkerMsg>,
     #[ignore_heap_size_of = "Defined in std"]
-    scope_url: Url
+    msg_port: Receiver<DOMMessage>,
+    #[ignore_heap_size_of = "Defined in std"]
+    scope_url: Url,
 }
 
 impl ServiceWorkerGlobalScope {
@@ -80,7 +100,8 @@ impl ServiceWorkerGlobalScope {
                      timer_event_chan: IpcSender<TimerEvent>,
                      timer_event_port: Receiver<()>,
                      swmanager_sender: IpcSender<ServiceWorkerMsg>,
-                     scope_url: Url)
+                     scope_url: Url,
+                     msg_port: Receiver<DOMMessage>)
                      -> ServiceWorkerGlobalScope {
         ServiceWorkerGlobalScope {
             workerglobalscope: WorkerGlobalScope::new_inherited(init,
@@ -93,9 +114,9 @@ impl ServiceWorkerGlobalScope {
             receiver: receiver,
             timer_event_port: timer_event_port,
             own_sender: own_sender,
-            worker: DOMRefCell::new(None),
             swmanager_sender: swmanager_sender,
-            scope_url: scope_url
+            scope_url: scope_url,
+            msg_port: msg_port
         }
     }
 
@@ -109,7 +130,8 @@ impl ServiceWorkerGlobalScope {
                timer_event_chan: IpcSender<TimerEvent>,
                timer_event_port: Receiver<()>,
                swmanager_sender: IpcSender<ServiceWorkerMsg>,
-               scope_url: Url)
+               scope_url: Url,
+               msg_port: Receiver<DOMMessage>)
                -> Root<ServiceWorkerGlobalScope> {
         let cx = runtime.cx();
         let scope = box ServiceWorkerGlobalScope::new_inherited(init,
@@ -122,7 +144,8 @@ impl ServiceWorkerGlobalScope {
                                                                   timer_event_chan,
                                                                   timer_event_port,
                                                                   swmanager_sender,
-                                                                  scope_url);
+                                                                  scope_url,
+                                                                  msg_port);
         ServiceWorkerGlobalScopeBinding::Wrap(cx, scope)
     }
 
@@ -132,7 +155,8 @@ impl ServiceWorkerGlobalScope {
                             receiver: Receiver<ServiceWorkerScriptMsg>,
                             devtools_receiver: IpcReceiver<DevtoolScriptControlMsg>,
                             swmanager_sender: IpcSender<ServiceWorkerMsg>,
-                            scope_url: Url) {
+                            scope_url: Url,
+                            msg_port: Receiver<DOMMessage>) {
         let ScopeThings { script_url,
                           pipeline_id,
                           init,
@@ -167,7 +191,7 @@ impl ServiceWorkerGlobalScope {
             let global = ServiceWorkerGlobalScope::new(
                 init, url, pipeline_id, devtools_mpsc_port, runtime,
                 own_sender, receiver,
-                timer_ipc_chan, timer_port, swmanager_sender, scope_url);
+                timer_ipc_chan, timer_port, swmanager_sender, scope_url, msg_port);
             let scope = global.upcast::<WorkerGlobalScope>();
 
             unsafe {
@@ -214,6 +238,17 @@ impl ServiceWorkerGlobalScope {
                 self.handle_script_event(msg);
                 true
             }
+            MixedMessage::PostMessage(data) => {
+                let DOMMessage(mut data) = data;
+                let data = StructuredCloneData::make_structured_clone(data.as_mut_ptr(), data.len());
+                let scope = self.upcast::<WorkerGlobalScope>();
+                let target = self.upcast();
+                let _ac = JSAutoCompartment::new(scope.get_cx(), scope.reflector().get_jsobject().get());
+                rooted!(in(scope.get_cx()) let mut message = UndefinedValue());
+                data.read(GlobalRef::Worker(scope), message.handle_mut());
+                MessageEvent::dispatch_jsval(target, GlobalRef::Worker(scope), message.handle());
+                true
+            }
             MixedMessage::FromTimeoutThread(_) => {
                 let _ = self.swmanager_sender.send(ServiceWorkerMsg::Timeout(self.scope_url.clone()));
                 false
@@ -225,15 +260,7 @@ impl ServiceWorkerGlobalScope {
         use self::ServiceWorkerScriptMsg::*;
 
         match msg {
-            CommonWorker(WorkerScriptMsg::DOMMessage(data)) => {
-                let scope = self.upcast::<WorkerGlobalScope>();
-                let target = self.upcast();
-                let _ac = JSAutoCompartment::new(scope.get_cx(),
-                                                 scope.reflector().get_jsobject().get());
-                rooted!(in(scope.get_cx()) let mut message = UndefinedValue());
-                data.read(GlobalRef::Worker(scope), message.handle_mut());
-                MessageEvent::dispatch_jsval(target, GlobalRef::Worker(scope), message.handle());
-            },
+            CommonWorker(WorkerScriptMsg::DOMMessage(_)) => { },
             CommonWorker(WorkerScriptMsg::Common(CommonScriptMsg::RunnableMsg(_, runnable))) => {
                 runnable.handler()
             },
@@ -260,17 +287,20 @@ impl ServiceWorkerGlobalScope {
         let worker_port = &self.receiver;
         let devtools_port = scope.from_devtools_receiver();
         let timer_event_port = &self.timer_event_port;
+        let msg_port = &self.msg_port;
 
         let sel = Select::new();
         let mut worker_handle = sel.handle(worker_port);
         let mut devtools_handle = sel.handle(devtools_port);
         let mut timer_port_handle = sel.handle(timer_event_port);
+        let mut msg_port_handle = sel.handle(msg_port);
         unsafe {
             worker_handle.add();
             if scope.from_devtools_sender().is_some() {
                 devtools_handle.add();
             }
             timer_port_handle.add();
+            msg_port_handle.add();
         }
 
         let ret = sel.wait();
@@ -280,6 +310,8 @@ impl ServiceWorkerGlobalScope {
             Ok(MixedMessage::FromDevtools(try!(devtools_port.recv())))
         } else if ret == timer_port_handle.id() {
             Ok(MixedMessage::FromTimeoutThread(try!(timer_event_port.recv())))
+        } else if ret == msg_port_handle.id() {
+            Ok(MixedMessage::PostMessage(try!(msg_port.recv())))
         } else {
             panic!("unexpected select result!")
         }
@@ -291,6 +323,12 @@ impl ServiceWorkerGlobalScope {
 
     pub fn process_event(&self, msg: CommonScriptMsg) {
         self.handle_script_event(ServiceWorkerScriptMsg::CommonWorker(WorkerScriptMsg::Common(msg)));
+    }
+
+    pub fn script_chan(&self) -> Box<ScriptChan + Send> {
+        box ServiceWorkerChan {
+            sender: self.own_sender.clone()
+        }
     }
 }
 

--- a/components/script/dom/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworkerregistration.rs
@@ -6,10 +6,11 @@ use dom::bindings::codegen::Bindings::ServiceWorkerBinding::ServiceWorkerState;
 use dom::bindings::codegen::Bindings::ServiceWorkerRegistrationBinding::{ServiceWorkerRegistrationMethods, Wrap};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, Root};
+use dom::bindings::refcounted::Trusted;
 use dom::bindings::reflector::reflect_dom_object;
 use dom::bindings::str::USVString;
 use dom::eventtarget::EventTarget;
-use dom::serviceworker::ServiceWorker;
+use dom::serviceworker::{ServiceWorker, TrustedServiceWorkerAddress};
 use dom::serviceworkercontainer::Controllable;
 use dom::workerglobalscope::prepare_workerscope_init;
 use script_traits::{WorkerScriptLoadOrigin, ScopeThings};
@@ -47,6 +48,10 @@ impl ServiceWorkerRegistration {
 
     pub fn get_installed(&self) -> &ServiceWorker {
         self.active.as_ref().unwrap()
+    }
+
+    pub fn get_trusted_worker(&self) -> TrustedServiceWorkerAddress {
+        Trusted::new(self.active.as_ref().unwrap())
     }
 
     pub fn create_scope_things(global: GlobalRef, script_url: Url) -> ScopeThings {

--- a/components/script/dom/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworkerregistration.rs
@@ -25,21 +25,21 @@ pub struct ServiceWorkerRegistration {
 }
 
 impl ServiceWorkerRegistration {
-    fn new_inherited(active_sw: &ServiceWorker, scope: String) -> ServiceWorkerRegistration {
+    fn new_inherited(active_sw: &ServiceWorker, scope: Url) -> ServiceWorkerRegistration {
         ServiceWorkerRegistration {
             eventtarget: EventTarget::new_inherited(),
             active: Some(JS::from_ref(active_sw)),
             installing: None,
             waiting: None,
-            scope: scope,
+            scope: scope.as_str().to_owned(),
         }
     }
     #[allow(unrooted_must_root)]
     pub fn new(global: GlobalRef,
                script_url: Url,
-               scope: String,
+               scope: Url,
                container: &Controllable) -> Root<ServiceWorkerRegistration> {
-        let active_worker = ServiceWorker::install_serviceworker(global, script_url.clone(), &scope, true);
+        let active_worker = ServiceWorker::install_serviceworker(global, script_url.clone(), scope.clone(), true);
         active_worker.set_transition_state(ServiceWorkerState::Installed);
         container.set_controller(&*active_worker.clone());
         reflect_dom_object(box ServiceWorkerRegistration::new_inherited(&*active_worker, scope), global, Wrap)

--- a/components/script/dom/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworkerregistration.rs
@@ -6,11 +6,10 @@ use dom::bindings::codegen::Bindings::ServiceWorkerBinding::ServiceWorkerState;
 use dom::bindings::codegen::Bindings::ServiceWorkerRegistrationBinding::{ServiceWorkerRegistrationMethods, Wrap};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, Root};
-use dom::bindings::refcounted::Trusted;
 use dom::bindings::reflector::reflect_dom_object;
 use dom::bindings::str::USVString;
 use dom::eventtarget::EventTarget;
-use dom::serviceworker::{ServiceWorker, TrustedServiceWorkerAddress};
+use dom::serviceworker::ServiceWorker;
 use dom::serviceworkercontainer::Controllable;
 use dom::workerglobalscope::prepare_workerscope_init;
 use script_traits::{WorkerScriptLoadOrigin, ScopeThings};
@@ -40,7 +39,7 @@ impl ServiceWorkerRegistration {
                script_url: Url,
                scope: String,
                container: &Controllable) -> Root<ServiceWorkerRegistration> {
-        let active_worker = ServiceWorker::install_serviceworker(global, script_url.clone(), true);
+        let active_worker = ServiceWorker::install_serviceworker(global, script_url.clone(), &scope, true);
         active_worker.set_transition_state(ServiceWorkerState::Installed);
         container.set_controller(&*active_worker.clone());
         reflect_dom_object(box ServiceWorkerRegistration::new_inherited(&*active_worker, scope), global, Wrap)
@@ -48,10 +47,6 @@ impl ServiceWorkerRegistration {
 
     pub fn get_installed(&self) -> &ServiceWorker {
         self.active.as_ref().unwrap()
-    }
-
-    pub fn get_trusted_worker(&self) -> TrustedServiceWorkerAddress {
-        Trusted::new(self.active.as_ref().unwrap())
     }
 
     pub fn create_scope_things(global: GlobalRef, script_url: Url) -> ScopeThings {

--- a/components/script/dom/webidls/ServiceWorker.webidl
+++ b/components/script/dom/webidls/ServiceWorker.webidl
@@ -7,7 +7,7 @@
 interface ServiceWorker : EventTarget {
   readonly attribute USVString scriptURL;
   readonly attribute ServiceWorkerState state;
-  //[Throws] void postMessage(any message/*, optional sequence<Transferable> transfer*/);
+  [Throws] void postMessage(any message/*, optional sequence<Transferable> transfer*/);
 
   // event
   attribute EventHandler onstatechange;

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -399,7 +399,7 @@ impl WorkerGlobalScope {
         } else if let Some(service_worker) = service_worker {
             return service_worker.script_chan();
         } else {
-            panic!("need to implement a sender for SharedWorker/ServiceWorker")
+            panic!("need to implement a sender for SharedWorker")
         }
     }
 

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -392,10 +392,12 @@ impl WorkerGlobalScope {
     }
 
     pub fn script_chan(&self) -> Box<ScriptChan + Send> {
-        let dedicated =
-            self.downcast::<DedicatedWorkerGlobalScope>();
+        let dedicated = self.downcast::<DedicatedWorkerGlobalScope>();
+        let service_worker = self.downcast::<ServiceWorkerGlobalScope>();
         if let Some(dedicated) = dedicated {
             return dedicated.script_chan();
+        } else if let Some(service_worker) = service_worker {
+            return service_worker.script_chan();
         } else {
             panic!("need to implement a sender for SharedWorker/ServiceWorker")
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -42,7 +42,7 @@ use dom::element::Element;
 use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::htmlanchorelement::HTMLAnchorElement;
 use dom::node::{Node, NodeDamage, window_from_node};
-use dom::serviceworker::{TrustedServiceWorkerAddress, ServiceWorker};
+use dom::serviceworker::TrustedServiceWorkerAddress;
 use dom::serviceworkerregistration::ServiceWorkerRegistration;
 use dom::servohtmlparser::ParserContext;
 use dom::uievent::UIEvent;
@@ -84,7 +84,7 @@ use script_traits::CompositorEvent::{TouchEvent, TouchpadPressureEvent};
 use script_traits::webdriver_msg::WebDriverScriptCommand;
 use script_traits::{CompositorEvent, ConstellationControlMsg, EventResult};
 use script_traits::{InitialScriptState, MouseButton, MouseEventType, MozBrowserEvent};
-use script_traits::{NewLayoutInfo, ScriptMsg as ConstellationMsg, DOMMessage};
+use script_traits::{NewLayoutInfo, ScriptMsg as ConstellationMsg};
 use script_traits::{ScriptThreadFactory, TimerEvent, TimerEventRequest, TimerSource};
 use script_traits::{TouchEventType, TouchId, UntrustedNodeAddress, WindowSizeData};
 use std::borrow::ToOwned;
@@ -924,8 +924,6 @@ impl ScriptThread {
                 self.handle_css_error_reporting(pipeline_id, filename, line, column, msg),
             ConstellationControlMsg::Reload(pipeline_id) =>
                 self.handle_reload(pipeline_id),
-            ConstellationControlMsg::ConnectServiceWorker(scope_url, chan) =>
-                self.connect_serviceworker_to_scope(scope_url, chan),
             msg @ ConstellationControlMsg::AttachLayout(..) |
             msg @ ConstellationControlMsg::Viewport(..) |
             msg @ ConstellationControlMsg::SetScrollState(..) |
@@ -1459,15 +1457,6 @@ impl ScriptThread {
             let _ = self.constellation_chan.send(ConstellationMsg::RegisterServiceWorker(scope_things, scope));
         } else {
             warn!("Registration failed for {}", scope);
-        }
-    }
-
-    // Set the sender to the corresponding scope of the service worker object.
-    fn connect_serviceworker_to_scope(&self, scope_url: Url, chan: IpcSender<DOMMessage>) {
-        let ref maybe_registration_ref = *self.registration_map.borrow();
-        if let Some(ref registration) = maybe_registration_ref.get(&scope_url) {
-            let trusted_worker = registration.get_trusted_worker();
-            ServiceWorker::store_sender(trusted_worker, chan);
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -42,7 +42,7 @@ use dom::element::Element;
 use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::htmlanchorelement::HTMLAnchorElement;
 use dom::node::{Node, NodeDamage, window_from_node};
-use dom::serviceworker::TrustedServiceWorkerAddress;
+use dom::serviceworker::{TrustedServiceWorkerAddress, ServiceWorker};
 use dom::serviceworkerregistration::ServiceWorkerRegistration;
 use dom::servohtmlparser::ParserContext;
 use dom::uievent::UIEvent;
@@ -84,7 +84,7 @@ use script_traits::CompositorEvent::{TouchEvent, TouchpadPressureEvent};
 use script_traits::webdriver_msg::WebDriverScriptCommand;
 use script_traits::{CompositorEvent, ConstellationControlMsg, EventResult};
 use script_traits::{InitialScriptState, MouseButton, MouseEventType, MozBrowserEvent};
-use script_traits::{NewLayoutInfo, ScriptMsg as ConstellationMsg};
+use script_traits::{NewLayoutInfo, ScriptMsg as ConstellationMsg, DOMMessage};
 use script_traits::{ScriptThreadFactory, TimerEvent, TimerEventRequest, TimerSource};
 use script_traits::{TouchEventType, TouchId, UntrustedNodeAddress, WindowSizeData};
 use std::borrow::ToOwned;
@@ -924,6 +924,8 @@ impl ScriptThread {
                 self.handle_css_error_reporting(pipeline_id, filename, line, column, msg),
             ConstellationControlMsg::Reload(pipeline_id) =>
                 self.handle_reload(pipeline_id),
+            ConstellationControlMsg::ConnectServiceWorker(scope_url, chan) =>
+                self.connect_serviceworker_to_scope(scope_url, chan),
             msg @ ConstellationControlMsg::AttachLayout(..) |
             msg @ ConstellationControlMsg::Viewport(..) |
             msg @ ConstellationControlMsg::SetScrollState(..) |
@@ -1456,7 +1458,16 @@ impl ScriptThread {
             let scope_things = ServiceWorkerRegistration::create_scope_things(global_ref, script_url);
             let _ = self.constellation_chan.send(ConstellationMsg::RegisterServiceWorker(scope_things, scope));
         } else {
-            warn!("Registration failed for {}", pipeline_id);
+            warn!("Registration failed for {}", scope);
+        }
+    }
+
+    // Set the sender to the corresponding scope of the service worker object.
+    fn connect_serviceworker_to_scope(&self, scope_url: Url, chan: IpcSender<DOMMessage>) {
+        let ref maybe_registration_ref = *self.registration_map.borrow();
+        if let Some(ref registration) = maybe_registration_ref.get(&scope_url) {
+            let trusted_worker = registration.get_trusted_worker();
+            ServiceWorker::store_sender(trusted_worker, chan);
         }
     }
 

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -123,9 +123,9 @@ impl ServiceWorkerManager {
         }
     }
 
-    #[inline(always)]
     fn forward_message(&self, msg: DOMMessage, sender: &Sender<ServiceWorkerScriptMsg>) {
-        let data = StructuredCloneData::make_structured_clone(msg);
+        let DOMMessage(data) = msg;
+        let data = StructuredCloneData::Vector(data);
         let _ = sender.send(ServiceWorkerScriptMsg::CommonWorker(WorkerScriptMsg::DOMMessage(data)));
     }
 

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -35,19 +35,23 @@ pub struct ServiceWorkerManager {
     // receiver to receive messages from constellation
     own_port: Receiver<ServiceWorkerMsg>,
     // to receive resource messages
-    resource_receiver: Receiver<CustomResponseMediator>
+    resource_receiver: Receiver<CustomResponseMediator>,
+    // to send message to constellation
+    constellation_sender: IpcSender<SWManagerMsg>
 }
 
 impl ServiceWorkerManager {
     fn new(own_sender: IpcSender<ServiceWorkerMsg>,
            from_constellation_receiver: Receiver<ServiceWorkerMsg>,
-           resource_port: Receiver<CustomResponseMediator>) -> ServiceWorkerManager {
+           resource_port: Receiver<CustomResponseMediator>,
+           constellation_sender: IpcSender<SWManagerMsg>) -> ServiceWorkerManager {
         ServiceWorkerManager {
             registered_workers: HashMap::new(),
             active_workers: HashMap::new(),
             own_sender: own_sender,
             own_port: from_constellation_receiver,
-            resource_receiver: resource_port
+            resource_receiver: resource_port,
+            constellation_sender: constellation_sender
         }
     }
 
@@ -58,8 +62,12 @@ impl ServiceWorkerManager {
         let resource_port = ROUTER.route_ipc_receiver_to_new_mpsc_receiver(resource_port);
         let _ = sw_senders.resource_sender.send(CoreResourceMsg::NetworkMediator(resource_chan));
         let _ = sw_senders.swmanager_sender.send(SWManagerMsg::OwnSender(own_sender.clone()));
+        let constellation_sender = sw_senders.swmanager_sender.clone();
         spawn_named("ServiceWorkerManager".to_owned(), move || {
-            ServiceWorkerManager::new(own_sender, from_constellation, resource_port).handle_message();
+            ServiceWorkerManager::new(own_sender,
+                                      from_constellation,
+                                      resource_port,
+                                      constellation_sender).handle_message();
         });
     }
 
@@ -93,12 +101,20 @@ impl ServiceWorkerManager {
                                                                              devtools_sender.clone(),
                                                                              page_info));
                 };
+                let (msg_chan, msg_port) = ipc::channel().unwrap();
+                let msg_port = ROUTER.route_ipc_receiver_to_new_mpsc_receiver(msg_port);
                 ServiceWorkerGlobalScope::run_serviceworker_scope(scope_things.clone(),
-                                                                              sender.clone(),
-                                                                              receiver,
-                                                                              devtools_receiver,
-                                                                              self.own_sender.clone(),
-                                                                              scope_url.clone());
+                                                                  sender.clone(),
+                                                                  receiver,
+                                                                  devtools_receiver,
+                                                                  self.own_sender.clone(),
+                                                                  scope_url.clone(),
+                                                                  msg_port);
+                // Send the message to constellation which then talks to the script thread for storing this msg_chan
+                let connection_msg = SWManagerMsg::ConnectServiceWorker(scope_url.clone(),
+                                                                        scope_things.pipeline_id,
+                                                                        msg_chan);
+                let _ = self.constellation_sender.send(connection_msg);
                 // We store the activated worker
                 self.active_workers.insert(scope_url, scope_things.clone());
                 return Some(sender);

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -71,7 +71,7 @@ use util::ipc::OptionalOpaqueIpcSender;
 use webdriver_msg::{LoadStatus, WebDriverScriptCommand};
 
 pub use script_msg::{LayoutMsg, ScriptMsg, EventResult, LogEntry};
-pub use script_msg::{ServiceWorkerMsg, ScopeThings, SWManagerMsg, SWManagerSenders};
+pub use script_msg::{ServiceWorkerMsg, ScopeThings, SWManagerMsg, SWManagerSenders, DOMMessage};
 
 /// The address of a node. Layout sends these back. They must be validated via
 /// `from_untrusted_node_address` before they can be used, because we do not trust layout.
@@ -208,6 +208,8 @@ pub enum ConstellationControlMsg {
     ReportCSSError(PipelineId, String, usize, usize, String),
     /// Reload the given page.
     Reload(PipelineId),
+    /// Requests the script thread to connect service worker object to its scope
+    ConnectServiceWorker(Url, IpcSender<DOMMessage>)
 }
 
 impl fmt::Debug for ConstellationControlMsg {
@@ -237,6 +239,7 @@ impl fmt::Debug for ConstellationControlMsg {
             FramedContentChanged(..) => "FramedContentChanged",
             ReportCSSError(..) => "ReportCSSError",
             Reload(..) => "Reload",
+            ConnectServiceWorker(..) => "ConnectServiceWorker"
         })
     }
 }

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -207,9 +207,7 @@ pub enum ConstellationControlMsg {
     /// Report an error from a CSS parser for the given pipeline
     ReportCSSError(PipelineId, String, usize, usize, String),
     /// Reload the given page.
-    Reload(PipelineId),
-    /// Requests the script thread to connect service worker object to its scope
-    ConnectServiceWorker(Url, IpcSender<DOMMessage>)
+    Reload(PipelineId)
 }
 
 impl fmt::Debug for ConstellationControlMsg {
@@ -238,8 +236,7 @@ impl fmt::Debug for ConstellationControlMsg {
             DispatchFrameLoadEvent { .. } => "DispatchFrameLoadEvent",
             FramedContentChanged(..) => "FramedContentChanged",
             ReportCSSError(..) => "ReportCSSError",
-            Reload(..) => "Reload",
-            ConnectServiceWorker(..) => "ConnectServiceWorker"
+            Reload(..) => "Reload"
         })
     }
 }

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -135,6 +135,9 @@ pub enum ScriptMsg {
     LogEntry(Option<PipelineId>, Option<String>, LogEntry),
     /// Notifies the constellation that this pipeline has exited.
     PipelineExited(PipelineId),
+    /// Send messages from postMessage calls from serviceworker
+    /// to constellation for storing in service worker manager
+    ForwardDOMMessage(DOMMessage, Url),
     /// Store the data required to activate a service worker for the given scope
     RegisterServiceWorker(ScopeThings, Url),
     /// Requests that the compositor shut down.
@@ -159,8 +162,8 @@ pub struct ScopeThings {
 }
 
 /// Message that gets passed to service worker scope on postMessage
-#[derive(Deserialize, Serialize, Debug)]
-pub struct DOMMessage(pub Vec<u64>);
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct DOMMessage(pub Vec<u8>);
 
 /// Channels to allow service worker manager to communicate with constellation and resource thread
 pub struct SWManagerSenders {
@@ -177,6 +180,8 @@ pub enum ServiceWorkerMsg {
     RegisterServiceWorker(ScopeThings, Url),
     /// Timeout message sent by active service workers
     Timeout(Url),
+    /// Backup message
+    ForwardDOMMessage(DOMMessage, Url),
     /// Exit the service worker manager
     Exit,
 }
@@ -185,8 +190,6 @@ pub enum ServiceWorkerMsg {
 #[derive(Deserialize, Serialize)]
 pub enum SWManagerMsg {
     /// Provide the constellation with a means of communicating with the Service Worker Manager
-    OwnSender(IpcSender<ServiceWorkerMsg>),
-    /// Message to ask to get a Trusted<ServiceWorker> to constellation
-    ConnectServiceWorker(Url, PipelineId, IpcSender<DOMMessage>)
+    OwnSender(IpcSender<ServiceWorkerMsg>)
 
 }

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -158,6 +158,10 @@ pub struct ScopeThings {
     pub worker_id: WorkerId,
 }
 
+/// Message that gets passed to service worker scope on postMessage
+#[derive(Deserialize, Serialize, Debug)]
+pub struct DOMMessage(pub Vec<u64>);
+
 /// Channels to allow service worker manager to communicate with constellation and resource thread
 pub struct SWManagerSenders {
     /// sender for communicating with constellation
@@ -182,4 +186,7 @@ pub enum ServiceWorkerMsg {
 pub enum SWManagerMsg {
     /// Provide the constellation with a means of communicating with the Service Worker Manager
     OwnSender(IpcSender<ServiceWorkerMsg>),
+    /// Message to ask to get a Trusted<ServiceWorker> to constellation
+    ConnectServiceWorker(Url, PipelineId, IpcSender<DOMMessage>)
+
 }

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -180,7 +180,7 @@ pub enum ServiceWorkerMsg {
     RegisterServiceWorker(ScopeThings, Url),
     /// Timeout message sent by active service workers
     Timeout(Url),
-    /// Backup message
+    /// Message sent by constellation to forward to a running service worker
     ForwardDOMMessage(DOMMessage, Url),
     /// Exit the service worker manager
     Exit,

--- a/tests/html/service-worker/demo_iframe.html
+++ b/tests/html/service-worker/demo_iframe.html
@@ -8,6 +8,5 @@
 <div>
 <a href="http://github.com/servo/servo">Servo Project</a>
 </div>
-
 </body>
 </html>

--- a/tests/html/service-worker/dummy.js
+++ b/tests/html/service-worker/dummy.js
@@ -1,0 +1,3 @@
+function test_importScripts() {
+	console.log('Hi from dummy.js');
+}

--- a/tests/html/service-worker/iframe_sw.js
+++ b/tests/html/service-worker/iframe_sw.js
@@ -5,3 +5,7 @@ self.addEventListener('activate', function(e) {
 self.addEventListener('fetch', function(e) {
 	console.log("A fetch event detected by /iframe service worker");
 });
+
+self.addEventListener('message', function(e) {
+	console.log('Post message payload ' + e.data.msg);
+})

--- a/tests/html/service-worker/iframe_sw.js
+++ b/tests/html/service-worker/iframe_sw.js
@@ -1,11 +1,11 @@
 self.addEventListener('activate', function(e) {
-	console.log("iframe service worker active");
+    console.log("iframe service worker active");
 });
 
 self.addEventListener('fetch', function(e) {
-	console.log("A fetch event detected by /iframe service worker");
+    console.log("A fetch event detected by /iframe service worker");
 });
 
 self.addEventListener('message', function(e) {
-	console.log('Post message payload ' + e.data.msg);
+    console.log(e.data.payload.msg + ' from '+ e.data.payload.worker_id);
 })

--- a/tests/html/service-worker/index.html
+++ b/tests/html/service-worker/index.html
@@ -16,42 +16,55 @@
     <button onclick="register_zero()">Register for Root (/)</button>
     <button onclick="register_one()">Register for Dashboard (/dashboard)</button>
     <button onclick="register_two()">Register for Profile (/profile)</button>
+    <button onclick="post_message_root()">Msg to Root service worker</button>
 </div>
-
     <script>
+
     var reg = navigator.serviceWorker.register('iframe_sw.js', { 'scope': '/demo_iframe.html' });
     console.log("From client worker registered: ", navigator.serviceWorker.controller);
     console.log("Registered script source: "+ navigator.serviceWorker.controller.scriptURL);
     document.getElementById('iframe_sw').src = 'demo_iframe.html';
-    var payload = { msg: 'Hi from /iframe service worker' };
-
-    // The delay is due to the sender being set in the service worker object after the scope starts.
-    // This won't be needed when service workers are wrapped with Promises.
-    setTimeout(function() {
-        navigator.serviceWorker.controller.postMessage(payload);
-    }, 1000);
+    post_message('/demo_iframe');
 
     function register_zero() {
-        var reg = navigator.serviceWorker.register('sw.js', { 'scope': './' });
+        var reg = navigator.serviceWorker.register('sw.js', { 'scope': './*' });
         console.log("From client worker registered: ", navigator.serviceWorker.controller);
         console.log("Registered script source: "+ navigator.serviceWorker.controller.scriptURL);
+    }
+
+    function post_message_root() {
+        // Testing repeated calls of postMessage
+        for(var i=0;i<100;i++){
+            navigator.serviceWorker.controller.postMessage({num:'Dummy message count: '+i});
+        }
     }
 
     function register_one() {
         var reg = navigator.serviceWorker.register('sw_dashboard.js', { 'scope': '/dashboard' });
         console.log("From client worker registered: ", navigator.serviceWorker.controller);
         console.log("Registered script source: "+ navigator.serviceWorker.controller.scriptURL);
+        post_message('/dashboard');
     }
 
     function register_two() {
         var reg = navigator.serviceWorker.register('sw_profile.js', { 'scope': '/profile' });
         console.log("From client worker registered: ", navigator.serviceWorker.controller);
         console.log("Registered script source: "+ navigator.serviceWorker.controller.scriptURL);
+        post_message('/profile');
     }
 
     navigator.serviceWorker.addEventListener('controllerchange', function(e) {
-        console.log("active Service Worker changed");
+        console.log("navigator.serviceWorker.controller changed");
     });
+
+    function post_message(worker_id) {
+        navigator.serviceWorker.controller.postMessage({
+        payload:{
+            msg:'Hi there! This is a dummy message for testing of postMessage calls from Service Workers',
+            worker_id:worker_id
+            }
+        });
+    }
 
     </script>
 </body>

--- a/tests/html/service-worker/index.html
+++ b/tests/html/service-worker/index.html
@@ -23,6 +23,13 @@
     console.log("From client worker registered: ", navigator.serviceWorker.controller);
     console.log("Registered script source: "+ navigator.serviceWorker.controller.scriptURL);
     document.getElementById('iframe_sw').src = 'demo_iframe.html';
+    var payload = { msg: 'Hi from /iframe service worker' };
+
+    // The delay is due to the sender being set in the service worker object after the scope starts.
+    // This won't be needed when service workers are wrapped with Promises.
+    setTimeout(function() {
+        navigator.serviceWorker.controller.postMessage(payload);
+    }, 1000);
 
     function register_zero() {
         var reg = navigator.serviceWorker.register('sw.js', { 'scope': './' });

--- a/tests/html/service-worker/sw.js
+++ b/tests/html/service-worker/sw.js
@@ -1,0 +1,11 @@
+self.addEventListener('activate', function(e) {
+    console.log('Root service worker active');
+});
+
+self.addEventListener('fetch', function(e) {
+    console.log("A fetch event detected by / service worker");
+});
+
+self.addEventListener('message', function(e) {
+    console.log(e.data.num);
+})

--- a/tests/html/service-worker/sw_dashboard.js
+++ b/tests/html/service-worker/sw_dashboard.js
@@ -1,9 +1,11 @@
-importScripts('dashboard_helper.js');
-
 self.addEventListener('activate', function(e) {
-	status_from_dashboard();
+    console.log('Dashboard service worker active');
 });
 
 self.addEventListener('fetch', function(e) {
-	console.log("A fetch event detected by /dashboard service worker");
+    console.log("A fetch event detected by /dashboard service worker");
 });
+
+self.addEventListener('message', function(e) {
+    console.log(e.data.payload.msg + ' from '+ e.data.payload.worker_id);
+})

--- a/tests/html/service-worker/sw_profile.js
+++ b/tests/html/service-worker/sw_profile.js
@@ -1,8 +1,12 @@
 
 self.addEventListener('activate', function(e) {
-	console.log("profile service worker active");
+    console.log("profile service worker active");
 });
 
 self.addEventListener('fetch', function(e) {
-	console.log("A fetch event detected by /profile service worker");
+    console.log("A fetch event detected by /profile service worker");
 });
+
+self.addEventListener('message', function(e) {
+    console.log(e.data.payload.msg + ' from '+ e.data.payload.worker_id);
+})


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fixes #12773
r? @jdm

Changes:
- Implements `postMessage` on `ServiceWorker` object.
- Removes unused channels from sw and their scopes.
- Fixes a crash when calling `scope.script_chan()` in sw-scopes event handling.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12773

<!-- Either: -->
- [X] There are tests for these changes at `tests/html/service-worker`

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12910)

<!-- Reviewable:end -->
