### PR TITLE
Fix most typoes for: "referer" -> "referrer"

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -676,8 +676,8 @@ pub fn modify_request_headers(headers: &mut Headers,
                                                referrer_url.clone(),
                                                url.clone());
 
-    if let Some(referer_val) = referrer_url.clone() {
-        headers.set(Referer(referer_val.into_string()));
+    if let Some(referrer_val) = referrer_url.clone() {
+        headers.set(Referer(referrer_val.into_string()));
     }
 }
 

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -43,11 +43,11 @@ pub enum Origin {
 
 /// A [referer](https://fetch.spec.whatwg.org/#concept-request-referrer)
 #[derive(Clone, PartialEq, HeapSizeOf)]
-pub enum Referer {
-    NoReferer,
-    /// Default referer if nothing is specified
+pub enum Referrer {
+    NoReferrer,
+    /// Default referrer if nothing is specified
     Client,
-    RefererUrl(Url)
+    ReferrerUrl(Url)
 }
 
 /// A [request mode](https://fetch.spec.whatwg.org/#concept-request-mode)
@@ -132,7 +132,7 @@ pub struct RequestInit {
     // doesn't have info about the client right now
     pub origin: Url,
     // XXXManishearth these should be part of the client object
-    pub referer_url: Option<Url>,
+    pub referrer_url: Option<Url>,
     pub referrer_policy: Option<ReferrerPolicy>,
     pub pipeline_id: Option<PipelineId>,
 }
@@ -164,7 +164,7 @@ pub struct Request {
     pub omit_origin_header: Cell<bool>,
     pub same_origin_data: Cell<bool>,
     /// https://fetch.spec.whatwg.org/#concept-request-referrer
-    pub referer: RefCell<Referer>,
+    pub referrer: RefCell<Referrer>,
     pub referrer_policy: Cell<Option<ReferrerPolicy>>,
     pub pipeline_id: Cell<Option<PipelineId>>,
     pub synchronous: bool,
@@ -205,7 +205,7 @@ impl Request {
             origin: RefCell::new(origin.unwrap_or(Origin::Client)),
             omit_origin_header: Cell::new(false),
             same_origin_data: Cell::new(false),
-            referer: RefCell::new(Referer::Client),
+            referrer: RefCell::new(Referrer::Client),
             referrer_policy: Cell::new(None),
             pipeline_id: Cell::new(pipeline_id),
             synchronous: false,
@@ -238,10 +238,10 @@ impl Request {
         req.use_cors_preflight = init.use_cors_preflight;
         req.credentials_mode = init.credentials_mode;
         req.use_url_credentials = init.use_url_credentials;
-        *req.referer.borrow_mut() = if let Some(url) = init.referer_url {
-            Referer::RefererUrl(url)
+        *req.referrer.borrow_mut() = if let Some(url) = init.referrer_url {
+            Referrer::ReferrerUrl(url)
         } else {
-            Referer::NoReferer
+            Referrer::NoReferrer
         };
         req.referrer_policy.set(init.referrer_policy);
         req.pipeline_id.set(init.pipeline_id);
@@ -271,7 +271,7 @@ impl Request {
             origin: RefCell::new(Origin::Client),
             omit_origin_header: Cell::new(false),
             same_origin_data: Cell::new(false),
-            referer: RefCell::new(Referer::Client),
+            referrer: RefCell::new(Referrer::Client),
             referrer_policy: Cell::new(None),
             synchronous: false,
             // Step 1-2
@@ -325,26 +325,26 @@ impl Request {
     }
 }
 
-impl Referer {
+impl Referrer {
     pub fn to_url(&self) -> Option<&Url> {
         match *self {
-            Referer::NoReferer | Referer::Client => None,
-            Referer::RefererUrl(ref url) => Some(url)
+            Referrer::NoReferrer | Referrer::Client => None,
+            Referrer::ReferrerUrl(ref url) => Some(url)
         }
     }
     pub fn from_url(url: Option<Url>) -> Self {
         if let Some(url) = url {
-            Referer::RefererUrl(url)
+            Referrer::ReferrerUrl(url)
         } else {
-            Referer::NoReferer
+            Referrer::NoReferrer
         }
     }
     pub fn take(&mut self) -> Option<Url> {
-        let mut new = Referer::Client;
+        let mut new = Referrer::Client;
         swap(self, &mut new);
         match new {
-            Referer::NoReferer | Referer::Client => None,
-            Referer::RefererUrl(url) => Some(url)
+            Referrer::NoReferrer | Referrer::Client => None,
+            Referrer::ReferrerUrl(url) => Some(url)
         }
     }
 }

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -28,7 +28,7 @@ use net_traits::request::CacheMode as NetTraitsRequestCache;
 use net_traits::request::CredentialsMode as NetTraitsRequestCredentials;
 use net_traits::request::Destination as NetTraitsRequestDestination;
 use net_traits::request::RedirectMode as NetTraitsRequestRedirect;
-use net_traits::request::Referer as NetTraitsRequestReferer;
+use net_traits::request::Referrer as NetTraitsRequestReferrer;
 use net_traits::request::Request as NetTraitsRequest;
 use net_traits::request::RequestMode as NetTraitsRequestMode;
 use net_traits::request::Type as NetTraitsRequestType;
@@ -154,7 +154,7 @@ impl Request {
         *request.origin.borrow_mut() = Origin::Client;
         request.omit_origin_header = temporary_request.omit_origin_header;
         request.same_origin_data.set(true);
-        request.referer = temporary_request.referer;
+        request.referrer = temporary_request.referrer;
         request.referrer_policy = temporary_request.referrer_policy;
         request.mode = temporary_request.mode;
         request.credentials_mode = temporary_request.credentials_mode;
@@ -182,7 +182,7 @@ impl Request {
                 // Step 13.2
                 request.omit_origin_header.set(false);
                 // Step 13.3
-                *request.referer.borrow_mut() = NetTraitsRequestReferer::Client;
+                *request.referrer.borrow_mut() = NetTraitsRequestReferrer::Client;
                 // Step 13.4
                 request.referrer_policy.set(None);
             }
@@ -193,7 +193,7 @@ impl Request {
             let ref referrer = init_referrer.0;
             // Step 14.2
             if referrer.is_empty() {
-                *request.referer.borrow_mut() = NetTraitsRequestReferer::NoReferer;
+                *request.referrer.borrow_mut() = NetTraitsRequestReferrer::NoReferrer;
             } else {
                 // Step 14.3
                 let parsed_referrer = base_url.join(referrer);
@@ -207,7 +207,7 @@ impl Request {
                     if parsed_referrer.cannot_be_a_base() &&
                         parsed_referrer.scheme() == "about" &&
                         parsed_referrer.path() == "client" {
-                            *request.referer.borrow_mut() = NetTraitsRequestReferer::Client;
+                            *request.referrer.borrow_mut() = NetTraitsRequestReferrer::Client;
                         } else {
                             // Step 14.6
                             if parsed_referrer.origin() != origin {
@@ -215,7 +215,7 @@ impl Request {
                                     "RequestInit's referrer has invalid origin".to_string()));
                             }
                             // Step 14.7
-                            *request.referer.borrow_mut() = NetTraitsRequestReferer::RefererUrl(parsed_referrer);
+                            *request.referrer.borrow_mut() = NetTraitsRequestReferrer::ReferrerUrl(parsed_referrer);
                         }
                 }
             }
@@ -538,11 +538,11 @@ impl RequestMethods for Request {
     // https://fetch.spec.whatwg.org/#dom-request-referrer
     fn Referrer(&self) -> USVString {
         let r = self.request.borrow();
-        let referrer = r.referer.borrow();
+        let referrer = r.referrer.borrow();
         USVString(match &*referrer {
-            &NetTraitsRequestReferer::NoReferer => String::from("no-referrer"),
-            &NetTraitsRequestReferer::Client => String::from("client"),
-            &NetTraitsRequestReferer::RefererUrl(ref u) => {
+            &NetTraitsRequestReferrer::NoReferrer => String::from("no-referrer"),
+            &NetTraitsRequestReferrer::Client => String::from("client"),
+            &NetTraitsRequestReferrer::ReferrerUrl(ref u) => {
                 let u_c = u.clone();
                 u_c.into_string()
             }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -593,7 +593,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
             credentials_mode: credentials_mode,
             use_url_credentials: use_url_credentials,
             origin: self.global().r().get_url(),
-            referer_url: self.referrer_url.clone(),
+            referrer_url: self.referrer_url.clone(),
             referrer_policy: self.referrer_policy.clone(),
             pipeline_id: self.pipeline_id(),
         };

--- a/tests/unit/net/fetch.rs
+++ b/tests/unit/net/fetch.rs
@@ -24,7 +24,7 @@ use net::fetch::cors_cache::CORSCache;
 use net::fetch::methods::{FetchContext, fetch, fetch_with_cors_cache};
 use net::http_loader::HttpState;
 use net_traits::FetchTaskTarget;
-use net_traits::request::{Origin, RedirectMode, Referer, Request, RequestMode};
+use net_traits::request::{Origin, RedirectMode, Referrer, Request, RequestMode};
 use net_traits::response::{CacheState, Response, ResponseBody, ResponseType};
 use std::fs::File;
 use std::io::Read;
@@ -94,7 +94,7 @@ fn test_fetch_response_is_not_network_error() {
 
     let origin = Origin::Origin(url.origin());
     let request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     let fetch_response = fetch_sync(request, None);
     let _ = server.close();
 
@@ -113,7 +113,7 @@ fn test_fetch_response_body_matches_const_message() {
 
     let origin = Origin::Origin(url.origin());
     let request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     let fetch_response = fetch_sync(request, None);
     let _ = server.close();
 
@@ -133,7 +133,7 @@ fn test_fetch_aboutblank() {
     let url = Url::parse("about:blank").unwrap();
     let origin = Origin::Origin(url.origin());
     let request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     let fetch_response = fetch_sync(request, None);
     assert!(!fetch_response.is_network_error());
     assert!(*fetch_response.body.lock().unwrap() == ResponseBody::Done(vec![]));
@@ -217,7 +217,7 @@ fn test_cors_preflight_fetch() {
 
     let origin = Origin::Origin(UrlOrigin::new_opaque());
     let mut request = Request::new(url.clone(), Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::RefererUrl(target_url);
+    *request.referrer.borrow_mut() = Referrer::ReferrerUrl(target_url);
     *request.referrer_policy.get_mut() = Some(ReferrerPolicy::Origin);
     request.use_cors_preflight = true;
     request.mode = RequestMode::CORSMode;
@@ -255,7 +255,7 @@ fn test_cors_preflight_cache_fetch() {
 
     let origin = Origin::Origin(UrlOrigin::new_opaque());
     let mut request = Request::new(url.clone(), Some(origin.clone()), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     request.use_cors_preflight = true;
     request.mode = RequestMode::CORSMode;
     let wrapped_request0 = Rc::new(request.clone());
@@ -307,7 +307,7 @@ fn test_cors_preflight_fetch_network_error() {
     let origin = Origin::Origin(UrlOrigin::new_opaque());
     let mut request = Request::new(url, Some(origin), false, None);
     *request.method.borrow_mut() = Method::Extension("CHICKEN".to_owned());
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     request.use_cors_preflight = true;
     request.mode = RequestMode::CORSMode;
     let fetch_response = fetch_sync(request, None);
@@ -330,7 +330,7 @@ fn test_fetch_response_is_basic_filtered() {
 
     let origin = Origin::Origin(url.origin());
     let request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     let fetch_response = fetch_sync(request, None);
     let _ = server.close();
 
@@ -375,7 +375,7 @@ fn test_fetch_response_is_cors_filtered() {
     // an origin mis-match will stop it from defaulting to a basic filtered response
     let origin = Origin::Origin(UrlOrigin::new_opaque());
     let mut request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     request.mode = RequestMode::CORSMode;
     let fetch_response = fetch_sync(request, None);
     let _ = server.close();
@@ -407,7 +407,7 @@ fn test_fetch_response_is_opaque_filtered() {
     // an origin mis-match will fall through to an Opaque filtered response
     let origin = Origin::Origin(UrlOrigin::new_opaque());
     let request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     let fetch_response = fetch_sync(request, None);
     let _ = server.close();
 
@@ -454,7 +454,7 @@ fn test_fetch_response_is_opaque_redirect_filtered() {
 
     let origin = Origin::Origin(url.origin());
     let request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     request.redirect_mode.set(RedirectMode::Manual);
     let fetch_response = fetch_sync(request, None);
     let _ = server.close();
@@ -488,7 +488,7 @@ fn test_fetch_with_local_urls_only() {
     let do_fetch = |url: Url| {
         let origin = Origin::Origin(url.origin());
         let mut request = Request::new(url, Some(origin), false, None);
-        *request.referer.borrow_mut() = Referer::NoReferer;
+        *request.referrer.borrow_mut() = Referrer::NoReferrer;
 
         // Set the flag.
         request.local_urls_only = true;
@@ -529,7 +529,7 @@ fn setup_server_and_fetch(message: &'static [u8], redirect_cap: u32) -> Response
 
     let origin = Origin::Origin(url.origin());
     let request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     let fetch_response = fetch_sync(request, None);
     let _ = server.close();
     fetch_response
@@ -612,7 +612,7 @@ fn test_fetch_redirect_updates_method_runner(tx: Sender<bool>, status_code: Stat
 
     let origin = Origin::Origin(url.origin());
     let request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     *request.method.borrow_mut() = method;
 
     let _ = fetch_sync(request, None);
@@ -687,7 +687,7 @@ fn test_fetch_async_returns_complete_response() {
 
     let origin = Origin::Origin(url.origin());
     let request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
 
     let (tx, rx) = channel();
     let listener = Box::new(FetchResponseCollector {
@@ -712,7 +712,7 @@ fn test_opaque_filtered_fetch_async_returns_complete_response() {
     // an origin mis-match will fall through to an Opaque filtered response
     let origin = Origin::Origin(UrlOrigin::new_opaque());
     let request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
 
     let (tx, rx) = channel();
     let listener = Box::new(FetchResponseCollector {
@@ -752,7 +752,7 @@ fn test_opaque_redirect_filtered_fetch_async_returns_complete_response() {
 
     let origin = Origin::Origin(url.origin());
     let request = Request::new(url, Some(origin), false, None);
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
     request.redirect_mode.set(RedirectMode::Manual);
 
     let (tx, rx) = channel();
@@ -780,7 +780,7 @@ fn test_fetch_with_devtools() {
     let origin = Origin::Origin(url.origin());
     let pipeline_id = PipelineId::fake_root_pipeline_id();
     let request = Request::new(url.clone(), Some(origin), false, Some(pipeline_id));
-    *request.referer.borrow_mut() = Referer::NoReferer;
+    *request.referrer.borrow_mut() = Referrer::NoReferrer;
 
     let (devtools_chan, devtools_port) = channel::<DevtoolsControlMsg>();
 

--- a/tests/unit/net/http_loader.rs
+++ b/tests/unit/net/http_loader.rs
@@ -1625,9 +1625,9 @@ fn test_auth_ui_needs_www_auth() {
     }
 }
 
-fn assert_referer_header_matches(origin_info: &LoadOrigin,
-                                 request_url: &str,
-                                 expected_referrer: &str) {
+fn assert_referrer_header_matches(origin_info: &LoadOrigin,
+                                  request_url: &str,
+                                  expected_referrer: &str) {
     let url = Url::parse(request_url).unwrap();
     let ui_provider = TestProvider::new();
 
@@ -1635,20 +1635,20 @@ fn assert_referer_header_matches(origin_info: &LoadOrigin,
                                   url.clone(),
                                   origin_info);
 
-    let mut referer_headers = Headers::new();
-    referer_headers.set(Referer(expected_referrer.to_owned()));
+    let mut referrer_headers = Headers::new();
+    referrer_headers.set(Referer(expected_referrer.to_owned()));
 
     let http_state = HttpState::new();
 
     let _ = load(&load_data.clone(), &ui_provider, &http_state, None,
                  &AssertMustIncludeHeadersRequestFactory {
-                     expected_headers: referer_headers,
+                     expected_headers: referrer_headers,
                      body: <[_]>::to_vec(&[])
                  }, DEFAULT_USER_AGENT.to_owned(),
                  &CancellationListener::new(None), None);
 }
 
-fn assert_referer_header_not_included(origin_info: &LoadOrigin, request_url: &str) {
+fn assert_referrer_header_not_included(origin_info: &LoadOrigin, request_url: &str) {
     let url = Url::parse(request_url).unwrap();
     let ui_provider = TestProvider::new();
 
@@ -1667,7 +1667,7 @@ fn assert_referer_header_not_included(origin_info: &LoadOrigin, request_url: &st
 }
 
 #[test]
-fn test_referer_set_to_origin_with_origin_policy() {
+fn test_referrer_set_to_origin_with_origin_policy() {
     let request_url = "http://mozilla.com";
     let referrer_url = "http://username:password@someurl.com/some/path#fragment";
     let referrer_policy = Some(ReferrerPolicy::Origin);
@@ -1678,11 +1678,11 @@ fn test_referer_set_to_origin_with_origin_policy() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
-fn test_referer_set_to_ref_url_with_sameorigin_policy_same_orig() {
+fn test_referrer_set_to_ref_url_with_sameorigin_policy_same_orig() {
     let request_url = "http://mozilla.com";
     let referrer_url = "http://username:password@mozilla.com/some/path#fragment";
     let referrer_policy = Some(ReferrerPolicy::SameOrigin);
@@ -1693,11 +1693,11 @@ fn test_referer_set_to_ref_url_with_sameorigin_policy_same_orig() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
-fn test_no_referer_set_with_sameorigin_policy_cross_orig() {
+fn test_no_referrer_set_with_sameorigin_policy_cross_orig() {
     let request_url = "http://mozilla.com";
     let referrer_url = "http://username:password@someurl.com/some/path#fragment";
     let referrer_policy = Some(ReferrerPolicy::SameOrigin);
@@ -1707,11 +1707,11 @@ fn test_no_referer_set_with_sameorigin_policy_cross_orig() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_not_included(&origin_info, request_url);
+    assert_referrer_header_not_included(&origin_info, request_url);
 }
 
 #[test]
-fn test_referer_set_to_stripped_url_with_unsafeurl_policy() {
+fn test_referrer_set_to_stripped_url_with_unsafeurl_policy() {
     let request_url = "http://mozilla.com";
     let referrer_url = "http://username:password@someurl.com/some/path#fragment";
     let referrer_policy = Some(ReferrerPolicy::UnsafeUrl);
@@ -1721,11 +1721,11 @@ fn test_referer_set_to_stripped_url_with_unsafeurl_policy() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
-fn test_referer_with_originwhencrossorigin_policy_cross_orig() {
+fn test_referrer_with_originwhencrossorigin_policy_cross_orig() {
     let request_url = "http://mozilla.com";
     let referrer_url = "http://username:password@someurl.com/some/path#fragment";
     let referrer_policy = Some(ReferrerPolicy::OriginWhenCrossOrigin);
@@ -1736,11 +1736,11 @@ fn test_referer_with_originwhencrossorigin_policy_cross_orig() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
-fn test_referer_with_originwhencrossorigin_policy_same_orig() {
+fn test_referrer_with_originwhencrossorigin_policy_same_orig() {
     let request_url = "http://mozilla.com";
     let referrer_url = "http://username:password@mozilla.com/some/path#fragment";
     let referrer_policy = Some(ReferrerPolicy::OriginWhenCrossOrigin);
@@ -1751,11 +1751,11 @@ fn test_referer_with_originwhencrossorigin_policy_same_orig() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
-fn test_http_to_https_considered_cross_origin_for_referer_header_logic() {
+fn test_http_to_https_considered_cross_origin_for_referrer_header_logic() {
     let request_url = "https://mozilla.com";
     let referrer_url = "http://mozilla.com/some/path";
     let referrer_policy = Some(ReferrerPolicy::OriginWhenCrossOrigin);
@@ -1766,11 +1766,11 @@ fn test_http_to_https_considered_cross_origin_for_referer_header_logic() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
-fn test_referer_set_to_ref_url_with_noreferrerwhendowngrade_policy_https_to_https() {
+fn test_referrer_set_to_ref_url_with_noreferrerwhendowngrade_policy_https_to_https() {
     let request_url = "https://mozilla.com";
     let referrer_url = "https://username:password@mozilla.com/some/path#fragment";
     let referrer_policy = Some(ReferrerPolicy::NoReferrerWhenDowngrade);
@@ -1781,11 +1781,11 @@ fn test_referer_set_to_ref_url_with_noreferrerwhendowngrade_policy_https_to_http
         referrer_policy: referrer_policy,
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
-fn test_no_referer_set_with_noreferrerwhendowngrade_policy_https_to_http() {
+fn test_no_referrer_set_with_noreferrerwhendowngrade_policy_https_to_http() {
     let request_url = "http://mozilla.com";
     let referrer_url = "https://username:password@mozilla.com/some/path#fragment";
     let referrer_policy = Some(ReferrerPolicy::NoReferrerWhenDowngrade);
@@ -1795,11 +1795,11 @@ fn test_no_referer_set_with_noreferrerwhendowngrade_policy_https_to_http() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_not_included(&origin_info, request_url)
+    assert_referrer_header_not_included(&origin_info, request_url)
 }
 
 #[test]
-fn test_referer_set_to_ref_url_with_noreferrerwhendowngrade_policy_http_to_https() {
+fn test_referrer_set_to_ref_url_with_noreferrerwhendowngrade_policy_http_to_https() {
     let request_url = "https://mozilla.com";
     let referrer_url = "http://username:password@mozilla.com/some/path#fragment";
     let referrer_policy = Some(ReferrerPolicy::NoReferrerWhenDowngrade);
@@ -1810,11 +1810,11 @@ fn test_referer_set_to_ref_url_with_noreferrerwhendowngrade_policy_http_to_https
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
-fn test_referer_set_to_ref_url_with_noreferrerwhendowngrade_policy_http_to_http() {
+fn test_referrer_set_to_ref_url_with_noreferrerwhendowngrade_policy_http_to_http() {
     let request_url = "http://mozilla.com";
     let referrer_url = "http://username:password@mozilla.com/some/path#fragment";
     let referrer_policy = Some(ReferrerPolicy::NoReferrerWhenDowngrade);
@@ -1825,7 +1825,7 @@ fn test_referer_set_to_ref_url_with_noreferrerwhendowngrade_policy_http_to_http(
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
@@ -1840,7 +1840,7 @@ fn test_no_referrer_policy_follows_noreferrerwhendowngrade_https_to_https() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
@@ -1854,7 +1854,7 @@ fn test_no_referrer_policy_follows_noreferrerwhendowngrade_https_to_http() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_not_included(&origin_info, request_url);
+    assert_referrer_header_not_included(&origin_info, request_url);
 }
 
 #[test]
@@ -1869,7 +1869,7 @@ fn test_no_referrer_policy_follows_noreferrerwhendowngrade_http_to_https() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
@@ -1884,11 +1884,11 @@ fn test_no_referrer_policy_follows_noreferrerwhendowngrade_http_to_http() {
         referrer_policy: referrer_policy
     };
 
-    assert_referer_header_matches(&origin_info, request_url, expected_referrer);
+    assert_referrer_header_matches(&origin_info, request_url, expected_referrer);
 }
 
 #[test]
-fn test_no_referer_set_with_noreferrer_policy() {
+fn test_no_referrer_set_with_noreferrer_policy() {
     let request_url = "http://mozilla.com";
     let referrer_url = "http://someurl.com";
     let referrer_policy = Some(ReferrerPolicy::NoReferrer);
@@ -1898,7 +1898,7 @@ fn test_no_referer_set_with_noreferrer_policy() {
         referrer_policy: referrer_policy,
     };
 
-    assert_referer_header_not_included(&origin_info, request_url)
+    assert_referrer_header_not_included(&origin_info, request_url)
 }
 
 fn load_request_for_custom_response(expected_body: Vec<u8>) -> (Metadata, String) {


### PR DESCRIPTION
Replace most uses of the word "referer" with "referrer", except for `hyper::header::Referer`. Also update the unit tests to compile & pass after those changes.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13286

<!-- Either: -->
- [ ]  There are tests for these changes OR
- [X] These changes do not require tests because they're only typo fixes.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13294)

<!-- Reviewable:end -->
