### PR TITLE
Change the separator used in rust path into os.path.join

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -286,9 +286,9 @@ class CommandBase(object):
     def rust_path(self):
         version = self.rust_version()
         if self._use_stable_rust:
-            return "%s/rustc-%s-%s" % (version, version, host_triple())
+            return os.path.join(version, "rustc-%s-%s" % (version, host_triple()))
         else:
-            return "%s/rustc-nightly-%s" % (version, host_triple())
+            return os.path.join(version, "rustc-nightly-%s" % (host_triple()))
 
     def rust_version(self):
         if self._rust_version is None or self._use_stable_rust != self._rust_version_is_stable:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Trying to solve #12961 and following the suggestion in it.
Already run test-unit and no red appeared.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #12961 (github issue number if applicable).

<!-- Either: -->
- [x] These changes do not require tests because it's a cleanup of `mach`

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12971)

<!-- Reviewable:end -->
