### PR TITLE
Flush style sharing cache on parent mismatch.

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -708,6 +708,7 @@ pub trait ElementMatchMethods : TElement {
             _ => return StyleSharingResult::CannotShare,
         };
 
+        let mut should_clear_cache = false;
         for (i, &mut (ref mut candidate, ())) in style_sharing_candidate_cache.iter_mut().enumerate() {
             let sharing_result = self.share_style_with_candidate_if_possible(parent,
                                                                              shared_context,
@@ -750,6 +751,11 @@ pub trait ElementMatchMethods : TElement {
                     // Cache miss, let's see what kind of failure to decide
                     // whether we keep trying or not.
                     match miss {
+                        // Cache miss because of parent, clear the candidate cache.
+                        CacheMiss::Parent => {
+                            should_clear_cache = true;
+                            break;
+                        },
                         // Too expensive failure, give up, we don't want another
                         // one of these.
                         CacheMiss::CommonStyleAffectingAttributes |
@@ -760,6 +766,9 @@ pub trait ElementMatchMethods : TElement {
                     }
                 }
             }
+        }
+        if should_clear_cache {
+            style_sharing_candidate_cache.clear();
         }
 
         StyleSharingResult::CannotShare


### PR DESCRIPTION
Fixes #12913. No new tests were added, but we should at least make sure existing tests still pass.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12913

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13312)

<!-- Reviewable:end -->
