### PR TITLE
Style anonymous tables with user agent CSS

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -360,7 +360,8 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
         let style_context = self.style_context();
         if child.is_table_cell() {
             let mut style = child_node.style(style_context);
-            properties::modify_style_for_anonymous_table_object(&mut style, display::T::table_row);
+            style = self.style_context().stylist.
+                precomputed_values_for_pseudo(&PseudoElement::ServoAnonymousTableRow, Some(&style)).unwrap();
             let fragment = Fragment::from_opaque_node_and_style(child_node.opaque(),
                                                                 PseudoElementType::Normal,
                                                                 style,
@@ -374,7 +375,8 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
         }
         if child.is_table_row() || child.is_table_rowgroup() {
             let mut style = child_node.style(style_context);
-            properties::modify_style_for_anonymous_table_object(&mut style, display::T::table);
+            style = self.style_context().stylist.
+                precomputed_values_for_pseudo(&PseudoElement::ServoAnonymousTable, Some(&style)).unwrap();
             let fragment = Fragment::from_opaque_node_and_style(child_node.opaque(),
                                                                 PseudoElementType::Normal,
                                                                 style,
@@ -388,7 +390,8 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
         }
         if child.is_table() {
             let mut style = child_node.style(style_context);
-            properties::modify_style_for_anonymous_table_object(&mut style, display::T::table);
+            style = self.style_context().stylist.
+                precomputed_values_for_pseudo(&PseudoElement::ServoAnonymousTable, Some(&style)).unwrap();
             let fragment =
                 Fragment::from_opaque_node_and_style(child_node.opaque(),
                                                      PseudoElementType::Normal,

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -55,6 +55,7 @@ use style::context::SharedStyleContext;
 use style::dom::TRestyleDamage;
 use style::logical_geometry::{LogicalRect, LogicalSize, WritingMode};
 use style::properties::{self, ServoComputedValues};
+use style::servo_selector_impl::PseudoElement;
 use style::values::computed::LengthOrPercentageOrAuto;
 use table::{ColumnComputedInlineSize, ColumnIntrinsicInlineSize, TableFlow};
 use table_caption::TableCaptionFlow;
@@ -1256,9 +1257,8 @@ impl<'a> ImmutableFlowUtils for &'a Flow {
         let mut style = node.style(style_context);
         match self.class() {
             FlowClass::Table | FlowClass::TableRowGroup => {
-                properties::modify_style_for_anonymous_table_object(
-                    &mut style,
-                    display::T::table_row);
+                style = style_context.stylist
+                    .precomputed_values_for_pseudo(&PseudoElement::ServoAnonymousTableRow, Some(&style)).unwrap();
                 let fragment = Fragment::from_opaque_node_and_style(
                     node.opaque(),
                     PseudoElementType::Normal,
@@ -1269,9 +1269,8 @@ impl<'a> ImmutableFlowUtils for &'a Flow {
                 Arc::new(TableRowFlow::from_fragment(fragment))
             },
             FlowClass::TableRow => {
-                properties::modify_style_for_anonymous_table_object(
-                    &mut style,
-                    display::T::table_cell);
+                style = style_context.stylist
+                    .precomputed_values_for_pseudo(&PseudoElement::ServoAnonymousTableCell, Some(&style)).unwrap();
                 let fragment = Fragment::from_opaque_node_and_style(
                     node.opaque(),
                     PseudoElementType::Normal,

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1905,18 +1905,6 @@ pub fn modify_border_style_for_inline_sides(style: &mut Arc<ComputedValues>,
     }
 }
 
-/// Adjusts the display and position properties as appropriate for an anonymous table object.
-#[cfg(feature = "servo")]
-#[inline]
-pub fn modify_style_for_anonymous_table_object(
-        style: &mut Arc<ComputedValues>,
-        new_display_value: longhands::display::computed_value::T) {
-    let mut style = Arc::make_mut(style);
-    let box_style = Arc::make_mut(&mut style.box_);
-    box_style.display = new_display_value;
-    box_style.position = longhands::position::computed_value::T::static_;
-}
-
 /// Adjusts the `position` property as necessary for the outer fragment wrapper of an inline-block.
 #[cfg(feature = "servo")]
 #[inline]

--- a/components/style/servo_selector_impl.rs
+++ b/components/style/servo_selector_impl.rs
@@ -21,6 +21,9 @@ pub enum PseudoElement {
     Selection,
     DetailsSummary,
     DetailsContent,
+    ServoAnonymousTable,
+    ServoAnonymousTableCell,
+    ServoAnonymousTableRow,
     ServoInputText,
 }
 
@@ -33,6 +36,9 @@ impl ToCss for PseudoElement {
             Selection => "::selection",
             DetailsSummary => "::-servo-details-summary",
             DetailsContent => "::-servo-details-content",
+            ServoAnonymousTable => "::-servo-anonymous-table",
+            ServoAnonymousTableCell => "::-servo-anonymous-table-cell",
+            ServoAnonymousTableRow => "::-servo-anonymous-table-row",
             ServoInputText => "::-servo-input-text",
         })
     }
@@ -57,6 +63,9 @@ impl PseudoElement {
             PseudoElement::Selection => PseudoElementCascadeType::Eager,
             PseudoElement::DetailsSummary => PseudoElementCascadeType::Lazy,
             PseudoElement::DetailsContent |
+            PseudoElement::ServoAnonymousTable |
+            PseudoElement::ServoAnonymousTableCell |
+            PseudoElement::ServoAnonymousTableRow |
             PseudoElement::ServoInputText => PseudoElementCascadeType::Precomputed,
         }
     }
@@ -204,6 +213,24 @@ impl SelectorImpl for ServoSelectorImpl {
                 }
                 DetailsContent
             },
+            "-servo-anonymous-table" => {
+                if !context.in_user_agent_stylesheet {
+                    return Err(())
+                }
+                ServoAnonymousTable
+            },
+            "-servo-anonymous-table-cell" => {
+                if !context.in_user_agent_stylesheet {
+                    return Err(())
+                }
+                ServoAnonymousTableCell
+            },
+            "-servo-anonymous-table-row" => {
+                if !context.in_user_agent_stylesheet {
+                    return Err(())
+                }
+                ServoAnonymousTableRow
+            },
             "-servo-input-text" => {
                 if !context.in_user_agent_stylesheet {
                     return Err(())
@@ -231,6 +258,9 @@ impl ServoSelectorImpl {
         fun(PseudoElement::DetailsContent);
         fun(PseudoElement::DetailsSummary);
         fun(PseudoElement::Selection);
+        fun(PseudoElement::ServoAnonymousTable);
+        fun(PseudoElement::ServoAnonymousTableCell);
+        fun(PseudoElement::ServoAnonymousTableRow);
         fun(PseudoElement::ServoInputText);
     }
 

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -171,3 +171,18 @@ svg > * {
 *|*::-servo-input-text {
     margin: 0;
 }
+
+*|*::-servo-anonymous-table {
+    display: table;
+    position: static;
+}
+
+*|*::-servo-anonymous-table-cell {
+    display: table-cell;
+    position: static;
+}
+
+*|*::-servo-anonymous-table-row {
+    display: table-row;
+    position: static;
+}


### PR DESCRIPTION
Styles the anonymous table and table-row pseudo-elements with user-agent CSS rather than hard-coded styles, as part of #8570

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because they are a refactoring of existing code

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13434)

<!-- Reviewable:end -->
