### PR TITLE
layout: Remove margins from inline absolute hypothetical boxes.

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1233,7 +1233,8 @@ impl Fragment {
             SpecificFragmentInfo::Table |
             SpecificFragmentInfo::TableCell |
             SpecificFragmentInfo::TableRow |
-            SpecificFragmentInfo::TableColumn(_) => {
+            SpecificFragmentInfo::TableColumn(_) |
+            SpecificFragmentInfo::InlineAbsoluteHypothetical(_) => {
                 self.margin.inline_start = Au(0);
                 self.margin.inline_end = Au(0);
                 return

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2432,6 +2432,18 @@
             "url": "/_mozilla/css/inline_absolute_hypothetical_line_metrics_a.html"
           }
         ],
+        "css/inline_absolute_hypothetical_margin_a.html": [
+          {
+            "path": "css/inline_absolute_hypothetical_margin_a.html",
+            "references": [
+              [
+                "/_mozilla/css/inline_absolute_hypothetical_margin_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/inline_absolute_hypothetical_margin_a.html"
+          }
+        ],
         "css/inline_absolute_hypothetical_metrics_a.html": [
           {
             "path": "css/inline_absolute_hypothetical_metrics_a.html",
@@ -16266,6 +16278,18 @@
             ]
           ],
           "url": "/_mozilla/css/inline_absolute_hypothetical_line_metrics_a.html"
+        }
+      ],
+      "css/inline_absolute_hypothetical_margin_a.html": [
+        {
+          "path": "css/inline_absolute_hypothetical_margin_a.html",
+          "references": [
+            [
+              "/_mozilla/css/inline_absolute_hypothetical_margin_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/inline_absolute_hypothetical_margin_a.html"
         }
       ],
       "css/inline_absolute_hypothetical_metrics_a.html": [

--- a/tests/wpt/mozilla/tests/css/inline_absolute_hypothetical_margin_a.html
+++ b/tests/wpt/mozilla/tests/css/inline_absolute_hypothetical_margin_a.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="inline_absolute_hypothetical_margin_ref.html">
+<style>
+div, span {
+    position: absolute;
+}
+span {
+    top: 0;
+    margin-left: 16px;
+}
+</style>
+<div>Wikipedia<span>X</span></div>
+

--- a/tests/wpt/mozilla/tests/css/inline_absolute_hypothetical_margin_ref.html
+++ b/tests/wpt/mozilla/tests/css/inline_absolute_hypothetical_margin_ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+span {
+    margin-left: 16px;
+}
+</style>
+<div>Wikipedia<span>X</span></div>
+
+


### PR DESCRIPTION
As they're hypothetical, their margins shouldn't take up space!

Improves Google search results.

Closes #13915.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13923)

<!-- Reviewable:end -->
