### PR TITLE
Decode UTF-8 with from_utf8_lossy in DedicatedWorkerGlobalScope

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -173,20 +173,20 @@ impl DedicatedWorkerGlobalScope {
 
             let roots = RootCollection::new();
             let _stack_roots_tls = StackRootTLS::new(&roots);
-            let (url, source) = match load_whole_resource(LoadContext::Script,
-                                                          &init.resource_threads.sender(),
-                                                          worker_url,
-                                                          &worker_load_origin) {
+            let (metadata, bytes) = match load_whole_resource(LoadContext::Script,
+                                                              &init.resource_threads.sender(),
+                                                              worker_url,
+                                                              &worker_load_origin) {
                 Err(_) => {
                     println!("error loading script {}", serialized_worker_url);
                     parent_sender.send(CommonScriptMsg::RunnableMsg(WorkerEvent,
                         box SimpleWorkerErrorHandler::new(worker))).unwrap();
                     return;
                 }
-                Ok((metadata, bytes)) => {
-                    (metadata.final_url, String::from_utf8(bytes).unwrap())
-                }
+                Ok((metadata, bytes)) => (metadata, bytes)
             };
+            let url = metadata.final_url;
+            let source = String::from_utf8_lossy(&bytes);
 
             let runtime = unsafe { new_rt_and_cx() };
             *worker_rt_for_mainthread.lock().unwrap() = Some(SharedRt::new(&runtime));

--- a/tests/wpt/metadata/workers/semantics/encodings/004.worker.js.ini
+++ b/tests/wpt/metadata/workers/semantics/encodings/004.worker.js.ini
@@ -1,4 +1,0 @@
-[004.worker]
-  type: testharness
-  bug: https://github.com/servo/servo/issues/13247
-  expected: CRASH


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13247

<!-- Either: -->
- [X] There are tests for these changes: `./mach test-wpt /workers/semantics/encodings/004.worker` passes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13306)

<!-- Reviewable:end -->
