### PR TITLE
Constellation manages script thread lifetime

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -840,10 +840,9 @@ impl ScriptThread {
 
             let result = self.profile_event(category, move || {
                 match msg {
-                    FromConstellation(ConstellationControlMsg::ExitPipeline(id)) => {
-                        if self.handle_exit_pipeline_msg(id) {
-                            return Some(false)
-                        }
+                    FromConstellation(ConstellationControlMsg::ExitScriptThread) => {
+                        self.handle_exit_script_thread_msg();
+                        return Some(false);
                     },
                     FromConstellation(inner_msg) => self.handle_msg_from_constellation(inner_msg),
                     FromScript(inner_msg) => self.handle_msg_from_script(inner_msg),
@@ -990,11 +989,13 @@ impl ScriptThread {
                 self.handle_css_error_reporting(pipeline_id, filename, line, column, msg),
             ConstellationControlMsg::Reload(pipeline_id) =>
                 self.handle_reload(pipeline_id),
+            ConstellationControlMsg::ExitPipeline(pipeline_id) =>
+                self.handle_exit_pipeline_msg(pipeline_id),
             msg @ ConstellationControlMsg::AttachLayout(..) |
             msg @ ConstellationControlMsg::Viewport(..) |
             msg @ ConstellationControlMsg::SetScrollState(..) |
             msg @ ConstellationControlMsg::Resize(..) |
-            msg @ ConstellationControlMsg::ExitPipeline(..) =>
+            msg @ ConstellationControlMsg::ExitScriptThread =>
                       panic!("should have handled {:?} already", msg),
         }
     }
@@ -1487,10 +1488,9 @@ impl ScriptThread {
         document.send_title_to_compositor();
     }
 
-    /// Handles a request to exit the script thread and shut down layout.
-    /// Returns true if the script thread should shut down and false otherwise.
-    fn handle_exit_pipeline_msg(&self, id: PipelineId) -> bool {
-        debug!("Exiting pipeline {:?}.", id);
+    /// Handles a request to exit a pipeline and shut down layout.
+    fn handle_exit_pipeline_msg(&self, id: PipelineId) {
+        debug!("Exiting pipeline {}.", id);
 
         self.closed_pipelines.borrow_mut().insert(id);
 
@@ -1507,7 +1507,7 @@ impl ScriptThread {
             let (response_chan, response_port) = channel();
             let chan = &load.layout_chan;
             if chan.send(message::Msg::PrepareToExit(response_chan)).is_ok() {
-                debug!("shutting down layout for page {:?}", id);
+                debug!("shutting down layout for page {}", id);
                 response_port.recv().unwrap();
                 chan.send(message::Msg::ExitNow).ok();
             }
@@ -1518,13 +1518,22 @@ impl ScriptThread {
             let _ = self.constellation_chan.send(ConstellationMsg::PipelineExited(id));
         }
 
-        let no_pending_loads = self.incomplete_loads.borrow().is_empty();
-        let no_remaining_contexts = self.documents.borrow().is_empty();
+        debug!("Exited pipeline {}.", id);
+    }
 
-        debug!("Exited pipeline {:?} ({}&{}).", id, no_pending_loads, no_remaining_contexts);
+    /// Handles a request to exit the script thread and shut down layout.
+    fn handle_exit_script_thread_msg(&self) {
+        debug!("Exiting script thread.");
 
-        // Exit if no pending loads and no remaining contexts
-        no_pending_loads && no_remaining_contexts
+        let mut pipeline_ids = Vec::new();
+        pipeline_ids.extend(self.incomplete_loads.borrow().iter().next().map(|load| load.pipeline_id));
+        pipeline_ids.extend(self.documents.borrow().iter().next().map(|(pipeline_id, _)| pipeline_id));
+
+        for pipeline_id in pipeline_ids {
+            self.handle_exit_pipeline_msg(pipeline_id);
+        }
+
+        debug!("Exited script thread.");
     }
 
     /// Handles when layout thread finishes all animation in one tick

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -195,6 +195,8 @@ pub enum ConstellationControlMsg {
     ResizeInactive(PipelineId, WindowSizeData),
     /// Notifies the script that a pipeline should be closed.
     ExitPipeline(PipelineId),
+    /// Notifies the script that the whole thread should be closed.
+    ExitScriptThread,
     /// Sends a DOM event.
     SendEvent(PipelineId, CompositorEvent),
     /// Notifies script of the viewport.
@@ -259,6 +261,7 @@ impl fmt::Debug for ConstellationControlMsg {
             Resize(..) => "Resize",
             ResizeInactive(..) => "ResizeInactive",
             ExitPipeline(..) => "ExitPipeline",
+            ExitScriptThread => "ExitScriptThread",
             SendEvent(..) => "SendEvent",
             Viewport(..) => "Viewport",
             SetScrollState(..) => "SetScrollState",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Yet another step towards fixing #633...

At the moment, script threads are responsible for killing themselves when they have no more pipelines to manage. This is fine right now, because script threads have a root pipeline: once it is closed, everything is closed. It's not fine once we fix #633 because there's a race condition where the constellation could kill the last pipeline in a script thread, then open a new one in the same script thread.

We can't have the constellation block on the script thread, waiting to make sure a pipeline is created, since this could introduce deadlock. The easiest solution is to have the constellation manage the script thread lifetime: when the constellation discovers that a script thread is not managing any live pipelines, it closes the script thread, and updates its own state.

Most of the commits are from #14013, its just "Script thread lifetime is now managed by the constellation." (9ac6e4d2badc8f973300d6dc9ee2bc2e30b49fc9) that's new.

cc @jdm @ConnorGBrewster 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because refactoring

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14052)
<!-- Reviewable:end -->
