### PR TITLE
Added FormData Iterable

### DIFF
--- a/components/script/dom/webidls/FormData.webidl
+++ b/components/script/dom/webidls/FormData.webidl
@@ -19,5 +19,5 @@ interface FormData {
   boolean has(USVString name);
   void set(USVString name, USVString value);
   void set(USVString name, Blob value, optional USVString filename);
-  // iterable<USVString, FormDataEntryValue>;
+  iterable<USVString, FormDataEntryValue>;
 };

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -12838,6 +12838,10 @@
         "url": "/XMLHttpRequest/formdata-delete.htm"
       },
       {
+        "path": "XMLHttpRequest/formdata-foreach.html",
+        "url": "/XMLHttpRequest/formdata-foreach.html"
+      },
+      {
         "path": "XMLHttpRequest/formdata-get.htm",
         "url": "/XMLHttpRequest/formdata-get.htm"
       },

--- a/tests/wpt/metadata/XMLHttpRequest/formdata-foreach.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/formdata-foreach.html.ini
@@ -1,0 +1,13 @@
+[formdata-foreach.html]
+  type: testharness
+  [Iterator should return duplicate keys and non-deleted values]
+    expected: FAIL
+
+  [Entries iterator should return duplicate keys and non-deleted values]
+    expected: FAIL
+
+  [Keys iterator should return duplicates]
+    expected: FAIL
+
+  [Values iterator should return non-deleted values]
+    expected: FAIL

--- a/tests/wpt/web-platform-tests/XMLHttpRequest/formdata-foreach.html
+++ b/tests/wpt/web-platform-tests/XMLHttpRequest/formdata-foreach.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang=en>
+<meta charset=utf-8>
+<title>FormData: foreach</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#interface-formdata" />
+<script>
+    var fd = new FormData();
+    fd.append('n1', 'v1');
+    fd.append('n2', 'v2');
+    fd.append('n3', 'v3');
+    fd.append('n1', 'v4');
+    fd.append('n2', 'v5');
+    fd.append('n3', 'v6');
+    fd.delete('n2');
+    var expected_keys = ['n1', 'n3', 'n1', 'n3'];
+    var expected_values = ['v1', 'v3', 'v4', 'v6'];
+    test(function() {
+        var mykeys = [], myvalues = [];
+        for(var entry of fd) {
+            assert_equals(entry.length, 2,
+                          'Default iterator should yield key/value pairs');
+            mykeys.push(entry[0]);
+            myvalues.push(entry[1]);
+        }
+        assert_array_equals(mykeys, expected_keys,
+                            'Default iterator should see duplicate keys');
+        assert_array_equals(myvalues, expected_values,
+                            'Default iterator should see non-deleted values');
+    }, 'Iterator should return duplicate keys and non-deleted values');
+    test(function() {
+        var mykeys = [], myvalues = [];
+        for(var entry of fd.entries()) {
+            assert_equals(entry.length, 2,
+                          'entries() iterator should yield key/value pairs');
+            mykeys.push(entry[0]);
+            myvalues.push(entry[1]);
+        }
+        assert_array_equals(mykeys, expected_keys,
+                            'entries() iterator should see duplicate keys');
+        assert_array_equals(myvalues, expected_values,
+                            'entries() iterator should see non-deleted values');
+    }, 'Entries iterator should return duplicate keys and non-deleted values');
+    test(function() {
+        var mykeys = [];
+        for(var entry of fd.keys())
+            mykeys.push(entry);
+        assert_array_equals(mykeys, expected_keys,
+                            'keys() iterator should see duplicate keys');
+    }, 'Keys iterator should return duplicates');
+    test(function() {
+        var myvalues = [];
+        for(var entry of fd.values())
+            myvalues.push(entry);
+        assert_array_equals(myvalues, expected_values,
+                            'values() iterator should see non-deleted values');
+    }, 'Values iterator should return non-deleted values');
+</script>


### PR DESCRIPTION
Implement FormData's iterator
Rebased from #13104.
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13020 
- [X] There are tests for these changes (It adds `./mach test-wpt tests/wpt/web-platform-tests/XMLHttpRequest/formdata-foreach.html`)

Notice: Our `FormData` is implemented by `HashMap` ,  which is different from [Gecko's array implementation](https://github.com/mozilla/gecko-dev/blob/3c6ff93c8f92d822ab6a2ae42f55a9f837d62fe9/dom/base/FormData.h#L160). So our `FormData`'s iterator order is different from Gecko's, as there is no way to keep our key's original insertion order.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13396)

<!-- Reviewable:end -->
