### PR TITLE
Stop passing now-unrecognized --no-type-renaming to rust-bindgen.

### DIFF
--- a/components/style/binding_tools/regen.py
+++ b/components/style/binding_tools/regen.py
@@ -22,7 +22,7 @@ COMPILATION_TARGETS = {
     # Flags common for all the targets.
     COMMON_BUILD_KEY: {
         "flags": [
-            "--no-unstable-rust", "--no-type-renaming",
+            "--no-unstable-rust",
         ],
         "clang_flags": [
             "-x", "c++", "-std=c++14",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

r? @emilio 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13974)

<!-- Reviewable:end -->
