### PR TITLE
Add to_css_single_value for serializing a single PropertyDeclarationBlock 

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -313,6 +313,42 @@ impl PropertyDeclarationBlock {
     }
 }
 
+impl PropertyDeclarationBlock {
+    // Take a declaration block known to contain a single property,
+    // and serialize it
+    pub fn to_css_single_value<W>(&self, dest: &mut W, name: &str)
+        -> fmt::Result where W: fmt::Write {
+        match self.declarations.len() {
+            0 => Err(fmt::Error),
+            1 if self.declarations[0].0.name().eq_str_ignore_ascii_case(name) => {
+                self.declarations[0].0.to_css(dest)
+            }
+            _ => {
+                // we use this function because a closure won't be `Clone`
+                fn get_declaration(dec: &(PropertyDeclaration, Importance))
+                    -> &PropertyDeclaration {
+                    &dec.0
+                }
+                let shorthand = try!(Shorthand::from_name(name).ok_or(fmt::Error));
+                if !self.declarations.iter().all(|decl| decl.0.shorthands().contains(&shorthand)) {
+                    return Err(fmt::Error)
+                }
+                let success = try!(shorthand.serialize_shorthand_to_buffer(
+                    dest,
+                    self.declarations.iter()
+                                     .map(get_declaration as fn(_) -> _),
+                    &mut true)
+                );
+                if success {
+                    Ok(())
+                } else {
+                    Err(fmt::Error)
+                }
+            }
+        }
+    }
+}
+
 impl ToCss for PropertyDeclarationBlock {
     // https://drafts.csswg.org/cssom/#serialize-a-css-declaration-block
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
@@ -885,6 +921,16 @@ pub enum PropertyDeclarationName {
     Longhand(&'static str),
     Custom(::custom_properties::Name),
     Internal
+}
+
+impl PropertyDeclarationName {
+    pub fn eq_str_ignore_ascii_case(&self, other: &str) -> bool {
+        match *self {
+            PropertyDeclarationName::Longhand(s) => s.eq_ignore_ascii_case(other),
+            PropertyDeclarationName::Custom(ref n) => n.eq_str_ignore_ascii_case(other),
+            PropertyDeclarationName::Internal => false
+        }
+    }
 }
 
 impl PartialEq<str> for PropertyDeclarationName {


### PR DESCRIPTION
(fixes #13423)

r? @birtles

This needs to take the name of the property in question as input so that it can figure out which shorthand to serialize to (if any), since some props are part of multiple shorthands (and you need a way to distinguish between the lone value and the shorthand). I can tweak this to accept an `Option<Shorthand>` in case you only want to pass in the property name for shorthands.

In case you don't want to handle shorthands at all, we probably don't need this method at all, since you can just assert that there's a single field and serialize that.

Also, is `!important` involved here?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13556)

<!-- Reviewable:end -->
