### PR TITLE
Fix path to browserhtml in Linux runservo.sh

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -300,7 +300,7 @@ class PackageCommands(CommandBase):
             print("Copying files")
             dir_to_resources = path.join(dir_to_temp, 'resources')
             shutil.copytree(path.join(self.get_top_dir(), 'resources'), dir_to_resources)
-            shutil.copytree(browserhtml_path, path.join(dir_to_temp, 'build'))
+            shutil.copytree(browserhtml_path, path.join(dir_to_temp, 'browserhtml'))
             shutil.copy(binary_path, dir_to_temp)
 
             print("Writing runservo.sh")
@@ -309,7 +309,7 @@ class PackageCommands(CommandBase):
                           '--pref', 'dom.mozbrowser.enabled',
                           '--pref', 'dom.forcetouch.enabled',
                           '--pref', 'shell.builtin-key-shortcuts.enabled=false',
-                          path.join('./build/' + browserhtml_path.split('/')[-1], 'out', 'index.html')]
+                          path.join('./browserhtml', 'out', 'index.html')]
 
             runservo = os.open(dir_to_temp + '/runservo.sh', os.O_WRONLY | os.O_CREAT, int("0755", 8))
             os.write(runservo, "#!/usr/bin/env sh\n./servo " + ' '.join(servo_args))


### PR DESCRIPTION
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13552 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because needs to be verified manually

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13558)

<!-- Reviewable:end -->
