### PR TITLE
Support creating StyleAnimationValue objects from Servo

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -70,6 +70,16 @@ pub struct GeckoDeclarationBlock {
     pub immutable: AtomicBool,
 }
 
+impl PartialEq for GeckoDeclarationBlock {
+    fn eq(&self, other: &GeckoDeclarationBlock) -> bool {
+        match (&self.declarations, &other.declarations) {
+            (&None, &None) => true,
+            (&Some(ref s), &Some(ref other)) => *s.read() == *other.read(),
+            _ => false,
+        }
+    }
+}
+
 unsafe impl HasFFI for GeckoDeclarationBlock {
     type FFIType = bindings::ServoDeclarationBlock;
 }

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -165,6 +165,7 @@ use gecko_bindings::structs::nsINode;
 use gecko_bindings::structs::nsIDocument;
 use gecko_bindings::structs::nsIPrincipal;
 use gecko_bindings::structs::nsIURI;
+use gecko_bindings::structs::nsString;
 use gecko_bindings::structs::RawGeckoNode;
 use gecko_bindings::structs::RawGeckoElement;
 use gecko_bindings::structs::RawGeckoDocument;
@@ -398,6 +399,11 @@ extern "C" {
                                           aString:
                                               *const ::std::os::raw::c_char,
                                           aLength: u32) -> bool;
+}
+extern "C" {
+    pub fn Gecko_Utf8SliceToString(aString: *mut nsString,
+                                   aBuffer: *const u8,
+                                   aBufferLen: usize);
 }
 extern "C" {
     pub fn Gecko_FontFamilyList_Clear(aList: *mut FontFamilyList);

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -848,6 +848,18 @@ extern "C" {
                                                      RawServoStyleSheetBorrowed);
 }
 extern "C" {
+    pub fn Servo_ParseProperty(property_bytes: *const u8,
+                               property_length: u32,
+                               value_bytes: *const u8,
+                               value_length: u32,
+                               base_bytes: *const u8,
+                               base_length: u32,
+                               base: *mut ThreadSafeURIHolder,
+                               referrer: *mut ThreadSafeURIHolder,
+                               principal: *mut ThreadSafePrincipalHolder)
+    -> ServoDeclarationBlockStrong;
+}
+extern "C" {
     pub fn Servo_ParseStyleAttribute(bytes: *const u8, length: u32,
                                      cache: *mut nsHTMLCSSStyleSheet)
      -> ServoDeclarationBlockStrong;

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -953,6 +953,11 @@ extern "C" {
                                 set: RawServoStyleSetBorrowedMut);
 }
 extern "C" {
+    pub fn Servo_RestyleWithAddedDeclaration(declarations: ServoDeclarationBlockBorrowed,
+                                             previous_style: ServoComputedValuesBorrowed)
+     -> ServoComputedValuesStrong;
+}
+extern "C" {
     pub fn Servo_GetStyleFont(computed_values:
                                   ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleFont;

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -873,6 +873,11 @@ extern "C" {
                                               ServoDeclarationBlockBorrowed);
 }
 extern "C" {
+    pub fn Servo_DeclarationBlock_Equals(a: ServoDeclarationBlockBorrowed,
+                                         b: ServoDeclarationBlockBorrowed)
+     -> bool;
+}
+extern "C" {
     pub fn Servo_DeclarationBlock_GetCache(declarations:
                                                ServoDeclarationBlockBorrowed)
      -> *mut nsHTMLCSSStyleSheet;

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -3,6 +3,7 @@ name = "geckoservo"
 version = "0.0.1"
 dependencies = [
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -407,6 +408,7 @@ name = "stylo_tests"
 version = "0.0.1"
 dependencies = [
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "geckoservo 0.0.1",

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 app_units = "0.3"
+cssparser = {version = "0.7"}
 env_logger = "0.3"
 euclid = "0.10.1"
 lazy_static = "0.2"

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -414,6 +414,13 @@ pub extern "C" fn Servo_DeclarationBlock_Release(declarations: ServoDeclarationB
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_DeclarationBlock_Equals(a: ServoDeclarationBlockBorrowed,
+                                                b: ServoDeclarationBlockBorrowed)
+                                                -> bool {
+    GeckoDeclarationBlock::as_arc(&a) == GeckoDeclarationBlock::as_arc(&b)
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_DeclarationBlock_GetCache(declarations: ServoDeclarationBlockBorrowed)
                                                  -> *mut nsHTMLCSSStyleSheet {
     GeckoDeclarationBlock::as_arc(&declarations).cache.load(Ordering::Relaxed)

--- a/ports/geckolib/lib.rs
+++ b/ports/geckolib/lib.rs
@@ -5,6 +5,7 @@
 
 #[macro_use]extern crate style;
 extern crate app_units;
+extern crate cssparser;
 extern crate env_logger;
 extern crate euclid;
 extern crate libc;

--- a/tests/unit/stylo/Cargo.toml
+++ b/tests/unit/stylo/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 
 [dependencies]
 app_units = "0.3"
+cssparser = {version = "0.7"}
 env_logger = "0.3"
 euclid = "0.10.1"
 lazy_static = "0.2"

--- a/tests/unit/stylo/lib.rs
+++ b/tests/unit/stylo/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate app_units;
+extern crate cssparser;
 extern crate env_logger;
 extern crate euclid;
 extern crate geckoservo;


### PR DESCRIPTION
These are the servo-side changes for [bug 1302949](https://bugzilla.mozilla.org/show_bug.cgi?id=1302949#c59). @Manishearth has already reviewed them there.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [bug 1302949](https://bugzilla.mozilla.org/show_bug.cgi?id=1302949#c59)
- [X] These changes do not require tests because there are existing tests for this in mozilla-central

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13553)

<!-- Reviewable:end -->
