### PR TITLE
Make GeckoDeclarationBlock refcounted

### DIFF
--- a/ports/geckolib/binding_tools/regen.py
+++ b/ports/geckolib/binding_tools/regen.py
@@ -148,7 +148,10 @@ COMPILATION_TARGETS = {
         "void_types": [
             "nsINode", "nsIDocument", "nsIPrincipal", "nsIURI",
         ],
-        "servo_arc_types": ["ServoComputedValues", "RawServoStyleSheet"]
+        "servo_arc_types": [
+            "ServoComputedValues", "RawServoStyleSheet",
+            "ServoDeclarationBlock"
+        ]
     },
 
     "atoms": {

--- a/ports/geckolib/gecko_bindings/bindings.rs
+++ b/ports/geckolib/gecko_bindings/bindings.rs
@@ -9,6 +9,8 @@ pub type ServoComputedValuesStrong = ::sugar::refptr::Strong<ServoComputedValues
 pub type ServoComputedValuesBorrowed<'a> = ::sugar::refptr::Borrowed<'a, ServoComputedValues>;
 pub type RawServoStyleSheetStrong = ::sugar::refptr::Strong<RawServoStyleSheet>;
 pub type RawServoStyleSheetBorrowed<'a> = ::sugar::refptr::Borrowed<'a, RawServoStyleSheet>;
+pub type ServoDeclarationBlockStrong = ::sugar::refptr::Strong<ServoDeclarationBlock>;
+pub type ServoDeclarationBlockBorrowed<'a> = ::sugar::refptr::Borrowed<'a, ServoDeclarationBlock>;
 use structs::nsStyleFont;
 unsafe impl Send for nsStyleFont {}
 unsafe impl Sync for nsStyleFont {}
@@ -254,7 +256,7 @@ extern "C" {
                                           classList: *mut *mut *mut nsIAtom)
      -> u32;
     pub fn Gecko_GetServoDeclarationBlock(element: *mut RawGeckoElement)
-     -> *mut ServoDeclarationBlock;
+     -> ServoDeclarationBlockBorrowed;
     pub fn Gecko_GetNodeData(node: *mut RawGeckoNode) -> *mut ServoNodeData;
     pub fn Gecko_SetNodeData(node: *mut RawGeckoNode,
                              data: *mut ServoNodeData);
@@ -467,16 +469,18 @@ extern "C" {
     pub fn Servo_DropStyleSet(set: *mut RawServoStyleSet);
     pub fn Servo_ParseStyleAttribute(bytes: *const u8, length: u32,
                                      cache: *mut nsHTMLCSSStyleSheet)
-     -> *mut ServoDeclarationBlock;
-    pub fn Servo_DropDeclarationBlock(declarations:
-                                          *mut ServoDeclarationBlock);
+     -> ServoDeclarationBlockStrong;
+    pub fn Servo_DeclarationBlock_AddRef(declarations:
+                                             ServoDeclarationBlockBorrowed);
+    pub fn Servo_DeclarationBlock_Release(declarations:
+                                              ServoDeclarationBlockBorrowed);
     pub fn Servo_GetDeclarationBlockCache(declarations:
-                                              *mut ServoDeclarationBlock)
+                                              ServoDeclarationBlockBorrowed)
      -> *mut nsHTMLCSSStyleSheet;
     pub fn Servo_SetDeclarationBlockImmutable(declarations:
-                                                  *mut ServoDeclarationBlock);
+                                                  ServoDeclarationBlockBorrowed);
     pub fn Servo_ClearDeclarationBlockCachePointer(declarations:
-                                                       *mut ServoDeclarationBlock);
+                                                       ServoDeclarationBlockBorrowed);
     pub fn Servo_CSSSupports(name: *const u8, name_length: u32,
                              value: *const u8, value_length: u32) -> bool;
     pub fn Servo_GetComputedValues(node: *mut RawGeckoNode)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This makes GeckoDeclarationBlock refcounted, so that it can share most of the logic Gecko currently uses for its existing `css::Declaration`. Although this is almost only useful for Gecko side, doing this in Servo side eliminates additional object allocation for holding it in the Gecko side.

Its Gecko side code change is in [bug 1296186](https://bugzilla.mozilla.org/show_bug.cgi?id=1296186). We may not want to land this before that part also gets reviewed.

r? @Manishearth 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because for Gecko binding only

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12933)

<!-- Reviewable:end -->
