### PR TITLE
Windows MSVC: Define vcvars in mach.bat

### DIFF
--- a/mach.bat
+++ b/mach.bat
@@ -1,2 +1,19 @@
 @echo off
+
+SET VS_VCVARS=%VS140COMNTOOLS%..\..\VC\vcvarsall.bat
+IF EXIST "%VS_VCVARS%" (
+  IF NOT DEFINED VisualStudioVersion (
+    IF EXIST "%ProgramFiles(x86)%" (
+      call "%VS_VCVARS%" x64
+    ) ELSE (
+      ECHO 32-bit Windows is currently unsupported.
+      EXIT /B
+    )
+  )
+) ELSE (
+  ECHO Visual Studio 2015 is not installed.
+  ECHO Download and install Visual Studio 2015 from https://www.visualstudio.com/
+  EXIT /B
+)
+
 python mach %*


### PR DESCRIPTION
Define vcvars for msvc build, if they have not yet been. If vcvars not exist, show message that visual studio 2015 is not installed and where to download it.
Fixes #12948

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12956)

<!-- Reviewable:end -->
