### PR TITLE
Update selectors to 0.11

### DIFF
--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -33,7 +33,7 @@ range = {path = "../range"}
 rustc-serialize = "0.3"
 script_layout_interface = {path = "../script_layout_interface"}
 script_traits = {path = "../script_traits"}
-selectors = {version = "0.10", features = ["heap_size"]}
+selectors = {version = "0.11", features = ["heap_size"]}
 serde_macros = "0.8"
 smallvec = "0.1"
 string_cache = {version = "0.2.23", features = ["heap_size"]}

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -62,7 +62,7 @@ regex = "0.1.43"
 rustc-serialize = "0.3"
 script_layout_interface = {path = "../script_layout_interface"}
 script_traits = {path = "../script_traits"}
-selectors = {version = "0.10", features = ["heap_size"]}
+selectors = {version = "0.11", features = ["heap_size"]}
 serde = "0.8"
 smallvec = "0.1"
 string_cache = {version = "0.2.23", features = ["heap_size", "unstable"]}

--- a/components/script_layout_interface/Cargo.toml
+++ b/components/script_layout_interface/Cargo.toml
@@ -27,7 +27,7 @@ plugins = {path = "../plugins"}
 profile_traits = {path = "../profile_traits"}
 range = {path = "../range"}
 script_traits = {path = "../script_traits"}
-selectors = {version = "0.10", features = ["heap_size"]}
+selectors = {version = "0.11", features = ["heap_size"]}
 string_cache = {version = "0.2.23", features = ["heap_size"]}
 style = {path = "../style"}
 url = {version = "1.2", features = ["heap_size"]}

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1162,7 +1162,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_layout_interface 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1931,7 +1931,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_layout_interface 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1967,7 +1967,7 @@ dependencies = [
  "profile_traits 0.0.1",
  "range 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2238,7 +2238,7 @@ dependencies = [
  "plugins 0.0.1",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2258,7 +2258,7 @@ dependencies = [
  "cssparser 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -38,7 +38,7 @@ num-traits = "0.1.32"
 ordered-float = "0.2.2"
 rand = "0.3"
 rustc-serialize = "0.3"
-selectors = "0.10.1"
+selectors = "0.11"
 serde = {version = "0.8", optional = true}
 serde_macros = {version = "0.8", optional = true}
 smallvec = "0.1"

--- a/components/style/selector_matching.rs
+++ b/components/style/selector_matching.rs
@@ -175,7 +175,7 @@ impl Stylist {
                         };
 
                         map.$priority.insert(Rule {
-                            selector: selector.compound_selectors.clone(),
+                            selector: selector.complex_selector.clone(),
                             declarations: DeclarationBlock {
                                 specificity: selector.specificity,
                                 declarations: $style_rule.declarations.$priority.clone(),
@@ -195,7 +195,7 @@ impl Stylist {
                     rules_source_order += 1;
 
                     for selector in &style_rule.selectors {
-                        self.state_deps.note_selector(&selector.compound_selectors);
+                        self.state_deps.note_selector(&selector.complex_selector);
                         if selector.affects_siblings() {
                             self.sibling_affecting_selectors.push(selector.clone());
                         }
@@ -452,20 +452,20 @@ impl Stylist {
     where E: ElementExt
     {
         use selectors::matching::StyleRelations;
-        use selectors::matching::matches_compound_selector;
+        use selectors::matching::matches_complex_selector;
         // XXX we can probably do better, the candidate should already know what
         // rules it matches.
         //
         // XXX Could the bloom filter help here? Should be available.
         for ref selector in self.non_common_style_affecting_attributes_selectors.iter() {
-            let element_matches = matches_compound_selector(&selector.compound_selectors,
-                                                            element,
-                                                            None,
-                                                            &mut StyleRelations::empty());
-            let candidate_matches = matches_compound_selector(&selector.compound_selectors,
-                                                              candidate,
-                                                              None,
-                                                              &mut StyleRelations::empty());
+            let element_matches = matches_complex_selector(&selector.complex_selector,
+                                                           element,
+                                                           None,
+                                                           &mut StyleRelations::empty());
+            let candidate_matches = matches_complex_selector(&selector.complex_selector,
+                                                             candidate,
+                                                             None,
+                                                             &mut StyleRelations::empty());
 
             if element_matches != candidate_matches {
                 return false;
@@ -481,25 +481,25 @@ impl Stylist {
     where E: ElementExt
     {
         use selectors::matching::StyleRelations;
-        use selectors::matching::matches_compound_selector;
+        use selectors::matching::matches_complex_selector;
         // XXX we can probably do better, the candidate should already know what
         // rules it matches.
         //
         // XXX The bloom filter would help here, and should be available.
         for ref selector in self.sibling_affecting_selectors.iter() {
-            let element_matches = matches_compound_selector(&selector.compound_selectors,
-                                                            element,
-                                                            None,
-                                                            &mut StyleRelations::empty());
+            let element_matches = matches_complex_selector(&selector.complex_selector,
+                                                           element,
+                                                           None,
+                                                           &mut StyleRelations::empty());
 
-            let candidate_matches = matches_compound_selector(&selector.compound_selectors,
-                                                              candidate,
-                                                              None,
-                                                              &mut StyleRelations::empty());
+            let candidate_matches = matches_complex_selector(&selector.complex_selector,
+                                                             candidate,
+                                                             None,
+                                                             &mut StyleRelations::empty());
 
             if element_matches != candidate_matches {
                 debug!("match_same_sibling_affecting_rules: Failure due to {:?}",
-                       selector.compound_selectors);
+                       selector.complex_selector);
                 return false;
             }
         }

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -1070,7 +1070,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_layout_interface 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1783,7 +1783,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_layout_interface 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1819,7 +1819,7 @@ dependencies = [
  "profile_traits 0.0.1",
  "range 0.0.1",
  "script_traits 0.0.1",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2121,7 +2121,7 @@ dependencies = [
  "plugins 0.0.1",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -170,7 +170,7 @@ dependencies = [
  "gecko_bindings 0.0.1",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -311,7 +311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "selectors"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -367,7 +367,7 @@ dependencies = [
  "ordered-float 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "selectors 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "0.2"
 libc = "0.2"
 log = {version = "0.3.5", features = ["release_max_level_info"]}
 num_cpus = "0.2.2"
-selectors = "0.10"
+selectors = "0.11"
 style = {path = "../../components/style", features = ["gecko"]}
 style_traits = {path = "../../components/style_traits"}
 url = "1.2"

--- a/ports/geckolib/string_cache/Cargo.toml
+++ b/ports/geckolib/string_cache/Cargo.toml
@@ -14,5 +14,5 @@ cfg-if = "0.1.0"
 gecko_bindings = {version = "0.0.1", path = "../gecko_bindings"}
 heapsize = "0.3.5"
 libc = "0.2"
-selectors = "0.10"
+selectors = "0.11"
 serde = "0.8"

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -14,7 +14,7 @@ app_units = "0.3"
 cssparser = {version = "0.5.7", features = ["heap_size"]}
 euclid = "0.9"
 rustc-serialize = "0.3"
-selectors = {version = "0.10", features = ["heap_size"]}
+selectors = {version = "0.11", features = ["heap_size"]}
 string_cache = {version = "0.2.23", features = ["heap_size"]}
 style = {path = "../../../components/style"}
 style_traits = {path = "../../../components/style_traits"}

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -45,8 +45,8 @@ fn test_parse_stylesheet() {
             CSSRule::Style(StyleRule {
                 selectors: vec![
                     Selector {
-                        compound_selectors: Arc::new(CompoundSelector {
-                            simple_selectors: vec![
+                        complex_selector: Arc::new(ComplexSelector {
+                            compound_selector: vec![
                                 SimpleSelector::Namespace(Namespace {
                                     prefix: None,
                                     url: NsAtom(Atom::from("http://www.w3.org/1999/xhtml"))
@@ -81,8 +81,8 @@ fn test_parse_stylesheet() {
             CSSRule::Style(StyleRule {
                 selectors: vec![
                     Selector {
-                        compound_selectors: Arc::new(CompoundSelector {
-                            simple_selectors: vec![
+                        complex_selector: Arc::new(ComplexSelector {
+                            compound_selector: vec![
                                 SimpleSelector::Namespace(Namespace {
                                     prefix: None,
                                     url: NsAtom(Atom::from("http://www.w3.org/1999/xhtml"))
@@ -98,8 +98,8 @@ fn test_parse_stylesheet() {
                         specificity: (0 << 20) + (0 << 10) + (1 << 0),
                     },
                     Selector {
-                        compound_selectors: Arc::new(CompoundSelector {
-                            simple_selectors: vec![
+                        complex_selector: Arc::new(ComplexSelector {
+                            compound_selector: vec![
                                 SimpleSelector::Namespace(Namespace {
                                     prefix: None,
                                     url: NsAtom(Atom::from("http://www.w3.org/1999/xhtml"))
@@ -126,16 +126,16 @@ fn test_parse_stylesheet() {
             CSSRule::Style(StyleRule {
                 selectors: vec![
                     Selector {
-                        compound_selectors: Arc::new(CompoundSelector {
-                            simple_selectors: vec![
+                        complex_selector: Arc::new(ComplexSelector {
+                            compound_selector: vec![
                                 SimpleSelector::Namespace(Namespace {
                                     prefix: None,
                                     url: NsAtom(Atom::from("http://www.w3.org/1999/xhtml"))
                                 }),
                                 SimpleSelector::Class(Atom::from("ok")),
                             ],
-                            next: Some((Arc::new(CompoundSelector {
-                                simple_selectors: vec![
+                            next: Some((Arc::new(ComplexSelector {
+                                compound_selector: vec![
                                     SimpleSelector::Namespace(Namespace {
                                         prefix: None,
                                         url: NsAtom(Atom::from("http://www.w3.org/1999/xhtml"))


### PR DESCRIPTION
This brings :not() with proper list of complex selectors as argument.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12947)

<!-- Reviewable:end -->
