### PR TITLE
Report tidy error for space after (

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -593,7 +593,7 @@ impl HTMLFormElement {
                 "file" | "textarea" => (), // TODO
                 _ => {
                     datum.name = clean_crlf(&datum.name);
-                    datum.value = FormDatumValue::String(clean_crlf( match datum.value {
+                    datum.value = FormDatumValue::String(clean_crlf(match datum.value {
                         FormDatumValue::String(ref s) => s,
                         FormDatumValue::File(_) => unreachable!()
                     }));

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -483,6 +483,7 @@ def check_rust(file_name, lines):
             (r"\{[A-Za-z0-9_]+\};", "use statement contains braces for single import",
                 lambda match, line: line.startswith('use ')),
             (r"^\s*else {", "else braces should be on the same line", no_filter),
+            (r"[^$ ]\([ \t]", "extra space after (", no_filter),
         ]
 
         for pattern, message, filter_func in regex_rules:

--- a/python/tidy/servo_tidy_tests/rust_tidy.rs
+++ b/python/tidy/servo_tidy_tests/rust_tidy.rs
@@ -49,4 +49,12 @@ impl test {
         }
     }
 
+    type Text_Fun3 = fn( i32) -> i32;
+
+    fn test_fun3<Text_Fun3>( y: Text_Fun3) {
+        test_fun( 1);
+    }
+
+    // Should not be triggered
+    macro_rules! test_macro ( ( $( $fun:ident = $flag:ident ; )* ) => ());
 }

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -109,6 +109,9 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('use &T instead of &Root<T>', errors.next()[2])
         self.assertEqual('operators should go at the end of the first line', errors.next()[2])
         self.assertEqual('else braces should be on the same line', errors.next()[2])
+        self.assertEqual('extra space after (', errors.next()[2])
+        self.assertEqual('extra space after (', errors.next()[2])
+        self.assertEqual('extra space after (', errors.next()[2])
         self.assertNoMoreErrors(errors)
 
     def test_spec_link(self):


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add report in tidy for code which have a space after the `(` like `some_function( argument)`

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13350 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13361)

<!-- Reviewable:end -->
