### PR TITLE
Fix style unit tests, move parse_longhand macro to parse tests module

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -237,7 +237,9 @@ class MachCommands(CommandBase):
 
             if features:
                 args += ["--features", "%s" % ' '.join(features)]
-            return call(args, env=env, cwd=self.servo_crate())
+            err = call(args, env=env, cwd=self.servo_crate())
+            if err is not 0:
+                return err
 
         # Run style tests with the testing feature
         if has_style:

--- a/tests/unit/style/parsing/mask.rs
+++ b/tests/unit/style/parsing/mask.rs
@@ -11,14 +11,6 @@ use style::properties::shorthands::mask;
 use style::stylesheets::Origin;
 use url::Url;
 
-macro_rules! parse_longhand {
-    ($name:ident, $s:expr) => {{
-        let url = Url::parse("http://localhost").unwrap();
-        let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
-        $name::parse(&context, &mut Parser::new($s)).unwrap()
-    }};
-}
-
 #[test]
 fn mask_shorthand_should_parse_all_available_properties_when_specified() {
     let url = Url::parse("http://localhost").unwrap();

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -32,6 +32,14 @@ macro_rules! assert_roundtrip {
 }
 
 
+macro_rules! parse_longhand {
+    ($name:ident, $s:expr) => {{
+        let url = Url::parse("http://localhost").unwrap();
+        let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+        $name::parse(&context, &mut Parser::new($s)).unwrap()
+    }};
+}
+
 mod basic_shape;
 mod mask;
 mod position;

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -421,7 +421,8 @@ mod shorthand_serialization {
 
             let position = DeclaredValue::Value(ListStylePosition::inside);
             let image = DeclaredValue::Value(ListStyleImage::Url(
-                Url::parse("http://servo/test.png").unwrap()
+                Url::parse("http://servo/test.png").unwrap(),
+                UrlExtraData {},
             ));
             let style_type = DeclaredValue::Value(ListStyleType::disc);
 


### PR DESCRIPTION
We weren't running the style unit tests.

The parse_longhand macro is useful for all tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13814)

<!-- Reviewable:end -->
