### PR TITLE
Don't double-apply transform and other effect styles for text (fixes #11300)

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1924,13 +1924,15 @@ pub fn modify_style_for_outer_inline_block_fragment(style: &mut Arc<ComputedValu
     box_style.position = longhands::position::computed_value::T::static_
 }
 
-/// Adjusts the `position` and `padding` properties as necessary to account for text.
+/// Adjusts properties as necessary to account for text.
 ///
 /// Text is never directly relatively positioned; it's always contained within an element that is
 /// itself relatively positioned.
 #[cfg(feature = "servo")]
 #[inline]
 pub fn modify_style_for_text(style: &mut Arc<ComputedValues>) {
+    use computed_values::transform_style;
+
     if style.box_.position == longhands::position::computed_value::T::relative {
         // We leave the `position` property set to `relative` so that we'll still establish a
         // containing block if needed. But we reset all position offsets to `auto`.
@@ -1954,10 +1956,16 @@ pub fn modify_style_for_text(style: &mut Arc<ComputedValues>) {
         padding.padding_left = computed::LengthOrPercentage::Length(Au(0));
     }
 
-    if style.effects.opacity != 1.0 {
+    if style.get_used_transform_style() != transform_style::T::auto {
         let mut style = Arc::make_mut(style);
         let mut effects = Arc::make_mut(&mut style.effects);
+
         effects.opacity = 1.0;
+        effects.clip = longhands::clip::get_initial_value();
+        effects.transform = longhands::transform::get_initial_value();
+        effects.filter = longhands::filter::get_initial_value();
+        effects.perspective = computed::LengthOrNone::None;
+        effects.transform_style = transform_style::T::auto;
     }
 }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5460,16 +5460,16 @@
             "url": "/_mozilla/css/text_justify_none_a.html"
           }
         ],
-        "css/text_node_opacity.html": [
+        "css/text_node_effects.html": [
           {
-            "path": "css/text_node_opacity.html",
+            "path": "css/text_node_effects.html",
             "references": [
               [
-                "/_mozilla/css/text_node_opacity_ref.html",
+                "/_mozilla/css/text_node_effects_ref.html",
                 "=="
               ]
             ],
-            "url": "/_mozilla/css/text_node_opacity.html"
+            "url": "/_mozilla/css/text_node_effects.html"
           }
         ],
         "css/text_overflow_a.html": [
@@ -20310,16 +20310,16 @@
           "url": "/_mozilla/css/text_justify_none_a.html"
         }
       ],
-      "css/text_node_opacity.html": [
+      "css/text_node_effects.html": [
         {
-          "path": "css/text_node_opacity.html",
+          "path": "css/text_node_effects.html",
           "references": [
             [
-              "/_mozilla/css/text_node_opacity_ref.html",
+              "/_mozilla/css/text_node_effects_ref.html",
               "=="
             ]
           ],
-          "url": "/_mozilla/css/text_node_opacity.html"
+          "url": "/_mozilla/css/text_node_effects.html"
         }
       ],
       "css/text_overflow_a.html": [

--- a/tests/wpt/mozilla/tests/css/text_node_effects.html
+++ b/tests/wpt/mozilla/tests/css/text_node_effects.html
@@ -1,21 +1,22 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <link rel='match' href='text_node_opacity_ref.html'>
+        <link rel='match' href='text_node_effects_ref.html'>
         <link rel="stylesheet" type="text/css" href="css/ahem.css">
         <style type="text/css">
             html, body {
-                margin: 0;
+                margin: 20px;
                 font-size: 100px;
                 line-height: 1;
             }
             div {
-                opacity: 0.5;
+                display: inline-block;
                 color: green;
             }
         </style>
     </head>
     <body>
-        <div>A</div>
+      <div style="opacity: 0.5;">A</div><!--
+      --><div style="transform: rotateZ(45deg);">A</div>
     </body>
 </html>

--- a/tests/wpt/mozilla/tests/css/text_node_effects_ref.html
+++ b/tests/wpt/mozilla/tests/css/text_node_effects_ref.html
@@ -3,18 +3,18 @@
     <head>
         <style type="text/css">
             html, body {
-                margin: 0;
+                margin: 20px;
             }
             div {
-                position: absolute;
                 width: 100px;
                 height: 100px;
-                opacity: 0.5;
+                display: inline-block;
                 background-color: green;
             }
         </style>
     </head>
     <body>
-        <div></div>
+      <div style="opacity: 0.5;"></div><!--
+      --><div style="transform: rotateZ(45deg);"></div>
     </body>
 </html>


### PR DESCRIPTION
Rebase of #11421.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14078)
<!-- Reviewable:end -->
