### PR TITLE
layout: Use the margin box for vertical positioning of `inline-block` fragments if `overflow` is not `visible` per CSS 2.1 § 10.8.1.

### DIFF
--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_box-clear.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_box-clear.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_box-clear.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/vertical-align-baseline-004a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/vertical-align-baseline-004a.htm.ini
@@ -1,3 +1,0 @@
-[vertical-align-baseline-004a.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/vertical-align-baseline-005a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/vertical-align-baseline-005a.htm.ini
@@ -1,3 +1,0 @@
-[vertical-align-baseline-005a.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2540,6 +2540,18 @@
             "url": "/_mozilla/css/inline_block_centering_a.html"
           }
         ],
+        "css/inline_block_explicit_height_a.html": [
+          {
+            "path": "css/inline_block_explicit_height_a.html",
+            "references": [
+              [
+                "/_mozilla/css/inline_block_explicit_height_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/inline_block_explicit_height_a.html"
+          }
+        ],
         "css/inline_block_height_with_out_of_flow_child_a.html": [
           {
             "path": "css/inline_block_height_with_out_of_flow_child_a.html",
@@ -2622,18 +2634,6 @@
               ]
             ],
             "url": "/_mozilla/css/inline_block_opacity_change.html"
-          }
-        ],
-        "css/inline_block_overflow.html": [
-          {
-            "path": "css/inline_block_overflow.html",
-            "references": [
-              [
-                "/_mozilla/css/inline_block_overflow_ref.html",
-                "=="
-              ]
-            ],
-            "url": "/_mozilla/css/inline_block_overflow.html"
           }
         ],
         "css/inline_block_overflow_hidden_a.html": [
@@ -16322,6 +16322,18 @@
           "url": "/_mozilla/css/inline_block_centering_a.html"
         }
       ],
+      "css/inline_block_explicit_height_a.html": [
+        {
+          "path": "css/inline_block_explicit_height_a.html",
+          "references": [
+            [
+              "/_mozilla/css/inline_block_explicit_height_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/inline_block_explicit_height_a.html"
+        }
+      ],
       "css/inline_block_height_with_out_of_flow_child_a.html": [
         {
           "path": "css/inline_block_height_with_out_of_flow_child_a.html",
@@ -16404,18 +16416,6 @@
             ]
           ],
           "url": "/_mozilla/css/inline_block_opacity_change.html"
-        }
-      ],
-      "css/inline_block_overflow.html": [
-        {
-          "path": "css/inline_block_overflow.html",
-          "references": [
-            [
-              "/_mozilla/css/inline_block_overflow_ref.html",
-              "=="
-            ]
-          ],
-          "url": "/_mozilla/css/inline_block_overflow.html"
         }
       ],
       "css/inline_block_overflow_hidden_a.html": [

--- a/tests/wpt/mozilla/tests/css/inline_block_explicit_height_a.html
+++ b/tests/wpt/mozilla/tests/css/inline_block_explicit_height_a.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="inline_block_explicit_height_ref.html">
+<link rel="stylesheet" type="text/css" href="css/ahem.css">
+<style>
+body, html {
+    margin: 0;
+    font: 25px Ahem;
+    line-height: 25px;
+}
+div {
+    display: inline-block;
+    background: green;
+    color: blue;
+}
+.tall {
+    height: 100px;
+}
+</style>
+<div class=tall>X</div><div>X</div>
+

--- a/tests/wpt/mozilla/tests/css/inline_block_explicit_height_ref.html
+++ b/tests/wpt/mozilla/tests/css/inline_block_explicit_height_ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+body, html {
+    margin: 0;
+}
+div {
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+#a {
+    width: 25px;
+    height: 100px;
+    background: green;
+}
+#b {
+    width: 50px;
+    height: 25px;
+    background: blue;
+}
+</style>
+<div id=a></div><div id=b></div>
+

--- a/tests/wpt/mozilla/tests/css/inline_block_overflow.html
+++ b/tests/wpt/mozilla/tests/css/inline_block_overflow.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-<html>
-<link rel='match' href='inline_block_overflow_ref.html'>
-<body>
-  a<span style="display: inline-block; overflow: hidden">b</span>
-</body>
-</html>

--- a/tests/wpt/mozilla/tests/css/inline_block_overflow_ref.html
+++ b/tests/wpt/mozilla/tests/css/inline_block_overflow_ref.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
-<html>
-<body>
-  ab
-</body>
-</html>

--- a/tests/wpt/mozilla/tests/css/input_selection_a.html
+++ b/tests/wpt/mozilla/tests/css/input_selection_a.html
@@ -10,9 +10,10 @@
         border: 0 none;
         margin: 0;
         padding: 0;
+        color: white;
       }
       ::selection {
-        color: black;
+        color: white;
         background: rgba(176, 214, 255, 1.0);
       }
     </style>

--- a/tests/wpt/mozilla/tests/css/input_selection_incremental_a.html
+++ b/tests/wpt/mozilla/tests/css/input_selection_incremental_a.html
@@ -10,6 +10,7 @@
         border: 0 none;
         margin: 0;
         padding: 0;
+        color: white;
       }
       ::selection {
         color: white;

--- a/tests/wpt/mozilla/tests/css/input_selection_incremental_ref.html
+++ b/tests/wpt/mozilla/tests/css/input_selection_incremental_ref.html
@@ -9,8 +9,10 @@
         background: rgba(176, 214, 255, 1.0);
       }
       div {
+        color: white;
         font: 16px sans-serif;
         display: inline-block;
+        overflow: hidden;
       }
     </style>
   </head>

--- a/tests/wpt/mozilla/tests/css/input_selection_ref.html
+++ b/tests/wpt/mozilla/tests/css/input_selection_ref.html
@@ -6,8 +6,10 @@
     <style>
       span {
         font: 16px sans-serif;
-        color: black;
         background: rgba(176, 214, 255, 1.0);
+        overflow: hidden;
+        display: inline-block;
+        color: white;
       }
     </style>
   </head>


### PR DESCRIPTION
Additionally, this patch reverts the change introduced in #12642 in
favor of the spec-compliant behavior described above. This patch also
removes the `inline_block_overflow.html` reftest introduced in #3725, as
the behavior it expected contradicted CSS 2.1 (and in fact the test
fails in Gecko).

The changes that this patch makes to `input_selection_a.html` and
`input_selection_incremental_a.html` are necessary workarounds to make
the tests pass in light of the fact that Servo's UA stylesheet applies
`overflow: hidden` to `<input>` elements. I believe that the changes are
not necessary in other rendering engines because they hard-code
`overflow: hidden`-like behavior for `<input>` elements, while Servo
uses the actual CSS `overflow: hidden` behavior. As far as I can tell,
Servo's behavior is arguably more spec-compliant, but it remains to be
seen how Web compatible it is.

Improves the Google results pages.

Closes #13707.

r? @notriddle

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13732)

<!-- Reviewable:end -->
