### PR TITLE
Make DOMTokenList Iterable

### DIFF
--- a/components/script/dom/webidls/DOMTokenList.webidl
+++ b/components/script/dom/webidls/DOMTokenList.webidl
@@ -25,4 +25,5 @@ interface DOMTokenList {
            attribute DOMString value;
 
   stringifier;
+  iterable<DOMString?>;
 };

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -37478,7 +37478,16 @@
   "local_changes": {
     "deleted": [],
     "deleted_reftests": {},
-    "items": {},
+    "items": {
+      "testharness": {
+        "dom/lists/DOMTokenList-Iterable.html": [
+          {
+            "path": "dom/lists/DOMTokenList-Iterable.html",
+            "url": "/dom/lists/DOMTokenList-Iterable.html"
+          }
+        ]
+      }
+    },
     "reftest_nodes": {}
   },
   "reftest_nodes": {

--- a/tests/wpt/web-platform-tests/dom/lists/DOMTokenList-Iterable.html
+++ b/tests/wpt/web-platform-tests/dom/lists/DOMTokenList-Iterable.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>DOMTokenList Iterable Test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<span class="foo   Foo foo   "></span>
+<script>
+    var elementClasses;
+    setup(function() {
+        elementClasses = document.querySelector("span").classList;
+    })
+    test(function() {
+        assert_true('length' in elementClasses);
+    }, 'DOMTokenList has length method.');
+    test(function() {
+        assert_true('values' in elementClasses);
+    }, 'DOMTokenList has values method.');
+    test(function() {
+        assert_true('entries' in elementClasses);
+    }, 'DOMTokenList has entries method.');
+    test(function() {
+        assert_true('forEach' in elementClasses);
+    }, 'DOMTokenList has forEach method.');
+    test(function() {
+        assert_true(Symbol.iterator in elementClasses);
+    }, 'DOMTokenList has Symbol.iterator.');
+    test(function() {
+        var classList = [];
+        for (var className of elementClasses){
+            classList.push(className);
+        }
+        assert_array_equals(classList, ['foo', 'Foo']);
+    }, 'DOMTokenList is iterable via for-of loop.');
+</script>


### PR DESCRIPTION
Make DOMTokenList Iterable.
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13019 
- [X] There are tests for these changes (It adds tests/wpt/web-platform-tests/dom/lists/DOMTokenList-Iterable.html)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13280)

<!-- Reviewable:end -->
