### PR TITLE
Remove `android_start!`

### DIFF
--- a/components/servo/main.rs
+++ b/components/servo/main.rs
@@ -257,13 +257,6 @@ extern {
 }
 
 
-// This macro must be used at toplevel because it defines a nested
-// module, but macros can only accept identifiers - not paths -
-// preventing the expansion of this macro within the android module
-// without use of an additionl stub method or other hackery.
-#[cfg(target_os = "android")]
-android_start!(main);
-
 #[cfg(target_os = "android")]
 mod android {
     extern crate android_glue;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Due to the API changes in `glutin` (1.x -> 2.x), the `android_start!` macro is no longer needed, and causes build error.

(This is a fix for servo/servo#13154)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13856)

<!-- Reviewable:end -->
