### PR TITLE
Rename hyper import and update as HttpMethod

### DIFF
--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -24,7 +24,7 @@ use dom::bindings::str::{ByteString, DOMString, USVString};
 use dom::headers::{Guard, Headers};
 use dom::promise::Promise;
 use dom::xmlhttprequest::Extractable;
-use hyper;
+use hyper::method::Method as HttpMethod;
 use msg::constellation_msg::ReferrerPolicy as MsgReferrerPolicy;
 use net_traits::request::{Origin, Window};
 use net_traits::request::CacheMode as NetTraitsRequestCache;
@@ -359,9 +359,9 @@ impl Request {
                 let req = r.request.borrow();
                 let req_method = req.method.borrow();
                 match &*req_method {
-                    &hyper::method::Method::Get => return Err(Error::Type(
+                    &HttpMethod::Get => return Err(Error::Type(
                         "Init's body is non-null, and request method is GET".to_string())),
-                    &hyper::method::Method::Head => return Err(Error::Type(
+                    &HttpMethod::Head => return Err(Error::Type(
                         "Init's body is non-null, and request method is HEAD".to_string())),
                     _ => {},
                 }
@@ -461,15 +461,15 @@ fn net_request_from_global(global: GlobalRef,
                           Some(pipeline_id))
 }
 
-fn normalized_method_to_typed_method(m: &str) -> hyper::method::Method {
+fn normalized_method_to_typed_method(m: &str) -> HttpMethod {
     match m {
-        "DELETE" => hyper::method::Method::Delete,
-        "GET" => hyper::method::Method::Get,
-        "HEAD" => hyper::method::Method::Head,
-        "OPTIONS" => hyper::method::Method::Options,
-        "POST" => hyper::method::Method::Post,
-        "PUT" => hyper::method::Method::Put,
-        a => hyper::method::Method::Extension(a.to_string())
+        "DELETE" => HttpMethod::Delete,
+        "GET" => HttpMethod::Get,
+        "HEAD" => HttpMethod::Head,
+        "OPTIONS" => HttpMethod::Options,
+        "POST" => HttpMethod::Post,
+        "PUT" => HttpMethod::Put,
+        a => HttpMethod::Extension(a.to_string())
     }
 }
 
@@ -512,10 +512,10 @@ fn is_forbidden_method(m: &ByteString) -> bool {
 }
 
 // https://fetch.spec.whatwg.org/#cors-safelisted-method
-fn is_cors_safelisted_method(m: &hyper::method::Method) -> bool {
-    m == &hyper::method::Method::Get ||
-        m == &hyper::method::Method::Head ||
-        m == &hyper::method::Method::Post
+fn is_cors_safelisted_method(m: &HttpMethod) -> bool {
+    m == &HttpMethod::Get ||
+        m == &HttpMethod::Head ||
+        m == &HttpMethod::Post
 }
 
 // https://url.spec.whatwg.org/#include-credentials


### PR DESCRIPTION
The same expanded hyper::method::Method method was used throughout the file, causing unneeded repetition. Import this method as HttpMethod and replace all references in the file.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13543 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13544)

<!-- Reviewable:end -->
