### PR TITLE
Remove the concept of nested stacking contexts from display list builder

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -935,7 +935,7 @@ impl LayoutThread {
                                                  Matrix4D::identity(),
                                                  Matrix4D::identity(),
                                                  true,
-                                                 false,
+                                                 None,
                                                  None);
 
                         let display_list_entries =


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they should not change behavior.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

With the removal of the legacy rendering path, we don't need to worry
about nested stacking contexts. This change just pushes the
complication to the WebRender conversion step, but a later change will
remove the concept from WebRender as well.

This also helps to prepare for the introduction of ids for particular
scrolling regions, an integral part of multiple ScrollLayers per block.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13820)

<!-- Reviewable:end -->
