### PR TITLE
layout: Keep track of whether we've deferred the painting of the document due to a script query.

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -85,7 +85,7 @@ use net_traits::image_cache_thread::{ImageCacheChan, ImageCacheResult, ImageCach
 use profile_traits::mem::{self, Report, ReportKind, ReportsChan};
 use profile_traits::time::{TimerMetadataFrameType, TimerMetadataReflowType};
 use profile_traits::time::{self, TimerMetadata, profile};
-use script::layout_wrapper::ServoLayoutNode;
+use script::layout_wrapper::{ServoLayoutDocument, ServoLayoutNode};
 use script_layout_interface::message::{Msg, NewLayoutThreadInfo, Reflow, ReflowQueryType, ScriptReflow};
 use script_layout_interface::reporter::CSSErrorReporter;
 use script_layout_interface::restyle_damage::{REPAINT, STORE_OVERFLOW, REFLOW_OUT_OF_FLOW, REFLOW};
@@ -629,6 +629,7 @@ impl LayoutThread {
                                                                   reflow_info.goal);
 
         self.perform_post_style_recalc_layout_passes(&reflow_info,
+                                                     None,
                                                      &mut *rw_data,
                                                      &mut layout_context);
 
@@ -901,6 +902,7 @@ impl LayoutThread {
 
     fn compute_abs_pos_and_build_display_list(&mut self,
                                               data: &Reflow,
+                                              document: Option<&ServoLayoutDocument>,
                                               layout_root: &mut Flow,
                                               shared_layout_context: &mut SharedLayoutContext,
                                               rw_data: &mut LayoutThreadData) {
@@ -962,59 +964,69 @@ impl LayoutThread {
                     Some(Arc::new(DisplayList::new(root_stacking_context, display_list_entries)))
             }
 
-            if data.goal == ReflowGoal::ForDisplay {
-                let display_list = (*rw_data.display_list.as_ref().unwrap()).clone();
+            if data.goal != ReflowGoal::ForDisplay {
+                // Defer the paint step until the next ForDisplay.
+                //
+                // We need to tell the document about this so it doesn't
+                // incorrectly suppress reflows. See #13131.
+                document.expect("No document in a non-display reflow?")
+                        .needs_paint_from_layout();
+                return;
+            }
+            if let Some(document) = document {
+                document.will_paint();
+            }
+            let display_list = (*rw_data.display_list.as_ref().unwrap()).clone();
 
-                if opts::get().dump_display_list {
-                    display_list.print();
-                }
-                if opts::get().dump_display_list_json {
-                    println!("{}", serde_json::to_string_pretty(&display_list).unwrap());
-                }
+            if opts::get().dump_display_list {
+                display_list.print();
+            }
+            if opts::get().dump_display_list_json {
+                println!("{}", serde_json::to_string_pretty(&display_list).unwrap());
+            }
 
-                debug!("Layout done!");
+            debug!("Layout done!");
 
-                self.epoch.next();
+            self.epoch.next();
 
-                if let Some(ref mut webrender_api) = self.webrender_api {
-                    // TODO: Avoid the temporary conversion and build webrender sc/dl directly!
-                    let Epoch(epoch_number) = self.epoch;
-                    let epoch = webrender_traits::Epoch(epoch_number);
-                    let pipeline_id = self.id.to_webrender();
+            if let Some(ref mut webrender_api) = self.webrender_api {
+                // TODO: Avoid the temporary conversion and build webrender sc/dl directly!
+                let Epoch(epoch_number) = self.epoch;
+                let epoch = webrender_traits::Epoch(epoch_number);
+                let pipeline_id = self.id.to_webrender();
 
-                    // TODO(gw) For now only create a root scrolling layer!
-                    let mut frame_builder = WebRenderFrameBuilder::new(pipeline_id);
-                    let root_scroll_layer_id = frame_builder.next_scroll_layer_id();
-                    let sc_id = rw_data.display_list.as_ref().unwrap().convert_to_webrender(
-                        webrender_api,
-                        pipeline_id,
-                        epoch,
-                        Some(root_scroll_layer_id),
-                        &mut frame_builder);
-                    let root_background_color = get_root_flow_background_color(layout_root);
-                    let root_background_color =
-                        webrender_traits::ColorF::new(root_background_color.r,
-                                                      root_background_color.g,
-                                                      root_background_color.b,
-                                                      root_background_color.a);
+                // TODO(gw) For now only create a root scrolling layer!
+                let mut frame_builder = WebRenderFrameBuilder::new(pipeline_id);
+                let root_scroll_layer_id = frame_builder.next_scroll_layer_id();
+                let sc_id = rw_data.display_list.as_ref().unwrap().convert_to_webrender(
+                    webrender_api,
+                    pipeline_id,
+                    epoch,
+                    Some(root_scroll_layer_id),
+                    &mut frame_builder);
+                let root_background_color = get_root_flow_background_color(layout_root);
+                let root_background_color =
+                    webrender_traits::ColorF::new(root_background_color.r,
+                                                  root_background_color.g,
+                                                  root_background_color.b,
+                                                  root_background_color.a);
 
-                    let viewport_size = Size2D::new(self.viewport_size.width.to_f32_px(),
-                                                    self.viewport_size.height.to_f32_px());
+                let viewport_size = Size2D::new(self.viewport_size.width.to_f32_px(),
+                                                self.viewport_size.height.to_f32_px());
 
-                    webrender_api.set_root_stacking_context(
-                        sc_id,
-                        root_background_color,
-                        epoch,
-                        pipeline_id,
-                        viewport_size,
-                        frame_builder.stacking_contexts,
-                        frame_builder.display_lists,
-                        frame_builder.auxiliary_lists_builder.finalize());
-                } else {
-                    self.paint_chan
-                        .send(LayoutToPaintMsg::PaintInit(self.epoch, display_list))
-                        .unwrap();
-                }
+                webrender_api.set_root_stacking_context(
+                    sc_id,
+                    root_background_color,
+                    epoch,
+                    pipeline_id,
+                    viewport_size,
+                    frame_builder.stacking_contexts,
+                    frame_builder.display_lists,
+                    frame_builder.auxiliary_lists_builder.finalize());
+            } else {
+                self.paint_chan
+                    .send(LayoutToPaintMsg::PaintInit(self.epoch, display_list))
+                    .unwrap();
             }
         });
     }
@@ -1205,6 +1217,7 @@ impl LayoutThread {
 
         // Perform post-style recalculation layout passes.
         self.perform_post_style_recalc_layout_passes(&data.reflow_info,
+                                                     Some(&document),
                                                      &mut rw_data,
                                                      &mut shared_layout_context);
 
@@ -1327,7 +1340,7 @@ impl LayoutThread {
                                                                   false,
                                                                   reflow_info.goal);
 
-        self.perform_post_main_layout_passes(&reflow_info, &mut *rw_data, &mut layout_context);
+        self.perform_post_main_layout_passes(&reflow_info, None, &mut *rw_data, &mut layout_context);
         true
     }
 
@@ -1385,6 +1398,7 @@ impl LayoutThread {
         }
 
         self.perform_post_style_recalc_layout_passes(&reflow_info,
+                                                     None,
                                                      &mut *rw_data,
                                                      &mut layout_context);
     }
@@ -1407,12 +1421,14 @@ impl LayoutThread {
             return
         }
         self.perform_post_style_recalc_layout_passes(&reflow_info,
+                                                     None,
                                                      &mut *rw_data,
                                                      &mut layout_context);
     }
 
     fn perform_post_style_recalc_layout_passes(&mut self,
                                                data: &Reflow,
+                                               document: Option<&ServoLayoutDocument>,
                                                rw_data: &mut LayoutThreadData,
                                                layout_context: &mut SharedLayoutContext) {
         if let Some(mut root_flow) = self.root_flow.clone() {
@@ -1487,17 +1503,19 @@ impl LayoutThread {
                                            flow_ref::deref_mut(&mut root_flow) as &mut Flow);
             });
 
-            self.perform_post_main_layout_passes(data, rw_data, layout_context);
+            self.perform_post_main_layout_passes(data, document, rw_data, layout_context);
         }
     }
 
     fn perform_post_main_layout_passes(&mut self,
                                        data: &Reflow,
+                                       document: Option<&ServoLayoutDocument>,
                                        rw_data: &mut LayoutThreadData,
                                        layout_context: &mut SharedLayoutContext) {
         // Build the display list if necessary, and send it to the painter.
         if let Some(mut root_flow) = self.root_flow.clone() {
             self.compute_abs_pos_and_build_display_list(data,
+                                                        document,
                                                         flow_ref::deref_mut(&mut root_flow),
                                                         &mut *layout_context,
                                                         rw_data);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1200,9 +1200,11 @@ impl Window {
         if !for_display || self.Document().needs_reflow() {
             issued_reflow = self.force_reflow(goal, query_type, reason);
 
-            // If window_size is `None`, we don't reflow, so the document stays dirty.
-            // Otherwise, we shouldn't need a reflow immediately after a reflow.
+            // If window_size is `None`, we don't reflow, so the document stays
+            // dirty. Otherwise, we shouldn't need a reflow immediately after a
+            // reflow, except if we're waiting for a deferred paint.
             assert!(!self.Document().needs_reflow() ||
+                    (!for_display && self.Document().needs_paint()) ||
                     self.window_size.get().is_none() ||
                     self.suppress_reflow.get());
         } else {

--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -405,6 +405,14 @@ impl<'ld> TDocument for ServoLayoutDocument<'ld> {
         let elements =  unsafe { self.document.drain_modified_elements() };
         elements.into_iter().map(|(el, snapshot)| (ServoLayoutElement::from_layout_js(el), snapshot)).collect()
     }
+
+    fn needs_paint_from_layout(&self) {
+        unsafe { self.document.needs_paint_from_layout(); }
+    }
+
+    fn will_paint(&self) {
+        unsafe { self.document.will_paint(); }
+    }
 }
 
 impl<'ld> ServoLayoutDocument<'ld> {

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -179,6 +179,9 @@ pub trait TDocument : Sized + Copy + Clone {
 
     fn drain_modified_elements(&self) -> Vec<(Self::ConcreteElement,
                                               <Self::ConcreteElement as ElementExt>::Snapshot)>;
+
+    fn needs_paint_from_layout(&self);
+    fn will_paint(&self);
 }
 
 pub trait PresentationalHintsSynthetizer {

--- a/ports/geckolib/wrapper.rs
+++ b/ports/geckolib/wrapper.rs
@@ -414,6 +414,8 @@ impl<'ld> TDocument for GeckoDocument<'ld> {
         let elements =  unsafe { self.document.drain_modified_elements() };
         elements.into_iter().map(|(el, snapshot)| (ServoLayoutElement::from_layout_js(el), snapshot)).collect()*/
     }
+    fn will_paint(&self) { unimplemented!() }
+    fn needs_paint_from_layout(&self) { unimplemented!() }
 }
 
 #[derive(Clone, Copy)]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1356,6 +1356,18 @@
             "url": "/_mozilla/css/data_img_a.html"
           }
         ],
+        "css/deferred-paint.html": [
+          {
+            "path": "css/deferred-paint.html",
+            "references": [
+              [
+                "/_mozilla/css/deferred-paint-ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/deferred-paint.html"
+          }
+        ],
         "css/direction_style_caching.html": [
           {
             "path": "css/direction_style_caching.html",
@@ -10688,6 +10700,30 @@
             ]
           ],
           "url": "/_mozilla/css/data_img_a.html"
+        }
+      ],
+      "css/deferred-paint-ref.html": [
+        {
+          "path": "css/deferred-paint-ref.html",
+          "references": [
+            [
+              "/_mozilla/css/deferred-paint-ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/deferred-paint-ref.html"
+        }
+      ],
+      "css/deferred-paint.html": [
+        {
+          "path": "css/deferred-paint.html",
+          "references": [
+            [
+              "/_mozilla/css/deferred-paint-ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/deferred-paint.html"
         }
       ],
       "css/direction_style_caching.html": [

--- a/tests/wpt/mozilla/tests/css/deferred-paint-ref.html
+++ b/tests/wpt/mozilla/tests/css/deferred-paint-ref.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS test reference</title>
+<link rel="match" href="deferred-paint-ref.html">
+<style>
+  .container div {
+    width: 50px;
+    height: 50px;
+    background: blue;
+  }
+</style>
+<div class="container">
+  <div></div>
+  <div></div>
+</div>

--- a/tests/wpt/mozilla/tests/css/deferred-paint.html
+++ b/tests/wpt/mozilla/tests/css/deferred-paint.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>A deferred paint gets properly re-scheduled</title>
+<link rel="match" href="deferred-paint-ref.html">
+<style>
+  .container div {
+    width: 50px;
+    height: 50px;
+    background: blue;
+  }
+</style>
+<div class="container">
+  <div></div>
+</div>
+<script>
+  let container = document.querySelector('.container');
+  window.onload = function() {
+    container.insertBefore(document.createElement('div'), container.firstChild);
+    container.firstChild.offsetTop;
+  }
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13131

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

r? @pcwalton

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13132)

<!-- Reviewable:end -->
