### PR TITLE
Remove same-origin-data-url flag from fetch implementation

### DIFF
--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -120,7 +120,6 @@ pub struct RequestInit {
             serialize_with = "::hyper_serde::serialize")]
     pub headers: Headers,
     pub unsafe_request: bool,
-    pub same_origin_data: bool,
     pub body: Option<Vec<u8>>,
     // TODO: client object
     pub type_: Type,
@@ -146,7 +145,6 @@ impl Default for RequestInit {
             url: Url::parse("about:blank").unwrap(),
             headers: Headers::new(),
             unsafe_request: false,
-            same_origin_data: false,
             body: None,
             type_: Type::None,
             destination: Destination::None,
@@ -188,7 +186,6 @@ pub struct Request {
     // TODO: priority object
     pub origin: RefCell<Origin>,
     pub omit_origin_header: Cell<bool>,
-    pub same_origin_data: Cell<bool>,
     /// https://fetch.spec.whatwg.org/#concept-request-referrer
     pub referrer: RefCell<Referrer>,
     pub referrer_policy: Cell<Option<ReferrerPolicy>>,
@@ -230,7 +227,6 @@ impl Request {
             destination: Destination::None,
             origin: RefCell::new(origin.unwrap_or(Origin::Client)),
             omit_origin_header: Cell::new(false),
-            same_origin_data: Cell::new(false),
             referrer: RefCell::new(Referrer::Client),
             referrer_policy: Cell::new(None),
             pipeline_id: Cell::new(pipeline_id),
@@ -256,7 +252,6 @@ impl Request {
         *req.method.borrow_mut() = init.method;
         *req.headers.borrow_mut() = init.headers;
         req.unsafe_request = init.unsafe_request;
-        req.same_origin_data.set(init.same_origin_data);
         *req.body.borrow_mut() = init.body;
         req.type_ = init.type_;
         req.destination = init.destination;

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -244,8 +244,6 @@ fn fetch_a_classic_script(script: &HTMLScriptElement,
         },
         origin: doc.url().clone(),
         pipeline_id: Some(script.global().r().pipeline_id()),
-        // FIXME: Set to true for now, discussion in https://github.com/whatwg/fetch/issues/381
-        same_origin_data: true,
         referrer_url: Some(doc.url().clone()),
         referrer_policy: doc.get_referrer_policy(),
         .. RequestInit::default()

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -159,7 +159,6 @@ impl Request {
         // TODO: `entry settings object` is not implemented in Servo yet.
         *request.origin.borrow_mut() = Origin::Client;
         request.omit_origin_header = temporary_request.omit_origin_header;
-        request.same_origin_data.set(true);
         request.referrer = temporary_request.referrer;
         request.referrer_policy = temporary_request.referrer_policy;
         request.mode = temporary_request.mode;

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -587,7 +587,6 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
             url: self.request_url.borrow().clone().unwrap(),
             headers: (*self.request_headers.borrow()).clone(),
             unsafe_request: true,
-            same_origin_data: true,
             // XXXManishearth figure out how to avoid this clone
             body: extracted.as_ref().map(|e| e.0.clone()),
             // XXXManishearth actually "subresource", but it doesn't exist

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -44,7 +44,6 @@ fn request_init_from_request(request: NetTraitsRequest) -> NetTraitsRequestInit 
         url: request.url(),
         headers: request.headers.borrow().clone(),
         unsafe_request: request.unsafe_request,
-        same_origin_data: request.same_origin_data.get(),
         body: request.body.borrow().clone(),
         type_: request.type_,
         destination: request.destination,

--- a/tests/unit/net/fetch.rs
+++ b/tests/unit/net/fetch.rs
@@ -144,7 +144,6 @@ fn test_fetch_data() {
     let url = Url::parse("data:text/html,<p>Servo</p>").unwrap();
     let origin = Origin::Origin(url.origin());
     let request = Request::new(url, Some(origin), false, None);
-    request.same_origin_data.set(true);
     let expected_resp_body = "<p>Servo</p>".to_owned();
     let fetch_response = fetch_sync(request, None);
 
@@ -173,7 +172,6 @@ fn test_fetch_file() {
     let url = Url::from_file_path(path.clone()).unwrap();
     let origin = Origin::Origin(url.origin());
     let request = Request::new(url, Some(origin), false, None);
-    request.same_origin_data.set(true);
 
     let fetch_response = fetch_sync(request, None);
     assert!(!fetch_response.is_network_error());


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The spec removed it. Check the scheme instead, data is always same origin now,
except for workers.
Closes #13362

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13362 .

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they only remove code.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13467)

<!-- Reviewable:end -->
