### PR TITLE
Implement parsing for font-language-override property

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -475,3 +475,49 @@ ${helpers.single_keyword("font-variant-position",
         }
     }
 </%helpers:longhand>
+
+// https://www.w3.org/TR/css-fonts-3/#propdef-font-language-override
+<%helpers:longhand name="font-language-override" products="none" animatable="False">
+    use values::NoViewportPercentage;
+    use values::computed::ComputedValueAsSpecified;
+    pub use self::computed_value::T as SpecifiedValue;
+
+    impl ComputedValueAsSpecified for SpecifiedValue {}
+    impl NoViewportPercentage for SpecifiedValue {}
+
+    pub mod computed_value {
+        use cssparser::ToCss;
+        use std::fmt;
+
+        impl ToCss for T {
+            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+                match *self {
+                    T::Normal => dest.write_str("normal"),
+                    T::Override(ref lang) => write!(dest, "\"{}\"", lang),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug, PartialEq)]
+        #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+        pub enum T {
+            Normal,
+            Override(String),
+        }
+    }
+
+    #[inline]
+    pub fn get_initial_value() -> computed_value::T {
+        computed_value::T::Normal
+    }
+
+    pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
+        if input.try(|input| input.expect_ident_matching("normal")).is_ok() {
+            Ok(SpecifiedValue::Normal)
+        } else {
+            input.expect_string().map(|cow| {
+                SpecifiedValue::Override(cow.into_owned())
+            })
+        }
+    }
+</%helpers:longhand>

--- a/tests/unit/style/parsing/font.rs
+++ b/tests/unit/style/parsing/font.rs
@@ -76,3 +76,31 @@ fn font_feature_settings_to_css() {
     assert_roundtrip_with_context!(font_feature_settings::parse, "\"abcd\" 4");
     assert_roundtrip_with_context!(font_feature_settings::parse, "\"abcd\", \"efgh\"");
 }
+
+#[test]
+fn font_language_override_should_parse_properly() {
+    use style::properties::longhands::font_language_override::{self, SpecifiedValue};
+
+    let normal = parse_longhand!(font_language_override, "normal");
+    assert_eq!(normal, SpecifiedValue::Normal);
+
+    let empty_str = parse_longhand!(font_language_override, "\"\"");
+    assert_eq!(empty_str, SpecifiedValue::Override("".to_string()));
+
+    let normal_str = parse_longhand!(font_language_override, "\"normal\"");
+    assert_eq!(normal_str, SpecifiedValue::Override("normal".to_string()));
+
+    let turkic = parse_longhand!(font_language_override, "\"TRK\"");
+    assert_eq!(turkic, SpecifiedValue::Override("TRK".to_string()));
+
+    let danish = parse_longhand!(font_language_override, "\"DAN\"");
+    assert_eq!(danish, SpecifiedValue::Override("DAN".to_string()));
+}
+
+#[test]
+#[should_panic]
+fn font_language_override_should_fail_on_empty_str() {
+    use style::properties::longhands::font_language_override::{self, SpecifiedValue};
+
+    parse_longhand!(font_language_override, "");
+}


### PR DESCRIPTION
Implement and test parsing of the `font-language-override` style property.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13874
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13950)

<!-- Reviewable:end -->
