### PR TITLE
Form action url 11219

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -98,7 +98,7 @@ impl HTMLFormElementMethods for HTMLFormElement {
     make_setter!(SetAcceptCharset, "accept-charset");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-action
-    make_url_or_base_getter!(Action, "action");
+    make_string_or_document_url_getter!(Action, "action");
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-action
     make_setter!(SetAction, "action");
@@ -295,7 +295,7 @@ impl HTMLFormElement {
     pub fn submit(&self, submit_method_flag: SubmittedFrom, submitter: FormSubmitter) {
         // Step 1
         let doc = document_from_node(self);
-        let base = doc.url();
+        let base = doc.base_url();
         // TODO: Handle browsing contexts (Step 2, 3)
         // Step 4
         if submit_method_flag == SubmittedFrom::NotFromForm &&

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -124,6 +124,26 @@ macro_rules! make_url_or_base_getter(
 );
 
 #[macro_export]
+macro_rules! make_string_or_document_url_getter(
+    ( $attr:ident, $htmlname:tt ) => (
+        fn $attr(&self) -> DOMString {
+            use dom::bindings::inheritance::Castable;
+            use dom::element::Element;
+            use dom::node::document_from_node;
+            let element = self.upcast::<Element>();
+            let val = element.get_string_attribute(&atom!($htmlname));
+
+            if val.is_empty() {
+                let doc = document_from_node(self);
+                DOMString::from(doc.url().clone().into_string())
+            } else {
+                val
+            }
+        }
+    );
+);
+
+#[macro_export]
 macro_rules! make_enumerated_getter(
     ( $attr:ident, $htmlname:tt, $default:expr, $(($choices: pat))|+) => (
         fn $attr(&self) -> DOMString {

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -37715,6 +37715,12 @@
     "deleted_reftests": {},
     "items": {
       "testharness": {
+        "html/semantics/forms/the-form-element/form-action-url.html": [
+          {
+            "path": "html/semantics/forms/the-form-element/form-action-url.html",
+            "url": "/html/semantics/forms/the-form-element/form-action-url.html"
+          }
+        ],
         "html/semantics/forms/the-select-element/common-HTMLOptionsCollection-add.html": [
           {
             "path": "html/semantics/forms/the-select-element/common-HTMLOptionsCollection-add.html",

--- a/tests/wpt/web-platform-tests/html/semantics/forms/the-form-element/form-action-url.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/the-form-element/form-action-url.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  var t = async_test("Submit a form from an iframe with a base url");
+  var success = function() { t.done(); };
+</script>
+
+<iframe src="resources/form-action-url-iframe.html">

--- a/tests/wpt/web-platform-tests/html/semantics/forms/the-form-element/resources/form-action-url-iframe.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/the-form-element/resources/form-action-url-iframe.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<base href="target/"></base>
+
+<form action="form-action-url-target.html">
+  <input type="submit" value="Submit" /> 
+</form>
+
+<script>
+  var form = document.getElementsByTagName("form")[0];
+  form.submit();
+</script>

--- a/tests/wpt/web-platform-tests/html/semantics/forms/the-form-element/resources/target/form-action-url-target.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/the-form-element/resources/target/form-action-url-target.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<script>
+  window.parent.success();
+</script>


### PR DESCRIPTION
First pass at fixing #10580.
I've added a new macro that returns a DomString with either the attr val or the doc url.
I then made the form element use that macro on the action attribute.
I also added a test that contains an iframe with a form and base url that submits to a page in
a resources directory.

I made all these changes based on https://github.com/servo/servo/pull/11219#issuecomment-223318881.

The only thing I'm confused on is how to change step 8. It looks to just be getting the action so I'm wondering if I need to change either step 9 or 10 instead?

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #10580 (github issue number if applicable).
- [X] There are tests for these changes OR

using that macro with the form action,
making the form submit process use base url,
adding tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13358)

<!-- Reviewable:end -->
