### PR TITLE
Implement `word-break: keep-all` (#9673)

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -148,6 +148,8 @@ bitflags! {
         const DISABLE_KERNING_SHAPING_FLAG = 0x04,
         #[doc = "Text direction is right-to-left."]
         const RTL_FLAG = 0x08,
+        #[doc = "Set if word-break is set to keep-all."]
+        const KEEP_ALL_FLAG = 0x10,
     }
 }
 

--- a/components/gfx/text/text_run.rs
+++ b/components/gfx/text/text_run.rs
@@ -135,6 +135,53 @@ impl<'a> Iterator for NaturalWordSliceIterator<'a> {
     }
 }
 
+pub struct SoftWrapSliceIterator<'a> {
+    text: &'a str,
+    glyph_run: Option<&'a GlyphRun>,
+    glyph_run_iter: Iter<'a, GlyphRun>,
+    range: Range<ByteIndex>,
+}
+
+// This is like NaturalWordSliceIterator, except that soft-wrap opportunities
+// are allowed. That is, word boundaries are defined solely by UAX#29,
+// regardless of whether the sequence being broken into different slices is
+// a sequence of alphanumeric characters. This shouldn't make a difference in
+// the case of Latin text, but it does in ideographic characters, as well as
+// scripts such as Thai.
+impl<'a> Iterator for SoftWrapSliceIterator<'a> {
+    type Item = TextRunSlice<'a>;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<TextRunSlice<'a>> {
+        let glyph_run = match self.glyph_run {
+            None => return None,
+            Some(glyph_run) => glyph_run,
+        };
+
+        let text_start = self.range.begin();
+        let text = &self.text[text_start.to_usize()..glyph_run.range.end().to_usize()];
+        let slice_text = match LineBreakIterator::new(text).next() {
+            Some((idx, _)) => &text[0..idx],
+            None => unreachable!()
+        };
+
+        let slice_len = ByteIndex(slice_text.len() as isize);
+        self.range.adjust_by(slice_len, -slice_len);
+        if self.range.is_empty() {
+            self.glyph_run = None
+        } else if self.range.intersect(&glyph_run.range).is_empty() {
+            self.glyph_run = self.glyph_run_iter.next();
+        }
+
+        let index_within_glyph_run = text_start - glyph_run.range.begin();
+        Some(TextRunSlice {
+            glyphs: &*glyph_run.glyph_store,
+            offset: glyph_run.range.begin(),
+            range: Range::new(index_within_glyph_run, slice_len),
+        })
+    }
+}
+
 pub struct CharacterSliceIterator<'a> {
     text: &'a str,
     glyph_run: Option<&'a GlyphRun>,
@@ -206,11 +253,13 @@ impl<'a> TextRun {
             // Split off any trailing whitespace into a separate glyph run.
             let mut whitespace = slice.end..slice.end;
             if let Some((i, _)) = word.char_indices().rev()
-                                     .take_while(|&(_, c)| char_is_whitespace(c)).last() {
-                whitespace.start = slice.start + i;
-                slice.end = whitespace.start;
-            }
-
+                .take_while(|&(_, c)| char_is_whitespace(c)).last() {
+                    whitespace.start = slice.start + i;
+                    slice.end = whitespace.start;
+                } else if idx != text.len() {
+                    // If there's no whitespace, try increasing the slice.
+                    continue;
+                }
             if slice.len() > 0 {
                 glyphs.push(GlyphRun {
                     glyph_store: font.shape_text(&text[slice.clone()], options),
@@ -340,6 +389,24 @@ impl<'a> TextRun {
             index: index,
             range: *range,
             reverse: reverse,
+        }
+    }
+
+    /// Returns an iterator that will iterate over all slices of glyphs that represent natural
+    /// words in the given range, where soft wrap opportunities are taken into account.
+    pub fn soft_wrap_slices_in_range(&'a self, range: &Range<ByteIndex>)
+                                        -> SoftWrapSliceIterator<'a> {
+        let index = match self.index_of_first_glyph_run_containing(range.begin()) {
+            None => self.glyphs.len(),
+            Some(index) => index,
+        };
+        let mut glyph_run_iter = self.glyphs[index..].iter();
+        let first_glyph_run = glyph_run_iter.next();
+        SoftWrapSliceIterator {
+            text: &self.text,
+            glyph_run: first_glyph_run,
+            glyph_run_iter: glyph_run_iter,
+            range: *range,
         }
     }
 

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1638,11 +1638,11 @@ impl Fragment {
 
         match self.style().get_inheritedtext().word_break {
             word_break::T::normal => {
-                // Break at normal word boundaries.
-                let natural_word_breaking_strategy =
-                    text_fragment_info.run.natural_word_slices_in_range(&text_fragment_info.range);
+                // Break at normal word boundaries, allowing for soft wrap opportunities.
+                let soft_wrap_breaking_strategy =
+                    text_fragment_info.run.soft_wrap_slices_in_range(&text_fragment_info.range);
                 self.calculate_split_position_using_breaking_strategy(
-                    natural_word_breaking_strategy,
+                    soft_wrap_breaking_strategy,
                     max_inline_size,
                     flags)
             }
@@ -1653,6 +1653,15 @@ impl Fragment {
                 flags.remove(RETRY_AT_CHARACTER_BOUNDARIES);
                 self.calculate_split_position_using_breaking_strategy(
                     character_breaking_strategy,
+                    max_inline_size,
+                    flags)
+            },
+            word_break::T::keep_all => {
+                // Break at word boundaries, and forbid soft wrap opportunities.
+                let natural_word_breaking_strategy =
+                    text_fragment_info.run.natural_word_slices_in_range(&text_fragment_info.range);
+                self.calculate_split_position_using_breaking_strategy(
+                    natural_word_breaking_strategy,
                     max_inline_size,
                     flags)
             }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1637,12 +1637,12 @@ impl Fragment {
         }
 
         match self.style().get_inheritedtext().word_break {
-            word_break::T::normal => {
-                // Break at normal word boundaries, allowing for soft wrap opportunities.
-                let soft_wrap_breaking_strategy =
+            word_break::T::normal | word_break::T::keep_all => {
+                // Break at normal word boundaries. keep-all forbids soft wrap opportunities.
+                let natural_word_breaking_strategy =
                     text_fragment_info.run.natural_word_slices_in_range(&text_fragment_info.range);
                 self.calculate_split_position_using_breaking_strategy(
-                    soft_wrap_breaking_strategy,
+                    natural_word_breaking_strategy,
                     max_inline_size,
                     flags)
             }
@@ -1653,15 +1653,6 @@ impl Fragment {
                 flags.remove(RETRY_AT_CHARACTER_BOUNDARIES);
                 self.calculate_split_position_using_breaking_strategy(
                     character_breaking_strategy,
-                    max_inline_size,
-                    flags)
-            },
-            word_break::T::keep_all => {
-                // Break at word boundaries, and forbid soft wrap opportunities.
-                let natural_word_breaking_strategy =
-                    text_fragment_info.run.natural_word_slices_in_range(&text_fragment_info.range);
-                self.calculate_split_position_using_breaking_strategy(
-                    natural_word_breaking_strategy,
                     max_inline_size,
                     flags)
             }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1640,7 +1640,7 @@ impl Fragment {
             word_break::T::normal => {
                 // Break at normal word boundaries, allowing for soft wrap opportunities.
                 let soft_wrap_breaking_strategy =
-                    text_fragment_info.run.soft_wrap_slices_in_range(&text_fragment_info.range);
+                    text_fragment_info.run.natural_word_slices_in_range(&text_fragment_info.range);
                 self.calculate_split_position_using_breaking_strategy(
                     soft_wrap_breaking_strategy,
                     max_inline_size,

--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -385,8 +385,7 @@ ${helpers.single_keyword("overflow-wrap",
 
 // TODO(pcwalton): Support `word-break: keep-all` once we have better CJK support.
 ${helpers.single_keyword("word-break",
-                         "normal break-all",
-                         extra_gecko_values="keep-all",
+                         "normal break-all keep-all",
                          gecko_constant_prefix="NS_STYLE_WORDBREAK",
                          animatable=False)}
 

--- a/tests/wpt/metadata/html/infrastructure/common-dom-interfaces/collections/htmloptionscollection.html.ini
+++ b/tests/wpt/metadata/html/infrastructure/common-dom-interfaces/collections/htmloptionscollection.html.ini
@@ -17,3 +17,4 @@
 
   [HTMLOptionsCollection.add method insert HTMLOptionElement Option element]
     expected: FAIL
+

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5946,6 +5946,54 @@
             "url": "/_mozilla/css/width_nonreplaced_block_simple_a.html"
           }
         ],
+        "css/word-break-keep-all-005.htm": [
+          {
+            "path": "css/word-break-keep-all-005.htm",
+            "references": [
+              [
+                "/_mozilla/css/word-break-keep-all-ref-005.htm",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/word-break-keep-all-005.htm"
+          }
+        ],
+        "css/word-break-keep-all-006.htm": [
+          {
+            "path": "css/word-break-keep-all-006.htm",
+            "references": [
+              [
+                "/_mozilla/css/word-break-keep-all-ref-006.htm",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/word-break-keep-all-006.htm"
+          }
+        ],
+        "css/word-break-keep-all-007.htm": [
+          {
+            "path": "css/word-break-keep-all-007.htm",
+            "references": [
+              [
+                "/_mozilla/css/word-break-keep-all-ref-007.htm",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/word-break-keep-all-007.htm"
+          }
+        ],
+        "css/word-break-keep-all-008.htm": [
+          {
+            "path": "css/word-break-keep-all-008.htm",
+            "references": [
+              [
+                "/_mozilla/css/word-break-keep-all-ref-008.htm",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/word-break-keep-all-008.htm"
+          }
+        ],
         "css/word-spacing.html": [
           {
             "path": "css/word-spacing.html",
@@ -19582,6 +19630,54 @@
             ]
           ],
           "url": "/_mozilla/css/width_nonreplaced_block_simple_a.html"
+        }
+      ],
+      "css/word-break-keep-all-005.htm": [
+        {
+          "path": "css/word-break-keep-all-005.htm",
+          "references": [
+            [
+              "/_mozilla/css/word-break-keep-all-ref-005.htm",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/word-break-keep-all-005.htm"
+        }
+      ],
+      "css/word-break-keep-all-006.htm": [
+        {
+          "path": "css/word-break-keep-all-006.htm",
+          "references": [
+            [
+              "/_mozilla/css/word-break-keep-all-ref-006.htm",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/word-break-keep-all-006.htm"
+        }
+      ],
+      "css/word-break-keep-all-007.htm": [
+        {
+          "path": "css/word-break-keep-all-007.htm",
+          "references": [
+            [
+              "/_mozilla/css/word-break-keep-all-ref-007.htm",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/word-break-keep-all-007.htm"
+        }
+      ],
+      "css/word-break-keep-all-008.htm": [
+        {
+          "path": "css/word-break-keep-all-008.htm",
+          "references": [
+            [
+              "/_mozilla/css/word-break-keep-all-ref-008.htm",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/word-break-keep-all-008.htm"
         }
       ],
       "css/word-spacing.html": [

--- a/tests/wpt/mozilla/meta/css/word-break-keep-all-008.htm.ini
+++ b/tests/wpt/mozilla/meta/css/word-break-keep-all-008.htm.ini
@@ -1,0 +1,3 @@
+[word-break-keep-all-008.htm]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/tests/css/word-break-keep-all-005.htm
+++ b/tests/wpt/mozilla/tests/css/word-break-keep-all-005.htm
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>word-break: keep-all, latin</title>
+<meta content="word-break: keep-all means breaking is forbidden within 'words'." name="assert">
+<link href="https://drafts.csswg.org/css-text-3/#word-break-property" rel="help">
+<link href="word-break-keep-all-ref-005.htm" rel="match">
+<link href="mailto:ishida@w3.org" rel="author" title="Richard Ishida">
+<style type="text/css">
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id="instructions">Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">Latin latin latin latin</span></div></div>
+<div class="ref"><span>Latin latin latin<br>latin</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').getBoundingClientRect().width;
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+
+</body></html>

--- a/tests/wpt/mozilla/tests/css/word-break-keep-all-006.htm
+++ b/tests/wpt/mozilla/tests/css/word-break-keep-all-006.htm
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>word-break: keep-all, japanese</title>
+<meta content="word-break: keep-all means breaking is forbidden within 'words'.  In this style, sequences of CJK characters do not break." name="assert">
+<link href="https://drafts.csswg.org/css-text-3/#word-break-property" rel="help">
+<link href="word-break-keep-all-ref-006.htm" rel="match">
+<style type="text/css">
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif ; }
+</style>
+</head>
+<body>
+<div id="instructions">Test passes if the two orange boxes are the same.</div>
+<div lang="ja" class="test"><div id="testdiv"><span id="testspan">日本語 日本語 日本語</span></div></div>
+<div lang="ja" class="ref"><span>日本語 日本語<br>日本語</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').getBoundingClientRect().width;
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+
+</body></html>

--- a/tests/wpt/mozilla/tests/css/word-break-keep-all-007.htm
+++ b/tests/wpt/mozilla/tests/css/word-break-keep-all-007.htm
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>word-break: keep-all, korean</title>
+<meta content="word-break: keep-all means breaking is forbidden within 'words'.  In this style, sequences of CJK characters do not break." name="assert">
+<link href="https://drafts.csswg.org/css-text-3/#word-break-property" rel="help">
+<link href="word-break-keep-all-ref-007.htm" rel="match">
+<style type="text/css">
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id="instructions">Test passes if the two orange boxes are the same.</div>
+<div lang="ko" class="test"><div id="testdiv"><span id="testspan">한글이 한글이 한글이</span></div></div>
+<div lang="ko" class="ref"><span>한글이 한글이<br>한글이</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').getBoundingClientRect().width;
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+
+</body></html>

--- a/tests/wpt/mozilla/tests/css/word-break-keep-all-008.htm
+++ b/tests/wpt/mozilla/tests/css/word-break-keep-all-008.htm
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>word-break: keep-all, thai</title>
+<meta content="word-break: keep-all means breaking is forbidden within 'words',  except where opportunities exist due to dictionary-based breaking (such as in Thai)." name="assert">
+<link href="https://drafts.csswg.org/css-text-3/#word-break-property" rel="help">
+<link href="word-break-keep-all-ref-008.htm" rel="match">
+<style type="text/css">
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id="instructions">Test passes if the two orange boxes are the same.</div>
+<div lang="th" class="test"><div id="testdiv"><span id="testspan">แและ แและแและ</span></div></div>
+<div lang="th" class="ref"><span>แและ แและ<br>แและ</span></div>
+<script>
+var sentenceWidth = document.getElementById('testspan').getBoundingClientRect().width;
+document.getElementById('testdiv').style.width = String(sentenceWidth - 5)+'px'
+</script>
+
+</body></html>

--- a/tests/wpt/mozilla/tests/css/word-break-keep-all-ref-005.htm
+++ b/tests/wpt/mozilla/tests/css/word-break-keep-all-ref-005.htm
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>word-break: keep-all, latin</title>
+<link href="mailto:ishida@w3.org" rel="author" title="Richard Ishida">
+<style type="text/css">
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id="instructions">Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>Latin latin latin<br>latin</span></div>
+<div class="ref"><span>Latin latin latin<br>latin</span></div>
+
+</body></html>

--- a/tests/wpt/mozilla/tests/css/word-break-keep-all-ref-006.htm
+++ b/tests/wpt/mozilla/tests/css/word-break-keep-all-ref-006.htm
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>word-break: keep-all, japanese</title>
+<link href="mailto:ishida@w3.org" rel="author" title="Richard Ishida">
+<style type="text/css">
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id="instructions">Test passes if the two orange boxes are the same.</div>
+<div lang="ja" class="ref"><span>日本語 日本語<br>日本語</span></div>
+<div lang="ja" class="ref"><span>日本語 日本語<br>日本語</span></div>
+
+</body></html>

--- a/tests/wpt/mozilla/tests/css/word-break-keep-all-ref-007.htm
+++ b/tests/wpt/mozilla/tests/css/word-break-keep-all-ref-007.htm
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>word-break: keep-all, korean</title>
+<link href="mailto:ishida@w3.org" rel="author" title="Richard Ishida">
+<style type="text/css">
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id="instructions">Test passes if the two orange boxes are the same.</div>
+<div lang="ko" class="ref"><span>한글이 한글이<br>한글이</span></div>
+<div lang="ko" class="ref"><span>한글이 한글이<br>한글이</span></div>
+
+</body></html>

--- a/tests/wpt/mozilla/tests/css/word-break-keep-all-ref-008.htm
+++ b/tests/wpt/mozilla/tests/css/word-break-keep-all-ref-008.htm
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>word-break: keep-all, thai</title>
+<link href="mailto:ishida@w3.org" rel="author" title="Richard Ishida">
+<style type="text/css">
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 390px; font: 36px/1 sans-serif; }
+</style>
+</head>
+<body>
+<div id="instructions">Test passes if the two orange boxes are the same.</div>
+<div lang="th" class="ref"><span>แและ แและ<br>แและ</span></div>
+<div lang="th" class="ref"><span>แและ แและ<br>แและ</span></div>
+
+</body></html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Implement the `keep-all` value for the `word-break` property, as specified in [CSS](https://drafts.csswg.org/css-text-3/#word-break-property).

The relevant CSSWG tests (in `tests/wpt/css-tests/css-text-3_dev/html/word-break-keep-all-*.htm`) do not currently pass. As far as I can tell, this is because the tests use some JavaScript code that is not working properly. (But then, it seems that most tests in this directory are failing at the moment. I'm not sure what can be done here for now.)

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #9673.

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13414)

<!-- Reviewable:end -->
