### PR TITLE
Allow Request's Headers to be created with various objects

### DIFF
--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -40,7 +40,6 @@ use std::cell::{Cell, Ref};
 use std::rc::Rc;
 use url::Url;
 
-use dom::bindings::js::RootedReference;
 #[dom_struct]
 pub struct Request {
     reflector_: Reflector,

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -361,7 +361,8 @@ impl Request {
                     try!(r.Headers().fill(Some(HeadersInit::Headers(input_request.Headers()))));
                 }
             },
-            Some(_) => try!(r.Headers().fill(Some(HeadersInit::Headers(headers_copy)))),
+            Some(HeadersInit::Headers(_)) => try!(r.Headers().fill(Some(HeadersInit::Headers(headers_copy)))),
+            _ => {},
         }
 
         // Step 32

--- a/tests/wpt/metadata/fetch/api/request/request-headers.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-headers.html.ini
@@ -1,8 +1,5 @@
 [request-headers.html]
   type: testharness
-  [Testing request header creations with various objects]
-    expected: FAIL
-
   [Testing empty Request Content-Type header]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

While Headers could be constructed correctly with an array or
object (open ended dictionary/MozMap), Request's Headers failed to be
created with non-Headers object (such as array or open ended
dictionary/MozMap).

Before, Request's Headers could be filled with only a Headers object in
Step 28. This has been expanded to accommodate array and open ended
dictionary.

Step 29 empties the Request's Headers list after it had been filled in
Step 28, thus resulting in an empty Headers object when it shouldn't
be. This step has been removed with a comment in this commit.

If a RequestInit Headers is _not_ given, but a RequestInfo Headers is
given, RequestInfo Headers should be used to construct Request
Headers. That step has been added after Step 31.

Corresponding wpt result is updated in this commit.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13758 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13802)

<!-- Reviewable:end -->
