### PR TITLE
Remove ignore-heap-size comment to enable memory measurement on HashSet

### DIFF
--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -145,7 +145,7 @@ pub struct TimelineMarker {
     pub end_stack: Option<Vec<()>>,
 }
 
-#[derive(PartialEq, Eq, Hash, Clone, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Hash, Clone, Deserialize, Serialize, HeapSizeOf)]
 pub enum TimelineMarkerType {
     Reflow,
     DOMEvent,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -195,7 +195,6 @@ pub struct Window {
     devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
     /// For sending timeline markers. Will be ignored if
     /// no devtools server
-    #[ignore_heap_size_of = "TODO(#6909) need to measure HashSet"]
     devtools_markers: DOMRefCell<HashSet<TimelineMarkerType>>,
     #[ignore_heap_size_of = "channels are hard"]
     devtools_marker_sender: DOMRefCell<Option<IpcSender<TimelineMarker>>>,


### PR DESCRIPTION
Remove the ignore-heap-size comment to enable the memory measurement.
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #6909 
- [x] These changes do not require tests because they just enabled memory measurement

@jdm the build fails, and I'm not so sure why. Assistance please? 😄

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13531)

<!-- Reviewable:end -->
