### PR TITLE
Warn and exit mach if it detects MinGW Python

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -195,6 +195,14 @@ def bootstrap(topdir):
         print('Current path:', topdir)
         sys.exit(1)
 
+    # We don't support MinGW Python
+    if os.path.join(os.sep, 'mingw64', 'bin') in sys.executable:
+        print('Cannot run mach with MinGW Python.')
+        print('\nPlease rename following files:')
+        print(' /mingw64/bin/python2.exe   -> /mingw64/bin/python2-mingw64.exe')
+        print(' /mingw64/bin/python2.7.exe -> /mingw64/bin/python2.7-mingw64.exe')
+        sys.exit(1)
+
     # Ensure we are running Python 2.7+. We put this check here so we generate a
     # user-friendly error message rather than a cryptic stack trace on module import.
     if not (3, 0) > sys.version_info >= (2, 7):


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

r? @Wafflespeanut 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13644

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13661)

<!-- Reviewable:end -->
