### PR TITLE
Fixed layout flow tree JSON serialization

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -997,7 +997,7 @@ impl fmt::Debug for BaseFlow {
 
 impl Encodable for BaseFlow {
     fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
-        e.emit_struct("base", 0, |e| {
+        e.emit_struct("base", 5, |e| {
             try!(e.emit_struct_field("id", 0, |e| self.debug_id().encode(e)));
             try!(e.emit_struct_field("stacking_relative_position",
                                      1,
@@ -1010,7 +1010,7 @@ impl Encodable for BaseFlow {
                 e.emit_seq(self.children.len(), |e| {
                     for (i, c) in self.children.iter().enumerate() {
                         try!(e.emit_seq_elt(i, |e| {
-                            try!(e.emit_struct("flow", 0, |e| {
+                            try!(e.emit_struct("flow", 2, |e| {
                                 try!(e.emit_struct_field("class", 0, |e| c.class().encode(e)));
                                 e.emit_struct_field("data", 1, |e| {
                                     match c.class() {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -132,7 +132,7 @@ pub struct Fragment {
 
 impl Encodable for Fragment {
     fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
-        e.emit_struct("fragment", 0, |e| {
+        e.emit_struct("fragment", 3, |e| {
             try!(e.emit_struct_field("id", 0, |e| self.debug_id.encode(e)));
             try!(e.emit_struct_field("border_box", 1, |e| self.border_box.encode(e)));
             e.emit_struct_field("margin", 2, |e| self.margin.encode(e))


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The second argument for the `emit_struct()` is the number of fields, if given `0`, the output JSON will always be empty.

This is used in `./mach run -d -Z trace-layout https://servo.org`, which will dump the layout flow tree into a `layout_trace.json` file for debugging. 

This also unblocks https://github.com/servo/servo/issues/12675

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because its a debugging tool, not critical for normal code path

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12935)

<!-- Reviewable:end -->
