### PR TITLE
Make readystatechange fire more often (fixes #13481)

### DIFF
--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -974,9 +974,16 @@ impl XMLHttpRequest {
                 *self.response.borrow_mut() = partial_response;
                 if !self.sync.get() {
                     if self.ready_state.get() == XMLHttpRequestState::HeadersReceived {
-                        self.change_ready_state(XMLHttpRequestState::Loading);
-                        return_if_fetch_was_terminated!();
+                        self.ready_state.set(XMLHttpRequestState::Loading);
                     }
+                    let global = self.global();
+                    let event = Event::new(
+                        global.r(),
+                        atom!("readystatechange"),
+                        EventBubbles::DoesNotBubble,
+                        EventCancelable::Cancelable);
+                    event.fire(self.upcast());
+                    return_if_fetch_was_terminated!();
                     self.dispatch_response_progress_event(atom!("progress"));
                 }
             },

--- a/tests/wpt/web-platform-tests/XMLHttpRequest/event-readystatechange-loaded.htm
+++ b/tests/wpt/web-platform-tests/XMLHttpRequest/event-readystatechange-loaded.htm
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>XMLHttpRequest: the LOADING state change should only happen once</title>
+    <title>XMLHttpRequest: the LOADING state change may be emitted multiple times</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following::ol[1]/li[10]/dt[1]">
@@ -26,7 +26,7 @@ test.step(function() {
         }
 
         if (client.readyState === 4) {
-            assert_equals(countedLoading, 1, "LOADING state change may only be emitted once");
+            assert_equals(countedLoading, 10, "LOADING state change may be emitted multiple times");
 
             test.done();
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13481 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13485)

<!-- Reviewable:end -->
