### PR TITLE
Fix `test-geckolib`

### DIFF
--- a/tests/unit/stylo/lib.rs
+++ b/tests/unit/stylo/lib.rs
@@ -4,7 +4,6 @@
 
 extern crate app_units;
 extern crate cssparser;
-extern crate gecko_bindings;
 extern crate style;
 extern crate style_traits;
 


### PR DESCRIPTION
This will make Travis green again.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's only cleanup

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13528)

<!-- Reviewable:end -->
