### PR TITLE
Test that Servo_* functions have the right signatures

### DIFF
--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -178,9 +178,6 @@ extern "C" {
     pub fn Gecko_ClearPODTArray(aArray: *mut ::std::os::raw::c_void,
                                 aElementSize: usize, aElementAlign: usize);
 }
-extern "C" {
-    pub fn Servo_Node_ClearNodeData(arg1: *mut nsINode);
-}
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsHTMLCSSStyleSheet {
@@ -800,6 +797,9 @@ extern "C" {
     pub fn Gecko_Destroy_nsStyleEffects(ptr: *mut nsStyleEffects);
 }
 extern "C" {
+    pub fn Servo_Node_ClearNodeData(node: RawGeckoNodeBorrowed);
+}
+extern "C" {
     pub fn Servo_StyleSheet_FromUTF8Bytes(bytes: *const u8, length: u32,
                                           parsing_mode: SheetParsingMode,
                                           base_bytes: *const u8,
@@ -920,7 +920,7 @@ extern "C" {
     pub fn Servo_Shutdown();
 }
 extern "C" {
-    pub fn Servo_ComputeRestyleHint(element: *mut RawGeckoElement,
+    pub fn Servo_ComputeRestyleHint(element: RawGeckoElementBorrowed,
                                     snapshot: *mut ServoElementSnapshot,
                                     set: RawServoStyleSetBorrowed)
      -> nsRestyleHint;
@@ -930,106 +930,122 @@ extern "C" {
                                 set: RawServoStyleSetBorrowedMut);
 }
 extern "C" {
-    pub fn Servo_GetStyleFont(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleFont(computed_values:
+                                  ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleFont;
 }
 extern "C" {
-    pub fn Servo_GetStyleColor(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleColor(computed_values:
+                                   ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleColor;
 }
 extern "C" {
-    pub fn Servo_GetStyleList(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleList(computed_values:
+                                  ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleList;
 }
 extern "C" {
-    pub fn Servo_GetStyleText(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleText(computed_values:
+                                  ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleText;
 }
 extern "C" {
     pub fn Servo_GetStyleVisibility(computed_values:
-                                        ServoComputedValuesBorrowed)
+                                        ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleVisibility;
 }
 extern "C" {
     pub fn Servo_GetStyleUserInterface(computed_values:
-                                           ServoComputedValuesBorrowed)
+                                           ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleUserInterface;
 }
 extern "C" {
     pub fn Servo_GetStyleTableBorder(computed_values:
-                                         ServoComputedValuesBorrowed)
+                                         ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleTableBorder;
 }
 extern "C" {
-    pub fn Servo_GetStyleSVG(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleSVG(computed_values:
+                                 ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleSVG;
 }
 extern "C" {
     pub fn Servo_GetStyleVariables(computed_values:
-                                       ServoComputedValuesBorrowed)
+                                       ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleVariables;
 }
 extern "C" {
     pub fn Servo_GetStyleBackground(computed_values:
-                                        ServoComputedValuesBorrowed)
+                                        ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleBackground;
 }
 extern "C" {
     pub fn Servo_GetStylePosition(computed_values:
-                                      ServoComputedValuesBorrowed)
+                                      ServoComputedValuesBorrowedOrNull)
      -> *const nsStylePosition;
 }
 extern "C" {
     pub fn Servo_GetStyleTextReset(computed_values:
-                                       ServoComputedValuesBorrowed)
+                                       ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleTextReset;
 }
 extern "C" {
-    pub fn Servo_GetStyleDisplay(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleDisplay(computed_values:
+                                     ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleDisplay;
 }
 extern "C" {
-    pub fn Servo_GetStyleContent(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleContent(computed_values:
+                                     ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleContent;
 }
 extern "C" {
-    pub fn Servo_GetStyleUIReset(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleUIReset(computed_values:
+                                     ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleUIReset;
 }
 extern "C" {
-    pub fn Servo_GetStyleTable(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleTable(computed_values:
+                                   ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleTable;
 }
 extern "C" {
-    pub fn Servo_GetStyleMargin(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleMargin(computed_values:
+                                    ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleMargin;
 }
 extern "C" {
-    pub fn Servo_GetStylePadding(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStylePadding(computed_values:
+                                     ServoComputedValuesBorrowedOrNull)
      -> *const nsStylePadding;
 }
 extern "C" {
-    pub fn Servo_GetStyleBorder(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleBorder(computed_values:
+                                    ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleBorder;
 }
 extern "C" {
-    pub fn Servo_GetStyleOutline(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleOutline(computed_values:
+                                     ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleOutline;
 }
 extern "C" {
-    pub fn Servo_GetStyleXUL(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleXUL(computed_values:
+                                 ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleXUL;
 }
 extern "C" {
     pub fn Servo_GetStyleSVGReset(computed_values:
-                                      ServoComputedValuesBorrowed)
+                                      ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleSVGReset;
 }
 extern "C" {
-    pub fn Servo_GetStyleColumn(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleColumn(computed_values:
+                                    ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleColumn;
 }
 extern "C" {
-    pub fn Servo_GetStyleEffects(computed_values: ServoComputedValuesBorrowed)
+    pub fn Servo_GetStyleEffects(computed_values:
+                                     ServoComputedValuesBorrowedOrNull)
      -> *const nsStyleEffects;
 }

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1933,7 +1933,7 @@ clip-path
 <%def name="define_ffi_struct_accessor(style_struct)">
 #[no_mangle]
 #[allow(non_snake_case, unused_variables)]
-pub extern "C" fn Servo_GetStyle${style_struct.gecko_name}(computed_values:
+pub unsafe extern "C" fn Servo_GetStyle${style_struct.gecko_name}(computed_values:
         ServoComputedValuesBorrowedOrNull) -> *const ${style_struct.gecko_ffi_name} {
     ComputedValues::arc_from_borrowed(&computed_values).unwrap().get_${style_struct.name_lower}().get_gecko()
         as *const ${style_struct.gecko_ffi_name}

--- a/ports/geckolib/Cargo.lock
+++ b/ports/geckolib/Cargo.lock
@@ -52,7 +52,6 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -408,9 +407,18 @@ name = "stylo_tests"
 version = "0.0.1"
 dependencies = [
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geckoservo 0.0.1",
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![allow(unsafe_code)]
-
 use app_units::Au;
 use env_logger;
 use euclid::Size2D;

--- a/tests/unit/stylo/Cargo.toml
+++ b/tests/unit/stylo/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 
+build = "build.rs"
+
 [lib]
 name = "stylo_tests"
 path = "lib.rs"
@@ -11,6 +13,15 @@ doctest = false
 
 [dependencies]
 app_units = "0.3"
-cssparser = {version = "0.7", features = ["heap_size"]}
-style = {path = "../../../components/style", features = ["gecko"]}
+env_logger = "0.3"
+euclid = "0.10.1"
+lazy_static = "0.2"
+libc = "0.2"
+log = {version = "0.3.5", features = ["release_max_level_info"]}
+num_cpus = "0.2.2"
+parking_lot = "0.3"
+selectors = "0.13"
+url = "1.2"
 style_traits = {path = "../../../components/style_traits"}
+geckoservo = {path = "../../../ports/geckolib"}
+style = {path = "../../../components/style", features = ["gecko"]}

--- a/tests/unit/stylo/build.rs
+++ b/tests/unit/stylo/build.rs
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=check_bindings.py");
+    println!("cargo:rerun-if-changed=../../../ports/geckolib/glue.rs");
+    assert!(Command::new("python").arg("./check_bindings.py")
+                                  .spawn().unwrap().wait().unwrap().success());
+}

--- a/tests/unit/stylo/check_bindings.py
+++ b/tests/unit/stylo/check_bindings.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import re
+
+ROOT_PATH = os.path.join("..", "..", "..")
+INPUT_FILE = os.path.join(ROOT_PATH, "components", "style", "gecko_bindings", "bindings.rs")
+OUTPUT_FILE = os.path.join(os.environ["OUT_DIR"], "check_bindings.rs")
+GLUE_FILE = os.path.join(ROOT_PATH, "ports", "geckolib", "glue.rs")
+GLUE_OUTPUT_FILE = os.path.join(os.environ["OUT_DIR"], "glue.rs")
+
+TEMPLATE = """\
+    [ Servo_{name}, bindings::Servo_{name} ];
+"""
+
+with open(INPUT_FILE, "r") as bindings, open(OUTPUT_FILE, "w+") as tests:
+    tests.write("fn assert_types() {\n")
+
+    pattern = re.compile("fn\s*Servo_([a-zA-Z0-9_]+)\s*\(")
+
+    for line in bindings:
+        match = pattern.search(line)
+
+        # GetStyleVariables is a Servo_* function, but temporarily defined on
+        # the gecko side
+        if match and match.group(1) != "GetStyleVariables":
+            tests.write(TEMPLATE.format(name=match.group(1)))
+
+    tests.write("}\n")
+
+with open(GLUE_FILE, "r") as glue, open(GLUE_OUTPUT_FILE, "w+") as glue_output:
+    for line in glue:
+        glue_output.write(line.replace("pub extern \"C\" fn", "pub unsafe extern \"C\" fn"))

--- a/tests/unit/stylo/lib.rs
+++ b/tests/unit/stylo/lib.rs
@@ -3,8 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate app_units;
-extern crate cssparser;
+extern crate env_logger;
+extern crate euclid;
+extern crate geckoservo;
+extern crate libc;
+#[macro_use] extern crate log;
+extern crate parking_lot;
 extern crate style;
-extern crate style_traits;
+extern crate url;
 
 mod sanity_checks;
+
+mod servo_function_signatures;
+

--- a/tests/unit/stylo/servo_function_signatures.rs
+++ b/tests/unit/stylo/servo_function_signatures.rs
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![allow(unused)]
+
+use self::glue::*;
+use style::gecko_bindings::bindings;
+use style::gecko_properties::*;
+
+include!(concat!(env!("OUT_DIR"), "/check_bindings.rs"));
+
+#[allow(non_snake_case, unused_unsafe, private_no_mangle_fns)]
+mod glue {
+    // this module pretends to be glue.rs, with the safe functions swapped for unsafe ones. This is
+    // a hack to compensate for the fact that `fn` types cannot coerce to `unsafe fn` types. The
+    // imports are populated with the same things so the type assertion should be equivalent
+    use geckoservo::*;
+    include!(concat!(env!("OUT_DIR"), "/glue.rs"));
+}


### PR DESCRIPTION
Fixes #12992

Needs #13617 

Not very happy with this solution (and perhaps it should be done in pure Rust, though that can be split out as another easy bug).

But it works. The bindings changes are from running a regen on [bug 1308234](https://bugzilla.mozilla.org/show_bug.cgi?id=1308234)

r? @emilio

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13620)

<!-- Reviewable:end -->
