### PR TITLE
Style input-text pseudo with user-agent CSS

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -48,6 +48,7 @@ use style::computed_values::content::ContentItem;
 use style::computed_values::position;
 use style::context::SharedStyleContext;
 use style::properties::{self, ServoComputedValues};
+use style::servo_selector_impl::PseudoElement;
 use table::TableFlow;
 use table_caption::TableCaptionFlow;
 use table_cell::TableCellFlow;
@@ -693,7 +694,8 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
 
             let mut style = node.style(self.style_context()).clone();
             if node_is_input_or_text_area {
-                properties::modify_style_for_input_text(&mut style);
+                style = self.style_context().stylist.
+                    precomputed_values_for_pseudo(&PseudoElement::ServoInputText, Some(&style)).unwrap();
             }
 
             self.create_fragments_for_node_text_content(&mut initial_fragments, node, &style)

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2278,20 +2278,6 @@ pub fn modify_style_for_text(style: &mut Arc<ComputedValues>) {
     }
 }
 
-/// Adjusts the `margin` property as necessary to account for the text of an `input` element.
-///
-/// Margins apply to the `input` element itself, so including them in the text will cause them to
-/// be double-counted.
-#[cfg(feature = "servo")]
-pub fn modify_style_for_input_text(style: &mut Arc<ComputedValues>) {
-    let mut style = Arc::make_mut(style);
-    let margin_style = Arc::make_mut(&mut style.margin);
-    margin_style.margin_top = computed::LengthOrPercentageOrAuto::Length(Au(0));
-    margin_style.margin_right = computed::LengthOrPercentageOrAuto::Length(Au(0));
-    margin_style.margin_bottom = computed::LengthOrPercentageOrAuto::Length(Au(0));
-    margin_style.margin_left = computed::LengthOrPercentageOrAuto::Length(Au(0));
-}
-
 /// Adjusts the `clip` property so that an inline absolute hypothetical fragment doesn't clip its
 /// children.
 #[cfg(feature = "servo")]

--- a/components/style/servo_selector_impl.rs
+++ b/components/style/servo_selector_impl.rs
@@ -21,6 +21,7 @@ pub enum PseudoElement {
     Selection,
     DetailsSummary,
     DetailsContent,
+    ServoInputText,
 }
 
 impl ToCss for PseudoElement {
@@ -32,6 +33,7 @@ impl ToCss for PseudoElement {
             Selection => "::selection",
             DetailsSummary => "::-servo-details-summary",
             DetailsContent => "::-servo-details-content",
+            ServoInputText => "::-servo-input-text",
         })
     }
 }
@@ -54,7 +56,8 @@ impl PseudoElement {
             PseudoElement::After |
             PseudoElement::Selection => PseudoElementCascadeType::Eager,
             PseudoElement::DetailsSummary => PseudoElementCascadeType::Lazy,
-            PseudoElement::DetailsContent => PseudoElementCascadeType::Precomputed,
+            PseudoElement::DetailsContent |
+            PseudoElement::ServoInputText => PseudoElementCascadeType::Precomputed,
         }
     }
 }
@@ -201,6 +204,12 @@ impl SelectorImpl for ServoSelectorImpl {
                 }
                 DetailsContent
             },
+            "-servo-input-text" => {
+                if !context.in_user_agent_stylesheet {
+                    return Err(())
+                }
+                ServoInputText
+            },
             _ => return Err(())
         };
 
@@ -222,6 +231,7 @@ impl ServoSelectorImpl {
         fun(PseudoElement::DetailsContent);
         fun(PseudoElement::DetailsSummary);
         fun(PseudoElement::Selection);
+        fun(PseudoElement::ServoInputText);
     }
 
     #[inline]

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -165,3 +165,7 @@ details[open]::-servo-details-summary {
 svg > * {
   display: none;
 }
+
+*|*::-servo-input-text {
+    margin: 0;
+}

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-vertical-align-effect.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flex-vertical-align-effect.htm.ini
@@ -1,3 +1,0 @@
-[flex-vertical-align-effect.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
This changes the input-text pseudo-element to be styled with user-agent CSS rather than having a hard-coded style, as part of #8570 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they're a refactoring of existing functionality

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13354)

<!-- Reviewable:end -->
