### PR TITLE
Remove unused Servo_RestyleDocument function.

### DIFF
--- a/ports/geckolib/gecko_bindings/bindings.rs
+++ b/ports/geckolib/gecko_bindings/bindings.rs
@@ -944,10 +944,6 @@ extern "C" {
      -> nsRestyleHint;
 }
 extern "C" {
-    pub fn Servo_RestyleDocument(doc: RawGeckoDocumentBorrowed,
-                                 set: RawServoStyleSetBorrowedMut);
-}
-extern "C" {
     pub fn Servo_RestyleSubtree(node: RawGeckoNodeBorrowed,
                                 set: RawServoStyleSetBorrowedMut);
 }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -121,16 +121,6 @@ pub extern "C" fn Servo_RestyleSubtree(node: RawGeckoNodeBorrowed,
 }
 
 #[no_mangle]
-pub extern "C" fn Servo_RestyleDocument(doc: RawGeckoDocumentBorrowed, raw_data: RawServoStyleSetBorrowedMut) -> () {
-    let document = GeckoDocument(doc);
-    let node = match document.root_node() {
-        Some(x) => x,
-        None => return,
-    };
-    restyle_subtree(node, raw_data);
-}
-
-#[no_mangle]
 pub extern "C" fn Servo_StyleWorkerThreadCount() -> u32 {
     *NUM_THREADS as u32
 }


### PR DESCRIPTION
This is no longer used from Gecko.

r? @Manishearth 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's just geckolib unused code removal

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13367)

<!-- Reviewable:end -->
