### PR TITLE
Don't mark the first/last fragment of an {ib} split as FIRST/LAST_FRAGMENT_OF_ELEMENT.

### DIFF
--- a/tests/wpt/metadata-css/css21_dev/html4/block-in-inline-insert-017.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/block-in-inline-insert-017.htm.ini
@@ -1,3 +1,0 @@
-[block-in-inline-insert-017.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/inline-box-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/inline-box-001.htm.ini
@@ -1,3 +1,0 @@
-[inline-box-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/ltr-ib.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/ltr-ib.htm.ini
@@ -1,3 +1,0 @@
-[ltr-ib.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/rtl-ib.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/rtl-ib.htm.ini
@@ -1,3 +1,0 @@
-[rtl-ib.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This change allows inline margins, borders, and padding to interact correctly with {ib} splits.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14030
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14035)
<!-- Reviewable:end -->
