### PR TITLE
Blind attempt to fix #13626

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -44,7 +44,7 @@ pub use self::declaration_block::*;
     import os.path
 %>
 
-#[path="${os.path.join(os.path.dirname(__file__), 'declaration_block.rs')}"]
+#[path="${repr(os.path.join(os.path.dirname(__file__), 'declaration_block.rs'))[1:-1]}"]
 pub mod declaration_block;
 
 pub mod longhands {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The error message was:

```
error: unknown character escape: d
  --> C:\projects\servo\target\debug\build\style-9b556a6c7bb4f044\out/properties.rs:44:55
   |
44 | #[path="C:/projects/servo/components/style/properties\declaration_block.rs"]
   |
```

Use `repr()` to get a Python string literal (whose character escaping is compatible enough with Rust’s) and `[1:-1]` to remove the single quotes.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13626 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13634)

<!-- Reviewable:end -->
