### PR TITLE
Acceptor

### DIFF
--- a/components/debugger/Cargo.toml
+++ b/components/debugger/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "debugger"
+version = "0.0.1"
+authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
+publish = false
+
+[lib]
+name = "debugger"
+path = "lib.rs"
+crate_type = ["rlib"]
+
+[dependencies]
+util = { path = "../util" }
+websocket = "0.17.1"

--- a/components/debugger/lib.rs
+++ b/components/debugger/lib.rs
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate util;
+extern crate websocket;
+
+use util::thread::spawn_named;
+use websocket::{Message, Receiver, Sender, Server};
+use websocket::message::Type;
+
+pub fn start_server(port: u16) {
+    println!("Starting debugger server.");
+    spawn_named("debugger-server".to_owned(), move || {
+        run_server(port)
+    });
+}
+
+fn run_server(port: u16) {
+    let server = Server::bind(("127.0.0.1", port)).unwrap();
+    for connection in server {
+        spawn_named("debugger-connection".to_owned(), move || {
+            let connection = connection.unwrap();
+            let request = connection.read_request().unwrap();
+            let response = request.accept();
+            let client = response.send().unwrap();
+            let (mut sender, mut receiver) = client.split();
+            for message in receiver.incoming_messages() {
+                let message: Message = message.unwrap();
+                match message.opcode {
+                    Type::Close => {
+                        let message = Message::close();
+                        sender.send_message(&message).unwrap();
+                        break;
+                    }
+                    Type::Ping => {
+                        let message = Message::pong(message.payload);
+                        sender.send_message(&message).unwrap();
+                    }
+                    Type::Text => {
+                        sender.send_message(&message).unwrap();
+                    }
+                    _ => {
+                        panic!("Unexpected message type.");
+                    }
+                }
+            }
+        });
+    }
+}

--- a/components/debugger/lib.rs
+++ b/components/debugger/lib.rs
@@ -5,46 +5,66 @@
 extern crate util;
 extern crate websocket;
 
+use std::sync::mpsc;
+use std::sync::mpsc::channel;
 use util::thread::spawn_named;
-use websocket::{Message, Receiver, Sender, Server};
+use websocket::{Message, Receiver, Server, WebSocketStream};
 use websocket::message::Type;
+use websocket::server::Connection;
+
+enum DebuggerMessage {
+    ConnectionAccepted(Connection<WebSocketStream, WebSocketStream>)
+}
 
 pub fn start_server(port: u16) {
     println!("Starting debugger server.");
-    spawn_named("debugger-server".to_owned(), move || {
-        run_server(port)
+    let (sender, receiver) = channel();
+    spawn_named("debugger".to_owned(), move || {
+        run_server(port, sender, receiver)
     });
 }
 
-fn run_server(port: u16) {
+fn run_server(port: u16, sender: mpsc::Sender<DebuggerMessage>, receiver: mpsc::Receiver<DebuggerMessage>) {
     let server = Server::bind(("127.0.0.1", port)).unwrap();
-    for connection in server {
-        spawn_named("debugger-connection".to_owned(), move || {
-            let connection = connection.unwrap();
-            let request = connection.read_request().unwrap();
-            let response = request.accept();
-            let client = response.send().unwrap();
-            let (mut sender, mut receiver) = client.split();
-            for message in receiver.incoming_messages() {
-                let message: Message = message.unwrap();
-                match message.opcode {
-                    Type::Close => {
-                        let message = Message::close();
-                        sender.send_message(&message).unwrap();
-                        break;
-                    }
-                    Type::Ping => {
-                        let message = Message::pong(message.payload);
-                        sender.send_message(&message).unwrap();
-                    }
-                    Type::Text => {
-                        sender.send_message(&message).unwrap();
-                    }
-                    _ => {
-                        panic!("Unexpected message type.");
-                    }
-                }
+    spawn_named("debugger-connection-acceptor".to_owned(), move || {
+        for connection in server {
+            sender.send(DebuggerMessage::ConnectionAccepted(connection.unwrap())).unwrap();
+        }
+    });
+    while let Ok(message) = receiver.recv() {
+        match message {
+            DebuggerMessage::ConnectionAccepted(connection) => {
+                spawn_named("debugger-connection-handler".to_owned(), move || {
+                    handle_connection(connection);
+                });
             }
-        });
+        }
+    }
+}
+
+fn handle_connection(connection: Connection<WebSocketStream, WebSocketStream>) {
+    let request = connection.read_request().unwrap();
+    let response = request.accept();
+    let client = response.send().unwrap();
+    let (mut sender, mut receiver) = client.split();
+    for message in receiver.incoming_messages() {
+        let message: Message = message.unwrap();
+        match message.opcode {
+            Type::Close => {
+                let message = Message::close();
+                websocket::Sender::send_message(&mut sender, &message).unwrap();
+                break;
+            }
+            Type::Ping => {
+                let message = Message::pong(message.payload);
+                websocket::Sender::send_message(&mut sender, &message).unwrap();
+            }
+            Type::Text => {
+                websocket::Sender::send_message(&mut sender, &message).unwrap();
+            }
+            _ => {
+                panic!("Unexpected message type.");
+            }
+        }
     }
 }

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "compiletest_helper 0.0.1",
  "compositing 0.0.1",
  "constellation 0.0.1",
+ "debugger 0.0.1",
  "devtools 0.0.1",
  "devtools_traits 0.0.1",
  "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -479,6 +480,14 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "debugger"
+version = "0.0.1"
+dependencies = [
+ "util 0.0.1",
+ "websocket 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -49,6 +49,7 @@ canvas = {path = "../canvas"}
 canvas_traits = {path = "../canvas_traits"}
 compositing = {path = "../compositing"}
 constellation = {path = "../constellation"}
+debugger = {path = "../debugger"}
 devtools = {path = "../devtools"}
 devtools_traits = {path = "../devtools_traits"}
 env_logger = "0.3"

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -28,6 +28,7 @@ pub extern crate canvas;
 pub extern crate canvas_traits;
 pub extern crate compositing;
 pub extern crate constellation;
+pub extern crate debugger;
 pub extern crate devtools;
 pub extern crate devtools_traits;
 pub extern crate euclid;
@@ -125,6 +126,9 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
         let time_profiler_chan = profile_time::Profiler::create(&opts.time_profiling,
                                                                 opts.time_profiler_trace_path.clone());
         let mem_profiler_chan = profile_mem::Profiler::create(opts.mem_profiler_period);
+        if let Some(port) = opts.debugger_port {
+            debugger::start_server(port)
+        }
         let devtools_chan = opts.devtools_port.map(|port| {
             devtools::start_server(port)
         });

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -123,6 +123,10 @@ pub struct Opts {
     /// Enable all heartbeats for profiling.
     pub profile_heartbeats: bool,
 
+    /// `None` to disable debugger or `Some` with a port number to start a server to listen to
+    /// remote Firefox debugger connections.
+    pub debugger_port: Option<u16>,
+
     /// `None` to disable devtools or `Some` with a port number to start a server to listen to
     /// remote Firefox devtools connections.
     pub devtools_port: Option<u16>,
@@ -502,6 +506,7 @@ pub fn default_opts() -> Opts {
         enable_text_antialiasing: false,
         enable_canvas_antialiasing: false,
         trace_layout: false,
+        debugger_port: None,
         devtools_port: None,
         webdriver_port: None,
         initial_window_size: TypedSize2D::new(1024, 740),
@@ -562,6 +567,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     opts.optflag("z", "headless", "Headless mode");
     opts.optflag("f", "hard-fail", "Exit on thread failure instead of displaying about:failure");
     opts.optflag("F", "soft-fail", "Display about:failure on thread failure instead of exiting");
+    opts.optflagopt("", "remote-debugging-port", "Start remote debugger server on port", "2794");
     opts.optflagopt("", "devtools", "Start remote devtools server on port", "6000");
     opts.optflagopt("", "webdriver", "Start remote WebDriver server on port", "7000");
     opts.optopt("", "resolution", "Set window resolution.", "1024x740");
@@ -721,6 +727,11 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         bubble_inline_sizes_separately = true;
     }
 
+    let debugger_port = opt_match.opt_default("remote-debugging-port", "2794").map(|port| {
+        port.parse()
+            .unwrap_or_else(|err| args_fail(&format!("Error parsing option: --remote-debugging-port ({})", err)))
+    });
+
     let devtools_port = opt_match.opt_default("devtools", "6000").map(|port| {
         port.parse().unwrap_or_else(|err| args_fail(&format!("Error parsing option: --devtools ({})", err)))
     });
@@ -802,6 +813,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         profile_script_events: debug_options.profile_script_events,
         profile_heartbeats: debug_options.profile_heartbeats,
         trace_layout: debug_options.trace_layout,
+        debugger_port: debugger_port,
         devtools_port: devtools_port,
         webdriver_port: webdriver_port,
         initial_window_size: initial_window_size,

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -440,6 +440,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugger"
+version = "0.0.1"
+dependencies = [
+ "util 0.0.1",
+ "websocket 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "deque"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,6 +1980,7 @@ dependencies = [
  "canvas_traits 0.0.1",
  "compositing 0.0.1",
  "constellation 0.0.1",
+ "debugger 0.0.1",
  "devtools 0.0.1",
  "devtools_traits 0.0.1",
  "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This pull request changes the debugger server to accept WebSocket connections in a separate thread. 

The reason for this change is that the debugger server thread needs to wait on both a mpsc receiver (for incoming messages from the browser) and a TCP socket (for incoming connections from the WebSocket server), but it cannot select on both. By listening for incoming connections in a separate thread, and then sending the connection over the mpsc channel, we can get the debugger server thread to wait for either event.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X ] These changes do not require tests because this is a prototype

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13237)

<!-- Reviewable:end -->
