### PR TITLE
Update `etc/ci/check_dynamic_symbols.py`

### DIFF
--- a/etc/ci/check_dynamic_symbols.py
+++ b/etc/ci/check_dynamic_symbols.py
@@ -9,16 +9,19 @@
 
 from __future__ import absolute_import, print_function
 
-import sys
+import os
 import re
 import subprocess
+import sys
 
 symbol_regex = re.compile(b"D  \*UND\*\t(.*) (.*)$")
 allowed_symbols = frozenset([b'unshare', b'malloc_usable_size'])
 actual_symbols = set()
 
 objdump_output = subprocess.check_output([
-    'arm-linux-androideabi-objdump',
+    os.path.join(
+        os.environ['ANDROID_NDK'], 'toolchains', 'arm-linux-androideabi-4.9',
+        'prebuilt', 'linux-x86_64', 'bin', 'arm-linux-androideabi-objdump'),
     '-T',
     'target/arm-linux-androideabi/debug/libservo.so']
 ).split(b'\n')


### PR DESCRIPTION
Update `etc/ci/check_dynamic_symbols.py` to work after [the latest changes](https://github.com/servo/servo/pull/13945) in the Android build system.

Part of #13154.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13946)

<!-- Reviewable:end -->
