### PR TITLE
Fix origin/clip parsing behavior in mask and background shorthands

### DIFF
--- a/components/style/properties/shorthand/background.mako.rs
+++ b/components/style/properties/shorthand/background.mako.rs
@@ -11,6 +11,20 @@
     use properties::longhands::{background_color, background_position, background_repeat, background_attachment};
     use properties::longhands::{background_image, background_size, background_origin, background_clip};
 
+    impl From<background_origin::single_value::SpecifiedValue> for background_clip::single_value::SpecifiedValue {
+        fn from(origin: background_origin::single_value::SpecifiedValue) ->
+            background_clip::single_value::SpecifiedValue {
+            match origin {
+                background_origin::single_value::SpecifiedValue::content_box =>
+                    background_clip::single_value::SpecifiedValue::content_box,
+                background_origin::single_value::SpecifiedValue::padding_box =>
+                    background_clip::single_value::SpecifiedValue::padding_box,
+                background_origin::single_value::SpecifiedValue::border_box =>
+                    background_clip::single_value::SpecifiedValue::border_box,
+            }
+        }
+    }
+
     pub fn parse_value(context: &ParserContext, input: &mut Parser) -> Result<Longhands, ()> {
         let mut background_color = None;
 
@@ -55,6 +69,11 @@
                     }
                 % endfor
                 break
+            }
+            if clip.is_none() {
+                if let Some(origin) = origin {
+                    clip = Some(background_clip::single_value::SpecifiedValue::from(origin));
+                }
             }
             let mut any = false;
             % for name in "image position repeat size attachment origin clip".split():
@@ -198,14 +217,6 @@
                                 try!(clip.to_css(dest));
                             }
                         }
-                    },
-                    (Some(origin), _) => {
-                        try!(write!(dest, " "));
-                        try!(origin.to_css(dest));
-                    },
-                    (_, Some(clip)) => {
-                        try!(write!(dest, " "));
-                        try!(clip.to_css(dest));
                     },
                     _ => {}
                 };

--- a/tests/unit/style/parsing/mask.rs
+++ b/tests/unit/style/parsing/mask.rs
@@ -106,8 +106,8 @@ fn mask_shorthand_should_parse_origin_and_clip_correctly() {
     let mut parser = Parser::new("padding-box");
     let result = mask::parse_value(&context, &mut parser).unwrap();
 
-    // TODO(#13466): We should fix origin/clip parsing behavior.
     assert_eq!(result.mask_origin.unwrap(), parse_longhand!(mask_origin, "padding-box"));
+    assert_eq!(result.mask_clip.unwrap(), parse_longhand!(mask_clip, "padding-box"));
 }
 
 #[test]

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-335.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-335.htm.ini
@@ -1,5 +1,0 @@
-[background-335.htm]
-  type: testharness
-  [background_specified_box_one_clip]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

We have tests for mask shorthand parsing, but we don't have tests for background parsing. Should I add some for it?
Also deleted inaccessible match arms in serialization function.
r? @Manishearth 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13466 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13541)

<!-- Reviewable:end -->
