### PR TITLE
Update mozjs_sys to fix the build failure on macOS Sierra

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1392,7 +1392,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.0.0"
-source = "git+https://github.com/servo/mozjs#87c47526cfe64c1ccfb98daaaa14f63de6295be4"
+source = "git+https://github.com/servo/mozjs#cdf21f7c5596cb6e02eb9afdfc51841deea84a1f"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.0.0"
-source = "git+https://github.com/servo/mozjs#87c47526cfe64c1ccfb98daaaa14f63de6295be4"
+source = "git+https://github.com/servo/mozjs#cdf21f7c5596cb6e02eb9afdfc51841deea84a1f"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
- https://github.com/servo/servo/issues/13348
- This only fixes the failure to compile mozjs_sys. Linking problem with xcode 8 is still opened (https://github.com/servo/servo/issues/11846)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13349)

<!-- Reviewable:end -->
