### PR TITLE
glutin: Close the window if the event stream is closed.

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -522,7 +522,7 @@ impl Window {
                 let event = match window.wait_events().next() {
                     None => {
                         warn!("Window event stream closed.");
-                        return false;
+                        return true;
                     },
                     Some(event) => event,
                 };
@@ -550,7 +550,7 @@ impl Window {
                 let event = match window.wait_events().next() {
                     None => {
                         warn!("Window event stream closed.");
-                        return false;
+                        return true;
                     },
                     Some(event) => event,
                 };


### PR DESCRIPTION
Otherwise we can end up infinitely spinning for no good reason.

This happened today to me. Obviously the underlying situation is also buggy, but this seemed like a more sane behavior compared to infinitely spin waiting for a never-arriving event.

r? @glennw

<!-- Please describe your changes on the following line: -->

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13983)

<!-- Reviewable:end -->
