### PR TITLE
Setting a devtools timeline marker may fail, due to pipeline lookup failure

### DIFF
--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -190,6 +190,7 @@ pub struct AutoMargins {
 }
 
 /// Messages to process in a particular script thread, as instructed by a devtools client.
+/// TODO: better error handling, e.g. if pipeline id lookup fails?
 #[derive(Deserialize, Serialize)]
 pub enum DevtoolScriptControlMsg {
     /// Evaluate a JS snippet in the context of the global for the given pipeline.
@@ -209,7 +210,7 @@ pub enum DevtoolScriptControlMsg {
     /// Request live console messages for a given pipeline (true if desired, false otherwise).
     WantsLiveNotifications(PipelineId, bool),
     /// Request live notifications for a given set of timeline events for a given pipeline.
-    SetTimelineMarkers(PipelineId, Vec<TimelineMarkerType>, IpcSender<TimelineMarker>),
+    SetTimelineMarkers(PipelineId, Vec<TimelineMarkerType>, IpcSender<Option<TimelineMarker>>),
     /// Withdraw request for live timeline notifications for a given pipeline.
     DropTimelineMarkers(PipelineId, Vec<TimelineMarkerType>),
     /// Request a callback directed at the given actor name from the next animation frame

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -250,16 +250,21 @@ pub fn handle_wants_live_notifications(global: &GlobalScope, send_notifications:
 }
 
 pub fn handle_set_timeline_markers(context: &BrowsingContext,
+                                   pipeline: PipelineId,
                                    marker_types: Vec<TimelineMarkerType>,
-                                   reply: IpcSender<TimelineMarker>) {
-    let window = context.active_window();
-    window.set_devtools_timeline_markers(marker_types, reply);
+                                   reply: IpcSender<Option<TimelineMarker>>) {
+    match context.find(pipeline) {
+        None => reply.send(None).unwrap(),
+        Some(context) => context.active_window().set_devtools_timeline_markers(marker_types, reply),
+    }
 }
 
 pub fn handle_drop_timeline_markers(context: &BrowsingContext,
+                                    pipeline: PipelineId,
                                     marker_types: Vec<TimelineMarkerType>) {
-    let window = context.active_window();
-    window.drop_devtools_timeline_markers(marker_types);
+    if let Some(context) = context.find(pipeline) {
+        context.active_window().drop_devtools_timeline_markers(marker_types);
+    }
 }
 
 pub fn handle_request_animation_frame(context: &BrowsingContext,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -172,7 +172,7 @@ pub struct Window {
     /// no devtools server
     devtools_markers: DOMRefCell<HashSet<TimelineMarkerType>>,
     #[ignore_heap_size_of = "channels are hard"]
-    devtools_marker_sender: DOMRefCell<Option<IpcSender<TimelineMarker>>>,
+    devtools_marker_sender: DOMRefCell<Option<IpcSender<Option<TimelineMarker>>>>,
 
     /// Pending resize event, if any.
     resize_event: Cell<Option<(WindowSizeData, WindowSizeType)>>,
@@ -1435,12 +1435,12 @@ impl Window {
     pub fn emit_timeline_marker(&self, marker: TimelineMarker) {
         let sender = self.devtools_marker_sender.borrow();
         let sender = sender.as_ref().expect("There is no marker sender");
-        sender.send(marker).unwrap();
+        sender.send(Some(marker)).unwrap();
     }
 
     pub fn set_devtools_timeline_markers(&self,
                                          markers: Vec<TimelineMarkerType>,
-                                         reply: IpcSender<TimelineMarker>) {
+                                         reply: IpcSender<Option<TimelineMarker>>) {
         *self.devtools_marker_sender.borrow_mut() = Some(reply);
         self.devtools_markers.borrow_mut().extend(markers.into_iter());
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1004,8 +1004,8 @@ impl ScriptThread {
                 devtools::handle_get_children(&context, id, node_id, reply),
             DevtoolScriptControlMsg::GetLayout(id, node_id, reply) =>
                 devtools::handle_get_layout(&context, id, node_id, reply),
-            DevtoolScriptControlMsg::GetCachedMessages(pipeline_id, message_types, reply) =>
-                devtools::handle_get_cached_messages(pipeline_id, message_types, reply),
+            DevtoolScriptControlMsg::GetCachedMessages(id, message_types, reply) =>
+                devtools::handle_get_cached_messages(id, message_types, reply),
             DevtoolScriptControlMsg::ModifyAttribute(id, node_id, modifications) =>
                 devtools::handle_modify_attribute(&context, id, node_id, modifications),
             DevtoolScriptControlMsg::WantsLiveNotifications(id, to_send) => {
@@ -1015,14 +1015,14 @@ impl ScriptThread {
                 };
                 devtools::handle_wants_live_notifications(window.upcast(), to_send)
             },
-            DevtoolScriptControlMsg::SetTimelineMarkers(_pipeline_id, marker_types, reply) =>
-                devtools::handle_set_timeline_markers(&context, marker_types, reply),
-            DevtoolScriptControlMsg::DropTimelineMarkers(_pipeline_id, marker_types) =>
-                devtools::handle_drop_timeline_markers(&context, marker_types),
-            DevtoolScriptControlMsg::RequestAnimationFrame(pipeline_id, name) =>
-                devtools::handle_request_animation_frame(&context, pipeline_id, name),
-            DevtoolScriptControlMsg::Reload(pipeline_id) =>
-                devtools::handle_reload(&context, pipeline_id),
+            DevtoolScriptControlMsg::SetTimelineMarkers(id, marker_types, reply) =>
+                devtools::handle_set_timeline_markers(&context, id, marker_types, reply),
+            DevtoolScriptControlMsg::DropTimelineMarkers(id, marker_types) =>
+                devtools::handle_drop_timeline_markers(&context, id, marker_types),
+            DevtoolScriptControlMsg::RequestAnimationFrame(id, name) =>
+                devtools::handle_request_animation_frame(&context, id, name),
+            DevtoolScriptControlMsg::Reload(id) =>
+                devtools::handle_reload(&context, id),
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Allow setting a devtools timeline marker to fail, due to pipeline lookup failure. This is part of tidying up pipeline lookup.

cc @jdm

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because I'm not sure how to test devtools.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13728)

<!-- Reviewable:end -->
