### PR TITLE
layout: Bubble inline sizes for the last constructed anonymous table flow.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -529,6 +529,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                         self.generate_anonymous_missing_child(consecutive_siblings, flow, node);
                     }
                     self.generate_anonymous_table_flows_if_necessary(flow, &mut kid_flow, &kid);
+                    kid_flow.finish();
                     flow.add_new_child(kid_flow);
                 }
                 abs_descendants.push_descendants(kid_abs_descendants);

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1424,6 +1424,18 @@
             "url": "/_mozilla/css/dirty_viewport.html"
           }
         ],
+        "css/display_table_cell_intrinsic_width_a.html": [
+          {
+            "path": "css/display_table_cell_intrinsic_width_a.html",
+            "references": [
+              [
+                "/_mozilla/css/display_table_cell_intrinsic_width_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/display_table_cell_intrinsic_width_a.html"
+          }
+        ],
         "css/empty_cells_a.html": [
           {
             "path": "css/empty_cells_a.html",
@@ -15252,6 +15264,18 @@
             ]
           ],
           "url": "/_mozilla/css/dirty_viewport.html"
+        }
+      ],
+      "css/display_table_cell_intrinsic_width_a.html": [
+        {
+          "path": "css/display_table_cell_intrinsic_width_a.html",
+          "references": [
+            [
+              "/_mozilla/css/display_table_cell_intrinsic_width_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/display_table_cell_intrinsic_width_a.html"
         }
       ],
       "css/empty_cells_a.html": [

--- a/tests/wpt/mozilla/tests/css/display_table_cell_intrinsic_width_a.html
+++ b/tests/wpt/mozilla/tests/css/display_table_cell_intrinsic_width_a.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="display_table_cell_intrinsic_width_ref.html">
+<style>
+body, html {
+    margin: 0;
+}
+table, tbody, tr, td {
+    padding: 0;
+    margin: 0;
+    border: none;
+    border-collapse: collapse;
+}
+</style>
+<div style="display: table-cell">Hello world</div>

--- a/tests/wpt/mozilla/tests/css/display_table_cell_intrinsic_width_ref.html
+++ b/tests/wpt/mozilla/tests/css/display_table_cell_intrinsic_width_ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+body, html {
+    margin: 0;
+}
+table, tbody, tr, td {
+    padding: 0;
+    margin: 0;
+    border: none;
+    border-collapse: collapse;
+}
+</style>
+<table><tr><td>Hello world</td></tr></table>
+


### PR DESCRIPTION
Without this change, elements with `display: table-cell` not nested in
other table elements will not have their intrinsic inline sizes
computed.

Improves etsy.com.

Closes #13782.

r? @mbrubeck

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13805)

<!-- Reviewable:end -->
