### PR TITLE
Remove duplicated definition of 'doc'.

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -259,8 +259,6 @@ fn fetch_a_classic_script(script: &HTMLScriptElement,
         status: Ok(())
     }));
 
-    let doc = document_from_node(script);
-
     let (action_sender, action_receiver) = ipc::channel().unwrap();
     let listener = NetworkListener {
         context: context,


### PR DESCRIPTION
The same line exists higher up in the function.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13568)

<!-- Reviewable:end -->
