### PR TITLE
Further improve OSX openssl docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,26 +35,18 @@ pip install virtualenv
 ``` sh
 sudo port install python27 py27-virtualenv cmake
 ```
-#### On OS X 10.11 (El Capitan), you also have to install openssl
+#### On OS X <= 10.11 (El Capitan), you also have to install openssl
 
 ``` sh
 brew install openssl
-brew link --force openssl
-```
 
-If you get this error during the brew link step:
-```sh
-Warning: Refusing to link: openssl
-```
-followed by a compile error not being able to find one or more
-openssl/ include files, you may want to try:
-```sh
 export OPENSSL_INCLUDE_DIR="$(brew --prefix openssl)/include"
 export OPENSSL_LIB_DIR="$(brew --prefix openssl)/lib"
+
 ./mach build ...
 ```
 
-If you've already partially compiled servo but forgot to do this step, run ./mach clean, link openssl, and recompile.
+If you've already partially compiled servo but forgot to do this step, run ./mach clean, set the shell variables, and recompile.
 
 #### On Debian-based Linuxes
 


### PR DESCRIPTION
force linking doesn't work anymore and setting the environment variables is the recommended way of linking to non system openssl. sorry for not including everything on the same pull request but I wasn't sure before that this always happens.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] These changes do not require tests because its a documentation change

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

force linking doesn't work anymore and setting the environment variables is the recommended way of linking to non system openssl.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13271)

<!-- Reviewable:end -->
