### PR TITLE
 #13262 Add a unit test verifying that SpecificFragmentInfo size

### DIFF
--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -98,3 +98,4 @@ pub mod wrapper;
 
 // For unit tests:
 pub use fragment::Fragment;
+pub use fragment::SpecificFragmentInfo;

--- a/tests/unit/layout/size_of.rs
+++ b/tests/unit/layout/size_of.rs
@@ -3,24 +3,35 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use layout::Fragment;
+use layout::SpecificFragmentInfo;
 use std::mem::size_of;
+
+fn check_size_for(name: &'static str, expected: usize, actual: usize) {
+    if actual < expected {
+        panic!("Your changes have decreased the stack size of {} \
+                from {} to {}. Good work! Please update the size in tests/unit/layout/size_of.rs",
+                name, expected, actual);
+    }
+
+    if actual > expected {
+        panic!("Your changes have increased the stack size of {} \
+                from {} to {}.  Please consider choosing a design which avoids this increase. \
+                If you feel that the increase is necessary, update the size in \
+                tests/unit/layout/size_of.rs.",
+                name, expected, actual);
+    }
+}
 
 #[test]
 fn test_size_of_fragment() {
     let expected = 160;
     let actual = size_of::<Fragment>();
+    check_size_for("layout::fragment::Fragment", expected, actual);
+}
 
-    if actual < expected {
-        panic!("Your changes have decreased the stack size of layout::fragment::Fragment \
-                from {} to {}. Good work! Please update the size in tests/unit/layout/size_of.rs",
-                expected, actual);
-    }
-
-    if actual > expected {
-        panic!("Your changes have increased the stack size of layout::fragment::Fragment \
-                from {} to {}.  Please consider choosing a design which avoids this increase. \
-                If you feel that the increase is necessary, update the size in \
-                tests/unit/layout/size_of.rs.",
-                expected, actual);
-    }
+#[test]
+fn test_size_of_specific_fragment_info() {
+    let expected = 24;
+    let actual = size_of::<SpecificFragmentInfo>();
+    check_size_for("layout::fragment::SpecificFragmentInfo", expected, actual);
 }


### PR DESCRIPTION
Add a unit test for `SpecificFragmentInfo`.

I made a similar test as for Fragment in size_of.rs, not sure whether that's the right way or what is asked. Don't hesitate to tell me your expectations :).

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes fix #13262(github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13407)

<!-- Reviewable:end -->
