### PR TITLE
Fix missing `backtrace` build error on Android

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -45,6 +45,7 @@ style_tests = {path = "../../tests/unit/style"}
 util_tests = {path = "../../tests/unit/util"}
 
 [dependencies]
+backtrace = "0.2"
 browserhtml = {git = "https://github.com/browserhtml/browserhtml", branch = "crate"}
 canvas = {path = "../canvas"}
 canvas_traits = {path = "../canvas_traits"}
@@ -88,7 +89,6 @@ features = ["serde_derive"]
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 sig = "0.1"
-backtrace = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
 log = "0.3"

--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -20,7 +20,6 @@
 #[cfg(target_os = "android")]
 #[macro_use]
 extern crate android_glue;
-#[cfg(not(target_os = "android"))]
 extern crate backtrace;
 // The window backed by glutin
 extern crate glutin_app as app;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The missing `backtrace` causes compile errors when building for Android (introduced by servo/servo#12657). This PR fixes the problem by enabling `backtrace` on Android too.

(This is a fix for servo/servo#13154)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13855)

<!-- Reviewable:end -->
