### PR TITLE
Include "content-type" in cors safelisted request headers.

### DIFF
--- a/tests/wpt/metadata/fetch/api/request/request-headers.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-headers.html.ini
@@ -1,23 +1,5 @@
 [request-headers.html]
   type: testharness
-  [Adding valid no-cors request header "content-type: application/x-www-form-urlencoded"]
-    expected: FAIL
-
-  [Adding valid no-cors request header "content-type: application/x-www-form-urlencoded;charset=UTF-8"]
-    expected: FAIL
-
-  [Adding valid no-cors request header "content-type: multipart/form-data"]
-    expected: FAIL
-
-  [Adding valid no-cors request header "content-type: multipart/form-data;charset=UTF-8"]
-    expected: FAIL
-
-  [Adding valid no-cors request header "content-TYPE: text/plain"]
-    expected: FAIL
-
-  [Adding valid no-cors request header "CONTENT-type: text/plain;charset=UTF-8"]
-    expected: FAIL
-
   [Request should get its content-type from the body if none is provided]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The changes in headers.rs will allow headers with "content-type" name to be classified as cors safelisted request headers, depending on its value according to [the Fetch spec](https://fetch.spec.whatwg.org/#cors-safelisted-request-header). As a result of this change, more request web platform tests pass, whose expected test results are updated with this commit.

There is possibly one TODO related to this PR:
- Figure out what `name/'invalid'` is in step 4 of the [Headers Delete method](https://fetch.spec.whatwg.org/#dom-headers-delete), and how to implement that.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because web platform tests for the changes already exist.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

This commit allows headers with "content-type" name to be classified as valid header name, depending on its value according to [the Fetch spec](https://fetch.spec.whatwg.org/#cors-safelisted-request-header). As a result of this change, more request web platform tests pass, whose expected test results are updated as well.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12915)

<!-- Reviewable:end -->
