### PR TITLE
Inline reconstruct#12602

### DIFF
--- a/components/script_layout_interface/restyle_damage.rs
+++ b/components/script_layout_interface/restyle_damage.rs
@@ -247,7 +247,7 @@ fn compute_damage(old: &ServoComputedValues, new: &ServoComputedValues) -> Resty
         get_effects.box_shadow, get_effects.clip, get_inheritedtext.text_shadow, get_effects.filter,
         get_effects.transform, get_effects.backface_visibility, get_effects.transform_style,
         get_effects.transform_origin, get_effects.perspective, get_effects.perspective_origin,
-        get_effects.mix_blend_mode, get_inheritedbox.image_rendering,
+        get_effects.mix_blend_mode, get_effects.opacity, get_inheritedbox.image_rendering,
 
         // Note: May require REFLOW et al. if `visibility: collapse` is implemented.
         get_inheritedbox.visibility

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -179,7 +179,7 @@ pub trait DomTraversalContext<N: TNode> {
     /// Note that this is true unconditionally for servo, since it requires to
     /// bubble the widths bottom-up for all the DOM.
     fn should_process(&self, node: N) -> bool {
-        node.is_dirty() || node.has_dirty_descendants()
+        opts::get().nonincremental_layout || node.is_dirty() || node.has_dirty_descendants()
     }
 
     /// Do an action over the child before pushing him to the work queue.

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2496,6 +2496,18 @@
             "url": "/_mozilla/css/inline_block_min_width.html"
           }
         ],
+        "css/inline_block_opacity_change.html": [
+          {
+            "path": "css/inline_block_opacity_change.html",
+            "references": [
+              [
+                "/_mozilla/css/inline_block_opacity_change_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/inline_block_opacity_change.html"
+          }
+        ],
         "css/inline_block_overflow.html": [
           {
             "path": "css/inline_block_overflow.html",
@@ -11762,6 +11774,18 @@
             ]
           ],
           "url": "/_mozilla/css/inline_block_min_width.html"
+        }
+      ],
+      "css/inline_block_opacity_change.html": [
+        {
+          "path": "css/inline_block_opacity_change.html",
+          "references": [
+            [
+              "/_mozilla/css/inline_block_opacity_change_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/inline_block_opacity_change.html"
         }
       ],
       "css/inline_block_overflow.html": [

--- a/tests/wpt/mozilla/tests/css/inline_block_opacity_change.html
+++ b/tests/wpt/mozilla/tests/css/inline_block_opacity_change.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="match" href="inline_block_opacity_change_ref.html">
+    <style>
+    #a {
+        background-color: green;
+        display: inline-block;
+        width: 1em;
+        opacity: 0.2;
+    }
+
+    #a.go {
+        opacity: 1;
+    }
+    </style>
+</head>
+
+<body>
+    <span style="transition: opacity .1s ease-out;" id="a">a</span>
+    <script>
+            document.body.offsetWidth; // force layout
+            document.querySelector('#a').classList.add('go');
+    </script>
+</body>
+</html>

--- a/tests/wpt/mozilla/tests/css/inline_block_opacity_change_ref.html
+++ b/tests/wpt/mozilla/tests/css/inline_block_opacity_change_ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+    #a {
+        background-color: green;
+        display: inline-block;
+        width: 1em;
+        opacity: 1;
+    }
+    </style>
+</head>
+
+<body>
+    <span id="a">a</span>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR fixes two different issues:
1) In non-incremental layout mode if the inline node hasn't changes - the style pass was skipped, that leads to the corresponding ConstructionResult was not produced. When the parent was rebuilt, the child without the ConstructionResult was omited.
2) When the opacity was changed (or other style change, causing only repaint) for image (and others, producing only ConstructionItem) the damage is calculated only from children's flows, not from individual fragments. So for now, let's pretend we've newly constructed the ConstructionItem and thus need to rebuild the parent's flow.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12602 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/12981)

<!-- Reviewable:end -->
