### PR TITLE
Remove steps for unused linux-dev-yaml test builder

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -54,18 +54,6 @@ linux-dev:
   - bash ./etc/ci/manifest_changed.sh
   - bash ./etc/ci/check_no_unwrap.sh
 
-linux-dev-yaml:
-  - ./mach test-tidy --no-progress --all
-  - ./mach test-tidy --no-progress --self-test
-  - ./mach build --dev
-  - ./mach test-compiletest
-  - ./mach test-unit
-  - ./mach build-cef
-  - ./mach build-geckolib
-  - bash ./etc/ci/lockfile_changed.sh
-  - bash ./etc/ci/manifest_changed.sh
-  - bash ./etc/ci/check_no_unwrap.sh
-
 linux-rel-wpt:
   - ./mach build --release
   - ./mach test-wpt-failure


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

r? @larsbergstrom 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because that is #13838 

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

These steps were used while testing the transition to dynamic steps.
Now that dynamic steps are working properly, this builder has been
decommissioned, and its steps are no longer needed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13968)

<!-- Reviewable:end -->
