### PR TITLE
changed set_value() to set() in gecko.mako.rs

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1530,7 +1530,7 @@ fn static_assert() {
 
     pub fn set_letter_spacing(&mut self, v: longhands::letter_spacing::computed_value::T) {
         match v.0 {
-            Some(au) => self.gecko.mLetterSpacing.set_value(CoordDataValue::Coord(au.0)),
+            Some(au) => self.gecko.mLetterSpacing.set(au),
             None => self.gecko.mLetterSpacing.set_value(CoordDataValue::Normal)
         }
     }
@@ -1541,11 +1541,7 @@ fn static_assert() {
         use values::computed::LengthOrPercentage::*;
 
         match v.0 {
-            Some(lop) => match lop {
-                Length(au) => self.gecko.mWordSpacing.set_value(CoordDataValue::Coord(au.0)),
-                Percentage(f) => self.gecko.mWordSpacing.set_value(CoordDataValue::Percent(f)),
-                Calc(l_p) => self.gecko.mWordSpacing.set_value(CoordDataValue::Calc(l_p.into())),
-            },
+            Some(lop) => self.gecko.mWordSpacing.set(lop),
             // https://drafts.csswg.org/css-text-3/#valdef-word-spacing-normal
             None => self.gecko.mWordSpacing.set_value(CoordDataValue::Coord(0)),
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Changed `set_value()` to `set()` in gecko.mako.rs

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13657 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because just the `set_value()` call was changed to `set()`

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13663)

<!-- Reviewable:end -->
