### PR TITLE
Storage notifications routed via the constellation.

### DIFF
--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -17,6 +17,7 @@ use ipc_channel::ipc::{self, IpcSender};
 use net_traits::IpcSend;
 use net_traits::storage_thread::{StorageThreadMsg, StorageType};
 use script_thread::{Runnable, ScriptThread};
+use script_traits::ScriptMsg;
 use task_source::TaskSource;
 use url::Url;
 
@@ -149,60 +150,60 @@ impl Storage {
     /// https://html.spec.whatwg.org/multipage/#send-a-storage-notification
     fn broadcast_change_notification(&self, key: Option<String>, old_value: Option<String>,
                                      new_value: Option<String>) {
+        let pipeline_id = self.global().pipeline_id();
+        let storage = self.storage_type;
+        let url = self.get_url();
+        let msg = ScriptMsg::BroadcastStorageEvent(pipeline_id, storage, url, key, old_value, new_value);
+        self.global().constellation_chan().send(msg).unwrap();
+    }
+
+    /// https://html.spec.whatwg.org/multipage/#send-a-storage-notification
+    pub fn queue_storage_event(&self, url: Url,
+                               key: Option<String>, old_value: Option<String>, new_value: Option<String>) {
         let global = self.global();
         let window = global.as_window();
         let task_source = window.dom_manipulation_task_source();
         let trusted_storage = Trusted::new(self);
         task_source
             .queue(
-                box StorageEventRunnable::new(trusted_storage, key, old_value, new_value), &global)
+                box StorageEventRunnable::new(trusted_storage, url, key, old_value, new_value), &global)
             .unwrap();
     }
 }
 
 pub struct StorageEventRunnable {
     element: Trusted<Storage>,
+    url: Url,
     key: Option<String>,
     old_value: Option<String>,
     new_value: Option<String>
 }
 
 impl StorageEventRunnable {
-    fn new(storage: Trusted<Storage>, key: Option<String>, old_value: Option<String>,
-           new_value: Option<String>) -> StorageEventRunnable {
-        StorageEventRunnable { element: storage, key: key, old_value: old_value, new_value: new_value }
+    fn new(storage: Trusted<Storage>, url: Url,
+           key: Option<String>, old_value: Option<String>, new_value: Option<String>) -> StorageEventRunnable {
+        StorageEventRunnable { element: storage, url: url, key: key, old_value: old_value, new_value: new_value }
     }
 }
 
 impl Runnable for StorageEventRunnable {
     fn name(&self) -> &'static str { "StorageEventRunnable" }
 
-    fn main_thread_handler(self: Box<StorageEventRunnable>, script_thread: &ScriptThread) {
+    fn main_thread_handler(self: Box<StorageEventRunnable>, _: &ScriptThread) {
         let this = *self;
         let storage = this.element.root();
         let global = storage.global();
-        let ev_url = storage.get_url();
+        let window = global.as_window();
 
         let storage_event = StorageEvent::new(
             &global,
             atom!("storage"),
             EventBubbles::DoesNotBubble, EventCancelable::NotCancelable,
             this.key.map(DOMString::from), this.old_value.map(DOMString::from), this.new_value.map(DOMString::from),
-            DOMString::from(ev_url.to_string()),
+            DOMString::from(this.url.into_string()),
             Some(&storage)
         );
 
-        // TODO: This is only iterating over documents in the current script
-        // thread, so we are not firing events to other script threads.
-        // NOTE: once that is fixed, we can remove borrow_documents from ScriptThread.
-        for (id, document) in script_thread.borrow_documents().iter() {
-            if ev_url.origin() == document.window().get_url().origin() {
-                // TODO: Such a Document object is not necessarily fully active, but events fired on such
-                // objects are ignored by the event loop until the Document becomes fully active again.
-                if global.pipeline_id() != id {
-                    storage_event.upcast::<Event>().fire(document.window().upcast());
-                }
-            }
-        }
+        storage_event.upcast::<Event>().fire(window.upcast());
     }
 }

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -60,6 +60,7 @@ use net_traits::{ReferrerPolicy, ResourceThreads};
 use net_traits::image::base::Image;
 use net_traits::image_cache_thread::ImageCacheThread;
 use net_traits::response::HttpsState;
+use net_traits::storage_thread::StorageType;
 use profile_traits::mem;
 use profile_traits::time as profile_time;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -244,6 +245,9 @@ pub enum ConstellationControlMsg {
         /// The pipeline that has completed loading.
         child: PipelineId,
     },
+    /// Cause a `storage` event to be dispatched at the appropriate window.
+    /// The strings are key, old value and new value.
+    DispatchStorageEvent(PipelineId, StorageType, Url, Option<String>, Option<String>, Option<String>),
     /// Notifies a parent pipeline that one of its child frames is now active.
     /// PipelineId is for the parent, FrameId is the child frame.
     FramedContentChanged(PipelineId, FrameId),
@@ -279,6 +283,7 @@ impl fmt::Debug for ConstellationControlMsg {
             TransitionEnd(..) => "TransitionEnd",
             WebFontLoaded(..) => "WebFontLoaded",
             DispatchFrameLoadEvent { .. } => "DispatchFrameLoadEvent",
+            DispatchStorageEvent(..) => "DispatchStorageEvent",
             FramedContentChanged(..) => "FramedContentChanged",
             ReportCSSError(..) => "ReportCSSError",
             Reload(..) => "Reload"

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -18,6 +18,7 @@ use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::{Key, KeyModifiers, KeyState};
 use msg::constellation_msg::{PipelineId, TraversalDirection};
 use net_traits::CoreResourceMsg;
+use net_traits::storage_thread::StorageType;
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use style_traits::cursor::Cursor;
 use style_traits::viewport::ViewportConstraints;
@@ -59,6 +60,9 @@ pub enum LogEntry {
 /// Messages from the script to the constellation.
 #[derive(Deserialize, Serialize)]
 pub enum ScriptMsg {
+    /// Broadcast a storage event to every same-origin pipeline.
+    /// The strings are key, old value and new value.
+    BroadcastStorageEvent(PipelineId, StorageType, Url, Option<String>, Option<String>, Option<String>),
     /// Indicates whether this pipeline is currently running animations.
     ChangeRunningAnimationsState(PipelineId, AnimationState),
     /// Requests that a new 2D canvas thread be created. (This is done in the constellation because

--- a/tests/wpt/metadata/html/browsers/windows/noreferrer.html.ini
+++ b/tests/wpt/metadata/html/browsers/windows/noreferrer.html.ini
@@ -1,6 +1,5 @@
 [noreferrer.html]
   type: testharness
-  expected: CRASH
   [rel=noreferrer nullifies window.opener]
-    expected: CRASH
+    expected: FAIL
 

--- a/tests/wpt/metadata/webstorage/event_local_removeitem.html.ini
+++ b/tests/wpt/metadata/webstorage/event_local_removeitem.html.ini
@@ -1,5 +1,0 @@
-[event_local_removeitem.html]
-  type: testharness
-  [key property test of local event]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webstorage/event_session_removeitem.html.ini
+++ b/tests/wpt/metadata/webstorage/event_session_removeitem.html.ini
@@ -1,5 +1,0 @@
-[event_session_removeitem.html]
-  type: testharness
-  [key property test of session event]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

At the moment, storage notifications are only sent within a script thread, not to same-origin pipelines in different script threads. This PR fixes that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #5196
- [X] These changes do not require tests because existing tests now pass

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14023)
<!-- Reviewable:end -->
