### PR TITLE
Fix radial gradient's <size>/<ending-shape> parsing

### DIFF
--- a/components/style/values/specified/position.rs
+++ b/components/style/values/specified/position.rs
@@ -215,6 +215,15 @@ impl Position {
             }
         }
     }
+
+    pub fn center() -> Position {
+        Position {
+            horiz_keyword: Some(Keyword::Center),
+            horiz_position: None,
+            vert_keyword: Some(Keyword::Center),
+            vert_position: None,
+        }
+    }
 }
 
 impl Keyword {

--- a/tests/unit/style/parsing/image.rs
+++ b/tests/unit/style/parsing/image.rs
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use cssparser::Parser;
+use media_queries::CSSErrorReporterTest;
+use style::parser::ParserContext;
+use style::stylesheets::Origin;
+use style::values::specified::image::*;
+use url::Url;
+
+#[test]
+fn test_radial_gradient() {
+    // Parsing with all values
+    assert_roundtrip_with_context!(Image::parse, "radial-gradient(circle closest-side at 20px 30px, red, green)");
+    assert_roundtrip_with_context!(Image::parse, "radial-gradient(ellipse closest-side at 20px 30px, red, green)");
+    assert_roundtrip_with_context!(Image::parse, "radial-gradient(closest-side circle at 20px 30px, red, green)",
+                                                 "radial-gradient(circle closest-side at 20px 30px, red, green)");
+    assert_roundtrip_with_context!(Image::parse, "radial-gradient(closest-side ellipse at 20px 30px, red, green)",
+                                                 "radial-gradient(ellipse closest-side at 20px 30px, red, green)");
+
+    // Parsing with <shape-keyword> and <size> reversed
+    assert_roundtrip_with_context!(Image::parse, "radial-gradient(closest-side circle at 20px 30px, red, green)",
+                                                 "radial-gradient(circle closest-side at 20px 30px, red, green)");
+    assert_roundtrip_with_context!(Image::parse, "radial-gradient(closest-corner ellipse at 20px 30px, red, green)",
+                                                 "radial-gradient(ellipse closest-corner at 20px 30px, red, green)");
+    assert_roundtrip_with_context!(Image::parse, "radial-gradient(30px circle, red, green)",
+                                                 "radial-gradient(circle 30px at center center, red, green)");
+    assert_roundtrip_with_context!(Image::parse, "radial-gradient(30px 40px ellipse, red, green)",
+                                                 "radial-gradient(ellipse 30px 40px at center center, red, green)");
+
+    // Parsing without <size>
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(circle, red, green)",
+                                   "radial-gradient(circle farthest-corner at center center, red, green)");
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(ellipse, red, green)",
+                                   "radial-gradient(ellipse farthest-corner at center center, red, green)");
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(circle at 20px 30px, red, green)",
+                                   "radial-gradient(circle farthest-corner at 20px 30px, red, green)");
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(ellipse at 20px 30px, red, green)",
+                                   "radial-gradient(ellipse farthest-corner at 20px 30px, red, green)");
+
+
+    // Parsing without <shape-keyword>
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(20px at 20px 30px, red, green)",
+                                   "radial-gradient(circle 20px at 20px 30px, red, green)");
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(20px 30px at left center, red, green)",
+                                   "radial-gradient(ellipse 20px 30px at left center, red, green)");
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(closest-side at center, red, green)",
+                                   "radial-gradient(ellipse closest-side at center center, red, green)");
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(20px, red, green)",
+                                   "radial-gradient(circle 20px at center center, red, green)");
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(20px 30px, red, green)",
+                                   "radial-gradient(ellipse 20px 30px at center center, red, green)");
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(closest-side, red, green)",
+                                   "radial-gradient(ellipse closest-side at center center, red, green)");
+
+    // Parsing without <shape-keyword> and <size>
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(at center, red, green)",
+                                   "radial-gradient(ellipse farthest-corner at center center, red, green)");
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(at center bottom, red, green)",
+                                   "radial-gradient(ellipse farthest-corner at center bottom, red, green)");
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(at 40px 50px, red, green)",
+                                   "radial-gradient(ellipse farthest-corner at 40px 50px, red, green)");
+
+    // Parsing with just color stops
+    assert_roundtrip_with_context!(Image::parse,
+                                   "radial-gradient(red, green)",
+                                   "radial-gradient(ellipse farthest-corner at center center, red, green)");
+
+    // Parsing repeating radial gradient
+    assert_roundtrip_with_context!(Image::parse,
+                                   "repeating-radial-gradient(red, green)",
+                                   "repeating-radial-gradient(ellipse farthest-corner at center center, red, green)");
+}

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -31,8 +31,30 @@ macro_rules! assert_roundtrip {
     }
 }
 
+macro_rules! assert_roundtrip_with_context {
+    ($fun:expr, $string:expr) => {
+        assert_roundtrip_with_context!($fun, $string, $string);
+    };
+    ($fun:expr,$input:expr, $output:expr) => {
+        let url = Url::parse("http://localhost").unwrap();
+        let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+        let mut parser = Parser::new($input);
+        let parsed = $fun(&context, &mut parser)
+                     .expect(&format!("Failed to parse {}", $input));
+        let serialized = ::cssparser::ToCss::to_css_string(&parsed);
+        assert_eq!(serialized, $output);
+
+        let mut parser = Parser::new(&serialized);
+        let re_parsed = $fun(&context, &mut parser)
+                        .expect(&format!("Failed to parse {}", $input));
+        let re_serialized = ::cssparser::ToCss::to_css_string(&re_parsed);
+        assert_eq!(serialized, re_serialized);
+    }
+}
+
 
 mod basic_shape;
+mod image;
 mod mask;
 mod position;
 mod selectors;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Parsing now handles sizes and shapes in various order.
I had to delete `EndingShape`'s parse implementation and mix it with `Position` in `parse_radial`. It became a bit complicated to read but I couldn't make it simpler.
r? @Manishearth 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13664 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13804)

<!-- Reviewable:end -->
