### PR TITLE
Invoke failure steps if there's no metadata

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -105,8 +105,13 @@ impl AsyncResponseListener for HTMLMediaElementContext {
     fn response_complete(&mut self, status: Result<(), NetworkError>) {
         let elem = self.elem.root();
 
+        // => "If the media data can be fetched but is found by inspection to be in an unsupported
+        //     format, or can otherwise not be rendered at all"
+        if !self.have_metadata {
+            elem.queue_dedicated_media_source_failure_steps();
+        }
         // => "Once the entire media resource has been fetched..."
-        if status.is_ok() {
+        else if status.is_ok() {
             elem.change_ready_state(HAVE_ENOUGH_DATA);
 
             elem.fire_simple_event("progress");

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -2433,27 +2433,6 @@
   [HTMLMediaElement interface: operation addTextTrack(TextTrackKind,DOMString,DOMString)]
     expected: FAIL
 
-  [MediaError must be primary interface of errorVideo.error]
-    expected: FAIL
-
-  [Stringification of errorVideo.error]
-    expected: FAIL
-
-  [MediaError interface: errorVideo.error must inherit property "MEDIA_ERR_ABORTED" with the proper type (0)]
-    expected: FAIL
-
-  [MediaError interface: errorVideo.error must inherit property "MEDIA_ERR_NETWORK" with the proper type (1)]
-    expected: FAIL
-
-  [MediaError interface: errorVideo.error must inherit property "MEDIA_ERR_DECODE" with the proper type (2)]
-    expected: FAIL
-
-  [MediaError interface: errorVideo.error must inherit property "MEDIA_ERR_SRC_NOT_SUPPORTED" with the proper type (3)]
-    expected: FAIL
-
-  [MediaError interface: errorVideo.error must inherit property "code" with the proper type (4)]
-    expected: FAIL
-
   [AudioTrackList interface: existence and properties of interface object]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_canplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_canplay.html.ini
@@ -1,0 +1,6 @@
+[event_canplay.html]
+  type: testharness
+  expected: TIMEOUT
+  [setting src attribute on autoplay audio should trigger canplay event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_canplay_noautoplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_canplay_noautoplay.html.ini
@@ -1,0 +1,6 @@
+[event_canplay_noautoplay.html]
+  type: testharness
+  expected: TIMEOUT
+  [setting src attribute on non-autoplay audio should trigger canplay event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_canplaythrough.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_canplaythrough.html.ini
@@ -1,0 +1,6 @@
+[event_canplaythrough.html]
+  type: testharness
+  expected: TIMEOUT
+  [setting src attribute on autoplay audio should trigger canplaythrough event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_canplaythrough_noautoplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_canplaythrough_noautoplay.html.ini
@@ -1,0 +1,6 @@
+[event_canplaythrough_noautoplay.html]
+  type: testharness
+  expected: TIMEOUT
+  [setting src attribute on non-autoplay audio should trigger canplaythrough event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_canplay_canplaythrough.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_canplay_canplaythrough.html.ini
@@ -1,0 +1,6 @@
+[event_order_canplay_canplaythrough.html]
+  type: testharness
+  expected: TIMEOUT
+  [setting src attribute on autoplay audio should trigger canplay then canplaythrough event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_canplay_playing.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_canplay_playing.html.ini
@@ -1,0 +1,6 @@
+[event_order_canplay_playing.html]
+  type: testharness
+  expected: TIMEOUT
+  [setting src attribute on autoplay audio should trigger canplay then playing event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_loadstart_progress.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_loadstart_progress.html.ini
@@ -1,0 +1,6 @@
+[event_order_loadstart_progress.html]
+  type: testharness
+  expected: TIMEOUT
+  [setting src attribute on autoplay audio should trigger loadstart then progress event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_pause.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_pause.html.ini
@@ -1,0 +1,6 @@
+[event_pause.html]
+  type: testharness
+  expected: TIMEOUT
+  [calling pause() on autoplay audio should trigger pause event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_play.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_play.html.ini
@@ -1,0 +1,6 @@
+[event_play.html]
+  type: testharness
+  expected: TIMEOUT
+  [setting src attribute on autoplay audio should trigger play event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_playing.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_playing.html.ini
@@ -1,0 +1,6 @@
+[event_playing.html]
+  type: testharness
+  expected: TIMEOUT
+  [setting src attribute on autoplay audio should trigger playing event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_playing_noautoplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_playing_noautoplay.html.ini
@@ -1,0 +1,6 @@
+[event_playing_noautoplay.html]
+  type: testharness
+  expected: TIMEOUT
+  [calling play() on audio should trigger playing event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_progress.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_progress.html.ini
@@ -1,0 +1,6 @@
+[event_progress.html]
+  type: testharness
+  expected: TIMEOUT
+  [setting src attribute on autoplay audio should trigger progress event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_progress_noautoplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_progress_noautoplay.html.ini
@@ -1,0 +1,6 @@
+[event_progress_noautoplay.html]
+  type: testharness
+  expected: TIMEOUT
+  [setting src attribute on non-autoplay audio should trigger progress event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/autoplay-overrides-preload.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/autoplay-overrides-preload.html.ini
@@ -1,0 +1,15 @@
+[autoplay-overrides-preload.html]
+  type: testharness
+  expected: TIMEOUT
+  [autoplay (set first) overrides preload "none"]
+    expected: TIMEOUT
+
+  [autoplay (set last) overrides preload "none"]
+    expected: TIMEOUT
+
+  [autoplay (set first) overrides preload "metadata"]
+    expected: TIMEOUT
+
+  [autoplay (set last) overrides preload "metadata"]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/load-events-networkState.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/load-events-networkState.html.ini
@@ -1,6 +1,6 @@
 [load-events-networkState.html]
   type: testharness
   expected: TIMEOUT
-  [NETWORK_NO_SOURCE]
+  [NETWORK_IDLE]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-insert-into-iframe.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-insert-into-iframe.html.ini
@@ -1,6 +1,5 @@
 [resource-selection-invoke-insert-into-iframe.html]
   type: testharness
-  expected: TIMEOUT
   [NOT invoking resource selection by inserting into other document with src set]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-pause-networkState.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-pause-networkState.html.ini
@@ -1,5 +1,0 @@
-[resource-selection-invoke-pause-networkState.html]
-  type: testharness
-  [NOT invoking resource selection with pause() when networkState is not NETWORK_EMPTY]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-remove-from-document-networkState.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-remove-from-document-networkState.html.ini
@@ -1,5 +1,0 @@
-[resource-selection-invoke-remove-from-document-networkState.html]
-  type: testharness
-  [NOT invoking resource selection with implicit pause() when networkState is not NETWORK_EMPTY]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/networkState_during_progress.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/networkState_during_progress.html.ini
@@ -1,0 +1,6 @@
+[networkState_during_progress.html]
+  type: testharness
+  expected: TIMEOUT
+  [audioElement.networkState should be NETWORK_LOADING during progress event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/paused_false_during_play.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/paused_false_during_play.html.ini
@@ -1,0 +1,6 @@
+[paused_false_during_play.html]
+  type: testharness
+  expected: TIMEOUT
+  [audio.paused should be false during play event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/ready-states/autoplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/ready-states/autoplay.html.ini
@@ -1,0 +1,18 @@
+[autoplay.html]
+  type: testharness
+  expected: TIMEOUT
+  [audio.autoplay]
+    expected: TIMEOUT
+
+  [audio.autoplay and load()]
+    expected: TIMEOUT
+
+  [audio.autoplay and play()]
+    expected: TIMEOUT
+
+  [audio.autoplay and pause()]
+    expected: TIMEOUT
+
+  [audio.autoplay and internal pause steps]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_canplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_canplay.html.ini
@@ -1,0 +1,6 @@
+[readyState_during_canplay.html]
+  type: testharness
+  expected: TIMEOUT
+  [audio.readyState should be >= HAVE_FUTURE_DATA during canplay event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_canplaythrough.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_canplaythrough.html.ini
@@ -1,0 +1,6 @@
+[readyState_during_canplaythrough.html]
+  type: testharness
+  expected: TIMEOUT
+  [audio.readyState should be HAVE_ENOUGH_DATA during canplaythrough event]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_playing.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_playing.html.ini
@@ -1,0 +1,6 @@
+[readyState_during_playing.html]
+  type: testharness
+  expected: TIMEOUT
+  [audio.readyState should be >= HAVE_FUTURE_DATA during playing event]
+    expected: NOTRUN
+


### PR DESCRIPTION
Media element network response processing code should invoke failure steps if there's no metadata.

Fixes #13375.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13412)

<!-- Reviewable:end -->
