### PR TITLE
Fix return types of Owned<T>::into_box Gecko sugar types.

### DIFF
--- a/components/style/gecko_bindings/sugar/ownership.rs
+++ b/components/style/gecko_bindings/sugar/ownership.rs
@@ -204,7 +204,7 @@ pub struct Owned<T> {
 
 impl<T> Owned<T> {
     /// Owned<GeckoType> -> Box<ServoType>
-    pub fn into_box<U>(self) -> Box<T> where U: HasBoxFFI<FFIType = T> {
+    pub fn into_box<U>(self) -> Box<U> where U: HasBoxFFI<FFIType = T> {
         unsafe { transmute(self) }
     }
     pub fn maybe(self) -> OwnedOrNull<T> {
@@ -238,7 +238,7 @@ impl<T> OwnedOrNull<T> {
         self.ptr == ptr::null_mut()
     }
     /// OwnedOrNull<GeckoType> -> Option<Box<ServoType>>
-    pub fn into_box_opt<U>(self) -> Option<Box<T>> where U: HasBoxFFI<FFIType = T> {
+    pub fn into_box_opt<U>(self) -> Option<Box<U>> where U: HasBoxFFI<FFIType = T> {
         if self.is_null() {
             None
         } else {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

We're not transmuting to the right type.  The only current use of `into_box` is to drop a `PerDocumentStyleData`, so we weren't accidentally doing anything terribly bad, just not calling the `Drop` impl for that type.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13692)

<!-- Reviewable:end -->
