### PR TITLE
Remove Class from DisplayItem enum names

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -400,7 +400,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   style.get_cursor(Cursor::Default),
                                                   display_list_section);
         state.add_display_item(
-            DisplayItem::SolidColorClass(box SolidColorDisplayItem {
+            DisplayItem::SolidColor(box SolidColorDisplayItem {
                 base: base,
                 color: background_color.to_gfx_color(),
             }));
@@ -635,7 +635,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                     self.node,
                                                     style.get_cursor(Cursor::Default),
                                                     display_list_section);
-            state.add_display_item(DisplayItem::ImageClass(box ImageDisplayItem {
+            state.add_display_item(DisplayItem::Image(box ImageDisplayItem {
               base: base,
               webrender_image: webrender_image,
               image_data: None,
@@ -774,7 +774,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   style.get_cursor(Cursor::Default),
                                                   display_list_section);
-        let gradient_display_item = DisplayItem::GradientClass(box GradientDisplayItem {
+        let gradient_display_item = DisplayItem::Gradient(box GradientDisplayItem {
             base: base,
             start_point: center - delta,
             end_point: center + delta,
@@ -804,7 +804,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                       self.node,
                                                       style.get_cursor(Cursor::Default),
                                                       display_list_section);
-            state.add_display_item(DisplayItem::BoxShadowClass(box BoxShadowDisplayItem {
+            state.add_display_item(DisplayItem::BoxShadow(box BoxShadowDisplayItem {
                 base: base,
                 box_bounds: *absolute_bounds,
                 color: style.resolve_color(box_shadow.color).to_gfx_color(),
@@ -876,7 +876,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   style.get_cursor(Cursor::Default),
                                                   display_list_section);
-        state.add_display_item(DisplayItem::BorderClass(box BorderDisplayItem {
+        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
             border_widths: border.to_physical(style.writing_mode),
             color: SideOffsets2D::new(colors.top.to_gfx_color(),
@@ -919,7 +919,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   style.get_cursor(Cursor::Default),
                                                   DisplayListSection::Outlines);
-        state.add_display_item(DisplayItem::BorderClass(box BorderDisplayItem {
+        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(width),
             color: SideOffsets2D::new_all_same(color),
@@ -944,7 +944,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   style.get_cursor(Cursor::Default),
                                                   DisplayListSection::Content);
-        state.add_display_item(DisplayItem::BorderClass(box BorderDisplayItem {
+        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
             color: SideOffsets2D::new_all_same(color::rgb(0, 0, 200)),
@@ -965,7 +965,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   style.get_cursor(Cursor::Default),
                                                   DisplayListSection::Content);
-        state.add_display_item(DisplayItem::LineClass(box LineDisplayItem {
+        state.add_display_item(DisplayItem::Line(box LineDisplayItem {
             base: base,
             color: color::rgb(0, 200, 0),
             style: border_style::T::dashed,
@@ -982,7 +982,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   self.style.get_cursor(Cursor::Default),
                                                   DisplayListSection::Content);
-        state.add_display_item(DisplayItem::BorderClass(box BorderDisplayItem {
+        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
             color: SideOffsets2D::new_all_same(color::rgb(0, 0, 200)),
@@ -1034,7 +1034,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                       self.style.get_cursor(Cursor::Default),
                                                       display_list_section);
             state.add_display_item(
-                DisplayItem::SolidColorClass(box SolidColorDisplayItem {
+                DisplayItem::SolidColor(box SolidColorDisplayItem {
                     base: base,
                     color: background_color.to_gfx_color(),
             }));
@@ -1072,7 +1072,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   self.style.get_cursor(cursor),
                                                   display_list_section);
-        state.add_display_item(DisplayItem::SolidColorClass(box SolidColorDisplayItem {
+        state.add_display_item(DisplayItem::SolidColor(box SolidColorDisplayItem {
             base: base,
             color: self.style().get_color().color.to_gfx_color(),
         }));
@@ -1261,7 +1261,7 @@ impl FragmentDisplayListBuilding for Fragment {
                         self.node,
                         self.style.get_cursor(Cursor::Default),
                         DisplayListSection::Content);
-                    let item = DisplayItem::IframeClass(box IframeDisplayItem {
+                    let item = DisplayItem::Iframe(box IframeDisplayItem {
                         base: base,
                         iframe: fragment_info.pipeline_id,
                     });
@@ -1278,7 +1278,7 @@ impl FragmentDisplayListBuilding for Fragment {
                         self.node,
                         self.style.get_cursor(Cursor::Default),
                         DisplayListSection::Content);
-                    state.add_display_item(DisplayItem::ImageClass(box ImageDisplayItem {
+                    state.add_display_item(DisplayItem::Image(box ImageDisplayItem {
                         base: base,
                         webrender_image: WebRenderImageInfo::from_image(image),
                         image_data: Some(Arc::new(image.bytes.clone())),
@@ -1316,7 +1316,7 @@ impl FragmentDisplayListBuilding for Fragment {
                         DisplayListSection::Content);
                     let display_item = match canvas_data {
                         CanvasData::Pixels(canvas_data) => {
-                            DisplayItem::ImageClass(box ImageDisplayItem {
+                            DisplayItem::Image(box ImageDisplayItem {
                                 base: base,
                                 image_data: Some(Arc::new(canvas_data.image_data)),
                                 webrender_image: WebRenderImageInfo {
@@ -1331,7 +1331,7 @@ impl FragmentDisplayListBuilding for Fragment {
                             })
                         }
                         CanvasData::WebGL(context_id) => {
-                            DisplayItem::WebGLClass(box WebGLDisplayItem {
+                            DisplayItem::WebGL(box WebGLDisplayItem {
                                 base: base,
                                 context_id: context_id,
                             })
@@ -1560,7 +1560,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   self.style().get_cursor(cursor),
                                                   DisplayListSection::Content);
-        state.add_display_item(DisplayItem::TextClass(box TextDisplayItem {
+        state.add_display_item(DisplayItem::Text(box TextDisplayItem {
             base: base,
             text_run: text_fragment.run.clone(),
             range: text_fragment.range,
@@ -1638,7 +1638,7 @@ impl FragmentDisplayListBuilding for Fragment {
             self.node,
             self.style.get_cursor(Cursor::Default),
             DisplayListSection::Content);
-        state.add_display_item(DisplayItem::BoxShadowClass(box BoxShadowDisplayItem {
+        state.add_display_item(DisplayItem::BoxShadow(box BoxShadowDisplayItem {
             base: base,
             box_bounds: stacking_relative_box,
             color: color.to_gfx_color(),
@@ -2054,7 +2054,7 @@ impl BaseFlowDisplayListBuilding for BaseFlow {
             node,
             None,
             DisplayListSection::Content);
-        state.add_display_item(DisplayItem::BorderClass(box BorderDisplayItem {
+        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(2)),
             color: SideOffsets2D::new_all_same(color),

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -262,7 +262,7 @@ impl WebRenderStackingContextConverter for StackingContext {
                                          _force_positioned_stacking_level: bool) {
         while let Some(item) = traversal.next() {
             match item {
-                &DisplayItem::PushStackingContextClass(ref stacking_context_item) => {
+                &DisplayItem::PushStackingContext(ref stacking_context_item) => {
                     let stacking_context = &stacking_context_item.stacking_context;
                     debug_assert!(stacking_context.context_type == StackingContextType::Real);
 
@@ -283,7 +283,7 @@ impl WebRenderStackingContextConverter for StackingContext {
                     builder.push_stacking_context(stacking_context_id);
 
                 }
-                &DisplayItem::PopStackingContextClass(_) => return,
+                &DisplayItem::PopStackingContext(_) => return,
                 _ => item.convert_to_webrender(builder, frame_builder),
             }
         }
@@ -354,7 +354,7 @@ impl WebRenderDisplayListConverter for DisplayList {
         let mut traversal = DisplayListTraversal::new(self);
         let item = traversal.next();
         match item {
-            Some(&DisplayItem::PushStackingContextClass(ref stacking_context_item)) => {
+            Some(&DisplayItem::PushStackingContext(ref stacking_context_item)) => {
                 let stacking_context = &stacking_context_item.stacking_context;
                 stacking_context.convert_to_webrender(&mut traversal,
                                                       api,
@@ -375,7 +375,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                             builder: &mut webrender_traits::DisplayListBuilder,
                             frame_builder: &mut WebRenderFrameBuilder) {
         match *self {
-            DisplayItem::SolidColorClass(ref item) => {
+            DisplayItem::SolidColor(ref item) => {
                 let color = item.color.to_colorf();
                 if color.a > 0.0 {
                     builder.push_rect(item.base.bounds.to_rectf(),
@@ -383,7 +383,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                       color);
                 }
             }
-            DisplayItem::TextClass(ref item) => {
+            DisplayItem::Text(ref item) => {
                 let mut origin = item.baseline_origin.clone();
                 let mut glyphs = vec!();
 
@@ -418,7 +418,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                       &mut frame_builder.auxiliary_lists_builder);
                 }
             }
-            DisplayItem::ImageClass(ref item) => {
+            DisplayItem::Image(ref item) => {
                 if let Some(id) = item.webrender_image.key {
                     if item.stretch_size.width > Au(0) &&
                        item.stretch_size.height > Au(0) {
@@ -431,12 +431,12 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                     }
                 }
             }
-            DisplayItem::WebGLClass(ref item) => {
+            DisplayItem::WebGL(ref item) => {
                 builder.push_webgl_canvas(item.base.bounds.to_rectf(),
                                           item.base.clip.to_clip_region(frame_builder),
                                           item.context_id);
             }
-            DisplayItem::BorderClass(ref item) => {
+            DisplayItem::Border(ref item) => {
                 let rect = item.base.bounds.to_rectf();
                 let left = webrender_traits::BorderSide {
                     width: item.border_widths.left.to_f32_px(),
@@ -467,7 +467,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                     bottom,
                                     radius);
             }
-            DisplayItem::GradientClass(ref item) => {
+            DisplayItem::Gradient(ref item) => {
                 let rect = item.base.bounds.to_rectf();
                 let start_point = item.start_point.to_pointf();
                 let end_point = item.end_point.to_pointf();
@@ -482,13 +482,13 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                       stops,
                                       &mut frame_builder.auxiliary_lists_builder);
             }
-            DisplayItem::LineClass(..) => {
-                println!("TODO DisplayItem::LineClass");
+            DisplayItem::Line(..) => {
+                println!("TODO DisplayItem::Line");
             }
-            DisplayItem::LayeredItemClass(..) => {
+            DisplayItem::LayeredItem(..) => {
                 panic!("Unexpected in webrender!");
             }
-            DisplayItem::BoxShadowClass(ref item) => {
+            DisplayItem::BoxShadow(ref item) => {
                 let rect = item.base.bounds.to_rectf();
                 let box_bounds = item.box_bounds.to_rectf();
                 builder.push_box_shadow(rect,
@@ -501,14 +501,14 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                         item.border_radius.to_f32_px(),
                                         item.clip_mode.to_clip_mode());
             }
-            DisplayItem::IframeClass(ref item) => {
+            DisplayItem::Iframe(ref item) => {
                 let rect = item.base.bounds.to_rectf();
                 let pipeline_id = item.iframe.to_webrender();
                 builder.push_iframe(rect,
                                     item.base.clip.to_clip_region(frame_builder),
                                     pipeline_id);
             }
-            DisplayItem::PushStackingContextClass(_) | DisplayItem::PopStackingContextClass(_) => {}
+            DisplayItem::PushStackingContext(_) | DisplayItem::PopStackingContext(_) => {}
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this PR does not change behavior. It's only a rename.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

This is probably a holdover from the days before namespaced enums. We
can remove this part of the name to avoid a lot of visual noise.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13810)

<!-- Reviewable:end -->
