### PR TITLE
webgl: Fix validation of drawElements()'s type argument.

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1165,10 +1165,12 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11
     fn DrawElements(&self, mode: u32, count: i32, type_: u32, offset: i64) {
+        // From the GLES 2.0.25 spec, page 21:
+        //
+        //     "type must be one of UNSIGNED_BYTE or UNSIGNED_SHORT"
         let type_size = match type_ {
-            constants::BYTE | constants::UNSIGNED_BYTE => 1,
-            constants::SHORT | constants::UNSIGNED_SHORT => 2,
-            constants::INT | constants::UNSIGNED_INT | constants::FLOAT => 4,
+            constants::UNSIGNED_BYTE => 1,
+            constants::UNSIGNED_SHORT => 2,
             _ => return self.webgl_error(InvalidEnum),
         };
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-drawelements.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-drawelements.html.ini
@@ -1,3 +1,0 @@
-[gl-drawelements.html]
-  type: testharness
-  expected: CRASH


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

webgl: Fix validation of drawElements()'s type argument.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Fixes crash due to unexpected GL errors in gl-drawelements.html.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13052)

<!-- Reviewable:end -->
