### PR TITLE
Allow improper_ctypes in atom_macro.

### DIFF
--- a/ports/geckolib/string_cache/lib.rs
+++ b/ports/geckolib/string_cache/lib.rs
@@ -28,6 +28,7 @@ use std::ops::Deref;
 use std::slice;
 
 #[macro_use]
+#[allow(improper_ctypes)]
 pub mod atom_macro;
 pub mod namespace;
 


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13374)

<!-- Reviewable:end -->
