### PR TITLE
Implement WebGLRenderingContext::isEnabled

### DIFF
--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -603,7 +603,7 @@ interface WebGLRenderingContextBase
 
     void hint(GLenum target, GLenum mode);
     [WebGLHandlesContextLoss] GLboolean isBuffer(WebGLBuffer? buffer);
-    //[WebGLHandlesContextLoss] GLboolean isEnabled(GLenum cap);
+    [WebGLHandlesContextLoss] GLboolean isEnabled(GLenum cap);
     [WebGLHandlesContextLoss] GLboolean isFramebuffer(WebGLFramebuffer? framebuffer);
     [WebGLHandlesContextLoss] GLboolean isProgram(WebGLProgram? program);
     [WebGLHandlesContextLoss] GLboolean isRenderbuffer(WebGLRenderbuffer? renderbuffer);

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/methods.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/methods.html.ini
@@ -71,9 +71,6 @@
   [WebGL test #22: Property either does not exist or is not a function: isContextLost]
     expected: FAIL
 
-  [WebGL test #23: Property either does not exist or is not a function: isEnabled]
-    expected: FAIL
-
   [WebGL test #24: Property either does not exist or is not a function: isFramebuffer]
     expected: FAIL
 
@@ -215,9 +212,6 @@
   [WebGL test #18: Property either does not exist or is not a function: isContextLost]
     expected: FAIL
 
-  [WebGL test #19: Property either does not exist or is not a function: isEnabled]
-    expected: FAIL
-
   [WebGL test #20: Property either does not exist or is not a function: isFramebuffer]
     expected: FAIL
 
@@ -307,4 +301,3 @@
 
   [WebGL test #49: Property either does not exist or is not a function: validateProgram]
     expected: FAIL
-

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/state/gl-enable-enum-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/state/gl-enable-enum-test.html.ini
@@ -1,62 +1,10 @@
 [gl-enable-enum-test.html]
   type: testharness
-  [WebGL test #59: gl.isEnabled(gl.BLEND) should be true. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #60: gl.isEnabled(gl.BLEND) should be false. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #62: gl.isEnabled(gl.CULL_FACE) should be true. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #63: gl.isEnabled(gl.CULL_FACE) should be false. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #65: gl.isEnabled(gl.DEPTH_TEST) should be true. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #66: gl.isEnabled(gl.DEPTH_TEST) should be false. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #68: gl.isEnabled(gl.DITHER) should be true. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #69: gl.isEnabled(gl.DITHER) should be false. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #71: gl.isEnabled(gl.POLYGON_OFFSET_FILL) should be true. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #72: gl.isEnabled(gl.POLYGON_OFFSET_FILL) should be false. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #74: gl.isEnabled(gl.SAMPLE_ALPHA_TO_COVERAGE) should be true. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #75: gl.isEnabled(gl.SAMPLE_ALPHA_TO_COVERAGE) should be false. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #77: gl.isEnabled(gl.SAMPLE_COVERAGE) should be true. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #78: gl.isEnabled(gl.SAMPLE_COVERAGE) should be false. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #80: gl.isEnabled(gl.SCISSOR_TEST) should be true. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #81: gl.isEnabled(gl.SCISSOR_TEST) should be false. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
   [WebGL test #82: getError expected: NO_ERROR. Was INVALID_ENUM : gl.enable must succeed when passed gl.STENCIL_TEST]
     expected: FAIL
 
-  [WebGL test #83: gl.isEnabled(gl.STENCIL_TEST) should be true. Threw exception TypeError: gl.isEnabled is not a function]
-    expected: FAIL
-
-  [WebGL test #84: gl.isEnabled(gl.STENCIL_TEST) should be false. Threw exception TypeError: gl.isEnabled is not a function]
+  [WebGL test #83: gl.isEnabled(gl.STENCIL_TEST) should be true. Was false.]
     expected: FAIL
 
   [WebGL test #85: getError expected: NO_ERROR. Was INVALID_ENUM : there should be no errors]
     expected: FAIL
-


### PR DESCRIPTION
Implemented WebGLRenderingContext::isEnabled
- Please note the return value of the implementation, not sure about returning `false` on `InvalidEnum`.
- the `webgl/conformance-1.0.3/conformance/state/gl-enable-enum-test.html` wpt test is disabled on linux but was enabled on my machine and run to validate expectations.
- the `/webgl/conformance-1.0.3/conformance/context/methods.html` test is disabled everywhere. Enabling and running on my machine showed incorrect expectations beyond `isEnabled`. The test was temporarily edited to test just for `isEnabled` and it ran successfully.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13040 
- [X] There are tests for these changes (please read details above)
- [ ] These changes do not require tests because _____

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13337)

<!-- Reviewable:end -->
