### PR TITLE
Invert conditional and return early from report_pending_exception

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -202,52 +202,52 @@ impl ErrorInfo {
 /// The `dispatch_event` argument is temporary and non-standard; passing false
 /// prevents dispatching the `error` event.
 pub unsafe fn report_pending_exception(cx: *mut JSContext, dispatch_event: bool) {
-    if JS_IsExceptionPending(cx) {
-        rooted!(in(cx) let mut value = UndefinedValue());
-        if !JS_GetPendingException(cx, value.handle_mut()) {
-            JS_ClearPendingException(cx);
-            error!("Uncaught exception: JS_GetPendingException failed");
-            return;
-        }
+    if !JS_IsExceptionPending(cx) { return; }
 
+    rooted!(in(cx) let mut value = UndefinedValue());
+    if !JS_GetPendingException(cx, value.handle_mut()) {
         JS_ClearPendingException(cx);
-        let error_info = if value.is_object() {
-            rooted!(in(cx) let object = value.to_object());
-            let error_info = ErrorInfo::from_native_error(cx, object.handle())
-                .or_else(|| ErrorInfo::from_dom_exception(object.handle()));
-            match error_info {
-                Some(error_info) => error_info,
-                None => {
-                    error!("Uncaught exception: failed to extract information");
-                    return;
-                }
-            }
-        } else {
-            match USVString::from_jsval(cx, value.handle(), ()) {
-                Ok(ConversionResult::Success(USVString(string))) => {
-                    ErrorInfo {
-                        message: format!("uncaught exception: {}", string),
-                        filename: String::new(),
-                        lineno: 0,
-                        column: 0,
-                    }
-                },
-                _ => {
-                    panic!("Uncaught exception: failed to stringify primitive");
-                },
-            }
-        };
+        error!("Uncaught exception: JS_GetPendingException failed");
+        return;
+    }
 
-        error!("Error at {}:{}:{} {}",
-               error_info.filename,
-               error_info.lineno,
-               error_info.column,
-               error_info.message);
-
-        if dispatch_event {
-            GlobalScope::from_context(cx)
-                .report_an_error(error_info, value.handle());
+    JS_ClearPendingException(cx);
+    let error_info = if value.is_object() {
+        rooted!(in(cx) let object = value.to_object());
+        let error_info = ErrorInfo::from_native_error(cx, object.handle())
+            .or_else(|| ErrorInfo::from_dom_exception(object.handle()));
+        match error_info {
+            Some(error_info) => error_info,
+            None => {
+                error!("Uncaught exception: failed to extract information");
+                return;
+            }
         }
+    } else {
+        match USVString::from_jsval(cx, value.handle(), ()) {
+            Ok(ConversionResult::Success(USVString(string))) => {
+                ErrorInfo {
+                    message: format!("uncaught exception: {}", string),
+                    filename: String::new(),
+                    lineno: 0,
+                    column: 0,
+                }
+            },
+            _ => {
+                panic!("Uncaught exception: failed to stringify primitive");
+            },
+        }
+    };
+
+    error!("Error at {}:{}:{} {}",
+           error_info.filename,
+           error_info.lineno,
+           error_info.column,
+           error_info.message);
+
+    if dispatch_event {
+        GlobalScope::from_context(cx)
+            .report_an_error(error_info, value.handle());
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Previously, almost the entire body of `report_pending_exception` was in a conditional branch. We now return early if the function body does not need to be executed.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13746 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they don't add any new functionality.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13755)

<!-- Reviewable:end -->
