### PR TITLE
Return the error codes instead of implicitly returning None

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -246,9 +246,7 @@ class MachCommands(CommandBase):
 
             if features:
                 args += ["--features", "%s" % ' '.join(features)]
-            result = call(args, env=env, cwd=self.servo_crate())
-            if result != 0:
-                return result
+            return call(args, env=env, cwd=self.servo_crate())
 
         # Run style tests with the testing feature
         if has_style:
@@ -257,9 +255,7 @@ class MachCommands(CommandBase):
                 args += ["%s" % ' '.join(features + ["testing"])]
             else:
                 args += ["testing"]
-            result = call(args, env=env, cwd=self.servo_crate())
-            if result != 0:
-                return result
+            return call(args, env=env, cwd=self.servo_crate())
 
     @Command('test-stylo',
              description='Run stylo unit tests',
@@ -273,10 +269,7 @@ class MachCommands(CommandBase):
         env["CARGO_TARGET_DIR"] = path.join(self.context.topdir, "target", "geckolib").encode("UTF-8")
 
         with cd(path.join("ports", "geckolib")):
-            result = call(["cargo", "test", "-p", "stylo_tests"], env=env)
-
-        if result != 0:
-            return result
+            return call(["cargo", "test", "-p", "stylo_tests"], env=env)
 
     @Command('test-compiletest',
              description='Run compiletests',
@@ -333,9 +326,7 @@ class MachCommands(CommandBase):
         else:
             env["BUILD_MODE"] = "debug"
 
-        result = call(args, env=env, cwd=self.servo_crate())
-        if result != 0:
-            return result
+        return call(args, env=env, cwd=self.servo_crate())
 
     @Command('test-content',
              description='Run the content tests',


### PR DESCRIPTION
See https://github.com/servo/servo/issues/13344

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13344 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because refactoring without logic changes, 0 is falsey as None

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13513)

<!-- Reviewable:end -->
