### PR TITLE
Not use llvm_stable feature for bindgen

### DIFF
--- a/ports/geckolib/binding_tools/regen.py
+++ b/ports/geckolib/binding_tools/regen.py
@@ -256,7 +256,7 @@ def build(objdir, target_name, debug, debugger, kind_name=None,
 
     if os.path.isdir(bindgen):
         bindgen = ["cargo", "run", "--manifest-path",
-                   os.path.join(bindgen, "Cargo.toml"), "--features", "llvm_stable", "--"]
+                   os.path.join(bindgen, "Cargo.toml"), "--"]
     else:
         bindgen = [bindgen]
 

--- a/ports/geckolib/binding_tools/setup_bindgen.sh
+++ b/ports/geckolib/binding_tools/setup_bindgen.sh
@@ -42,4 +42,4 @@ fi
 cd rust-bindgen
 
 multirust override nightly
-cargo build --features llvm_stable
+cargo build


### PR DESCRIPTION
It seems regen doesn't work properly with `--features llvm_stable` on Windows. It converts many types to `::std::os::raw::c_void`, and the generated code doesn't compile.

I have no idea why is that. But if dropping this feature doesn't break bindings generated on Linux and OS X, we should probably just remove it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13229)

<!-- Reviewable:end -->
