### PR TITLE
Avoid a possible deadlock in main_fetch's synchronous code.

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -312,15 +312,18 @@ fn main_fetch(request: Rc<Request>, cache: &mut CORSCache, cors_flag: bool,
                     Data::Done => break,
                 }
             }
-        } else if let ResponseBody::Done(ref vec) = *response.body.lock().unwrap() {
-            // in case there was no channel to wait for, the body was
-            // obtained synchronously via basic_fetch for data/file/about/etc
-            // We should still send the body across as a chunk
-            if let Some(ref mut target) = *target {
-                target.process_response_chunk(vec.clone());
-            }
         } else {
-            assert!(*response.body.lock().unwrap() == ResponseBody::Empty)
+            let body = response.body.lock().unwrap();
+            if let ResponseBody::Done(ref vec) = *body {
+                // in case there was no channel to wait for, the body was
+                // obtained synchronously via basic_fetch for data/file/about/etc
+                // We should still send the body across as a chunk
+                if let Some(ref mut target) = *target {
+                    target.process_response_chunk(vec.clone());
+                }
+            } else {
+                assert!(*body == ResponseBody::Empty)
+            }
         }
 
         // overloaded similarly to process_response


### PR DESCRIPTION
On playpen, similar code caused a deadlock on 1.11 stable, and worked fine
on nightly 1.13; it seems safer to avoid the pattern entirely.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13388)

<!-- Reviewable:end -->
