### PR TITLE
Avoid unecessary loop evaluation on empty lines for tidy check_license

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -149,8 +149,9 @@ def check_license(file_name, lines):
         l = l.rstrip('\n')
         if not l.strip():
             blank_lines += 1
-        if blank_lines >= max_blank_lines:
-            break
+            if blank_lines >= max_blank_lines:
+                break
+            continue
         line = uncomment(l)
         if line is not None:
             license_block.append(line)

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -55,7 +55,7 @@ class CheckTidiness(unittest.TestCase):
         self.assertTrue('links to WHATWG single-page url, change to multi page:' in errors.next()[2])
         self.assertNoMoreErrors(errors)
 
-    def test_licence(self):
+    def test_license(self):
         errors = tidy.collect_errors_for_files(iterFile('incorrect_license.rs'), [], [tidy.check_license], print_text=False)
         self.assertEqual('incorrect license', errors.next()[2])
         self.assertNoMoreErrors(errors)


### PR DESCRIPTION
Refactored file line loop in `check_license()` to skip when a blank line is encountered. Only difference should be a very very small performance boost.

Also changed the name of a test from the mispelling `test_licence()` to `test_license()`

---
- [ ] `./mach build -d` does not report any errors (I'm not able to download the rust compiler on my laptop due to me probably just needing to update openssl: `Error downloading Rust compiler: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590). The failing URL was: https://static-rust-lang-org.s3.amazonaws.com/dist/2016-09-21/rustc-nightly-x86_64-apple-darwin.tar.gz`)
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are no added tests for this since `test_license()`, `test_shebang_license()` and  `test_apache2_incomplete()` should suffice in this case. Though I'd be more than happy to add a test if requested.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13538)

<!-- Reviewable:end -->
