### PR TITLE
resources: Give button elements `white-space: normal` again.

### DIFF
--- a/resources/servo.css
+++ b/resources/servo.css
@@ -9,7 +9,6 @@ input {
   color: black;
   font-family: sans-serif;
   font-size: 0.8333em;
-  white-space: pre;
   text-align: left;
   line-height: 1.8;
 }
@@ -130,6 +129,10 @@ textarea {
   cursor: text;
   overflow: hidden;
   -servo-overflow-clip-box: content-box;
+}
+
+input:not([type=radio i]):not([type=checkbox i]):not([type=reset i]):not([type=button i]):not([type=submit i]) {
+  white-space: pre;
 }
 
 textarea {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1220,6 +1220,18 @@
             "url": "/_mozilla/css/button_css_width.html"
           }
         ],
+        "css/button_whitespace_a.html": [
+          {
+            "path": "css/button_whitespace_a.html",
+            "references": [
+              [
+                "/_mozilla/css/button_whitespace_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/button_whitespace_a.html"
+          }
+        ],
         "css/calc-basic.html": [
           {
             "path": "css/calc-basic.html",
@@ -14844,6 +14856,18 @@
             ]
           ],
           "url": "/_mozilla/css/button_css_width.html"
+        }
+      ],
+      "css/button_whitespace_a.html": [
+        {
+          "path": "css/button_whitespace_a.html",
+          "references": [
+            [
+              "/_mozilla/css/button_whitespace_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/button_whitespace_a.html"
         }
       ],
       "css/calc-basic.html": [

--- a/tests/wpt/mozilla/tests/css/button_whitespace_a.html
+++ b/tests/wpt/mozilla/tests/css/button_whitespace_a.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title></title>
+<link rel="match" href="button_whitespace_ref.html">
+<button>A
+
+B</button>

--- a/tests/wpt/mozilla/tests/css/button_whitespace_ref.html
+++ b/tests/wpt/mozilla/tests/css/button_whitespace_ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title></title>
+<button>A B</button>
+


### PR DESCRIPTION
Fixes Twitter.

Originally regressed in 0a86543e6decf02860a5a98c46e01940e79af6fa.

r? @metajack

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13445)

<!-- Reviewable:end -->
