### PR TITLE
Solved wrong referrer policy in cors_preflight_fetch

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -1112,7 +1112,7 @@ fn cors_preflight_fetch(request: Rc<Request>, cache: &mut CORSCache,
     preflight.type_ = request.type_.clone();
     preflight.destination = request.destination.clone();
     *preflight.referer.borrow_mut() = request.referer.borrow().clone();
-    preflight.referrer_policy.set(preflight.referrer_policy.get());
+    preflight.referrer_policy.set(request.referrer_policy.get());
 
     // Step 2
     preflight.headers.borrow_mut().set::<AccessControlRequestMethod>(


### PR DESCRIPTION
Solved wrong referrer policy in cors_preflight_fetch
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13026 
- [X] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13071)

<!-- Reviewable:end -->
