### PR TITLE
Ensure that SERVO_ENABLE_DEBUG_ASSERTIONS is also used in build-cef

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -324,9 +324,18 @@ class MachCommands(CommandBase):
             opts += ["--features", "%s" % ' '.join("servo/" + x for x in servo_features)]
 
         build_start = time()
+        env = self.build_env(is_build=True)
+
+        # TODO: If this ends up making it, we should probably add a
+        # --release-with-debug-assertions option or similar, so it's easier to
+        # build locally.
+        if env.get("SERVO_ENABLE_DEBUG_ASSERTIONS", None):
+            env["RUSTFLAGS"] = "-C debug_assertions"
+
         with cd(path.join("ports", "cef")):
             ret = call(["cargo", "build"] + opts,
-                       env=self.build_env(is_build=True), verbose=verbose)
+                       env=env,
+                       verbose=verbose)
         elapsed = time() - build_start
 
         # Generate Desktop Notification if elapsed-time > some threshold value


### PR DESCRIPTION
r? @nox 

Fixes #13591

This fixes the problem with rebuilding all of CEF on the linux-rel builders by ensuring it gets the same `RUSTFLAGS`. Proof:

```
[larsberg@larsberg servo2]$ ./mach build-cef -r
   Compiling embedding v0.0.1 (file:///Users/larsberg/servo2/ports/cef)
    Finished release [optimized] target(s) in 35.42 secs
[Warning] Could not generate notification! Optional Python module 'pyobjc' is not installed.
CEF build completed in 0:00:38
[larsberg@larsberg servo2]$ 
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13601)

<!-- Reviewable:end -->
