### PR TITLE
Fix Request's Headers to be cloned correctly

### DIFF
--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -420,7 +420,7 @@ impl Request {
         r
     }
 
-    fn clone_from(r: &Request) -> Root<Request> {
+    fn clone_from(r: &Request) -> Fallible<Root<Request>> {
         let req = r.request.borrow();
         let url = req.url();
         let is_service_worker_global_scope = req.is_service_worker_global_scope;
@@ -436,8 +436,9 @@ impl Request {
         *r_clone.request.borrow_mut() = req.clone();
         r_clone.body_used.set(body_used);
         *r_clone.mime_type.borrow_mut() = mime_type;
+        try!(r_clone.Headers().fill(Some(HeadersInit::Headers(r.Headers()))));
         r_clone.Headers().set_guard(headers_guard);
-        r_clone
+        Ok(r_clone)
     }
 
     pub fn get_request(&self) -> NetTraitsRequest {
@@ -613,7 +614,7 @@ impl RequestMethods for Request {
         }
 
         // Step 2
-        Ok(Request::clone_from(self))
+        Request::clone_from(self)
     }
 
     #[allow(unrooted_must_root)]

--- a/tests/wpt/metadata/fetch/api/request/request-clone.sub.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-clone.sub.html.ini
@@ -1,8 +1,0 @@
-[request-clone.sub.html]
-  type: testharness
-  [Check cloning a request]
-    expected: FAIL
-
-  [Check cloning a request copies the headers]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Previously, when `Clone()` was called, Headers of the template Request did not get cloned properly. This commit fixes that issue, and updates the expected wpt results.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11894 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13733)

<!-- Reviewable:end -->
