### PR TITLE
Make Response's `Clone()` method to clone headers.

### DIFF
--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -5,7 +5,7 @@
 use body::{BodyOperations, BodyType, consume_body, consume_body_with_promise};
 use core::cell::Cell;
 use dom::bindings::cell::DOMRefCell;
-use dom::bindings::codegen::Bindings::HeadersBinding::HeadersMethods;
+use dom::bindings::codegen::Bindings::HeadersBinding::{HeadersInit, HeadersMethods};
 use dom::bindings::codegen::Bindings::ResponseBinding;
 use dom::bindings::codegen::Bindings::ResponseBinding::{ResponseMethods, ResponseType as DOMResponseType};
 use dom::bindings::codegen::Bindings::XMLHttpRequestBinding::BodyInit;
@@ -303,6 +303,7 @@ impl ResponseMethods for Response {
         // Step 2
         let new_response = Response::new(&self.global());
         new_response.Headers().set_guard(self.Headers().get_guard());
+        try!(new_response.Headers().fill(Some(HeadersInit::Headers(self.Headers()))));
 
         // https://fetch.spec.whatwg.org/#concept-response-clone
         // Instead of storing a net_traits::Response internally, we

--- a/tests/wpt/metadata/fetch/api/response/response-clone.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-clone.html.ini
@@ -1,8 +1,5 @@
 [response-clone.html]
   type: testharness
-  [Check Response's clone has the expected attribute values]
-    expected: FAIL
-
   [Check orginal response's body after cloning]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This patch allows the response clone to have the same headers list as the original's. Previously, only the cloned response's headers guard was set to be the same as the original response's headers guard.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13882)

<!-- Reviewable:end -->
