### PR TITLE
Update mozjs_sys to expose proper locale callbacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Please select your operating system:
 #### On OS X (homebrew)
 
 ``` sh
-brew install automake pkg-config python cmake
+brew install automake pkg-config python cmake yasm
 pip install virtualenv
 ```
 #### On OS X (MacPorts)
 
 ``` sh
-sudo port install python27 py27-virtualenv cmake
+sudo port install python27 py27-virtualenv cmake yasm
 ```
 #### On OS X >= 10.11 (El Capitan), you also have to install OpenSSL
 

--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -1358,7 +1358,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.0.0"
-source = "git+https://github.com/servo/mozjs#34c3e075138bb7eff2ed8b5924ccb9067dcd017e"
+source = "git+https://github.com/servo/mozjs#f7917c480e3378441ee54c0554f6a3af9fb57464"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -1258,7 +1258,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.0.0"
-source = "git+https://github.com/servo/mozjs#34c3e075138bb7eff2ed8b5924ccb9067dcd017e"
+source = "git+https://github.com/servo/mozjs#f7917c480e3378441ee54c0554f6a3af9fb57464"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7094,6 +7094,12 @@
             "url": "/_mozilla/mozilla/load_event.html"
           }
         ],
+        "mozilla/localeCompare.html": [
+          {
+            "path": "mozilla/localeCompare.html",
+            "url": "/_mozilla/mozilla/localeCompare.html"
+          }
+        ],
         "mozilla/mime_sniffing_font_context.html": [
           {
             "path": "mozilla/mime_sniffing_font_context.html",

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.js
@@ -20,6 +20,7 @@ function test_interfaces(interfaceNamesInGlobalScope) {
       "Int32Array",
       "Int8Array",
       "InternalError",
+      "Intl",
       "Iterator",
       "JSON",
       "Map",

--- a/tests/wpt/mozilla/tests/mozilla/localeCompare.html
+++ b/tests/wpt/mozilla/tests/mozilla/localeCompare.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>localeCompare should return the same as other browsers, even though it's implementation-dependent</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  assert_equals("ab".localeCompare("aZ"), -1);
+})
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13788 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Fixes #13788

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13836)

<!-- Reviewable:end -->
