### PR TITLE
Extract panic-catching for JS engine callbacks into a separate function

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2383,16 +2383,8 @@ class CGAbstractMethod(CGThing):
 
         if self.catchPanic:
             body = CGWrapper(CGIndenter(body),
-                             pre="let result = panic::catch_unwind(AssertUnwindSafe(|| {\n",
-                             post=("""}));
-match result {
-    Ok(result) => result,
-    Err(error) => {
-        store_panic_result(error);
-        return%s;
-    }
-}
-""" % ("" if self.returnType == "void" else " false")))
+                             pre="return wrap_panic(|| {\n",
+                             post=("""}, %s);""" % ("()" if self.returnType == "void" else "false")))
 
         return CGWrapper(CGIndenter(body),
                          pre=self.definition_prologue(),
@@ -5567,6 +5559,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'dom::bindings::utils::resolve_global',
         'dom::bindings::utils::set_dictionary_property',
         'dom::bindings::utils::trace_global',
+        'dom::bindings::utils::wrap_panic',
         'dom::bindings::trace::JSTraceable',
         'dom::bindings::trace::RootedTraceable',
         'dom::bindings::callback::CallSetup',
@@ -5618,14 +5611,12 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'libc',
         'util::prefs::PREFS',
         'script_runtime::maybe_take_panic_result',
-        'script_runtime::store_panic_result',
         'std::borrow::ToOwned',
         'std::cmp',
         'std::mem',
         'std::num',
         'std::os',
         'std::panic',
-        'std::panic::AssertUnwindSafe',
         'std::ptr',
         'std::str',
         'std::rc',

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -32,8 +32,11 @@ use js::jsapi::{JS_StringHasLatin1Chars, MutableHandleValue, ObjectOpResult};
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::{GCMethods, ToString};
 use libc;
+use script_runtime::store_panic_result;
 use std::ffi::CString;
 use std::os::raw::c_void;
+use std::panic;
+use std::panic::AssertUnwindSafe;
 use std::ptr;
 use std::slice;
 
@@ -513,3 +516,15 @@ unsafe extern "C" fn instance_class_has_proto_at_depth(clasp: *const js::jsapi::
 pub const DOM_CALLBACKS: DOMCallbacks = DOMCallbacks {
     instanceClassMatchesProto: Some(instance_class_has_proto_at_depth),
 };
+
+/// Generic wrapper for JS engine callbacks panic-catching
+pub fn wrap_panic<T: FnMut() -> R, R>(function: T, generic_return_type: R) -> R {
+    let result = panic::catch_unwind(AssertUnwindSafe(function));
+    match result {
+        Ok(result) => result,
+        Err(error) => {
+            store_panic_result(error);
+            generic_return_type
+        }
+    }
+}


### PR DESCRIPTION
All of our generated code for script contains inline code like this:

```
let result = panic::catch_unwind(AssertUnwindSafe(|| {
    ...
};
match result {
    Ok(result) => result,
    Err(error) => {
        store_panic_result(error);
        return false;
    }
}
```

This PR change it to something like this:

```
wrap_panic(|| { ... }, false)
```

---
- [X] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #13377
- [ ] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13406)

<!-- Reviewable:end -->
