### PR TITLE
Invert conditional and return early for AddEventListener/RemoveEventL…

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -515,21 +515,23 @@ impl EventTargetMethods for EventTarget {
                         ty: DOMString,
                         listener: Option<Rc<EventListener>>,
                         capture: bool) {
-        if let Some(listener) = listener {
-            let mut handlers = self.handlers.borrow_mut();
-            let entry = match handlers.entry(Atom::from(ty)) {
-                Occupied(entry) => entry.into_mut(),
-                Vacant(entry) => entry.insert(EventListeners(vec!())),
-            };
+        let listener = match listener {
+            Some(l) => l,
+            None => return,
+        };
+        let mut handlers = self.handlers.borrow_mut();
+        let entry = match handlers.entry(Atom::from(ty)) {
+            Occupied(entry) => entry.into_mut(),
+            Vacant(entry) => entry.insert(EventListeners(vec!())),
+        };
 
-            let phase = if capture { ListenerPhase::Capturing } else { ListenerPhase::Bubbling };
-            let new_entry = EventListenerEntry {
-                phase: phase,
-                listener: EventListenerType::Additive(listener)
-            };
-            if !entry.contains(&new_entry) {
-                entry.push(new_entry);
-            }
+        let phase = if capture { ListenerPhase::Capturing } else { ListenerPhase::Bubbling };
+        let new_entry = EventListenerEntry {
+            phase: phase,
+            listener: EventListenerType::Additive(listener)
+        };
+        if !entry.contains(&new_entry) {
+            entry.push(new_entry);
         }
     }
 
@@ -538,18 +540,20 @@ impl EventTargetMethods for EventTarget {
                            ty: DOMString,
                            listener: Option<Rc<EventListener>>,
                            capture: bool) {
-        if let Some(ref listener) = listener {
-            let mut handlers = self.handlers.borrow_mut();
-            let entry = handlers.get_mut(&Atom::from(ty));
-            for entry in entry {
-                let phase = if capture { ListenerPhase::Capturing } else { ListenerPhase::Bubbling };
-                let old_entry = EventListenerEntry {
-                    phase: phase,
-                    listener: EventListenerType::Additive(listener.clone())
-                };
-                if let Some(position) = entry.iter().position(|e| *e == old_entry) {
-                    entry.remove(position);
-                }
+        let ref listener = match listener {
+            Some(l) => l,
+            None => return,
+        };
+        let mut handlers = self.handlers.borrow_mut();
+        let entry = handlers.get_mut(&Atom::from(ty));
+        for entry in entry {
+            let phase = if capture { ListenerPhase::Capturing } else { ListenerPhase::Bubbling };
+            let old_entry = EventListenerEntry {
+                phase: phase,
+                listener: EventListenerType::Additive(listener.clone())
+            };
+            if let Some(position) = entry.iter().position(|e| *e == old_entry) {
+                entry.remove(position);
             }
         }
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Cleans up code as described in #13586 by returning early instead of nesting everything in an `if` statement.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13586 

<!-- Either: -->
- [x] These changes do not require tests because the change is a cleanup of code and the author of the issue stated that new tests were not required.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

…istener

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13600)

<!-- Reviewable:end -->
