### PR TITLE
Unprefix text-align-last for geckolib

### DIFF
--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -395,11 +395,10 @@ ${helpers.single_keyword("text-justify",
                          products="servo",
                          animatable=False)}
 
-${helpers.single_keyword("-moz-text-align-last",
+${helpers.single_keyword("text-align-last",
                          "auto start end left right center justify",
                          products="gecko",
                          gecko_constant_prefix="NS_STYLE_TEXT_ALIGN",
-                         gecko_ffi_name="mTextAlignLast",
                          animatable=False)}
 
 <%helpers:longhand name="-servo-text-decorations-in-effect"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

[`text-align-last` has been unprefixed](https://bugzilla.mozilla.org/show_bug.cgi?id=1039541) since Firefox 49.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13834)

<!-- Reviewable:end -->
