### PR TITLE
Add redirect_mode to RequestInit

### DIFF
--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -268,6 +268,7 @@ impl Request {
         };
         req.referrer_policy.set(init.referrer_policy);
         req.pipeline_id.set(init.pipeline_id);
+        req.redirect_mode.set(init.redirect_mode);
         req
     }
 

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -81,7 +81,7 @@ pub enum CacheMode {
 }
 
 /// [Redirect mode](https://fetch.spec.whatwg.org/#concept-request-redirect-mode)
-#[derive(Copy, Clone, PartialEq, HeapSizeOf)]
+#[derive(Copy, Clone, PartialEq, Serialize, Deserialize, HeapSizeOf)]
 pub enum RedirectMode {
     Follow,
     Error,
@@ -137,6 +137,7 @@ pub struct RequestInit {
     pub referrer_url: Option<Url>,
     pub referrer_policy: Option<ReferrerPolicy>,
     pub pipeline_id: Option<PipelineId>,
+    pub redirect_mode: RedirectMode,
 }
 
 impl Default for RequestInit {
@@ -158,6 +159,7 @@ impl Default for RequestInit {
             referrer_url: None,
             referrer_policy: None,
             pipeline_id: None,
+            redirect_mode: RedirectMode::Follow,
         }
     }
 }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -61,6 +61,7 @@ fn request_init_from_request(request: NetTraitsRequest) -> NetTraitsRequestInit 
         referrer_url: from_referrer_to_referrer_url(&request),
         referrer_policy: request.referrer_policy.get(),
         pipeline_id: request.pipeline_id.get(),
+        redirect_mode: request.redirect_mode.get(),
     }
 }
 

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-mode-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-mode-worker.html.ini
@@ -1,30 +1,15 @@
 [redirect-mode-worker.html]
   type: testharness
-  [Redirect 301 in "error" mode ]
-    expected: FAIL
-
   [Redirect 301 in "manual" mode ]
-    expected: FAIL
-
-  [Redirect 302 in "error" mode ]
     expected: FAIL
 
   [Redirect 302 in "manual" mode ]
     expected: FAIL
 
-  [Redirect 303 in "error" mode ]
-    expected: FAIL
-
   [Redirect 303 in "manual" mode ]
     expected: FAIL
 
-  [Redirect 307 in "error" mode ]
-    expected: FAIL
-
   [Redirect 307 in "manual" mode ]
-    expected: FAIL
-
-  [Redirect 308 in "error" mode ]
     expected: FAIL
 
   [Redirect 308 in "manual" mode ]

--- a/tests/wpt/metadata/fetch/api/redirect/redirect-mode.html.ini
+++ b/tests/wpt/metadata/fetch/api/redirect/redirect-mode.html.ini
@@ -1,30 +1,15 @@
 [redirect-mode.html]
   type: testharness
-  [Redirect 301 in "error" mode ]
-    expected: FAIL
-
   [Redirect 301 in "manual" mode ]
-    expected: FAIL
-
-  [Redirect 302 in "error" mode ]
     expected: FAIL
 
   [Redirect 302 in "manual" mode ]
     expected: FAIL
 
-  [Redirect 303 in "error" mode ]
-    expected: FAIL
-
   [Redirect 303 in "manual" mode ]
     expected: FAIL
 
-  [Redirect 307 in "error" mode ]
-    expected: FAIL
-
   [Redirect 307 in "manual" mode ]
-    expected: FAIL
-
-  [Redirect 308 in "error" mode ]
     expected: FAIL
 
   [Redirect 308 in "manual" mode ]


### PR DESCRIPTION
This adds support for non-follow redirect modes for `RequestInit`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14018 (github issue number if applicable).
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14083)
<!-- Reviewable:end -->
