### PR TITLE
Issue 13363 - Step 1.2 of compiling event handler

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -373,7 +373,10 @@ impl EventTarget {
             None => self.downcast::<Window>().unwrap().Document(),
         };
 
-        // TODO step 1.2 (browsing context/scripting enabled)
+        // Step 1.2
+        if !document.is_scripting_enabled() {
+            return None;
+        }
 
         // Step 1.3
         let body: Vec<u16> = handler.source.encode_utf16().collect();

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -37756,6 +37756,12 @@
             "path": "html/semantics/forms/the-select-element/common-HTMLOptionsCollection-add.html",
             "url": "/html/semantics/forms/the-select-element/common-HTMLOptionsCollection-add.html"
           }
+        ],
+        "html/webappapis/scripting/events/uncompiled_event_handler_with_scripting_disabled.html": [
+          {
+            "path": "html/webappapis/scripting/events/uncompiled_event_handler_with_scripting_disabled.html",
+            "url": "/html/webappapis/scripting/events/uncompiled_event_handler_with_scripting_disabled.html"
+          }
         ]
       }
     },

--- a/tests/wpt/web-platform-tests/html/webappapis/scripting/events/uncompiled_event_handler_with_scripting_disabled.html
+++ b/tests/wpt/web-platform-tests/html/webappapis/scripting/events/uncompiled_event_handler_with_scripting_disabled.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Uncompiled event handler check that scripting is enabled</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  setup({ allow_uncaught_exception: true });
+  test(function() {
+    var invoked = false;
+    window.addEventListener("error", function() {
+      invoked = true;
+    });
+
+    // Make sure that `this_will_error` will in fact error when it's referenced
+    assert_equals(typeof this_will_error, "undefined");
+    var dom = (new DOMParser()).parseFromString("<div id=\"has-event-handler\" onclick=\"this_will_error;\"></div>", "text/html");
+    var click = new MouseEvent("click");
+    dom.getElementById("has-event-handler").dispatchEvent(click);
+    assert_equals(invoked, false);
+  }, "when scripting is disabled, the handler is never compiled");
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Adds the conditional to test that scripting is enabled in `EventTarget#get_compiled_event_handler`, and return `None` early if not.

Adds tests for "scripting enabled" and "scripting disabled" cases.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13363 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13784)

<!-- Reviewable:end -->
