### PR TITLE
Fix debug assertion introduced in #13108 by me.

### DIFF
--- a/components/style/restyle_hints.rs
+++ b/components/style/restyle_hints.rs
@@ -470,10 +470,10 @@ impl DependencySet {
             return;
         }
         for dep in deps {
-            debug_assert!(state_changes.intersects(dep.sensitivities.states) ||
-                          attrs_changed && dep.sensitivities.attrs,
-                          "Testing a completely ineffective dependency?");
-            if !hint.intersects(dep.hint) {
+            debug_assert!((!state_changes.is_empty() && !dep.sensitivities.states.is_empty()) ||
+                          (attrs_changed && dep.sensitivities.attrs),
+                          "Testing a known ineffective dependency?");
+            if (attrs_changed || state_changes.intersects(dep.sensitivities.states)) && !hint.intersects(dep.hint) {
                 let matched_then =
                     matches_complex_selector(&dep.selector, snapshot, None,
                                              &mut StyleRelations::empty());


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13125 (github issue number if applicable).

<!-- Either: -->
- [x] These changes do not require tests because https://github.com/servo/servo/issues/13127

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

I'm stupid, and when I did the last moving-the-code-around, I failed miserably
to double-check it in a debug build.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13128)

<!-- Reviewable:end -->
