### PR TITLE
stylo: Fix incorrect flag syntax in regen.py

### DIFF
--- a/ports/geckolib/binding_tools/regen.py
+++ b/ports/geckolib/binding_tools/regen.py
@@ -321,7 +321,7 @@ def build(objdir, target_name, debug, debugger, kind_name=None,
             flags.append("{}Strong".format(ty))
             flags.append("--raw-line")
             flags.append("pub type {0}Strong = ::sugar::refptr::Strong<{0}>;".format(ty))
-            flags.append("-blacklist-type")
+            flags.append("--blacklist-type")
             flags.append("{}Borrowed".format(ty))
             flags.append("--raw-line")
             flags.append("pub type {0}Borrowed<'a> = ::sugar::refptr::Borrowed<'a, {0}>;".format(ty))


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13112)

<!-- Reviewable:end -->
