### PR TITLE
Stop ticking animations on non-dirty nodes during traversal

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1536,6 +1536,9 @@ impl ScriptThread {
         let node = unsafe { node.get_jsmanaged().get_for_script() };
         let window = window_from_node(node);
 
+        // Not quite the right thing - see #13865.
+        node.dirty(NodeDamage::NodeStyleDamaged);
+
         if let Some(el) = node.downcast::<Element>() {
             if &*window.GetComputedStyle(el, None).Display() == "none" {
                 return;

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -4,7 +4,6 @@
 
 //! Traversing the DOM tree; the bloom filter.
 
-use animation;
 use context::{LocalStyleContext, SharedStyleContext, StyleContext};
 use dom::{OpaqueNode, TNode, UnsafeNode};
 use matching::{ApplicableDeclarations, ElementMatchMethods, MatchMethods, StyleSharingResult};
@@ -366,17 +365,6 @@ pub fn recalc_style_at<'a, N, C>(context: &'a C,
                 style_sharing_candidate_cache.touch(index);
                 node.set_restyle_damage(damage);
             }
-        }
-    } else {
-        // Finish any expired transitions.
-        let mut existing_style = node.get_existing_style().unwrap();
-        let had_animations_to_expire = animation::complete_expired_transitions(
-            node.opaque(),
-            &mut existing_style,
-            context.shared_context()
-        );
-        if had_animations_to_expire {
-            node.set_style(existing_style);
         }
     }
 

--- a/tests/wpt/mozilla/meta/css/animations/basic-transition.html.ini
+++ b/tests/wpt/mozilla/meta/css/animations/basic-transition.html.ini
@@ -1,0 +1,2 @@
+[basic-transition.html]
+  disabled: https://github.com/servo/servo/issues/13865


### PR DESCRIPTION
See #13865.

r? @emilio

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13866)

<!-- Reviewable:end -->
