### PR TITLE
Fix margin size calculation for TableWrapper

### DIFF
--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -778,7 +778,13 @@ fn initial_computed_inline_size(block: &mut BlockFlow,
                                                        containing_block_inline_size);
     match inline_size_from_style {
         MaybeAuto::Auto => {
-            MaybeAuto::Specified(min(containing_block_inline_size, preferred_width_of_all_columns))
+            if preferred_width_of_all_columns + table_border_padding <= containing_block_inline_size {
+                MaybeAuto::Specified(preferred_width_of_all_columns + table_border_padding)
+            } else if minimum_width_of_all_columns > containing_block_inline_size {
+                MaybeAuto::Specified(minimum_width_of_all_columns)
+            } else {
+                MaybeAuto::Auto
+            }
         }
         MaybeAuto::Specified(inline_size_from_style) => {
             MaybeAuto::Specified(max(inline_size_from_style - table_border_padding,

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5220,6 +5220,18 @@
             "url": "/_mozilla/css/table_intrinsic_style_specified_width_a.html"
           }
         ],
+        "css/table_margin_a.html": [
+          {
+            "path": "css/table_margin_a.html",
+            "references": [
+              [
+                "/_mozilla/css/table_margin_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/table_margin_a.html"
+          }
+        ],
         "css/table_margin_auto_a.html": [
           {
             "path": "css/table_margin_auto_a.html",
@@ -20284,6 +20296,18 @@
             ]
           ],
           "url": "/_mozilla/css/table_intrinsic_style_specified_width_a.html"
+        }
+      ],
+      "css/table_margin_a.html": [
+        {
+          "path": "css/table_margin_a.html",
+          "references": [
+            [
+              "/_mozilla/css/table_margin_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/table_margin_a.html"
         }
       ],
       "css/table_margin_auto_a.html": [

--- a/tests/wpt/mozilla/tests/css/table_margin_a.html
+++ b/tests/wpt/mozilla/tests/css/table_margin_a.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="match" href="table_margin_ref.html" />
+    <style type="text/css">
+    table.ombox {
+      margin: 0 0 0 50%;
+      background: #f9f9f9;
+    }
+
+    td, tr, table {
+      padding: 0;
+      margin: 0;
+    }
+
+    .template-documentation {
+      width: 100%;
+      background-color: #ecfcf4;
+      padding: 0;
+    }
+    </style>
+  </head>
+  <body>
+    <div class="template-documentation">
+      <table class="ombox">
+        <tr>
+          <td>
+            This is a test. This line is large, large enough so that it will wrap.
+            Issue #12748, for which this test was created, is about the table margin not behaving correctly.
+          </td>
+        </tr>
+      </table>
+    </div>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/table_margin_ref.html
+++ b/tests/wpt/mozilla/tests/css/table_margin_ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style type="text/css">
+    .ombox {
+      margin-left: 50%;
+      background: #f9f9f9;
+      padding: 2px;
+    }
+    .template-documentation {
+      background-color: #ecfcf4;
+      width: 100%;
+    }
+    </style>
+  </head>
+  <body>
+    <div class="template-documentation">
+      <div class="ombox">
+        This is a test. This line is large, large enough so that it will wrap.
+        Issue #12748, for which this test was created, is about the table margin not behaving correctly.
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fixes inline size calculation for TableWrapper. The table's width was always reaching the inline size equation solver as a specified variable, which was causing the system to be overdetermined when there was a margin specified for the table, and this caused the overflow reported in #12748. The fix consists in handling three cases when the table's width is not specified: if the preferred size of all columns fits, it is returned; if the minimum size does not fit, it is returned instead (it will overflow), otherwise, it is returned as a free variable (that should be solved together with the margin to some value above the minimum width and below the preferred width).

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12748
- [X] There are tests for these changes

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13681)

<!-- Reviewable:end -->
