### PR TITLE
Support multiprocess constellation on Windows

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -43,7 +43,6 @@ use webrender_traits;
 pub enum ChildProcess {
     #[cfg(not(target_os = "windows"))]
     Sandboxed(gaol::platform::process::Process),
-    #[cfg(not(target_os = "windows"))]
     Unsandboxed(process::Child),
 }
 
@@ -530,13 +529,40 @@ impl UnprivilegedPipelineContent {
         Ok(child_process)
     }
 
+    // gaol is not supported on Windows yet, so this is just multiprocess
+    // without sandboxing
     #[cfg(target_os = "windows")]
     pub fn spawn_multiprocess(self) -> Result<ChildProcess, IOError> {
-        error!("Multiprocess is not supported on Windows.");
-        process::exit(1);
+        use ipc_channel::ipc::IpcOneShotServer;
+
+        if opts::get().sandbox {
+            error!("Windows can't create sandboxed child processes yet");
+            process::exit(1);
+        }
+
+        // Note that this function can panic, due to process creation,
+        // avoiding this panic would require a mechanism for dealing
+        // with low-resource scenarios.
+        let (server, token) =
+            IpcOneShotServer::<IpcSender<UnprivilegedPipelineContent>>::new()
+            .expect("Failed to create IPC one-shot server.");
+
+        let child_process = {
+            let path_to_self = env::current_exe()
+                .expect("Failed to get current executor.");
+            let mut child_process = process::Command::new(path_to_self);
+            self.setup_common(&mut child_process, token);
+
+            ChildProcess::Unsandboxed(child_process.spawn()
+                                      .expect("Failed to start unsandboxed child process!"))
+        };
+
+        let (_receiver, sender) = server.accept().expect("Server failed to accept.");
+        try!(sender.send(self));
+
+        Ok(child_process)
     }
 
-    #[cfg(not(windows))]
     fn setup_common<C: CommandMethods>(&self, command: &mut C, token: String) {
         C::arg(command, "--content-process");
         C::arg(command, token);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Allow `-M` on windows to use multiprocess mode.  Sandboxing is still disallowed, as `gaol` is not implemented on Windows.  This depends on https://github.com/servo/ipc-channel/pull/108 to provide windows support in ipc-channel.  At the moment this causes a panic in ipc-channel when run with multiprocess (works fine single process), but I wanted to put this up so that others can test.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13609)

<!-- Reviewable:end -->
