### PR TITLE
Implement minlength attribute for text inputs

### DIFF
--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -105,7 +105,7 @@ impl HTMLTextAreaElement {
                 HTMLElement::new_inherited_with_state(IN_ENABLED_STATE | IN_READ_WRITE_STATE,
                                                       local_name, prefix, document),
             textinput: DOMRefCell::new(TextInput::new(
-                    Lines::Multiple, DOMString::new(), chan, None, SelectionDirection::None)),
+                    Lines::Multiple, DOMString::new(), chan, None, None, SelectionDirection::None)),
             value_changed: Cell::new(false),
         }
     }

--- a/components/script/dom/webidls/HTMLInputElement.webidl
+++ b/components/script/dom/webidls/HTMLInputElement.webidl
@@ -27,7 +27,8 @@ interface HTMLInputElement : HTMLElement {
           [SetterThrows]
           attribute long maxLength;
            attribute DOMString min;
-  //         attribute long minLength;
+          [SetterThrows]
+          attribute long minLength;
            attribute boolean multiple;
            attribute DOMString name;
            attribute DOMString pattern;

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -73,6 +73,7 @@ pub struct TextInput<T: ClipboardProvider> {
     ///
     /// https://html.spec.whatwg.org/multipage/#attr-fe-maxlength
     pub max_length: Option<usize>,
+    pub min_length: Option<usize>,
     pub selection_direction: SelectionDirection,
 }
 
@@ -150,6 +151,7 @@ impl<T: ClipboardProvider> TextInput<T> {
     /// Instantiate a new text input control
     pub fn new(lines: Lines, initial: DOMString,
                clipboard_provider: T, max_length: Option<usize>,
+               min_length: Option<usize>,
                selection_direction: SelectionDirection) -> TextInput<T> {
         let mut i = TextInput {
             lines: vec!(),
@@ -158,6 +160,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             multiline: lines == Lines::Multiple,
             clipboard_provider: clipboard_provider,
             max_length: max_length,
+            min_length: min_length,
             selection_direction: selection_direction,
         };
         i.set_content(initial);

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -17,13 +17,18 @@ use script::dom::bindings::str::DOMString;
 use script::textinput::{TextInput, TextPoint, Selection, Lines, Direction, SelectionDirection};
 
 fn text_input(lines: Lines, s: &str) -> TextInput<DummyClipboardContext> {
-    TextInput::new(lines, DOMString::from(s), DummyClipboardContext::new(""), None, SelectionDirection::None)
+    TextInput::new(lines,
+                   DOMString::from(s),
+                   DummyClipboardContext::new(""),
+                   None,
+                   None,
+                   SelectionDirection::None)
 }
 
 #[test]
 fn test_set_content_ignores_max_length() {
     let mut textinput = TextInput::new(
-        Lines::Single, DOMString::from(""), DummyClipboardContext::new(""), Some(1), SelectionDirection::None
+        Lines::Single, DOMString::from(""), DummyClipboardContext::new(""), Some(1), None, SelectionDirection::None
     );
 
     textinput.set_content(DOMString::from("mozilla rocks"));
@@ -37,6 +42,7 @@ fn test_textinput_when_inserting_multiple_lines_over_a_selection_respects_max_le
         DOMString::from("hello\nworld"),
         DummyClipboardContext::new(""),
         Some(17),
+        None,
         SelectionDirection::None,
     );
 
@@ -61,6 +67,7 @@ fn test_textinput_when_inserting_multiple_lines_still_respects_max_length() {
         DOMString::from("hello\nworld"),
         DummyClipboardContext::new(""),
         Some(17),
+        None,
         SelectionDirection::None
     );
 
@@ -78,6 +85,7 @@ fn test_textinput_when_content_is_already_longer_than_max_length_and_theres_no_s
         DOMString::from("abc"),
         DummyClipboardContext::new(""),
         Some(1),
+        None,
         SelectionDirection::None,
     );
 
@@ -93,6 +101,7 @@ fn test_multi_line_textinput_with_maxlength_doesnt_allow_appending_characters_wh
         DOMString::from("abc\nd"),
         DummyClipboardContext::new(""),
         Some(5),
+        None,
         SelectionDirection::None,
     );
 
@@ -108,6 +117,7 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
         DOMString::from("abcde"),
         DummyClipboardContext::new(""),
         Some(5),
+        None,
         SelectionDirection::None,
     );
 
@@ -129,6 +139,7 @@ fn test_single_line_textinput_with_max_length_multibyte() {
         DOMString::from(""),
         DummyClipboardContext::new(""),
         Some(2),
+        None,
         SelectionDirection::None,
     );
 
@@ -147,6 +158,7 @@ fn test_single_line_textinput_with_max_length_multi_code_unit() {
         DOMString::from(""),
         DummyClipboardContext::new(""),
         Some(3),
+        None,
         SelectionDirection::None,
     );
 
@@ -167,6 +179,7 @@ fn test_single_line_textinput_with_max_length_inside_char() {
         DOMString::from("\u{10437}"),
         DummyClipboardContext::new(""),
         Some(1),
+        None,
         SelectionDirection::None,
     );
 
@@ -181,6 +194,7 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
         DOMString::from("a"),
         DummyClipboardContext::new(""),
         Some(1),
+        None,
         SelectionDirection::None,
     );
 
@@ -397,6 +411,7 @@ fn test_clipboard_paste() {
     let mut textinput = TextInput::new(Lines::Single,
                                        DOMString::from("defg"),
                                        DummyClipboardContext::new("abc"),
+                                       None,
                                        None,
                                        SelectionDirection::None);
     assert_eq!(textinput.get_content(), "defg");

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -37499,6 +37499,12 @@
             "path": "dom/lists/DOMTokenList-Iterable.html",
             "url": "/dom/lists/DOMTokenList-Iterable.html"
           }
+        ],
+        "html/semantics/forms/the-input-element/minlength.html": [
+          {
+            "path": "html/semantics/forms/the-input-element/minlength.html",
+            "url": "/html/semantics/forms/the-input-element/minlength.html"
+          }
         ]
       }
     },

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -3555,9 +3555,6 @@
   [HTMLInputElement interface: attribute list]
     expected: FAIL
 
-  [HTMLInputElement interface: attribute minLength]
-    expected: FAIL
-
   [HTMLInputElement interface: attribute valueAsDate]
     expected: FAIL
 
@@ -3625,9 +3622,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: document.createElement("input") must inherit property "list" with the proper type (18)]
-    expected: FAIL
-
-  [HTMLInputElement interface: document.createElement("input") must inherit property "minLength" with the proper type (22)]
     expected: FAIL
 
   [HTMLInputElement interface: document.createElement("input") must inherit property "valueAsDate" with the proper type (35)]
@@ -6906,9 +6900,6 @@
   [HTMLInputElement interface: createInput("text") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("text") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("text") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -6991,9 +6982,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("hidden") must inherit property "list" with the proper type (18)]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("hidden") must inherit property "minLength" with the proper type (22)]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("hidden") must inherit property "valueAsDate" with the proper type (35)]
@@ -7080,9 +7068,6 @@
   [HTMLInputElement interface: createInput("search") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("search") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("search") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -7165,9 +7150,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("tel") must inherit property "list" with the proper type (18)]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("tel") must inherit property "minLength" with the proper type (22)]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("tel") must inherit property "valueAsDate" with the proper type (35)]
@@ -7254,9 +7236,6 @@
   [HTMLInputElement interface: createInput("url") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("url") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("url") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -7339,9 +7318,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("email") must inherit property "list" with the proper type (18)]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("email") must inherit property "minLength" with the proper type (22)]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("email") must inherit property "valueAsDate" with the proper type (35)]
@@ -7428,9 +7404,6 @@
   [HTMLInputElement interface: createInput("password") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("password") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("password") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -7513,9 +7486,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("date") must inherit property "list" with the proper type (18)]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("date") must inherit property "minLength" with the proper type (22)]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("date") must inherit property "valueAsDate" with the proper type (35)]
@@ -7602,9 +7572,6 @@
   [HTMLInputElement interface: createInput("month") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("month") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("month") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -7687,9 +7654,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("week") must inherit property "list" with the proper type (18)]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("week") must inherit property "minLength" with the proper type (22)]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("week") must inherit property "valueAsDate" with the proper type (35)]
@@ -7776,9 +7740,6 @@
   [HTMLInputElement interface: createInput("time") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("time") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("time") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -7861,9 +7822,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("datetime-local") must inherit property "list" with the proper type (18)]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("datetime-local") must inherit property "minLength" with the proper type (22)]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("datetime-local") must inherit property "valueAsDate" with the proper type (35)]
@@ -7950,9 +7908,6 @@
   [HTMLInputElement interface: createInput("number") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("number") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("number") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -8035,9 +7990,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("range") must inherit property "list" with the proper type (18)]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("range") must inherit property "minLength" with the proper type (22)]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("range") must inherit property "valueAsDate" with the proper type (35)]
@@ -8124,9 +8076,6 @@
   [HTMLInputElement interface: createInput("color") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("color") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("color") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -8211,9 +8160,6 @@
   [HTMLInputElement interface: createInput("checkbox") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("checkbox") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("checkbox") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -8296,9 +8242,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("radio") must inherit property "list" with the proper type (18)]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("radio") must inherit property "minLength" with the proper type (22)]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("radio") must inherit property "valueAsDate" with the proper type (35)]
@@ -8388,9 +8331,6 @@
   [HTMLInputElement interface: createInput("file") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("file") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("file") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -8473,9 +8413,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("submit") must inherit property "list" with the proper type (18)]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("submit") must inherit property "minLength" with the proper type (22)]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("submit") must inherit property "valueAsDate" with the proper type (35)]
@@ -8562,9 +8499,6 @@
   [HTMLInputElement interface: createInput("image") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("image") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("image") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -8649,9 +8583,6 @@
   [HTMLInputElement interface: createInput("reset") must inherit property "list" with the proper type (18)]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("reset") must inherit property "minLength" with the proper type (22)]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("reset") must inherit property "valueAsDate" with the proper type (35)]
     expected: FAIL
 
@@ -8734,9 +8665,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("button") must inherit property "list" with the proper type (18)]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("button") must inherit property "minLength" with the proper type (22)]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("button") must inherit property "valueAsDate" with the proper type (35)]

--- a/tests/wpt/web-platform-tests/html/semantics/forms/the-input-element/minlength.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/the-input-element/minlength.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>input min length</title>
+    <link rel="author" title="Taryn Hill" href="mailto:Phrohdoh@gmail.com">
+    <link rel=help href="https://html.spec.whatwg.org/multipage/forms.html#the-minlength-and-minlength-attributes">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+    <h1>Text input element</h1>
+
+    <div style="display: none">
+      <input id="none" />
+      <input id="negative" minlength=-5 />
+      <input id="non-numeric" minlength="not-a-number" />
+      <input id="assign-negative" />
+      <input id="assign-non-numeric" />
+    </div>
+
+    <div id="log"></div>
+
+    <script type="text/javascript">
+      test(
+        function() {
+          assert_equals(document.getElementById("none").minLength, -1);
+        }, "Unset minlength is -1");
+
+      test(
+        function() {
+          assert_equals(document.getElementById("negative").minLength, -1);
+        }, "Negative minlength is always -1");
+
+      test(
+        function() {
+          assert_equals(document.getElementById("non-numeric").minLength, -1);
+        }, "Non-numeric minlength is -1");
+
+      test(
+          function() {
+            assert_throws("INDEX_SIZE_ERR", function() {
+              document.getElementById("assign-negative").minLength = -5;
+            });
+          }, "Assigning negative integer throws IndexSizeError");
+
+      test(
+          function() {
+            document.getElementById("assign-non-numeric").minLength = "not-a-number";
+            assert_equals(document.getElementById("assign-non-numeric").minLength, 0);
+          }, "Assigning non-numeric to minlength sets minlength to 0");
+    </script>
+  </body>
+</html>
+


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

**This is not ready to be merged:
I need help writing tests as I am not familiar with the methods used in the `maxlength` tests (introduced in  tests/unit/script/textinput.rs).**

I also need to write the `minlength-manual` test.

Closes #13313
This depends on #13314 (and includes the commit from it so will need to be rebased once that patch lands).

I am just looking for a quick review to make sure I am on the right path.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13313

<!-- Either: -->
- [X] There ~~are~~ _will be_ tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13315)

<!-- Reviewable:end -->
