### PR TITLE
Switch glutin to use the crates.io version of osmesa-sys to remove a duplicate

### DIFF
--- a/components/servo/Cargo.lock
+++ b/components/servo/Cargo.lock
@@ -889,7 +889,7 @@ dependencies = [
  "msg 0.0.1",
  "net_traits 0.0.1",
  "osmesa-src 12.0.1 (git+https://github.com/servo/osmesa-src)",
- "osmesa-sys 0.1.2 (git+https://github.com/daggerbot/osmesa-rs)",
+ "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "servo-egl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1677,14 +1677,6 @@ dependencies = [
 name = "osmesa-src"
 version = "12.0.1"
 source = "git+https://github.com/servo/osmesa-src#ec520f5f2230e96dc94658d100fa882b0076a397"
-
-[[package]]
-name = "osmesa-sys"
-version = "0.1.2"
-source = "git+https://github.com/daggerbot/osmesa-rs#7ef7ebc612302794e7ed3bd068c93b70950218a1"
-dependencies = [
- "shared_library 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "osmesa-sys"
@@ -2926,7 +2918,6 @@ dependencies = [
 "checksum openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ed86cce894f6b0ed4572e21eb34026f1dc8869cb9ee3869029131bc8c3feb2d"
 "checksum ordered-float 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cc511538298611a79d5a4ddfbb75315b866d942ed26a00bdc3590795c68b7279"
 "checksum osmesa-src 12.0.1 (git+https://github.com/servo/osmesa-src)" = "<none>"
-"checksum osmesa-sys 0.1.2 (git+https://github.com/daggerbot/osmesa-rs)" = "<none>"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum owning_ref 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8d91377085359426407a287ab16884a0111ba473aa6844ff01d4ec20ce3d75e7"
 "checksum parking_lot 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3562f3de7bdff194212be82366abf5c6565aff8a433b71c53c63d0e7c9913878"

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
  "msg 0.0.1",
  "net_traits 0.0.1",
  "osmesa-src 12.0.1 (git+https://github.com/servo/osmesa-src)",
- "osmesa-sys 0.1.2 (git+https://github.com/daggerbot/osmesa-rs)",
+ "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "servo-egl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-glutin 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1548,14 +1548,6 @@ dependencies = [
 name = "osmesa-src"
 version = "12.0.1"
 source = "git+https://github.com/servo/osmesa-src#ec520f5f2230e96dc94658d100fa882b0076a397"
-
-[[package]]
-name = "osmesa-sys"
-version = "0.1.2"
-source = "git+https://github.com/daggerbot/osmesa-rs#7ef7ebc612302794e7ed3bd068c93b70950218a1"
-dependencies = [
- "shared_library 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "osmesa-sys"
@@ -2778,7 +2770,6 @@ dependencies = [
 "checksum openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ed86cce894f6b0ed4572e21eb34026f1dc8869cb9ee3869029131bc8c3feb2d"
 "checksum ordered-float 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cc511538298611a79d5a4ddfbb75315b866d942ed26a00bdc3590795c68b7279"
 "checksum osmesa-src 12.0.1 (git+https://github.com/servo/osmesa-src)" = "<none>"
-"checksum osmesa-sys 0.1.2 (git+https://github.com/daggerbot/osmesa-rs)" = "<none>"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum owning_ref 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8d91377085359426407a287ab16884a0111ba473aa6844ff01d4ec20ce3d75e7"
 "checksum parking_lot 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3562f3de7bdff194212be82366abf5c6565aff8a433b71c53c63d0e7c9913878"

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -24,7 +24,7 @@ url = {version = "1.2", features = ["heap_size"]}
 util = {path = "../../components/util"}
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-osmesa-sys = {git = "https://github.com/daggerbot/osmesa-rs"}
+osmesa-sys = "0.1.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = "2.0.0"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This removes the use of a git reference to osmesa-sys in glutin, to use the crates.io one with the same version that is already used in servo:
fabrice@fabrice-ThinkPad-X260:~/dev/servo/components/servo$ cargo tree -i -p osmesa-sys
error: There are multiple `osmesa-sys` packages in your project, and the specification `osmesa-sys` is ambiguous.
Please re-run this command with `-p <spec>` where `<spec>` is one of the following:
  https://github.com/daggerbot/osmesa-rs#osmesa-sys:0.1.2
  https://github.com/rust-lang/crates.io-index#osmesa-sys:0.1.2

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X ] `./mach build -d` does not report any errors
- [X ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X ] These changes do not require tests because this is building the same code from a different source.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13935)

<!-- Reviewable:end -->
