### PR TITLE
Check PLATFORM for proper toolchain when use msvc

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -104,7 +104,16 @@ def host_triple():
         os_type = "unknown"
 
     cpu_type = platform.machine().lower()
-    if cpu_type in ["i386", "i486", "i686", "i768", "x86"]:
+    if os_type.endswith("-msvc"):
+        # vcvars*.bat should set it properly
+        platform_env = os.environ.get("PLATFORM")
+        if platform_env == "X86":
+            cpu_type = "i686"
+        elif platform_env == "X64":
+            cpu_type = "x86_64"
+        else:
+            cpu_type = "unknown"
+    elif cpu_type in ["i386", "i486", "i686", "i768", "x86"]:
         cpu_type = "i686"
     elif cpu_type in ["x86_64", "x86-64", "x64", "amd64"]:
         cpu_type = "x86_64"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Currently, x86_64 toolchain would always pick the amd64 MSVC linker, which will fail to link when it runs in an environment configured for building x86 program (has `PLATFORM=X86` in environment variable).

This commit picks the proper host triple according to the environment variable when using the MSVC backend.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because build system only

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12922)

<!-- Reviewable:end -->
