### PR TITLE
Make async promise test assertion more specific

### DIFF
--- a/tests/wpt/mozilla/tests/mozilla/promise.html
+++ b/tests/wpt/mozilla/tests/mozilla/promise.html
@@ -60,7 +60,7 @@
       t.resolvePromiseDelayed(p, 'success', 100);
       return p.then(function(v) {
           var end = Date.now();
-          assert_true(end - start > 100);
+          assert_greater_than_equal(end - start, 100);
           assert_equals(v, 'success');
       });
   }, 'Native promise from async callback can be resolved');


### PR DESCRIPTION
This will either yield more debuggable failures or fix the problem revealed in #13384 entirely.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13385)

<!-- Reviewable:end -->
