### PR TITLE
Use enum BorderWidth as SpecifiedValue

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -88,7 +88,7 @@ use style::matching::{common_style_affecting_attributes, rare_style_affecting_at
 use style::parser::ParserContextExtraData;
 use style::properties::{DeclaredValue, Importance};
 use style::properties::{PropertyDeclaration, PropertyDeclarationBlock, parse_style_attribute};
-use style::properties::longhands::{self, background_image, border_spacing, font_family, font_size, overflow_x};
+use style::properties::longhands::{background_image, border_spacing, font_family, font_size, overflow_x};
 use style::selector_impl::{NonTSPseudoClass, ServoSelectorImpl};
 use style::selector_matching::ApplicableDeclarationBlock;
 use style::sink::Push;
@@ -574,19 +574,16 @@ impl LayoutElementHelpers for LayoutJS<Element> {
         };
 
         if let Some(border) = border {
-            let width_value = specified::Length::Absolute(Au::from_px(border as i32));
+            let width_value = specified::BorderWidth::from_length(
+                specified::Length::Absolute(Au::from_px(border as i32)));
             hints.push(from_declaration(
-                PropertyDeclaration::BorderTopWidth(DeclaredValue::Value(
-                    longhands::border_top_width::SpecifiedValue(width_value)))));
+                PropertyDeclaration::BorderTopWidth(DeclaredValue::Value(width_value))));
             hints.push(from_declaration(
-                PropertyDeclaration::BorderLeftWidth(DeclaredValue::Value(
-                    longhands::border_left_width::SpecifiedValue(width_value)))));
+                PropertyDeclaration::BorderLeftWidth(DeclaredValue::Value(width_value))));
             hints.push(from_declaration(
-                PropertyDeclaration::BorderBottomWidth(DeclaredValue::Value(
-                    longhands::border_bottom_width::SpecifiedValue(width_value)))));
+                PropertyDeclaration::BorderBottomWidth(DeclaredValue::Value(width_value))));
             hints.push(from_declaration(
-                PropertyDeclaration::BorderRightWidth(DeclaredValue::Value(
-                    longhands::border_right_width::SpecifiedValue(width_value)))));
+                PropertyDeclaration::BorderRightWidth(DeclaredValue::Value(width_value))));
         }
     }
 

--- a/components/style/properties/longhand/border.mako.rs
+++ b/components/style/properties/longhand/border.mako.rs
@@ -27,27 +27,14 @@
         use cssparser::ToCss;
         use std::fmt;
         use values::HasViewportPercentage;
+        use values::specified::BorderWidth;
 
-        impl ToCss for SpecifiedValue {
-            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-                self.0.to_css(dest)
-            }
-        }
+        pub type SpecifiedValue = BorderWidth;
 
         #[inline]
         pub fn parse(_context: &ParserContext, input: &mut Parser)
-                               -> Result<SpecifiedValue, ()> {
-            specified::parse_border_width(input).map(SpecifiedValue)
-        }
-        #[derive(Debug, Clone, PartialEq)]
-        #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-        pub struct SpecifiedValue(pub specified::Length);
-
-        impl HasViewportPercentage for SpecifiedValue {
-            fn has_viewport_percentage(&self) -> bool {
-                let &SpecifiedValue(length) = self;
-                length.has_viewport_percentage()
-            }
+                     -> Result<SpecifiedValue, ()> {
+            BorderWidth::parse(input)
         }
 
         pub mod computed_value {
@@ -56,20 +43,6 @@
         }
         #[inline] pub fn get_initial_value() -> computed_value::T {
             Au::from_px(3)  // medium
-        }
-
-        impl ToComputedValue for SpecifiedValue {
-            type ComputedValue = computed_value::T;
-
-            #[inline]
-            fn to_computed_value(&self, context: &Context) -> computed_value::T {
-                self.0.to_computed_value(context)
-            }
-
-            #[inline]
-            fn from_computed_value(computed: &computed_value::T) -> Self {
-                SpecifiedValue(ToComputedValue::from_computed_value(computed))
-            }
         }
     </%helpers:longhand>
 % endfor

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -6,7 +6,7 @@ pub use cssparser::ToCss;
 pub use std::sync::Arc;
 pub use style::computed_values::display::T::inline_block;
 pub use style::properties::{DeclaredValue, PropertyDeclaration, PropertyDeclarationBlock, Importance};
-pub use style::values::specified::{BorderStyle, CSSColor, Length};
+pub use style::values::specified::{BorderStyle, BorderWidth, CSSColor, Length};
 pub use style::values::specified::{LengthOrPercentage, LengthOrPercentageOrAuto, LengthOrPercentageOrAutoOrContent};
 pub use style::properties::longhands::outline_color::computed_value::T as ComputedColor;
 pub use style::values::RGBA;
@@ -192,18 +192,13 @@ mod shorthand_serialization {
 
         #[test]
         fn border_width_should_serialize_correctly() {
-            use style::properties::longhands::border_bottom_width::SpecifiedValue as BottomContainer;
-            use style::properties::longhands::border_left_width::SpecifiedValue as LeftContainer;
-            use style::properties::longhands::border_right_width::SpecifiedValue as RightContainer;
-            use style::properties::longhands::border_top_width::SpecifiedValue as TopContainer;
-
             let mut properties = Vec::new();
 
-            let top_px = DeclaredValue::Value(TopContainer(Length::from_px(10f32)));
-            let bottom_px = DeclaredValue::Value(BottomContainer(Length::from_px(10f32)));
+            let top_px = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(10f32)));
+            let bottom_px = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(10f32)));
 
-            let right_px = DeclaredValue::Value(RightContainer(Length::from_px(15f32)));
-            let left_px = DeclaredValue::Value(LeftContainer(Length::from_px(15f32)));
+            let right_px = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(15f32)));
+            let left_px = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(15f32)));
 
             properties.push(PropertyDeclaration::BorderTopWidth(top_px));
             properties.push(PropertyDeclaration::BorderRightWidth(right_px));
@@ -212,6 +207,24 @@ mod shorthand_serialization {
 
             let serialization = shorthand_properties_to_string(properties);
             assert_eq!(serialization, "border-width: 10px 15px;");
+        }
+
+        #[test]
+        fn border_width_with_keywords_should_serialize_correctly() {
+            let mut properties = Vec::new();
+
+            let top_px = DeclaredValue::Value(BorderWidth::Thin);
+            let right_px = DeclaredValue::Value(BorderWidth::Medium);
+            let bottom_px = DeclaredValue::Value(BorderWidth::Thick);
+            let left_px = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(15f32)));
+
+            properties.push(PropertyDeclaration::BorderTopWidth(top_px));
+            properties.push(PropertyDeclaration::BorderRightWidth(right_px));
+            properties.push(PropertyDeclaration::BorderBottomWidth(bottom_px));
+            properties.push(PropertyDeclaration::BorderLeftWidth(left_px));
+
+            let serialization = shorthand_properties_to_string(properties);
+            assert_eq!(serialization, "border-width: thin medium thick 15px;");
         }
 
         #[test]
@@ -257,10 +270,6 @@ mod shorthand_serialization {
 
 
     mod border_shorthands {
-        use style::properties::longhands::border_bottom_width::SpecifiedValue as BottomContainer;
-        use style::properties::longhands::border_left_width::SpecifiedValue as LeftContainer;
-        use style::properties::longhands::border_right_width::SpecifiedValue as RightContainer;
-        use style::properties::longhands::border_top_width::SpecifiedValue as TopContainer;
         use super::*;
 
         // we can use border-top as a base to test out the different combinations
@@ -270,7 +279,7 @@ mod shorthand_serialization {
         fn directional_border_should_show_all_properties_when_values_are_set() {
             let mut properties = Vec::new();
 
-            let width = DeclaredValue::Value(TopContainer(Length::from_px(4f32)));
+            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let style = DeclaredValue::Value(BorderStyle::solid);
             let color = DeclaredValue::Value(CSSColor {
                 parsed: ComputedColor::RGBA(RGBA { red: 1f32, green: 0f32, blue: 0f32, alpha: 1f32 }),
@@ -289,7 +298,7 @@ mod shorthand_serialization {
         fn directional_border_with_no_specified_style_will_show_style_as_none() {
             let mut properties = Vec::new();
 
-            let width = DeclaredValue::Value(TopContainer(Length::from_px(4f32)));
+            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let style = DeclaredValue::Initial;
             let color = DeclaredValue::Value(CSSColor {
                 parsed: ComputedColor::RGBA(RGBA { red: 1f32, green: 0f32, blue: 0f32, alpha: 1f32 }),
@@ -308,7 +317,7 @@ mod shorthand_serialization {
         fn directional_border_with_no_specified_color_will_not_show_color() {
             let mut properties = Vec::new();
 
-            let width = DeclaredValue::Value(TopContainer(Length::from_px(4f32)));
+            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let style = DeclaredValue::Value(BorderStyle::solid);
             let color = DeclaredValue::Initial;
 
@@ -324,7 +333,7 @@ mod shorthand_serialization {
         fn border_right_should_serialize_correctly() {
             let mut properties = Vec::new();
 
-            let width = DeclaredValue::Value(RightContainer(Length::from_px(4f32)));
+            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let style = DeclaredValue::Value(BorderStyle::solid);
             let color = DeclaredValue::Initial;
 
@@ -340,7 +349,7 @@ mod shorthand_serialization {
         fn border_bottom_should_serialize_correctly() {
             let mut properties = Vec::new();
 
-            let width = DeclaredValue::Value(BottomContainer(Length::from_px(4f32)));
+            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let style = DeclaredValue::Value(BorderStyle::solid);
             let color = DeclaredValue::Initial;
 
@@ -356,7 +365,7 @@ mod shorthand_serialization {
         fn border_left_should_serialize_correctly() {
             let mut properties = Vec::new();
 
-            let width = DeclaredValue::Value(LeftContainer(Length::from_px(4f32)));
+            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let style = DeclaredValue::Value(BorderStyle::solid);
             let color = DeclaredValue::Initial;
 
@@ -372,7 +381,7 @@ mod shorthand_serialization {
         fn border_should_serialize_correctly() {
             let mut properties = Vec::new();
 
-            let top_width = DeclaredValue::Value(TopContainer(Length::from_px(4f32)));
+            let top_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let top_style = DeclaredValue::Value(BorderStyle::solid);
             let top_color = DeclaredValue::Initial;
 
@@ -380,7 +389,7 @@ mod shorthand_serialization {
             properties.push(PropertyDeclaration::BorderTopStyle(top_style));
             properties.push(PropertyDeclaration::BorderTopColor(top_color));
 
-            let right_width = DeclaredValue::Value(RightContainer(Length::from_px(4f32)));
+            let right_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let right_style = DeclaredValue::Value(BorderStyle::solid);
             let right_color = DeclaredValue::Initial;
 
@@ -388,7 +397,7 @@ mod shorthand_serialization {
             properties.push(PropertyDeclaration::BorderRightStyle(right_style));
             properties.push(PropertyDeclaration::BorderRightColor(right_color));
 
-            let bottom_width = DeclaredValue::Value(BottomContainer(Length::from_px(4f32)));
+            let bottom_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let bottom_style = DeclaredValue::Value(BorderStyle::solid);
             let bottom_color = DeclaredValue::Initial;
 
@@ -396,7 +405,7 @@ mod shorthand_serialization {
             properties.push(PropertyDeclaration::BorderBottomStyle(bottom_style));
             properties.push(PropertyDeclaration::BorderBottomColor(bottom_color));
 
-            let left_width = DeclaredValue::Value(LeftContainer(Length::from_px(4f32)));
+            let left_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let left_style = DeclaredValue::Value(BorderStyle::solid);
             let left_color = DeclaredValue::Initial;
 

--- a/tests/unit/style/properties/viewport.rs
+++ b/tests/unit/style/properties/viewport.rs
@@ -12,14 +12,14 @@ use style::values::specified::{Length, ViewportPercentageLength};
 fn has_viewport_percentage_for_specified_value() {
     //TODO: test all specified value with a HasViewportPercentage impl
     let pvw = PropertyDeclaration::BorderTopWidth(
-        DeclaredValue::Value(border_top_width::SpecifiedValue(
+        DeclaredValue::Value(border_top_width::SpecifiedValue::from_length(
             Length::ViewportPercentage(ViewportPercentageLength::Vw(100.))
         ))
     );
     assert!(pvw.has_viewport_percentage());
 
     let pabs = PropertyDeclaration::BorderTopWidth(
-        DeclaredValue::Value(border_top_width::SpecifiedValue(
+        DeclaredValue::Value(border_top_width::SpecifiedValue::from_length(
             Length::Absolute(Au(100))
         ))
     );


### PR DESCRIPTION
Use enum BorderWidth instead of a tuple-like struct to store the specified
value. BorderWidth is needed to be used in both longhand and shorthand
border width properties, so I put it in `specified` module.

Fixed #13869.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13869 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13908)

<!-- Reviewable:end -->
