### PR TITLE
incremental restyle: Introduce StylingMode and deprecate explicit dirtiness

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1146,7 +1146,7 @@ impl LayoutThread {
         if !needs_dirtying {
             for (el, snapshot) in modified_elements {
                 let hint = rw_data.stylist.compute_restyle_hint(&el, &snapshot, el.get_state());
-                el.note_restyle_hint(hint);
+                el.note_restyle_hint::<RecalcStyleAndConstructFlows>(hint);
             }
         }
 

--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -115,14 +115,14 @@ impl RestyleData {
 #[derive(Debug)]
 pub struct NodeData {
     styles: NodeDataStyles,
-    pub restyle: Option<RestyleData>,
+    pub restyle_data: Option<RestyleData>,
 }
 
 impl NodeData {
     pub fn new() -> Self {
         NodeData {
             styles: NodeDataStyles::Uninitialized,
-            restyle: None,
+            restyle_data: None,
         }
     }
 
@@ -175,25 +175,24 @@ impl NodeData {
         self.styles = match mem::replace(&mut self.styles, Uninitialized) {
             Uninitialized => Previous(f()),
             Current(x) => Previous(Some(x)),
-            _ => panic!("Already have previous styles"),
+            Previous(x) => Previous(x),
         };
     }
 
-    // FIXME(bholley): Called in future patches.
     pub fn ensure_restyle_data(&mut self) {
-        if self.restyle.is_none() {
-            self.restyle = Some(RestyleData::new());
+        if self.restyle_data.is_none() {
+            self.restyle_data = Some(RestyleData::new());
         }
     }
 
     pub fn style_text_node(&mut self, style: Arc<ComputedValues>) {
-        debug_assert!(self.restyle.is_none());
         self.styles = NodeDataStyles::Current(NodeStyles::new(style));
+        self.restyle_data = None;
     }
 
     pub fn finish_styling(&mut self, styles: NodeStyles) {
         debug_assert!(self.styles.is_previous());
         self.styles = NodeDataStyles::Current(styles);
-        self.restyle = None;
+        self.restyle_data = None;
     }
 }

--- a/components/style/gecko/traversal.rs
+++ b/components/style/gecko/traversal.rs
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use atomic_refcell::AtomicRefCell;
 use context::{LocalStyleContext, SharedStyleContext, StyleContext};
+use data::NodeData;
 use dom::OpaqueNode;
 use gecko::context::StandaloneStyleContext;
 use gecko::wrapper::GeckoNode;
@@ -29,7 +31,7 @@ impl<'lc, 'ln> DomTraversalContext<GeckoNode<'ln>> for RecalcStyleOnly<'lc> {
     }
 
     fn process_preorder(&self, node: GeckoNode<'ln>) -> RestyleResult {
-        recalc_style_at(&self.context, self.root, node)
+        recalc_style_at::<_, _, Self>(&self.context, self.root, node)
     }
 
     fn process_postorder(&self, _: GeckoNode<'ln>) {
@@ -38,6 +40,10 @@ impl<'lc, 'ln> DomTraversalContext<GeckoNode<'ln>> for RecalcStyleOnly<'lc> {
 
     /// We don't use the post-order traversal for anything.
     fn needs_postorder_traversal(&self) -> bool { false }
+
+    fn ensure_node_data<'a>(node: &'a GeckoNode<'ln>) -> &'a AtomicRefCell<NodeData> {
+        node.ensure_data()
+    }
 
     fn local_context(&self) -> &LocalStyleContext {
         self.context.local_context()

--- a/components/style/parallel.rs
+++ b/components/style/parallel.rs
@@ -8,7 +8,7 @@
 
 #![allow(unsafe_code)]
 
-use dom::{OpaqueNode, TNode, UnsafeNode};
+use dom::{OpaqueNode, StylingMode, TNode, UnsafeNode};
 use std::mem;
 use std::sync::atomic::Ordering;
 use traversal::{RestyleResult, DomTraversalContext};
@@ -47,6 +47,7 @@ pub fn traverse_dom<N, C>(root: N,
     where N: TNode,
           C: DomTraversalContext<N>
 {
+    debug_assert!(root.styling_mode() != StylingMode::Stop);
     if opts::get().style_sharing_stats {
         STYLE_SHARING_CACHE_HITS.store(0, Ordering::SeqCst);
         STYLE_SHARING_CACHE_MISSES.store(0, Ordering::SeqCst);
@@ -80,28 +81,13 @@ fn top_down_dom<N, C>(unsafe_nodes: UnsafeNodeList,
         // Get a real layout node.
         let node = unsafe { N::from_unsafe(&unsafe_node) };
 
-        if !context.should_process(node) {
-            continue;
-        }
-
-        // Possibly enqueue the children.
-        let mut children_to_process = 0isize;
         // Perform the appropriate traversal.
+        let mut children_to_process = 0isize;
         if let RestyleResult::Continue = context.process_preorder(node) {
-            for kid in node.children() {
-                // Trigger the hook pre-adding the kid to the list. This can
-                // (and in fact uses to) change the result of the should_process
-                // operation.
-                //
-                // As of right now, this hook takes care of propagating the
-                // restyle flag down the tree. In the future, more accurate
-                // behavior is probably going to be needed.
-                context.pre_process_child_hook(node, kid);
-                if context.should_process(kid) {
-                    children_to_process += 1;
-                    discovered_child_nodes.push(kid.to_unsafe())
-                }
-            }
+            C::traverse_children(node, |kid| {
+                children_to_process += 1;
+                discovered_child_nodes.push(kid.to_unsafe())
+            });
         }
 
         // Reset the count of children if we need to do a bottom-up traversal

--- a/components/style/sequential.rs
+++ b/components/style/sequential.rs
@@ -4,7 +4,7 @@
 
 //! Implements sequential traversal over the DOM tree.
 
-use dom::TNode;
+use dom::{StylingMode, TNode};
 use traversal::{RestyleResult, DomTraversalContext};
 
 pub fn traverse_dom<N, C>(root: N,
@@ -16,14 +16,8 @@ pub fn traverse_dom<N, C>(root: N,
         where N: TNode,
               C: DomTraversalContext<N>
     {
-        debug_assert!(context.should_process(node));
         if let RestyleResult::Continue = context.process_preorder(node) {
-            for kid in node.children() {
-                context.pre_process_child_hook(node, kid);
-                if context.should_process(kid) {
-                    doit::<N, C>(context, kid);
-                }
-            }
+            C::traverse_children(node, |kid| doit::<N, C>(context, kid));
         }
 
         if context.needs_postorder_traversal() {
@@ -31,10 +25,10 @@ pub fn traverse_dom<N, C>(root: N,
         }
     }
 
+    debug_assert!(root.styling_mode() != StylingMode::Stop);
     let context = C::new(shared, root.opaque());
-    if context.should_process(root) {
-        doit::<N, C>(&context, root);
-    }
+    doit::<N, C>(&context, root);
+
     // Clear the local LRU cache since we store stateful elements inside.
     context.local_context().style_sharing_candidate_cache.borrow_mut().clear();
 }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -13,7 +13,7 @@ use std::str::from_utf8_unchecked;
 use std::sync::{Arc, Mutex};
 use style::arc_ptr_eq;
 use style::context::{LocalStyleContextCreationInfo, ReflowGoal, SharedStyleContext};
-use style::dom::{NodeInfo, TElement, TNode};
+use style::dom::{NodeInfo, StylingMode, TElement, TNode};
 use style::error_reporting::StdoutErrorReporter;
 use style::gecko::data::{NUM_THREADS, PerDocumentStyleData};
 use style::gecko::selector_impl::{GeckoSelectorImpl, PseudoElement};
@@ -107,8 +107,11 @@ fn restyle_subtree(node: GeckoNode, raw_data: RawServoStyleSetBorrowed) {
         timer: Timer::new(),
     };
 
-    // We ensure this is true before calling Servo_RestyleSubtree()
-    debug_assert!(node.is_dirty() || node.has_dirty_descendants());
+    if node.styling_mode() == StylingMode::Stop {
+        error!("Unnecessary call to restyle_subtree");
+        return;
+    }
+
     if per_doc_data.num_threads == 1 || per_doc_data.work_queue.is_none() {
         sequential::traverse_dom::<GeckoNode, RecalcStyleOnly>(node, &shared_style_context);
     } else {


### PR DESCRIPTION
This is another chunk of work to move us toward the new incremental restyle architecture.

Eventually, we'll make a fine-grained decision at each node about what style to recompute based on the RestyleHint on the node data (along with other things). For now, we use the existence of RestyleData as a coarse-grained approximation of this.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13913)

<!-- Reviewable:end -->
