### PR TITLE
Make `FlowRef` a newtype

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -40,7 +40,6 @@ use flow::{FragmentationContext, MARGINS_CANNOT_COLLAPSE, PreorderFlowTraversal}
 use flow::{ImmutableFlowUtils, LateAbsolutePositionInfo, MutableFlowUtils, OpaqueFlow};
 use flow::IS_ABSOLUTELY_POSITIONED;
 use flow_list::FlowList;
-use flow_ref::FlowRef;
 use fragment::{CoordinateSystem, Fragment, FragmentBorderBoxIterator, Overflow};
 use fragment::SpecificFragmentInfo;
 use gfx::display_list::{ClippingRegion, StackingContext};
@@ -791,7 +790,7 @@ impl BlockFlow {
                                             layout_context: &'a LayoutContext<'a>,
                                             mut fragmentation_context: Option<FragmentationContext>,
                                             margins_may_collapse: MarginsMayCollapseFlag)
-                                            -> Option<FlowRef> {
+                                            -> Option<Arc<Flow>> {
         let _scope = layout_debug_scope!("assign_block_size_block_base {:x}",
                                          self.base.debug_id());
 
@@ -1101,9 +1100,9 @@ impl BlockFlow {
             } else {
                 let mut children = self.base.children.split_off(i);
                 if let Some(child) = child_remaining {
-                    children.push_front(child);
+                    children.push_front_arc(child);
                 }
-                Some(Arc::new(self.clone_with_children(children)) as FlowRef)
+                Some(Arc::new(self.clone_with_children(children)) as Arc<Flow>)
             }
         })
     }
@@ -1898,7 +1897,7 @@ impl Flow for BlockFlow {
 
     fn fragment(&mut self, layout_context: &LayoutContext,
                 fragmentation_context: Option<FragmentationContext>)
-                -> Option<FlowRef> {
+                -> Option<Arc<Flow>> {
         if self.is_replaced_content() {
             let _scope = layout_debug_scope!("assign_replaced_block_size_if_necessary {:x}",
                                              self.base.debug_id());

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -18,7 +18,7 @@ use context::SharedLayoutContext;
 use euclid::{Matrix4D, Point2D, Radians, Rect, SideOffsets2D, Size2D};
 use flex::FlexFlow;
 use flow::{BaseFlow, Flow, IS_ABSOLUTELY_POSITIONED};
-use flow_ref;
+use flow_ref::FlowRef;
 use fragment::{CoordinateSystem, Fragment, ImageFragmentInfo, ScannedTextFragmentInfo};
 use fragment::SpecificFragmentInfo;
 use gfx::display_list::{BLUR_INFLATION_FACTOR, BaseDisplayItem, BorderDisplayItem};
@@ -1994,11 +1994,11 @@ impl InlineFlowDisplayListBuilding for InlineFlow {
         for mut fragment in self.fragments.fragments.iter_mut() {
             match fragment.specific {
                 SpecificFragmentInfo::InlineBlock(ref mut block_flow) => {
-                    let block_flow = flow_ref::deref_mut(&mut block_flow.flow_ref);
+                    let block_flow = FlowRef::deref_mut(&mut block_flow.flow_ref);
                     block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
                 }
                 SpecificFragmentInfo::InlineAbsoluteHypothetical(ref mut block_flow) => {
-                    let block_flow = flow_ref::deref_mut(&mut block_flow.flow_ref);
+                    let block_flow = FlowRef::deref_mut(&mut block_flow.flow_ref);
                     block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
                 }
                 _ if fragment.establishes_stacking_context() => {

--- a/components/layout/flow_list.rs
+++ b/components/layout/flow_list.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use flow::Flow;
-use flow_ref::{self, FlowRef};
+use flow_ref::FlowRef;
 use std::collections::{LinkedList, linked_list};
+use std::sync::Arc;
 
 /// This needs to be reworked now that we have dynamically-sized types in Rust.
 /// Until then, it's just a wrapper around LinkedList.
@@ -31,6 +32,10 @@ impl FlowList {
         self.flows.push_back(new_tail);
     }
 
+    pub fn push_back_arc(&mut self, new_head: Arc<Flow>) {
+        self.flows.push_back(FlowRef::new(new_head));
+    }
+
     pub fn back(&self) -> Option<&Flow> {
         self.flows.back().map(|x| &**x)
     }
@@ -42,8 +47,12 @@ impl FlowList {
         self.flows.push_front(new_head);
     }
 
-    pub fn pop_front(&mut self) -> Option<FlowRef> {
-        self.flows.pop_front()
+    pub fn push_front_arc(&mut self, new_head: Arc<Flow>) {
+        self.flows.push_front(FlowRef::new(new_head));
+    }
+
+    pub fn pop_front_arc(&mut self) -> Option<Arc<Flow>> {
+        self.flows.pop_front().map(FlowRef::into_arc)
     }
 
     pub fn front(&self) -> Option<&Flow> {
@@ -114,7 +123,7 @@ impl FlowList {
 
 impl<'a> DoubleEndedIterator for MutFlowListIterator<'a> {
     fn next_back(&mut self) -> Option<&'a mut Flow> {
-        self.it.next_back().map(flow_ref::deref_mut)
+        self.it.next_back().map(FlowRef::deref_mut)
     }
 }
 
@@ -122,7 +131,7 @@ impl<'a> Iterator for MutFlowListIterator<'a> {
     type Item = &'a mut Flow;
     #[inline]
     fn next(&mut self) -> Option<&'a mut Flow> {
-        self.it.next().map(flow_ref::deref_mut)
+        self.it.next().map(FlowRef::deref_mut)
     }
 
     #[inline]
@@ -146,6 +155,6 @@ impl<'a> FlowListRandomAccessMut<'a> {
                 Some(next_flow) => self.cache.push((*next_flow).clone()),
             }
         }
-        flow_ref::deref_mut(&mut self.cache[index])
+        FlowRef::deref_mut(&mut self.cache[index])
     }
 }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -12,7 +12,7 @@ use context::{LayoutContext, SharedLayoutContext};
 use euclid::{Point2D, Rect, Size2D};
 use floats::ClearType;
 use flow::{self, ImmutableFlowUtils};
-use flow_ref::{self, FlowRef};
+use flow_ref::FlowRef;
 use gfx;
 use gfx::display_list::{BLUR_INFLATION_FACTOR, OpaqueNode};
 use gfx::text::glyph::ByteIndex;
@@ -1985,7 +1985,7 @@ impl Fragment {
 
         match self.specific {
             SpecificFragmentInfo::InlineAbsoluteHypothetical(ref mut info) => {
-                let block_flow = flow_ref::deref_mut(&mut info.flow_ref).as_mut_block();
+                let block_flow = FlowRef::deref_mut(&mut info.flow_ref).as_mut_block();
                 block_flow.base.position.size.inline =
                     block_flow.base.intrinsic_inline_sizes.preferred_inline_size;
 
@@ -1993,7 +1993,7 @@ impl Fragment {
                 self.border_box.size.inline = Au(0);
             }
             SpecificFragmentInfo::InlineBlock(ref mut info) => {
-                let block_flow = flow_ref::deref_mut(&mut info.flow_ref).as_mut_block();
+                let block_flow = FlowRef::deref_mut(&mut info.flow_ref).as_mut_block();
                 self.border_box.size.inline =
                     max(block_flow.base.intrinsic_inline_sizes.minimum_inline_size,
                         block_flow.base.intrinsic_inline_sizes.preferred_inline_size);
@@ -2001,7 +2001,7 @@ impl Fragment {
                 block_flow.base.block_container_writing_mode = self.style.writing_mode;
             }
             SpecificFragmentInfo::InlineAbsolute(ref mut info) => {
-                let block_flow = flow_ref::deref_mut(&mut info.flow_ref).as_mut_block();
+                let block_flow = FlowRef::deref_mut(&mut info.flow_ref).as_mut_block();
                 self.border_box.size.inline =
                     max(block_flow.base.intrinsic_inline_sizes.minimum_inline_size,
                         block_flow.base.intrinsic_inline_sizes.preferred_inline_size);
@@ -2133,18 +2133,18 @@ impl Fragment {
             }
             SpecificFragmentInfo::InlineBlock(ref mut info) => {
                 // Not the primary fragment, so we do not take the noncontent size into account.
-                let block_flow = flow_ref::deref_mut(&mut info.flow_ref).as_block();
+                let block_flow = FlowRef::deref_mut(&mut info.flow_ref).as_block();
                 self.border_box.size.block = block_flow.base.position.size.block +
                     block_flow.fragment.margin.block_start_end()
             }
             SpecificFragmentInfo::InlineAbsoluteHypothetical(ref mut info) => {
                 // Not the primary fragment, so we do not take the noncontent size into account.
-                let block_flow = flow_ref::deref_mut(&mut info.flow_ref).as_block();
+                let block_flow = FlowRef::deref_mut(&mut info.flow_ref).as_block();
                 self.border_box.size.block = block_flow.base.position.size.block;
             }
             SpecificFragmentInfo::InlineAbsolute(ref mut info) => {
                 // Not the primary fragment, so we do not take the noncontent size into account.
-                let block_flow = flow_ref::deref_mut(&mut info.flow_ref).as_block();
+                let block_flow = FlowRef::deref_mut(&mut info.flow_ref).as_block();
                 self.border_box.size.block = block_flow.base.position.size.block +
                     block_flow.fragment.margin.block_start_end()
             }
@@ -2481,7 +2481,7 @@ impl Fragment {
     /// block size assignment.
     pub fn update_late_computed_replaced_inline_size_if_necessary(&mut self) {
         if let SpecificFragmentInfo::InlineBlock(ref mut inline_block_info) = self.specific {
-            let block_flow = flow_ref::deref_mut(&mut inline_block_info.flow_ref).as_block();
+            let block_flow = FlowRef::deref_mut(&mut inline_block_info.flow_ref).as_block();
             let margin = block_flow.fragment.style.logical_margin();
             self.border_box.size.inline = block_flow.fragment.border_box.size.inline +
                 MaybeAuto::from_style(margin.inline_start, Au(0)).specified_or_zero() +
@@ -2492,7 +2492,7 @@ impl Fragment {
     pub fn update_late_computed_inline_position_if_necessary(&mut self) {
         if let SpecificFragmentInfo::InlineAbsoluteHypothetical(ref mut info) = self.specific {
             let position = self.border_box.start.i;
-            flow_ref::deref_mut(&mut info.flow_ref)
+            FlowRef::deref_mut(&mut info.flow_ref)
                 .update_late_computed_inline_position_if_necessary(position)
         }
     }
@@ -2500,7 +2500,7 @@ impl Fragment {
     pub fn update_late_computed_block_position_if_necessary(&mut self) {
         if let SpecificFragmentInfo::InlineAbsoluteHypothetical(ref mut info) = self.specific {
             let position = self.border_box.start.b;
-            flow_ref::deref_mut(&mut info.flow_ref)
+            FlowRef::deref_mut(&mut info.flow_ref)
                 .update_late_computed_block_position_if_necessary(position)
         }
     }

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -13,7 +13,7 @@ use floats::{FloatKind, Floats, PlacementInfo};
 use flow::{self, BaseFlow, Flow, FlowClass, ForceNonfloatedFlag, IS_ABSOLUTELY_POSITIONED};
 use flow::{CONTAINS_TEXT_OR_REPLACED_FRAGMENTS, EarlyAbsolutePositionInfo, MutableFlowUtils};
 use flow::OpaqueFlow;
-use flow_ref;
+use flow_ref::FlowRef;
 use fragment::{CoordinateSystem, Fragment, FragmentBorderBoxIterator, Overflow};
 use fragment::SpecificFragmentInfo;
 use gfx::display_list::{OpaqueNode, StackingContext};
@@ -1468,14 +1468,14 @@ impl Flow for InlineFlow {
         self.mutate_fragments(&mut |f: &mut Fragment| {
             match f.specific {
                 SpecificFragmentInfo::InlineBlock(ref mut info) => {
-                    let block = flow_ref::deref_mut(&mut info.flow_ref);
+                    let block = FlowRef::deref_mut(&mut info.flow_ref);
                     flow::mut_base(block).early_absolute_position_info = EarlyAbsolutePositionInfo {
                         relative_containing_block_size: containing_block_size,
                         relative_containing_block_mode: writing_mode,
                     };
                 }
                 SpecificFragmentInfo::InlineAbsolute(ref mut info) => {
-                    let block = flow_ref::deref_mut(&mut info.flow_ref);
+                    let block = FlowRef::deref_mut(&mut info.flow_ref);
                     flow::mut_base(block).early_absolute_position_info = EarlyAbsolutePositionInfo {
                         relative_containing_block_size: containing_block_size,
                         relative_containing_block_mode: writing_mode,
@@ -1551,7 +1551,7 @@ impl Flow for InlineFlow {
             let is_positioned = fragment.is_positioned();
             match fragment.specific {
                 SpecificFragmentInfo::InlineBlock(ref mut info) => {
-                    let flow = flow_ref::deref_mut(&mut info.flow_ref);
+                    let flow = FlowRef::deref_mut(&mut info.flow_ref);
                     let block_flow = flow.as_mut_block();
                     block_flow.base.late_absolute_position_info =
                         self.base.late_absolute_position_info;
@@ -1573,7 +1573,7 @@ impl Flow for InlineFlow {
                     block_flow.base.clip = self.base.clip.clone()
                 }
                 SpecificFragmentInfo::InlineAbsoluteHypothetical(ref mut info) => {
-                    let flow = flow_ref::deref_mut(&mut info.flow_ref);
+                    let flow = FlowRef::deref_mut(&mut info.flow_ref);
                     let block_flow = flow.as_mut_block();
                     block_flow.base.late_absolute_position_info =
                         self.base.late_absolute_position_info;
@@ -1585,7 +1585,7 @@ impl Flow for InlineFlow {
                     block_flow.base.clip = self.base.clip.clone()
                 }
                 SpecificFragmentInfo::InlineAbsolute(ref mut info) => {
-                    let flow = flow_ref::deref_mut(&mut info.flow_ref);
+                    let flow = FlowRef::deref_mut(&mut info.flow_ref);
                     let block_flow = flow.as_mut_block();
                     block_flow.base.late_absolute_position_info =
                         self.base.late_absolute_position_info;


### PR DESCRIPTION
This creates a sharp distinction between `Arc<Flow>`s, which may be
owned by anyone, and `FlowRef`s, which may only be owned by the
traversal code. By checking the reference count, we ensure that a `Flow`
cannot be pointed to by `Arc`s and `FlowRef`s simultaneously.

This is not a complete fix for #6503, though it is a necessary start
(enforcing the no-aliasing rule of `FlowRef::deref_mut` will require far
more work).

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14014 (github issue number if applicable).
- [X] These changes do not require tests because the existing tests, plus the added assertions, should be sufficient

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14053)
<!-- Reviewable:end -->
