### PR TITLE
Run bindings tests with whole crate

### DIFF
--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 [lib]
 name = "style"
 path = "lib.rs"
+doctest = false
 
 [features]
 gecko = []

--- a/components/style/binding_tools/regen.py
+++ b/components/style/binding_tools/regen.py
@@ -11,7 +11,6 @@ import argparse
 import platform
 import copy
 import subprocess
-import tempfile
 
 import regen_atoms
 
@@ -42,7 +41,6 @@ COMPILATION_TARGETS = {
     # Generation of style structs.
     "structs": {
         "target_dir": "../gecko_bindings",
-        "test": True,
         "flags": [
             "--ignore-functions",
             "--ignore-methods",
@@ -542,48 +540,10 @@ Option<&'a {0}>;".format(ty))
         return 1
 
     print("OK")
+    print("(please test with ./mach test-stylo)")
 
     if verbose:
         print(output)
-
-    if current_target.get("test", False) and not skip_test:
-        print("[RUSTC]... ", end='')
-        sys.stdout.flush()
-
-        with tempfile.NamedTemporaryFile(delete=False) as f:
-            test_file = f.name
-        output = None
-        try:
-            rustc_command = ["rustc", output_filename, "--test", "-o", test_file]
-            output = subprocess.check_output(rustc_command, stderr=subprocess.STDOUT)
-            output = output.decode('utf8')
-        except subprocess.CalledProcessError as e:
-            print("FAIL\n", e.output.decode('utf8'))
-            return 1
-
-        print("OK")
-
-        if verbose:
-            print(output)
-
-        print("[RUSTC_TEST]... ", end='')
-        sys.stdout.flush()
-
-        try:
-            output = subprocess.check_output([test_file], stderr=subprocess.STDOUT)
-            output = output.decode('utf8')
-        except subprocess.CalledProcessError as e:
-            print("tests failed: ", e.output.decode('utf8'))
-            return 1
-
-        os.remove(test_file)
-        print("OK")
-
-        # TODO: this -3 is hacky as heck
-        print(output.split('\n')[-3])
-
-        if verbose:
-            print(output)
 
     return 0
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -260,7 +260,9 @@ class MachCommands(CommandBase):
     @Command('test-stylo',
              description='Run stylo unit tests',
              category='testing')
-    def test_stylo(self):
+    @CommandArgument('--release', default=False, action="store_true",
+                     help="Run with a release build of servo")
+    def test_stylo(self, release=False):
         self.set_use_stable_rust()
         self.ensure_bootstrapped()
 
@@ -268,8 +270,14 @@ class MachCommands(CommandBase):
         env["RUST_BACKTRACE"] = "1"
         env["CARGO_TARGET_DIR"] = path.join(self.context.topdir, "target", "geckolib").encode("UTF-8")
 
+        release = ["--release"] if release else []
+        ret = 0
         with cd(path.join("ports", "geckolib")):
-            return call(["cargo", "test", "-p", "stylo_tests"], env=env)
+            ret = call(["cargo", "test", "-p", "stylo_tests"] + release, env=env)
+        if ret != 0:
+            return ret
+        with cd(path.join("ports", "geckolib")):
+            return call(["cargo", "test", "-p", "style"] + release, env=env)
 
     @Command('test-compiletest',
              description='Run compiletests',


### PR DESCRIPTION
We currently run bindgen's autogenerated `#[test]` blocks directly on the structs files.

That is, after generating them, we run `rustc --test` on them. This works fine for now, but
if you want to refer to types defined outside of these files (e.g. in https://bugzilla.mozilla.org/show_bug.cgi?id=1309165),
the tests are broken.

This puts a `cargo test -p style` in `./mach test-stylo`. I disabled doctests because they were failing (unable to find the `ns!()` and `atom!()` macros), and I couldn't figure out why -- will investigate in a later bug.

r? @emilio

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13700)

<!-- Reviewable:end -->
