### PR TITLE
Changed first line of script to line 1 instead of line 0

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -946,7 +946,7 @@ impl<'a, T: Reflectable> ScriptHelpers for &'a T {
                 let filename = CString::new(filename).unwrap();
 
                 let _ac = JSAutoCompartment::new(cx, globalhandle.get());
-                let options = CompileOptionsWrapper::new(cx, filename.as_ptr(), 0);
+                let options = CompileOptionsWrapper::new(cx, filename.as_ptr(), 1);
                 unsafe {
                     if !Evaluate2(cx, options.ptr, code.as_ptr(),
                                   code.len() as libc::size_t,


### PR DESCRIPTION
Changed starting line of script to line 1 instead of line 0

---
- [ ] `./mach build -d` fails, but it fails on master on my system too due to some sort of problem with cygwin
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12996

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13005)

<!-- Reviewable:end -->
