### PR TITLE
layout: Don't touch the inline positions of block children unless they are to be reflowed.

### DIFF
--- a/tests/html/incremental_float.html
+++ b/tests/html/incremental_float.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+.float {
+    float: right;
+}
+.bad {
+    display: inline-block;
+    background-color: gray;
+    height: 30px;
+    width: 30px;
+}
+.bad:hover {
+    opacity: .85;
+}
+</style>
+<div class=float>
+    <a class="bad"></a>
+</div>
+<p style="clear: both">Mouse over the preceding gray square. It should change color but remain in place.</p>
+


### PR DESCRIPTION
See the comment added to
`BlockFlow::propagate_assigned_inline_size_to_children()` for details.

Closes #13704.

r? @notriddle

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13705)

<!-- Reviewable:end -->
