### PR TITLE
Partial fix for #12415: DOM interfaces

### DIFF
--- a/components/script/dom/webidls/DOMStringMap.webidl
+++ b/components/script/dom/webidls/DOMStringMap.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // https://html.spec.whatwg.org/multipage/#the-domstringmap-interface
-[OverrideBuiltins, Exposed=(Window,Worker)]
+[OverrideBuiltins]
 interface DOMStringMap {
   getter DOMString (DOMString name);
   [Throws]

--- a/components/script/dom/webidls/DOMTokenList.webidl
+++ b/components/script/dom/webidls/DOMTokenList.webidl
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // https://dom.spec.whatwg.org/#domtokenlist
-[Exposed=(Window,Worker)]
 interface DOMTokenList {
   [Pure]
   readonly attribute unsigned long length;

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
@@ -20,8 +20,6 @@ test_interfaces([
   "CustomEvent",
   "DedicatedWorkerGlobalScope",
   "DOMException",
-  "DOMTokenList",
-  "DOMStringMap",
   "ErrorEvent",
   "Event",
   "EventTarget",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fix exposure of DOM interfaces. Only two of the interfaces needed changing and I want someone to double check on `DOMException` (which I left exposed to both `Window` and `Worker`), but I used Firefox's definition as my source since the specs don't lay it out explicitly.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix (partially) #12415  (github issue number if applicable).

<!-- Either: -->
- [X] These changes do not require tests because they only remove code.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13897)

<!-- Reviewable:end -->
