### PR TITLE
Disable EventSource until it is fully implemented.

### DIFF
--- a/components/script/dom/webidls/EventSource.webidl
+++ b/components/script/dom/webidls/EventSource.webidl
@@ -7,7 +7,8 @@
  */
 
 [Constructor(DOMString url, optional EventSourceInit eventSourceInitDict),
- Exposed=(Window,Worker)]
+ Exposed=(Window,Worker),
+ Pref="dom.eventsource.enabled"]
 interface EventSource : EventTarget {
   readonly attribute DOMString url;
   readonly attribute boolean withCredentials;

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-close.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-close.htm.ini
@@ -1,6 +1,5 @@
 [eventsource-close.htm]
   type: testharness
-  expected: TIMEOUT
   [dedicated worker - EventSource: close()]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-constructor-non-same-origin.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-constructor-non-same-origin.htm.ini
@@ -1,20 +1,20 @@
 [eventsource-constructor-non-same-origin.htm]
   type: testharness
   [dedicated worker - EventSource: constructor (act as if there is a network error) (http://example.not/)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [dedicated worker - EventSource: constructor (act as if there is a network error) (https://example.not/test)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [dedicated worker - EventSource: constructor (act as if there is a network error) (ftp://example.not/)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [dedicated worker - EventSource: constructor (act as if there is a network error) (about:blank)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [dedicated worker - EventSource: constructor (act as if there is a network error) (mailto:whatwg@awesome.example)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [dedicated worker - EventSource: constructor (act as if there is a network error) (javascript:alert('FAIL'))]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-constructor-url-bogus.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-constructor-url-bogus.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-constructor-url-bogus.htm]
+  type: testharness
+  [dedicated worker - EventSource: constructor (invalid URL)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-eventtarget.worker.js.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-eventtarget.worker.js.ini
@@ -1,7 +1,6 @@
 [eventsource-eventtarget.worker]
   type: testharness
-  expected: TIMEOUT
   bug: https://github.com/servo/servo/issues/8925
   [dedicated worker - EventSource: addEventListener()]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-onmesage.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-onmesage.htm.ini
@@ -1,6 +1,5 @@
 [eventsource-onmesage.htm]
   type: testharness
-  expected: TIMEOUT
   [dedicated worker - EventSource: onmessage]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-onopen.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-onopen.htm.ini
@@ -1,6 +1,5 @@
 [eventsource-onopen.htm]
   type: testharness
-  expected: TIMEOUT
   [dedicated worker - EventSource: onopen (announcing the connection)]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-prototype.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-prototype.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-prototype.htm]
+  type: testharness
+  [dedicated worker - EventSource: prototype et al]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-url.htm.ini
+++ b/tests/wpt/metadata/eventsource/dedicated-worker/eventsource-url.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-url.htm]
+  type: testharness
+  [dedicated worker - EventSource: url]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/event-data.html.ini
+++ b/tests/wpt/metadata/eventsource/event-data.html.ini
@@ -1,6 +1,5 @@
 [event-data.html]
   type: testharness
-  expected: TIMEOUT
   [EventSource: lines and data parsing]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/eventsource-close.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-close.htm.ini
@@ -1,9 +1,8 @@
 [eventsource-close.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: close()]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: close(), test events]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/eventsource-constructor-document-domain.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-constructor-document-domain.htm.ini
@@ -1,6 +1,5 @@
 [eventsource-constructor-document-domain.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: document.domain]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/eventsource-constructor-non-same-origin.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-constructor-non-same-origin.htm.ini
@@ -1,20 +1,20 @@
 [eventsource-constructor-non-same-origin.htm]
   type: testharness
   [EventSource: constructor (act as if there is a network error) (http://example.not/)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: constructor (act as if there is a network error) (https://example.not/test)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: constructor (act as if there is a network error) (ftp://example.not/)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: constructor (act as if there is a network error) (about:blank)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: constructor (act as if there is a network error) (mailto:whatwg@awesome.example)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: constructor (act as if there is a network error) (javascript:alert('FAIL'))]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/eventsource-constructor-stringify.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-constructor-stringify.htm.ini
@@ -1,6 +1,14 @@
 [eventsource-constructor-stringify.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: stringify argument, object]
-    expected: TIMEOUT
+    expected: FAIL
+
+  [EventSource: stringify argument, 1]
+    expected: FAIL
+
+  [EventSource: stringify argument, null]
+    expected: FAIL
+
+  [EventSource: stringify argument, undefined]
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/eventsource-constructor-url-bogus.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-constructor-url-bogus.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-constructor-url-bogus.htm]
+  type: testharness
+  [EventSource: constructor (invalid URL)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/eventsource-cross-origin.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-cross-origin.htm.ini
@@ -1,21 +1,20 @@
 [eventsource-cross-origin.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: cross-origin basic use]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: cross-origin redirect use]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: cross-origin redirect use recon]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: cross-origin allow-origin: http://example.org should fail]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: cross-origin allow-origin:'' should fail]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: cross-origin No allow-origin should fail]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/eventsource-eventtarget.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-eventtarget.htm.ini
@@ -1,6 +1,5 @@
 [eventsource-eventtarget.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: addEventListener()]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/eventsource-onmessage.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-onmessage.htm.ini
@@ -1,6 +1,5 @@
 [eventsource-onmessage.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: onmessage]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/eventsource-onopen.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-onopen.htm.ini
@@ -1,6 +1,5 @@
 [eventsource-onopen.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: onopen (announcing the connection)]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/eventsource-prototype.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-prototype.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-prototype.htm]
+  type: testharness
+  [EventSource: prototype et al]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/eventsource-reconnect.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-reconnect.htm.ini
@@ -1,9 +1,8 @@
 [eventsource-reconnect.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: reconnection 200]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: reconnection, test reconnection events]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/eventsource-url.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-url.htm.ini
@@ -1,0 +1,5 @@
+[eventsource-url.htm]
+  type: testharness
+  [EventSource: url]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/format-bom-2.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-bom-2.htm.ini
@@ -1,6 +1,5 @@
 [format-bom-2.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: Double BOM]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-bom.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-bom.htm.ini
@@ -1,6 +1,5 @@
 [format-bom.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: BOM]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-comments.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-comments.htm.ini
@@ -1,6 +1,5 @@
 [format-comments.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: comment fest]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-data-before-final-empty-line.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-data-before-final-empty-line.htm.ini
@@ -1,6 +1,5 @@
 [format-data-before-final-empty-line.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: a data before final empty line]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-field-data.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-data.htm.ini
@@ -1,6 +1,5 @@
 [format-field-data.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: data field parsing]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-field-event-empty.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-event-empty.htm.ini
@@ -1,6 +1,5 @@
 [format-field-event-empty.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: empty "event" field]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-field-event.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-event.htm.ini
@@ -1,6 +1,5 @@
 [format-field-event.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: custom event name]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-field-id-2.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-id-2.htm.ini
@@ -1,6 +1,5 @@
 [format-field-id-2.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: Last-Event-ID (2)]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-field-id.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-id.htm.ini
@@ -1,6 +1,5 @@
 [format-field-id.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: Last-Event-ID]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-field-parsing.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-parsing.htm.ini
@@ -1,6 +1,5 @@
 [format-field-parsing.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: field parsing]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-field-retry-bogus.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-retry-bogus.htm.ini
@@ -1,6 +1,5 @@
 [format-field-retry-bogus.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: "retry" field (bogus)]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-field-retry-empty.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-retry-empty.htm.ini
@@ -1,6 +1,5 @@
 [format-field-retry-empty.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: empty retry field]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-field-retry.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-retry.htm.ini
@@ -1,6 +1,5 @@
 [format-field-retry.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: "retry" field]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-field-unknown.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-field-unknown.htm.ini
@@ -1,6 +1,5 @@
 [format-field-unknown.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: unknown fields and parsing fun]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-leading-space.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-leading-space.htm.ini
@@ -1,6 +1,5 @@
 [format-leading-space.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: leading space]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-mime-bogus.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-mime-bogus.htm.ini
@@ -1,6 +1,5 @@
 [format-mime-bogus.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: bogus MIME type]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-mime-trailing-semicolon.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-mime-trailing-semicolon.htm.ini
@@ -1,6 +1,5 @@
 [format-mime-trailing-semicolon.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: MIME type with trailing ;]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-mime-valid-bogus.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-mime-valid-bogus.htm.ini
@@ -1,6 +1,5 @@
 [format-mime-valid-bogus.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: incorrect valid MIME type]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-newlines.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-newlines.htm.ini
@@ -1,6 +1,5 @@
 [format-newlines.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: newline fest]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-null-character.html.ini
+++ b/tests/wpt/metadata/eventsource/format-null-character.html.ini
@@ -1,6 +1,5 @@
 [format-null-character.html]
   type: testharness
-  expected: TIMEOUT
   [EventSource: null character in response]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/format-utf-8.htm.ini
+++ b/tests/wpt/metadata/eventsource/format-utf-8.htm.ini
@@ -1,6 +1,5 @@
 [format-utf-8.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: always UTF-8]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/interfaces.html.ini
+++ b/tests/wpt/metadata/eventsource/interfaces.html.ini
@@ -9,3 +9,84 @@
   [Stringification of new EventSource("http://foo")]
     expected: FAIL
 
+  [EventSource interface object length]
+    expected: FAIL
+
+  [EventSource interface object name]
+    expected: FAIL
+
+  [EventSource interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [EventSource interface: attribute url]
+    expected: FAIL
+
+  [EventSource interface: attribute withCredentials]
+    expected: FAIL
+
+  [EventSource interface: constant CONNECTING on interface object]
+    expected: FAIL
+
+  [EventSource interface: constant CONNECTING on interface prototype object]
+    expected: FAIL
+
+  [EventSource interface: constant OPEN on interface object]
+    expected: FAIL
+
+  [EventSource interface: constant OPEN on interface prototype object]
+    expected: FAIL
+
+  [EventSource interface: constant CLOSED on interface object]
+    expected: FAIL
+
+  [EventSource interface: constant CLOSED on interface prototype object]
+    expected: FAIL
+
+  [EventSource interface: attribute readyState]
+    expected: FAIL
+
+  [EventSource interface: attribute onopen]
+    expected: FAIL
+
+  [EventSource interface: attribute onmessage]
+    expected: FAIL
+
+  [EventSource interface: attribute onerror]
+    expected: FAIL
+
+  [EventSource interface: operation close()]
+    expected: FAIL
+
+  [EventSource must be primary interface of new EventSource("http://foo")]
+    expected: FAIL
+
+  [EventSource interface: new EventSource("http://foo") must inherit property "url" with the proper type (0)]
+    expected: FAIL
+
+  [EventSource interface: new EventSource("http://foo") must inherit property "withCredentials" with the proper type (1)]
+    expected: FAIL
+
+  [EventSource interface: new EventSource("http://foo") must inherit property "CONNECTING" with the proper type (2)]
+    expected: FAIL
+
+  [EventSource interface: new EventSource("http://foo") must inherit property "OPEN" with the proper type (3)]
+    expected: FAIL
+
+  [EventSource interface: new EventSource("http://foo") must inherit property "CLOSED" with the proper type (4)]
+    expected: FAIL
+
+  [EventSource interface: new EventSource("http://foo") must inherit property "readyState" with the proper type (5)]
+    expected: FAIL
+
+  [EventSource interface: new EventSource("http://foo") must inherit property "onopen" with the proper type (6)]
+    expected: FAIL
+
+  [EventSource interface: new EventSource("http://foo") must inherit property "onmessage" with the proper type (7)]
+    expected: FAIL
+
+  [EventSource interface: new EventSource("http://foo") must inherit property "onerror" with the proper type (8)]
+    expected: FAIL
+
+  [EventSource interface: new EventSource("http://foo") must inherit property "close" with the proper type (9)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/eventsource/request-accept.htm.ini
+++ b/tests/wpt/metadata/eventsource/request-accept.htm.ini
@@ -1,6 +1,5 @@
 [request-accept.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: Accept header]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/request-cache-control.htm.ini
+++ b/tests/wpt/metadata/eventsource/request-cache-control.htm.ini
@@ -1,9 +1,8 @@
 [request-cache-control.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: Cache-Control]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: Cache-Control 1]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/request-credentials.htm.ini
+++ b/tests/wpt/metadata/eventsource/request-credentials.htm.ini
@@ -1,12 +1,11 @@
 [request-credentials.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: credentials: credentials enabled]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: credentials: credentials disabled]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: credentials: credentials default]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/request-redirect.htm.ini
+++ b/tests/wpt/metadata/eventsource/request-redirect.htm.ini
@@ -1,15 +1,14 @@
 [request-redirect.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: redirect (301)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: redirect (302)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: redirect (303)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: redirect (307)]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/eventsource/request-status-error.htm.ini
+++ b/tests/wpt/metadata/eventsource/request-status-error.htm.ini
@@ -1,24 +1,23 @@
 [request-status-error.htm]
   type: testharness
-  expected: TIMEOUT
   [EventSource: incorrect HTTP status code (204)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: incorrect HTTP status code (205)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: incorrect HTTP status code (210)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: incorrect HTTP status code (299)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: incorrect HTTP status code (404)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: incorrect HTTP status code (410)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [EventSource: incorrect HTTP status code (503)]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/browsers/history/the-location-interface/location_assign.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-location-interface/location_assign.html.ini
@@ -2,3 +2,4 @@
   type: testharness
   [location assign]
     expected: FAIL
+

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -10599,3 +10599,57 @@
   [Navigator interface: window.navigator must inherit property "hardwareConcurrency" with the proper type (22)]
     expected: FAIL
 
+  [EventSource interface: existence and properties of interface object]
+    expected: FAIL
+
+  [EventSource interface object length]
+    expected: FAIL
+
+  [EventSource interface object name]
+    expected: FAIL
+
+  [EventSource interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [EventSource interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [EventSource interface: attribute url]
+    expected: FAIL
+
+  [EventSource interface: attribute withCredentials]
+    expected: FAIL
+
+  [EventSource interface: constant CONNECTING on interface object]
+    expected: FAIL
+
+  [EventSource interface: constant CONNECTING on interface prototype object]
+    expected: FAIL
+
+  [EventSource interface: constant OPEN on interface object]
+    expected: FAIL
+
+  [EventSource interface: constant OPEN on interface prototype object]
+    expected: FAIL
+
+  [EventSource interface: constant CLOSED on interface object]
+    expected: FAIL
+
+  [EventSource interface: constant CLOSED on interface prototype object]
+    expected: FAIL
+
+  [EventSource interface: attribute readyState]
+    expected: FAIL
+
+  [EventSource interface: attribute onopen]
+    expected: FAIL
+
+  [EventSource interface: attribute onmessage]
+    expected: FAIL
+
+  [EventSource interface: attribute onerror]
+    expected: FAIL
+
+  [EventSource interface: operation close()]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/infrastructure/common-dom-interfaces/collections/htmloptionscollection.html.ini
+++ b/tests/wpt/metadata/html/infrastructure/common-dom-interfaces/collections/htmloptionscollection.html.ini
@@ -17,3 +17,4 @@
 
   [HTMLOptionsCollection.add method insert HTMLOptionElement Option element]
     expected: FAIL
+

--- a/tests/wpt/metadata/workers/constructors/Worker/expected-self-properties.worker.js.ini
+++ b/tests/wpt/metadata/workers/constructors/Worker/expected-self-properties.worker.js.ini
@@ -6,3 +6,6 @@
   [existence of SharedWorker]
     expected: FAIL
 
+  [existence of EventSource]
+    expected: FAIL
+

--- a/tests/wpt/metadata/workers/semantics/interface-objects/001.worker.js.ini
+++ b/tests/wpt/metadata/workers/semantics/interface-objects/001.worker.js.ini
@@ -81,3 +81,6 @@
   [The IDBTransaction interface object should be exposed.]
     expected: FAIL
 
+  [The EventSource interface object should be exposed.]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.html
@@ -41,7 +41,6 @@ test_interfaces([
   "Element",
   "ErrorEvent",
   "Event",
-  "EventSource",
   "EventTarget",
   "File",
   "FileList",

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
@@ -35,7 +35,6 @@ test_interfaces([
   "Element",
   "ErrorEvent",
   "Event",
-  "EventSource",
   "EventTarget",
   "File",
   "FileList",


### PR DESCRIPTION
This also causes a number of tests that currently time out to fail quickly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13475)

<!-- Reviewable:end -->
