### PR TITLE
Reenable importScripts tests that no longer crash.

### DIFF
--- a/tests/wpt/metadata/workers/interfaces/WorkerUtils/importScripts/004.html.ini
+++ b/tests/wpt/metadata/workers/interfaces/WorkerUtils/importScripts/004.html.ini
@@ -1,3 +1,0 @@
-[004.html]
-  type: testharness
-  disabled: flaky crash detection

--- a/tests/wpt/metadata/workers/interfaces/WorkerUtils/importScripts/005.html.ini
+++ b/tests/wpt/metadata/workers/interfaces/WorkerUtils/importScripts/005.html.ini
@@ -1,3 +1,0 @@
-[005.html]
-  type: testharness
-  disabled: flaky crash detection

--- a/tests/wpt/metadata/workers/interfaces/WorkerUtils/importScripts/006.html.ini
+++ b/tests/wpt/metadata/workers/interfaces/WorkerUtils/importScripts/006.html.ini
@@ -1,3 +1,0 @@
-[006.html]
-  type: testharness
-  disabled: flaky crash detection


### PR DESCRIPTION
These now pass, since #3247 doesn't apply any more.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13250)

<!-- Reviewable:end -->
