### PR TITLE
Remove static usage at compile-time of GIT_INFO to enable builds outs…

### DIFF
--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -355,7 +355,7 @@ unsafe fn build_mozbrowser_event_detail(event: MozBrowserEvent,
                 type_: Some(DOMString::from(error_type.name())),
                 description: Some(DOMString::from(description)),
                 report: Some(DOMString::from(report)),
-                version: Some(DOMString::from_string(servo_version().into())),
+                version: Some(DOMString::from_string(servo_version())),
             }.to_jsval(cx, rval);
         },
         MozBrowserEvent::SecurityChange(https_state) => {

--- a/components/util/lib.rs
+++ b/components/util/lib.rs
@@ -36,6 +36,11 @@ pub mod prefs;
 pub mod resource_files;
 pub mod thread;
 
-pub fn servo_version() -> &'static str {
-    concat!("Servo ", env!("CARGO_PKG_VERSION"), env!("GIT_INFO"))
+pub fn servo_version() -> String {
+    let cargo_version = env!("CARGO_PKG_VERSION");
+    let git_info = option_env!("GIT_INFO");
+    match git_info {
+        Some(info) => format!("Servo {}{}", cargo_version, info),
+        None => format!("Servo {}", cargo_version),
+    }
 }


### PR DESCRIPTION
r? @metajack 

The issue here is that if we build Servo from a expanded copy of the sources w/o a git repository present in-tree, this will fail. Further, we can't switch to `option_env` with an `unwrap_or` because `concat!` expects string literals.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13063)

<!-- Reviewable:end -->
