### PR TITLE
Rename GeckoArc macro so it sounds like it's useful for already-threadsafely-refcounted objects.

### DIFF
--- a/ports/geckolib/gecko_bindings/ptr.rs
+++ b/ports/geckolib/gecko_bindings/ptr.rs
@@ -7,17 +7,20 @@ use heapsize::HeapSizeOf;
 use std::fmt::{self, Debug};
 
 // Defines an Arc-like type that manages a refcounted Gecko object stored
-// in a ThreadSafeFooHolder smart pointer.  Used in tandem with the
-// NS_DECL_HOLDER_FFI_REFCOUNTING-defined types and functions in Gecko.
-macro_rules! define_holder_arc {
-    ($arc_type:ident, $name:ident, $holder_type:ident, $addref: ident, $release: ident) => (
+// in a ThreadSafeFooHolder smart pointer (for those Gecko classes that
+// do not have thread-safe refcounting support) or as raw pointers (for
+// those that do have thread-safe refcounting support).  Used in tandem
+// with the NS_DECL_(HOLDER|THREADSAFE)_FFI_REFCOUNTING-defined types and
+// functions in Gecko.
+macro_rules! define_arc {
+    ($arc_type:ident, $name:ident, $gecko_type:ident, $addref: ident, $release: ident) => (
         #[derive(PartialEq)]
         pub struct $arc_type {
-            ptr: *mut $holder_type,
+            ptr: *mut $gecko_type,
         }
 
         impl $arc_type {
-            pub fn new(data: *mut $holder_type) -> $arc_type {
+            pub fn new(data: *mut $gecko_type) -> $arc_type {
                 debug_assert!(!data.is_null());
                 unsafe { $addref(data); }
                 $arc_type {
@@ -25,7 +28,7 @@ macro_rules! define_holder_arc {
                 }
             }
 
-            pub fn as_raw(&self) -> *mut $holder_type { self.ptr }
+            pub fn as_raw(&self) -> *mut $gecko_type { self.ptr }
         }
 
         unsafe impl Send for $arc_type {}
@@ -55,7 +58,7 @@ macro_rules! define_holder_arc {
     )
 }
 
-define_holder_arc!(GeckoArcPrincipal, Principal, ThreadSafePrincipalHolder,
-                   Gecko_AddRefPrincipalArbitraryThread, Gecko_ReleasePrincipalArbitraryThread);
-define_holder_arc!(GeckoArcURI, URI, ThreadSafeURIHolder,
-                   Gecko_AddRefURIArbitraryThread, Gecko_ReleaseURIArbitraryThread);
+define_arc!(GeckoArcPrincipal, Principal, ThreadSafePrincipalHolder,
+            Gecko_AddRefPrincipalArbitraryThread, Gecko_ReleasePrincipalArbitraryThread);
+define_arc!(GeckoArcURI, URI, ThreadSafeURIHolder,
+            Gecko_AddRefURIArbitraryThread, Gecko_ReleaseURIArbitraryThread);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is just some renaming.  I will want to use this macro with some objects that support thread-safe refcounting, and which thus don't use `nsMainThreadPtrHolder`.  For fun I pushed a stylo try run with this change: https://treeherder.mozilla.org/#/jobs?repo=try&revision=4b6d906b423e

r? @Manishearth 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13370)

<!-- Reviewable:end -->
