### PR TITLE
Create separate layout trace file for each reflow

### DIFF
--- a/components/layout/layout_debug.rs
+++ b/components/layout/layout_debug.rs
@@ -121,13 +121,13 @@ pub fn begin_trace(flow_root: FlowRef) {
 /// End the debug layout trace. This will write the layout
 /// trace to disk in the current directory. The output
 /// file can then be viewed with an external tool.
-pub fn end_trace() {
+pub fn end_trace(generation: u32) {
     let mut thread_state = STATE_KEY.with(|ref r| r.borrow_mut().take().unwrap());
     assert!(thread_state.scope_stack.len() == 1);
     let mut root_scope = thread_state.scope_stack.pop().unwrap();
     root_scope.post = json::encode(&flow::base(&*thread_state.flow_root)).unwrap();
 
     let result = json::encode(&root_scope).unwrap();
-    let mut file = File::create("layout_trace.json").unwrap();
+    let mut file = File::create(format!("layout_trace-{}.json", generation)).unwrap();
     file.write_all(result.as_bytes()).unwrap();
 }

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1522,7 +1522,7 @@ impl LayoutThread {
             self.first_reflow = false;
 
             if opts::get().trace_layout {
-                layout_debug::end_trace();
+                layout_debug::end_trace(self.generation);
             }
 
             if opts::get().dump_flow_tree {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Currently only the layout trace from the last reflow is dumped to the file. But the interesting reflow may not be the last one. So we are dumping each of them with filename `layout_trace-{generation}.json`. 

This will be used by a GUI viewer to visualize the layout process, which I will check-in later.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because its a minor debug tool

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13214)

<!-- Reviewable:end -->
