### PR TITLE
test-tidy: Check for space between function name and `(`

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1620,7 +1620,7 @@ impl<ConcreteThreadSafeLayoutNode> NodeUtils for ConcreteThreadSafeLayoutNode
     fn construction_result_mut(self, data: &mut PersistentLayoutData) -> &mut ConstructionResult {
         match self.get_pseudo_element_type() {
             PseudoElementType::Before(_) => &mut data.before_flow_construction_result,
-            PseudoElementType::After (_) => &mut data.after_flow_construction_result,
+            PseudoElementType::After(_) => &mut data.after_flow_construction_result,
             PseudoElementType::DetailsSummary(_) => &mut data.details_summary_flow_construction_result,
             PseudoElementType::DetailsContent(_) => &mut data.details_content_flow_construction_result,
             PseudoElementType::Normal    => &mut data.flow_construction_result,

--- a/components/net/bluetooth_thread.rs
+++ b/components/net/bluetooth_thread.rs
@@ -162,7 +162,7 @@ pub struct BluetoothManager {
 }
 
 impl BluetoothManager {
-    pub fn new (receiver: IpcReceiver<BluetoothMethodMsg>, adapter: Option<BluetoothAdapter>) -> BluetoothManager {
+    pub fn new(receiver: IpcReceiver<BluetoothMethodMsg>, adapter: Option<BluetoothAdapter>) -> BluetoothManager {
         BluetoothManager {
             receiver: receiver,
             adapter: adapter,

--- a/components/net/fetch/cors_cache.rs
+++ b/components/net/fetch/cors_cache.rs
@@ -94,7 +94,7 @@ impl CORSCache {
     }
 
     /// [Clear the cache](https://fetch.spec.whatwg.org/#concept-cache-clear)
-    pub fn clear (&mut self, request: &Request) {
+    pub fn clear(&mut self, request: &Request) {
         let CORSCache(buf) = self.clone();
         let new_buf: Vec<CORSCacheEntry> =
             buf.into_iter().filter(|e| e.origin == *request.origin.borrow() &&

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -416,8 +416,8 @@ pub fn Navigate(iframe: &HTMLIFrameElement, direction: TraversalDirection) -> Er
 
         Ok(())
     } else {
-        debug!("this frame is not mozbrowser: mozbrowser attribute missing, or not a top
-            level window, or mozbrowser preference not set (use --pref dom.mozbrowser.enabled)");
+        debug!(concat!("this frame is not mozbrowser: mozbrowser attribute missing, or not a top",
+            "level window, or mozbrowser preference not set (use --pref dom.mozbrowser.enabled)"));
         Err(Error::NotSupported)
     }
 }
@@ -499,8 +499,8 @@ impl HTMLIFrameElementMethods for HTMLIFrameElement {
             }
             Ok(())
         } else {
-            debug!("this frame is not mozbrowser: mozbrowser attribute missing, or not a top
-                level window, or mozbrowser preference not set (use --pref dom.mozbrowser.enabled)");
+            debug!(concat!("this frame is not mozbrowser: mozbrowser attribute missing, or not a top",
+                "level window, or mozbrowser preference not set (use --pref dom.mozbrowser.enabled)"));
             Err(Error::NotSupported)
         }
     }
@@ -511,8 +511,8 @@ impl HTMLIFrameElementMethods for HTMLIFrameElement {
             self.set_visible(visible);
             Ok(())
         } else {
-            debug!("this frame is not mozbrowser: mozbrowser attribute missing, or not a top
-                level window, or mozbrowser preference not set (use --pref dom.mozbrowser.enabled)");
+            debug!(concat!("this frame is not mozbrowser: mozbrowser attribute missing, or not a top",
+                "level window, or mozbrowser preference not set (use --pref dom.mozbrowser.enabled)"));
             Err(Error::NotSupported)
         }
     }
@@ -522,8 +522,8 @@ impl HTMLIFrameElementMethods for HTMLIFrameElement {
         if self.Mozbrowser() {
             Ok(self.visibility.get())
         } else {
-            debug!("this frame is not mozbrowser: mozbrowser attribute missing, or not a top
-                level window, or mozbrowser preference not set (use --pref dom.mozbrowser.enabled)");
+            debug!(concat!("this frame is not mozbrowser: mozbrowser attribute missing, or not a top",
+                "level window, or mozbrowser preference not set (use --pref dom.mozbrowser.enabled)"));
             Err(Error::NotSupported)
         }
     }

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -215,7 +215,7 @@ impl TreeWalkerMethods for TreeWalker {
                 }
                 match node.GetFirstChild() {
                     None => break,
-                    Some (child) => {
+                    Some(child) => {
                         // "1. Set node to its first child."
                         node = child;
                         // "2. Filter node and set result to the return value."

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -525,7 +525,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
         // Step 7
         self.upload_complete.set(match extracted {
             None => true,
-            Some (ref e) if e.0.is_empty() => true,
+            Some(ref e) if e.0.is_empty() => true,
             _ => false
         });
         // Step 8

--- a/components/style/viewport.rs
+++ b/components/style/viewport.rs
@@ -94,7 +94,7 @@ declare_viewport_descriptor! {
 }
 
 trait FromMeta: Sized {
-    fn from_meta (value: &str) -> Option<Self>;
+    fn from_meta(value: &str) -> Option<Self>;
 }
 
 // ViewportLength is a length | percentage | auto | extend-to-zoom

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -442,6 +442,13 @@ def check_rust(file_name, lines):
         regex_rules = [
             (r",[^\s]", "missing space after ,",
                 lambda match, line: '$' not in line and not is_attribute),
+            (r"([A-Za-z0-9_]+) (\()", "extra space after {0}",
+                lambda match, line: not (
+                    is_attribute or
+                    re.match(r"\bmacro_rules!\s+", line[:match.start()]) or
+                    re.search(r"[^']'[A-Za-z0-9_]+ \($", line[:match.end()]) or
+                    match.group(1) in ['const', 'fn', 'for', 'if', 'in',
+                                       'let', 'match', 'mut', 'return'])),
             (r"[A-Za-z0-9\"]=", "missing space before =",
                 lambda match, line: is_attribute),
             (r"=[A-Za-z0-9\"]", "missing space after =",

--- a/python/tidy/servo_tidy_tests/rust_tidy.rs
+++ b/python/tidy/servo_tidy_tests/rust_tidy.rs
@@ -52,7 +52,9 @@ impl test {
     type Text_Fun3 = fn( i32) -> i32;
 
     fn test_fun3<Text_Fun3>( y: Text_Fun3) {
-        test_fun( 1);
+        let (x, y) = (1, 2) // Should not trigger
+        test_fun( x);
+        test_fun (y);
     }
 
     // Should not be triggered

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -124,6 +124,7 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('extra space after (', errors.next()[2])
         self.assertEqual('extra space after (', errors.next()[2])
         self.assertEqual('extra space after (', errors.next()[2])
+        self.assertEqual('extra space after test_fun', errors.next()[2])
         self.assertNoMoreErrors(errors)
 
     def test_spec_link(self):


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Disallow an extraneous space in a function call between
the function name and the opening parenthesis in Rust
code, while ignoring macro declarations.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --all` does not report any errors
- [x] `./mach test-tidy --self` does not report any errors
- [x] These changes fix #13980

<!-- Either: -->
- [x] There are tests for these changes, these are written in
 - `python/tidy/servo_tidy_tests/rust_tidy.rs`
 - `python/tidy/servo_tidy_tests/test_tidy.py`
- [ ] These changes do not require tests

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/13988)

<!-- Reviewable:end -->
