### PR TITLE
Don't leak GitHub tokens when pushing

### DIFF
--- a/etc/ci/update_brew.sh
+++ b/etc/ci/update_brew.sh
@@ -16,7 +16,6 @@ PACKAGENAME=$(basename ${PACKAGEPATH})
 REGEX="s/servo-.*\([0-9]\{4\}\)-\([0-9]\{2\}\)-\([0-9]\{2\}\).tar.gz/\1.\2.\3/p"
 VERSION=$(echo ${PACKAGENAME}| sed -n "${REGEX}")
 SHA=$(shasum -a 256 ${PACKAGEPATH} | sed -e 's/ .*//')
-GIT="https://${TOKEN}@github.com/servo/homebrew-servo.git"
 
 # See upload_nightly.sh
 PACKAGEURL="https://download.servo.org/nightly/macbrew/${PACKAGENAME}"
@@ -31,7 +30,7 @@ cd ${TMP_DIR}
 echo ${TMP_DIR}
 
 echo "Cloning"
-git clone ${GIT}
+git clone https://github.com/servo/homebrew-servo.git
 cd homebrew-servo
 
 # Not using "/" as it's used in PACKAGEURL
@@ -43,5 +42,7 @@ cat ${SCRIPTDIR}/servo-binary-formula.rb.in | sed \
 git add ./Formula/servo-bin.rb
 git commit -m "Version bump: ${VERSION}"
 
-git push -q ${GIT} master
+git push -qf \
+    "https://${TOKEN}@github.com/servo/homebrew-servo.git" master \
+    >/dev/null 2>&1
 rm -rf ${TMP_DIR}

--- a/etc/ci/upload_docs.sh
+++ b/etc/ci/upload_docs.sh
@@ -27,4 +27,6 @@ cp apis.html ../../target/doc/servo/
 cd ../..
 
 ghp-import -n target/doc
-git push -qf "https://${TOKEN}@github.com/servo/doc.servo.org.git" gh-pages
+git push -qf \
+    "https://${TOKEN}@github.com/servo/doc.servo.org.git" gh-pages \
+    >/dev/null 2>&1


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they just remove output/were lightly tested by hand

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

If git is unable to resolve the repo address (which includes the token),
it will print a message to stderr with the path to the repo, thus
leaking the token. Avoid doing this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13507)

<!-- Reviewable:end -->
