### PR TITLE
Removed the session history from BrowsingContext.

### DIFF
--- a/components/script/dom/browsingcontext.rs
+++ b/components/script/dom/browsingcontext.rs
@@ -3,12 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::cell::DOMRefCell;
-use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::conversions::{ToJSValConvertible, root_from_handleobject};
-use dom::bindings::js::{JS, Root, RootedReference};
+use dom::bindings::js::{JS, MutNullableHeap, Root, RootedReference};
 use dom::bindings::proxyhandler::{fill_property_descriptor, get_property_descriptor};
 use dom::bindings::reflector::{Reflectable, MutReflectable, Reflector};
-use dom::bindings::str::DOMString;
 use dom::bindings::trace::JSTraceable;
 use dom::bindings::utils::WindowProxyHandler;
 use dom::bindings::utils::get_array_index_from_id;
@@ -28,9 +26,12 @@ use js::jsapi::{ObjectOpResult, PropertyDescriptor};
 use js::jsval::{UndefinedValue, PrivateValue};
 use msg::constellation_msg::PipelineId;
 use std::cell::Cell;
-use url::Url;
 
 #[dom_struct]
+// NOTE: the browsing context for a window is managed in two places:
+// here, in script, but also in the constellation. The constellation
+// manages the session history, which in script is accessed through
+// History objects, messaging the constellation.
 pub struct BrowsingContext {
     reflector: Reflector,
 
@@ -40,15 +41,15 @@ pub struct BrowsingContext {
     /// Indicates if reflow is required when reloading.
     needs_reflow: Cell<bool>,
 
-    /// Stores this context's session history
-    history: DOMRefCell<Vec<SessionHistoryEntry>>,
-
-    /// The index of the active session history entry
-    active_index: Cell<usize>,
-
     /// Stores the child browsing contexts (ex. iframe browsing context)
     children: DOMRefCell<Vec<JS<BrowsingContext>>>,
 
+    /// The current active document.
+    /// Note that the session history is stored in the constellation,
+    /// in the script thread we just track the current active document.
+    active_document: MutNullableHeap<JS<Document>>,
+
+    /// The containing iframe element, if this is a same-origin iframe
     frame_element: Option<JS<Element>>,
 }
 
@@ -58,9 +59,8 @@ impl BrowsingContext {
             reflector: Reflector::new(),
             id: id,
             needs_reflow: Cell::new(true),
-            history: DOMRefCell::new(vec![]),
-            active_index: Cell::new(0),
             children: DOMRefCell::new(vec![]),
+            active_document: Default::default(),
             frame_element: frame_element.map(JS::from_ref),
         }
     }
@@ -90,29 +90,16 @@ impl BrowsingContext {
         }
     }
 
-    pub fn init(&self, document: &Document) {
-        assert!(self.history.borrow().is_empty());
-        assert_eq!(self.active_index.get(), 0);
-        self.history.borrow_mut().push(SessionHistoryEntry::new(document, document.url().clone(), document.Title()));
-    }
-
-    pub fn push_history(&self, document: &Document) {
-        let mut history = self.history.borrow_mut();
-        // Clear all session history entries after the active index
-        history.drain((self.active_index.get() + 1)..);
-        history.push(SessionHistoryEntry::new(document, document.url().clone(), document.Title()));
-        self.active_index.set(self.active_index.get() + 1);
-        assert_eq!(self.active_index.get(), history.len() - 1);
+    pub fn set_active_document(&self, document: &Document) {
+        self.active_document.set(Some(document))
     }
 
     pub fn active_document(&self) -> Root<Document> {
-        Root::from_ref(&self.history.borrow()[self.active_index.get()].document)
+        self.active_document.get().expect("No active document.")
     }
 
     pub fn maybe_active_document(&self) -> Option<Root<Document>> {
-        self.history.borrow().get(self.active_index.get()).map(|entry| {
-            Root::from_ref(&*entry.document)
-        })
+        self.active_document.get()
     }
 
     pub fn active_window(&self) -> Root<Window> {
@@ -167,9 +154,8 @@ impl BrowsingContext {
         }).map(|context| context.active_window())
     }
 
-    pub fn clear_session_history(&self) {
-        self.active_index.set(0);
-        self.history.borrow_mut().clear();
+    pub fn unset_active_document(&self) {
+        self.active_document.set(None)
     }
 
     pub fn iter(&self) -> ContextIterator {
@@ -205,27 +191,6 @@ impl Iterator for ContextIterator {
                                               .map(|c| Root::from_ref(&**c)));
         }
         popped
-    }
-}
-
-// This isn't a DOM struct, just a convenience struct
-// without a reflector, so we don't mark this as #[dom_struct]
-#[must_root]
-#[privatize]
-#[derive(JSTraceable, HeapSizeOf)]
-pub struct SessionHistoryEntry {
-    document: JS<Document>,
-    url: Url,
-    title: DOMString,
-}
-
-impl SessionHistoryEntry {
-    fn new(document: &Document, url: Url, title: DOMString) -> SessionHistoryEntry {
-        SessionHistoryEntry {
-            document: JS::from_ref(document),
-            url: url,
-            title: title,
-        }
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The session history is stored in the constellation and accessed via the `History` object, so `BrowsingContext` doesn't need to track it.

cc @jdm @ConnorGBrewster @Ms2ger 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's a refactoring.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13580)

<!-- Reviewable:end -->
