### PR TITLE
Do not define Pipeline::setup_common on Windows

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -538,6 +538,7 @@ impl UnprivilegedPipelineContent {
         process::exit(1);
     }
 
+    #[cfg(not(windows))]
     fn setup_common<C: CommandMethods>(&self, command: &mut C, token: String) {
         C::arg(command, "--content-process");
         C::arg(command, token);


### PR DESCRIPTION
## Fixes #12856 

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #12856.

<!-- Either: -->
- [x] These changes do not require tests because it just removes the compiler warning

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12968)

<!-- Reviewable:end -->
