### PR TITLE
Use conditional compilation for stylo properties; output unimplemented logs for all properties

### DIFF
--- a/components/style/properties/longhand/column.mako.rs
+++ b/components/style/properties/longhand/column.mako.rs
@@ -153,7 +153,7 @@
 </%helpers:longhand>
 
 // FIXME: This prop should be animatable.
-<%helpers:longhand name="column-gap" experimental="True" animatable="False">
+<%helpers:longhand name="column-gap" experimental="True" products="servo" animatable="False">
     use cssparser::ToCss;
     use std::fmt;
     use values::LocalToCss;

--- a/components/style/properties/longhand/counters.mako.rs
+++ b/components/style/properties/longhand/counters.mako.rs
@@ -173,7 +173,7 @@
     }
 </%helpers:longhand>
 
-<%helpers:longhand name="counter-increment" animatable="False">
+<%helpers:longhand name="counter-increment" products="servo" animatable="False">
     use std::fmt;
     use super::content;
     use values::NoViewportPercentage;
@@ -245,7 +245,7 @@
     }
 </%helpers:longhand>
 
-<%helpers:longhand name="counter-reset" animatable="False">
+<%helpers:longhand name="counter-reset" products="servo" animatable="False">
     pub use super::counter_increment::{SpecifiedValue, computed_value, get_initial_value};
     use super::counter_increment::{parse_common};
 

--- a/components/style/properties/longhand/effects.mako.rs
+++ b/components/style/properties/longhand/effects.mako.rs
@@ -175,7 +175,7 @@ ${helpers.predefined_type("opacity",
 </%helpers:vector_longhand>
 
 // FIXME: This prop should be animatable
-<%helpers:longhand name="clip" animatable="False">
+<%helpers:longhand name="clip" products="servo" animatable="False">
     use cssparser::ToCss;
     use std::fmt;
     use values::LocalToCss;
@@ -185,6 +185,7 @@ ${helpers.predefined_type("opacity",
 
     pub mod computed_value {
         use app_units::Au;
+        use properties::animated_properties::Interpolate;
 
         #[derive(Clone, PartialEq, Eq, Copy, Debug)]
         #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
@@ -198,6 +199,20 @@ ${helpers.predefined_type("opacity",
         #[derive(Debug, Clone, PartialEq)]
         #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
         pub struct T(pub Option<ClipRect>);
+
+
+        /// https://drafts.csswg.org/css-transitions/#animtype-rect
+        impl Interpolate for ClipRect {
+            #[inline]
+            fn interpolate(&self, other: &Self, time: f64) -> Result<Self, ()> {
+                Ok(ClipRect {
+                    top: try!(self.top.interpolate(&other.top, time)),
+                    right: try!(self.right.interpolate(&other.right, time)),
+                    bottom: try!(self.bottom.interpolate(&other.bottom, time)),
+                    left: try!(self.left.interpolate(&other.left, time)),
+                })
+            }
+        }
     }
 
     impl ToCss for computed_value::T {
@@ -364,7 +379,7 @@ ${helpers.predefined_type("opacity",
 </%helpers:longhand>
 
 // FIXME: This prop should be animatable
-<%helpers:longhand name="filter" animatable="False">
+<%helpers:longhand name="filter" products="servo" animatable="False">
     //pub use self::computed_value::T as SpecifiedValue;
     use cssparser::ToCss;
     use std::fmt;
@@ -617,7 +632,7 @@ ${helpers.predefined_type("opacity",
     }
 </%helpers:longhand>
 
-<%helpers:longhand name="transform" animatable="True">
+<%helpers:longhand name="transform" products="servo" animatable="True">
     use app_units::Au;
     use values::CSSFloat;
     use values::HasViewportPercentage;
@@ -1196,7 +1211,7 @@ ${helpers.single_keyword("transform-style",
                          "auto flat preserve-3d",
                          animatable=False)}
 
-<%helpers:longhand name="transform-origin" animatable="True">
+<%helpers:longhand name="transform-origin" products="servo" animatable="True">
     use app_units::Au;
     use values::LocalToCss;
     use values::HasViewportPercentage;
@@ -1206,6 +1221,7 @@ ${helpers.single_keyword("transform-style",
     use std::fmt;
 
     pub mod computed_value {
+        use properties::animated_properties::Interpolate;
         use values::computed::{Length, LengthOrPercentage};
 
         #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1214,6 +1230,16 @@ ${helpers.single_keyword("transform-style",
             pub horizontal: LengthOrPercentage,
             pub vertical: LengthOrPercentage,
             pub depth: Length,
+        }
+
+        impl Interpolate for T {
+            fn interpolate(&self, other: &Self, time: f64) -> Result<Self, ()> {
+                Ok(T {
+                    horizontal: try!(self.horizontal.interpolate(&other.horizontal, time)),
+                    vertical: try!(self.vertical.interpolate(&other.vertical, time)),
+                    depth: try!(self.depth.interpolate(&other.depth, time)),
+                })
+            }
         }
     }
 
@@ -1288,10 +1314,11 @@ ${helpers.single_keyword("transform-style",
 ${helpers.predefined_type("perspective",
                           "LengthOrNone",
                           "computed::LengthOrNone::None",
+                          products="servo",
                           animatable=True)}
 
 // FIXME: This prop should be animatable
-<%helpers:longhand name="perspective-origin" animatable="False">
+<%helpers:longhand name="perspective-origin" products="servo" animatable="False">
     use values::HasViewportPercentage;
     use values::specified::{LengthOrPercentage, Percentage};
 

--- a/components/style/properties/longhand/inherited_box.mako.rs
+++ b/components/style/properties/longhand/inherited_box.mako.rs
@@ -40,7 +40,7 @@ ${helpers.single_keyword("color-adjust",
                          "economy exact", products="gecko",
                          animatable=False)}
 
-<%helpers:longhand name="image-rendering" animatable="False">
+<%helpers:longhand name="image-rendering" products="servo" animatable="False">
     pub mod computed_value {
         use cssparser::ToCss;
         use std::fmt;

--- a/components/style/properties/longhand/inherited_table.mako.rs
+++ b/components/style/properties/longhand/inherited_table.mako.rs
@@ -16,7 +16,7 @@ ${helpers.single_keyword("caption-side", "top bottom",
                          extra_gecko_values="right left top-outside bottom-outside",
                          animatable=False)}
 
-<%helpers:longhand name="border-spacing" animatable="False">
+<%helpers:longhand name="border-spacing" products="servo" animatable="False">
     use app_units::Au;
     use values::LocalToCss;
     use values::HasViewportPercentage;
@@ -26,12 +26,24 @@ ${helpers.single_keyword("caption-side", "top bottom",
 
     pub mod computed_value {
         use app_units::Au;
+        use properties::animated_properties::Interpolate;
 
         #[derive(Clone, Copy, Debug, PartialEq, RustcEncodable)]
         #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
         pub struct T {
             pub horizontal: Au,
             pub vertical: Au,
+        }
+
+        /// https://drafts.csswg.org/css-transitions/#animtype-simple-list
+        impl Interpolate for T {
+            #[inline]
+            fn interpolate(&self, other: &Self, time: f64) -> Result<Self, ()> {
+                Ok(T {
+                    horizontal: try!(self.horizontal.interpolate(&other.horizontal, time)),
+                    vertical: try!(self.vertical.interpolate(&other.vertical, time)),
+                })
+            }
         }
     }
 

--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -192,7 +192,7 @@
 </%helpers:longhand>
 
 // FIXME: This prop should be animatable.
-<%helpers:longhand name="letter-spacing" animatable="False">
+<%helpers:longhand name="letter-spacing" products="servo" animatable="False">
     use cssparser::ToCss;
     use std::fmt;
     use values::LocalToCss;

--- a/components/style/properties/longhand/list.mako.rs
+++ b/components/style/properties/longhand/list.mako.rs
@@ -96,7 +96,7 @@ ${helpers.single_keyword("list-style-type", """
     }
 </%helpers:longhand>
 
-<%helpers:longhand name="quotes" animatable="False">
+<%helpers:longhand name="quotes" products="servo" animatable="False">
     use std::borrow::Cow;
     use std::fmt;
     use values::NoViewportPercentage;

--- a/components/style/properties/longhand/outline.mako.rs
+++ b/components/style/properties/longhand/outline.mako.rs
@@ -78,4 +78,4 @@ ${helpers.predefined_type("outline-color", "CSSColor", "::cssparser::Color::Curr
                               animatable=False)}
 % endfor
 
-${helpers.predefined_type("outline-offset", "Length", "Au(0)", animatable=True)}
+${helpers.predefined_type("outline-offset", "Length", "Au(0)", products="servo", animatable=True)}

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -110,7 +110,7 @@ ${helpers.single_keyword("align-self", "auto stretch flex-start flex-end center 
                          animatable=False)}
 
 // https://drafts.csswg.org/css-flexbox/#propdef-order
-<%helpers:longhand name="order" animatable="True">
+<%helpers:longhand name="order" products="servo" animatable="True">
     use values::computed::ComputedValueAsSpecified;
 
     impl ComputedValueAsSpecified for SpecifiedValue {}

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1152,7 +1152,12 @@ impl PropertyDeclaration {
                 },
             % endfor
 
-            _ => PropertyDeclarationParseResult::UnknownProperty
+            _ => {
+                if cfg!(all(debug_assertions, feature = "gecko")) && !name.starts_with('-') {
+                    println!("stylo: Unimplemented property setter: {}", name);
+                }
+                PropertyDeclarationParseResult::UnknownProperty
+            }
         }
     }
 


### PR DESCRIPTION
Till now we were only emitting unimplemented property logs for properties which servo implements but stylo doesn't.
This list is getting smaller, and we really should be emitting this for any unexpected property we encounter.

I also made it so that longhands which stylo does not implement will not be compiled in stylo builds; instead of what we currently do,
which is to parse them and then basically ignore the result.

There are still a few exceptions -- we generate stubs for properties that are parts of shorthands because otherwise we'd have to add fiddly conditional compilation to the shorthand code.

r? @bholley

cc @emilio

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13163)

<!-- Reviewable:end -->
