### PR TITLE
Use default console subsystem on Windows for dev builds

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -259,9 +259,11 @@ class MachCommands(CommandBase):
                             servo_exe_dir)
                 if "msvc" in (target or host_triple()):
                     msvc_x64 = "64" if "x86_64" in (target or host_triple()) else ""
-                    # on msvc builds, use editbin to change the subsystem to windows
-                    call(["editbin", "/nologo", "/subsystem:windows", path.join(servo_exe_dir, "servo.exe")],
-                         verbose=verbose)
+                    # on msvc builds, use editbin to change the subsystem to windows, but only
+                    # on release builds -- on debug builds, it hides log output
+                    if not dev:
+                        call(["editbin", "/nologo", "/subsystem:windows", path.join(servo_exe_dir, "servo.exe")],
+                             verbose=verbose)
                     # on msvc, we need to copy in some DLLs in to the servo.exe dir
                     for ssl_lib in ["ssleay32md.dll", "libeay32md.dll"]:
                         shutil.copy(path.join(env['OPENSSL_LIB_DIR'], "../bin" + msvc_x64, ssl_lib),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

If we keep the windows subsystem, we don't get any kind of log output.  We should keep the normal console subsystem for dev builds.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13488)

<!-- Reviewable:end -->
