### PR TITLE
layout: Rewrite clipping to be a two-phase process that takes physical border box positions and transforms into account.

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -977,6 +977,11 @@ impl ClippingRegion {
             }).collect(),
         }
     }
+
+    #[inline]
+    pub fn is_max(&self) -> bool {
+        self.main == max_rect() && self.complex.is_empty()
+    }
 }
 
 impl fmt::Debug for ClippingRegion {

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -935,7 +935,9 @@ pub struct BaseFlow {
     /// assignment.
     pub late_absolute_position_info: LateAbsolutePositionInfo,
 
-    /// The clipping region for this flow and its descendants, in layer coordinates.
+    /// The clipping region for this flow and its descendants, in the coordinate system of the
+    /// nearest ancestor stacking context. If this flow itself represents a stacking context, then
+    /// this is in the flow's own coordinate system.
     pub clip: ClippingRegion,
 
     /// The stacking-relative position of the display port.

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-transformable-inline-block.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-transformable-inline-block.htm.ini
@@ -1,3 +1,0 @@
-[transform-transformable-inline-block.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -4668,6 +4668,18 @@
             "url": "/_mozilla/css/quotes_simple_a.html"
           }
         ],
+        "css/relative_position_clip_a.html": [
+          {
+            "path": "css/relative_position_clip_a.html",
+            "references": [
+              [
+                "/_mozilla/css/relative_position_clip_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/relative_position_clip_a.html"
+          }
+        ],
         "css/relative_position_vertical_percentage_a.html": [
           {
             "path": "css/relative_position_vertical_percentage_a.html",
@@ -18484,6 +18496,18 @@
             ]
           ],
           "url": "/_mozilla/css/quotes_simple_a.html"
+        }
+      ],
+      "css/relative_position_clip_a.html": [
+        {
+          "path": "css/relative_position_clip_a.html",
+          "references": [
+            [
+              "/_mozilla/css/relative_position_clip_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/relative_position_clip_a.html"
         }
       ],
       "css/relative_position_vertical_percentage_a.html": [

--- a/tests/wpt/mozilla/tests/css/relative_position_clip_a.html
+++ b/tests/wpt/mozilla/tests/css/relative_position_clip_a.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="relative_position_clip_ref.html">
+<style>
+body, html {
+    margin: 0;
+}
+#a {
+    overflow: hidden;
+}
+#b {
+    background: lightgray;
+    position: relative;
+    left: 50%;
+    transform: translateX(-50%);
+}
+</style>
+<div id=a><div id=b>X
+

--- a/tests/wpt/mozilla/tests/css/relative_position_clip_ref.html
+++ b/tests/wpt/mozilla/tests/css/relative_position_clip_ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+body, html {
+    margin: 0;
+}
+div {
+    background: lightgray;
+}
+</style>
+<div>X
+


### PR DESCRIPTION
Clipping region computation now follows a simple process: (1) in the
parent's coordinate system, parents store appropriate clipping regions
into children; (2) each child moves its clipping region to its own
coordinate system if necessary.

Because clipping region computation is now based on stacking-relative
border box positions and the `transform_rect` method, it can handle
`position: relative` offsets and more types of transforms, such as
scaling.

Improves etsy.com.

Closes #13753.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13756)

<!-- Reviewable:end -->
