### PR TITLE
Don't use mem::uninitialized() for making calc values

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -35,7 +35,7 @@ use logical_geometry::WritingMode;
 use properties::CascadePropertyFn;
 use properties::longhands;
 use std::fmt::{self, Debug};
-use std::mem::{transmute, uninitialized, zeroed};
+use std::mem::{transmute, zeroed};
 use std::ptr;
 use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -1133,7 +1133,7 @@ fn static_assert() {
                             }
                         }
 
-                        let mut coord: nsStyleCoord = unsafe { uninitialized() };
+                        let mut coord: nsStyleCoord = nsStyleCoord::null();
                         for (index, stop) in gradient.stops.iter().enumerate() {
                             // NB: stops are guaranteed to be none in the gecko side by
                             // default.

--- a/ports/geckolib/gecko_bindings/sugar/ns_style_coord.rs
+++ b/ports/geckolib/gecko_bindings/sugar/ns_style_coord.rs
@@ -3,8 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use bindings::{Gecko_ResetStyleCoord, Gecko_SetStyleCoordCalcValue, Gecko_AddRefCalcArbitraryThread};
+use std::mem;
 use structs::{nsStyleCoord_Calc, nsStyleUnit, nsStyleUnion, nsStyleCoord, nsStyleSides, nsStyleCorners};
 use structs::{nsStyleCoord_CalcValue, nscoord};
+
+impl nsStyleCoord {
+    #[inline]
+    pub fn null() -> Self {
+        // Can't construct directly because it has private fields
+        let mut coord: Self = unsafe { mem::zeroed() };
+        coord.leaky_set_null();
+        coord
+    }
+}
 
 impl CoordData for nsStyleCoord {
     #[inline]


### PR DESCRIPTION
We had code relying on `nsStyleCoord::set()` being leaky (like it was
before we patched up the calc bindings). Added `nsStyleCoord::null()` for
this use case since it's not possible to construct directly anymore.

r? @emilio

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13148)

<!-- Reviewable:end -->
