### PR TITLE
Refactor style logic to avoid direct access to the node data during the cascade

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -627,7 +627,7 @@ pub fn process_node_scroll_area_request< N: LayoutNode>(requested_node: N, layou
 fn ensure_node_data_initialized<N: LayoutNode>(node: &N) {
     let mut cur = Some(node.clone());
     while let Some(current) = cur {
-        if current.borrow_data().is_some() {
+        if current.borrow_layout_data().is_some() {
             break;
         }
 

--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -68,7 +68,7 @@ impl<T: LayoutNode> LayoutNodeLayoutData for T {
     }
 
     fn initialize_data(self) {
-        if self.borrow_data().is_none() {
+        if self.borrow_layout_data().is_none() {
             let ptr: NonOpaqueStyleAndLayoutData =
                 Box::into_raw(box AtomicRefCell::new(PersistentLayoutData::new()));
             let opaque = OpaqueStyleAndLayoutData {

--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -10,13 +10,14 @@ use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use std::sync::Arc;
 
+pub type PseudoStyles = HashMap<PseudoElement, Arc<ComputedValues>,
+                                BuildHasherDefault<::fnv::FnvHasher>>;
 pub struct PersistentStyleData {
     /// The results of CSS styling for this node.
     pub style: Option<Arc<ComputedValues>>,
 
     /// The results of CSS styling for each pseudo-element (if any).
-    pub per_pseudo: HashMap<PseudoElement, Arc<ComputedValues>,
-                            BuildHasherDefault<::fnv::FnvHasher>>,
+    pub per_pseudo: PseudoStyles,
 }
 
 impl PersistentStyleData {

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -260,7 +260,7 @@ pub extern "C" fn Servo_StyleSheet_Release(sheet: RawServoStyleSheetBorrowed) ->
 pub extern "C" fn Servo_ComputedValues_Get(node: RawGeckoNodeBorrowed)
      -> ServoComputedValuesStrong {
     let node = GeckoNode(node);
-    let arc_cv = match node.borrow_data().map_or(None, |data| data.style.clone()) {
+    let arc_cv = match node.get_existing_style() {
         Some(style) => style,
         None => {
             // FIXME(bholley): This case subverts the intended semantics of this
@@ -322,10 +322,7 @@ pub extern "C" fn Servo_ComputedValues_GetForPseudoElement(parent_style: ServoCo
     match GeckoSelectorImpl::pseudo_element_cascade_type(&pseudo) {
         PseudoElementCascadeType::Eager => {
             let node = element.as_node();
-            let maybe_computed = node.borrow_data()
-                                     .and_then(|data| {
-                                         data.per_pseudo.get(&pseudo).map(|c| c.clone())
-                                     });
+            let maybe_computed = node.get_pseudo_style(&pseudo);
             maybe_computed.map_or_else(parent_or_null, FFIArcHelpers::into_strong)
         }
         PseudoElementCascadeType::Lazy => {


### PR DESCRIPTION
The new restyle architecture doesn't store these things in consistent places, so we need a more abstract API.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13656)

<!-- Reviewable:end -->
