### PR TITLE
Skip dependencyci checks for known deprecated modules.

### DIFF
--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -1,0 +1,5 @@
+platforms:
+  pypi:
+    charade:
+      tests:
+        unmaintained: skip


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14045)
<!-- Reviewable:end -->
