### PR TITLE
Improve windows compiling instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ window and update the core libraries and install new packages. The extra step at
 downgrate GCC to 5.4, as the GCC6 versions in mingw currently fail to compile some of our
 dependencies. We are upgrading to a gcc-free build on Windows as soon as possible:
 
+**IMPORTANT**
+If your python is installed in other dir than `C:\Python27` you need to create a symbolic link otherwise mozjs will fail to build.
+To do it, open Command Prompt as admin and run this:
+```bat
+mkdir C:\Python27
+mklink /D C:\Python27 YOUR_PYTHON_PATH
+```
+
 ```sh
 pacman -Su
 pacman -Sy git mingw-w64-x86_64-toolchain mingw-w64-x86_64-freetype \


### PR DESCRIPTION
When you have python in any dir that is not the default one in C: it will break with this message:

```
Build failed, waiting for other jobs to finish...
error: failed to run custom build command for `mozjs_sys v0.0.0 (https://github.com/servo/mozjs#87c47526)`
process didn't exit successfully: `D:/p/personal/servo/target\debug\build\mozjs_sys-661d4efe7c7ca939\build-script-build` (exit code: 101)
--- stderr
makefile.cargo:102: *** recipe commences before first target.  Stop.
thread 'main' panicked at 'assertion failed: result.success()', D:/p/personal/servo/.cargo\git\checkouts\mozjs-fa11ffc7d4f1cc2d\master\build.rs:43
stack backtrace:
   0:           0x44940e - <unknown>
   1:           0x4475c3 - <unknown>
   2:           0x447daa - <unknown>
   3:           0x404ef2 - <unknown>
   4:           0x40ef42 - <unknown>
   5:           0x447a28 - <unknown>
   6:           0x451d08 - <unknown>
   7:           0x446cc3 - <unknown>
   8:           0x40f81a - <unknown>
   9:           0x4013b4 - <unknown>
  10:           0x4014c7 - <unknown>
  11:     0x7ffc6b728643 - <unknown>

Build FAILED in 0:00:33
```

Creating a symbolic link to the python directory worked.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13277)

<!-- Reviewable:end -->
