### PR TITLE
Support taking screenshots when a webdriver server is active.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -715,6 +715,9 @@ impl<Window: WindowMethods> IOCompositor<Window> {
 
             (Msg::CreatePng(reply), ShutdownState::NotShuttingDown) => {
                 let res = self.composite_specific_target(CompositeTarget::WindowAndPng);
+                if let Err(ref e) = res {
+                    info!("Error retrieving PNG: {:?}", e);
+                }
                 let img = res.unwrap_or(None);
                 if let Err(e) = reply.send(img) {
                     warn!("Sending reply to create png failed ({}).", e);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1124,7 +1124,9 @@ impl Window {
         // When all these conditions are met, notify the constellation
         // that this pipeline is ready to write the image (from the script thread
         // perspective at least).
-        if (opts::get().output_file.is_some() || opts::get().exit_after_load) && for_display {
+        if (opts::get().output_file.is_some() ||
+            opts::get().exit_after_load ||
+            opts::get().webdriver_port.is_some()) && for_display {
             let document = self.Document();
 
             // Checks if the html element has reftest-wait attribute present.

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -772,7 +772,7 @@ impl Handler {
         let mut img = None;
         let pipeline_id = try!(self.root_pipeline());
 
-        let interval = 20;
+        let interval = 1000;
         let iterations = 30_000 / interval;
 
         for _ in 0..iterations {


### PR DESCRIPTION
Improve the experience of using webdriver to take screenshots of Servo. When a screenshot can't be obtained immediately, increase the delay before trying again from 2ms to 1s.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13826
- [X] These changes do not require tests because we can't test webdriver yet.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13827)

<!-- Reviewable:end -->
