### PR TITLE
Trigger image.onerror

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -86,14 +86,14 @@ impl Runnable for ImageResponseHandlerRunnable {
         // Update the image field
         let element = self.element.root();
         let element_ref = element.r();
-        let (image, metadata, trigger_image_load) = match self.image {
+        let (image, metadata, trigger_image_load, trigger_image_error) = match self.image {
             ImageResponse::Loaded(image) | ImageResponse::PlaceholderLoaded(image) => {
-                (Some(image.clone()), Some(ImageMetadata { height: image.height, width: image.width } ), true)
+                (Some(image.clone()), Some(ImageMetadata { height: image.height, width: image.width } ), true, false)
             }
             ImageResponse::MetadataLoaded(meta) => {
-                (None, Some(meta), false)
+                (None, Some(meta), false, false)
             }
-            ImageResponse::None => (None, None, true)
+            ImageResponse::None => (None, None, false, true)
         };
         element_ref.current_request.borrow_mut().image = image;
         element_ref.current_request.borrow_mut().metadata = metadata;
@@ -105,6 +105,11 @@ impl Runnable for ImageResponseHandlerRunnable {
         // Fire image.onload
         if trigger_image_load {
             element.upcast::<EventTarget>().fire_simple_event("load");
+        }
+
+        // Fire image.onerror
+        if trigger_image_error {
+            element.upcast::<EventTarget>().fire_simple_event("error");
         }
 
         // Trigger reflow

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -19306,6 +19306,10 @@
         "url": "/html/semantics/embedded-content/the-img-element/invalid-src.html"
       },
       {
+        "path": "html/semantics/embedded-content/the-img-element/nonexistent-image.html",
+        "url": "/html/semantics/embedded-content/the-img-element/nonexistent-image.html"
+      },
+      {
         "path": "html/semantics/embedded-content/the-img-element/relevant-mutations.html",
         "url": "/html/semantics/embedded-content/the-img-element/relevant-mutations.html"
       },

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-svg-image.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/tex-image-and-sub-image-2d-with-svg-image.html.ini
@@ -1,5 +1,6 @@
 [tex-image-and-sub-image-2d-with-svg-image.html]
   type: testharness
+  expected: TIMEOUT
   [WebGL test #0: at (4, 4) expected: 0,255,0 was 0,0,0]
     expected: FAIL
 

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/nonexistent-image.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/nonexistent-image.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<title>Loading an nonexisting image should fail; triggering appropriate events</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<img>
+
+<script>
+  async_test(function(t) {
+    var img = document.querySelector("img");
+    img.onload = this.step_func_done(function() {
+      assert_unreached("image.onload() was not supposed to be called");
+    });
+    img.onerror = this.step_func_done(function(e) {
+      assert_equals(e.type, "error", "image.onerror() called");
+      t.done();
+    });
+    img.src = "404";
+  });
+</script>


### PR DESCRIPTION
---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #12885 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12921)

<!-- Reviewable:end -->
