### PR TITLE
Correct the unicode codes used for tree printing

### DIFF
--- a/components/gfx_traits/print_tree.rs
+++ b/components/gfx_traits/print_tree.rs
@@ -15,7 +15,7 @@ pub struct PrintTree {
 
 impl PrintTree {
     pub fn new(title: String) -> PrintTree {
-        println!("\u{9484} {}", title);
+        println!("\u{250c} {}", title);
         PrintTree {
             level: 1,
             queued_item: None,
@@ -24,29 +24,29 @@ impl PrintTree {
 
     /// Descend one level in the tree with the given title.
     pub fn new_level(&mut self, title: String) {
-        self.flush_queued_item("\u{9500}\u{9472}");
+        self.flush_queued_item("\u{251C}\u{2500}");
 
         self.print_level_prefix();
-        println!("\u{9500}\u{9472} {}", title);
+        println!("\u{251C}\u{2500} {}", title);
 
         self.level = self.level + 1;
     }
 
     /// Ascend one level in the tree.
     pub fn end_level(&mut self) {
-        self.flush_queued_item("\u{9492}\u{9472}");
+        self.flush_queued_item("\u{2514}\u{2500}");
         self.level = self.level - 1;
     }
 
     /// Add an item to the current level in the tree.
     pub fn add_item(&mut self, text: String) {
-        self.flush_queued_item("\u{9500}\u{9472}");
+        self.flush_queued_item("\u{251C}\u{2500}");
         self.queued_item = Some(text);
     }
 
     fn print_level_prefix(&self) {
         for _ in 0..self.level {
-            print!("\u{9474}  ");
+            print!("\u{2502}  ");
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the tree printing code is untested and this is just a correction of a build fix.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

These were converted from inline UTF-8 to escape sequences, but the
sequences should be in hexadecimal instead of decimal.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13693)

<!-- Reviewable:end -->
