### PR TITLE
Simplify TNode a bit, removing has_changed from style

### DIFF
--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -118,12 +118,7 @@ fn construct_flows_at<'a, N: LayoutNode>(context: &'a LayoutContext<'a>, root: O
         tnode.set_restyle_damage(RestyleDamage::empty());
     }
 
-    unsafe {
-        node.set_changed(false);
-        node.set_dirty(false);
-        node.set_dirty_descendants(false);
-    }
-
+    unsafe { node.clear_dirty_bits(); }
     remove_from_bloom_filter(context, root, node);
 }
 

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1135,12 +1135,12 @@ impl LayoutThread {
                 while let Some(node) = next {
                     if node.needs_dirty_on_viewport_size_changed() {
                         // NB: The dirty bit is propagated down the tree.
-                        unsafe { node.set_dirty(true); }
+                        unsafe { node.set_dirty(); }
 
                         let mut current = node.parent_node();
                         while let Some(node) = current {
                             if node.has_dirty_descendants() { break; }
-                            unsafe { node.set_dirty_descendants(true); }
+                            unsafe { node.set_dirty_descendants(); }
                             current = node.parent_node();
                         }
 
@@ -1161,7 +1161,7 @@ impl LayoutThread {
             if needs_dirtying {
                 // NB: The dirty flag is propagated down during the restyle
                 // process.
-                node.set_dirty(true);
+                node.set_dirty();
             }
         }
         if needs_reflow {

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unsafe_code)]
+
 use HTMLCanvasData;
 use LayoutNodeType;
 use OpaqueStyleAndLayoutData;
@@ -76,6 +78,10 @@ pub trait LayoutNode: TNode {
 
     /// Returns the type ID of this node.
     fn type_id(&self) -> LayoutNodeType;
+
+    fn has_changed(&self) -> bool;
+
+    unsafe fn clear_dirty_bits(&self);
 
     fn get_style_data(&self) -> Option<&AtomicRefCell<PersistentStyleData>>;
 

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -116,17 +116,13 @@ pub trait TNode : Sized + Copy + Clone + NodeInfo {
 
     fn as_document(&self) -> Option<Self::ConcreteDocument>;
 
-    fn has_changed(&self) -> bool;
-
-    unsafe fn set_changed(&self, value: bool);
-
     fn is_dirty(&self) -> bool;
 
-    unsafe fn set_dirty(&self, value: bool);
+    unsafe fn set_dirty(&self);
 
     fn has_dirty_descendants(&self) -> bool;
 
-    unsafe fn set_dirty_descendants(&self, value: bool);
+    unsafe fn set_dirty_descendants(&self);
 
     fn needs_dirty_on_viewport_size_changed(&self) -> bool;
 
@@ -155,7 +151,7 @@ pub trait TNode : Sized + Copy + Clone + NodeInfo {
     fn get_existing_style(&self) -> Option<Arc<ComputedValues>>;
 
     /// Sets the computed style for this node.
-    fn set_style(&self, style: Option<Arc<ComputedValues>>);
+    fn set_style(&self, style: Arc<ComputedValues>);
 
     /// Transfers ownership of the existing pseudo styles, if any, to the
     /// caller. The stored pseudo styles are replaced with an empty map.
@@ -163,6 +159,9 @@ pub trait TNode : Sized + Copy + Clone + NodeInfo {
 
     /// Sets the pseudo styles on the element, replacing any existing styles.
     fn set_pseudo_styles(&self, styles: PseudoStyles);
+
+    /// Set the style for a text node.
+    fn style_text_node(&self, style: Arc<ComputedValues>);
 
     /// Get the description of how to account for recent style changes.
     fn restyle_damage(self) -> Self::ConcreteRestyleDamage;
@@ -235,19 +234,19 @@ pub trait TElement : PartialEq + Debug + Sized + Copy + Clone + ElementExt + Pre
         let mut curr = node;
         while let Some(parent) = curr.parent_node() {
             if parent.has_dirty_descendants() { break }
-            unsafe { parent.set_dirty_descendants(true); }
+            unsafe { parent.set_dirty_descendants(); }
             curr = parent;
         }
 
         // Process hints.
         if hint.contains(RESTYLE_SELF) {
-            unsafe { node.set_dirty(true); }
+            unsafe { node.set_dirty(); }
         // XXX(emilio): For now, dirty implies dirty descendants if found.
         } else if hint.contains(RESTYLE_DESCENDANTS) {
-            unsafe { node.set_dirty_descendants(true); }
+            unsafe { node.set_dirty_descendants(); }
             let mut current = node.first_child();
             while let Some(node) = current {
-                unsafe { node.set_dirty(true); }
+                unsafe { node.set_dirty(); }
                 current = node.next_sibling();
             }
         }
@@ -256,7 +255,7 @@ pub trait TElement : PartialEq + Debug + Sized + Copy + Clone + ElementExt + Pre
             let mut next = ::selectors::Element::next_sibling_element(self);
             while let Some(sib) = next {
                 let sib_node = sib.as_node();
-                unsafe { sib_node.set_dirty(true) };
+                unsafe { sib_node.set_dirty() };
                 next = ::selectors::Element::next_sibling_element(&sib);
             }
         }

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -745,7 +745,7 @@ pub trait ElementMatchMethods : TElement {
                         RestyleResult::Continue
                     };
 
-                    node.set_style(Some(shared_style));
+                    node.set_style(shared_style);
 
                     return StyleSharingResult::StyleWasShared(i, damage, restyle_result)
                 }
@@ -890,9 +890,7 @@ pub trait MatchMethods : TNode {
         // In Servo, this is also true, since text nodes generate UnscannedText
         // fragments, which aren't repairable by incremental layout.
         if self.is_text_node() {
-            let cloned_parent_style = ComputedValues::style_for_child_text_node(parent_style.as_ref().unwrap());
-
-            self.set_style(Some(cloned_parent_style));
+            self.style_text_node(ComputedValues::style_for_child_text_node(parent_style.as_ref().unwrap()));
 
             return RestyleResult::Continue;
         }
@@ -931,7 +929,7 @@ pub trait MatchMethods : TNode {
                                                         context, applicable_declarations,
                                                         &mut applicable_declarations_cache);
 
-            self.set_style(Some(new_style));
+            self.set_style(new_style);
 
             self.set_can_be_fragmented(parent.map_or(false, |p| {
                 p.can_be_fragmented() ||


### PR DESCRIPTION
A couple of changes here:
- Remove the option to unset with the dirty bit settes.
- Add an explicit API for setting text node style.
- Hoist has_changed handling into the restyle damage setter and text node style setter.
- Make set_style take a non-Option.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13841)

<!-- Reviewable:end -->
