### PR TITLE
layout: Don't use the existing block position as the float ceiling when placing block formatting contexts in the sequential fallback.

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1494,11 +1494,9 @@ impl BlockFlow {
         debug_assert!(!self.is_flex());
 
         // Compute the available space for us, based on the actual floats.
-        let rect = self.base.floats.available_rect(
-            self.base.position.start.b,
-            self.fragment.border_box.size.block,
-            content_box.size.inline
-        );
+        let rect = self.base.floats.available_rect(Au(0),
+                                                   self.fragment.border_box.size.block,
+                                                   content_box.size.inline);
         let available_inline_size = if let Some(rect) = rect {
             // Offset our position by whatever displacement is needed to not impact the floats.
             // Also, account for margins sliding behind floats.


### PR DESCRIPTION
The existing block position isn't yet computed at that time, so it
contains junk data. It just so happened to work on first reflow because
that value is usually set to zero, but it usually failed on subsequent
reflows.

Improves certain Wikipedia pages.

Closes #13630 (though Google is still broken; it was a separate bug and
will be split off into a separate issue).

r? @notriddle

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13685)

<!-- Reviewable:end -->
