### PR TITLE
Avoid huge numbers of warnings for atom_macro.

### DIFF
--- a/components/style/gecko_string_cache/mod.rs
+++ b/components/style/gecko_string_cache/mod.rs
@@ -22,7 +22,7 @@ use std::ops::Deref;
 use std::slice;
 
 #[macro_use]
-#[allow(improper_ctypes)]
+#[allow(improper_ctypes, safe_extern_statics)]
 pub mod atom_macro;
 #[macro_use]
 pub mod namespace;


### PR DESCRIPTION
This avoids the perma-Travis failure from exceeding the log size due to the number of warnings from this module. I am filing a separate PR to fix the code generation to avoid the warning.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13433)

<!-- Reviewable:end -->
