### PR TITLE
Don't check untracked file in tidy

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -830,14 +830,11 @@ def check_dep_license_errors(filenames, progress=True):
 
 def get_file_list(directory, only_changed_files=False, exclude_dirs=[]):
     if only_changed_files:
-        # only check the files that have been changed since the last merge
+        # only check tracked files that have been changed since the last merge
         args = ["git", "log", "-n1", "--author=bors-servo", "--format=%H"]
         last_merge = subprocess.check_output(args).strip()
         args = ["git", "diff", "--name-only", last_merge, directory]
         file_list = subprocess.check_output(args)
-        # also check untracked files
-        args = ["git", "ls-files", "--others", "--exclude-standard", directory]
-        file_list += subprocess.check_output(args)
         for f in file_list.splitlines():
             f = os.path.join(*f.split("/")) if sys.platform == "win32" else f
             if not any(os.path.join('.', os.path.dirname(f)).startswith(path) for path in exclude_dirs):


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

As discussed in #13938, disabling tidy check on untracked file to reduce noise

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13938 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because mocking `git` calls for the unit test is probably not worth the effort.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13955)

<!-- Reviewable:end -->
