### PR TITLE
Don't pref-gate properties in geckolib mode

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -60,7 +60,7 @@
         match_ignore_ascii_case! { try!(input.expect_ident()),
             % for value in values:
                 "${value}" => {
-                    % if value in experimental_values:
+                    % if value in experimental_values and product == "servo":
                         if !::util::prefs::PREFS.get("layout.${value}.enabled")
                             .as_boolean().unwrap_or(false) {
                             return Err(())

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -767,7 +767,7 @@ impl PropertyDeclaration {
                                 return PropertyDeclarationParseResult::UnknownProperty
                             }
                         % endif
-                        % if property.experimental:
+                        % if property.experimental and product == "servo":
                             if !::util::prefs::PREFS.get("${property.experimental}")
                                 .as_boolean().unwrap_or(false) {
                                 return PropertyDeclarationParseResult::ExperimentalProperty
@@ -797,7 +797,7 @@ impl PropertyDeclaration {
                             return PropertyDeclarationParseResult::UnknownProperty
                         }
                     % endif
-                    % if shorthand.experimental:
+                    % if shorthand.experimental and product == "servo":
                         if !::util::prefs::PREFS.get("${shorthand.experimental}")
                             .as_boolean().unwrap_or(false) {
                             return PropertyDeclarationParseResult::ExperimentalProperty

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -504,7 +504,8 @@ impl<'a, 'b> AtRuleParser for NestedRuleParser<'a, 'b> {
                 Ok(AtRuleType::WithBlock(AtRulePrelude::FontFace))
             },
             "viewport" => {
-                if ::util::prefs::PREFS.get("layout.viewport.enabled").as_boolean().unwrap_or(false) {
+                if ::util::prefs::PREFS.get("layout.viewport.enabled").as_boolean().unwrap_or(false) ||
+                   cfg!(feature = "gecko") {
                     Ok(AtRuleType::WithBlock(AtRulePrelude::Viewport))
                 } else {
                     Err(())


### PR DESCRIPTION
This led to me wasting a lot of time trying to figure out why my column-count implementation in gecko didn't work.

We might eventually want to hook into the Gecko prefs, but the mechanism would probably be different

r? @emilio

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13673)

<!-- Reviewable:end -->
