### PR TITLE
moving datetimestamping responsibilities from mach package

### DIFF
--- a/etc/ci/upload_nightly.sh
+++ b/etc/ci/upload_nightly.sh
@@ -16,10 +16,11 @@ usage() {
 
 
 upload() {
-    local package_filename
-    package_filename="$(basename "${2}")"
+    local nightly_filename nightly_timestamp
+    nightly_timestamp="$(date -u +"%Y-%m-%dT%H-%M-%SZ")"
+    nightly_filename="${nightly_timestamp}-$(basename "${2}")"
     local -r nightly_upload_dir="s3://servo-builds/nightly/${1}"
-    local -r package_upload_path="${nightly_upload_dir}/${package_filename}"
+    local -r package_upload_path="${nightly_upload_dir}/${nightly_filename}"
     s3cmd --mime-type="application/octet-stream" \
           put "${2}" "${package_upload_path}"
     s3cmd cp "${package_upload_path}" "${nightly_upload_dir}/servo-latest.${3}"

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -19,7 +19,6 @@ import subprocess
 import mako.template
 
 from mach.registrar import Registrar
-from datetime import datetime
 
 from mach.decorators import (
     CommandArgument,
@@ -155,7 +154,6 @@ class PackageCommands(CommandBase):
 
             dir_to_build = '/'.join(binary_path.split('/')[:-1])
             dir_to_root = '/'.join(binary_path.split('/')[:-3])
-            now = datetime.utcnow()
 
             print("Creating Servo.app")
             dir_to_dmg = '/'.join(binary_path.split('/')[:-2]) + '/dmg'
@@ -212,9 +210,7 @@ class PackageCommands(CommandBase):
             print("Creating dmg")
             os.symlink('/Applications', dir_to_dmg + '/Applications')
             dmg_path = '/'.join(dir_to_build.split('/')[:-1]) + '/'
-            time = now.replace(microsecond=0).isoformat()
-            time = time.replace(':', '-')
-            dmg_path += time + "-servo-tech-demo.dmg"
+            dmg_path += "servo-tech-demo.dmg"
             try:
                 subprocess.check_call(['hdiutil', 'create', '-volname', 'Servo', dmg_path, '-srcfolder', dir_to_dmg])
             except subprocess.CalledProcessError as e:
@@ -229,7 +225,7 @@ class PackageCommands(CommandBase):
             dir_to_tar = '/'.join(dir_to_build.split('/')[:-1]) + '/brew/'
             if not path.exists(dir_to_tar):
                 os.makedirs(dir_to_tar)
-            tar_path = dir_to_tar + now.strftime("servo-%Y-%m-%d.tar.gz")
+            tar_path = dir_to_tar + "servo.tar.gz"
             if path.exists(dir_to_brew):
                 print("Cleaning up from previous packaging")
                 delete(dir_to_brew)
@@ -316,9 +312,7 @@ class PackageCommands(CommandBase):
             os.close(runservo)
 
             print("Creating tarball")
-            time = datetime.utcnow().replace(microsecond=0).isoformat()
-            time = time.replace(':', "-")
-            tar_path = path.join(self.get_target_dir(), time + '-servo-tech-demo.tar.gz')
+            tar_path = path.join(self.get_target_dir(), 'servo-tech-demo.tar.gz')
 
             archive_deterministically(dir_to_temp, tar_path, prepend_path='servo/')
 


### PR DESCRIPTION
to CI upload, swaps semicolons for dashes

<!-- Please describe your changes on the following line: -->
This fixes #12128 by moving the datetimestamping responsibility from the python packaging script to the CI build shell script.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12128 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they are part of CI build

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14058)
<!-- Reviewable:end -->
