### PR TITLE
Run style tests with all properties included

### DIFF
--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -18,6 +18,7 @@ servo = ["serde", "serde/unstable", "serde_macros", "heapsize", "heapsize_plugin
          "cssparser/heap_size", "cssparser/serde-serialization",
          "selectors/heap_size", "selectors/unstable", "string_cache",
          "url/heap_size", "plugins"]
+testing = []
 
 [dependencies]
 app_units = "0.3"

--- a/components/style/build.rs
+++ b/components/style/build.rs
@@ -55,6 +55,7 @@ fn main() {
         .arg(&script)
         .arg(product)
         .arg("style-crate")
+        .arg(if cfg!(feature = "testing") { "testing" } else { "regular" })
         .status()
         .unwrap();
     if !status.success() {

--- a/components/style/properties/build.py
+++ b/components/style/properties/build.py
@@ -18,15 +18,17 @@ import data
 
 
 def main():
-    usage = "Usage: %s [ servo | gecko ] [ style-crate | html ]" % sys.argv[0]
-    if len(sys.argv) < 3:
+    usage = "Usage: %s [ servo | gecko ] [ style-crate | html ] [ testing | regular ]" % sys.argv[0]
+    if len(sys.argv) < 4:
         abort(usage)
     product = sys.argv[1]
     output = sys.argv[2]
+    testing = sys.argv[3] == "testing"
+
     if product not in ["servo", "gecko"] or output not in ["style-crate", "geckolib", "html"]:
         abort(usage)
 
-    properties = data.PropertiesData(product=product)
+    properties = data.PropertiesData(product=product, testing=testing)
     rust = render(os.path.join(BASE, "properties.mako.rs"), product=product, data=properties)
     if output == "style-crate":
         write(os.environ["OUT_DIR"], "properties.rs", rust)

--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -160,8 +160,16 @@ class StyleStruct(object):
 
 
 class PropertiesData(object):
-    def __init__(self, product):
+    """
+        The `testing` parameter means that we're running tests.
+
+        In this situation, the `product` value is ignored while choosing
+        which shorthands and longhands to generate; and instead all properties for
+        which code exists for either servo or stylo are generated.
+    """
+    def __init__(self, product, testing):
         self.product = product
+        self.testing = testing
         self.style_structs = []
         self.current_style_struct = None
         self.longhands = []
@@ -179,7 +187,7 @@ class PropertiesData(object):
 
     def declare_longhand(self, name, products="gecko servo", **kwargs):
         products = products.split()
-        if self.product not in products:
+        if self.product not in products and not self.testing:
             return
 
         longhand = Longhand(self.current_style_struct, name, **kwargs)
@@ -194,7 +202,7 @@ class PropertiesData(object):
 
     def declare_shorthand(self, name, sub_properties, products="gecko servo", *args, **kwargs):
         products = products.split()
-        if self.product not in products:
+        if self.product not in products and not self.testing:
             return
 
         sub_properties = [self.longhands_by_name[s] for s in sub_properties]

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -208,7 +208,7 @@ class MachCommands(CommandBase):
         if not packages:
             packages = set(os.listdir(path.join(self.context.topdir, "tests", "unit")))
 
-        packages.remove('stylo')
+        packages.discard('stylo')
 
         args = ["cargo", "test"]
         for crate in packages:

--- a/tests/unit/style/properties/scaffolding.rs
+++ b/tests/unit/style/properties/scaffolding.rs
@@ -21,6 +21,7 @@ fn properties_list_json() {
         .arg(&script)
         .arg("servo")
         .arg("html")
+        .arg("regular")
         .status()
         .unwrap();
     assert!(status.success());


### PR DESCRIPTION
This turns on all properties (including stylo-only ones) when the style unit tests are compiled. This lets us test the parsing of gecko-only properties.

These tests can't go in tests/stylo since this introduces dependencies on `Gecko_*` symbols. This method lets us test parsing and serialization of geckolib properties compiled in Servo mode (e.g. using Servo atoms, Servo URLs)

r? @emilio

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13386)

<!-- Reviewable:end -->
