### PR TITLE
Update glue for -moz-user-input style const change.

### DIFF
--- a/components/style/properties/longhand/pointing.mako.rs
+++ b/components/style/properties/longhand/pointing.mako.rs
@@ -60,7 +60,7 @@ ${helpers.single_keyword("pointer-events", "auto none", animatable=False)}
 
 ${helpers.single_keyword("-moz-user-input", "none enabled disabled",
                          products="gecko", gecko_ffi_name="mUserInput",
-                         gecko_constant_prefix="NS_STYLE_USER_INPUT",
+                         gecko_enum_prefix="StyleUserInput",
                          animatable=False)}
 
 ${helpers.single_keyword("-moz-user-modify", "read-only read-write write-only",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1312173 changed -moz-user-input to use an enum class.

r? @emilio 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13976)

<!-- Reviewable:end -->
