### PR TITLE
Ignore the Content-Type header completely for @font-face.

### DIFF
--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -25,7 +25,6 @@ ipc-channel = "0.5"
 lazy_static = "0.2"
 libc = "0.2"
 log = "0.3.5"
-mime = "0.2"
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}
 ordered-float = "0.2.2"

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -62,7 +62,6 @@ extern crate lazy_static;
 extern crate libc;
 #[macro_use]
 extern crate log;
-extern crate mime;
 extern crate msg;
 extern crate net_traits;
 extern crate ordered_float;

--- a/tests/wpt/mozilla/meta/mozilla/mime_sniffing_font_context.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/mime_sniffing_font_context.html.ini
@@ -1,3 +1,2 @@
 [mime_sniffing_font_context.html]
   type: testharness
-  prefs: [network.mime.sniff:true]

--- a/tests/wpt/mozilla/tests/mozilla/mime_sniffing_font_context.html
+++ b/tests/wpt/mozilla/tests/mozilla/mime_sniffing_font_context.html
@@ -51,8 +51,8 @@ async_test(function() {
   var xhr = new XMLHttpRequest();
   xhr.open('GET', 'resources/no_mime_type.py?Content-Type=application/xhtml%2Bxml', true);
   xhr.onload = this.step_func_done(function() {
-    t4.step_timeout(checkFontNotLoaded.bind(t4, 'fifth', 'sixth'), 500);
     assert_equals(xhr.getResponseHeader('Content-Type'), 'application/xhtml+xml');
+    t4.step_timeout(checkFontLoaded, 500);
   });
   xhr.send();
 }, "XHR Content-Type has xhtml+xml");
@@ -61,8 +61,8 @@ async_test(function() {
   var xhr = new XMLHttpRequest();
   xhr.open('GET', 'resources/no_mime_type.py?Content-Type=application/xml', true);
   xhr.onload = this.step_func_done(function() {
-    t3.step_timeout(checkFontNotLoaded.bind(t3, 'third', 'fourth'), 500);
     assert_equals(xhr.getResponseHeader('Content-Type'), 'application/xml');
+    t3.step_timeout(checkFontLoaded, 500);
   });
   xhr.send();
 }, "XHR Content-Type has xml");


### PR DESCRIPTION
This matches the previous default (network.mime.sniff off) behaviour in all
but one case: we will now accept a font without a `Content-Type` header, which
would previously have been ignored.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13931)
<!-- Reviewable:end -->
