### PR TITLE
Console message packets should have a '_type' attribute

### DIFF
--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -252,7 +252,7 @@ bitflags! {
 
 #[derive(Deserialize, Serialize)]
 pub struct PageError {
-    #[serde(rename = "type")]
+    #[serde(rename = "_type")]
     pub type_: String,
     pub errorMessage: String,
     pub sourceName: String,
@@ -270,7 +270,7 @@ pub struct PageError {
 
 #[derive(Deserialize, Serialize)]
 pub struct ConsoleAPI {
-    #[serde(rename = "type")]
+    #[serde(rename = "_type")]
     pub type_: String,
     pub level: String,
     pub filename: String,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Renamed the `type_` attribute of `PageError` and `ConsoleAPI` structs to make them correct Firefox RDP packets.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13137 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because devtools component doesn't have any

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13138)

<!-- Reviewable:end -->
