### PR TITLE
Run style unit tests in testing mode, disable some properties in testing mode

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -24,6 +24,7 @@ default = ["webdriver", "max_log_level"]
 max_log_level = ["log/release_max_level_info"]
 webdriver = ["webdriver_server"]
 energy-profiling = ["profile_traits/energy-profiling"]
+testing = ["style/testing"]
 
 [profile.release]
 opt-level = 3

--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -185,9 +185,9 @@ class PropertiesData(object):
     def active_style_structs(self):
         return [s for s in self.style_structs if s.additional_methods or s.longhands]
 
-    def declare_longhand(self, name, products="gecko servo", **kwargs):
+    def declare_longhand(self, name, products="gecko servo", disable_when_testing=False, **kwargs):
         products = products.split()
-        if self.product not in products and not self.testing:
+        if self.product not in products and not (self.testing and not disable_when_testing):
             return
 
         longhand = Longhand(self.current_style_struct, name, **kwargs)
@@ -200,9 +200,10 @@ class PropertiesData(object):
 
         return longhand
 
-    def declare_shorthand(self, name, sub_properties, products="gecko servo", *args, **kwargs):
+    def declare_shorthand(self, name, sub_properties, products="gecko servo",
+                          disable_when_testing=False, *args, **kwargs):
         products = products.split()
-        if self.product not in products and not self.testing:
+        if self.product not in products and not (self.testing and not disable_when_testing):
             return
 
         sub_properties = [self.longhands_by_name[s] for s in sub_properties]

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -920,7 +920,7 @@ ${helpers.single_keyword("-moz-appearance",
                          animatable=False)}
 
 // Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-binding
-<%helpers:longhand name="-moz-binding" products="gecko" animatable="False">
+<%helpers:longhand name="-moz-binding" products="gecko" animatable="False" disable_when_testing="True">
     use cssparser::{CssStringWriter, ToCss};
     use gecko_bindings::ptr::{GeckoArcPrincipal, GeckoArcURI};
     use std::fmt::{self, Write};

--- a/components/style/properties/longhand/text.mako.rs
+++ b/components/style/properties/longhand/text.mako.rs
@@ -21,7 +21,8 @@ ${helpers.single_keyword("unicode-bidi",
 // FIXME: This prop should be animatable.
 <%helpers:longhand name="${'text-decoration' if product == 'servo' else 'text-decoration-line'}"
                    custom_cascade="${product == 'servo'}"
-                   animatable="False">
+                   animatable="False"
+                   disable_when_testing="True">
     use cssparser::ToCss;
     use std::fmt;
     use values::computed::ComputedValueAsSpecified;

--- a/components/style/properties/shorthand/text.mako.rs
+++ b/components/style/properties/shorthand/text.mako.rs
@@ -8,7 +8,8 @@
                     sub_properties="text-decoration-color
                                     text-decoration-line
                                     text-decoration-style"
-                    products="gecko">
+                    products="gecko"
+                    disable_when_testing="True">
     use cssparser::Color as CSSParserColor;
     use properties::longhands::{text_decoration_color, text_decoration_line, text_decoration_style};
     use values::specified::CSSColor;

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -210,14 +210,11 @@ class MachCommands(CommandBase):
 
         packages.discard('stylo')
 
-        args = ["cargo", "test"]
-        for crate in packages:
-            args += ["-p", "%s_tests" % crate]
-        args += test_patterns
-
-        features = self.servo_features()
-        if features:
-            args += ["--features", "%s" % ' '.join(features)]
+        has_style = True
+        try:
+            packages.remove('style')
+        except KeyError:
+            has_style = False
 
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
@@ -230,9 +227,29 @@ class MachCommands(CommandBase):
             else:
                 env["RUSTFLAGS"] = "-C link-args=-Wl,--subsystem,windows"
 
-        result = call(args, env=env, cwd=self.servo_crate())
-        if result != 0:
-            return result
+        features = self.servo_features()
+        if len(packages) > 0:
+            args = ["cargo", "test"]
+            for crate in packages:
+                args += ["-p", "%s_tests" % crate]
+            args += test_patterns
+
+            if features:
+                args += ["--features", "%s" % ' '.join(features)]
+            result = call(args, env=env, cwd=self.servo_crate())
+            if result != 0:
+                return result
+
+        # Run style tests with the testing feature
+        if has_style:
+            args = ["cargo", "test", "-p", "style_tests", "--features"]
+            if features:
+                args += ["%s" % ' '.join(features + ["testing"])]
+            else:
+                args += ["testing"]
+            result = call(args, env=env, cwd=self.servo_crate())
+            if result != 0:
+                return result
 
     @Command('test-stylo',
              description='Run stylo unit tests',


### PR DESCRIPTION
Another crack at making it possible to test geckolib properties.

In the previous PR I added support for a testing mode but neglected to use it in the style unit tests.

Using it brought out some bugs with properties that exist in both gecko and servo but have different names. Added the ability to disable them.

Hopefully this isn't too unweildy.

r? @emilio

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13415)

<!-- Reviewable:end -->
