### PR TITLE
Make Assign throw error on invalid url

### DIFF
--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -4,6 +4,7 @@
 
 use dom::bindings::codegen::Bindings::LocationBinding;
 use dom::bindings::codegen::Bindings::LocationBinding::LocationMethods;
+use dom::bindings::error::{Error, ErrorResult};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::js::{JS, Root};
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
@@ -46,12 +47,15 @@ impl Location {
 
 impl LocationMethods for Location {
     // https://html.spec.whatwg.org/multipage/#dom-location-assign
-    fn Assign(&self, url: USVString) {
+    fn Assign(&self, url: USVString) -> ErrorResult {
         // TODO: per spec, we should use the _API base URL_ specified by the
         //       _entry settings object_.
         let base_url = self.window.get_url();
         if let Ok(url) = base_url.join(&url.0) {
             self.window.load_url(url, false, None);
+            Ok(())
+        } else {
+            Err(Error::Syntax)
         }
     }
 

--- a/components/script/dom/webidls/Location.webidl
+++ b/components/script/dom/webidls/Location.webidl
@@ -14,6 +14,7 @@
            attribute USVString search;
            attribute USVString hash;
 
+  [Throws]
   void assign(USVString url);
   //void replace(USVString url);
   void reload();

--- a/tests/wpt/metadata/html/browsers/history/the-location-interface/location_assign.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-location-interface/location_assign.html.ini
@@ -2,7 +2,3 @@
   type: testharness
   [location assign]
     expected: FAIL
-
-  [URL that fails to parse]
-    expected: FAIL
-


### PR DESCRIPTION
Step 2 of: https://html.spec.whatwg.org/multipage/browsers.html#dom-location-assign says we should throw an error. This makes it do that.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13420  (github issue number if applicable).
- [x] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13422)

<!-- Reviewable:end -->
