### PR TITLE
Replace instances of old ServiceWorker specification URL with new one

### DIFF
--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -41,17 +41,17 @@ impl Client {
 }
 
 impl ClientMethods for Client {
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#client-url-attribute
+    // https://w3c.github.io/ServiceWorker/#client-url-attribute
     fn Url(&self) -> USVString {
         self.url.clone()
     }
 
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#client-frametype
+    // https://w3c.github.io/ServiceWorker/#client-frametype
     fn FrameType(&self) -> FrameType {
         self.frame_type
     }
 
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#client-id
+    // https://w3c.github.io/ServiceWorker/#client-id
     fn Id(&self) -> DOMString {
         let uid_str = format!("{}", self.id);
         DOMString::from_string(uid_str)

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -103,7 +103,7 @@ impl NavigatorMethods for Navigator {
         false
     }
 
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-attribute
+    // https://w3c.github.io/ServiceWorker/#navigator-service-worker-attribute
     fn ServiceWorker(&self) -> Root<ServiceWorkerContainer> {
         self.service_worker.or_init(|| ServiceWorkerContainer::new(self.global().r()))
     }

--- a/components/script/dom/serviceworker.rs
+++ b/components/script/dom/serviceworker.rs
@@ -70,17 +70,17 @@ impl ServiceWorker {
 }
 
 impl ServiceWorkerMethods for ServiceWorker {
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-state-attribute
+    // https://w3c.github.io/ServiceWorker/#service-worker-state-attribute
     fn State(&self) -> ServiceWorkerState {
         self.state.get()
     }
 
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-url-attribute
+    // https://w3c.github.io/ServiceWorker/#service-worker-url-attribute
     fn ScriptURL(&self) -> USVString {
         USVString(self.script_url.borrow().clone())
     }
 
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-postmessage
+    // https://w3c.github.io/ServiceWorker/#service-worker-postmessage
     fn PostMessage(&self, cx: *mut JSContext, message: HandleValue) -> ErrorResult {
         // Step 1
         if let ServiceWorkerState::Redundant = self.state.get() {
@@ -94,10 +94,10 @@ impl ServiceWorkerMethods for ServiceWorker {
         Ok(())
     }
 
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-container-onerror-attribute
+    // https://w3c.github.io/ServiceWorker/#service-worker-container-onerror-attribute
     event_handler!(error, GetOnerror, SetOnerror);
 
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#ref-for-service-worker-onstatechange-attribute-1
+    // https://w3c.github.io/ServiceWorker/#ref-for-service-worker-onstatechange-attribute-1
     event_handler!(statechange, GetOnstatechange, SetOnstatechange);
 }
 

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -48,12 +48,12 @@ impl Controllable for ServiceWorkerContainer {
 }
 
 impl ServiceWorkerContainerMethods for ServiceWorkerContainer {
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-container-controller-attribute
+    // https://w3c.github.io/ServiceWorker/#service-worker-container-controller-attribute
     fn GetController(&self) -> Option<Root<ServiceWorker>> {
         return self.controller.get()
     }
 
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-container-register-method
+    // https://w3c.github.io/ServiceWorker/#service-worker-container-register-method
     fn Register(&self,
                 script_url: USVString,
                 options: &RegistrationOptions) -> Fallible<Root<ServiceWorkerRegistration>> {

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -334,6 +334,6 @@ unsafe extern "C" fn interrupt_callback(cx: *mut JSContext) -> bool {
 }
 
 impl ServiceWorkerGlobalScopeMethods for ServiceWorkerGlobalScope {
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-onmessage-attribute
+    // https://w3c.github.io/ServiceWorker/#service-worker-global-scope-onmessage-attribute
     event_handler!(message, GetOnmessage, SetOnmessage);
 }

--- a/components/script/dom/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworkerregistration.rs
@@ -83,22 +83,22 @@ pub fn longest_prefix_match(stored_scope: &Url, potential_match: &Url) -> bool {
 }
 
 impl ServiceWorkerRegistrationMethods for ServiceWorkerRegistration {
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-registration-installing-attribute
+    // https://w3c.github.io/ServiceWorker/#service-worker-registration-installing-attribute
     fn GetInstalling(&self) -> Option<Root<ServiceWorker>> {
         self.installing.as_ref().map(|sw| Root::from_ref(&**sw))
     }
 
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-registration-active-attribute
+    // https://w3c.github.io/ServiceWorker/#service-worker-registration-active-attribute
     fn GetActive(&self) -> Option<Root<ServiceWorker>> {
         self.active.as_ref().map(|sw| Root::from_ref(&**sw))
     }
 
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-registration-waiting-attribute
+    // https://w3c.github.io/ServiceWorker/#service-worker-registration-waiting-attribute
     fn GetWaiting(&self) -> Option<Root<ServiceWorker>> {
         self.waiting.as_ref().map(|sw| Root::from_ref(&**sw))
     }
 
-    // https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-registration-scope-attribute
+    // https://w3c.github.io/ServiceWorker/#service-worker-registration-scope-attribute
     fn Scope(&self) -> USVString {
         USVString(self.scope.clone())
     }

--- a/components/script/dom/webidls/Client.webidl
+++ b/components/script/dom/webidls/Client.webidl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#client
+// https://w3c.github.io/ServiceWorker/#client
 
 [Pref="dom.serviceworker.enabled", Exposed=(Window,Worker)]
 interface Client {

--- a/components/script/dom/webidls/Navigator.webidl
+++ b/components/script/dom/webidls/Navigator.webidl
@@ -33,7 +33,7 @@ interface NavigatorBluetooth {
     readonly attribute Bluetooth bluetooth;
 };
 
-// https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker
+// https://w3c.github.io/ServiceWorker/#navigator-service-worker
 partial interface Navigator {
   [SameObject, Pref="dom.serviceworker.enabled"] readonly attribute ServiceWorkerContainer serviceWorker;
 };

--- a/components/script/dom/webidls/ServiceWorker.webidl
+++ b/components/script/dom/webidls/ServiceWorker.webidl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// http://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-obj
+// http://w3c.github.io/ServiceWorker/#service-worker-obj
 [Pref="dom.serviceworker.enabled", Exposed=(Window,Worker)]
 interface ServiceWorker : EventTarget {
   readonly attribute USVString scriptURL;

--- a/components/script/dom/webidls/ServiceWorkerContainer.webidl
+++ b/components/script/dom/webidls/ServiceWorkerContainer.webidl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-container
+// https://w3c.github.io/ServiceWorker/#service-worker-container
 [Pref="dom.serviceworker.enabled", Exposed=(Window,Worker)]
 interface ServiceWorkerContainer : EventTarget {
   [Unforgeable] readonly attribute ServiceWorker? controller;

--- a/components/script/dom/webidls/ServiceWorkerGlobalScope.webidl
+++ b/components/script/dom/webidls/ServiceWorkerGlobalScope.webidl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope
+// https://w3c.github.io/ServiceWorker/#service-worker-global-scope
 
 [Global=(Worker,ServiceWorker), Exposed=ServiceWorker,
  Pref="dom.serviceworker.enabled"]

--- a/components/script/dom/webidls/ServiceWorkerRegistration.webidl
+++ b/components/script/dom/webidls/ServiceWorkerRegistration.webidl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-registration-obj
+// https://w3c.github.io/ServiceWorker/#service-worker-registration-obj
 [Pref="dom.serviceworker.enabled", Exposed=(Window,Worker)]
 interface ServiceWorkerRegistration : EventTarget {
   [Unforgeable] readonly attribute ServiceWorker? installing;

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -69,7 +69,6 @@ WEBIDL_STANDARDS = [
     "//w3c.github.io",
     "//heycam.github.io/webidl",
     "//webbluetoothcg.github.io/web-bluetooth/",
-    "//slightlyoff.github.io/ServiceWorker/spec/service_worker/",
     # Not a URL
     "// This interface is entirely internal to Servo, and should not be" +
     " accessible to\n// web pages."

--- a/tests/wpt/css-tests/resources/docs/api.md
+++ b/tests/wpt/css-tests/resources/docs/api.md
@@ -272,7 +272,7 @@ is called, the two conditions above apply like normal.
 Dedicated and shared workers don't have an event that corresponds to the `load`
 event in a document. Therefore these worker tests always behave as if the
 `explicit_done` property is set to true. Service workers depend on the
-[install](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-install-event)
+[install](https://w3c.github.io/ServiceWorker/index.html#service-worker-global-scope-install-event)
 event which is fired following the completion of [running the
 worker](https://html.spec.whatwg.org/multipage/workers.html#run-a-worker).
 
@@ -374,7 +374,7 @@ object. These objects are structures as follows:
 
 The `testharness.js` script can be used from within [dedicated workers, shared
 workers](https://html.spec.whatwg.org/multipage/workers.html) and [service
-workers](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/).
+workers](https://w3c.github.io/ServiceWorker/).
 
 Testing from a worker script is different from testing from an HTML document in
 several ways:
@@ -401,7 +401,7 @@ several ways:
   complete](#determining-when-all-tests-are-complete)). So these worker tests
   behave as if they were started with the `explicit_done` option. Service
   workers depend on the
-  [oninstall](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-install-event)
+  [oninstall](https://w3c.github.io/ServiceWorker/index.html#service-worker-global-scope-install-event)
   event and don't require an explicit `done` call.
 
 Here's an example that uses a dedicated worker.
@@ -434,7 +434,7 @@ Here's an example that uses a dedicated worker.
 The argument to the `fetch_tests_from_worker` function can be a
 [`Worker`](https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface),
 a [`SharedWorker`](https://html.spec.whatwg.org/multipage/workers.html#shared-workers-and-the-sharedworker-interface)
-or a [`ServiceWorker`](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-obj).
+or a [`ServiceWorker`](https://w3c.github.io/ServiceWorker/#service-worker-obj).
 Once called, the containing document fetches all the tests from the worker and
 behaves as if those tests were running in the containing document itself.
 

--- a/tests/wpt/css-tests/resources/webidl2/test/syntax/idl/generic.widl
+++ b/tests/wpt/css-tests/resources/webidl2/test/syntax/idl/generic.widl
@@ -2,14 +2,14 @@ interface Foo {
   Promise<ResponsePromise<sequence<DOMString?>>> bar();
 };
 
-// Extracted from https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ on 2014-05-08
+// Extracted from https://w3c.github.io/ServiceWorker/ on 2014-05-08
 
 interface ServiceWorkerClients {
   Promise<Client[]?> getServiced();
   Promise<any> reloadAll();
 };
 
-// Extracted from https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ on 2014-05-13
+// Extracted from https://w3c.github.io/ServiceWorker/ on 2014-05-13
 
 interface FetchEvent : Event {
   ResponsePromise<any> default();

--- a/tests/wpt/css-tests/resources/webidl2/test/syntax/idl/map.widl
+++ b/tests/wpt/css-tests/resources/webidl2/test/syntax/idl/map.widl
@@ -1,4 +1,4 @@
-// Extracted from https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ on 2014-05-06
+// Extracted from https://w3c.github.io/ServiceWorker/ on 2014-05-06
 
 [MapClass(DOMString, DOMString)]
 interface HeaderMap {

--- a/tests/wpt/web-platform-tests/resources/docs/api.md
+++ b/tests/wpt/web-platform-tests/resources/docs/api.md
@@ -418,7 +418,7 @@ is called, the two conditions above apply like normal.
 Dedicated and shared workers don't have an event that corresponds to the `load`
 event in a document. Therefore these worker tests always behave as if the
 `explicit_done` property is set to true. Service workers depend on the
-[install](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-install-event)
+[install](https://w3c.github.io/ServiceWorker/index.html#service-worker-global-scope-install-event)
 event which is fired following the completion of [running the
 worker](https://html.spec.whatwg.org/multipage/workers.html#run-a-worker).
 
@@ -526,7 +526,7 @@ object. These objects are structures as follows:
 
 The `testharness.js` script can be used from within [dedicated workers, shared
 workers](https://html.spec.whatwg.org/multipage/workers.html) and [service
-workers](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/).
+workers](https://w3c.github.io/ServiceWorker/).
 
 Testing from a worker script is different from testing from an HTML document in
 several ways:
@@ -553,7 +553,7 @@ several ways:
   complete](#determining-when-all-tests-are-complete)). So these worker tests
   behave as if they were started with the `explicit_done` option. Service
   workers depend on the
-  [oninstall](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-install-event)
+  [oninstall](https://w3c.github.io/ServiceWorker/index.html#service-worker-global-scope-install-event)
   event and don't require an explicit `done` call.
 
 Here's an example that uses a dedicated worker.
@@ -590,7 +590,7 @@ fetch_tests_from_worker(new Worker("worker.js"));
 The argument to the `fetch_tests_from_worker` function can be a
 [`Worker`](https://html.spec.whatwg.org/multipage/workers.html#dedicated-workers-and-the-worker-interface),
 a [`SharedWorker`](https://html.spec.whatwg.org/multipage/workers.html#shared-workers-and-the-sharedworker-interface)
-or a [`ServiceWorker`](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-obj).
+or a [`ServiceWorker`](https://w3c.github.io/ServiceWorker/#service-worker-obj).
 Once called, the containing document fetches all the tests from the worker and
 behaves as if those tests were running in the containing document itself.
 

--- a/tests/wpt/web-platform-tests/resources/webidl2/test/syntax/idl/generic.widl
+++ b/tests/wpt/web-platform-tests/resources/webidl2/test/syntax/idl/generic.widl
@@ -3,14 +3,14 @@ interface Foo {
   readonly attribute Promise<DOMString>[] baz;
 };
 
-// Extracted from https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ on 2014-05-08
+// Extracted from https://w3c.github.io/ServiceWorker/ on 2014-05-08
 
 interface ServiceWorkerClients {
   Promise<Client[]?> getServiced();
   Promise<any> reloadAll();
 };
 
-// Extracted from https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ on 2014-05-13
+// Extracted from https://w3c.github.io/ServiceWorker/ on 2014-05-13
 
 interface FetchEvent : Event {
   ResponsePromise<any> default();

--- a/tests/wpt/web-platform-tests/resources/webidl2/test/syntax/idl/map.widl
+++ b/tests/wpt/web-platform-tests/resources/webidl2/test/syntax/idl/map.widl
@@ -1,4 +1,4 @@
-// Extracted from https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ on 2014-05-06
+// Extracted from https://w3c.github.io/ServiceWorker/ on 2014-05-06
 
 [MapClass(DOMString, DOMString)]
 interface HeaderMap {

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/common.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/common.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache Storage: Verify that Window and Workers see same storage</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-add.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-add.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache.add and Cache.addAll</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-add">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-add">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-delete.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-delete.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache.delete</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-delete">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-delete">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-match.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-match.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache.match</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-match">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-match">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-matchAll.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-matchAll.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache.matchAll</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-matchall">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-matchall">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-put.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-put.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache.put</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-put">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-put">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-storage-keys.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-storage-keys.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>CacheStorage.keys</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-storage-match.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-storage-match.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>CacheStorage.match</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage-match">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage-match">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-storage.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/cache-storage.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>CacheStorage</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/credentials.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/serviceworker/credentials.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <title>Cache Storage: Verify credentials are respected by Cache operations</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../service-worker/resources/test-helpers.sub.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-add.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-add.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache Storage: Cache.add and Cache.addAll</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-add">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-add">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-delete.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-delete.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache Storage: Cache.delete</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-delete">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-delete">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-match.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-match.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache Storage: Cache.match</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-match">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-match">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-matchAll.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-matchAll.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache.matchAll</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-matchall">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-matchall">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-put.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-put.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache Storage: Cache.put</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-put">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-put">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-storage-keys.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-storage-keys.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache Storage: CacheStorage.keys</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-storage-match.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-storage-match.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache Storage: CacheStorage.match</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage-match">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage-match">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-storage.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/window/cache-storage.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache Storage: CacheStorage</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/window/sandboxed-iframes.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/window/sandboxed-iframes.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache Storage: Verify access in sandboxed iframes</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-add.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-add.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache.add and Cache.addAll</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-add">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-add">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-delete.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-delete.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache.delete</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-delete">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-delete">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-match.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-match.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache.match</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-match">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-match">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-matchAll.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-matchAll.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache.matchAll</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-matchall">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-matchall">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-put.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-put.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Cache.put</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-put">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-put">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-storage-keys.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-storage-keys.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>CacheStorage.keys</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-storage-match.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-storage-match.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>CacheStorage.match</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage-match">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage-match">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-storage.https.html
+++ b/tests/wpt/web-platform-tests/service-workers/cache-storage/worker/cache-storage.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>CacheStorage</title>
-<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/tests/wpt/web-platform-tests/service-workers/specgen.json
+++ b/tests/wpt/web-platform-tests/service-workers/specgen.json
@@ -654,5 +654,5 @@
             "testable": false
         }
     ],
-    "specUrl": "https://slightlyoff.github.io/ServiceWorker/spec/service_worker/"
+    "specUrl": "https://w3c.github.io/ServiceWorker/"
 }

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.1-service-worker-obj.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.1-service-worker-obj.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: ServiceWorker</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-obj">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-obj">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.1.1-service-worker-scope.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.1.1-service-worker-scope.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: scope</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-scope">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-scope">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.1.2-service-worker-url.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.1.2-service-worker-url.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: url</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-url">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-url">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.1.3-service-worker-state.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.1.3-service-worker-state.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: state</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-state">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-state">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.1.4-service-worker-on-state-change.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.1.4-service-worker-on-state-change.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: onstatechange</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-on-state-change">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-on-state-change">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2-navigator-service-worker.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2-navigator-service-worker.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: navigator.serviceWorker</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.1-navigator-service-worker-installing.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.1-navigator-service-worker-installing.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: installing</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-installing">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-installing">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.10-navigator-service-worker-oncontrollerchange.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.10-navigator-service-worker-oncontrollerchange.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: oncontrollerchange</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-oncontrollerchange">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-oncontrollerchange">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.11-navigator-service-worker-onreloadpage.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.11-navigator-service-worker-onreloadpage.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: onreloadpage</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-onreloadpage">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-onreloadpage">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.12-navigator-service-worker-onerror.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.12-navigator-service-worker-onerror.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: onerror</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-onerror">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-onerror">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.2-navigator-service-worker-waiting.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.2-navigator-service-worker-waiting.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: waiting</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-waiting">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-waiting">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.3-navigator-service-worker-active.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.3-navigator-service-worker-active.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: active</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-active">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-active">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.4-navigator-service-worker-controller.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.4-navigator-service-worker-controller.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: controller</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-controller">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-controller">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.5-navigator-service-worker-ready.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.5-navigator-service-worker-ready.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: ready</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-ready">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-ready">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.6-navigator-service-worker-getAll.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.6-navigator-service-worker-getAll.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: getAll()</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-getAll">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-getAll">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.7-navigator-service-worker-register.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.7-navigator-service-worker-register.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: register()</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-register">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-register">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.8-navigator-service-worker-unregister.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.8-navigator-service-worker-unregister.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: unregister()</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-unregister">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-unregister">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-3.2.9-navigator-service-worker-onupdatefound.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-3.2.9-navigator-service-worker-onupdatefound.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: onupdatefound</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#navigator-service-worker-onupdatefound">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#navigator-service-worker-onupdatefound">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.1-service-worker-global-scope.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.1-service-worker-global-scope.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: ServiceWorkerGlobalScope</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.1.1-service-worker-global-scope-caches.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.1.1-service-worker-global-scope-caches.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: caches</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-caches">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-caches">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.1.2-service-worker-global-scope-clients.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.1.2-service-worker-global-scope-clients.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: clients</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-clients">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-clients">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.1.3-service-worker-global-scope-scope.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.1.3-service-worker-global-scope-scope.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: scope</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-scope">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-scope">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.1.4-service-worker-global-scope-fetch.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.1.4-service-worker-global-scope-fetch.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: fetch(request)</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-fetch">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-fetch">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.1.5-service-worker-global-scope-update.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.1.5-service-worker-global-scope-update.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: update()</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-update">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-update">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.1.6-service-worker-global-scope-unregister.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.1.6-service-worker-global-scope-unregister.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: unregister()</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-unregister">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-unregister">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.1.7-service-worker-global-scope-onmessage.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.1.7-service-worker-global-scope-onmessage.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: onmessage</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-onmessage">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-onmessage">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.2-client.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.2-client.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: Client</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#client">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#client">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.3-service-worker-clients.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.3-service-worker-clients.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: ServiceWorkerClients</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-clients">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#service-worker-clients">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.3.1-get-serviced-method.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.3.1-get-serviced-method.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: getServiced()</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#get-serviced-method">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#get-serviced-method">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.3.2-reloadall-method.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.3.2-reloadall-method.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: reloadAll()</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#reloadall-method">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#reloadall-method">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.4-request-objects.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.4-request-objects.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: Request Objects</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#request-objects">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#request-objects">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.5-response-objects.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.5-response-objects.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: Response Objects</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#response-objects">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#response-objects">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.5.2-response.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.5.2-response.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: Response</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#response">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#response">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.5.4-opaque-response.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.5.4-opaque-response.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: OpaqueResponse</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#opaque-response">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#opaque-response">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.6-cache-objects.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.6-cache-objects.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: Caches</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-objects">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-objects">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.6.1-cache-lifetimes.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.6.1-cache-lifetimes.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: Understanding Cache Lifetimes</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-lifetimes">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-lifetimes">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.6.2-cache.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.6.2-cache.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: Cache</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#cache">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.6.3-cache-storage.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.6.3-cache-storage.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: CacheStorage</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#cache-storage">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.7.1-install-phase-event.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.7.1-install-phase-event.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: InstallPhaseEvent</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#install-phase-event">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#install-phase-event">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.7.1.1-wait-until-method.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.7.1.1-wait-until-method.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: event.waitUntil(f)</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#wait-until-method">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#wait-until-method">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.7.2-install-event.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.7.2-install-event.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: install Event</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#install-event">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#install-event">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.7.2.1-install-event-section.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.7.2.1-install-event-section.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: InstallEvent</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#install-event-section">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#install-event-section">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.7.2.2-replace-method.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.7.2.2-replace-method.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: event.replace()</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#replace-method">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#replace-method">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.7.3-activate-event.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.7.3-activate-event.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: activate Event</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#activate-event">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#activate-event">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.7.4.1-fetch-event-section.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.7.4.1-fetch-event-section.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: FetchEvent</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#fetch-event-section">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#fetch-event-section">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.7.4.2-respond-with-method.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.7.4.2-respond-with-method.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: event.respondWith(r)</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#respond-with-method">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#respond-with-method">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.7.4.3-default-method.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.7.4.3-default-method.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: event.default()</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#default-method">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#default-method">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-4.7.4.4-is-reload-attribute.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-4.7.4.4-is-reload-attribute.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: event.isReload</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#is-reload-attribute">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#is-reload-attribute">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-5.1-origin-relativity.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-5.1-origin-relativity.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: Origin Relativity</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#origin-relativity">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#origin-relativity">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 

--- a/tests/wpt/web-platform-tests/service-workers/stub-5.2-cross-origin-resources.html
+++ b/tests/wpt/web-platform-tests/service-workers/stub-5.2-cross-origin-resources.html
@@ -2,7 +2,7 @@
 <html>
 <title>Service Workers: Cross-Origin Resources &amp; CORS</title>
     <head>
-        <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cross-origin-resources">
+        <link rel="help" href="https://w3c.github.io/ServiceWorker/#cross-origin-resources">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The old specification URL is
https://slightlyoff.github.io/ServiceWorker/spec/service_worker/, which has
been replaced by the new one at https://w3c.github.io/ServiceWorker/.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13408 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because all the changes are in commented parts of the code.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

The old specification URL is
https://slightlyoff.github.io/ServiceWorker/spec/service_worker/ has
been replaced by the new one at https://w3c.github.io/ServiceWorker/.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13416)

<!-- Reviewable:end -->
