### PR TITLE
style: Properly track whether negative values of calc() are allowed

### DIFF
--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -167,6 +167,7 @@ impl ToComputedValue for specified::CalcLengthOrPercentage {
         self.compute_from_viewport_and_font_size(context.viewport_size(),
                                                  context.style().get_font().clone_font_size(),
                                                  context.style().root_font_size())
+
     }
 }
 

--- a/components/style_traits/values.rs
+++ b/components/style_traits/values.rs
@@ -63,6 +63,8 @@ macro_rules! __define_css_keyword_enum__actual {
 
 
 pub mod specified {
+    #[repr(u8)]
+    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     pub enum AllowedNumericType {
         All,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

r? @SimonSapin 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

In order to clamp them at computed value time.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13121)

<!-- Reviewable:end -->
