### PR TITLE
switch to using DOMRefCell<VeqDeque<String>> for ServoParser::pending…

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -78,7 +78,7 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::boxed::FnBox;
 use std::cell::{Cell, UnsafeCell};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::hash::{BuildHasher, Hash};
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
@@ -200,6 +200,15 @@ impl JSTraceable for Heap<JSVal> {
 // XXXManishearth Check if the following three are optimized to no-ops
 // if e.trace() is a no-op (e.g it is an no_jsmanaged_fields type)
 impl<T: JSTraceable> JSTraceable for Vec<T> {
+    #[inline]
+    fn trace(&self, trc: *mut JSTracer) {
+        for e in &*self {
+            e.trace(trc);
+        }
+    }
+}
+
+impl<T: JSTraceable> JSTraceable for VecDeque<T> {
     #[inline]
     fn trace(&self, trc: *mut JSTracer) {
         for e in &*self {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The field ServoParser::pending_input should be a DOMRefCell<VeqDeque<String>>, this lets us use VecDeque::pop_front instead of Vec::remove in ServoParser::take_next_input_chunk.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13690 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

…_input

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13785)

<!-- Reviewable:end -->
