### PR TITLE
Move mako out of wptrunner required packages

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,6 +5,7 @@ mozinfo == 0.8
 mozlog == 3.3
 setuptools == 18.5
 toml == 0.9.1
+Mako == 1.0.4
 
 # For Python linting
 flake8 == 2.4.1

--- a/tests/wpt/harness/requirements_servo.txt
+++ b/tests/wpt/harness/requirements_servo.txt
@@ -1,3 +1,2 @@
 mozprocess >= 0.19
-Mako >= 1.0.4
 


### PR DESCRIPTION
There was a review comment about this in https://github.com/servo/servo/pull/13382#issuecomment-249453104 that was never addressed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13562)

<!-- Reviewable:end -->
