### PR TITLE
Remove CollectMemoryReports from compositor (fixes #13735)

### DIFF
--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -105,8 +105,6 @@ pub enum Msg {
     NewFavicon(Url),
     /// <head> tag finished parsing
     HeadParsed,
-    /// Collect memory reports and send them back to the given mem::ReportsChan.
-    CollectMemoryReports(mem::ReportsChan),
     /// A status message to be displayed by the browser chrome.
     Status(Option<String>),
     /// Get Window Informations size and position
@@ -154,7 +152,6 @@ impl Debug for Msg {
             Msg::IsReadyToSaveImageReply(..) => write!(f, "IsReadyToSaveImageReply"),
             Msg::NewFavicon(..) => write!(f, "NewFavicon"),
             Msg::HeadParsed => write!(f, "HeadParsed"),
-            Msg::CollectMemoryReports(..) => write!(f, "CollectMemoryReports"),
             Msg::Status(..) => write!(f, "Status"),
             Msg::GetClientWindow(..) => write!(f, "GetClientWindow"),
             Msg::MoveTo(..) => write!(f, "MoveTo"),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1025,6 +1025,8 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         if self.shutting_down { return; }
         self.shutting_down = true;
 
+        self.mem_profiler_chan.send(mem::ProfilerMsg::Exit);
+
         // TODO: exit before the root frame is initialized?
         debug!("Removing root frame.");
         let root_frame_id = self.root_frame_id;


### PR DESCRIPTION
Remove all of the code in compositor.rs related to:

* sending the RegisterReporter message
* sending the UnregisterReporter message
* the mem_profiler_chan member of IOCompositor
* move the code that sends the ProfilerMsg::Exit message into Constellation::handle_exit instead



---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13735 (github issue number if applicable).

- [ ] There are tests for these changes OR
- [x] These changes do not require tests because _____

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14087)
<!-- Reviewable:end -->
