### PR TITLE
Handle None_ => None enum changes

### DIFF
--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -46,12 +46,9 @@ class Keyword(object):
 
     def gecko_constant(self, value):
         if self.gecko_enum_prefix:
-            if value == "none":
-                return self.gecko_enum_prefix + "::None_"
-            else:
-                parts = value.replace("-moz-", "").split("-")
-                parts = [p.title() for p in parts]
-                return self.gecko_enum_prefix + "::" + "".join(parts)
+            parts = value.replace("-moz-", "").split("-")
+            parts = [p.title() for p in parts]
+            return self.gecko_enum_prefix + "::" + "".join(parts)
         else:
             return self.gecko_constant_prefix + "_" + value.replace("-moz-", "").replace("-", "_").upper()
 

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1545,7 +1545,7 @@ fn static_assert() {
         // clean up existing struct
         unsafe { Gecko_DestroyClipPath(clip_path) };
 
-        clip_path.mType = StyleShapeSourceType::None_;
+        clip_path.mType = StyleShapeSourceType::None;
 
         match v {
             ShapeSource::Url(..) => println!("stylo: clip-path: url() not yet implemented"),
@@ -1646,7 +1646,7 @@ fn static_assert() {
         let ref clip_path = self.gecko.mClipPath;
 
         match clip_path.mType {
-            StyleShapeSourceType::None_ => ShapeSource::None,
+            StyleShapeSourceType::None => ShapeSource::None,
             StyleShapeSourceType::Box => {
                 ShapeSource::Box(clip_path.mReferenceBox.into())
             }

--- a/ports/geckolib/gecko_bindings/structs_debug.rs
+++ b/ports/geckolib/gecko_bindings/structs_debug.rs
@@ -3956,7 +3956,7 @@ pub enum StyleBoxShadowType { Inset = 0, }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum StyleClear {
-    None_ = 0,
+    None = 0,
     Left = 1,
     Right = 2,
     InlineStart = 3,
@@ -3983,7 +3983,7 @@ pub enum StyleFillRule { Nonzero = 0, Evenodd = 1, }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum StyleFloat {
-    None_ = 0,
+    None = 0,
     Left = 1,
     Right = 2,
     InlineStart = 3,
@@ -4003,11 +4003,11 @@ pub enum StyleShapeOutsideShapeBox {
 }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum StyleShapeSourceType { None_ = 0, URL = 1, Shape = 2, Box = 3, }
+pub enum StyleShapeSourceType { None = 0, URL = 1, Shape = 2, Box = 3, }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum StyleUserFocus {
-    None_ = 0,
+    None = 0,
     Ignore = 1,
     Normal = 2,
     SelectAll = 3,
@@ -4019,7 +4019,7 @@ pub enum StyleUserFocus {
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum StyleUserSelect {
-    None_ = 0,
+    None = 0,
     Text = 1,
     Element = 2,
     Elements = 3,
@@ -4033,7 +4033,7 @@ pub enum StyleUserSelect {
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum StyleDisplay {
-    None_ = 0,
+    None = 0,
     Block = 1,
     Inline = 2,
     InlineBlock = 3,

--- a/ports/geckolib/gecko_bindings/structs_release.rs
+++ b/ports/geckolib/gecko_bindings/structs_release.rs
@@ -3935,7 +3935,7 @@ pub enum StyleBoxShadowType { Inset = 0, }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum StyleClear {
-    None_ = 0,
+    None = 0,
     Left = 1,
     Right = 2,
     InlineStart = 3,
@@ -3962,7 +3962,7 @@ pub enum StyleFillRule { Nonzero = 0, Evenodd = 1, }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum StyleFloat {
-    None_ = 0,
+    None = 0,
     Left = 1,
     Right = 2,
     InlineStart = 3,
@@ -3982,11 +3982,11 @@ pub enum StyleShapeOutsideShapeBox {
 }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum StyleShapeSourceType { None_ = 0, URL = 1, Shape = 2, Box = 3, }
+pub enum StyleShapeSourceType { None = 0, URL = 1, Shape = 2, Box = 3, }
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum StyleUserFocus {
-    None_ = 0,
+    None = 0,
     Ignore = 1,
     Normal = 2,
     SelectAll = 3,
@@ -3998,7 +3998,7 @@ pub enum StyleUserFocus {
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum StyleUserSelect {
-    None_ = 0,
+    None = 0,
     Text = 1,
     Element = 2,
     Elements = 3,
@@ -4012,7 +4012,7 @@ pub enum StyleUserSelect {
 #[repr(i8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum StyleDisplay {
-    None_ = 0,
+    None = 0,
     Block = 1,
     Inline = 2,
     InlineBlock = 3,


### PR DESCRIPTION
Pulls in changes from https://bugzilla.mozilla.org/show_bug.cgi?id=1300337

r? @SimonSapin

don't mark for landing, I'll manually r= this when I do the next sync

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13212)

<!-- Reviewable:end -->
