### PR TITLE
Add rlib type for linking inside of the Rust staticlib in Gecko

### DIFF
--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 [lib]
 name = "geckoservo"
 path = "lib.rs"
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 app_units = "0.3"


### PR DESCRIPTION
r? @metajack 

Super simple - just want to be able to both build as libgeckoservo.a and the .rlib so that the build system works either standalone or inside of m-c for Gecko.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13064)

<!-- Reviewable:end -->
