### PR TITLE
Fix wrong calculation of inline element's block size

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2008,10 +2008,8 @@ impl Fragment {
                 let font_derived_metrics =
                     InlineMetrics::from_font_metrics(&info.run.font_metrics, line_height);
                 InlineMetrics {
-                    block_size_above_baseline: font_derived_metrics.block_size_above_baseline +
-                                                   self.border_padding.block_start,
-                    depth_below_baseline: font_derived_metrics.depth_below_baseline +
-                        self.border_padding.block_end,
+                    block_size_above_baseline: font_derived_metrics.block_size_above_baseline,
+                    depth_below_baseline: font_derived_metrics.depth_below_baseline,
                     ascent: font_derived_metrics.ascent + self.border_padding.block_start,
                 }
             }

--- a/tests/wpt/metadata-css/css21_dev/html4/border-padding-bleed-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-padding-bleed-001.htm.ini
@@ -1,3 +1,0 @@
-[border-padding-bleed-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-padding-bleed-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-padding-bleed-002.htm.ini
@@ -1,3 +1,0 @@
-[border-padding-bleed-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-padding-bleed-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-padding-bleed-003.htm.ini
@@ -1,3 +1,0 @@
-[border-padding-bleed-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/border-width-applies-to-008.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-width-applies-to-008.htm.ini
@@ -1,3 +1,0 @@
-[border-width-applies-to-008.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/c5506-ipadn-t-000.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/c5506-ipadn-t-000.htm.ini
@@ -1,3 +1,0 @@
-[c5506-ipadn-t-000.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/c5506-ipadn-t-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/c5506-ipadn-t-002.htm.ini
@@ -1,3 +1,0 @@
-[c5506-ipadn-t-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/c5508-ipadn-b-000.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/c5508-ipadn-b-000.htm.ini
@@ -1,3 +1,0 @@
-[c5508-ipadn-b-000.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/c5510-ipadn-000.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/c5510-ipadn-000.htm.ini
@@ -1,3 +1,4 @@
 [c5510-ipadn-000.htm]
   type: reftest
-  expected: FAIL
+  expected:
+    if os != "mac": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/inline-formatting-context-022.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inline-formatting-context-022.htm.ini
@@ -1,3 +1,0 @@
-[inline-formatting-context-022.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/inline-formatting-context-023.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inline-formatting-context-023.htm.ini
@@ -1,3 +1,0 @@
-[inline-formatting-context-023.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/inline-non-replaced-height-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inline-non-replaced-height-002.htm.ini
@@ -1,3 +1,0 @@
-[inline-non-replaced-height-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/inline-non-replaced-height-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inline-non-replaced-height-003.htm.ini
@@ -1,3 +1,0 @@
-[inline-non-replaced-height-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-bottom-applies-to-008.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-bottom-applies-to-008.htm.ini
@@ -1,3 +1,0 @@
-[margin-bottom-applies-to-008.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/margin-top-applies-to-008.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/margin-top-applies-to-008.htm.ini
@@ -1,3 +1,0 @@
-[margin-top-applies-to-008.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2616,6 +2616,18 @@
             "url": "/_mozilla/css/inline_element_border_a.html"
           }
         ],
+        "css/inline_element_padding_margin.html": [
+          {
+            "path": "css/inline_element_padding_margin.html",
+            "references": [
+              [
+                "/_mozilla/css/inline_element_padding_margin_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/inline_element_padding_margin.html"
+          }
+        ],
         "css/inline_font_size_zero_a.html": [
           {
             "path": "css/inline_font_size_zero_a.html",
@@ -11870,6 +11882,18 @@
             ]
           ],
           "url": "/_mozilla/css/inline_element_border_a.html"
+        }
+      ],
+      "css/inline_element_padding_margin.html": [
+        {
+          "path": "css/inline_element_padding_margin.html",
+          "references": [
+            [
+              "/_mozilla/css/inline_element_padding_margin_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/inline_element_padding_margin.html"
         }
       ],
       "css/inline_font_size_zero_a.html": [

--- a/tests/wpt/mozilla/tests/css/inline_element_padding_margin.html
+++ b/tests/wpt/mozilla/tests/css/inline_element_padding_margin.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Border, padding and margin properties' top and bottom values of inline elements shouldn't affect element's height</title>
+    <link rel="match" href="inline_element_padding_margin_ref.html">
+    <style>
+        a {
+            border-top: 20px solid transparent;
+            border-bottom: 20px solid transparent;
+            padding: 20px 0;
+            margin: 20px 0;
+        }
+    </style>
+</head>
+<body>
+    <a href="#">foo</a>
+    <br>
+    bar
+</body>
+</html>

--- a/tests/wpt/mozilla/tests/css/inline_element_padding_margin_ref.html
+++ b/tests/wpt/mozilla/tests/css/inline_element_padding_margin_ref.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Border, padding and margin properties' top and bottom values of inline elements shouldn't affect element's height</title>
+</head>
+<body>
+    <a href="#">foo</a>
+    <br>
+    bar
+</body>
+</html>


### PR DESCRIPTION
Border, padding and margin properties' top and bottom values of inline elements were affecting the element's height. It shouldn't affect it normally. Fixed it and added a test.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11729 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12930)

<!-- Reviewable:end -->
