### PR TITLE
Regenerate bindings (fixes #13847)

### DIFF
--- a/components/style/gecko_bindings/structs_debug.rs
+++ b/components/style/gecko_bindings/structs_debug.rs
@@ -1529,15 +1529,15 @@ impl Clone for JSObject {
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct Value {
-    pub data: Value__bindgen_ty_bindgen_id_54313,
+    pub data: Value__bindgen_ty_bindgen_id_54317,
 }
 pub type Value_PayloadType = u64;
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct Value__bindgen_ty_bindgen_id_54313 {
+pub struct Value__bindgen_ty_bindgen_id_54317 {
     pub asBits: __BindgenUnionField<u64>,
-    pub debugView: __BindgenUnionField<Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54316>,
-    pub s: __BindgenUnionField<Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322>,
+    pub debugView: __BindgenUnionField<Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54320>,
+    pub s: __BindgenUnionField<Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326>,
     pub asDouble: __BindgenUnionField<f64>,
     pub asPtr: __BindgenUnionField<*mut ::std::os::raw::c_void>,
     pub asWord: __BindgenUnionField<usize>,
@@ -1546,21 +1546,21 @@ pub struct Value__bindgen_ty_bindgen_id_54313 {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54316 {
+pub struct Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54320 {
     pub _bitfield_1: u64,
 }
 #[test]
-fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54316() {
-    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54316>()
+fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54320() {
+    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54320>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54316>()
+    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54320>()
                , 8usize);
 }
-impl Clone for Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54316
+impl Clone for Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54320
  {
     fn clone(&self) -> Self { *self }
 }
-impl Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54316 {
+impl Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54320 {
     #[inline]
     pub fn payload47(&self) -> u64 {
         unsafe {
@@ -1593,48 +1593,48 @@ impl Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54316 {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322 {
-    pub payload: Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322__bindgen_ty_bindgen_id_54323,
+pub struct Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326 {
+    pub payload: Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326__bindgen_ty_bindgen_id_54327,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322__bindgen_ty_bindgen_id_54323 {
+pub struct Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326__bindgen_ty_bindgen_id_54327 {
     pub i32: __BindgenUnionField<i32>,
     pub u32: __BindgenUnionField<u32>,
     pub why: __BindgenUnionField<JSWhyMagic>,
     pub bindgen_union_field: u32,
 }
 #[test]
-fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322__bindgen_ty_bindgen_id_54323() {
-    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322__bindgen_ty_bindgen_id_54323>()
+fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326__bindgen_ty_bindgen_id_54327() {
+    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326__bindgen_ty_bindgen_id_54327>()
                , 4usize);
-    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322__bindgen_ty_bindgen_id_54323>()
+    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326__bindgen_ty_bindgen_id_54327>()
                , 4usize);
 }
 impl Clone for
- Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322__bindgen_ty_bindgen_id_54323
+ Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326__bindgen_ty_bindgen_id_54327
  {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322() {
-    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322>()
+fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326() {
+    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326>()
                , 4usize);
-    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322>()
+    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326>()
                , 4usize);
 }
-impl Clone for Value__bindgen_ty_bindgen_id_54313__bindgen_ty_bindgen_id_54322
+impl Clone for Value__bindgen_ty_bindgen_id_54317__bindgen_ty_bindgen_id_54326
  {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_54313() {
-    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_54313>() ,
+fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_54317() {
+    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_54317>() ,
                8usize);
-    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_54313>() ,
+    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_54317>() ,
                8usize);
 }
-impl Clone for Value__bindgen_ty_bindgen_id_54313 {
+impl Clone for Value__bindgen_ty_bindgen_id_54317 {
     fn clone(&self) -> Self { *self }
 }
 impl Clone for Value {
@@ -1715,9 +1715,33 @@ pub type nsAString_internal_const_char_iterator =
     *const nsAString_internal_char_type;
 pub type nsAString_internal_size_type = u32;
 pub type nsAString_internal_index_type = u32;
+pub const nsAString_internal_F_NONE:
+          nsAString_internal__bindgen_ty_bindgen_id_69066 =
+    nsAString_internal__bindgen_ty_bindgen_id_69066::F_NONE;
+pub const nsAString_internal_F_TERMINATED:
+          nsAString_internal__bindgen_ty_bindgen_id_69066 =
+    nsAString_internal__bindgen_ty_bindgen_id_69066::F_TERMINATED;
+pub const nsAString_internal_F_VOIDED:
+          nsAString_internal__bindgen_ty_bindgen_id_69066 =
+    nsAString_internal__bindgen_ty_bindgen_id_69066::F_VOIDED;
+pub const nsAString_internal_F_SHARED:
+          nsAString_internal__bindgen_ty_bindgen_id_69066 =
+    nsAString_internal__bindgen_ty_bindgen_id_69066::F_SHARED;
+pub const nsAString_internal_F_OWNED:
+          nsAString_internal__bindgen_ty_bindgen_id_69066 =
+    nsAString_internal__bindgen_ty_bindgen_id_69066::F_OWNED;
+pub const nsAString_internal_F_FIXED:
+          nsAString_internal__bindgen_ty_bindgen_id_69066 =
+    nsAString_internal__bindgen_ty_bindgen_id_69066::F_FIXED;
+pub const nsAString_internal_F_LITERAL:
+          nsAString_internal__bindgen_ty_bindgen_id_69066 =
+    nsAString_internal__bindgen_ty_bindgen_id_69066::F_LITERAL;
+pub const nsAString_internal_F_CLASS_FIXED:
+          nsAString_internal__bindgen_ty_bindgen_id_69066 =
+    nsAString_internal__bindgen_ty_bindgen_id_69066::F_CLASS_FIXED;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsAString_internal__bindgen_ty_bindgen_id_69062 {
+pub enum nsAString_internal__bindgen_ty_bindgen_id_69066 {
     F_NONE = 0,
     F_TERMINATED = 1,
     F_VOIDED = 2,
@@ -1754,12 +1778,12 @@ impl Clone for nsSubstringTuple {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_69672 {
+pub struct bindgen_vtable__bindgen_id_69676 {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsStringComparator {
-    pub vtable_: *const bindgen_vtable__bindgen_id_69672,
+    pub vtable_: *const bindgen_vtable__bindgen_id_69676,
 }
 pub type nsStringComparator_char_type = u16;
 #[test]
@@ -1799,9 +1823,33 @@ pub type nsACString_internal_const_char_iterator =
     *const nsACString_internal_char_type;
 pub type nsACString_internal_size_type = u32;
 pub type nsACString_internal_index_type = u32;
+pub const nsACString_internal_F_NONE:
+          nsACString_internal__bindgen_ty_bindgen_id_70906 =
+    nsACString_internal__bindgen_ty_bindgen_id_70906::F_NONE;
+pub const nsACString_internal_F_TERMINATED:
+          nsACString_internal__bindgen_ty_bindgen_id_70906 =
+    nsACString_internal__bindgen_ty_bindgen_id_70906::F_TERMINATED;
+pub const nsACString_internal_F_VOIDED:
+          nsACString_internal__bindgen_ty_bindgen_id_70906 =
+    nsACString_internal__bindgen_ty_bindgen_id_70906::F_VOIDED;
+pub const nsACString_internal_F_SHARED:
+          nsACString_internal__bindgen_ty_bindgen_id_70906 =
+    nsACString_internal__bindgen_ty_bindgen_id_70906::F_SHARED;
+pub const nsACString_internal_F_OWNED:
+          nsACString_internal__bindgen_ty_bindgen_id_70906 =
+    nsACString_internal__bindgen_ty_bindgen_id_70906::F_OWNED;
+pub const nsACString_internal_F_FIXED:
+          nsACString_internal__bindgen_ty_bindgen_id_70906 =
+    nsACString_internal__bindgen_ty_bindgen_id_70906::F_FIXED;
+pub const nsACString_internal_F_LITERAL:
+          nsACString_internal__bindgen_ty_bindgen_id_70906 =
+    nsACString_internal__bindgen_ty_bindgen_id_70906::F_LITERAL;
+pub const nsACString_internal_F_CLASS_FIXED:
+          nsACString_internal__bindgen_ty_bindgen_id_70906 =
+    nsACString_internal__bindgen_ty_bindgen_id_70906::F_CLASS_FIXED;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsACString_internal__bindgen_ty_bindgen_id_70902 {
+pub enum nsACString_internal__bindgen_ty_bindgen_id_70906 {
     F_NONE = 0,
     F_TERMINATED = 1,
     F_VOIDED = 2,
@@ -1863,12 +1911,12 @@ fn bindgen_test_layout_nsCString() {
     assert_eq!(::std::mem::align_of::<nsCString>() , 8usize);
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_71454 {
+pub struct bindgen_vtable__bindgen_id_71458 {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsCStringComparator {
-    pub vtable_: *const bindgen_vtable__bindgen_id_71454,
+    pub vtable_: *const bindgen_vtable__bindgen_id_71458,
 }
 pub type nsCStringComparator_char_type = ::std::os::raw::c_char;
 #[test]
@@ -1880,7 +1928,7 @@ impl Clone for nsCStringComparator {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_71758 {
+pub struct bindgen_vtable__bindgen_id_71762 {
 }
 /**
  * Basic component object model interface. Objects which implement
@@ -1891,7 +1939,7 @@ pub struct bindgen_vtable__bindgen_id_71758 {
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsISupports {
-    pub vtable_: *const bindgen_vtable__bindgen_id_71758,
+    pub vtable_: *const bindgen_vtable__bindgen_id_71762,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1909,7 +1957,7 @@ impl Clone for nsISupports {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_72042 {
+pub struct bindgen_vtable__bindgen_id_72046 {
 }
 /**
  * Participant implementation classes
@@ -1917,7 +1965,7 @@ pub struct bindgen_vtable__bindgen_id_72042 {
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsCycleCollectionParticipant {
-    pub vtable_: *const bindgen_vtable__bindgen_id_72042,
+    pub vtable_: *const bindgen_vtable__bindgen_id_72046,
     pub mMightSkip: bool,
 }
 #[test]
@@ -2228,7 +2276,7 @@ fn bindgen_test_layout_ErrorResult() {
 #[derive(Debug)]
 pub struct TErrorResult<CleanupPolicy> {
     pub mResult: nsresult,
-    pub __bindgen_anon_1: TErrorResult__bindgen_ty_bindgen_id_79919<CleanupPolicy>,
+    pub __bindgen_anon_1: TErrorResult__bindgen_ty_bindgen_id_79923<CleanupPolicy>,
     pub mMightHaveUnreportedJSException: bool,
     pub mUnionState: TErrorResult_UnionState,
     pub _mOwningThread: nsAutoOwningThread,
@@ -2258,7 +2306,7 @@ pub struct TErrorResult_DOMExceptionInfo<CleanupPolicy> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TErrorResult__bindgen_ty_bindgen_id_79919<CleanupPolicy> {
+pub struct TErrorResult__bindgen_ty_bindgen_id_79923<CleanupPolicy> {
     pub mMessage: __BindgenUnionField<*mut TErrorResult_Message<CleanupPolicy>>,
     pub mJSException: __BindgenUnionField<Value>,
     pub mDOMExceptionInfo: __BindgenUnionField<*mut TErrorResult_DOMExceptionInfo<CleanupPolicy>>,
@@ -2416,9 +2464,21 @@ pub struct nsIPrincipal_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsIPrincipal_APP_STATUS_NOT_INSTALLED:
+          nsIPrincipal__bindgen_ty_bindgen_id_81162 =
+    nsIPrincipal__bindgen_ty_bindgen_id_81162::APP_STATUS_NOT_INSTALLED;
+pub const nsIPrincipal_APP_STATUS_INSTALLED:
+          nsIPrincipal__bindgen_ty_bindgen_id_81162 =
+    nsIPrincipal__bindgen_ty_bindgen_id_81162::APP_STATUS_INSTALLED;
+pub const nsIPrincipal_APP_STATUS_PRIVILEGED:
+          nsIPrincipal__bindgen_ty_bindgen_id_81162 =
+    nsIPrincipal__bindgen_ty_bindgen_id_81162::APP_STATUS_PRIVILEGED;
+pub const nsIPrincipal_APP_STATUS_CERTIFIED:
+          nsIPrincipal__bindgen_ty_bindgen_id_81162 =
+    nsIPrincipal__bindgen_ty_bindgen_id_81162::APP_STATUS_CERTIFIED;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPrincipal__bindgen_ty_bindgen_id_81158 {
+pub enum nsIPrincipal__bindgen_ty_bindgen_id_81162 {
     APP_STATUS_NOT_INSTALLED = 0,
     APP_STATUS_INSTALLED = 1,
     APP_STATUS_PRIVILEGED = 2,
@@ -2453,7 +2513,7 @@ impl Clone for nsISerializable {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_81326 {
+pub struct bindgen_vtable__bindgen_id_81330 {
 }
 /**
  * Class to store the wrapper for an object. This can only be used with objects
@@ -2495,7 +2555,7 @@ pub struct bindgen_vtable__bindgen_id_81326 {
 #[repr(C)]
 #[derive(Debug)]
 pub struct nsWrapperCache {
-    pub vtable_: *const bindgen_vtable__bindgen_id_81326,
+    pub vtable_: *const bindgen_vtable__bindgen_id_81330,
     pub mWrapper: *mut JSObject,
     pub mFlags: nsWrapperCache_FlagsType,
 }
@@ -2507,6 +2567,9 @@ pub struct nsWrapperCache_COMTypeInfo<T, U> {
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
 pub type nsWrapperCache_FlagsType = u32;
+pub const nsWrapperCache_WRAPPER_BIT_PRESERVED:
+          nsWrapperCache__bindgen_ty_bindgen_id_81537 =
+    nsWrapperCache__bindgen_ty_bindgen_id_81537::WRAPPER_BIT_PRESERVED;
 #[repr(u32)]
 /**
    * If this bit is set then we're preserving the wrapper, which in effect ties
@@ -2520,21 +2583,27 @@ pub type nsWrapperCache_FlagsType = u32;
    * NS_IMPL_CYCLE_COLLECTION_UNLINK_PRESERVED_WRAPPER).
    */
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsWrapperCache__bindgen_ty_bindgen_id_81533 {
+pub enum nsWrapperCache__bindgen_ty_bindgen_id_81537 {
     WRAPPER_BIT_PRESERVED = 1,
 }
+pub const nsWrapperCache_WRAPPER_IS_NOT_DOM_BINDING:
+          nsWrapperCache__bindgen_ty_bindgen_id_81540 =
+    nsWrapperCache__bindgen_ty_bindgen_id_81540::WRAPPER_IS_NOT_DOM_BINDING;
 #[repr(u32)]
 /**
    * If this bit is set then the wrapper for the native object is not a DOM
    * binding.
    */
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsWrapperCache__bindgen_ty_bindgen_id_81536 {
+pub enum nsWrapperCache__bindgen_ty_bindgen_id_81540 {
     WRAPPER_IS_NOT_DOM_BINDING = 2,
 }
+pub const nsWrapperCache_kWrapperFlagsMask:
+          nsWrapperCache__bindgen_ty_bindgen_id_81543 =
+    nsWrapperCache__bindgen_ty_bindgen_id_81543::kWrapperFlagsMask;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsWrapperCache__bindgen_ty_bindgen_id_81539 {
+pub enum nsWrapperCache__bindgen_ty_bindgen_id_81543 {
     kWrapperFlagsMask = 3,
 }
 #[test]
@@ -2576,7 +2645,7 @@ pub struct pair<_T1, _T2> {
 pub type pair_first_type<_T1> = _T1;
 pub type pair_second_type<_T2> = _T2;
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_129417 {
+pub struct bindgen_vtable__bindgen_id_129421 {
 }
 /**
  * A class of objects that return source code on demand.
@@ -2592,7 +2661,7 @@ pub struct bindgen_vtable__bindgen_id_129417 {
 #[repr(C)]
 #[derive(Debug)]
 pub struct SourceHook {
-    pub vtable_: *const bindgen_vtable__bindgen_id_129417,
+    pub vtable_: *const bindgen_vtable__bindgen_id_129421,
 }
 #[test]
 fn bindgen_test_layout_SourceHook() {
@@ -2802,9 +2871,12 @@ pub struct nsPtrHashKey<T> {
 }
 pub type nsPtrHashKey_KeyType<T> = *mut T;
 pub type nsPtrHashKey_KeyTypePointer<T> = *mut T;
+pub const nsPtrHashKey_ALLOW_MEMMOVE:
+          nsPtrHashKey__bindgen_ty_bindgen_id_136862 =
+    nsPtrHashKey__bindgen_ty_bindgen_id_136862::ALLOW_MEMMOVE;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsPtrHashKey__bindgen_ty_bindgen_id_136858 { ALLOW_MEMMOVE = 0, }
+pub enum nsPtrHashKey__bindgen_ty_bindgen_id_136862 { ALLOW_MEMMOVE = 0, }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsIRunnable {
@@ -2925,11 +2997,11 @@ pub struct nsIDocument {
     pub mCompatMode: nsCompatibility,
     pub mReadyState: nsIDocument_ReadyState,
     pub mVisibilityState: VisibilityState,
-    pub mStyleBackendType: StyleBackendType,
     pub _bitfield_1: u64,
     pub mType: nsIDocument_Type,
     pub mDefaultElementType: u8,
     pub mAllowXULXBL: nsIDocument_Tri,
+    pub mStyleBackendType: StyleBackendType,
     /**
    * This is true while FlushPendingLinkUpdates executes.  Calls to
    * [Un]RegisterPendingLinkUpdate will assert when this is true.
@@ -3806,7 +3878,7 @@ pub struct nsINode {
     pub mNextSibling: *mut nsIContent,
     pub mPreviousSibling: *mut nsIContent,
     pub mFirstChild: *mut nsIContent,
-    pub __bindgen_anon_1: nsINode__bindgen_ty_bindgen_id_143916,
+    pub __bindgen_anon_1: nsINode__bindgen_ty_bindgen_id_143920,
     pub mSlots: *mut nsINode_nsSlots,
     pub mServoData: ServoCell<*mut ServoNodeData>,
 }
@@ -3826,12 +3898,37 @@ pub struct nsINode_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsINode_eCONTENT: nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::eCONTENT;
+pub const nsINode_eDOCUMENT: nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::eDOCUMENT;
+pub const nsINode_eATTRIBUTE: nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::eATTRIBUTE;
+pub const nsINode_eTEXT: nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::eTEXT;
+pub const nsINode_ePROCESSING_INSTRUCTION:
+          nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::ePROCESSING_INSTRUCTION;
+pub const nsINode_eCOMMENT: nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::eCOMMENT;
+pub const nsINode_eHTML_FORM_CONTROL: nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::eHTML_FORM_CONTROL;
+pub const nsINode_eDOCUMENT_FRAGMENT: nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::eDOCUMENT_FRAGMENT;
+pub const nsINode_eDATA_NODE: nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::eDATA_NODE;
+pub const nsINode_eMEDIA: nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::eMEDIA;
+pub const nsINode_eANIMATION: nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::eANIMATION;
+pub const nsINode_eFILTER: nsINode__bindgen_ty_bindgen_id_140045 =
+    nsINode__bindgen_ty_bindgen_id_140045::eFILTER;
 #[repr(u32)]
 /**
    * Bit-flags to pass (or'ed together) to IsNodeOfType()
    */
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsINode__bindgen_ty_bindgen_id_140041 {
+pub enum nsINode__bindgen_ty_bindgen_id_140045 {
     eCONTENT = 1,
     eDOCUMENT = 2,
     eATTRIBUTE = 4,
@@ -3846,12 +3943,12 @@ pub enum nsINode__bindgen_ty_bindgen_id_140041 {
     eFILTER = 2048,
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_140810 {
+pub struct bindgen_vtable__bindgen_id_140814 {
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct nsINode_nsSlots {
-    pub vtable_: *const bindgen_vtable__bindgen_id_140810,
+    pub vtable_: *const bindgen_vtable__bindgen_id_140814,
     /**
      * A list of mutation observers
      */
@@ -3920,19 +4017,19 @@ pub enum nsINode_BooleanFlag {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsINode__bindgen_ty_bindgen_id_143916 {
+pub struct nsINode__bindgen_ty_bindgen_id_143920 {
     pub mPrimaryFrame: __BindgenUnionField<*mut nsIFrame>,
     pub mSubtreeRoot: __BindgenUnionField<*mut nsINode>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsINode__bindgen_ty_bindgen_id_143916() {
-    assert_eq!(::std::mem::size_of::<nsINode__bindgen_ty_bindgen_id_143916>()
+fn bindgen_test_layout_nsINode__bindgen_ty_bindgen_id_143920() {
+    assert_eq!(::std::mem::size_of::<nsINode__bindgen_ty_bindgen_id_143920>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsINode__bindgen_ty_bindgen_id_143916>()
+    assert_eq!(::std::mem::align_of::<nsINode__bindgen_ty_bindgen_id_143920>()
                , 8usize);
 }
-impl Clone for nsINode__bindgen_ty_bindgen_id_143916 {
+impl Clone for nsINode__bindgen_ty_bindgen_id_143920 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -4265,9 +4362,39 @@ pub struct nsIDOMNode_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsIDOMNode_ELEMENT_NODE: nsIDOMNode__bindgen_ty_bindgen_id_151880 =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::ELEMENT_NODE;
+pub const nsIDOMNode_ATTRIBUTE_NODE: nsIDOMNode__bindgen_ty_bindgen_id_151880
+          =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::ATTRIBUTE_NODE;
+pub const nsIDOMNode_TEXT_NODE: nsIDOMNode__bindgen_ty_bindgen_id_151880 =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::TEXT_NODE;
+pub const nsIDOMNode_CDATA_SECTION_NODE:
+          nsIDOMNode__bindgen_ty_bindgen_id_151880 =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::CDATA_SECTION_NODE;
+pub const nsIDOMNode_ENTITY_REFERENCE_NODE:
+          nsIDOMNode__bindgen_ty_bindgen_id_151880 =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::ENTITY_REFERENCE_NODE;
+pub const nsIDOMNode_ENTITY_NODE: nsIDOMNode__bindgen_ty_bindgen_id_151880 =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::ENTITY_NODE;
+pub const nsIDOMNode_PROCESSING_INSTRUCTION_NODE:
+          nsIDOMNode__bindgen_ty_bindgen_id_151880 =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::PROCESSING_INSTRUCTION_NODE;
+pub const nsIDOMNode_COMMENT_NODE: nsIDOMNode__bindgen_ty_bindgen_id_151880 =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::COMMENT_NODE;
+pub const nsIDOMNode_DOCUMENT_NODE: nsIDOMNode__bindgen_ty_bindgen_id_151880 =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::DOCUMENT_NODE;
+pub const nsIDOMNode_DOCUMENT_TYPE_NODE:
+          nsIDOMNode__bindgen_ty_bindgen_id_151880 =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::DOCUMENT_TYPE_NODE;
+pub const nsIDOMNode_DOCUMENT_FRAGMENT_NODE:
+          nsIDOMNode__bindgen_ty_bindgen_id_151880 =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::DOCUMENT_FRAGMENT_NODE;
+pub const nsIDOMNode_NOTATION_NODE: nsIDOMNode__bindgen_ty_bindgen_id_151880 =
+    nsIDOMNode__bindgen_ty_bindgen_id_151880::NOTATION_NODE;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIDOMNode__bindgen_ty_bindgen_id_151876 {
+pub enum nsIDOMNode__bindgen_ty_bindgen_id_151880 {
     ELEMENT_NODE = 1,
     ATTRIBUTE_NODE = 2,
     TEXT_NODE = 3,
@@ -4281,9 +4408,27 @@ pub enum nsIDOMNode__bindgen_ty_bindgen_id_151876 {
     DOCUMENT_FRAGMENT_NODE = 11,
     NOTATION_NODE = 12,
 }
+pub const nsIDOMNode_DOCUMENT_POSITION_DISCONNECTED:
+          nsIDOMNode__bindgen_ty_bindgen_id_152099 =
+    nsIDOMNode__bindgen_ty_bindgen_id_152099::DOCUMENT_POSITION_DISCONNECTED;
+pub const nsIDOMNode_DOCUMENT_POSITION_PRECEDING:
+          nsIDOMNode__bindgen_ty_bindgen_id_152099 =
+    nsIDOMNode__bindgen_ty_bindgen_id_152099::DOCUMENT_POSITION_PRECEDING;
+pub const nsIDOMNode_DOCUMENT_POSITION_FOLLOWING:
+          nsIDOMNode__bindgen_ty_bindgen_id_152099 =
+    nsIDOMNode__bindgen_ty_bindgen_id_152099::DOCUMENT_POSITION_FOLLOWING;
+pub const nsIDOMNode_DOCUMENT_POSITION_CONTAINS:
+          nsIDOMNode__bindgen_ty_bindgen_id_152099 =
+    nsIDOMNode__bindgen_ty_bindgen_id_152099::DOCUMENT_POSITION_CONTAINS;
+pub const nsIDOMNode_DOCUMENT_POSITION_CONTAINED_BY:
+          nsIDOMNode__bindgen_ty_bindgen_id_152099 =
+    nsIDOMNode__bindgen_ty_bindgen_id_152099::DOCUMENT_POSITION_CONTAINED_BY;
+pub const nsIDOMNode_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC:
+          nsIDOMNode__bindgen_ty_bindgen_id_152099 =
+    nsIDOMNode__bindgen_ty_bindgen_id_152099::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIDOMNode__bindgen_ty_bindgen_id_152095 {
+pub enum nsIDOMNode__bindgen_ty_bindgen_id_152099 {
     DOCUMENT_POSITION_DISCONNECTED = 1,
     DOCUMENT_POSITION_PRECEDING = 2,
     DOCUMENT_POSITION_FOLLOWING = 4,
@@ -5157,16 +5302,28 @@ pub struct nsIContent_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsIContent_eAllChildren: nsIContent__bindgen_ty_bindgen_id_156169 =
+    nsIContent__bindgen_ty_bindgen_id_156169::eAllChildren;
+pub const nsIContent_eAllButXBL: nsIContent__bindgen_ty_bindgen_id_156169 =
+    nsIContent__bindgen_ty_bindgen_id_156169::eAllButXBL;
+pub const nsIContent_eSkipPlaceholderContent:
+          nsIContent__bindgen_ty_bindgen_id_156169 =
+    nsIContent__bindgen_ty_bindgen_id_156169::eSkipPlaceholderContent;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIContent__bindgen_ty_bindgen_id_156165 {
+pub enum nsIContent__bindgen_ty_bindgen_id_156169 {
     eAllChildren = 0,
     eAllButXBL = 1,
     eSkipPlaceholderContent = 2,
 }
+pub const nsIContent_ATTR_MISSING: nsIContent__bindgen_ty_bindgen_id_156405 =
+    nsIContent__bindgen_ty_bindgen_id_156405::ATTR_MISSING;
+pub const nsIContent_ATTR_VALUE_NO_MATCH:
+          nsIContent__bindgen_ty_bindgen_id_156405 =
+    nsIContent__bindgen_ty_bindgen_id_156405::ATTR_VALUE_NO_MATCH;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIContent__bindgen_ty_bindgen_id_156401 {
+pub enum nsIContent__bindgen_ty_bindgen_id_156405 {
     ATTR_MISSING = -1,
     ATTR_VALUE_NO_MATCH = -2,
 }
@@ -5368,7 +5525,7 @@ pub struct FragmentOrElement_nsDOMSlots {
      * @see FragmentOrElement::GetAttributes
      */
     pub mAttributeMap: RefPtr<nsDOMAttributeMap>,
-    pub __bindgen_anon_1: FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157533,
+    pub __bindgen_anon_1: FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157537,
     /**
      * An object implementing the .children property for this element.
      */
@@ -5405,7 +5562,7 @@ pub struct FragmentOrElement_nsDOMSlots {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157533 {
+pub struct FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157537 {
     /**
       * The nearest enclosing content node with a binding that created us.
       * @see FragmentOrElement::GetBindingParent
@@ -5418,13 +5575,13 @@ pub struct FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157533 {
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157533() {
-    assert_eq!(::std::mem::size_of::<FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157533>()
+fn bindgen_test_layout_FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157537() {
+    assert_eq!(::std::mem::size_of::<FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157537>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157533>()
+    assert_eq!(::std::mem::align_of::<FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157537>()
                , 8usize);
 }
-impl Clone for FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157533 {
+impl Clone for FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_157537 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -5579,9 +5736,37 @@ pub struct nsIChannel_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsIChannel_LOAD_DOCUMENT_URI:
+          nsIChannel__bindgen_ty_bindgen_id_169435 =
+    nsIChannel__bindgen_ty_bindgen_id_169435::LOAD_DOCUMENT_URI;
+pub const nsIChannel_LOAD_RETARGETED_DOCUMENT_URI:
+          nsIChannel__bindgen_ty_bindgen_id_169435 =
+    nsIChannel__bindgen_ty_bindgen_id_169435::LOAD_RETARGETED_DOCUMENT_URI;
+pub const nsIChannel_LOAD_REPLACE: nsIChannel__bindgen_ty_bindgen_id_169435 =
+    nsIChannel__bindgen_ty_bindgen_id_169435::LOAD_REPLACE;
+pub const nsIChannel_LOAD_INITIAL_DOCUMENT_URI:
+          nsIChannel__bindgen_ty_bindgen_id_169435 =
+    nsIChannel__bindgen_ty_bindgen_id_169435::LOAD_INITIAL_DOCUMENT_URI;
+pub const nsIChannel_LOAD_TARGETED: nsIChannel__bindgen_ty_bindgen_id_169435 =
+    nsIChannel__bindgen_ty_bindgen_id_169435::LOAD_TARGETED;
+pub const nsIChannel_LOAD_CALL_CONTENT_SNIFFERS:
+          nsIChannel__bindgen_ty_bindgen_id_169435 =
+    nsIChannel__bindgen_ty_bindgen_id_169435::LOAD_CALL_CONTENT_SNIFFERS;
+pub const nsIChannel_LOAD_CLASSIFY_URI:
+          nsIChannel__bindgen_ty_bindgen_id_169435 =
+    nsIChannel__bindgen_ty_bindgen_id_169435::LOAD_CLASSIFY_URI;
+pub const nsIChannel_LOAD_MEDIA_SNIFFER_OVERRIDES_CONTENT_TYPE:
+          nsIChannel__bindgen_ty_bindgen_id_169435 =
+    nsIChannel__bindgen_ty_bindgen_id_169435::LOAD_MEDIA_SNIFFER_OVERRIDES_CONTENT_TYPE;
+pub const nsIChannel_LOAD_EXPLICIT_CREDENTIALS:
+          nsIChannel__bindgen_ty_bindgen_id_169435 =
+    nsIChannel__bindgen_ty_bindgen_id_169435::LOAD_EXPLICIT_CREDENTIALS;
+pub const nsIChannel_LOAD_BYPASS_SERVICE_WORKER:
+          nsIChannel__bindgen_ty_bindgen_id_169435 =
+    nsIChannel__bindgen_ty_bindgen_id_169435::LOAD_BYPASS_SERVICE_WORKER;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIChannel__bindgen_ty_bindgen_id_169431 {
+pub enum nsIChannel__bindgen_ty_bindgen_id_169435 {
     LOAD_DOCUMENT_URI = 65536,
     LOAD_RETARGETED_DOCUMENT_URI = 131072,
     LOAD_REPLACE = 262144,
@@ -5593,9 +5778,15 @@ pub enum nsIChannel__bindgen_ty_bindgen_id_169431 {
     LOAD_EXPLICIT_CREDENTIALS = 16777216,
     LOAD_BYPASS_SERVICE_WORKER = 33554432,
 }
+pub const nsIChannel_DISPOSITION_INLINE:
+          nsIChannel__bindgen_ty_bindgen_id_169455 =
+    nsIChannel__bindgen_ty_bindgen_id_169455::DISPOSITION_INLINE;
+pub const nsIChannel_DISPOSITION_ATTACHMENT:
+          nsIChannel__bindgen_ty_bindgen_id_169455 =
+    nsIChannel__bindgen_ty_bindgen_id_169455::DISPOSITION_ATTACHMENT;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIChannel__bindgen_ty_bindgen_id_169451 {
+pub enum nsIChannel__bindgen_ty_bindgen_id_169455 {
     DISPOSITION_INLINE = 0,
     DISPOSITION_ATTACHMENT = 1,
 }
@@ -5619,9 +5810,47 @@ pub struct nsIRequest_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsIRequest_LOAD_REQUESTMASK:
+          nsIRequest__bindgen_ty_bindgen_id_169273 =
+    nsIRequest__bindgen_ty_bindgen_id_169273::LOAD_REQUESTMASK;
+pub const nsIRequest_LOAD_NORMAL: nsIRequest__bindgen_ty_bindgen_id_169273 =
+    nsIRequest__bindgen_ty_bindgen_id_169273::LOAD_NORMAL;
+pub const nsIRequest_LOAD_BACKGROUND: nsIRequest__bindgen_ty_bindgen_id_169273
+          =
+    nsIRequest__bindgen_ty_bindgen_id_169273::LOAD_BACKGROUND;
+pub const nsIRequest_INHIBIT_PIPELINE:
+          nsIRequest__bindgen_ty_bindgen_id_169273 =
+    nsIRequest__bindgen_ty_bindgen_id_169273::INHIBIT_PIPELINE;
+pub const nsIRequest_INHIBIT_CACHING: nsIRequest__bindgen_ty_bindgen_id_169273
+          =
+    nsIRequest__bindgen_ty_bindgen_id_169273::INHIBIT_CACHING;
+pub const nsIRequest_INHIBIT_PERSISTENT_CACHING:
+          nsIRequest__bindgen_ty_bindgen_id_169273 =
+    nsIRequest__bindgen_ty_bindgen_id_169273::INHIBIT_PERSISTENT_CACHING;
+pub const nsIRequest_LOAD_BYPASS_CACHE:
+          nsIRequest__bindgen_ty_bindgen_id_169273 =
+    nsIRequest__bindgen_ty_bindgen_id_169273::LOAD_BYPASS_CACHE;
+pub const nsIRequest_LOAD_FROM_CACHE: nsIRequest__bindgen_ty_bindgen_id_169273
+          =
+    nsIRequest__bindgen_ty_bindgen_id_169273::LOAD_FROM_CACHE;
+pub const nsIRequest_VALIDATE_ALWAYS: nsIRequest__bindgen_ty_bindgen_id_169273
+          =
+    nsIRequest__bindgen_ty_bindgen_id_169273::VALIDATE_ALWAYS;
+pub const nsIRequest_VALIDATE_NEVER: nsIRequest__bindgen_ty_bindgen_id_169273
+          =
+    nsIRequest__bindgen_ty_bindgen_id_169273::VALIDATE_NEVER;
+pub const nsIRequest_VALIDATE_ONCE_PER_SESSION:
+          nsIRequest__bindgen_ty_bindgen_id_169273 =
+    nsIRequest__bindgen_ty_bindgen_id_169273::VALIDATE_ONCE_PER_SESSION;
+pub const nsIRequest_LOAD_ANONYMOUS: nsIRequest__bindgen_ty_bindgen_id_169273
+          =
+    nsIRequest__bindgen_ty_bindgen_id_169273::LOAD_ANONYMOUS;
+pub const nsIRequest_LOAD_FRESH_CONNECTION:
+          nsIRequest__bindgen_ty_bindgen_id_169273 =
+    nsIRequest__bindgen_ty_bindgen_id_169273::LOAD_FRESH_CONNECTION;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIRequest__bindgen_ty_bindgen_id_169269 {
+pub enum nsIRequest__bindgen_ty_bindgen_id_169273 {
     LOAD_REQUESTMASK = 65535,
     LOAD_NORMAL = 0,
     LOAD_BACKGROUND = 1,
@@ -6163,13 +6392,25 @@ pub enum nsIPresShell_ReflowRootHandling {
     eNoPositionOrSizeChange = 1,
     eInferFromBitToAdd = 2,
 }
-pub const SCROLL_LEFT: nsIPresShell__bindgen_ty_bindgen_id_188023 =
-    nsIPresShell__bindgen_ty_bindgen_id_188023::SCROLL_TOP;
-pub const SCROLL_RIGHT: nsIPresShell__bindgen_ty_bindgen_id_188023 =
-    nsIPresShell__bindgen_ty_bindgen_id_188023::SCROLL_BOTTOM;
+pub const nsIPresShell_SCROLL_TOP: nsIPresShell__bindgen_ty_bindgen_id_188027
+          =
+    nsIPresShell__bindgen_ty_bindgen_id_188027::SCROLL_TOP;
+pub const nsIPresShell_SCROLL_BOTTOM:
+          nsIPresShell__bindgen_ty_bindgen_id_188027 =
+    nsIPresShell__bindgen_ty_bindgen_id_188027::SCROLL_BOTTOM;
+pub const SCROLL_LEFT: nsIPresShell__bindgen_ty_bindgen_id_188027 =
+    nsIPresShell__bindgen_ty_bindgen_id_188027::SCROLL_TOP;
+pub const SCROLL_RIGHT: nsIPresShell__bindgen_ty_bindgen_id_188027 =
+    nsIPresShell__bindgen_ty_bindgen_id_188027::SCROLL_BOTTOM;
+pub const nsIPresShell_SCROLL_CENTER:
+          nsIPresShell__bindgen_ty_bindgen_id_188027 =
+    nsIPresShell__bindgen_ty_bindgen_id_188027::SCROLL_CENTER;
+pub const nsIPresShell_SCROLL_MINIMUM:
+          nsIPresShell__bindgen_ty_bindgen_id_188027 =
+    nsIPresShell__bindgen_ty_bindgen_id_188027::SCROLL_MINIMUM;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPresShell__bindgen_ty_bindgen_id_188023 {
+pub enum nsIPresShell__bindgen_ty_bindgen_id_188027 {
     SCROLL_TOP = 0,
     SCROLL_BOTTOM = 100,
     SCROLL_CENTER = 50,
@@ -6195,15 +6436,51 @@ fn bindgen_test_layout_nsIPresShell_ScrollAxis() {
 impl Clone for nsIPresShell_ScrollAxis {
     fn clone(&self) -> Self { *self }
 }
+pub const nsIPresShell_SCROLL_FIRST_ANCESTOR_ONLY:
+          nsIPresShell__bindgen_ty_bindgen_id_188058 =
+    nsIPresShell__bindgen_ty_bindgen_id_188058::SCROLL_FIRST_ANCESTOR_ONLY;
+pub const nsIPresShell_SCROLL_OVERFLOW_HIDDEN:
+          nsIPresShell__bindgen_ty_bindgen_id_188058 =
+    nsIPresShell__bindgen_ty_bindgen_id_188058::SCROLL_OVERFLOW_HIDDEN;
+pub const nsIPresShell_SCROLL_NO_PARENT_FRAMES:
+          nsIPresShell__bindgen_ty_bindgen_id_188058 =
+    nsIPresShell__bindgen_ty_bindgen_id_188058::SCROLL_NO_PARENT_FRAMES;
+pub const nsIPresShell_SCROLL_SMOOTH:
+          nsIPresShell__bindgen_ty_bindgen_id_188058 =
+    nsIPresShell__bindgen_ty_bindgen_id_188058::SCROLL_SMOOTH;
+pub const nsIPresShell_SCROLL_SMOOTH_AUTO:
+          nsIPresShell__bindgen_ty_bindgen_id_188058 =
+    nsIPresShell__bindgen_ty_bindgen_id_188058::SCROLL_SMOOTH_AUTO;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPresShell__bindgen_ty_bindgen_id_188054 {
+pub enum nsIPresShell__bindgen_ty_bindgen_id_188058 {
     SCROLL_FIRST_ANCESTOR_ONLY = 1,
     SCROLL_OVERFLOW_HIDDEN = 2,
     SCROLL_NO_PARENT_FRAMES = 4,
     SCROLL_SMOOTH = 8,
     SCROLL_SMOOTH_AUTO = 16,
 }
+pub const nsIPresShell_RENDER_IS_UNTRUSTED:
+          nsIPresShell__bindgen_ty_bindgen_id_188459 =
+    nsIPresShell__bindgen_ty_bindgen_id_188459::RENDER_IS_UNTRUSTED;
+pub const nsIPresShell_RENDER_IGNORE_VIEWPORT_SCROLLING:
+          nsIPresShell__bindgen_ty_bindgen_id_188459 =
+    nsIPresShell__bindgen_ty_bindgen_id_188459::RENDER_IGNORE_VIEWPORT_SCROLLING;
+pub const nsIPresShell_RENDER_CARET:
+          nsIPresShell__bindgen_ty_bindgen_id_188459 =
+    nsIPresShell__bindgen_ty_bindgen_id_188459::RENDER_CARET;
+pub const nsIPresShell_RENDER_USE_WIDGET_LAYERS:
+          nsIPresShell__bindgen_ty_bindgen_id_188459 =
+    nsIPresShell__bindgen_ty_bindgen_id_188459::RENDER_USE_WIDGET_LAYERS;
+pub const nsIPresShell_RENDER_ASYNC_DECODE_IMAGES:
+          nsIPresShell__bindgen_ty_bindgen_id_188459 =
+    nsIPresShell__bindgen_ty_bindgen_id_188459::RENDER_ASYNC_DECODE_IMAGES;
+pub const nsIPresShell_RENDER_DOCUMENT_RELATIVE:
+          nsIPresShell__bindgen_ty_bindgen_id_188459 =
+    nsIPresShell__bindgen_ty_bindgen_id_188459::RENDER_DOCUMENT_RELATIVE;
+pub const nsIPresShell_RENDER_DRAWWINDOW_NOT_FLUSHING:
+          nsIPresShell__bindgen_ty_bindgen_id_188459 =
+    nsIPresShell__bindgen_ty_bindgen_id_188459::RENDER_DRAWWINDOW_NOT_FLUSHING;
 #[repr(u32)]
 /**
    * Render the document into an arbitrary gfxContext
@@ -6244,7 +6521,7 @@ pub enum nsIPresShell__bindgen_ty_bindgen_id_188054 {
    * transform.
    */
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPresShell__bindgen_ty_bindgen_id_188455 {
+pub enum nsIPresShell__bindgen_ty_bindgen_id_188459 {
     RENDER_IS_UNTRUSTED = 1,
     RENDER_IGNORE_VIEWPORT_SCROLLING = 2,
     RENDER_CARET = 4,
@@ -6253,12 +6530,21 @@ pub enum nsIPresShell__bindgen_ty_bindgen_id_188455 {
     RENDER_DOCUMENT_RELATIVE = 32,
     RENDER_DRAWWINDOW_NOT_FLUSHING = 64,
 }
+pub const nsIPresShell_RENDER_IS_IMAGE:
+          nsIPresShell__bindgen_ty_bindgen_id_188477 =
+    nsIPresShell__bindgen_ty_bindgen_id_188477::RENDER_IS_IMAGE;
+pub const nsIPresShell_RENDER_AUTO_SCALE:
+          nsIPresShell__bindgen_ty_bindgen_id_188477 =
+    nsIPresShell__bindgen_ty_bindgen_id_188477::RENDER_AUTO_SCALE;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPresShell__bindgen_ty_bindgen_id_188473 {
+pub enum nsIPresShell__bindgen_ty_bindgen_id_188477 {
     RENDER_IS_IMAGE = 256,
     RENDER_AUTO_SCALE = 128,
 }
+pub const nsIPresShell_FORCE_DRAW: nsIPresShell__bindgen_ty_bindgen_id_188600
+          =
+    nsIPresShell__bindgen_ty_bindgen_id_188600::FORCE_DRAW;
 #[repr(u32)]
 /**
    * Add a solid color item to the bottom of aList with frame aFrame and bounds
@@ -6268,7 +6554,7 @@ pub enum nsIPresShell__bindgen_ty_bindgen_id_188473 {
    * transparent by default.
    */
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPresShell__bindgen_ty_bindgen_id_188596 { FORCE_DRAW = 1, }
+pub enum nsIPresShell__bindgen_ty_bindgen_id_188600 { FORCE_DRAW = 1, }
 #[repr(C)]
 #[derive(Debug)]
 pub struct nsIPresShell_PointerCaptureInfo {
@@ -6638,67 +6924,67 @@ pub struct DOMPointInit {
 impl Clone for DOMPointInit {
     fn clone(&self) -> Self { *self }
 }
-pub const NODE_HAS_LISTENERMANAGER: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_HAS_LISTENERMANAGER;
-pub const NODE_HAS_PROPERTIES: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_HAS_PROPERTIES;
-pub const NODE_IS_ANONYMOUS_ROOT: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_IS_ANONYMOUS_ROOT;
-pub const NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE;
-pub const NODE_IS_NATIVE_ANONYMOUS_ROOT: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_IS_NATIVE_ANONYMOUS_ROOT;
-pub const NODE_FORCE_XBL_BINDINGS: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_FORCE_XBL_BINDINGS;
-pub const NODE_MAY_BE_IN_BINDING_MNGR: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_MAY_BE_IN_BINDING_MNGR;
-pub const NODE_IS_EDITABLE: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_IS_EDITABLE;
-pub const NODE_MAY_HAVE_CLASS: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_MAY_HAVE_CLASS;
-pub const NODE_IS_IN_SHADOW_TREE: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_IS_IN_SHADOW_TREE;
-pub const NODE_HAS_EMPTY_SELECTOR: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_HAS_EMPTY_SELECTOR;
-pub const NODE_HAS_SLOW_SELECTOR: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_HAS_SLOW_SELECTOR;
-pub const NODE_HAS_EDGE_CHILD_SELECTOR: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_HAS_EDGE_CHILD_SELECTOR;
-pub const NODE_HAS_SLOW_SELECTOR_LATER_SIBLINGS: _bindgen_ty_bindgen_id_190008
+pub const NODE_HAS_LISTENERMANAGER: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_HAS_LISTENERMANAGER;
+pub const NODE_HAS_PROPERTIES: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_HAS_PROPERTIES;
+pub const NODE_IS_ANONYMOUS_ROOT: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_IS_ANONYMOUS_ROOT;
+pub const NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE;
+pub const NODE_IS_NATIVE_ANONYMOUS_ROOT: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_IS_NATIVE_ANONYMOUS_ROOT;
+pub const NODE_FORCE_XBL_BINDINGS: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_FORCE_XBL_BINDINGS;
+pub const NODE_MAY_BE_IN_BINDING_MNGR: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_MAY_BE_IN_BINDING_MNGR;
+pub const NODE_IS_EDITABLE: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_IS_EDITABLE;
+pub const NODE_MAY_HAVE_CLASS: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_MAY_HAVE_CLASS;
+pub const NODE_IS_IN_SHADOW_TREE: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_IS_IN_SHADOW_TREE;
+pub const NODE_HAS_EMPTY_SELECTOR: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_HAS_EMPTY_SELECTOR;
+pub const NODE_HAS_SLOW_SELECTOR: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_HAS_SLOW_SELECTOR;
+pub const NODE_HAS_EDGE_CHILD_SELECTOR: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_HAS_EDGE_CHILD_SELECTOR;
+pub const NODE_HAS_SLOW_SELECTOR_LATER_SIBLINGS: _bindgen_ty_bindgen_id_190012
           =
-    _bindgen_ty_bindgen_id_190008::NODE_HAS_SLOW_SELECTOR_LATER_SIBLINGS;
-pub const NODE_ALL_SELECTOR_FLAGS: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_ALL_SELECTOR_FLAGS;
-pub const NODE_NEEDS_FRAME: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_NEEDS_FRAME;
-pub const NODE_DESCENDANTS_NEED_FRAMES: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_DESCENDANTS_NEED_FRAMES;
-pub const NODE_HAS_ACCESSKEY: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_HAS_ACCESSKEY;
-pub const NODE_HAS_DIRECTION_RTL: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_HAS_DIRECTION_RTL;
-pub const NODE_HAS_DIRECTION_LTR: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_HAS_DIRECTION_LTR;
-pub const NODE_ALL_DIRECTION_FLAGS: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_ALL_DIRECTION_FLAGS;
-pub const NODE_CHROME_ONLY_ACCESS: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_CHROME_ONLY_ACCESS;
-pub const NODE_IS_ROOT_OF_CHROME_ONLY_ACCESS: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_IS_ROOT_OF_CHROME_ONLY_ACCESS;
-pub const NODE_SHARED_RESTYLE_BIT_1: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_SHARED_RESTYLE_BIT_1;
-pub const NODE_SHARED_RESTYLE_BIT_2: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_SHARED_RESTYLE_BIT_2;
-pub const NODE_IS_DIRTY_FOR_SERVO: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_SHARED_RESTYLE_BIT_1;
-pub const NODE_HAS_DIRTY_DESCENDANTS_FOR_SERVO: _bindgen_ty_bindgen_id_190008
+    _bindgen_ty_bindgen_id_190012::NODE_HAS_SLOW_SELECTOR_LATER_SIBLINGS;
+pub const NODE_ALL_SELECTOR_FLAGS: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_ALL_SELECTOR_FLAGS;
+pub const NODE_NEEDS_FRAME: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_NEEDS_FRAME;
+pub const NODE_DESCENDANTS_NEED_FRAMES: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_DESCENDANTS_NEED_FRAMES;
+pub const NODE_HAS_ACCESSKEY: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_HAS_ACCESSKEY;
+pub const NODE_HAS_DIRECTION_RTL: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_HAS_DIRECTION_RTL;
+pub const NODE_HAS_DIRECTION_LTR: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_HAS_DIRECTION_LTR;
+pub const NODE_ALL_DIRECTION_FLAGS: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_ALL_DIRECTION_FLAGS;
+pub const NODE_CHROME_ONLY_ACCESS: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_CHROME_ONLY_ACCESS;
+pub const NODE_IS_ROOT_OF_CHROME_ONLY_ACCESS: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_IS_ROOT_OF_CHROME_ONLY_ACCESS;
+pub const NODE_SHARED_RESTYLE_BIT_1: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_SHARED_RESTYLE_BIT_1;
+pub const NODE_SHARED_RESTYLE_BIT_2: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_SHARED_RESTYLE_BIT_2;
+pub const NODE_IS_DIRTY_FOR_SERVO: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_SHARED_RESTYLE_BIT_1;
+pub const NODE_HAS_DIRTY_DESCENDANTS_FOR_SERVO: _bindgen_ty_bindgen_id_190012
           =
-    _bindgen_ty_bindgen_id_190008::NODE_SHARED_RESTYLE_BIT_2;
-pub const NODE_TYPE_SPECIFIC_BITS_OFFSET: _bindgen_ty_bindgen_id_190008 =
-    _bindgen_ty_bindgen_id_190008::NODE_TYPE_SPECIFIC_BITS_OFFSET;
+    _bindgen_ty_bindgen_id_190012::NODE_SHARED_RESTYLE_BIT_2;
+pub const NODE_TYPE_SPECIFIC_BITS_OFFSET: _bindgen_ty_bindgen_id_190012 =
+    _bindgen_ty_bindgen_id_190012::NODE_TYPE_SPECIFIC_BITS_OFFSET;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum _bindgen_ty_bindgen_id_190008 {
+pub enum _bindgen_ty_bindgen_id_190012 {
     NODE_HAS_LISTENERMANAGER = 4,
     NODE_HAS_PROPERTIES = 8,
     NODE_IS_ANONYMOUS_ROOT = 16,
@@ -6754,9 +7040,20 @@ pub struct nsITimer_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsITimer_TYPE_ONE_SHOT: nsITimer__bindgen_ty_bindgen_id_202546 =
+    nsITimer__bindgen_ty_bindgen_id_202546::TYPE_ONE_SHOT;
+pub const nsITimer_TYPE_REPEATING_SLACK:
+          nsITimer__bindgen_ty_bindgen_id_202546 =
+    nsITimer__bindgen_ty_bindgen_id_202546::TYPE_REPEATING_SLACK;
+pub const nsITimer_TYPE_REPEATING_PRECISE:
+          nsITimer__bindgen_ty_bindgen_id_202546 =
+    nsITimer__bindgen_ty_bindgen_id_202546::TYPE_REPEATING_PRECISE;
+pub const nsITimer_TYPE_REPEATING_PRECISE_CAN_SKIP:
+          nsITimer__bindgen_ty_bindgen_id_202546 =
+    nsITimer__bindgen_ty_bindgen_id_202546::TYPE_REPEATING_PRECISE_CAN_SKIP;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsITimer__bindgen_ty_bindgen_id_202542 {
+pub enum nsITimer__bindgen_ty_bindgen_id_202546 {
     TYPE_ONE_SHOT = 0,
     TYPE_REPEATING_SLACK = 1,
     TYPE_REPEATING_PRECISE = 2,
@@ -6780,9 +7077,15 @@ impl Clone for nsITimer {
 pub struct nsExpirationState {
     pub _bitfield_1: u32,
 }
+pub const nsExpirationState_NOT_TRACKED:
+          nsExpirationState__bindgen_ty_bindgen_id_203022 =
+    nsExpirationState__bindgen_ty_bindgen_id_203022::NOT_TRACKED;
+pub const nsExpirationState_MAX_INDEX_IN_GENERATION:
+          nsExpirationState__bindgen_ty_bindgen_id_203022 =
+    nsExpirationState__bindgen_ty_bindgen_id_203022::MAX_INDEX_IN_GENERATION;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsExpirationState__bindgen_ty_bindgen_id_203018 {
+pub enum nsExpirationState__bindgen_ty_bindgen_id_203022 {
     NOT_TRACKED = 15,
     MAX_INDEX_IN_GENERATION = 268435455,
 }
@@ -6855,9 +7158,32 @@ pub struct imgIRequest_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const imgIRequest_STATUS_NONE: imgIRequest__bindgen_ty_bindgen_id_204537 =
+    imgIRequest__bindgen_ty_bindgen_id_204537::STATUS_NONE;
+pub const imgIRequest_STATUS_SIZE_AVAILABLE:
+          imgIRequest__bindgen_ty_bindgen_id_204537 =
+    imgIRequest__bindgen_ty_bindgen_id_204537::STATUS_SIZE_AVAILABLE;
+pub const imgIRequest_STATUS_LOAD_COMPLETE:
+          imgIRequest__bindgen_ty_bindgen_id_204537 =
+    imgIRequest__bindgen_ty_bindgen_id_204537::STATUS_LOAD_COMPLETE;
+pub const imgIRequest_STATUS_ERROR: imgIRequest__bindgen_ty_bindgen_id_204537
+          =
+    imgIRequest__bindgen_ty_bindgen_id_204537::STATUS_ERROR;
+pub const imgIRequest_STATUS_FRAME_COMPLETE:
+          imgIRequest__bindgen_ty_bindgen_id_204537 =
+    imgIRequest__bindgen_ty_bindgen_id_204537::STATUS_FRAME_COMPLETE;
+pub const imgIRequest_STATUS_DECODE_COMPLETE:
+          imgIRequest__bindgen_ty_bindgen_id_204537 =
+    imgIRequest__bindgen_ty_bindgen_id_204537::STATUS_DECODE_COMPLETE;
+pub const imgIRequest_STATUS_IS_ANIMATED:
+          imgIRequest__bindgen_ty_bindgen_id_204537 =
+    imgIRequest__bindgen_ty_bindgen_id_204537::STATUS_IS_ANIMATED;
+pub const imgIRequest_STATUS_HAS_TRANSPARENCY:
+          imgIRequest__bindgen_ty_bindgen_id_204537 =
+    imgIRequest__bindgen_ty_bindgen_id_204537::STATUS_HAS_TRANSPARENCY;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum imgIRequest__bindgen_ty_bindgen_id_204533 {
+pub enum imgIRequest__bindgen_ty_bindgen_id_204537 {
     STATUS_NONE = 0,
     STATUS_SIZE_AVAILABLE = 1,
     STATUS_LOAD_COMPLETE = 2,
@@ -6867,9 +7193,17 @@ pub enum imgIRequest__bindgen_ty_bindgen_id_204533 {
     STATUS_IS_ANIMATED = 32,
     STATUS_HAS_TRANSPARENCY = 64,
 }
+pub const imgIRequest_CORS_NONE: imgIRequest__bindgen_ty_bindgen_id_204617 =
+    imgIRequest__bindgen_ty_bindgen_id_204617::CORS_NONE;
+pub const imgIRequest_CORS_ANONYMOUS:
+          imgIRequest__bindgen_ty_bindgen_id_204617 =
+    imgIRequest__bindgen_ty_bindgen_id_204617::CORS_ANONYMOUS;
+pub const imgIRequest_CORS_USE_CREDENTIALS:
+          imgIRequest__bindgen_ty_bindgen_id_204617 =
+    imgIRequest__bindgen_ty_bindgen_id_204617::CORS_USE_CREDENTIALS;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum imgIRequest__bindgen_ty_bindgen_id_204613 {
+pub enum imgIRequest__bindgen_ty_bindgen_id_204617 {
     CORS_NONE = 1,
     CORS_ANONYMOUS = 2,
     CORS_USE_CREDENTIALS = 3,
@@ -7139,12 +7473,12 @@ fn bindgen_test_layout_URLValue() {
     assert_eq!(::std::mem::align_of::<URLValue>() , 8usize);
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_215093 {
+pub struct bindgen_vtable__bindgen_id_215097 {
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct URLValueData {
-    pub vtable_: *const bindgen_vtable__bindgen_id_215093,
+    pub vtable_: *const bindgen_vtable__bindgen_id_215097,
     pub mRefCnt: ThreadSafeAutoRefCnt,
     pub mURI: nsMainThreadPtrHandle<nsIURI>,
     pub mBaseURI: nsMainThreadPtrHandle<nsIURI>,
@@ -7361,9 +7695,12 @@ pub struct nsPresArena_FreeList {
 }
 pub type nsPresArena_FreeList_KeyType = u32;
 pub type nsPresArena_FreeList_KeyTypePointer = *const ::std::os::raw::c_void;
+pub const nsPresArena_FreeList_ALLOW_MEMMOVE:
+          nsPresArena_FreeList__bindgen_ty_bindgen_id_217251 =
+    nsPresArena_FreeList__bindgen_ty_bindgen_id_217251::ALLOW_MEMMOVE;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsPresArena_FreeList__bindgen_ty_bindgen_id_217247 {
+pub enum nsPresArena_FreeList__bindgen_ty_bindgen_id_217251 {
     ALLOW_MEMMOVE = 0,
 }
 #[test]
@@ -7388,9 +7725,36 @@ pub struct imgINotificationObserver_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const imgINotificationObserver_SIZE_AVAILABLE:
+          imgINotificationObserver__bindgen_ty_bindgen_id_217398 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_217398::SIZE_AVAILABLE;
+pub const imgINotificationObserver_FRAME_UPDATE:
+          imgINotificationObserver__bindgen_ty_bindgen_id_217398 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_217398::FRAME_UPDATE;
+pub const imgINotificationObserver_FRAME_COMPLETE:
+          imgINotificationObserver__bindgen_ty_bindgen_id_217398 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_217398::FRAME_COMPLETE;
+pub const imgINotificationObserver_LOAD_COMPLETE:
+          imgINotificationObserver__bindgen_ty_bindgen_id_217398 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_217398::LOAD_COMPLETE;
+pub const imgINotificationObserver_DECODE_COMPLETE:
+          imgINotificationObserver__bindgen_ty_bindgen_id_217398 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_217398::DECODE_COMPLETE;
+pub const imgINotificationObserver_DISCARD:
+          imgINotificationObserver__bindgen_ty_bindgen_id_217398 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_217398::DISCARD;
+pub const imgINotificationObserver_UNLOCKED_DRAW:
+          imgINotificationObserver__bindgen_ty_bindgen_id_217398 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_217398::UNLOCKED_DRAW;
+pub const imgINotificationObserver_IS_ANIMATED:
+          imgINotificationObserver__bindgen_ty_bindgen_id_217398 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_217398::IS_ANIMATED;
+pub const imgINotificationObserver_HAS_TRANSPARENCY:
+          imgINotificationObserver__bindgen_ty_bindgen_id_217398 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_217398::HAS_TRANSPARENCY;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum imgINotificationObserver__bindgen_ty_bindgen_id_217394 {
+pub enum imgINotificationObserver__bindgen_ty_bindgen_id_217398 {
     SIZE_AVAILABLE = 1,
     FRAME_UPDATE = 2,
     FRAME_COMPLETE = 3,
@@ -7637,9 +8001,13 @@ pub type gfxFontFeatureValueSet_FeatureValueHashEntry_KeyType =
     *const gfxFontFeatureValueSet_FeatureValueHashKey;
 pub type gfxFontFeatureValueSet_FeatureValueHashEntry_KeyTypePointer =
     *const gfxFontFeatureValueSet_FeatureValueHashKey;
+pub const gfxFontFeatureValueSet_FeatureValueHashEntry_ALLOW_MEMMOVE:
+          gfxFontFeatureValueSet_FeatureValueHashEntry__bindgen_ty_bindgen_id_218658
+          =
+    gfxFontFeatureValueSet_FeatureValueHashEntry__bindgen_ty_bindgen_id_218658::ALLOW_MEMMOVE;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum gfxFontFeatureValueSet_FeatureValueHashEntry__bindgen_ty_bindgen_id_218654
+pub enum gfxFontFeatureValueSet_FeatureValueHashEntry__bindgen_ty_bindgen_id_218658
          {
     ALLOW_MEMMOVE = 1,
 }
@@ -7978,23 +8346,23 @@ pub enum nsStyleUnit {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct _bindgen_ty_bindgen_id_219259 {
+pub struct _bindgen_ty_bindgen_id_219263 {
     pub mInt: __BindgenUnionField<i32>,
     pub mFloat: __BindgenUnionField<f32>,
     pub mPointer: __BindgenUnionField<*mut ::std::os::raw::c_void>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout__bindgen_ty_bindgen_id_219259() {
-    assert_eq!(::std::mem::size_of::<_bindgen_ty_bindgen_id_219259>() ,
+fn bindgen_test_layout__bindgen_ty_bindgen_id_219263() {
+    assert_eq!(::std::mem::size_of::<_bindgen_ty_bindgen_id_219263>() ,
                8usize);
-    assert_eq!(::std::mem::align_of::<_bindgen_ty_bindgen_id_219259>() ,
+    assert_eq!(::std::mem::align_of::<_bindgen_ty_bindgen_id_219263>() ,
                8usize);
 }
-impl Clone for _bindgen_ty_bindgen_id_219259 {
+impl Clone for _bindgen_ty_bindgen_id_219263 {
     fn clone(&self) -> Self { *self }
 }
-pub type nsStyleUnion = _bindgen_ty_bindgen_id_219259;
+pub type nsStyleUnion = _bindgen_ty_bindgen_id_219263;
 /**
  * Class that hold a single size specification used by the style
  * system.  The size specification consists of two parts -- a number
@@ -9037,7 +9405,7 @@ fn bindgen_test_layout_imgRequestProxy() {
     assert_eq!(::std::mem::align_of::<imgRequestProxy>() , 8usize);
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_228528 {
+pub struct bindgen_vtable__bindgen_id_228532 {
 }
 /**
  * An interface for observing changes to image state, as reported by
@@ -9054,7 +9422,7 @@ pub struct bindgen_vtable__bindgen_id_228528 {
 #[repr(C)]
 #[derive(Debug)]
 pub struct IProgressObserver {
-    pub vtable_: *const bindgen_vtable__bindgen_id_228528,
+    pub vtable_: *const bindgen_vtable__bindgen_id_228532,
     pub _base: u64,
 }
 #[test]
@@ -9074,9 +9442,24 @@ pub struct nsISupportsPriority_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsISupportsPriority_PRIORITY_HIGHEST:
+          nsISupportsPriority__bindgen_ty_bindgen_id_228613 =
+    nsISupportsPriority__bindgen_ty_bindgen_id_228613::PRIORITY_HIGHEST;
+pub const nsISupportsPriority_PRIORITY_HIGH:
+          nsISupportsPriority__bindgen_ty_bindgen_id_228613 =
+    nsISupportsPriority__bindgen_ty_bindgen_id_228613::PRIORITY_HIGH;
+pub const nsISupportsPriority_PRIORITY_NORMAL:
+          nsISupportsPriority__bindgen_ty_bindgen_id_228613 =
+    nsISupportsPriority__bindgen_ty_bindgen_id_228613::PRIORITY_NORMAL;
+pub const nsISupportsPriority_PRIORITY_LOW:
+          nsISupportsPriority__bindgen_ty_bindgen_id_228613 =
+    nsISupportsPriority__bindgen_ty_bindgen_id_228613::PRIORITY_LOW;
+pub const nsISupportsPriority_PRIORITY_LOWEST:
+          nsISupportsPriority__bindgen_ty_bindgen_id_228613 =
+    nsISupportsPriority__bindgen_ty_bindgen_id_228613::PRIORITY_LOWEST;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsISupportsPriority__bindgen_ty_bindgen_id_228609 {
+pub enum nsISupportsPriority__bindgen_ty_bindgen_id_228613 {
     PRIORITY_HIGHEST = -20,
     PRIORITY_HIGH = -10,
     PRIORITY_NORMAL = 0,
@@ -9511,7 +9894,7 @@ fn bindgen_test_layout_nsCSSValueFloatColor() {
 #[derive(Debug)]
 pub struct nsCSSValue {
     pub mUnit: nsCSSUnit,
-    pub mValue: nsCSSValue__bindgen_ty_bindgen_id_231612,
+    pub mValue: nsCSSValue__bindgen_ty_bindgen_id_231616,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -9527,7 +9910,7 @@ fn bindgen_test_layout_nsCSSValue_Array() {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsCSSValue__bindgen_ty_bindgen_id_231612 {
+pub struct nsCSSValue__bindgen_ty_bindgen_id_231616 {
     pub mInt: __BindgenUnionField<i32>,
     pub mFloat: __BindgenUnionField<f32>,
     pub mString: __BindgenUnionField<*mut nsStringBuffer>,
@@ -9552,13 +9935,13 @@ pub struct nsCSSValue__bindgen_ty_bindgen_id_231612 {
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsCSSValue__bindgen_ty_bindgen_id_231612() {
-    assert_eq!(::std::mem::size_of::<nsCSSValue__bindgen_ty_bindgen_id_231612>()
+fn bindgen_test_layout_nsCSSValue__bindgen_ty_bindgen_id_231616() {
+    assert_eq!(::std::mem::size_of::<nsCSSValue__bindgen_ty_bindgen_id_231616>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsCSSValue__bindgen_ty_bindgen_id_231612>()
+    assert_eq!(::std::mem::align_of::<nsCSSValue__bindgen_ty_bindgen_id_231616>()
                , 8usize);
 }
-impl Clone for nsCSSValue__bindgen_ty_bindgen_id_231612 {
+impl Clone for nsCSSValue__bindgen_ty_bindgen_id_231616 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -9579,12 +9962,12 @@ fn bindgen_test_layout_nsCSSValueGradientStop() {
     assert_eq!(::std::mem::align_of::<nsCSSValueGradientStop>() , 8usize);
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_231820 {
+pub struct bindgen_vtable__bindgen_id_231824 {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct CounterStyle {
-    pub vtable_: *const bindgen_vtable__bindgen_id_231820,
+    pub vtable_: *const bindgen_vtable__bindgen_id_231824,
     pub mStyle: i32,
 }
 #[test]
@@ -9759,26 +10142,26 @@ pub struct nsStyleImage {
     pub mCachedBIData: UniquePtr<CachedBorderImageData,
                                  DefaultDelete<CachedBorderImageData>>,
     pub mType: nsStyleImageType,
-    pub __bindgen_anon_1: nsStyleImage__bindgen_ty_bindgen_id_233720,
+    pub __bindgen_anon_1: nsStyleImage__bindgen_ty_bindgen_id_233724,
     pub mCropRect: UniquePtr<nsStyleSides, DefaultDelete<nsStyleSides>>,
     pub mImageTracked: bool,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleImage__bindgen_ty_bindgen_id_233720 {
+pub struct nsStyleImage__bindgen_ty_bindgen_id_233724 {
     pub mImage: __BindgenUnionField<*mut imgRequestProxy>,
     pub mGradient: __BindgenUnionField<*mut nsStyleGradient>,
     pub mElementId: __BindgenUnionField<*mut u16>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsStyleImage__bindgen_ty_bindgen_id_233720() {
-    assert_eq!(::std::mem::size_of::<nsStyleImage__bindgen_ty_bindgen_id_233720>()
+fn bindgen_test_layout_nsStyleImage__bindgen_ty_bindgen_id_233724() {
+    assert_eq!(::std::mem::size_of::<nsStyleImage__bindgen_ty_bindgen_id_233724>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsStyleImage__bindgen_ty_bindgen_id_233720>()
+    assert_eq!(::std::mem::align_of::<nsStyleImage__bindgen_ty_bindgen_id_233724>()
                , 8usize);
 }
-impl Clone for nsStyleImage__bindgen_ty_bindgen_id_233720 {
+impl Clone for nsStyleImage__bindgen_ty_bindgen_id_233724 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -9827,9 +10210,45 @@ pub struct nsStyleImageLayers {
     pub mCompositeCount: u32,
     pub mLayers: nsStyleAutoArray<nsStyleImageLayers_Layer>,
 }
+pub const nsStyleImageLayers_shorthand:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::shorthand;
+pub const nsStyleImageLayers_color:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::color;
+pub const nsStyleImageLayers_image:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::image;
+pub const nsStyleImageLayers_repeat:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::repeat;
+pub const nsStyleImageLayers_positionX:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::positionX;
+pub const nsStyleImageLayers_positionY:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::positionY;
+pub const nsStyleImageLayers_clip:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::clip;
+pub const nsStyleImageLayers_origin:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::origin;
+pub const nsStyleImageLayers_size:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::size;
+pub const nsStyleImageLayers_attachment:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::attachment;
+pub const nsStyleImageLayers_maskMode:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::maskMode;
+pub const nsStyleImageLayers_composite:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_233779 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_233779::composite;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsStyleImageLayers__bindgen_ty_bindgen_id_233775 {
+pub enum nsStyleImageLayers__bindgen_ty_bindgen_id_233779 {
     shorthand = 0,
     color = 1,
     image = 2,
@@ -10020,45 +10439,45 @@ pub struct nsStyleBorder {
     pub mFloatEdge: StyleFloatEdge,
     pub mBoxDecorationBreak: StyleBoxDecorationBreak,
     pub mBorderStyle: [u8; 4usize],
-    pub __bindgen_anon_1: nsStyleBorder__bindgen_ty_bindgen_id_234446,
+    pub __bindgen_anon_1: nsStyleBorder__bindgen_ty_bindgen_id_234450,
     pub mComputedBorder: nsMargin,
     pub mBorder: nsMargin,
     pub mTwipsPerPixel: nscoord,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleBorder__bindgen_ty_bindgen_id_234446 {
-    pub __bindgen_anon_1: __BindgenUnionField<nsStyleBorder__bindgen_ty_bindgen_id_234446__bindgen_ty_bindgen_id_234447>,
+pub struct nsStyleBorder__bindgen_ty_bindgen_id_234450 {
+    pub __bindgen_anon_1: __BindgenUnionField<nsStyleBorder__bindgen_ty_bindgen_id_234450__bindgen_ty_bindgen_id_234451>,
     pub mBorderColor: __BindgenUnionField<[StyleComplexColor; 4usize]>,
     pub bindgen_union_field: [u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleBorder__bindgen_ty_bindgen_id_234446__bindgen_ty_bindgen_id_234447 {
+pub struct nsStyleBorder__bindgen_ty_bindgen_id_234450__bindgen_ty_bindgen_id_234451 {
     pub mBorderTopColor: StyleComplexColor,
     pub mBorderRightColor: StyleComplexColor,
     pub mBorderBottomColor: StyleComplexColor,
     pub mBorderLeftColor: StyleComplexColor,
 }
 #[test]
-fn bindgen_test_layout_nsStyleBorder__bindgen_ty_bindgen_id_234446__bindgen_ty_bindgen_id_234447() {
-    assert_eq!(::std::mem::size_of::<nsStyleBorder__bindgen_ty_bindgen_id_234446__bindgen_ty_bindgen_id_234447>()
+fn bindgen_test_layout_nsStyleBorder__bindgen_ty_bindgen_id_234450__bindgen_ty_bindgen_id_234451() {
+    assert_eq!(::std::mem::size_of::<nsStyleBorder__bindgen_ty_bindgen_id_234450__bindgen_ty_bindgen_id_234451>()
                , 32usize);
-    assert_eq!(::std::mem::align_of::<nsStyleBorder__bindgen_ty_bindgen_id_234446__bindgen_ty_bindgen_id_234447>()
+    assert_eq!(::std::mem::align_of::<nsStyleBorder__bindgen_ty_bindgen_id_234450__bindgen_ty_bindgen_id_234451>()
                , 4usize);
 }
 impl Clone for
- nsStyleBorder__bindgen_ty_bindgen_id_234446__bindgen_ty_bindgen_id_234447 {
+ nsStyleBorder__bindgen_ty_bindgen_id_234450__bindgen_ty_bindgen_id_234451 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_nsStyleBorder__bindgen_ty_bindgen_id_234446() {
-    assert_eq!(::std::mem::size_of::<nsStyleBorder__bindgen_ty_bindgen_id_234446>()
+fn bindgen_test_layout_nsStyleBorder__bindgen_ty_bindgen_id_234450() {
+    assert_eq!(::std::mem::size_of::<nsStyleBorder__bindgen_ty_bindgen_id_234450>()
                , 32usize);
-    assert_eq!(::std::mem::align_of::<nsStyleBorder__bindgen_ty_bindgen_id_234446>()
+    assert_eq!(::std::mem::align_of::<nsStyleBorder__bindgen_ty_bindgen_id_234450>()
                , 4usize);
 }
-impl Clone for nsStyleBorder__bindgen_ty_bindgen_id_234446 {
+impl Clone for nsStyleBorder__bindgen_ty_bindgen_id_234450 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -10365,7 +10784,7 @@ impl Clone for nsStyleImageOrientation {
 #[derive(Debug, Copy)]
 pub struct nsTimingFunction {
     pub mType: nsTimingFunction_Type,
-    pub __bindgen_anon_1: nsTimingFunction__bindgen_ty_bindgen_id_235406,
+    pub __bindgen_anon_1: nsTimingFunction__bindgen_ty_bindgen_id_235410,
 }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -10384,56 +10803,56 @@ pub enum nsTimingFunction_Type {
 pub enum nsTimingFunction_Keyword { Implicit = 0, Explicit = 1, }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsTimingFunction__bindgen_ty_bindgen_id_235406 {
-    pub mFunc: __BindgenUnionField<nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235407>,
-    pub __bindgen_anon_1: __BindgenUnionField<nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235418>,
+pub struct nsTimingFunction__bindgen_ty_bindgen_id_235410 {
+    pub mFunc: __BindgenUnionField<nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235411>,
+    pub __bindgen_anon_1: __BindgenUnionField<nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235422>,
     pub bindgen_union_field: [u32; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235407 {
+pub struct nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235411 {
     pub mX1: f32,
     pub mY1: f32,
     pub mX2: f32,
     pub mY2: f32,
 }
 #[test]
-fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235407() {
-    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235407>()
+fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235411() {
+    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235411>()
                , 16usize);
-    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235407>()
+    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235411>()
                , 4usize);
 }
 impl Clone for
- nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235407
+ nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235411
  {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235418 {
+pub struct nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235422 {
     pub mSteps: u32,
 }
 #[test]
-fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235418() {
-    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235418>()
+fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235422() {
+    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235422>()
                , 4usize);
-    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235418>()
+    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235422>()
                , 4usize);
 }
 impl Clone for
- nsTimingFunction__bindgen_ty_bindgen_id_235406__bindgen_ty_bindgen_id_235418
+ nsTimingFunction__bindgen_ty_bindgen_id_235410__bindgen_ty_bindgen_id_235422
  {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_235406() {
-    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_235406>()
+fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_235410() {
+    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_235410>()
                , 16usize);
-    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_235406>()
+    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_235410>()
                , 4usize);
 }
-impl Clone for nsTimingFunction__bindgen_ty_bindgen_id_235406 {
+impl Clone for nsTimingFunction__bindgen_ty_bindgen_id_235410 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -10494,13 +10913,13 @@ fn bindgen_test_layout_StyleBasicShape() {
 #[repr(C)]
 #[derive(Debug)]
 pub struct StyleShapeSource<ReferenceBox> {
-    pub __bindgen_anon_1: StyleShapeSource__bindgen_ty_bindgen_id_235789<ReferenceBox>,
+    pub __bindgen_anon_1: StyleShapeSource__bindgen_ty_bindgen_id_235793<ReferenceBox>,
     pub mType: StyleShapeSourceType,
     pub mReferenceBox: ReferenceBox,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct StyleShapeSource__bindgen_ty_bindgen_id_235789<ReferenceBox> {
+pub struct StyleShapeSource__bindgen_ty_bindgen_id_235793<ReferenceBox> {
     pub mBasicShape: __BindgenUnionField<*mut StyleBasicShape>,
     pub mURL: __BindgenUnionField<*mut URLValue>,
     pub bindgen_union_field: u64,
@@ -10552,25 +10971,25 @@ pub enum nsStyleContentType {
 #[derive(Debug)]
 pub struct nsStyleContentData {
     pub mType: nsStyleContentType,
-    pub mContent: nsStyleContentData__bindgen_ty_bindgen_id_235873,
+    pub mContent: nsStyleContentData__bindgen_ty_bindgen_id_235877,
     pub mImageTracked: bool,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleContentData__bindgen_ty_bindgen_id_235873 {
+pub struct nsStyleContentData__bindgen_ty_bindgen_id_235877 {
     pub mString: __BindgenUnionField<*mut u16>,
     pub mImage: __BindgenUnionField<*mut imgRequestProxy>,
     pub mCounters: __BindgenUnionField<*mut nsCSSValue_Array>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsStyleContentData__bindgen_ty_bindgen_id_235873() {
-    assert_eq!(::std::mem::size_of::<nsStyleContentData__bindgen_ty_bindgen_id_235873>()
+fn bindgen_test_layout_nsStyleContentData__bindgen_ty_bindgen_id_235877() {
+    assert_eq!(::std::mem::size_of::<nsStyleContentData__bindgen_ty_bindgen_id_235877>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsStyleContentData__bindgen_ty_bindgen_id_235873>()
+    assert_eq!(::std::mem::align_of::<nsStyleContentData__bindgen_ty_bindgen_id_235877>()
                , 8usize);
 }
-impl Clone for nsStyleContentData__bindgen_ty_bindgen_id_235873 {
+impl Clone for nsStyleContentData__bindgen_ty_bindgen_id_235877 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -10693,25 +11112,25 @@ pub enum nsStyleSVGPaintType {
 #[repr(C)]
 #[derive(Debug)]
 pub struct nsStyleSVGPaint {
-    pub mPaint: nsStyleSVGPaint__bindgen_ty_bindgen_id_236320,
+    pub mPaint: nsStyleSVGPaint__bindgen_ty_bindgen_id_236324,
     pub mType: nsStyleSVGPaintType,
     pub mFallbackColor: nscolor,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleSVGPaint__bindgen_ty_bindgen_id_236320 {
+pub struct nsStyleSVGPaint__bindgen_ty_bindgen_id_236324 {
     pub mColor: __BindgenUnionField<nscolor>,
     pub mPaintServer: __BindgenUnionField<*mut URLValue>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsStyleSVGPaint__bindgen_ty_bindgen_id_236320() {
-    assert_eq!(::std::mem::size_of::<nsStyleSVGPaint__bindgen_ty_bindgen_id_236320>()
+fn bindgen_test_layout_nsStyleSVGPaint__bindgen_ty_bindgen_id_236324() {
+    assert_eq!(::std::mem::size_of::<nsStyleSVGPaint__bindgen_ty_bindgen_id_236324>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsStyleSVGPaint__bindgen_ty_bindgen_id_236320>()
+    assert_eq!(::std::mem::align_of::<nsStyleSVGPaint__bindgen_ty_bindgen_id_236324>()
                , 8usize);
 }
-impl Clone for nsStyleSVGPaint__bindgen_ty_bindgen_id_236320 {
+impl Clone for nsStyleSVGPaint__bindgen_ty_bindgen_id_236324 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -10744,9 +11163,30 @@ pub struct nsStyleSVG {
     pub mTextAnchor: u8,
     pub mContextFlags: u8,
 }
+pub const nsStyleSVG_FILL_OPACITY_SOURCE_MASK:
+          nsStyleSVG__bindgen_ty_bindgen_id_236484 =
+    nsStyleSVG__bindgen_ty_bindgen_id_236484::FILL_OPACITY_SOURCE_MASK;
+pub const nsStyleSVG_STROKE_OPACITY_SOURCE_MASK:
+          nsStyleSVG__bindgen_ty_bindgen_id_236484 =
+    nsStyleSVG__bindgen_ty_bindgen_id_236484::STROKE_OPACITY_SOURCE_MASK;
+pub const nsStyleSVG_STROKE_DASHARRAY_CONTEXT:
+          nsStyleSVG__bindgen_ty_bindgen_id_236484 =
+    nsStyleSVG__bindgen_ty_bindgen_id_236484::STROKE_DASHARRAY_CONTEXT;
+pub const nsStyleSVG_STROKE_DASHOFFSET_CONTEXT:
+          nsStyleSVG__bindgen_ty_bindgen_id_236484 =
+    nsStyleSVG__bindgen_ty_bindgen_id_236484::STROKE_DASHOFFSET_CONTEXT;
+pub const nsStyleSVG_STROKE_WIDTH_CONTEXT:
+          nsStyleSVG__bindgen_ty_bindgen_id_236484 =
+    nsStyleSVG__bindgen_ty_bindgen_id_236484::STROKE_WIDTH_CONTEXT;
+pub const nsStyleSVG_FILL_OPACITY_SOURCE_SHIFT:
+          nsStyleSVG__bindgen_ty_bindgen_id_236484 =
+    nsStyleSVG__bindgen_ty_bindgen_id_236484::FILL_OPACITY_SOURCE_SHIFT;
+pub const nsStyleSVG_STROKE_OPACITY_SOURCE_SHIFT:
+          nsStyleSVG__bindgen_ty_bindgen_id_236484 =
+    nsStyleSVG__bindgen_ty_bindgen_id_236484::STROKE_OPACITY_SOURCE_SHIFT;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsStyleSVG__bindgen_ty_bindgen_id_236480 {
+pub enum nsStyleSVG__bindgen_ty_bindgen_id_236484 {
     FILL_OPACITY_SOURCE_MASK = 3,
     STROKE_OPACITY_SOURCE_MASK = 12,
     STROKE_DASHARRAY_CONTEXT = 16,
@@ -10765,23 +11205,23 @@ fn bindgen_test_layout_nsStyleSVG() {
 pub struct nsStyleFilter {
     pub mType: i32,
     pub mFilterParameter: nsStyleCoord,
-    pub __bindgen_anon_1: nsStyleFilter__bindgen_ty_bindgen_id_236546,
+    pub __bindgen_anon_1: nsStyleFilter__bindgen_ty_bindgen_id_236550,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleFilter__bindgen_ty_bindgen_id_236546 {
+pub struct nsStyleFilter__bindgen_ty_bindgen_id_236550 {
     pub mURL: __BindgenUnionField<*mut URLValue>,
     pub mDropShadow: __BindgenUnionField<*mut nsCSSShadowArray>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsStyleFilter__bindgen_ty_bindgen_id_236546() {
-    assert_eq!(::std::mem::size_of::<nsStyleFilter__bindgen_ty_bindgen_id_236546>()
+fn bindgen_test_layout_nsStyleFilter__bindgen_ty_bindgen_id_236550() {
+    assert_eq!(::std::mem::size_of::<nsStyleFilter__bindgen_ty_bindgen_id_236550>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsStyleFilter__bindgen_ty_bindgen_id_236546>()
+    assert_eq!(::std::mem::align_of::<nsStyleFilter__bindgen_ty_bindgen_id_236550>()
                , 8usize);
 }
-impl Clone for nsStyleFilter__bindgen_ty_bindgen_id_236546 {
+impl Clone for nsStyleFilter__bindgen_ty_bindgen_id_236550 {
     fn clone(&self) -> Self { *self }
 }
 #[test]

--- a/components/style/gecko_bindings/structs_release.rs
+++ b/components/style/gecko_bindings/structs_release.rs
@@ -1529,15 +1529,15 @@ impl Clone for JSObject {
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct Value {
-    pub data: Value__bindgen_ty_bindgen_id_52237,
+    pub data: Value__bindgen_ty_bindgen_id_52241,
 }
 pub type Value_PayloadType = u64;
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct Value__bindgen_ty_bindgen_id_52237 {
+pub struct Value__bindgen_ty_bindgen_id_52241 {
     pub asBits: __BindgenUnionField<u64>,
-    pub debugView: __BindgenUnionField<Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52240>,
-    pub s: __BindgenUnionField<Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246>,
+    pub debugView: __BindgenUnionField<Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52244>,
+    pub s: __BindgenUnionField<Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250>,
     pub asDouble: __BindgenUnionField<f64>,
     pub asPtr: __BindgenUnionField<*mut ::std::os::raw::c_void>,
     pub asWord: __BindgenUnionField<usize>,
@@ -1546,21 +1546,21 @@ pub struct Value__bindgen_ty_bindgen_id_52237 {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52240 {
+pub struct Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52244 {
     pub _bitfield_1: u64,
 }
 #[test]
-fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52240() {
-    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52240>()
+fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52244() {
+    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52244>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52240>()
+    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52244>()
                , 8usize);
 }
-impl Clone for Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52240
+impl Clone for Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52244
  {
     fn clone(&self) -> Self { *self }
 }
-impl Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52240 {
+impl Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52244 {
     #[inline]
     pub fn payload47(&self) -> u64 {
         unsafe {
@@ -1593,48 +1593,48 @@ impl Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52240 {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246 {
-    pub payload: Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246__bindgen_ty_bindgen_id_52247,
+pub struct Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250 {
+    pub payload: Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250__bindgen_ty_bindgen_id_52251,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246__bindgen_ty_bindgen_id_52247 {
+pub struct Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250__bindgen_ty_bindgen_id_52251 {
     pub i32: __BindgenUnionField<i32>,
     pub u32: __BindgenUnionField<u32>,
     pub why: __BindgenUnionField<JSWhyMagic>,
     pub bindgen_union_field: u32,
 }
 #[test]
-fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246__bindgen_ty_bindgen_id_52247() {
-    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246__bindgen_ty_bindgen_id_52247>()
+fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250__bindgen_ty_bindgen_id_52251() {
+    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250__bindgen_ty_bindgen_id_52251>()
                , 4usize);
-    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246__bindgen_ty_bindgen_id_52247>()
+    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250__bindgen_ty_bindgen_id_52251>()
                , 4usize);
 }
 impl Clone for
- Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246__bindgen_ty_bindgen_id_52247
+ Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250__bindgen_ty_bindgen_id_52251
  {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246() {
-    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246>()
+fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250() {
+    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250>()
                , 4usize);
-    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246>()
+    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250>()
                , 4usize);
 }
-impl Clone for Value__bindgen_ty_bindgen_id_52237__bindgen_ty_bindgen_id_52246
+impl Clone for Value__bindgen_ty_bindgen_id_52241__bindgen_ty_bindgen_id_52250
  {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_52237() {
-    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_52237>() ,
+fn bindgen_test_layout_Value__bindgen_ty_bindgen_id_52241() {
+    assert_eq!(::std::mem::size_of::<Value__bindgen_ty_bindgen_id_52241>() ,
                8usize);
-    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_52237>() ,
+    assert_eq!(::std::mem::align_of::<Value__bindgen_ty_bindgen_id_52241>() ,
                8usize);
 }
-impl Clone for Value__bindgen_ty_bindgen_id_52237 {
+impl Clone for Value__bindgen_ty_bindgen_id_52241 {
     fn clone(&self) -> Self { *self }
 }
 impl Clone for Value {
@@ -1715,9 +1715,33 @@ pub type nsAString_internal_const_char_iterator =
     *const nsAString_internal_char_type;
 pub type nsAString_internal_size_type = u32;
 pub type nsAString_internal_index_type = u32;
+pub const nsAString_internal_F_NONE:
+          nsAString_internal__bindgen_ty_bindgen_id_66861 =
+    nsAString_internal__bindgen_ty_bindgen_id_66861::F_NONE;
+pub const nsAString_internal_F_TERMINATED:
+          nsAString_internal__bindgen_ty_bindgen_id_66861 =
+    nsAString_internal__bindgen_ty_bindgen_id_66861::F_TERMINATED;
+pub const nsAString_internal_F_VOIDED:
+          nsAString_internal__bindgen_ty_bindgen_id_66861 =
+    nsAString_internal__bindgen_ty_bindgen_id_66861::F_VOIDED;
+pub const nsAString_internal_F_SHARED:
+          nsAString_internal__bindgen_ty_bindgen_id_66861 =
+    nsAString_internal__bindgen_ty_bindgen_id_66861::F_SHARED;
+pub const nsAString_internal_F_OWNED:
+          nsAString_internal__bindgen_ty_bindgen_id_66861 =
+    nsAString_internal__bindgen_ty_bindgen_id_66861::F_OWNED;
+pub const nsAString_internal_F_FIXED:
+          nsAString_internal__bindgen_ty_bindgen_id_66861 =
+    nsAString_internal__bindgen_ty_bindgen_id_66861::F_FIXED;
+pub const nsAString_internal_F_LITERAL:
+          nsAString_internal__bindgen_ty_bindgen_id_66861 =
+    nsAString_internal__bindgen_ty_bindgen_id_66861::F_LITERAL;
+pub const nsAString_internal_F_CLASS_FIXED:
+          nsAString_internal__bindgen_ty_bindgen_id_66861 =
+    nsAString_internal__bindgen_ty_bindgen_id_66861::F_CLASS_FIXED;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsAString_internal__bindgen_ty_bindgen_id_66857 {
+pub enum nsAString_internal__bindgen_ty_bindgen_id_66861 {
     F_NONE = 0,
     F_TERMINATED = 1,
     F_VOIDED = 2,
@@ -1754,12 +1778,12 @@ impl Clone for nsSubstringTuple {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_67467 {
+pub struct bindgen_vtable__bindgen_id_67471 {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsStringComparator {
-    pub vtable_: *const bindgen_vtable__bindgen_id_67467,
+    pub vtable_: *const bindgen_vtable__bindgen_id_67471,
 }
 pub type nsStringComparator_char_type = u16;
 #[test]
@@ -1799,9 +1823,33 @@ pub type nsACString_internal_const_char_iterator =
     *const nsACString_internal_char_type;
 pub type nsACString_internal_size_type = u32;
 pub type nsACString_internal_index_type = u32;
+pub const nsACString_internal_F_NONE:
+          nsACString_internal__bindgen_ty_bindgen_id_68701 =
+    nsACString_internal__bindgen_ty_bindgen_id_68701::F_NONE;
+pub const nsACString_internal_F_TERMINATED:
+          nsACString_internal__bindgen_ty_bindgen_id_68701 =
+    nsACString_internal__bindgen_ty_bindgen_id_68701::F_TERMINATED;
+pub const nsACString_internal_F_VOIDED:
+          nsACString_internal__bindgen_ty_bindgen_id_68701 =
+    nsACString_internal__bindgen_ty_bindgen_id_68701::F_VOIDED;
+pub const nsACString_internal_F_SHARED:
+          nsACString_internal__bindgen_ty_bindgen_id_68701 =
+    nsACString_internal__bindgen_ty_bindgen_id_68701::F_SHARED;
+pub const nsACString_internal_F_OWNED:
+          nsACString_internal__bindgen_ty_bindgen_id_68701 =
+    nsACString_internal__bindgen_ty_bindgen_id_68701::F_OWNED;
+pub const nsACString_internal_F_FIXED:
+          nsACString_internal__bindgen_ty_bindgen_id_68701 =
+    nsACString_internal__bindgen_ty_bindgen_id_68701::F_FIXED;
+pub const nsACString_internal_F_LITERAL:
+          nsACString_internal__bindgen_ty_bindgen_id_68701 =
+    nsACString_internal__bindgen_ty_bindgen_id_68701::F_LITERAL;
+pub const nsACString_internal_F_CLASS_FIXED:
+          nsACString_internal__bindgen_ty_bindgen_id_68701 =
+    nsACString_internal__bindgen_ty_bindgen_id_68701::F_CLASS_FIXED;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsACString_internal__bindgen_ty_bindgen_id_68697 {
+pub enum nsACString_internal__bindgen_ty_bindgen_id_68701 {
     F_NONE = 0,
     F_TERMINATED = 1,
     F_VOIDED = 2,
@@ -1863,12 +1911,12 @@ fn bindgen_test_layout_nsCString() {
     assert_eq!(::std::mem::align_of::<nsCString>() , 8usize);
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_69249 {
+pub struct bindgen_vtable__bindgen_id_69253 {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsCStringComparator {
-    pub vtable_: *const bindgen_vtable__bindgen_id_69249,
+    pub vtable_: *const bindgen_vtable__bindgen_id_69253,
 }
 pub type nsCStringComparator_char_type = ::std::os::raw::c_char;
 #[test]
@@ -1880,7 +1928,7 @@ impl Clone for nsCStringComparator {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_69553 {
+pub struct bindgen_vtable__bindgen_id_69557 {
 }
 /**
  * Basic component object model interface. Objects which implement
@@ -1891,7 +1939,7 @@ pub struct bindgen_vtable__bindgen_id_69553 {
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsISupports {
-    pub vtable_: *const bindgen_vtable__bindgen_id_69553,
+    pub vtable_: *const bindgen_vtable__bindgen_id_69557,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1909,7 +1957,7 @@ impl Clone for nsISupports {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_69837 {
+pub struct bindgen_vtable__bindgen_id_69841 {
 }
 /**
  * Participant implementation classes
@@ -1917,7 +1965,7 @@ pub struct bindgen_vtable__bindgen_id_69837 {
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsCycleCollectionParticipant {
-    pub vtable_: *const bindgen_vtable__bindgen_id_69837,
+    pub vtable_: *const bindgen_vtable__bindgen_id_69841,
     pub mMightSkip: bool,
 }
 #[test]
@@ -2242,7 +2290,7 @@ fn bindgen_test_layout_ErrorResult() {
 #[derive(Debug)]
 pub struct TErrorResult<CleanupPolicy> {
     pub mResult: nsresult,
-    pub __bindgen_anon_1: TErrorResult__bindgen_ty_bindgen_id_74477<CleanupPolicy>,
+    pub __bindgen_anon_1: TErrorResult__bindgen_ty_bindgen_id_74481<CleanupPolicy>,
     pub _phantom_0: ::std::marker::PhantomData<CleanupPolicy>,
 }
 #[repr(C)]
@@ -2259,7 +2307,7 @@ pub struct TErrorResult_DOMExceptionInfo<CleanupPolicy> {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct TErrorResult__bindgen_ty_bindgen_id_74477<CleanupPolicy> {
+pub struct TErrorResult__bindgen_ty_bindgen_id_74481<CleanupPolicy> {
     pub mMessage: __BindgenUnionField<*mut TErrorResult_Message<CleanupPolicy>>,
     pub mJSException: __BindgenUnionField<Value>,
     pub mDOMExceptionInfo: __BindgenUnionField<*mut TErrorResult_DOMExceptionInfo<CleanupPolicy>>,
@@ -2403,9 +2451,21 @@ pub struct nsIPrincipal_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsIPrincipal_APP_STATUS_NOT_INSTALLED:
+          nsIPrincipal__bindgen_ty_bindgen_id_75504 =
+    nsIPrincipal__bindgen_ty_bindgen_id_75504::APP_STATUS_NOT_INSTALLED;
+pub const nsIPrincipal_APP_STATUS_INSTALLED:
+          nsIPrincipal__bindgen_ty_bindgen_id_75504 =
+    nsIPrincipal__bindgen_ty_bindgen_id_75504::APP_STATUS_INSTALLED;
+pub const nsIPrincipal_APP_STATUS_PRIVILEGED:
+          nsIPrincipal__bindgen_ty_bindgen_id_75504 =
+    nsIPrincipal__bindgen_ty_bindgen_id_75504::APP_STATUS_PRIVILEGED;
+pub const nsIPrincipal_APP_STATUS_CERTIFIED:
+          nsIPrincipal__bindgen_ty_bindgen_id_75504 =
+    nsIPrincipal__bindgen_ty_bindgen_id_75504::APP_STATUS_CERTIFIED;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPrincipal__bindgen_ty_bindgen_id_75500 {
+pub enum nsIPrincipal__bindgen_ty_bindgen_id_75504 {
     APP_STATUS_NOT_INSTALLED = 0,
     APP_STATUS_INSTALLED = 1,
     APP_STATUS_PRIVILEGED = 2,
@@ -2440,7 +2500,7 @@ impl Clone for nsISerializable {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_75668 {
+pub struct bindgen_vtable__bindgen_id_75672 {
 }
 /**
  * Class to store the wrapper for an object. This can only be used with objects
@@ -2482,7 +2542,7 @@ pub struct bindgen_vtable__bindgen_id_75668 {
 #[repr(C)]
 #[derive(Debug)]
 pub struct nsWrapperCache {
-    pub vtable_: *const bindgen_vtable__bindgen_id_75668,
+    pub vtable_: *const bindgen_vtable__bindgen_id_75672,
     pub mWrapper: *mut JSObject,
     pub mFlags: nsWrapperCache_FlagsType,
 }
@@ -2494,6 +2554,9 @@ pub struct nsWrapperCache_COMTypeInfo<T, U> {
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
 pub type nsWrapperCache_FlagsType = u32;
+pub const nsWrapperCache_WRAPPER_BIT_PRESERVED:
+          nsWrapperCache__bindgen_ty_bindgen_id_75868 =
+    nsWrapperCache__bindgen_ty_bindgen_id_75868::WRAPPER_BIT_PRESERVED;
 #[repr(u32)]
 /**
    * If this bit is set then we're preserving the wrapper, which in effect ties
@@ -2507,21 +2570,27 @@ pub type nsWrapperCache_FlagsType = u32;
    * NS_IMPL_CYCLE_COLLECTION_UNLINK_PRESERVED_WRAPPER).
    */
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsWrapperCache__bindgen_ty_bindgen_id_75864 {
+pub enum nsWrapperCache__bindgen_ty_bindgen_id_75868 {
     WRAPPER_BIT_PRESERVED = 1,
 }
+pub const nsWrapperCache_WRAPPER_IS_NOT_DOM_BINDING:
+          nsWrapperCache__bindgen_ty_bindgen_id_75871 =
+    nsWrapperCache__bindgen_ty_bindgen_id_75871::WRAPPER_IS_NOT_DOM_BINDING;
 #[repr(u32)]
 /**
    * If this bit is set then the wrapper for the native object is not a DOM
    * binding.
    */
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsWrapperCache__bindgen_ty_bindgen_id_75867 {
+pub enum nsWrapperCache__bindgen_ty_bindgen_id_75871 {
     WRAPPER_IS_NOT_DOM_BINDING = 2,
 }
+pub const nsWrapperCache_kWrapperFlagsMask:
+          nsWrapperCache__bindgen_ty_bindgen_id_75874 =
+    nsWrapperCache__bindgen_ty_bindgen_id_75874::kWrapperFlagsMask;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsWrapperCache__bindgen_ty_bindgen_id_75870 {
+pub enum nsWrapperCache__bindgen_ty_bindgen_id_75874 {
     kWrapperFlagsMask = 3,
 }
 #[test]
@@ -2563,7 +2632,7 @@ pub struct pair<_T1, _T2> {
 pub type pair_first_type<_T1> = _T1;
 pub type pair_second_type<_T2> = _T2;
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_123515 {
+pub struct bindgen_vtable__bindgen_id_123519 {
 }
 /**
  * A class of objects that return source code on demand.
@@ -2579,7 +2648,7 @@ pub struct bindgen_vtable__bindgen_id_123515 {
 #[repr(C)]
 #[derive(Debug)]
 pub struct SourceHook {
-    pub vtable_: *const bindgen_vtable__bindgen_id_123515,
+    pub vtable_: *const bindgen_vtable__bindgen_id_123519,
 }
 #[test]
 fn bindgen_test_layout_SourceHook() {
@@ -2758,9 +2827,12 @@ pub struct nsPtrHashKey<T> {
 }
 pub type nsPtrHashKey_KeyType<T> = *mut T;
 pub type nsPtrHashKey_KeyTypePointer<T> = *mut T;
+pub const nsPtrHashKey_ALLOW_MEMMOVE:
+          nsPtrHashKey__bindgen_ty_bindgen_id_130832 =
+    nsPtrHashKey__bindgen_ty_bindgen_id_130832::ALLOW_MEMMOVE;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsPtrHashKey__bindgen_ty_bindgen_id_130828 { ALLOW_MEMMOVE = 0, }
+pub enum nsPtrHashKey__bindgen_ty_bindgen_id_130832 { ALLOW_MEMMOVE = 0, }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct nsIRunnable {
@@ -2881,11 +2953,11 @@ pub struct nsIDocument {
     pub mCompatMode: nsCompatibility,
     pub mReadyState: nsIDocument_ReadyState,
     pub mVisibilityState: VisibilityState,
-    pub mStyleBackendType: StyleBackendType,
     pub _bitfield_1: u64,
     pub mType: nsIDocument_Type,
     pub mDefaultElementType: u8,
     pub mAllowXULXBL: nsIDocument_Tri,
+    pub mStyleBackendType: StyleBackendType,
     pub mScriptGlobalObject: nsCOMPtr<nsIScriptGlobalObject>,
     pub mOriginalDocument: nsCOMPtr<nsIDocument>,
     pub mBidiOptions: u32,
@@ -3162,7 +3234,7 @@ impl Clone for nsIDocument_FrameRequest {
 }
 #[test]
 fn bindgen_test_layout_nsIDocument() {
-    assert_eq!(::std::mem::size_of::<nsIDocument>() , 944usize);
+    assert_eq!(::std::mem::size_of::<nsIDocument>() , 952usize);
     assert_eq!(::std::mem::align_of::<nsIDocument>() , 8usize);
 }
 impl nsIDocument {
@@ -3757,7 +3829,7 @@ pub struct nsINode {
     pub mNextSibling: *mut nsIContent,
     pub mPreviousSibling: *mut nsIContent,
     pub mFirstChild: *mut nsIContent,
-    pub __bindgen_anon_1: nsINode__bindgen_ty_bindgen_id_137848,
+    pub __bindgen_anon_1: nsINode__bindgen_ty_bindgen_id_137852,
     pub mSlots: *mut nsINode_nsSlots,
     pub mServoData: ServoCell<*mut ServoNodeData>,
 }
@@ -3777,12 +3849,37 @@ pub struct nsINode_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsINode_eCONTENT: nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::eCONTENT;
+pub const nsINode_eDOCUMENT: nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::eDOCUMENT;
+pub const nsINode_eATTRIBUTE: nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::eATTRIBUTE;
+pub const nsINode_eTEXT: nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::eTEXT;
+pub const nsINode_ePROCESSING_INSTRUCTION:
+          nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::ePROCESSING_INSTRUCTION;
+pub const nsINode_eCOMMENT: nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::eCOMMENT;
+pub const nsINode_eHTML_FORM_CONTROL: nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::eHTML_FORM_CONTROL;
+pub const nsINode_eDOCUMENT_FRAGMENT: nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::eDOCUMENT_FRAGMENT;
+pub const nsINode_eDATA_NODE: nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::eDATA_NODE;
+pub const nsINode_eMEDIA: nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::eMEDIA;
+pub const nsINode_eANIMATION: nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::eANIMATION;
+pub const nsINode_eFILTER: nsINode__bindgen_ty_bindgen_id_133990 =
+    nsINode__bindgen_ty_bindgen_id_133990::eFILTER;
 #[repr(u32)]
 /**
    * Bit-flags to pass (or'ed together) to IsNodeOfType()
    */
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsINode__bindgen_ty_bindgen_id_133986 {
+pub enum nsINode__bindgen_ty_bindgen_id_133990 {
     eCONTENT = 1,
     eDOCUMENT = 2,
     eATTRIBUTE = 4,
@@ -3797,12 +3894,12 @@ pub enum nsINode__bindgen_ty_bindgen_id_133986 {
     eFILTER = 2048,
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_134755 {
+pub struct bindgen_vtable__bindgen_id_134759 {
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct nsINode_nsSlots {
-    pub vtable_: *const bindgen_vtable__bindgen_id_134755,
+    pub vtable_: *const bindgen_vtable__bindgen_id_134759,
     /**
      * A list of mutation observers
      */
@@ -3871,19 +3968,19 @@ pub enum nsINode_BooleanFlag {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsINode__bindgen_ty_bindgen_id_137848 {
+pub struct nsINode__bindgen_ty_bindgen_id_137852 {
     pub mPrimaryFrame: __BindgenUnionField<*mut nsIFrame>,
     pub mSubtreeRoot: __BindgenUnionField<*mut nsINode>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsINode__bindgen_ty_bindgen_id_137848() {
-    assert_eq!(::std::mem::size_of::<nsINode__bindgen_ty_bindgen_id_137848>()
+fn bindgen_test_layout_nsINode__bindgen_ty_bindgen_id_137852() {
+    assert_eq!(::std::mem::size_of::<nsINode__bindgen_ty_bindgen_id_137852>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsINode__bindgen_ty_bindgen_id_137848>()
+    assert_eq!(::std::mem::align_of::<nsINode__bindgen_ty_bindgen_id_137852>()
                , 8usize);
 }
-impl Clone for nsINode__bindgen_ty_bindgen_id_137848 {
+impl Clone for nsINode__bindgen_ty_bindgen_id_137852 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -4216,9 +4313,39 @@ pub struct nsIDOMNode_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsIDOMNode_ELEMENT_NODE: nsIDOMNode__bindgen_ty_bindgen_id_145958 =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::ELEMENT_NODE;
+pub const nsIDOMNode_ATTRIBUTE_NODE: nsIDOMNode__bindgen_ty_bindgen_id_145958
+          =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::ATTRIBUTE_NODE;
+pub const nsIDOMNode_TEXT_NODE: nsIDOMNode__bindgen_ty_bindgen_id_145958 =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::TEXT_NODE;
+pub const nsIDOMNode_CDATA_SECTION_NODE:
+          nsIDOMNode__bindgen_ty_bindgen_id_145958 =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::CDATA_SECTION_NODE;
+pub const nsIDOMNode_ENTITY_REFERENCE_NODE:
+          nsIDOMNode__bindgen_ty_bindgen_id_145958 =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::ENTITY_REFERENCE_NODE;
+pub const nsIDOMNode_ENTITY_NODE: nsIDOMNode__bindgen_ty_bindgen_id_145958 =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::ENTITY_NODE;
+pub const nsIDOMNode_PROCESSING_INSTRUCTION_NODE:
+          nsIDOMNode__bindgen_ty_bindgen_id_145958 =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::PROCESSING_INSTRUCTION_NODE;
+pub const nsIDOMNode_COMMENT_NODE: nsIDOMNode__bindgen_ty_bindgen_id_145958 =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::COMMENT_NODE;
+pub const nsIDOMNode_DOCUMENT_NODE: nsIDOMNode__bindgen_ty_bindgen_id_145958 =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::DOCUMENT_NODE;
+pub const nsIDOMNode_DOCUMENT_TYPE_NODE:
+          nsIDOMNode__bindgen_ty_bindgen_id_145958 =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::DOCUMENT_TYPE_NODE;
+pub const nsIDOMNode_DOCUMENT_FRAGMENT_NODE:
+          nsIDOMNode__bindgen_ty_bindgen_id_145958 =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::DOCUMENT_FRAGMENT_NODE;
+pub const nsIDOMNode_NOTATION_NODE: nsIDOMNode__bindgen_ty_bindgen_id_145958 =
+    nsIDOMNode__bindgen_ty_bindgen_id_145958::NOTATION_NODE;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIDOMNode__bindgen_ty_bindgen_id_145954 {
+pub enum nsIDOMNode__bindgen_ty_bindgen_id_145958 {
     ELEMENT_NODE = 1,
     ATTRIBUTE_NODE = 2,
     TEXT_NODE = 3,
@@ -4232,9 +4359,27 @@ pub enum nsIDOMNode__bindgen_ty_bindgen_id_145954 {
     DOCUMENT_FRAGMENT_NODE = 11,
     NOTATION_NODE = 12,
 }
+pub const nsIDOMNode_DOCUMENT_POSITION_DISCONNECTED:
+          nsIDOMNode__bindgen_ty_bindgen_id_146177 =
+    nsIDOMNode__bindgen_ty_bindgen_id_146177::DOCUMENT_POSITION_DISCONNECTED;
+pub const nsIDOMNode_DOCUMENT_POSITION_PRECEDING:
+          nsIDOMNode__bindgen_ty_bindgen_id_146177 =
+    nsIDOMNode__bindgen_ty_bindgen_id_146177::DOCUMENT_POSITION_PRECEDING;
+pub const nsIDOMNode_DOCUMENT_POSITION_FOLLOWING:
+          nsIDOMNode__bindgen_ty_bindgen_id_146177 =
+    nsIDOMNode__bindgen_ty_bindgen_id_146177::DOCUMENT_POSITION_FOLLOWING;
+pub const nsIDOMNode_DOCUMENT_POSITION_CONTAINS:
+          nsIDOMNode__bindgen_ty_bindgen_id_146177 =
+    nsIDOMNode__bindgen_ty_bindgen_id_146177::DOCUMENT_POSITION_CONTAINS;
+pub const nsIDOMNode_DOCUMENT_POSITION_CONTAINED_BY:
+          nsIDOMNode__bindgen_ty_bindgen_id_146177 =
+    nsIDOMNode__bindgen_ty_bindgen_id_146177::DOCUMENT_POSITION_CONTAINED_BY;
+pub const nsIDOMNode_DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC:
+          nsIDOMNode__bindgen_ty_bindgen_id_146177 =
+    nsIDOMNode__bindgen_ty_bindgen_id_146177::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIDOMNode__bindgen_ty_bindgen_id_146173 {
+pub enum nsIDOMNode__bindgen_ty_bindgen_id_146177 {
     DOCUMENT_POSITION_DISCONNECTED = 1,
     DOCUMENT_POSITION_PRECEDING = 2,
     DOCUMENT_POSITION_FOLLOWING = 4,
@@ -5105,16 +5250,28 @@ pub struct nsIContent_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsIContent_eAllChildren: nsIContent__bindgen_ty_bindgen_id_150198 =
+    nsIContent__bindgen_ty_bindgen_id_150198::eAllChildren;
+pub const nsIContent_eAllButXBL: nsIContent__bindgen_ty_bindgen_id_150198 =
+    nsIContent__bindgen_ty_bindgen_id_150198::eAllButXBL;
+pub const nsIContent_eSkipPlaceholderContent:
+          nsIContent__bindgen_ty_bindgen_id_150198 =
+    nsIContent__bindgen_ty_bindgen_id_150198::eSkipPlaceholderContent;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIContent__bindgen_ty_bindgen_id_150194 {
+pub enum nsIContent__bindgen_ty_bindgen_id_150198 {
     eAllChildren = 0,
     eAllButXBL = 1,
     eSkipPlaceholderContent = 2,
 }
+pub const nsIContent_ATTR_MISSING: nsIContent__bindgen_ty_bindgen_id_150434 =
+    nsIContent__bindgen_ty_bindgen_id_150434::ATTR_MISSING;
+pub const nsIContent_ATTR_VALUE_NO_MATCH:
+          nsIContent__bindgen_ty_bindgen_id_150434 =
+    nsIContent__bindgen_ty_bindgen_id_150434::ATTR_VALUE_NO_MATCH;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIContent__bindgen_ty_bindgen_id_150430 {
+pub enum nsIContent__bindgen_ty_bindgen_id_150434 {
     ATTR_MISSING = -1,
     ATTR_VALUE_NO_MATCH = -2,
 }
@@ -5316,7 +5473,7 @@ pub struct FragmentOrElement_nsDOMSlots {
      * @see FragmentOrElement::GetAttributes
      */
     pub mAttributeMap: RefPtr<nsDOMAttributeMap>,
-    pub __bindgen_anon_1: FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151526,
+    pub __bindgen_anon_1: FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151530,
     /**
      * An object implementing the .children property for this element.
      */
@@ -5353,7 +5510,7 @@ pub struct FragmentOrElement_nsDOMSlots {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151526 {
+pub struct FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151530 {
     /**
       * The nearest enclosing content node with a binding that created us.
       * @see FragmentOrElement::GetBindingParent
@@ -5366,13 +5523,13 @@ pub struct FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151526 {
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151526() {
-    assert_eq!(::std::mem::size_of::<FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151526>()
+fn bindgen_test_layout_FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151530() {
+    assert_eq!(::std::mem::size_of::<FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151530>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151526>()
+    assert_eq!(::std::mem::align_of::<FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151530>()
                , 8usize);
 }
-impl Clone for FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151526 {
+impl Clone for FragmentOrElement_nsDOMSlots__bindgen_ty_bindgen_id_151530 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -5527,9 +5684,37 @@ pub struct nsIChannel_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsIChannel_LOAD_DOCUMENT_URI:
+          nsIChannel__bindgen_ty_bindgen_id_163115 =
+    nsIChannel__bindgen_ty_bindgen_id_163115::LOAD_DOCUMENT_URI;
+pub const nsIChannel_LOAD_RETARGETED_DOCUMENT_URI:
+          nsIChannel__bindgen_ty_bindgen_id_163115 =
+    nsIChannel__bindgen_ty_bindgen_id_163115::LOAD_RETARGETED_DOCUMENT_URI;
+pub const nsIChannel_LOAD_REPLACE: nsIChannel__bindgen_ty_bindgen_id_163115 =
+    nsIChannel__bindgen_ty_bindgen_id_163115::LOAD_REPLACE;
+pub const nsIChannel_LOAD_INITIAL_DOCUMENT_URI:
+          nsIChannel__bindgen_ty_bindgen_id_163115 =
+    nsIChannel__bindgen_ty_bindgen_id_163115::LOAD_INITIAL_DOCUMENT_URI;
+pub const nsIChannel_LOAD_TARGETED: nsIChannel__bindgen_ty_bindgen_id_163115 =
+    nsIChannel__bindgen_ty_bindgen_id_163115::LOAD_TARGETED;
+pub const nsIChannel_LOAD_CALL_CONTENT_SNIFFERS:
+          nsIChannel__bindgen_ty_bindgen_id_163115 =
+    nsIChannel__bindgen_ty_bindgen_id_163115::LOAD_CALL_CONTENT_SNIFFERS;
+pub const nsIChannel_LOAD_CLASSIFY_URI:
+          nsIChannel__bindgen_ty_bindgen_id_163115 =
+    nsIChannel__bindgen_ty_bindgen_id_163115::LOAD_CLASSIFY_URI;
+pub const nsIChannel_LOAD_MEDIA_SNIFFER_OVERRIDES_CONTENT_TYPE:
+          nsIChannel__bindgen_ty_bindgen_id_163115 =
+    nsIChannel__bindgen_ty_bindgen_id_163115::LOAD_MEDIA_SNIFFER_OVERRIDES_CONTENT_TYPE;
+pub const nsIChannel_LOAD_EXPLICIT_CREDENTIALS:
+          nsIChannel__bindgen_ty_bindgen_id_163115 =
+    nsIChannel__bindgen_ty_bindgen_id_163115::LOAD_EXPLICIT_CREDENTIALS;
+pub const nsIChannel_LOAD_BYPASS_SERVICE_WORKER:
+          nsIChannel__bindgen_ty_bindgen_id_163115 =
+    nsIChannel__bindgen_ty_bindgen_id_163115::LOAD_BYPASS_SERVICE_WORKER;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIChannel__bindgen_ty_bindgen_id_163111 {
+pub enum nsIChannel__bindgen_ty_bindgen_id_163115 {
     LOAD_DOCUMENT_URI = 65536,
     LOAD_RETARGETED_DOCUMENT_URI = 131072,
     LOAD_REPLACE = 262144,
@@ -5541,9 +5726,15 @@ pub enum nsIChannel__bindgen_ty_bindgen_id_163111 {
     LOAD_EXPLICIT_CREDENTIALS = 16777216,
     LOAD_BYPASS_SERVICE_WORKER = 33554432,
 }
+pub const nsIChannel_DISPOSITION_INLINE:
+          nsIChannel__bindgen_ty_bindgen_id_163135 =
+    nsIChannel__bindgen_ty_bindgen_id_163135::DISPOSITION_INLINE;
+pub const nsIChannel_DISPOSITION_ATTACHMENT:
+          nsIChannel__bindgen_ty_bindgen_id_163135 =
+    nsIChannel__bindgen_ty_bindgen_id_163135::DISPOSITION_ATTACHMENT;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIChannel__bindgen_ty_bindgen_id_163131 {
+pub enum nsIChannel__bindgen_ty_bindgen_id_163135 {
     DISPOSITION_INLINE = 0,
     DISPOSITION_ATTACHMENT = 1,
 }
@@ -5567,9 +5758,47 @@ pub struct nsIRequest_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsIRequest_LOAD_REQUESTMASK:
+          nsIRequest__bindgen_ty_bindgen_id_162953 =
+    nsIRequest__bindgen_ty_bindgen_id_162953::LOAD_REQUESTMASK;
+pub const nsIRequest_LOAD_NORMAL: nsIRequest__bindgen_ty_bindgen_id_162953 =
+    nsIRequest__bindgen_ty_bindgen_id_162953::LOAD_NORMAL;
+pub const nsIRequest_LOAD_BACKGROUND: nsIRequest__bindgen_ty_bindgen_id_162953
+          =
+    nsIRequest__bindgen_ty_bindgen_id_162953::LOAD_BACKGROUND;
+pub const nsIRequest_INHIBIT_PIPELINE:
+          nsIRequest__bindgen_ty_bindgen_id_162953 =
+    nsIRequest__bindgen_ty_bindgen_id_162953::INHIBIT_PIPELINE;
+pub const nsIRequest_INHIBIT_CACHING: nsIRequest__bindgen_ty_bindgen_id_162953
+          =
+    nsIRequest__bindgen_ty_bindgen_id_162953::INHIBIT_CACHING;
+pub const nsIRequest_INHIBIT_PERSISTENT_CACHING:
+          nsIRequest__bindgen_ty_bindgen_id_162953 =
+    nsIRequest__bindgen_ty_bindgen_id_162953::INHIBIT_PERSISTENT_CACHING;
+pub const nsIRequest_LOAD_BYPASS_CACHE:
+          nsIRequest__bindgen_ty_bindgen_id_162953 =
+    nsIRequest__bindgen_ty_bindgen_id_162953::LOAD_BYPASS_CACHE;
+pub const nsIRequest_LOAD_FROM_CACHE: nsIRequest__bindgen_ty_bindgen_id_162953
+          =
+    nsIRequest__bindgen_ty_bindgen_id_162953::LOAD_FROM_CACHE;
+pub const nsIRequest_VALIDATE_ALWAYS: nsIRequest__bindgen_ty_bindgen_id_162953
+          =
+    nsIRequest__bindgen_ty_bindgen_id_162953::VALIDATE_ALWAYS;
+pub const nsIRequest_VALIDATE_NEVER: nsIRequest__bindgen_ty_bindgen_id_162953
+          =
+    nsIRequest__bindgen_ty_bindgen_id_162953::VALIDATE_NEVER;
+pub const nsIRequest_VALIDATE_ONCE_PER_SESSION:
+          nsIRequest__bindgen_ty_bindgen_id_162953 =
+    nsIRequest__bindgen_ty_bindgen_id_162953::VALIDATE_ONCE_PER_SESSION;
+pub const nsIRequest_LOAD_ANONYMOUS: nsIRequest__bindgen_ty_bindgen_id_162953
+          =
+    nsIRequest__bindgen_ty_bindgen_id_162953::LOAD_ANONYMOUS;
+pub const nsIRequest_LOAD_FRESH_CONNECTION:
+          nsIRequest__bindgen_ty_bindgen_id_162953 =
+    nsIRequest__bindgen_ty_bindgen_id_162953::LOAD_FRESH_CONNECTION;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIRequest__bindgen_ty_bindgen_id_162949 {
+pub enum nsIRequest__bindgen_ty_bindgen_id_162953 {
     LOAD_REQUESTMASK = 65535,
     LOAD_NORMAL = 0,
     LOAD_BACKGROUND = 1,
@@ -6109,13 +6338,25 @@ pub enum nsIPresShell_ReflowRootHandling {
     eNoPositionOrSizeChange = 1,
     eInferFromBitToAdd = 2,
 }
-pub const SCROLL_LEFT: nsIPresShell__bindgen_ty_bindgen_id_181668 =
-    nsIPresShell__bindgen_ty_bindgen_id_181668::SCROLL_TOP;
-pub const SCROLL_RIGHT: nsIPresShell__bindgen_ty_bindgen_id_181668 =
-    nsIPresShell__bindgen_ty_bindgen_id_181668::SCROLL_BOTTOM;
+pub const nsIPresShell_SCROLL_TOP: nsIPresShell__bindgen_ty_bindgen_id_181672
+          =
+    nsIPresShell__bindgen_ty_bindgen_id_181672::SCROLL_TOP;
+pub const nsIPresShell_SCROLL_BOTTOM:
+          nsIPresShell__bindgen_ty_bindgen_id_181672 =
+    nsIPresShell__bindgen_ty_bindgen_id_181672::SCROLL_BOTTOM;
+pub const SCROLL_LEFT: nsIPresShell__bindgen_ty_bindgen_id_181672 =
+    nsIPresShell__bindgen_ty_bindgen_id_181672::SCROLL_TOP;
+pub const SCROLL_RIGHT: nsIPresShell__bindgen_ty_bindgen_id_181672 =
+    nsIPresShell__bindgen_ty_bindgen_id_181672::SCROLL_BOTTOM;
+pub const nsIPresShell_SCROLL_CENTER:
+          nsIPresShell__bindgen_ty_bindgen_id_181672 =
+    nsIPresShell__bindgen_ty_bindgen_id_181672::SCROLL_CENTER;
+pub const nsIPresShell_SCROLL_MINIMUM:
+          nsIPresShell__bindgen_ty_bindgen_id_181672 =
+    nsIPresShell__bindgen_ty_bindgen_id_181672::SCROLL_MINIMUM;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPresShell__bindgen_ty_bindgen_id_181668 {
+pub enum nsIPresShell__bindgen_ty_bindgen_id_181672 {
     SCROLL_TOP = 0,
     SCROLL_BOTTOM = 100,
     SCROLL_CENTER = 50,
@@ -6141,15 +6382,51 @@ fn bindgen_test_layout_nsIPresShell_ScrollAxis() {
 impl Clone for nsIPresShell_ScrollAxis {
     fn clone(&self) -> Self { *self }
 }
+pub const nsIPresShell_SCROLL_FIRST_ANCESTOR_ONLY:
+          nsIPresShell__bindgen_ty_bindgen_id_181703 =
+    nsIPresShell__bindgen_ty_bindgen_id_181703::SCROLL_FIRST_ANCESTOR_ONLY;
+pub const nsIPresShell_SCROLL_OVERFLOW_HIDDEN:
+          nsIPresShell__bindgen_ty_bindgen_id_181703 =
+    nsIPresShell__bindgen_ty_bindgen_id_181703::SCROLL_OVERFLOW_HIDDEN;
+pub const nsIPresShell_SCROLL_NO_PARENT_FRAMES:
+          nsIPresShell__bindgen_ty_bindgen_id_181703 =
+    nsIPresShell__bindgen_ty_bindgen_id_181703::SCROLL_NO_PARENT_FRAMES;
+pub const nsIPresShell_SCROLL_SMOOTH:
+          nsIPresShell__bindgen_ty_bindgen_id_181703 =
+    nsIPresShell__bindgen_ty_bindgen_id_181703::SCROLL_SMOOTH;
+pub const nsIPresShell_SCROLL_SMOOTH_AUTO:
+          nsIPresShell__bindgen_ty_bindgen_id_181703 =
+    nsIPresShell__bindgen_ty_bindgen_id_181703::SCROLL_SMOOTH_AUTO;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPresShell__bindgen_ty_bindgen_id_181699 {
+pub enum nsIPresShell__bindgen_ty_bindgen_id_181703 {
     SCROLL_FIRST_ANCESTOR_ONLY = 1,
     SCROLL_OVERFLOW_HIDDEN = 2,
     SCROLL_NO_PARENT_FRAMES = 4,
     SCROLL_SMOOTH = 8,
     SCROLL_SMOOTH_AUTO = 16,
 }
+pub const nsIPresShell_RENDER_IS_UNTRUSTED:
+          nsIPresShell__bindgen_ty_bindgen_id_182073 =
+    nsIPresShell__bindgen_ty_bindgen_id_182073::RENDER_IS_UNTRUSTED;
+pub const nsIPresShell_RENDER_IGNORE_VIEWPORT_SCROLLING:
+          nsIPresShell__bindgen_ty_bindgen_id_182073 =
+    nsIPresShell__bindgen_ty_bindgen_id_182073::RENDER_IGNORE_VIEWPORT_SCROLLING;
+pub const nsIPresShell_RENDER_CARET:
+          nsIPresShell__bindgen_ty_bindgen_id_182073 =
+    nsIPresShell__bindgen_ty_bindgen_id_182073::RENDER_CARET;
+pub const nsIPresShell_RENDER_USE_WIDGET_LAYERS:
+          nsIPresShell__bindgen_ty_bindgen_id_182073 =
+    nsIPresShell__bindgen_ty_bindgen_id_182073::RENDER_USE_WIDGET_LAYERS;
+pub const nsIPresShell_RENDER_ASYNC_DECODE_IMAGES:
+          nsIPresShell__bindgen_ty_bindgen_id_182073 =
+    nsIPresShell__bindgen_ty_bindgen_id_182073::RENDER_ASYNC_DECODE_IMAGES;
+pub const nsIPresShell_RENDER_DOCUMENT_RELATIVE:
+          nsIPresShell__bindgen_ty_bindgen_id_182073 =
+    nsIPresShell__bindgen_ty_bindgen_id_182073::RENDER_DOCUMENT_RELATIVE;
+pub const nsIPresShell_RENDER_DRAWWINDOW_NOT_FLUSHING:
+          nsIPresShell__bindgen_ty_bindgen_id_182073 =
+    nsIPresShell__bindgen_ty_bindgen_id_182073::RENDER_DRAWWINDOW_NOT_FLUSHING;
 #[repr(u32)]
 /**
    * Render the document into an arbitrary gfxContext
@@ -6190,7 +6467,7 @@ pub enum nsIPresShell__bindgen_ty_bindgen_id_181699 {
    * transform.
    */
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPresShell__bindgen_ty_bindgen_id_182069 {
+pub enum nsIPresShell__bindgen_ty_bindgen_id_182073 {
     RENDER_IS_UNTRUSTED = 1,
     RENDER_IGNORE_VIEWPORT_SCROLLING = 2,
     RENDER_CARET = 4,
@@ -6199,12 +6476,21 @@ pub enum nsIPresShell__bindgen_ty_bindgen_id_182069 {
     RENDER_DOCUMENT_RELATIVE = 32,
     RENDER_DRAWWINDOW_NOT_FLUSHING = 64,
 }
+pub const nsIPresShell_RENDER_IS_IMAGE:
+          nsIPresShell__bindgen_ty_bindgen_id_182091 =
+    nsIPresShell__bindgen_ty_bindgen_id_182091::RENDER_IS_IMAGE;
+pub const nsIPresShell_RENDER_AUTO_SCALE:
+          nsIPresShell__bindgen_ty_bindgen_id_182091 =
+    nsIPresShell__bindgen_ty_bindgen_id_182091::RENDER_AUTO_SCALE;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPresShell__bindgen_ty_bindgen_id_182087 {
+pub enum nsIPresShell__bindgen_ty_bindgen_id_182091 {
     RENDER_IS_IMAGE = 256,
     RENDER_AUTO_SCALE = 128,
 }
+pub const nsIPresShell_FORCE_DRAW: nsIPresShell__bindgen_ty_bindgen_id_182207
+          =
+    nsIPresShell__bindgen_ty_bindgen_id_182207::FORCE_DRAW;
 #[repr(u32)]
 /**
    * Add a solid color item to the bottom of aList with frame aFrame and bounds
@@ -6214,7 +6500,7 @@ pub enum nsIPresShell__bindgen_ty_bindgen_id_182087 {
    * transparent by default.
    */
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsIPresShell__bindgen_ty_bindgen_id_182203 { FORCE_DRAW = 1, }
+pub enum nsIPresShell__bindgen_ty_bindgen_id_182207 { FORCE_DRAW = 1, }
 #[repr(C)]
 #[derive(Debug)]
 pub struct nsIPresShell_PointerCaptureInfo {
@@ -6584,67 +6870,67 @@ pub struct DOMPointInit {
 impl Clone for DOMPointInit {
     fn clone(&self) -> Self { *self }
 }
-pub const NODE_HAS_LISTENERMANAGER: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_HAS_LISTENERMANAGER;
-pub const NODE_HAS_PROPERTIES: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_HAS_PROPERTIES;
-pub const NODE_IS_ANONYMOUS_ROOT: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_IS_ANONYMOUS_ROOT;
-pub const NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE;
-pub const NODE_IS_NATIVE_ANONYMOUS_ROOT: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_IS_NATIVE_ANONYMOUS_ROOT;
-pub const NODE_FORCE_XBL_BINDINGS: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_FORCE_XBL_BINDINGS;
-pub const NODE_MAY_BE_IN_BINDING_MNGR: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_MAY_BE_IN_BINDING_MNGR;
-pub const NODE_IS_EDITABLE: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_IS_EDITABLE;
-pub const NODE_MAY_HAVE_CLASS: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_MAY_HAVE_CLASS;
-pub const NODE_IS_IN_SHADOW_TREE: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_IS_IN_SHADOW_TREE;
-pub const NODE_HAS_EMPTY_SELECTOR: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_HAS_EMPTY_SELECTOR;
-pub const NODE_HAS_SLOW_SELECTOR: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_HAS_SLOW_SELECTOR;
-pub const NODE_HAS_EDGE_CHILD_SELECTOR: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_HAS_EDGE_CHILD_SELECTOR;
-pub const NODE_HAS_SLOW_SELECTOR_LATER_SIBLINGS: _bindgen_ty_bindgen_id_183589
+pub const NODE_HAS_LISTENERMANAGER: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_HAS_LISTENERMANAGER;
+pub const NODE_HAS_PROPERTIES: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_HAS_PROPERTIES;
+pub const NODE_IS_ANONYMOUS_ROOT: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_IS_ANONYMOUS_ROOT;
+pub const NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE;
+pub const NODE_IS_NATIVE_ANONYMOUS_ROOT: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_IS_NATIVE_ANONYMOUS_ROOT;
+pub const NODE_FORCE_XBL_BINDINGS: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_FORCE_XBL_BINDINGS;
+pub const NODE_MAY_BE_IN_BINDING_MNGR: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_MAY_BE_IN_BINDING_MNGR;
+pub const NODE_IS_EDITABLE: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_IS_EDITABLE;
+pub const NODE_MAY_HAVE_CLASS: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_MAY_HAVE_CLASS;
+pub const NODE_IS_IN_SHADOW_TREE: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_IS_IN_SHADOW_TREE;
+pub const NODE_HAS_EMPTY_SELECTOR: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_HAS_EMPTY_SELECTOR;
+pub const NODE_HAS_SLOW_SELECTOR: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_HAS_SLOW_SELECTOR;
+pub const NODE_HAS_EDGE_CHILD_SELECTOR: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_HAS_EDGE_CHILD_SELECTOR;
+pub const NODE_HAS_SLOW_SELECTOR_LATER_SIBLINGS: _bindgen_ty_bindgen_id_183593
           =
-    _bindgen_ty_bindgen_id_183589::NODE_HAS_SLOW_SELECTOR_LATER_SIBLINGS;
-pub const NODE_ALL_SELECTOR_FLAGS: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_ALL_SELECTOR_FLAGS;
-pub const NODE_NEEDS_FRAME: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_NEEDS_FRAME;
-pub const NODE_DESCENDANTS_NEED_FRAMES: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_DESCENDANTS_NEED_FRAMES;
-pub const NODE_HAS_ACCESSKEY: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_HAS_ACCESSKEY;
-pub const NODE_HAS_DIRECTION_RTL: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_HAS_DIRECTION_RTL;
-pub const NODE_HAS_DIRECTION_LTR: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_HAS_DIRECTION_LTR;
-pub const NODE_ALL_DIRECTION_FLAGS: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_ALL_DIRECTION_FLAGS;
-pub const NODE_CHROME_ONLY_ACCESS: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_CHROME_ONLY_ACCESS;
-pub const NODE_IS_ROOT_OF_CHROME_ONLY_ACCESS: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_IS_ROOT_OF_CHROME_ONLY_ACCESS;
-pub const NODE_SHARED_RESTYLE_BIT_1: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_SHARED_RESTYLE_BIT_1;
-pub const NODE_SHARED_RESTYLE_BIT_2: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_SHARED_RESTYLE_BIT_2;
-pub const NODE_IS_DIRTY_FOR_SERVO: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_SHARED_RESTYLE_BIT_1;
-pub const NODE_HAS_DIRTY_DESCENDANTS_FOR_SERVO: _bindgen_ty_bindgen_id_183589
+    _bindgen_ty_bindgen_id_183593::NODE_HAS_SLOW_SELECTOR_LATER_SIBLINGS;
+pub const NODE_ALL_SELECTOR_FLAGS: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_ALL_SELECTOR_FLAGS;
+pub const NODE_NEEDS_FRAME: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_NEEDS_FRAME;
+pub const NODE_DESCENDANTS_NEED_FRAMES: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_DESCENDANTS_NEED_FRAMES;
+pub const NODE_HAS_ACCESSKEY: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_HAS_ACCESSKEY;
+pub const NODE_HAS_DIRECTION_RTL: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_HAS_DIRECTION_RTL;
+pub const NODE_HAS_DIRECTION_LTR: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_HAS_DIRECTION_LTR;
+pub const NODE_ALL_DIRECTION_FLAGS: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_ALL_DIRECTION_FLAGS;
+pub const NODE_CHROME_ONLY_ACCESS: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_CHROME_ONLY_ACCESS;
+pub const NODE_IS_ROOT_OF_CHROME_ONLY_ACCESS: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_IS_ROOT_OF_CHROME_ONLY_ACCESS;
+pub const NODE_SHARED_RESTYLE_BIT_1: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_SHARED_RESTYLE_BIT_1;
+pub const NODE_SHARED_RESTYLE_BIT_2: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_SHARED_RESTYLE_BIT_2;
+pub const NODE_IS_DIRTY_FOR_SERVO: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_SHARED_RESTYLE_BIT_1;
+pub const NODE_HAS_DIRTY_DESCENDANTS_FOR_SERVO: _bindgen_ty_bindgen_id_183593
           =
-    _bindgen_ty_bindgen_id_183589::NODE_SHARED_RESTYLE_BIT_2;
-pub const NODE_TYPE_SPECIFIC_BITS_OFFSET: _bindgen_ty_bindgen_id_183589 =
-    _bindgen_ty_bindgen_id_183589::NODE_TYPE_SPECIFIC_BITS_OFFSET;
+    _bindgen_ty_bindgen_id_183593::NODE_SHARED_RESTYLE_BIT_2;
+pub const NODE_TYPE_SPECIFIC_BITS_OFFSET: _bindgen_ty_bindgen_id_183593 =
+    _bindgen_ty_bindgen_id_183593::NODE_TYPE_SPECIFIC_BITS_OFFSET;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum _bindgen_ty_bindgen_id_183589 {
+pub enum _bindgen_ty_bindgen_id_183593 {
     NODE_HAS_LISTENERMANAGER = 4,
     NODE_HAS_PROPERTIES = 8,
     NODE_IS_ANONYMOUS_ROOT = 16,
@@ -6700,9 +6986,20 @@ pub struct nsITimer_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsITimer_TYPE_ONE_SHOT: nsITimer__bindgen_ty_bindgen_id_196125 =
+    nsITimer__bindgen_ty_bindgen_id_196125::TYPE_ONE_SHOT;
+pub const nsITimer_TYPE_REPEATING_SLACK:
+          nsITimer__bindgen_ty_bindgen_id_196125 =
+    nsITimer__bindgen_ty_bindgen_id_196125::TYPE_REPEATING_SLACK;
+pub const nsITimer_TYPE_REPEATING_PRECISE:
+          nsITimer__bindgen_ty_bindgen_id_196125 =
+    nsITimer__bindgen_ty_bindgen_id_196125::TYPE_REPEATING_PRECISE;
+pub const nsITimer_TYPE_REPEATING_PRECISE_CAN_SKIP:
+          nsITimer__bindgen_ty_bindgen_id_196125 =
+    nsITimer__bindgen_ty_bindgen_id_196125::TYPE_REPEATING_PRECISE_CAN_SKIP;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsITimer__bindgen_ty_bindgen_id_196121 {
+pub enum nsITimer__bindgen_ty_bindgen_id_196125 {
     TYPE_ONE_SHOT = 0,
     TYPE_REPEATING_SLACK = 1,
     TYPE_REPEATING_PRECISE = 2,
@@ -6726,9 +7023,15 @@ impl Clone for nsITimer {
 pub struct nsExpirationState {
     pub _bitfield_1: u32,
 }
+pub const nsExpirationState_NOT_TRACKED:
+          nsExpirationState__bindgen_ty_bindgen_id_196601 =
+    nsExpirationState__bindgen_ty_bindgen_id_196601::NOT_TRACKED;
+pub const nsExpirationState_MAX_INDEX_IN_GENERATION:
+          nsExpirationState__bindgen_ty_bindgen_id_196601 =
+    nsExpirationState__bindgen_ty_bindgen_id_196601::MAX_INDEX_IN_GENERATION;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsExpirationState__bindgen_ty_bindgen_id_196597 {
+pub enum nsExpirationState__bindgen_ty_bindgen_id_196601 {
     NOT_TRACKED = 15,
     MAX_INDEX_IN_GENERATION = 268435455,
 }
@@ -6801,9 +7104,32 @@ pub struct imgIRequest_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const imgIRequest_STATUS_NONE: imgIRequest__bindgen_ty_bindgen_id_198116 =
+    imgIRequest__bindgen_ty_bindgen_id_198116::STATUS_NONE;
+pub const imgIRequest_STATUS_SIZE_AVAILABLE:
+          imgIRequest__bindgen_ty_bindgen_id_198116 =
+    imgIRequest__bindgen_ty_bindgen_id_198116::STATUS_SIZE_AVAILABLE;
+pub const imgIRequest_STATUS_LOAD_COMPLETE:
+          imgIRequest__bindgen_ty_bindgen_id_198116 =
+    imgIRequest__bindgen_ty_bindgen_id_198116::STATUS_LOAD_COMPLETE;
+pub const imgIRequest_STATUS_ERROR: imgIRequest__bindgen_ty_bindgen_id_198116
+          =
+    imgIRequest__bindgen_ty_bindgen_id_198116::STATUS_ERROR;
+pub const imgIRequest_STATUS_FRAME_COMPLETE:
+          imgIRequest__bindgen_ty_bindgen_id_198116 =
+    imgIRequest__bindgen_ty_bindgen_id_198116::STATUS_FRAME_COMPLETE;
+pub const imgIRequest_STATUS_DECODE_COMPLETE:
+          imgIRequest__bindgen_ty_bindgen_id_198116 =
+    imgIRequest__bindgen_ty_bindgen_id_198116::STATUS_DECODE_COMPLETE;
+pub const imgIRequest_STATUS_IS_ANIMATED:
+          imgIRequest__bindgen_ty_bindgen_id_198116 =
+    imgIRequest__bindgen_ty_bindgen_id_198116::STATUS_IS_ANIMATED;
+pub const imgIRequest_STATUS_HAS_TRANSPARENCY:
+          imgIRequest__bindgen_ty_bindgen_id_198116 =
+    imgIRequest__bindgen_ty_bindgen_id_198116::STATUS_HAS_TRANSPARENCY;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum imgIRequest__bindgen_ty_bindgen_id_198112 {
+pub enum imgIRequest__bindgen_ty_bindgen_id_198116 {
     STATUS_NONE = 0,
     STATUS_SIZE_AVAILABLE = 1,
     STATUS_LOAD_COMPLETE = 2,
@@ -6813,9 +7139,17 @@ pub enum imgIRequest__bindgen_ty_bindgen_id_198112 {
     STATUS_IS_ANIMATED = 32,
     STATUS_HAS_TRANSPARENCY = 64,
 }
+pub const imgIRequest_CORS_NONE: imgIRequest__bindgen_ty_bindgen_id_198196 =
+    imgIRequest__bindgen_ty_bindgen_id_198196::CORS_NONE;
+pub const imgIRequest_CORS_ANONYMOUS:
+          imgIRequest__bindgen_ty_bindgen_id_198196 =
+    imgIRequest__bindgen_ty_bindgen_id_198196::CORS_ANONYMOUS;
+pub const imgIRequest_CORS_USE_CREDENTIALS:
+          imgIRequest__bindgen_ty_bindgen_id_198196 =
+    imgIRequest__bindgen_ty_bindgen_id_198196::CORS_USE_CREDENTIALS;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum imgIRequest__bindgen_ty_bindgen_id_198192 {
+pub enum imgIRequest__bindgen_ty_bindgen_id_198196 {
     CORS_NONE = 1,
     CORS_ANONYMOUS = 2,
     CORS_USE_CREDENTIALS = 3,
@@ -7085,12 +7419,12 @@ fn bindgen_test_layout_URLValue() {
     assert_eq!(::std::mem::align_of::<URLValue>() , 8usize);
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_208594 {
+pub struct bindgen_vtable__bindgen_id_208598 {
 }
 #[repr(C)]
 #[derive(Debug)]
 pub struct URLValueData {
-    pub vtable_: *const bindgen_vtable__bindgen_id_208594,
+    pub vtable_: *const bindgen_vtable__bindgen_id_208598,
     pub mRefCnt: ThreadSafeAutoRefCnt,
     pub mURI: nsMainThreadPtrHandle<nsIURI>,
     pub mBaseURI: nsMainThreadPtrHandle<nsIURI>,
@@ -7307,9 +7641,12 @@ pub struct nsPresArena_FreeList {
 }
 pub type nsPresArena_FreeList_KeyType = u32;
 pub type nsPresArena_FreeList_KeyTypePointer = *const ::std::os::raw::c_void;
+pub const nsPresArena_FreeList_ALLOW_MEMMOVE:
+          nsPresArena_FreeList__bindgen_ty_bindgen_id_210752 =
+    nsPresArena_FreeList__bindgen_ty_bindgen_id_210752::ALLOW_MEMMOVE;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsPresArena_FreeList__bindgen_ty_bindgen_id_210748 {
+pub enum nsPresArena_FreeList__bindgen_ty_bindgen_id_210752 {
     ALLOW_MEMMOVE = 0,
 }
 #[test]
@@ -7334,9 +7671,36 @@ pub struct imgINotificationObserver_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const imgINotificationObserver_SIZE_AVAILABLE:
+          imgINotificationObserver__bindgen_ty_bindgen_id_210899 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_210899::SIZE_AVAILABLE;
+pub const imgINotificationObserver_FRAME_UPDATE:
+          imgINotificationObserver__bindgen_ty_bindgen_id_210899 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_210899::FRAME_UPDATE;
+pub const imgINotificationObserver_FRAME_COMPLETE:
+          imgINotificationObserver__bindgen_ty_bindgen_id_210899 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_210899::FRAME_COMPLETE;
+pub const imgINotificationObserver_LOAD_COMPLETE:
+          imgINotificationObserver__bindgen_ty_bindgen_id_210899 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_210899::LOAD_COMPLETE;
+pub const imgINotificationObserver_DECODE_COMPLETE:
+          imgINotificationObserver__bindgen_ty_bindgen_id_210899 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_210899::DECODE_COMPLETE;
+pub const imgINotificationObserver_DISCARD:
+          imgINotificationObserver__bindgen_ty_bindgen_id_210899 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_210899::DISCARD;
+pub const imgINotificationObserver_UNLOCKED_DRAW:
+          imgINotificationObserver__bindgen_ty_bindgen_id_210899 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_210899::UNLOCKED_DRAW;
+pub const imgINotificationObserver_IS_ANIMATED:
+          imgINotificationObserver__bindgen_ty_bindgen_id_210899 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_210899::IS_ANIMATED;
+pub const imgINotificationObserver_HAS_TRANSPARENCY:
+          imgINotificationObserver__bindgen_ty_bindgen_id_210899 =
+    imgINotificationObserver__bindgen_ty_bindgen_id_210899::HAS_TRANSPARENCY;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum imgINotificationObserver__bindgen_ty_bindgen_id_210895 {
+pub enum imgINotificationObserver__bindgen_ty_bindgen_id_210899 {
     SIZE_AVAILABLE = 1,
     FRAME_UPDATE = 2,
     FRAME_COMPLETE = 3,
@@ -7583,9 +7947,13 @@ pub type gfxFontFeatureValueSet_FeatureValueHashEntry_KeyType =
     *const gfxFontFeatureValueSet_FeatureValueHashKey;
 pub type gfxFontFeatureValueSet_FeatureValueHashEntry_KeyTypePointer =
     *const gfxFontFeatureValueSet_FeatureValueHashKey;
+pub const gfxFontFeatureValueSet_FeatureValueHashEntry_ALLOW_MEMMOVE:
+          gfxFontFeatureValueSet_FeatureValueHashEntry__bindgen_ty_bindgen_id_212143
+          =
+    gfxFontFeatureValueSet_FeatureValueHashEntry__bindgen_ty_bindgen_id_212143::ALLOW_MEMMOVE;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum gfxFontFeatureValueSet_FeatureValueHashEntry__bindgen_ty_bindgen_id_212139
+pub enum gfxFontFeatureValueSet_FeatureValueHashEntry__bindgen_ty_bindgen_id_212143
          {
     ALLOW_MEMMOVE = 1,
 }
@@ -7924,23 +8292,23 @@ pub enum nsStyleUnit {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct _bindgen_ty_bindgen_id_212744 {
+pub struct _bindgen_ty_bindgen_id_212748 {
     pub mInt: __BindgenUnionField<i32>,
     pub mFloat: __BindgenUnionField<f32>,
     pub mPointer: __BindgenUnionField<*mut ::std::os::raw::c_void>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout__bindgen_ty_bindgen_id_212744() {
-    assert_eq!(::std::mem::size_of::<_bindgen_ty_bindgen_id_212744>() ,
+fn bindgen_test_layout__bindgen_ty_bindgen_id_212748() {
+    assert_eq!(::std::mem::size_of::<_bindgen_ty_bindgen_id_212748>() ,
                8usize);
-    assert_eq!(::std::mem::align_of::<_bindgen_ty_bindgen_id_212744>() ,
+    assert_eq!(::std::mem::align_of::<_bindgen_ty_bindgen_id_212748>() ,
                8usize);
 }
-impl Clone for _bindgen_ty_bindgen_id_212744 {
+impl Clone for _bindgen_ty_bindgen_id_212748 {
     fn clone(&self) -> Self { *self }
 }
-pub type nsStyleUnion = _bindgen_ty_bindgen_id_212744;
+pub type nsStyleUnion = _bindgen_ty_bindgen_id_212748;
 /**
  * Class that hold a single size specification used by the style
  * system.  The size specification consists of two parts -- a number
@@ -8983,7 +9351,7 @@ fn bindgen_test_layout_imgRequestProxy() {
     assert_eq!(::std::mem::align_of::<imgRequestProxy>() , 8usize);
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_221958 {
+pub struct bindgen_vtable__bindgen_id_221962 {
 }
 /**
  * An interface for observing changes to image state, as reported by
@@ -9000,7 +9368,7 @@ pub struct bindgen_vtable__bindgen_id_221958 {
 #[repr(C)]
 #[derive(Debug)]
 pub struct IProgressObserver {
-    pub vtable_: *const bindgen_vtable__bindgen_id_221958,
+    pub vtable_: *const bindgen_vtable__bindgen_id_221962,
     pub _base: u64,
 }
 #[test]
@@ -9020,9 +9388,24 @@ pub struct nsISupportsPriority_COMTypeInfo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<T>,
     pub _phantom_1: ::std::marker::PhantomData<U>,
 }
+pub const nsISupportsPriority_PRIORITY_HIGHEST:
+          nsISupportsPriority__bindgen_ty_bindgen_id_222038 =
+    nsISupportsPriority__bindgen_ty_bindgen_id_222038::PRIORITY_HIGHEST;
+pub const nsISupportsPriority_PRIORITY_HIGH:
+          nsISupportsPriority__bindgen_ty_bindgen_id_222038 =
+    nsISupportsPriority__bindgen_ty_bindgen_id_222038::PRIORITY_HIGH;
+pub const nsISupportsPriority_PRIORITY_NORMAL:
+          nsISupportsPriority__bindgen_ty_bindgen_id_222038 =
+    nsISupportsPriority__bindgen_ty_bindgen_id_222038::PRIORITY_NORMAL;
+pub const nsISupportsPriority_PRIORITY_LOW:
+          nsISupportsPriority__bindgen_ty_bindgen_id_222038 =
+    nsISupportsPriority__bindgen_ty_bindgen_id_222038::PRIORITY_LOW;
+pub const nsISupportsPriority_PRIORITY_LOWEST:
+          nsISupportsPriority__bindgen_ty_bindgen_id_222038 =
+    nsISupportsPriority__bindgen_ty_bindgen_id_222038::PRIORITY_LOWEST;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsISupportsPriority__bindgen_ty_bindgen_id_222034 {
+pub enum nsISupportsPriority__bindgen_ty_bindgen_id_222038 {
     PRIORITY_HIGHEST = -20,
     PRIORITY_HIGH = -10,
     PRIORITY_NORMAL = 0,
@@ -9457,7 +9840,7 @@ fn bindgen_test_layout_nsCSSValueFloatColor() {
 #[derive(Debug)]
 pub struct nsCSSValue {
     pub mUnit: nsCSSUnit,
-    pub mValue: nsCSSValue__bindgen_ty_bindgen_id_225037,
+    pub mValue: nsCSSValue__bindgen_ty_bindgen_id_225041,
 }
 #[repr(C)]
 #[derive(Debug)]
@@ -9473,7 +9856,7 @@ fn bindgen_test_layout_nsCSSValue_Array() {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsCSSValue__bindgen_ty_bindgen_id_225037 {
+pub struct nsCSSValue__bindgen_ty_bindgen_id_225041 {
     pub mInt: __BindgenUnionField<i32>,
     pub mFloat: __BindgenUnionField<f32>,
     pub mString: __BindgenUnionField<*mut nsStringBuffer>,
@@ -9498,13 +9881,13 @@ pub struct nsCSSValue__bindgen_ty_bindgen_id_225037 {
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsCSSValue__bindgen_ty_bindgen_id_225037() {
-    assert_eq!(::std::mem::size_of::<nsCSSValue__bindgen_ty_bindgen_id_225037>()
+fn bindgen_test_layout_nsCSSValue__bindgen_ty_bindgen_id_225041() {
+    assert_eq!(::std::mem::size_of::<nsCSSValue__bindgen_ty_bindgen_id_225041>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsCSSValue__bindgen_ty_bindgen_id_225037>()
+    assert_eq!(::std::mem::align_of::<nsCSSValue__bindgen_ty_bindgen_id_225041>()
                , 8usize);
 }
-impl Clone for nsCSSValue__bindgen_ty_bindgen_id_225037 {
+impl Clone for nsCSSValue__bindgen_ty_bindgen_id_225041 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -9525,12 +9908,12 @@ fn bindgen_test_layout_nsCSSValueGradientStop() {
     assert_eq!(::std::mem::align_of::<nsCSSValueGradientStop>() , 8usize);
 }
 #[repr(C)]
-pub struct bindgen_vtable__bindgen_id_225245 {
+pub struct bindgen_vtable__bindgen_id_225249 {
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
 pub struct CounterStyle {
-    pub vtable_: *const bindgen_vtable__bindgen_id_225245,
+    pub vtable_: *const bindgen_vtable__bindgen_id_225249,
     pub mStyle: i32,
 }
 #[test]
@@ -9705,25 +10088,25 @@ pub struct nsStyleImage {
     pub mCachedBIData: UniquePtr<CachedBorderImageData,
                                  DefaultDelete<CachedBorderImageData>>,
     pub mType: nsStyleImageType,
-    pub __bindgen_anon_1: nsStyleImage__bindgen_ty_bindgen_id_227145,
+    pub __bindgen_anon_1: nsStyleImage__bindgen_ty_bindgen_id_227149,
     pub mCropRect: UniquePtr<nsStyleSides, DefaultDelete<nsStyleSides>>,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleImage__bindgen_ty_bindgen_id_227145 {
+pub struct nsStyleImage__bindgen_ty_bindgen_id_227149 {
     pub mImage: __BindgenUnionField<*mut imgRequestProxy>,
     pub mGradient: __BindgenUnionField<*mut nsStyleGradient>,
     pub mElementId: __BindgenUnionField<*mut u16>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsStyleImage__bindgen_ty_bindgen_id_227145() {
-    assert_eq!(::std::mem::size_of::<nsStyleImage__bindgen_ty_bindgen_id_227145>()
+fn bindgen_test_layout_nsStyleImage__bindgen_ty_bindgen_id_227149() {
+    assert_eq!(::std::mem::size_of::<nsStyleImage__bindgen_ty_bindgen_id_227149>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsStyleImage__bindgen_ty_bindgen_id_227145>()
+    assert_eq!(::std::mem::align_of::<nsStyleImage__bindgen_ty_bindgen_id_227149>()
                , 8usize);
 }
-impl Clone for nsStyleImage__bindgen_ty_bindgen_id_227145 {
+impl Clone for nsStyleImage__bindgen_ty_bindgen_id_227149 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -9772,9 +10155,45 @@ pub struct nsStyleImageLayers {
     pub mCompositeCount: u32,
     pub mLayers: nsStyleAutoArray<nsStyleImageLayers_Layer>,
 }
+pub const nsStyleImageLayers_shorthand:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::shorthand;
+pub const nsStyleImageLayers_color:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::color;
+pub const nsStyleImageLayers_image:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::image;
+pub const nsStyleImageLayers_repeat:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::repeat;
+pub const nsStyleImageLayers_positionX:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::positionX;
+pub const nsStyleImageLayers_positionY:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::positionY;
+pub const nsStyleImageLayers_clip:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::clip;
+pub const nsStyleImageLayers_origin:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::origin;
+pub const nsStyleImageLayers_size:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::size;
+pub const nsStyleImageLayers_attachment:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::attachment;
+pub const nsStyleImageLayers_maskMode:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::maskMode;
+pub const nsStyleImageLayers_composite:
+          nsStyleImageLayers__bindgen_ty_bindgen_id_227202 =
+    nsStyleImageLayers__bindgen_ty_bindgen_id_227202::composite;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsStyleImageLayers__bindgen_ty_bindgen_id_227198 {
+pub enum nsStyleImageLayers__bindgen_ty_bindgen_id_227202 {
     shorthand = 0,
     color = 1,
     image = 2,
@@ -9965,45 +10384,45 @@ pub struct nsStyleBorder {
     pub mFloatEdge: StyleFloatEdge,
     pub mBoxDecorationBreak: StyleBoxDecorationBreak,
     pub mBorderStyle: [u8; 4usize],
-    pub __bindgen_anon_1: nsStyleBorder__bindgen_ty_bindgen_id_227869,
+    pub __bindgen_anon_1: nsStyleBorder__bindgen_ty_bindgen_id_227873,
     pub mComputedBorder: nsMargin,
     pub mBorder: nsMargin,
     pub mTwipsPerPixel: nscoord,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleBorder__bindgen_ty_bindgen_id_227869 {
-    pub __bindgen_anon_1: __BindgenUnionField<nsStyleBorder__bindgen_ty_bindgen_id_227869__bindgen_ty_bindgen_id_227870>,
+pub struct nsStyleBorder__bindgen_ty_bindgen_id_227873 {
+    pub __bindgen_anon_1: __BindgenUnionField<nsStyleBorder__bindgen_ty_bindgen_id_227873__bindgen_ty_bindgen_id_227874>,
     pub mBorderColor: __BindgenUnionField<[StyleComplexColor; 4usize]>,
     pub bindgen_union_field: [u32; 8usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleBorder__bindgen_ty_bindgen_id_227869__bindgen_ty_bindgen_id_227870 {
+pub struct nsStyleBorder__bindgen_ty_bindgen_id_227873__bindgen_ty_bindgen_id_227874 {
     pub mBorderTopColor: StyleComplexColor,
     pub mBorderRightColor: StyleComplexColor,
     pub mBorderBottomColor: StyleComplexColor,
     pub mBorderLeftColor: StyleComplexColor,
 }
 #[test]
-fn bindgen_test_layout_nsStyleBorder__bindgen_ty_bindgen_id_227869__bindgen_ty_bindgen_id_227870() {
-    assert_eq!(::std::mem::size_of::<nsStyleBorder__bindgen_ty_bindgen_id_227869__bindgen_ty_bindgen_id_227870>()
+fn bindgen_test_layout_nsStyleBorder__bindgen_ty_bindgen_id_227873__bindgen_ty_bindgen_id_227874() {
+    assert_eq!(::std::mem::size_of::<nsStyleBorder__bindgen_ty_bindgen_id_227873__bindgen_ty_bindgen_id_227874>()
                , 32usize);
-    assert_eq!(::std::mem::align_of::<nsStyleBorder__bindgen_ty_bindgen_id_227869__bindgen_ty_bindgen_id_227870>()
+    assert_eq!(::std::mem::align_of::<nsStyleBorder__bindgen_ty_bindgen_id_227873__bindgen_ty_bindgen_id_227874>()
                , 4usize);
 }
 impl Clone for
- nsStyleBorder__bindgen_ty_bindgen_id_227869__bindgen_ty_bindgen_id_227870 {
+ nsStyleBorder__bindgen_ty_bindgen_id_227873__bindgen_ty_bindgen_id_227874 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_nsStyleBorder__bindgen_ty_bindgen_id_227869() {
-    assert_eq!(::std::mem::size_of::<nsStyleBorder__bindgen_ty_bindgen_id_227869>()
+fn bindgen_test_layout_nsStyleBorder__bindgen_ty_bindgen_id_227873() {
+    assert_eq!(::std::mem::size_of::<nsStyleBorder__bindgen_ty_bindgen_id_227873>()
                , 32usize);
-    assert_eq!(::std::mem::align_of::<nsStyleBorder__bindgen_ty_bindgen_id_227869>()
+    assert_eq!(::std::mem::align_of::<nsStyleBorder__bindgen_ty_bindgen_id_227873>()
                , 4usize);
 }
-impl Clone for nsStyleBorder__bindgen_ty_bindgen_id_227869 {
+impl Clone for nsStyleBorder__bindgen_ty_bindgen_id_227873 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -10310,7 +10729,7 @@ impl Clone for nsStyleImageOrientation {
 #[derive(Debug, Copy)]
 pub struct nsTimingFunction {
     pub mType: nsTimingFunction_Type,
-    pub __bindgen_anon_1: nsTimingFunction__bindgen_ty_bindgen_id_228829,
+    pub __bindgen_anon_1: nsTimingFunction__bindgen_ty_bindgen_id_228833,
 }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -10329,56 +10748,56 @@ pub enum nsTimingFunction_Type {
 pub enum nsTimingFunction_Keyword { Implicit = 0, Explicit = 1, }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsTimingFunction__bindgen_ty_bindgen_id_228829 {
-    pub mFunc: __BindgenUnionField<nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228830>,
-    pub __bindgen_anon_1: __BindgenUnionField<nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228841>,
+pub struct nsTimingFunction__bindgen_ty_bindgen_id_228833 {
+    pub mFunc: __BindgenUnionField<nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228834>,
+    pub __bindgen_anon_1: __BindgenUnionField<nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228845>,
     pub bindgen_union_field: [u32; 4usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228830 {
+pub struct nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228834 {
     pub mX1: f32,
     pub mY1: f32,
     pub mX2: f32,
     pub mY2: f32,
 }
 #[test]
-fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228830() {
-    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228830>()
+fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228834() {
+    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228834>()
                , 16usize);
-    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228830>()
+    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228834>()
                , 4usize);
 }
 impl Clone for
- nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228830
+ nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228834
  {
     fn clone(&self) -> Self { *self }
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228841 {
+pub struct nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228845 {
     pub mSteps: u32,
 }
 #[test]
-fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228841() {
-    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228841>()
+fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228845() {
+    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228845>()
                , 4usize);
-    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228841>()
+    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228845>()
                , 4usize);
 }
 impl Clone for
- nsTimingFunction__bindgen_ty_bindgen_id_228829__bindgen_ty_bindgen_id_228841
+ nsTimingFunction__bindgen_ty_bindgen_id_228833__bindgen_ty_bindgen_id_228845
  {
     fn clone(&self) -> Self { *self }
 }
 #[test]
-fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_228829() {
-    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_228829>()
+fn bindgen_test_layout_nsTimingFunction__bindgen_ty_bindgen_id_228833() {
+    assert_eq!(::std::mem::size_of::<nsTimingFunction__bindgen_ty_bindgen_id_228833>()
                , 16usize);
-    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_228829>()
+    assert_eq!(::std::mem::align_of::<nsTimingFunction__bindgen_ty_bindgen_id_228833>()
                , 4usize);
 }
-impl Clone for nsTimingFunction__bindgen_ty_bindgen_id_228829 {
+impl Clone for nsTimingFunction__bindgen_ty_bindgen_id_228833 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -10439,13 +10858,13 @@ fn bindgen_test_layout_StyleBasicShape() {
 #[repr(C)]
 #[derive(Debug)]
 pub struct StyleShapeSource<ReferenceBox> {
-    pub __bindgen_anon_1: StyleShapeSource__bindgen_ty_bindgen_id_229212<ReferenceBox>,
+    pub __bindgen_anon_1: StyleShapeSource__bindgen_ty_bindgen_id_229216<ReferenceBox>,
     pub mType: StyleShapeSourceType,
     pub mReferenceBox: ReferenceBox,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct StyleShapeSource__bindgen_ty_bindgen_id_229212<ReferenceBox> {
+pub struct StyleShapeSource__bindgen_ty_bindgen_id_229216<ReferenceBox> {
     pub mBasicShape: __BindgenUnionField<*mut StyleBasicShape>,
     pub mURL: __BindgenUnionField<*mut URLValue>,
     pub bindgen_union_field: u64,
@@ -10497,24 +10916,24 @@ pub enum nsStyleContentType {
 #[derive(Debug)]
 pub struct nsStyleContentData {
     pub mType: nsStyleContentType,
-    pub mContent: nsStyleContentData__bindgen_ty_bindgen_id_229296,
+    pub mContent: nsStyleContentData__bindgen_ty_bindgen_id_229300,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleContentData__bindgen_ty_bindgen_id_229296 {
+pub struct nsStyleContentData__bindgen_ty_bindgen_id_229300 {
     pub mString: __BindgenUnionField<*mut u16>,
     pub mImage: __BindgenUnionField<*mut imgRequestProxy>,
     pub mCounters: __BindgenUnionField<*mut nsCSSValue_Array>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsStyleContentData__bindgen_ty_bindgen_id_229296() {
-    assert_eq!(::std::mem::size_of::<nsStyleContentData__bindgen_ty_bindgen_id_229296>()
+fn bindgen_test_layout_nsStyleContentData__bindgen_ty_bindgen_id_229300() {
+    assert_eq!(::std::mem::size_of::<nsStyleContentData__bindgen_ty_bindgen_id_229300>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsStyleContentData__bindgen_ty_bindgen_id_229296>()
+    assert_eq!(::std::mem::align_of::<nsStyleContentData__bindgen_ty_bindgen_id_229300>()
                , 8usize);
 }
-impl Clone for nsStyleContentData__bindgen_ty_bindgen_id_229296 {
+impl Clone for nsStyleContentData__bindgen_ty_bindgen_id_229300 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -10637,25 +11056,25 @@ pub enum nsStyleSVGPaintType {
 #[repr(C)]
 #[derive(Debug)]
 pub struct nsStyleSVGPaint {
-    pub mPaint: nsStyleSVGPaint__bindgen_ty_bindgen_id_229741,
+    pub mPaint: nsStyleSVGPaint__bindgen_ty_bindgen_id_229745,
     pub mType: nsStyleSVGPaintType,
     pub mFallbackColor: nscolor,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleSVGPaint__bindgen_ty_bindgen_id_229741 {
+pub struct nsStyleSVGPaint__bindgen_ty_bindgen_id_229745 {
     pub mColor: __BindgenUnionField<nscolor>,
     pub mPaintServer: __BindgenUnionField<*mut URLValue>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsStyleSVGPaint__bindgen_ty_bindgen_id_229741() {
-    assert_eq!(::std::mem::size_of::<nsStyleSVGPaint__bindgen_ty_bindgen_id_229741>()
+fn bindgen_test_layout_nsStyleSVGPaint__bindgen_ty_bindgen_id_229745() {
+    assert_eq!(::std::mem::size_of::<nsStyleSVGPaint__bindgen_ty_bindgen_id_229745>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsStyleSVGPaint__bindgen_ty_bindgen_id_229741>()
+    assert_eq!(::std::mem::align_of::<nsStyleSVGPaint__bindgen_ty_bindgen_id_229745>()
                , 8usize);
 }
-impl Clone for nsStyleSVGPaint__bindgen_ty_bindgen_id_229741 {
+impl Clone for nsStyleSVGPaint__bindgen_ty_bindgen_id_229745 {
     fn clone(&self) -> Self { *self }
 }
 #[test]
@@ -10688,9 +11107,30 @@ pub struct nsStyleSVG {
     pub mTextAnchor: u8,
     pub mContextFlags: u8,
 }
+pub const nsStyleSVG_FILL_OPACITY_SOURCE_MASK:
+          nsStyleSVG__bindgen_ty_bindgen_id_229905 =
+    nsStyleSVG__bindgen_ty_bindgen_id_229905::FILL_OPACITY_SOURCE_MASK;
+pub const nsStyleSVG_STROKE_OPACITY_SOURCE_MASK:
+          nsStyleSVG__bindgen_ty_bindgen_id_229905 =
+    nsStyleSVG__bindgen_ty_bindgen_id_229905::STROKE_OPACITY_SOURCE_MASK;
+pub const nsStyleSVG_STROKE_DASHARRAY_CONTEXT:
+          nsStyleSVG__bindgen_ty_bindgen_id_229905 =
+    nsStyleSVG__bindgen_ty_bindgen_id_229905::STROKE_DASHARRAY_CONTEXT;
+pub const nsStyleSVG_STROKE_DASHOFFSET_CONTEXT:
+          nsStyleSVG__bindgen_ty_bindgen_id_229905 =
+    nsStyleSVG__bindgen_ty_bindgen_id_229905::STROKE_DASHOFFSET_CONTEXT;
+pub const nsStyleSVG_STROKE_WIDTH_CONTEXT:
+          nsStyleSVG__bindgen_ty_bindgen_id_229905 =
+    nsStyleSVG__bindgen_ty_bindgen_id_229905::STROKE_WIDTH_CONTEXT;
+pub const nsStyleSVG_FILL_OPACITY_SOURCE_SHIFT:
+          nsStyleSVG__bindgen_ty_bindgen_id_229905 =
+    nsStyleSVG__bindgen_ty_bindgen_id_229905::FILL_OPACITY_SOURCE_SHIFT;
+pub const nsStyleSVG_STROKE_OPACITY_SOURCE_SHIFT:
+          nsStyleSVG__bindgen_ty_bindgen_id_229905 =
+    nsStyleSVG__bindgen_ty_bindgen_id_229905::STROKE_OPACITY_SOURCE_SHIFT;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum nsStyleSVG__bindgen_ty_bindgen_id_229901 {
+pub enum nsStyleSVG__bindgen_ty_bindgen_id_229905 {
     FILL_OPACITY_SOURCE_MASK = 3,
     STROKE_OPACITY_SOURCE_MASK = 12,
     STROKE_DASHARRAY_CONTEXT = 16,
@@ -10709,23 +11149,23 @@ fn bindgen_test_layout_nsStyleSVG() {
 pub struct nsStyleFilter {
     pub mType: i32,
     pub mFilterParameter: nsStyleCoord,
-    pub __bindgen_anon_1: nsStyleFilter__bindgen_ty_bindgen_id_229967,
+    pub __bindgen_anon_1: nsStyleFilter__bindgen_ty_bindgen_id_229971,
 }
 #[repr(C)]
 #[derive(Debug, Copy)]
-pub struct nsStyleFilter__bindgen_ty_bindgen_id_229967 {
+pub struct nsStyleFilter__bindgen_ty_bindgen_id_229971 {
     pub mURL: __BindgenUnionField<*mut URLValue>,
     pub mDropShadow: __BindgenUnionField<*mut nsCSSShadowArray>,
     pub bindgen_union_field: u64,
 }
 #[test]
-fn bindgen_test_layout_nsStyleFilter__bindgen_ty_bindgen_id_229967() {
-    assert_eq!(::std::mem::size_of::<nsStyleFilter__bindgen_ty_bindgen_id_229967>()
+fn bindgen_test_layout_nsStyleFilter__bindgen_ty_bindgen_id_229971() {
+    assert_eq!(::std::mem::size_of::<nsStyleFilter__bindgen_ty_bindgen_id_229971>()
                , 8usize);
-    assert_eq!(::std::mem::align_of::<nsStyleFilter__bindgen_ty_bindgen_id_229967>()
+    assert_eq!(::std::mem::align_of::<nsStyleFilter__bindgen_ty_bindgen_id_229971>()
                , 8usize);
 }
-impl Clone for nsStyleFilter__bindgen_ty_bindgen_id_229967 {
+impl Clone for nsStyleFilter__bindgen_ty_bindgen_id_229971 {
     fn clone(&self) -> Self { *self }
 }
 #[test]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This regen is on top of a change I just pushed to stylo/incubator to shuffle some `nsIDocument` fields around, to avoid a rust-bindgen problem: https://hg.mozilla.org/incubator/stylo/rev/b89a5e3184b97d685855178e4aaa4f023ebb797c

r? @Manishearth 
cc @emilio 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13851)

<!-- Reviewable:end -->
