### PR TITLE
Remove test-geckolib, run test-stylo on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
          - ./mach test-compiletest
          - ./mach test-unit
          - ./mach build-geckolib
-         - ./mach test-geckolib
+         - ./mach test-stylo
          - bash etc/ci/check_no_unwrap.sh
          - bash etc/ci/lockfile_changed.sh
          - bash etc/ci/manifest_changed.sh

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -62,7 +62,7 @@ extern crate heapsize;
 #[allow(unused_extern_crates)]
 #[macro_use]
 extern crate lazy_static;
-extern crate libc;
+#[cfg(feature = "gecko")] extern crate libc;
 #[macro_use]
 extern crate log;
 #[allow(unused_extern_crates)]

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -158,17 +158,6 @@ class MachCommands(CommandBase):
                     return suite
         return None
 
-    @Command('test-geckolib',
-             description='Test geckolib sanity checks',
-             category='testing')
-    def test_geckolib(self):
-        self.ensure_bootstrapped()
-
-        env = self.build_env()
-        env["RUST_BACKTRACE"] = "1"
-
-        return call(["cargo", "test"], env=env, cwd=path.join("ports", "geckolib"))
-
     @Command('test-perf',
              description='Run the page load performance test',
              category='testing')


### PR DESCRIPTION
test-geckolib used to do things, but almost all of geckolib has been moved to the style crate, with the tests in `tests/unit/stylo`. (`./mach test-stylo) Now test-geckolib does nothing.

Fixes #13721
r? @jdm

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13722)

<!-- Reviewable:end -->
