### PR TITLE
Implement -moz-text-align-last property

### DIFF
--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -395,6 +395,13 @@ ${helpers.single_keyword("text-justify",
                          products="servo",
                          animatable=False)}
 
+${helpers.single_keyword("-moz-text-align-last",
+                         "auto start end left right center justify",
+                         products="gecko",
+                         gecko_constant_prefix="NS_STYLE_TEXT_ALIGN",
+                         gecko_ffi_name="mTextAlignLast",
+                         animatable=False)}
+
 <%helpers:longhand name="-servo-text-decorations-in-effect"
                    derived_from="display text-decoration"
                    need_clone="True" products="servo"


### PR DESCRIPTION
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13638  (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

The test page in Firefox:
<img width="1392" alt="firefox" src="https://cloud.githubusercontent.com/assets/5279150/19276203/a43b486c-8fa3-11e6-9b56-a4cf45217e52.png">

The test page in Stylo:
<img width="1392" alt="servo" src="https://cloud.githubusercontent.com/assets/5279150/19276213/a9c7704e-8fa3-11e6-858b-d6e5f67d3a6c.png">

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13698)

<!-- Reviewable:end -->
