### PR TITLE
FIX TreeherderClient deprecated param

### DIFF
--- a/etc/ci/performance/README.md
+++ b/etc/ci/performance/README.md
@@ -12,7 +12,7 @@ Servo Page Load Time Test
 * Clone this repo
 * Download [tp5n.zip](http://people.mozilla.org/~jmaher/taloszips/zips/tp5n.zip), extract it to `page_load_test/tp5n`
 * Run `prepare_manifest.sh` to transform the tp5n manifest to our format
-* Install the Python3 `treeherder-client` package. For example, to install it in a virtualenv: `python3 -m virtualenv venv; source venv/bin/activate; pip install treeherder-client`
+* Install the Python3 `treeherder-client` package. For example, to install it in a virtualenv: `python3 -m virtualenv venv; source venv/bin/activate; pip install "treeherder-client>=3.0.0"`
 * Setup your Treeherder client ID and secret as environment variables `TREEHERDER_CLIENT_ID` and `TREEHERDER_CLIENT_SECRET`
 
 ## Build Servo

--- a/etc/ci/performance/submit_to_perfherder.py
+++ b/etc/ci/performance/submit_to_perfherder.py
@@ -317,8 +317,7 @@ def submit(perf_data, failures, revision, summary, engine):
         'secret': os.environ['TREEHERDER_CLIENT_SECRET']
     }
 
-    client = TreeherderClient(protocol='https',
-                              host='treeherder.allizom.org',
+    client = TreeherderClient(server_url='https://treeherder.mozilla.org',
                               client_id=cred['client_id'],
                               secret=cred['secret'])
 
@@ -331,7 +330,7 @@ def submit(perf_data, failures, revision, summary, engine):
 def main():
     parser = argparse.ArgumentParser(
         description=("Submit Servo performance data to Perfherder. "
-                     "Remember to set your Treeherder credentail as environment"
+                     "Remember to set your Treeherder credential as environment"
                      " variable \'TREEHERDER_CLIENT_ID\' and "
                      "\'TREEHERDER_CLIENT_SECRET\'"))
     parser.add_argument("perf_json",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13047 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it is low risk

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

According to warning from TreeherderClient(),
the parameters `host` and `protocol` are deprecated.
Then use `server_url` instead.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13073)

<!-- Reviewable:end -->
