### PR TITLE
webgl: Enable all the tests on linux

### DIFF
--- a/tests/wpt/metadata/webgl/conformance-1.0.3/__dir__.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/__dir__.ini
@@ -1,2 +1,0 @@
-disabled:
-  if os == "linux": https://github.com/servo/servo/issues/9331

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/readPixelsBadArgs.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/readPixelsBadArgs.html.ini
@@ -1,6 +1,8 @@
 [readPixelsBadArgs.html]
   type: testharness
-  expected: TIMEOUT
+  expected:
+    if os == "linux": CRASH
+    if os == "mac": TIMEOUT
   [WebGL test #0: testReadPixels]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/reading/read-pixels-pack-alignment.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/reading/read-pixels-pack-alignment.html.ini
@@ -1,6 +1,8 @@
 [read-pixels-pack-alignment.html]
   type: testharness
-  expected: TIMEOUT
+  expected:
+    if os == "linux": CRASH
+    if os == "mac": TIMEOUT
   [WebGL test #3: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-npot-video.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-npot-video.html.ini
@@ -1,5 +1,3 @@
 [texture-npot-video.html]
   type: testharness
-  expected:
-    if os == "linux": CRASH
-    if os == "mac": TIMEOUT
+  expected: TIMEOUT

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/uniform-default-values.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/uniforms/uniform-default-values.html.ini
@@ -1,5 +1,3 @@
 [uniform-default-values.html]
   type: testharness
-  expected:
-    if os == "linux": CRASH
-    if os == "mac": ERROR
+  expected: ERROR


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Now that testing is being done using OSMesa on the Linux side as well,
our test behavior matches Mac's pretty closely.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13629)

<!-- Reviewable:end -->
