### PR TITLE
README: OpenSSL steps on macOS are for 10.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install virtualenv
 ``` sh
 sudo port install python27 py27-virtualenv cmake
 ```
-#### On OS X <= 10.11 (El Capitan), you also have to install openssl
+#### On OS X >= 10.11 (El Capitan), you also have to install OpenSSL
 
 ``` sh
 brew install openssl
@@ -48,7 +48,7 @@ export OPENSSL_LIB_DIR="$(brew --prefix openssl)/lib"
 ./mach build ...
 ```
 
-If you've already partially compiled servo but forgot to do this step, run ./mach clean, set the shell variables, and recompile.
+If you've already partially compiled servo but forgot to do this step, run `./mach clean`, set the shell variables, and recompile.
 
 #### On Debian-based Linuxes
 


### PR DESCRIPTION
I ignored these instructions because it said `<=`, but this should be the other way around! 🙇‍♀️ 

---
- (n/a) `./mach build -d` does not report any errors
- (n/a) `./mach test-tidy` does not report any errors

<!-- I'm literally the one fixing GitHub's Markdown parser so this comment won't be necessary to divide the two lists. Soon! -->
- [ ] There are tests for these changes
- [x] These changes do not require tests because they're only to `README.md`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13815)

<!-- Reviewable:end -->
