### PR TITLE
Fix root flow's size at the browser window's size

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1336,10 +1336,10 @@ impl BlockFlow {
         };
         let parent_container_size = self.explicit_block_containing_size(shared_context);
         // https://drafts.csswg.org/css-ui-3/#box-sizing
-        let explicit_content_size = self
+        let mut explicit_content_size = self
                                     .explicit_block_size(parent_container_size)
                                     .map(|x| if x < box_border { Au(0) } else { x - box_border });
-
+        if self.is_root() { explicit_content_size = max(parent_container_size, explicit_content_size); }
         // Calculate containing block inline size.
         let containing_block_size = if flags.contains(IS_ABSOLUTELY_POSITIONED) {
             self.containing_block_size(&shared_context.viewport_size, opaque_self).inline

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -71,6 +71,18 @@
             "url": "/_mozilla/css/absolute_content_height.html"
           }
         ],
+        "css/absolute_css_width.html": [
+          {
+            "path": "css/absolute_css_width.html",
+            "references": [
+              [
+                "/_mozilla/css/absolute_css_width_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/absolute_css_width.html"
+          }
+        ],
         "css/absolute_hypothetical_float.html": [
           {
             "path": "css/absolute_hypothetical_float.html",
@@ -9373,6 +9385,18 @@
             ]
           ],
           "url": "/_mozilla/css/absolute_content_height.html"
+        }
+      ],
+      "css/absolute_css_width.html": [
+        {
+          "path": "css/absolute_css_width.html",
+          "references": [
+            [
+              "/_mozilla/css/absolute_css_width_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/absolute_css_width.html"
         }
       ],
       "css/absolute_hypothetical_float.html": [

--- a/tests/wpt/mozilla/tests/css/absolute_css_width.html
+++ b/tests/wpt/mozilla/tests/css/absolute_css_width.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>HTML expands to fit 100% body</title>
+<link rel="match" href="absolute_css_width_ref.html">
+<style>
+    body {
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+    }
+</style>
+<div style="position:absolute">X</div>
+

--- a/tests/wpt/mozilla/tests/css/absolute_css_width_ref.html
+++ b/tests/wpt/mozilla/tests/css/absolute_css_width_ref.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>HTML expands to fit 100% body</title>
+<div>X</div>
+


### PR DESCRIPTION
When `<body>` needs to calculate its size based on `<html>`'s size, that should be the size of the browser window itself.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12802 (github issue number if applicable).
- [X] There are tests for these changes OR

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13051)

<!-- Reviewable:end -->
