### PR TITLE
webgl: Add basic support for framebuffer attachments

### DIFF
--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -4,15 +4,27 @@
 
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use canvas_traits::CanvasMsg;
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::WebGLFramebufferBinding;
 use dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants as constants;
-use dom::bindings::js::Root;
+use dom::bindings::js::{HeapGCValue, JS, Root};
 use dom::bindings::reflector::reflect_dom_object;
 use dom::globalscope::GlobalScope;
 use dom::webglobject::WebGLObject;
+use dom::webglrenderbuffer::WebGLRenderbuffer;
+use dom::webgltexture::WebGLTexture;
 use ipc_channel::ipc::{self, IpcSender};
 use std::cell::Cell;
-use webrender_traits::{WebGLCommand, WebGLFramebufferBindingRequest, WebGLFramebufferId};
+use webrender_traits::{WebGLCommand, WebGLFramebufferBindingRequest, WebGLFramebufferId, WebGLResult, WebGLError};
+
+#[must_root]
+#[derive(JSTraceable, Clone, HeapSizeOf)]
+enum WebGLFramebufferAttachment {
+    Renderbuffer(JS<WebGLRenderbuffer>),
+    Texture(JS<WebGLTexture>),
+}
+
+impl HeapGCValue for WebGLFramebufferAttachment {}
 
 #[dom_struct]
 pub struct WebGLFramebuffer {
@@ -21,8 +33,16 @@ pub struct WebGLFramebuffer {
     /// target can only be gl::FRAMEBUFFER at the moment
     target: Cell<Option<u32>>,
     is_deleted: Cell<bool>,
+    status: Cell<u32>,
     #[ignore_heap_size_of = "Defined in ipc-channel"]
     renderer: IpcSender<CanvasMsg>,
+
+    // The attachment points for textures and renderbuffers on this
+    // FBO.
+    color: DOMRefCell<Option<WebGLFramebufferAttachment>>,
+    depth: DOMRefCell<Option<WebGLFramebufferAttachment>>,
+    stencil: DOMRefCell<Option<WebGLFramebufferAttachment>>,
+    depthstencil: DOMRefCell<Option<WebGLFramebufferAttachment>>,
 }
 
 impl WebGLFramebuffer {
@@ -35,6 +55,11 @@ impl WebGLFramebuffer {
             target: Cell::new(None),
             is_deleted: Cell::new(false),
             renderer: renderer,
+            status: Cell::new(constants::FRAMEBUFFER_UNSUPPORTED),
+            color: DOMRefCell::new(None),
+            depth: DOMRefCell::new(None),
+            stencil: DOMRefCell::new(None),
+            depthstencil: DOMRefCell::new(None),
         }
     }
 
@@ -80,10 +105,144 @@ impl WebGLFramebuffer {
         self.is_deleted.get()
     }
 
+    fn update_status(&self) {
+        let has_c = self.color.borrow().is_some();
+        let has_z = self.depth.borrow().is_some();
+        let has_s = self.stencil.borrow().is_some();
+        let has_zs = self.depthstencil.borrow().is_some();
+
+        // From the WebGL spec, 6.6 ("Framebuffer Object Attachments"):
+        //
+        //    "In the WebGL API, it is an error to concurrently attach
+        //     renderbuffers to the following combinations of
+        //     attachment points:
+        //
+        //     DEPTH_ATTACHMENT + DEPTH_STENCIL_ATTACHMENT
+        //     STENCIL_ATTACHMENT + DEPTH_STENCIL_ATTACHMENT
+        //     DEPTH_ATTACHMENT + STENCIL_ATTACHMENT
+        //
+        //     If any of the constraints above are violated, then:
+        //
+        //     checkFramebufferStatus must return FRAMEBUFFER_UNSUPPORTED."
+        if (has_zs && (has_z || has_s)) ||
+            (has_z && has_s) {
+            self.status.set(constants::FRAMEBUFFER_UNSUPPORTED);
+            return;
+        }
+
+        if has_c || has_z || has_zs || has_s {
+            self.status.set(constants::FRAMEBUFFER_COMPLETE);
+        } else {
+            self.status.set(constants::FRAMEBUFFER_UNSUPPORTED);
+        }
+    }
+
     pub fn check_status(&self) -> u32 {
-        // Until we build support for attaching renderbuffers or
-        // textures, all user FBOs are incomplete.
-        return constants::FRAMEBUFFER_UNSUPPORTED;
+        return self.status.get();
+    }
+
+    pub fn renderbuffer(&self, attachment: u32, rb: Option<&WebGLRenderbuffer>) -> WebGLResult<()> {
+        let binding = match attachment {
+            constants::COLOR_ATTACHMENT0 => &self.color,
+            constants::DEPTH_ATTACHMENT => &self.depth,
+            constants::STENCIL_ATTACHMENT => &self.stencil,
+            constants::DEPTH_STENCIL_ATTACHMENT => &self.depthstencil,
+            _ => return Err(WebGLError::InvalidEnum),
+        };
+
+        let rb_id = match rb {
+            Some(rb) => {
+                *binding.borrow_mut() = Some(WebGLFramebufferAttachment::Renderbuffer(JS::from_ref(rb)));
+                Some(rb.id())
+            }
+
+            _ => {
+                *binding.borrow_mut() = None;
+                None
+            }
+        };
+
+        self.renderer.send(CanvasMsg::WebGL(WebGLCommand::FramebufferRenderbuffer(constants::FRAMEBUFFER,
+                                                                                  attachment,
+                                                                                  constants::RENDERBUFFER,
+                                                                                  rb_id))).unwrap();
+
+        self.update_status();
+        Ok(())
+    }
+
+    pub fn texture2d(&self, attachment: u32, textarget: u32, texture: Option<&WebGLTexture>,
+                     level: i32) -> WebGLResult<()> {
+        let binding = match attachment {
+            constants::COLOR_ATTACHMENT0 => &self.color,
+            constants::DEPTH_ATTACHMENT => &self.depth,
+            constants::STENCIL_ATTACHMENT => &self.stencil,
+            constants::DEPTH_STENCIL_ATTACHMENT => &self.depthstencil,
+            _ => return Err(WebGLError::InvalidEnum),
+        };
+
+        let tex_id = match texture {
+            // Note, from the GLES 2.0.25 spec, page 113:
+            //      "If texture is zero, then textarget and level are ignored."
+            Some(texture) => {
+                *binding.borrow_mut() = Some(WebGLFramebufferAttachment::Texture(JS::from_ref(texture)));
+
+                // From the GLES 2.0.25 spec, page 113:
+                //
+                //     "level specifies the mipmap level of the texture image
+                //      to be attached to the framebuffer and must be
+                //      0. Otherwise, INVALID_VALUE is generated."
+                if level != 0 {
+                    return Err(WebGLError::InvalidValue);
+                }
+
+                //     "If texture is not zero, then texture must either
+                //      name an existing texture object with an target of
+                //      textarget, or texture must name an existing cube
+                //      map texture and textarget must be one of:
+                //      TEXTURE_CUBE_MAP_POSITIVE_X,
+                //      TEXTURE_CUBE_MAP_POSITIVE_Y,
+                //      TEXTURE_CUBE_MAP_POSITIVE_Z,
+                //      TEXTURE_CUBE_MAP_NEGATIVE_X,
+                //      TEXTURE_CUBE_MAP_NEGATIVE_Y, or
+                //      TEXTURE_CUBE_MAP_NEGATIVE_Z. Otherwise,
+                //      INVALID_OPERATION is generated."
+                let is_cube = match textarget {
+                    constants::TEXTURE_2D => false,
+
+                    constants::TEXTURE_CUBE_MAP_POSITIVE_X => true,
+                    constants::TEXTURE_CUBE_MAP_POSITIVE_Y => true,
+                    constants::TEXTURE_CUBE_MAP_POSITIVE_Z => true,
+                    constants::TEXTURE_CUBE_MAP_NEGATIVE_X => true,
+                    constants::TEXTURE_CUBE_MAP_NEGATIVE_Y => true,
+                    constants::TEXTURE_CUBE_MAP_NEGATIVE_Z => true,
+
+                    _ => return Err(WebGLError::InvalidEnum),
+                };
+
+                match texture.target() {
+                    Some(constants::TEXTURE_CUBE_MAP) if is_cube => {}
+                    Some(_) if !is_cube => {}
+                    _ => return Err(WebGLError::InvalidOperation),
+                }
+
+                Some(texture.id())
+            }
+
+            _ => {
+                *binding.borrow_mut() = None;
+                None
+            }
+        };
+
+        self.renderer.send(CanvasMsg::WebGL(WebGLCommand::FramebufferTexture2D(constants::FRAMEBUFFER,
+                                                                               attachment,
+                                                                               textarget,
+                                                                               tex_id,
+                                                                               level))).unwrap();
+
+        self.update_status();
+        Ok(())
     }
 
     pub fn target(&self) -> Option<u32> {

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -231,6 +231,7 @@ impl WebGLFramebuffer {
 
             _ => {
                 *binding.borrow_mut() = None;
+                self.update_status();
                 None
             }
         };
@@ -243,6 +244,49 @@ impl WebGLFramebuffer {
 
         self.update_status();
         Ok(())
+    }
+
+    pub fn detach_renderbuffer(&self, rb: &WebGLRenderbuffer) {
+        let attachments = [&self.color,
+                           &self.depth,
+                           &self.stencil,
+                           &self.depthstencil];
+
+        for attachment in &attachments {
+            let matched = {
+                match *attachment.borrow() {
+                    Some(WebGLFramebufferAttachment::Renderbuffer(ref att_rb))
+                        if rb.id() == att_rb.id() => true,
+                    _ => false,
+                }
+            };
+
+            if matched {
+                *attachment.borrow_mut() = None;
+                self.update_status();
+            }
+        }
+    }
+
+    pub fn detach_texture(&self, texture: &WebGLTexture) {
+        let attachments = [&self.color,
+                           &self.depth,
+                           &self.stencil,
+                           &self.depthstencil];
+
+        for attachment in &attachments {
+            let matched = {
+                match *attachment.borrow() {
+                    Some(WebGLFramebufferAttachment::Texture(ref att_texture))
+                        if texture.id() == att_texture.id() => true,
+                    _ => false,
+                }
+            };
+
+            if matched {
+                *attachment.borrow_mut() = None;
+            }
+        }
     }
 
     pub fn target(&self) -> Option<u32> {

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -89,6 +89,11 @@ impl WebGLFramebuffer {
     }
 
     pub fn bind(&self, target: u32) {
+        // Update the framebuffer status on binding.  It may have
+        // changed if its attachments were resized or deleted while
+        // we've been unbound.
+        self.update_status();
+
         self.target.set(Some(target));
         let cmd = WebGLCommand::BindFramebuffer(target, WebGLFramebufferBindingRequest::Explicit(self.id));
         self.renderer.send(CanvasMsg::WebGL(cmd)).unwrap();

--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -5,13 +5,14 @@
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use canvas_traits::CanvasMsg;
 use dom::bindings::codegen::Bindings::WebGLRenderbufferBinding;
+use dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants as constants;
 use dom::bindings::js::Root;
 use dom::bindings::reflector::reflect_dom_object;
 use dom::globalscope::GlobalScope;
 use dom::webglobject::WebGLObject;
 use ipc_channel::ipc::{self, IpcSender};
 use std::cell::Cell;
-use webrender_traits::{WebGLCommand, WebGLRenderbufferId};
+use webrender_traits::{WebGLCommand, WebGLRenderbufferId, WebGLResult, WebGLError};
 
 #[dom_struct]
 pub struct WebGLRenderbuffer {
@@ -19,6 +20,7 @@ pub struct WebGLRenderbuffer {
     id: WebGLRenderbufferId,
     ever_bound: Cell<bool>,
     is_deleted: Cell<bool>,
+    internal_format: Cell<Option<u32>>,
     #[ignore_heap_size_of = "Defined in ipc-channel"]
     renderer: IpcSender<CanvasMsg>,
 }
@@ -33,6 +35,7 @@ impl WebGLRenderbuffer {
             ever_bound: Cell::new(false),
             is_deleted: Cell::new(false),
             renderer: renderer,
+            internal_format: Cell::new(None),
         }
     }
 
@@ -80,5 +83,29 @@ impl WebGLRenderbuffer {
 
     pub fn ever_bound(&self) -> bool {
         self.ever_bound.get()
+    }
+
+    pub fn storage(&self, internal_format: u32, width: i32, height: i32) -> WebGLResult<()> {
+        // Validate the internal_format, and save it for completeness
+        // validation.
+        match internal_format {
+            constants::RGBA4 |
+            constants::DEPTH_STENCIL |
+            constants::DEPTH_COMPONENT16 |
+            constants::STENCIL_INDEX8 =>
+                self.internal_format.set(Some(internal_format)),
+
+            _ => return Err(WebGLError::InvalidEnum),
+        };
+
+        // FIXME: Check that w/h are < MAX_RENDERBUFFER_SIZE
+
+        // FIXME: Invalidate completeness after the call
+
+        let msg = CanvasMsg::WebGL(WebGLCommand::RenderbufferStorage(constants::RENDERBUFFER,
+                                                                     internal_format, width, height));
+        self.renderer.send(msg).unwrap();
+
+        Ok(())
     }
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1280,6 +1280,20 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         if let Some(renderbuffer) = renderbuffer {
             handle_object_deletion!(self, self.bound_renderbuffer, renderbuffer,
                                     Some(WebGLCommand::BindRenderbuffer(constants::RENDERBUFFER, None)));
+            // From the GLES 2.0.25 spec, page 113:
+            //
+            //     "If a renderbuffer object is deleted while its
+            //     image is attached to the currently bound
+            //     framebuffer, then it is as if
+            //     FramebufferRenderbuffer had been called, with a
+            //     renderbuffer of 0, for each attachment point to
+            //     which this image was attached in the currently
+            //     bound framebuffer."
+            //
+            if let Some(fb) = self.bound_framebuffer.get() {
+                fb.detach_renderbuffer(renderbuffer);
+            }
+
             renderbuffer.delete()
         }
     }
@@ -1291,6 +1305,18 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                                     Some(WebGLCommand::BindTexture(constants::TEXTURE_2D, None)));
             handle_object_deletion!(self, self.bound_texture_cube_map, texture,
                                     Some(WebGLCommand::BindTexture(constants::TEXTURE_CUBE_MAP, None)));
+
+            // From the GLES 2.0.25 spec, page 113:
+            //
+            //     "If a texture object is deleted while its image is
+            //      attached to the currently bound framebuffer, then
+            //      it is as if FramebufferTexture2D had been called,
+            //      with a texture of 0, for each attachment point to
+            //      which this image was attached in the currently
+            //      bound framebuffer."
+            if let Some(fb) = self.bound_framebuffer.get() {
+                fb.detach_texture(texture);
+            }
             texture.delete()
         }
     }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -2602,6 +2602,32 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         // FIXME: We need to clear the renderbuffer before it can be
         // accessed.  See https://github.com/servo/servo/issues/13710
     }
+
+    fn FramebufferRenderbuffer(&self, target: u32, attachment: u32,
+                               renderbuffertarget: u32,
+                               rb: Option<&WebGLRenderbuffer>) {
+        if target != constants::FRAMEBUFFER || renderbuffertarget != constants::RENDERBUFFER {
+            return self.webgl_error(InvalidEnum);
+        }
+
+        match self.bound_framebuffer.get() {
+            Some(fb) => handle_potential_webgl_error!(self, fb.renderbuffer(attachment, rb)),
+            None => self.webgl_error(InvalidOperation),
+        };
+    }
+
+    fn FramebufferTexture2D(&self, target: u32, attachment: u32,
+                            textarget: u32, texture: Option<&WebGLTexture>,
+                            level: i32) {
+        if target != constants::FRAMEBUFFER {
+            return self.webgl_error(InvalidEnum);
+        }
+
+        match self.bound_framebuffer.get() {
+            Some(fb) => handle_potential_webgl_error!(self, fb.texture2d(attachment, textarget, texture, level)),
+            None => self.webgl_error(InvalidOperation),
+        };
+    }
 }
 
 pub trait LayoutCanvasWebGLRenderingContextHelpers {

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -2552,6 +2552,23 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     fn TexParameteri(&self, target: u32, name: u32, value: i32) {
         self.tex_parameter(target, name, TexParameterValue::Int(value))
     }
+
+    fn CheckFramebufferStatus(&self, target: u32) -> u32 {
+        // From the GLES 2.0.25 spec, 4.4 ("Framebuffer Objects"):
+        //
+        //    "If target is not FRAMEBUFFER, INVALID_ENUM is
+        //     generated. If CheckFramebufferStatus generates an
+        //     error, 0 is returned."
+        if target != constants::FRAMEBUFFER {
+            self.webgl_error(InvalidEnum);
+            return 0;
+        }
+
+        match self.bound_framebuffer.get() {
+            Some(fb) => return fb.check_status(),
+            None => return constants::FRAMEBUFFER_COMPLETE,
+        }
+    }
 }
 
 pub trait LayoutCanvasWebGLRenderingContextHelpers {

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -2569,6 +2569,39 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             None => return constants::FRAMEBUFFER_COMPLETE,
         }
     }
+
+    fn RenderbufferStorage(&self, target: u32, internal_format: u32,
+                           width: i32, height: i32) {
+        // From the GLES 2.0.25 spec:
+        //
+        //    "target must be RENDERBUFFER."
+        if target != constants::RENDERBUFFER {
+            return self.webgl_error(InvalidOperation)
+        }
+
+        // From the GLES 2.0.25 spec:
+        //
+        //     "If either width or height is greater than the value of
+        //      MAX_RENDERBUFFER_SIZE , the error INVALID_VALUE is
+        //      generated."
+        //
+        // and we have to throw out negative-size values as well just
+        // like for TexImage.
+        //
+        // FIXME: Handle max_renderbuffer_size, which doesn't seem to
+        // be in limits.
+        if width < 0 || height < 0 {
+            return self.webgl_error(InvalidValue);
+        }
+
+        match self.bound_renderbuffer.get() {
+            Some(rb) => handle_potential_webgl_error!(self, rb.storage(internal_format, width, height)),
+            None => self.webgl_error(InvalidOperation),
+        };
+
+        // FIXME: We need to clear the renderbuffer before it can be
+        // accessed.  See https://github.com/servo/servo/issues/13710
+    }
 }
 
 pub trait LayoutCanvasWebGLRenderingContextHelpers {

--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -501,7 +501,7 @@ interface WebGLRenderingContextBase
     [Throws]
     void bufferSubData(GLenum target, GLintptr offset, object? data);
 
-    //[WebGLHandlesContextLoss] GLenum checkFramebufferStatus(GLenum target);
+    [WebGLHandlesContextLoss] GLenum checkFramebufferStatus(GLenum target);
     void clear(GLbitfield mask);
     void clearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha);
     void clearDepth(GLclampf depth);

--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -566,11 +566,11 @@ interface WebGLRenderingContextBase
     void enableVertexAttribArray(GLuint index);
     void finish();
     void flush();
-    //void framebufferRenderbuffer(GLenum target, GLenum attachment,
-    //                             GLenum renderbuffertarget,
-    //                             WebGLRenderbuffer? renderbuffer);
-    //void framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget,
-    //                          WebGLTexture? texture, GLint level);
+    void framebufferRenderbuffer(GLenum target, GLenum attachment,
+                                 GLenum renderbuffertarget,
+                                 WebGLRenderbuffer? renderbuffer);
+    void framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget,
+                              WebGLTexture? texture, GLint level);
     void frontFace(GLenum mode);
 
     void generateMipmap(GLenum target);

--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -626,8 +626,8 @@ interface WebGLRenderingContextBase
     void readPixels(GLint x, GLint y, GLsizei width, GLsizei height,
                     GLenum format, GLenum type, object? pixels);
 
-    //void renderbufferStorage(GLenum target, GLenum internalformat,
-    //                         GLsizei width, GLsizei height);
+    void renderbufferStorage(GLenum target, GLenum internalformat,
+                             GLsizei width, GLsizei height);
     void sampleCoverage(GLclampf value, GLboolean invert);
     void scissor(GLint x, GLint y, GLsizei width, GLsizei height);
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/buffers/index-validation.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/buffers/index-validation.html.ini
@@ -1,8 +1,5 @@
 [index-validation.html]
   type: testharness
-  [WebGL test #0: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Threw exception TypeError: gl.checkFramebufferStatus is not a function]
-    expected: FAIL
-
   [WebGL test #9: getError expected: INVALID_OPERATION. Was NO_ERROR : ]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/incorrect-context-object-behaviour.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/incorrect-context-object-behaviour.html.ini
@@ -32,12 +32,6 @@
   [WebGL test #12: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: contextA.bindTexture(contextA.TEXTURE_2D, textureB)]
     expected: FAIL
 
-  [WebGL test #13: contextA.framebufferRenderbuffer(contextA.FRAMEBUFFER, contextA.DEPTH_ATTACHMENT, contextA.RENDERBUFFER, renderBufferB) threw exception TypeError: contextA.framebufferRenderbuffer is not a function]
-    expected: FAIL
-
-  [WebGL test #14: contextA.framebufferTexture2D(contextA.FRAMEBUFFER, contextA.COLOR_ATTACHMENT0, contextA.TEXTURE_2D, textureB, 0) threw exception TypeError: contextA.framebufferTexture2D is not a function]
-    expected: FAIL
-
   [WebGL test #15: getError expected: INVALID_OPERATION. Was INVALID_ENUM : after evaluating: contextA.getProgramParameter(programB, 0)]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/methods.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/methods.html.ini
@@ -2,9 +2,6 @@
   type: testharness
   expected:
     if os == "mac": CRASH
-  [WebGL test #0: Property either does not exist or is not a function: checkFramebufferStatus]
-    expected: FAIL
-
   [WebGL test #1: Property either does not exist or is not a function: copyTexImage2D]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/methods.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/methods.html.ini
@@ -20,12 +20,6 @@
   [WebGL test #6: Property either does not exist or is not a function: flush]
     expected: FAIL
 
-  [WebGL test #7: Property either does not exist or is not a function: framebufferRenderbuffer]
-    expected: FAIL
-
-  [WebGL test #8: Property either does not exist or is not a function: framebufferTexture2D]
-    expected: FAIL
-
   [WebGL test #9: Property either does not exist or is not a function: generateMipmap]
     expected: FAIL
 
@@ -159,12 +153,6 @@
     expected: FAIL
 
   [WebGL test #3: Property either does not exist or is not a function: disableVertexAttribArray]
-    expected: FAIL
-
-  [WebGL test #4: Property either does not exist or is not a function: framebufferRenderbuffer]
-    expected: FAIL
-
-  [WebGL test #5: Property either does not exist or is not a function: framebufferTexture2D]
     expected: FAIL
 
   [WebGL test #6: Property either does not exist or is not a function: getActiveAttrib]

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/methods.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/methods.html.ini
@@ -86,9 +86,6 @@
   [WebGL test #29: Property either does not exist or is not a function: readPixels]
     expected: FAIL
 
-  [WebGL test #30: Property either does not exist or is not a function: renderbufferStorage]
-    expected: FAIL
-
   [WebGL test #31: Property either does not exist or is not a function: sampleCoverage]
     expected: FAIL
 
@@ -225,9 +222,6 @@
     expected: FAIL
 
   [WebGL test #25: Property either does not exist or is not a function: readPixels]
-    expected: FAIL
-
-  [WebGL test #26: Property either does not exist or is not a function: renderbufferStorage]
     expected: FAIL
 
   [WebGL test #27: Property either does not exist or is not a function: sampleCoverage]

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/bad-arguments-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/bad-arguments-test.html.ini
@@ -6,12 +6,6 @@
   [WebGL test #60: context.detachShader(argument, shader) should be undefined. Threw exception TypeError: context.detachShader is not a function]
     expected: FAIL
 
-  [WebGL test #68: context.framebufferRenderbuffer(context.FRAMEBUFFER, context.DEPTH_ATTACHMENT, context.RENDERBUFFER, argument) should be undefined. Threw exception TypeError: context.framebufferRenderbuffer is not a function]
-    expected: FAIL
-
-  [WebGL test #69: context.framebufferTexture2D(context.FRAMEBUFFER, context.COLOR_ATTACHMENT0, context.TEXTURE_2D, argument, 0) should be undefined. Threw exception TypeError: context.framebufferTexture2D is not a function]
-    expected: FAIL
-
   [WebGL test #70: context.uniform2fv(argument, new Float32Array([0.0, 0.0\])) should be undefined. Threw exception TypeError: context.uniform2fv is not a function]
     expected: FAIL
 
@@ -34,12 +28,6 @@
     expected: FAIL
 
   [WebGL test #86: context.detachShader(argument, shader) should be undefined. Threw exception TypeError: context.detachShader is not a function]
-    expected: FAIL
-
-  [WebGL test #94: context.framebufferRenderbuffer(context.FRAMEBUFFER, context.DEPTH_ATTACHMENT, context.RENDERBUFFER, argument) should be undefined. Threw exception TypeError: context.framebufferRenderbuffer is not a function]
-    expected: FAIL
-
-  [WebGL test #95: context.framebufferTexture2D(context.FRAMEBUFFER, context.COLOR_ATTACHMENT0, context.TEXTURE_2D, argument, 0) should be undefined. Threw exception TypeError: context.framebufferTexture2D is not a function]
     expected: FAIL
 
   [WebGL test #96: context.uniform2fv(argument, new Float32Array([0.0, 0.0\])) should be undefined. Threw exception TypeError: context.uniform2fv is not a function]

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/error-reporting.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/error-reporting.html.ini
@@ -24,13 +24,7 @@
   [WebGL test #11: getError expected: INVALID_VALUE. Was NO_ERROR : ]
     expected: FAIL
 
-  [WebGL test #15: context.framebufferRenderbuffer(context.FRAMEBUFFER, context.DEPTH_ATTACHMENT, context.RENDERBUFFER, null) should be undefined. Threw exception TypeError: context.framebufferRenderbuffer is not a function]
-    expected: FAIL
-
   [WebGL test #16: getError expected: INVALID_OPERATION. Was NO_ERROR : ]
-    expected: FAIL
-
-  [WebGL test #18: context.framebufferTexture2D(context.FRAMEBUFFER, context.COLOR_ATTACHMENT0, context.TEXTURE_2D, null, 0) should be undefined. Threw exception TypeError: context.framebufferTexture2D is not a function]
     expected: FAIL
 
   [WebGL test #19: getError expected: INVALID_OPERATION. Was NO_ERROR : ]

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/invalid-passed-params.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/invalid-passed-params.html.ini
@@ -45,12 +45,6 @@
   [WebGL test #23: getError expected: NO_ERROR. Was INVALID_VALUE : after evaluating: context.texSubImage2D(context.TEXTURE_2D, 0, 0, 0, 2, 2, context.RGBA, context.UNSIGNED_BYTE, pixels)]
     expected: FAIL
 
-  [WebGL test #30: context.renderbufferStorage(context.RENDERBUFFER, context.RGBA4, -2, -2) threw exception TypeError: context.renderbufferStorage is not a function]
-    expected: FAIL
-
-  [WebGL test #31: context.renderbufferStorage(context.RENDERBUFFER, context.RGBA4, 16, 16) threw exception TypeError: context.renderbufferStorage is not a function]
-    expected: FAIL
-
   [WebGL test #44: context.getError() should be 1281. Was 0.]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/object-deletion-behaviour.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/object-deletion-behaviour.html.ini
@@ -60,9 +60,6 @@
   [WebGL test #74: gl.isRenderbuffer(rbo) should be false. Threw exception TypeError: gl.isRenderbuffer is not a function]
     expected: FAIL
 
-  [WebGL test #83: gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, 16, 16) threw exception TypeError: gl.renderbufferStorage is not a function]
-    expected: FAIL
-
   [WebGL test #85: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]
     expected: FAIL
 
@@ -72,16 +69,10 @@
   [WebGL test #51: getError expected: NO_ERROR. Was INVALID_OPERATION : after evaluating: gl.bindTexture(gl.TEXTURE_2D, t)]
     expected: FAIL
 
-  [WebGL test #87: gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, 16, 16) threw exception TypeError: gl.renderbufferStorage is not a function]
-    expected: FAIL
-
   [WebGL test #89: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]
     expected: FAIL
 
   [WebGL test #94: gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0) threw exception TypeError: gl.framebufferTexture2D is not a function]
-    expected: FAIL
-
-  [WebGL test #98: gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, 16, 16) threw exception TypeError: gl.renderbufferStorage is not a function]
     expected: FAIL
 
   [WebGL test #100: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]
@@ -124,9 +115,6 @@
     expected: FAIL
 
   [WebGL test #156: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)]
-    expected: FAIL
-
-  [WebGL test #171: gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, 16, 16) threw exception TypeError: gl.renderbufferStorage is not a function]
     expected: FAIL
 
   [WebGL test #172: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/object-deletion-behaviour.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/object-deletion-behaviour.html.ini
@@ -1,6 +1,5 @@
 [object-deletion-behaviour.html]
   type: testharness
-  expected: ERROR
   [WebGL test #9: gl.isShader(vertexShader) should be true. Threw exception TypeError: gl.isShader is not a function]
     expected: FAIL
 
@@ -71,5 +70,68 @@
     expected: FAIL
 
   [WebGL test #51: getError expected: NO_ERROR. Was INVALID_OPERATION : after evaluating: gl.bindTexture(gl.TEXTURE_2D, t)]
+    expected: FAIL
+
+  [WebGL test #87: gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, 16, 16) threw exception TypeError: gl.renderbufferStorage is not a function]
+    expected: FAIL
+
+  [WebGL test #89: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]
+    expected: FAIL
+
+  [WebGL test #94: gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0) threw exception TypeError: gl.framebufferTexture2D is not a function]
+    expected: FAIL
+
+  [WebGL test #98: gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, 16, 16) threw exception TypeError: gl.renderbufferStorage is not a function]
+    expected: FAIL
+
+  [WebGL test #100: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]
+    expected: FAIL
+
+  [WebGL test #104: gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0) threw exception TypeError: gl.framebufferTexture2D is not a function]
+    expected: FAIL
+
+  [WebGL test #113: gl.getParameter(gl.ARRAY_BUFFER_BINDING) should be null. Was [object WebGLBuffer\].]
+    expected: FAIL
+
+  [WebGL test #122: gl.getParameter(gl.ARRAY_BUFFER_BINDING) should be null. Was [object WebGLBuffer\].]
+    expected: FAIL
+
+  [WebGL test #130: gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING) should be null. Was [object WebGLBuffer\].]
+    expected: FAIL
+
+  [WebGL test #133: gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW) threw exception TypeError: Value is not an object.]
+    expected: FAIL
+
+  [WebGL test #136: gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW) threw exception TypeError: Value is not an object.]
+    expected: FAIL
+
+  [WebGL test #147: gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #148: gl.getVertexAttrib(2, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #149: gl.getVertexAttrib(3, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #150: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.deleteBuffer(b2);]
+    expected: FAIL
+
+  [WebGL test #151: gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #154: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.deleteBuffer(b1);]
+    expected: FAIL
+
+  [WebGL test #156: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)]
+    expected: FAIL
+
+  [WebGL test #171: gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, 16, 16) threw exception TypeError: gl.renderbufferStorage is not a function]
+    expected: FAIL
+
+  [WebGL test #172: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]
+    expected: FAIL
+
+  [WebGL test #161: getError expected: NO_ERROR. Was INVALID_OPERATION : after evaluating: gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/object-deletion-behaviour.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/object-deletion-behaviour.html.ini
@@ -18,9 +18,6 @@
   [WebGL test #21: gl.isShader(fragmentShader) should be false. Threw exception TypeError: gl.isShader is not a function]
     expected: FAIL
 
-  [WebGL test #29: gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0) threw exception TypeError: gl.framebufferTexture2D is not a function]
-    expected: FAIL
-
   [WebGL test #30: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLTexture\]. Threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
     expected: FAIL
 
@@ -45,9 +42,6 @@
   [WebGL test #45: getError expected: NO_ERROR. Was INVALID_OPERATION : after evaluating: gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap)]
     expected: FAIL
 
-  [WebGL test #69: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]
-    expected: FAIL
-
   [WebGL test #70: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
     expected: FAIL
 
@@ -60,25 +54,10 @@
   [WebGL test #74: gl.isRenderbuffer(rbo) should be false. Threw exception TypeError: gl.isRenderbuffer is not a function]
     expected: FAIL
 
-  [WebGL test #85: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]
-    expected: FAIL
-
   [WebGL test #86: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
   [WebGL test #51: getError expected: NO_ERROR. Was INVALID_OPERATION : after evaluating: gl.bindTexture(gl.TEXTURE_2D, t)]
-    expected: FAIL
-
-  [WebGL test #89: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]
-    expected: FAIL
-
-  [WebGL test #94: gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0) threw exception TypeError: gl.framebufferTexture2D is not a function]
-    expected: FAIL
-
-  [WebGL test #100: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]
-    expected: FAIL
-
-  [WebGL test #104: gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0) threw exception TypeError: gl.framebufferTexture2D is not a function]
     expected: FAIL
 
   [WebGL test #113: gl.getParameter(gl.ARRAY_BUFFER_BINDING) should be null. Was [object WebGLBuffer\].]
@@ -117,9 +96,72 @@
   [WebGL test #156: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)]
     expected: FAIL
 
-  [WebGL test #172: gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo) threw exception TypeError: gl.framebufferRenderbuffer is not a function]
+  [WebGL test #161: getError expected: NO_ERROR. Was INVALID_OPERATION : after evaluating: gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)]
     expected: FAIL
 
-  [WebGL test #161: getError expected: NO_ERROR. Was INVALID_OPERATION : after evaluating: gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)]
+  [WebGL test #114: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
+    expected: FAIL
+
+  [WebGL test #115: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
+    expected: FAIL
+
+  [WebGL test #118: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 0. Threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
+    expected: FAIL
+
+  [WebGL test #119: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 0. Threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
+    expected: FAIL
+
+  [WebGL test #120: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36061.]
+    expected: FAIL
+
+  [WebGL test #121: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
+    expected: FAIL
+
+  [WebGL test #145: gl.getParameter(gl.ARRAY_BUFFER_BINDING) should be null. Was [object WebGLBuffer\].]
+    expected: FAIL
+
+  [WebGL test #154: gl.getParameter(gl.ARRAY_BUFFER_BINDING) should be null. Was [object WebGLBuffer\].]
+    expected: FAIL
+
+  [WebGL test #162: gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING) should be null. Was [object WebGLBuffer\].]
+    expected: FAIL
+
+  [WebGL test #165: gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW) threw exception TypeError: Value is not an object.]
+    expected: FAIL
+
+  [WebGL test #168: gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW) threw exception TypeError: Value is not an object.]
+    expected: FAIL
+
+  [WebGL test #179: gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #180: gl.getVertexAttrib(2, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #181: gl.getVertexAttrib(3, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #182: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.deleteBuffer(b2);]
+    expected: FAIL
+
+  [WebGL test #183: gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #186: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.deleteBuffer(b1);]
+    expected: FAIL
+
+  [WebGL test #188: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)]
+    expected: FAIL
+
+  [WebGL test #193: getError expected: NO_ERROR. Was INVALID_OPERATION : after evaluating: gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)]
+    expected: FAIL
+
+  [WebGL test #216: at (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #224: at (16, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #227: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/object-deletion-behaviour.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/object-deletion-behaviour.html.ini
@@ -165,3 +165,81 @@
   [WebGL test #227: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: FAIL
 
+  [WebGL test #168: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
+    expected: FAIL
+
+  [WebGL test #170: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
+    expected: FAIL
+
+  [WebGL test #171: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
+    expected: FAIL
+
+  [WebGL test #187: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should not be 36053.]
+    expected: FAIL
+
+  [WebGL test #196: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLTexture\]. Threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
+    expected: FAIL
+
+  [WebGL test #198: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) threw exception TypeError: gl.getFramebufferAttachmentParameter is not a function]
+    expected: FAIL
+
+  [WebGL test #199: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should not be 36053.]
+    expected: FAIL
+
+  [WebGL test #210: gl.getParameter(gl.ARRAY_BUFFER_BINDING) should be null. Was [object WebGLBuffer\].]
+    expected: FAIL
+
+  [WebGL test #219: gl.getParameter(gl.ARRAY_BUFFER_BINDING) should be null. Was [object WebGLBuffer\].]
+    expected: FAIL
+
+  [WebGL test #227: gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING) should be null. Was [object WebGLBuffer\].]
+    expected: FAIL
+
+  [WebGL test #230: gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW) threw exception TypeError: Value is not an object.]
+    expected: FAIL
+
+  [WebGL test #233: gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW) threw exception TypeError: Value is not an object.]
+    expected: FAIL
+
+  [WebGL test #244: gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #245: gl.getVertexAttrib(2, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #246: gl.getVertexAttrib(3, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #247: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.deleteBuffer(b2);]
+    expected: FAIL
+
+  [WebGL test #248: gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #251: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.deleteBuffer(b1);]
+    expected: FAIL
+
+  [WebGL test #253: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)]
+    expected: FAIL
+
+  [WebGL test #281: at (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #289: at (16, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #292: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #258: getError expected: NO_ERROR. Was INVALID_OPERATION : after evaluating: gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)]
+    expected: FAIL
+
+  [WebGL test #278: at (16, 16) expected: 0,0,0,0 was 9,0,0,0]
+    expected: FAIL
+
+  [WebGL test #281: at (0, 0) expected: 255,0,0,255 was 0,0,0,255]
+    expected: FAIL
+
+  [WebGL test #289: at (16, 0) expected: 0,255,0,255 was 0,0,0,14]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/uninitialized-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/uninitialized-test.html.ini
@@ -1,6 +1,6 @@
 [uninitialized-test.html]
   type: testharness
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/13710
+
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
-

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/conformance/quickCheckAPI-C.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/conformance/quickCheckAPI-C.html.ini
@@ -1,5 +1,0 @@
-[quickCheckAPI-C.html]
-  type: testharness
-  [WebGL test #0: testValidArgs]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/isTests.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/more/functions/isTests.html.ini
@@ -1,5 +1,0 @@
-[isTests.html]
-  type: testharness
-  [WebGL test #0: testIs]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/renderbuffers/feedback-loop.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/renderbuffers/feedback-loop.html.ini
@@ -1,9 +1,11 @@
 [feedback-loop.html]
   type: testharness
-  expected: ERROR
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+
+  [WebGL test #3: getError expected: INVALID_OPERATION. Was NO_ERROR : after draw with invalid feedback loop]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/renderbuffers/framebuffer-object-attachment.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/renderbuffers/framebuffer-object-attachment.html.ini
@@ -1,6 +1,6 @@
 [framebuffer-object-attachment.html]
   type: testharness
-  expected: ERROR
+  expected: CRASH
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/renderbuffers/renderbuffer-initialization.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/renderbuffers/renderbuffer-initialization.html.ini
@@ -1,9 +1,12 @@
 [renderbuffer-initialization.html]
   type: testharness
-  expected: ERROR
+  disabled: https://github.com/servo/servo/issues/13710
+
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-scissor-fbo-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-scissor-fbo-test.html.ini
@@ -1,6 +1,5 @@
 [gl-scissor-fbo-test.html]
   type: testharness
-  expected: ERROR
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/copy-tex-image-2d-formats.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/copy-tex-image-2d-formats.html.ini
@@ -1,6 +1,32 @@
 [copy-tex-image-2d-formats.html]
   type: testharness
-  expected: ERROR
   [WebGL test #16: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+
+  [WebGL test #16: Creating framebuffer from ALPHA texture succeeded even though it is not a renderable format]
+    expected: FAIL
+
+  [WebGL test #17: Creating framebuffer from LUMINANCE texture succeeded even though it is not a renderable format]
+    expected: FAIL
+
+  [WebGL test #18: Creating framebuffer from LUMINANCE_ALPHA texture succeeded even though it is not a renderable format]
+    expected: FAIL
+
+  [WebGL test #19: getError expected: INVALID_OPERATION. Was NO_ERROR : should not be able to copyTexImage2D ALPHA from RGB]
+    expected: FAIL
+
+  [WebGL test #23: getError expected: INVALID_OPERATION. Was NO_ERROR : should not be able to copyTexImage2D LUMINANCE_ALPHA from RGB]
+    expected: FAIL
+
+  [WebGL test #27: getError expected: INVALID_OPERATION. Was NO_ERROR : should not be able to copyTexImage2D RGBA from RGB]
+    expected: FAIL
+
+  [WebGL test #44: getError expected: INVALID_OPERATION. Was NO_ERROR : should not be able to copyTexImage2D ALPHA from RGB]
+    expected: FAIL
+
+  [WebGL test #48: getError expected: INVALID_OPERATION. Was NO_ERROR : should not be able to copyTexImage2D LUMINANCE_ALPHA from RGB]
+    expected: FAIL
+
+  [WebGL test #52: getError expected: INVALID_OPERATION. Was NO_ERROR : should not be able to copyTexImage2D RGBA from RGB]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/mipmap-fbo.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/mipmap-fbo.html.ini
@@ -1,6 +1,5 @@
 [mipmap-fbo.html]
   type: testharness
-  expected: ERROR
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-attachment-formats.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-attachment-formats.html.ini
@@ -1,6 +1,5 @@
 [texture-attachment-formats.html]
   type: testharness
-  expected: ERROR
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
@@ -8,5 +7,11 @@
     expected: FAIL
 
   [WebGL test #1: context does not exist]
+    expected: FAIL
+
+  [WebGL test #14: at (0, 0) expected: 63,63,63,255 was 64,0,0,255]
+    expected: FAIL
+
+  [WebGL test #16: at (0, 0) expected: 63,63,63,63 was 64,0,0,64]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-copying-feedback-loops.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-copying-feedback-loops.html.ini
@@ -1,6 +1,11 @@
 [texture-copying-feedback-loops.html]
   type: testharness
-  expected: ERROR
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+
+  [WebGL test #3: getError expected: INVALID_OPERATION. Was NO_ERROR : after copyTexImage2D to same texture same level, invalid feedback loop]
+    expected: FAIL
+
+  [WebGL test #6: getError expected: INVALID_OPERATION. Was NO_ERROR : after copyTexSubImage2D to same texture same level, invalid feedback loop]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-fakeblack.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-fakeblack.html.ini
@@ -1,6 +1,11 @@
 [texture-fakeblack.html]
   type: testharness
-  expected: ERROR
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+
+  [WebGL test #1: at (0, 0) expected: 0,0,0,255 was 255,0,0,255]
+    expected: FAIL
+
+  [WebGL test #3: at (0, 0) expected: 0,0,0,255 was 255,0,0,255]
     expected: FAIL
 


### PR DESCRIPTION
This is by no means a complete implementation, but I've slowed down on working on it, so I think we should look at what it takes to merge the current code.  There are some major features missing, like initializing renderbuffers to 0 (uninitialized memory leak), tracking the attachments' attributes (width/height/format) for parameter requests, and lots of missing glCheckFramebufferStatus() validation.  On the other hand, this is enough to run some demos using FBOs.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13639 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13872)

<!-- Reviewable:end -->
