### PR TITLE
Define NATIVE_WIN32_PYTHON environment variable

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -399,6 +399,10 @@ class CommandBase(object):
             # Link moztools
             env["MOZTOOLS_PATH"] = path.join(msvc_deps_dir, "moztools", "bin")
 
+        if is_windows():
+            if not os.environ.get("NATIVE_WIN32_PYTHON"):
+                env["NATIVE_WIN32_PYTHON"] = sys.executable
+
         if not self.config["tools"]["system-rust"] \
                 or self.config["tools"]["rust-root"]:
             env["RUST_ROOT"] = self.config["tools"]["rust-root"]


### PR DESCRIPTION
r? @Wafflespeanut or @larsbergstrom 

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13650)

<!-- Reviewable:end -->
