### PR TITLE
Send touch events to root pipeline, and allow forwarding to iframes.

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -874,22 +874,10 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                 debug!("constellation got focus message");
                 self.handle_focus_msg(pipeline_id);
             }
-            FromScriptMsg::ForwardMouseButtonEvent(pipeline_id, event_type, button, point) => {
-                let event = CompositorEvent::MouseButtonEvent(event_type, button, point);
+            FromScriptMsg::ForwardEvent(pipeline_id, event) => {
                 let msg = ConstellationControlMsg::SendEvent(pipeline_id, event);
                 let result = match self.pipelines.get(&pipeline_id) {
-                    None => { debug!("Pipeline {:?} got mouse button event after closure.", pipeline_id); return; }
-                    Some(pipeline) => pipeline.script_chan.send(msg),
-                };
-                if let Err(e) = result {
-                    self.handle_send_error(pipeline_id, e);
-                }
-            }
-            FromScriptMsg::ForwardMouseMoveEvent(pipeline_id, point) => {
-                let event = CompositorEvent::MouseMoveEvent(Some(point));
-                let msg = ConstellationControlMsg::SendEvent(pipeline_id, event);
-                let result = match self.pipelines.get(&pipeline_id) {
-                    None => { debug!("Pipeline {:?} got mouse move event after closure.", pipeline_id); return; }
+                    None => { debug!("Pipeline {:?} got event after closure.", pipeline_id); return; }
                     Some(pipeline) => pipeline.script_chan.send(msg),
                 };
                 if let Err(e) = result {

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -3,10 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use AnimationState;
+use CompositorEvent;
 use DocumentState;
 use IFrameLoadInfo;
-use MouseButton;
-use MouseEventType;
 use MozBrowserEvent;
 use WorkerGlobalScopeInit;
 use WorkerScriptLoadOrigin;
@@ -72,10 +71,8 @@ pub enum ScriptMsg {
                            IpcSender<Result<(IpcSender<CanvasMsg>, GLLimits), String>>),
     /// Notifies the constellation that this frame has received focus.
     Focus(PipelineId),
-    /// Re-send a mouse button event that was sent to the parent window.
-    ForwardMouseButtonEvent(PipelineId, MouseEventType, MouseButton, Point2D<f32>),
-    /// Re-send a mouse move event that was sent to the parent window.
-    ForwardMouseMoveEvent(PipelineId, Point2D<f32>),
+    /// Forward an event that was sent to the parent window.
+    ForwardEvent(PipelineId, CompositorEvent),
     /// Requests that the constellation retrieve the current contents of the clipboard
     GetClipboardContents(IpcSender<String>),
     /// <head> tag finished parsing


### PR DESCRIPTION
Instead of letting the compositor try to find the correct scroll
layer for a touch event, switch touch events to work the same way
that mouse events do.

Touch events are now dispatched to the root pipeline, and then
forwarded to child iframes as required.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13633)

<!-- Reviewable:end -->
