### PR TITLE
stylo: Don't calculate restyle damage on text nodes

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -871,21 +871,29 @@ pub trait MatchMethods : TNode {
             None => None,
         };
 
-        let mut applicable_declarations_cache =
-            context.local_context().applicable_declarations_cache.borrow_mut();
 
-        let (damage, restyle_result) = if self.is_text_node() {
+        // In the case we're styling a text node, we don't need to compute the
+        // restyle damage, since it's a subset of the restyle damage of the
+        // parent.
+        //
+        // In Gecko, we're done, we don't need anything else from text nodes.
+        //
+        // In Servo, this is also true, since text nodes generate UnscannedText
+        // fragments, which aren't repairable by incremental layout.
+        if self.is_text_node() {
             let mut data_ref = self.mutate_data().unwrap();
             let mut data = &mut *data_ref;
             let cloned_parent_style = ComputedValues::style_for_child_text_node(parent_style.unwrap());
 
-            let damage =
-                self.compute_restyle_damage(data.style.as_ref(), &cloned_parent_style, None);
-
             data.style = Some(cloned_parent_style);
 
-            (damage, RestyleResult::Continue)
-        } else {
+            return RestyleResult::Continue;
+        }
+
+        let mut applicable_declarations_cache =
+            context.local_context().applicable_declarations_cache.borrow_mut();
+
+        let (damage, restyle_result) = {
             let mut data_ref = self.mutate_data().unwrap();
             let mut data = &mut *data_ref;
             let final_style =


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes (the Servo-side, that is)

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12957)

<!-- Reviewable:end -->
