### PR TITLE
Adds parsing test for linear-gradient

### DIFF
--- a/tests/unit/style/parsing/image.rs
+++ b/tests/unit/style/parsing/image.rs
@@ -10,6 +10,36 @@ use style::values::specified::image::*;
 use url::Url;
 
 #[test]
+fn test_linear_gradient() {
+    // Parsing from the right
+    assert_roundtrip_with_context!(Image::parse, "linear-gradient(to left, red, green)",
+                                                 "linear-gradient(4.712389rad, red, green)");
+
+    // Parsing from the left
+    assert_roundtrip_with_context!(Image::parse, "linear-gradient(to right, red, green)",
+                                                 "linear-gradient(1.5707964rad, red, green)");
+
+    // Parsing with two values for <side-or-corner>
+    assert_roundtrip_with_context!(Image::parse, "linear-gradient(to right top, red, green)");
+
+    // Parsing with <angle>
+    assert_roundtrip_with_context!(Image::parse, "linear-gradient(45deg, red, green)",
+                                                 "linear-gradient(0.7853982rad, red, green)");
+
+   // Parsing with more than two entries in <color-stop-list>
+   assert_roundtrip_with_context!(Image::parse, "linear-gradient(red, yellow, green)",
+                                                "linear-gradient(3.1415927rad, red, yellow, green)");
+
+   // Parsing with percentage in the <color-stop-list>
+   assert_roundtrip_with_context!(Image::parse, "linear-gradient(red, green, yellow 50%)",
+                                                "linear-gradient(3.1415927rad, red, green, yellow 50%)");
+
+    // Parsing without <angle> and <side-or-corner>
+    assert_roundtrip_with_context!(Image::parse, "linear-gradient(red, green)",
+                                                 "linear-gradient(3.1415927rad, red, green)");
+}
+
+#[test]
 fn test_radial_gradient() {
     // Parsing with all values
     assert_roundtrip_with_context!(Image::parse, "radial-gradient(circle closest-side at 20px 30px, red, green)");


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Tests if `linear-gradient` is correctly parsed without `<side-or-corner>` as well as with `to left` and `to right`.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13837 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13886)

<!-- Reviewable:end -->
