### PR TITLE
11485 make dom methods taking mut js content unsafe

### DIFF
--- a/components/script/dom/bindings/iterable.rs
+++ b/components/script/dom/bindings/iterable.rs
@@ -85,7 +85,7 @@ impl<T: Reflectable + JSTraceable + Iterable> IterableIterator<T> {
     /// Create a new iterator instance for the provided iterable DOM interface.
     pub fn new(iterable: &T,
                type_: IteratorType,
-               wrap: fn(*mut JSContext, &GlobalScope, Box<IterableIterator<T>>)
+               wrap: unsafe fn(*mut JSContext, &GlobalScope, Box<IterableIterator<T>>)
                      -> Root<Self>) -> Root<Self> {
         let iterator = box IterableIterator {
             reflector: Reflector::new(),

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -16,12 +16,14 @@ use std::ptr;
 pub fn reflect_dom_object<T, U>(
         obj: Box<T>,
         global: &U,
-        wrap_fn: fn(*mut JSContext, &GlobalScope, Box<T>) -> Root<T>)
+        wrap_fn: unsafe fn(*mut JSContext, &GlobalScope, Box<T>) -> Root<T>)
         -> Root<T>
     where T: Reflectable, U: DerivedFrom<GlobalScope>
 {
     let global_scope = global.upcast();
-    wrap_fn(global_scope.get_cx(), global_scope, obj)
+    unsafe {
+        wrap_fn(global_scope.get_cx(), global_scope, obj)
+    }
 }
 
 /// A struct to store a reference to the reflector of a DOM object.

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -41,12 +41,12 @@ impl Crypto {
 impl CryptoMethods for Crypto {
     #[allow(unsafe_code)]
     // https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#Crypto-method-getRandomValues
-    fn GetRandomValues(&self,
+    unsafe fn GetRandomValues(&self,
                        _cx: *mut JSContext,
                        input: *mut JSObject)
                        -> Fallible<NonZero<*mut JSObject>> {
         assert!(!input.is_null());
-        let mut data = match unsafe { array_buffer_view_data::<u8>(input) } {
+        let mut data = match array_buffer_view_data::<u8>(input) {
             Some(data) => data,
             None => {
                 return Err(Error::Type("Argument to Crypto.getRandomValues is not an ArrayBufferView"
@@ -64,7 +64,7 @@ impl CryptoMethods for Crypto {
 
         self.rng.borrow_mut().fill_bytes(&mut data);
 
-        Ok(unsafe { NonZero::new(input) })
+        Ok(NonZero::new(input))
     }
 }
 

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -76,13 +76,15 @@ impl CustomEvent {
 }
 
 impl CustomEventMethods for CustomEvent {
+    #[allow(unsafe_code)]
     // https://dom.spec.whatwg.org/#dom-customevent-detail
-    fn Detail(&self, _cx: *mut JSContext) -> JSVal {
+    unsafe fn Detail(&self, _cx: *mut JSContext) -> JSVal {
         self.detail.get()
     }
 
+    #[allow(unsafe_code)]
     // https://dom.spec.whatwg.org/#dom-customevent-initcustomevent
-    fn InitCustomEvent(&self,
+    unsafe fn InitCustomEvent(&self,
                        _cx: *mut JSContext,
                        type_: DOMString,
                        can_bubble: bool,

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -117,6 +117,7 @@ impl DedicatedWorkerGlobalScope {
         }
     }
 
+    #[allow(unsafe_code)]
     pub fn new(init: WorkerGlobalScopeInit,
                worker_url: Url,
                from_devtools_receiver: Receiver<DevtoolScriptControlMsg>,
@@ -139,7 +140,9 @@ impl DedicatedWorkerGlobalScope {
                                                                   timer_event_chan,
                                                                   timer_event_port,
                                                                   closing);
-        DedicatedWorkerGlobalScopeBinding::Wrap(cx, scope)
+        unsafe {
+            DedicatedWorkerGlobalScopeBinding::Wrap(cx, scope)
+        }
     }
 
     #[allow(unsafe_code)]
@@ -366,8 +369,9 @@ unsafe extern "C" fn interrupt_callback(cx: *mut JSContext) -> bool {
 }
 
 impl DedicatedWorkerGlobalScopeMethods for DedicatedWorkerGlobalScope {
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-dedicatedworkerglobalscope-postmessage
-    fn PostMessage(&self, cx: *mut JSContext, message: HandleValue) -> ErrorResult {
+    unsafe fn PostMessage(&self, cx: *mut JSContext, message: HandleValue) -> ErrorResult {
         let data = try!(StructuredCloneData::write(cx, message));
         let worker = self.worker.borrow().as_ref().unwrap().clone();
         self.parent_sender

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2802,7 +2802,7 @@ impl DocumentMethods for Document {
 
     #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter
-    fn NamedGetter(&self, _cx: *mut JSContext, name: DOMString) -> Option<NonZero<*mut JSObject>> {
+    unsafe fn NamedGetter(&self, _cx: *mut JSContext, name: DOMString) -> Option<NonZero<*mut JSObject>> {
         #[derive(JSTraceable, HeapSizeOf)]
         struct NamedElementFilter {
             name: Atom,
@@ -2870,9 +2870,7 @@ impl DocumentMethods for Document {
                 if elements.peek().is_none() {
                     // TODO: Step 2.
                     // Step 3.
-                    return unsafe {
-                        Some(NonZero::new(first.reflector().get_jsobject().get()))
-                    };
+                    return Some(NonZero::new(first.reflector().get_jsobject().get()));
                 }
             } else {
                 return None;
@@ -2883,9 +2881,7 @@ impl DocumentMethods for Document {
             name: name,
         };
         let collection = HTMLCollection::create(self.window(), root, box filter);
-        unsafe {
-            Some(NonZero::new(collection.reflector().get_jsobject().get()))
-        }
+        Some(NonZero::new(collection.reflector().get_jsobject().get()))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tree-accessors:supported-property-names

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -130,8 +130,9 @@ impl ErrorEventMethods for ErrorEvent {
         self.filename.borrow().clone()
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-errorevent-error
-    fn Error(&self, _cx: *mut JSContext) -> JSVal {
+    unsafe fn Error(&self, _cx: *mut JSContext) -> JSVal {
         self.error.get()
     }
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -140,6 +140,7 @@ pub enum CompiledEventListener {
 }
 
 impl CompiledEventListener {
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#the-event-handler-processing-algorithm
     pub fn call_or_handle_event<T: Reflectable>(&self,
                                                 object: &T,
@@ -155,7 +156,7 @@ impl CompiledEventListener {
                     CommonEventHandler::ErrorEventHandler(ref handler) => {
                         if let Some(event) = event.downcast::<ErrorEvent>() {
                             let cx = object.global().get_cx();
-                            rooted!(in(cx) let error = event.Error(cx));
+                            rooted!(in(cx) let error = unsafe { event.Error(cx) });
                             let return_value = handler.Call_(object,
                                                              EventOrString::String(event.Message()),
                                                              Some(event.Filename()),

--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -74,8 +74,9 @@ impl ExtendableMessageEvent {
 }
 
 impl ExtendableMessageEventMethods for ExtendableMessageEvent {
+    #[allow(unsafe_code)]
     // https://w3c.github.io/ServiceWorker/#extendablemessage-event-data-attribute
-    fn Data(&self, _cx: *mut JSContext) -> JSVal {
+    unsafe fn Data(&self, _cx: *mut JSContext) -> JSVal {
         self.data.get()
     }
 

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -339,14 +339,12 @@ impl FileReaderMethods for FileReader {
 
     #[allow(unsafe_code)]
     // https://w3c.github.io/FileAPI/#dfn-result
-    fn GetResult(&self, _: *mut JSContext) -> Option<StringOrObject> {
+    unsafe fn GetResult(&self, _: *mut JSContext) -> Option<StringOrObject> {
         self.result.borrow().as_ref().map(|r| match *r {
             FileReaderResult::String(ref string) =>
                 StringOrObject::String(string.clone()),
             FileReaderResult::ArrayBuffer(ref arr_buffer) => {
-                unsafe {
-                    StringOrObject::Object((*arr_buffer.ptr.get()).to_object())
-                }
+                StringOrObject::Object((*arr_buffer.ptr.get()).to_object())
             }
         })
     }

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -235,8 +235,9 @@ impl HTMLCanvasElementMethods for HTMLCanvasElement {
     // https://html.spec.whatwg.org/multipage/#dom-canvas-height
     make_uint_setter!(SetHeight, "height", DEFAULT_HEIGHT);
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-canvas-getcontext
-    fn GetContext(&self,
+    unsafe fn GetContext(&self,
                   cx: *mut JSContext,
                   id: DOMString,
                   attributes: Vec<HandleValue>)
@@ -254,8 +255,9 @@ impl HTMLCanvasElementMethods for HTMLCanvasElement {
         }
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-canvas-todataurl
-    fn ToDataURL(&self,
+    unsafe fn ToDataURL(&self,
                  _context: *mut JSContext,
                  _mime_type: Option<DOMString>,
                  _arguments: Vec<HandleValue>) -> Fallible<DOMString> {

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -85,8 +85,8 @@ impl ImageDataMethods for ImageData {
 
     #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-imagedata-data
-    fn Data(&self, _: *mut JSContext) -> NonZero<*mut JSObject> {
+    unsafe fn Data(&self, _: *mut JSContext) -> NonZero<*mut JSObject> {
         assert!(!self.data.get().is_null());
-        unsafe { NonZero::new(self.data.get()) }
+        NonZero::new(self.data.get())
     }
 }

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -95,8 +95,9 @@ impl MessageEvent {
 }
 
 impl MessageEventMethods for MessageEvent {
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-messageevent-data
-    fn Data(&self, _cx: *mut JSContext) -> JSVal {
+    unsafe fn Data(&self, _cx: *mut JSContext) -> JSVal {
         self.data.get()
     }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1364,7 +1364,7 @@ impl Node {
     pub fn reflect_node<N>(
             node: Box<N>,
             document: &Document,
-            wrap_fn: extern "Rust" fn(*mut JSContext, &GlobalScope, Box<N>) -> Root<N>)
+            wrap_fn: unsafe extern "Rust" fn(*mut JSContext, &GlobalScope, Box<N>) -> Root<N>)
             -> Root<N>
         where N: DerivedFrom<Node> + Reflectable
     {

--- a/components/script/dom/popstateevent.rs
+++ b/components/script/dom/popstateevent.rs
@@ -67,8 +67,9 @@ impl PopStateEvent {
 }
 
 impl PopStateEventMethods for PopStateEvent {
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-popstateevent-state
-    fn State(&self, _cx: *mut JSContext) -> JSVal {
+    unsafe fn State(&self, _cx: *mut JSContext) -> JSVal {
         self.state.get()
     }
 

--- a/components/script/dom/serviceworker.rs
+++ b/components/script/dom/serviceworker.rs
@@ -80,8 +80,9 @@ impl ServiceWorkerMethods for ServiceWorker {
         USVString(self.script_url.borrow().clone())
     }
 
+    #[allow(unsafe_code)]
     // https://w3c.github.io/ServiceWorker/#service-worker-postmessage
-    fn PostMessage(&self, cx: *mut JSContext, message: HandleValue) -> ErrorResult {
+    unsafe fn PostMessage(&self, cx: *mut JSContext, message: HandleValue) -> ErrorResult {
         // Step 1
         if let ServiceWorkerState::Redundant = self.state.get() {
             return Err(Error::InvalidState);

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -110,6 +110,7 @@ impl ServiceWorkerGlobalScope {
         }
     }
 
+    #[allow(unsafe_code)]
     pub fn new(init: WorkerGlobalScopeInit,
                worker_url: Url,
                from_devtools_receiver: Receiver<DevtoolScriptControlMsg>,
@@ -132,7 +133,9 @@ impl ServiceWorkerGlobalScope {
                                                                   timer_event_port,
                                                                   swmanager_sender,
                                                                   scope_url);
-        ServiceWorkerGlobalScopeBinding::Wrap(cx, scope)
+        unsafe {
+            ServiceWorkerGlobalScopeBinding::Wrap(cx, scope)
+        }
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -149,24 +149,23 @@ impl TestBindingMethods for TestBinding {
     }
     fn SetUnion9Attribute(&self, _: ByteStringOrLong) {}
     #[allow(unsafe_code)]
-    fn ArrayAttribute(&self, cx: *mut JSContext) -> NonZero<*mut JSObject> {
-        unsafe {
-            rooted!(in(cx) let array = JS_NewUint8ClampedArray(cx, 16));
-            assert!(!array.is_null());
-            NonZero::new(array.get())
-        }
+    unsafe fn ArrayAttribute(&self, cx: *mut JSContext) -> NonZero<*mut JSObject> {
+        rooted!(in(cx) let array = JS_NewUint8ClampedArray(cx, 16));
+        assert!(!array.is_null());
+        NonZero::new(array.get())
     }
-    fn AnyAttribute(&self, _: *mut JSContext) -> JSVal { NullValue() }
-    fn SetAnyAttribute(&self, _: *mut JSContext, _: HandleValue) {}
     #[allow(unsafe_code)]
-    fn ObjectAttribute(&self, cx: *mut JSContext) -> NonZero<*mut JSObject> {
-        unsafe {
-            rooted!(in(cx) let obj = JS_NewPlainObject(cx));
-            assert!(!obj.is_null());
-            NonZero::new(obj.get())
-        }
+    unsafe fn AnyAttribute(&self, _: *mut JSContext) -> JSVal { NullValue() }
+    #[allow(unsafe_code)]
+    unsafe fn SetAnyAttribute(&self, _: *mut JSContext, _: HandleValue) {}
+    #[allow(unsafe_code)]
+    unsafe fn ObjectAttribute(&self, cx: *mut JSContext) -> NonZero<*mut JSObject> {
+        rooted!(in(cx) let obj = JS_NewPlainObject(cx));
+        assert!(!obj.is_null());
+        NonZero::new(obj.get())
     }
-    fn SetObjectAttribute(&self, _: *mut JSContext, _: *mut JSObject) {}
+    #[allow(unsafe_code)]
+    unsafe fn SetObjectAttribute(&self, _: *mut JSContext, _: *mut JSObject) {}
 
     fn GetBooleanAttributeNullable(&self) -> Option<bool> { Some(false) }
     fn SetBooleanAttributeNullable(&self, _: Option<bool>) {}
@@ -218,8 +217,10 @@ impl TestBindingMethods for TestBinding {
     fn SetInterfaceAttributeWeak(&self, url: Option<&URL>) {
         self.url.set(url);
     }
-    fn GetObjectAttributeNullable(&self, _: *mut JSContext) -> Option<NonZero<*mut JSObject>> { None }
-    fn SetObjectAttributeNullable(&self, _: *mut JSContext, _: *mut JSObject) {}
+    #[allow(unsafe_code)]
+    unsafe fn GetObjectAttributeNullable(&self, _: *mut JSContext) -> Option<NonZero<*mut JSObject>> { None }
+    #[allow(unsafe_code)]
+    unsafe fn SetObjectAttributeNullable(&self, _: *mut JSContext, _: *mut JSObject) {}
     fn GetUnionAttributeNullable(&self) -> Option<HTMLElementOrLong> {
         Some(HTMLElementOrLong::Long(0))
     }
@@ -266,8 +267,10 @@ impl TestBindingMethods for TestBinding {
     fn ReceiveInterface(&self) -> Root<Blob> {
         Blob::new(&self.global(), BlobImpl::new_from_bytes(vec![]), "".to_owned())
     }
-    fn ReceiveAny(&self, _: *mut JSContext) -> JSVal { NullValue() }
-    fn ReceiveObject(&self, cx: *mut JSContext) -> NonZero<*mut JSObject> {
+    #[allow(unsafe_code)]
+    unsafe fn ReceiveAny(&self, _: *mut JSContext) -> JSVal { NullValue() }
+    #[allow(unsafe_code)]
+    unsafe fn ReceiveObject(&self, cx: *mut JSContext) -> NonZero<*mut JSObject> {
         self.ObjectAttribute(cx)
     }
     fn ReceiveUnion(&self) -> HTMLElementOrLong { HTMLElementOrLong::Long(0) }
@@ -310,7 +313,8 @@ impl TestBindingMethods for TestBinding {
     fn ReceiveNullableInterface(&self) -> Option<Root<Blob>> {
         Some(Blob::new(&self.global(), BlobImpl::new_from_bytes(vec![]), "".to_owned()))
     }
-    fn ReceiveNullableObject(&self, cx: *mut JSContext) -> Option<NonZero<*mut JSObject>> {
+    #[allow(unsafe_code)]
+    unsafe fn ReceiveNullableObject(&self, cx: *mut JSContext) -> Option<NonZero<*mut JSObject>> {
         self.GetObjectAttributeNullable(cx)
     }
     fn ReceiveNullableUnion(&self) -> Option<HTMLElementOrLong> {
@@ -432,8 +436,10 @@ impl TestBindingMethods for TestBinding {
     fn PassUnion8(&self, _: ByteStringSequenceOrLong) {}
     fn PassUnionWithTypedef(&self, _: DocumentOrTestTypedef) {}
     fn PassUnionWithTypedef2(&self, _: LongSequenceOrTestTypedef) {}
-    fn PassAny(&self, _: *mut JSContext, _: HandleValue) {}
-    fn PassObject(&self, _: *mut JSContext, _: *mut JSObject) {}
+    #[allow(unsafe_code)]
+    unsafe fn PassAny(&self, _: *mut JSContext, _: HandleValue) {}
+    #[allow(unsafe_code)]
+    unsafe fn PassObject(&self, _: *mut JSContext, _: *mut JSObject) {}
     fn PassCallbackFunction(&self, _: Rc<Function>) {}
     fn PassCallbackInterface(&self, _: Rc<EventListener>) {}
     fn PassSequence(&self, _: Vec<i32>) {}
@@ -458,7 +464,8 @@ impl TestBindingMethods for TestBinding {
     fn PassNullableByteString(&self, _: Option<ByteString>) {}
     // fn PassNullableEnum(self, _: Option<TestEnum>) {}
     fn PassNullableInterface(&self, _: Option<&Blob>) {}
-    fn PassNullableObject(&self, _: *mut JSContext, _: *mut JSObject) {}
+    #[allow(unsafe_code)]
+    unsafe fn PassNullableObject(&self, _: *mut JSContext, _: *mut JSObject) {}
     fn PassNullableUnion(&self, _: Option<HTMLElementOrLong>) {}
     fn PassNullableUnion2(&self, _: Option<EventOrString>) {}
     fn PassNullableUnion3(&self, _: Option<StringOrLongSequence>) {}
@@ -493,8 +500,10 @@ impl TestBindingMethods for TestBinding {
     fn PassOptionalUnion4(&self, _: Option<LongSequenceOrBoolean>) {}
     fn PassOptionalUnion5(&self, _: Option<UnsignedLongOrBoolean>) {}
     fn PassOptionalUnion6(&self, _: Option<ByteStringOrLong>) {}
-    fn PassOptionalAny(&self, _: *mut JSContext, _: HandleValue) {}
-    fn PassOptionalObject(&self, _: *mut JSContext, _: Option<*mut JSObject>) {}
+    #[allow(unsafe_code)]
+    unsafe fn PassOptionalAny(&self, _: *mut JSContext, _: HandleValue) {}
+    #[allow(unsafe_code)]
+    unsafe fn PassOptionalObject(&self, _: *mut JSContext, _: Option<*mut JSObject>) {}
     fn PassOptionalCallbackFunction(&self, _: Option<Rc<Function>>) {}
     fn PassOptionalCallbackInterface(&self, _: Option<Rc<EventListener>>) {}
     fn PassOptionalSequence(&self, _: Option<Vec<i32>>) {}
@@ -517,7 +526,8 @@ impl TestBindingMethods for TestBinding {
     fn PassOptionalNullableByteString(&self, _: Option<Option<ByteString>>) {}
     // fn PassOptionalNullableEnum(self, _: Option<Option<TestEnum>>) {}
     fn PassOptionalNullableInterface(&self, _: Option<Option<&Blob>>) {}
-    fn PassOptionalNullableObject(&self, _: *mut JSContext, _: Option<*mut JSObject>) {}
+    #[allow(unsafe_code)]
+    unsafe fn PassOptionalNullableObject(&self, _: *mut JSContext, _: Option<*mut JSObject>) {}
     fn PassOptionalNullableUnion(&self, _: Option<Option<HTMLElementOrLong>>) {}
     fn PassOptionalNullableUnion2(&self, _: Option<Option<EventOrString>>) {}
     fn PassOptionalNullableUnion3(&self, _: Option<Option<StringOrLongSequence>>) {}
@@ -560,12 +570,14 @@ impl TestBindingMethods for TestBinding {
     fn PassOptionalNullableByteStringWithDefault(&self, _: Option<ByteString>) {}
     // fn PassOptionalNullableEnumWithDefault(self, _: Option<TestEnum>) {}
     fn PassOptionalNullableInterfaceWithDefault(&self, _: Option<&Blob>) {}
-    fn PassOptionalNullableObjectWithDefault(&self, _: *mut JSContext, _: *mut JSObject) {}
+    #[allow(unsafe_code)]
+    unsafe fn PassOptionalNullableObjectWithDefault(&self, _: *mut JSContext, _: *mut JSObject) {}
     fn PassOptionalNullableUnionWithDefault(&self, _: Option<HTMLElementOrLong>) {}
     fn PassOptionalNullableUnion2WithDefault(&self, _: Option<EventOrString>) {}
     // fn PassOptionalNullableCallbackFunctionWithDefault(self, _: Option<Function>) {}
     fn PassOptionalNullableCallbackInterfaceWithDefault(&self, _: Option<Rc<EventListener>>) {}
-    fn PassOptionalAnyWithDefault(&self, _: *mut JSContext, _: HandleValue) {}
+    #[allow(unsafe_code)]
+    unsafe fn PassOptionalAnyWithDefault(&self, _: *mut JSContext, _: HandleValue) {}
 
     fn PassOptionalNullableBooleanWithNonNullDefault(&self, _: Option<bool>) {}
     fn PassOptionalNullableByteWithNonNullDefault(&self, _: Option<i8>) {}
@@ -610,8 +622,10 @@ impl TestBindingMethods for TestBinding {
     fn PassVariadicUnion5(&self, _: Vec<StringOrUnsignedLong>) {}
     fn PassVariadicUnion6(&self, _: Vec<UnsignedLongOrBoolean>) {}
     fn PassVariadicUnion7(&self, _: Vec<ByteStringOrLong>) {}
-    fn PassVariadicAny(&self, _: *mut JSContext, _: Vec<HandleValue>) {}
-    fn PassVariadicObject(&self, _: *mut JSContext, _: Vec<*mut JSObject>) {}
+    #[allow(unsafe_code)]
+    unsafe fn PassVariadicAny(&self, _: *mut JSContext, _: Vec<HandleValue>) {}
+    #[allow(unsafe_code)]
+    unsafe fn PassVariadicObject(&self, _: *mut JSContext, _: Vec<*mut JSObject>) {}
     fn BooleanMozPreference(&self, pref_name: DOMString) -> bool {
         PREFS.get(pref_name.as_ref()).as_boolean().unwrap_or(false)
     }
@@ -654,20 +668,24 @@ impl TestBindingMethods for TestBinding {
     fn ReceiveAnyMozMap(&self) -> MozMap<JSVal> { MozMap::new() }
 
     #[allow(unrooted_must_root)]
-    fn ReturnResolvedPromise(&self, cx: *mut JSContext, v: HandleValue) -> Fallible<Rc<Promise>> {
+    #[allow(unsafe_code)]
+    unsafe fn ReturnResolvedPromise(&self, cx: *mut JSContext, v: HandleValue) -> Fallible<Rc<Promise>> {
         Promise::Resolve(&self.global(), cx, v)
     }
 
     #[allow(unrooted_must_root)]
-    fn ReturnRejectedPromise(&self, cx: *mut JSContext, v: HandleValue) -> Fallible<Rc<Promise>> {
+    #[allow(unsafe_code)]
+    unsafe fn ReturnRejectedPromise(&self, cx: *mut JSContext, v: HandleValue) -> Fallible<Rc<Promise>> {
         Promise::Reject(&self.global(), cx, v)
     }
 
-    fn PromiseResolveNative(&self, cx: *mut JSContext, p: &Promise, v: HandleValue) {
+    #[allow(unsafe_code)]
+    unsafe fn PromiseResolveNative(&self, cx: *mut JSContext, p: &Promise, v: HandleValue) {
         p.resolve(cx, v);
     }
 
-    fn PromiseRejectNative(&self, cx: *mut JSContext, p: &Promise, v: HandleValue) {
+    #[allow(unsafe_code)]
+    unsafe fn PromiseRejectNative(&self, cx: *mut JSContext, p: &Promise, v: HandleValue) {
         p.reject(cx, v);
     }
 

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -78,14 +78,14 @@ impl TextDecoderMethods for TextDecoder {
 
     #[allow(unsafe_code)]
     // https://encoding.spec.whatwg.org/#dom-textdecoder-decode
-    fn Decode(&self, _cx: *mut JSContext, input: Option<*mut JSObject>)
+    unsafe fn Decode(&self, _cx: *mut JSContext, input: Option<*mut JSObject>)
               -> Fallible<USVString> {
         let input = match input {
             Some(input) => input,
             None => return Ok(USVString("".to_owned())),
         };
 
-        let data = match unsafe { array_buffer_view_data::<u8>(input) } {
+        let data = match array_buffer_view_data::<u8>(input) {
             Some(data) => data,
             None => {
                 return Err(Error::Type("Argument to TextDecoder.decode is not an ArrayBufferView".to_owned()));

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -50,17 +50,15 @@ impl TextEncoderMethods for TextEncoder {
 
     #[allow(unsafe_code)]
     // https://encoding.spec.whatwg.org/#dom-textencoder-encode
-    fn Encode(&self, cx: *mut JSContext, input: USVString) -> NonZero<*mut JSObject> {
-        unsafe {
-            let encoded = UTF_8.encode(&input.0, EncoderTrap::Strict).unwrap();
-            let length = encoded.len() as u32;
-            rooted!(in(cx) let js_object = JS_NewUint8Array(cx, length));
-            assert!(!js_object.is_null());
-            let mut is_shared = false;
-            let js_object_data: *mut uint8_t = JS_GetUint8ArrayData(js_object.get(), &mut is_shared, ptr::null());
-            assert!(!is_shared);
-            ptr::copy_nonoverlapping(encoded.as_ptr(), js_object_data, length as usize);
-            NonZero::new(js_object.get())
-        }
+    unsafe fn Encode(&self, cx: *mut JSContext, input: USVString) -> NonZero<*mut JSObject> {
+        let encoded = UTF_8.encode(&input.0, EncoderTrap::Strict).unwrap();
+        let length = encoded.len() as u32;
+        rooted!(in(cx) let js_object = JS_NewUint8Array(cx, length));
+        assert!(!js_object.is_null());
+        let mut is_shared = false;
+        let js_object_data: *mut uint8_t = JS_GetUint8ArrayData(js_object.get(), &mut is_shared, ptr::null());
+        assert!(!is_shared);
+        ptr::copy_nonoverlapping(encoded.as_ptr(), js_object_data, length as usize);
+        NonZero::new(js_object.get())
     }
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -94,9 +94,7 @@ macro_rules! object_binding_to_js_or_null {
         {
             rooted!(in($cx) let mut rval = NullValue());
             if let Some(bound_object) = $binding.get() {
-                unsafe {
-                    bound_object.to_jsval($cx, rval.handle_mut());
-                }
+                bound_object.to_jsval($cx, rval.handle_mut());
             }
             rval.get()
         }
@@ -624,8 +622,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         receiver.recv().unwrap()
     }
 
+    #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
-    fn GetBufferParameter(&self, _cx: *mut JSContext, target: u32, parameter: u32) -> JSVal {
+    unsafe fn GetBufferParameter(&self, _cx: *mut JSContext, target: u32, parameter: u32) -> JSVal {
         let (sender, receiver) = ipc::channel().unwrap();
         self.ipc_renderer
             .send(CanvasMsg::WebGL(WebGLCommand::GetBufferParameter(target, parameter, sender)))
@@ -642,7 +641,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
-    fn GetParameter(&self, cx: *mut JSContext, parameter: u32) -> JSVal {
+    unsafe fn GetParameter(&self, cx: *mut JSContext, parameter: u32) -> JSVal {
         // Handle the GL_*_BINDING without going all the way
         // to the GL, since we would just need to map back from GL's
         // returned ID to the WebGL* object we're tracking.
@@ -693,9 +692,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             WebGLParameter::FloatArray(_) => panic!("Parameter should not be float array"),
             WebGLParameter::String(val) => {
                 rooted!(in(cx) let mut rval = UndefinedValue());
-                unsafe {
-                    val.to_jsval(cx, rval.handle_mut());
-                }
+                val.to_jsval(cx, rval.handle_mut());
                 rval.get()
             }
             WebGLParameter::Invalid => NullValue(),
@@ -748,8 +745,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         Some(vec![])
     }
 
+    #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14
-    fn GetExtension(&self, _cx: *mut JSContext, _name: DOMString)
+    unsafe fn GetExtension(&self, _cx: *mut JSContext, _name: DOMString)
                     -> Option<NonZero<*mut JSObject>> {
         None
     }
@@ -927,17 +925,15 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
-    fn BufferData(&self, _cx: *mut JSContext, target: u32, data: *mut JSObject, usage: u32) -> Fallible<()> {
+    unsafe fn BufferData(&self, _cx: *mut JSContext, target: u32, data: *mut JSObject, usage: u32) -> Fallible<()> {
         if data.is_null() {
             return Ok(self.webgl_error(InvalidValue));
         }
 
-        let data_vec = unsafe {
-            match array_buffer_to_vec::<u8>(data) {
-                Some(data) => data,
-                // Not an ArrayBuffer object, maybe an ArrayBufferView?
-                None => try!(fallible_array_buffer_view_to_vec::<u8>(data)),
-            }
+        let data_vec = match array_buffer_to_vec::<u8>(data) {
+            Some(data) => data,
+            // Not an ArrayBuffer object, maybe an ArrayBufferView?
+            None => try!(fallible_array_buffer_view_to_vec::<u8>(data)),
         };
 
         let bound_buffer = match target {
@@ -965,17 +961,15 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
-    fn BufferSubData(&self, _cx: *mut JSContext, target: u32, offset: i64, data: *mut JSObject) -> Fallible<()> {
+    unsafe fn BufferSubData(&self, _cx: *mut JSContext, target: u32, offset: i64, data: *mut JSObject) -> Fallible<()> {
         if data.is_null() {
             return Ok(self.webgl_error(InvalidValue));
         }
 
-        let data_vec = unsafe {
-            match array_buffer_to_vec::<u8>(data) {
-                Some(data) => data,
-                // Not an ArrayBuffer object, maybe an ArrayBufferView?
-                None => try!(fallible_array_buffer_view_to_vec::<u8>(data)),
-            }
+        let data_vec = match array_buffer_to_vec::<u8>(data) {
+            Some(data) => data,
+            // Not an ArrayBuffer object, maybe an ArrayBufferView?
+            None => try!(fallible_array_buffer_view_to_vec::<u8>(data)),
         };
 
         let bound_buffer = match target {
@@ -1005,9 +999,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
-    fn CompressedTexImage2D(&self, _cx: *mut JSContext, _target: u32, _level: i32, _internal_format: u32,
+    unsafe fn CompressedTexImage2D(&self, _cx: *mut JSContext, _target: u32, _level: i32, _internal_format: u32,
                             _width: i32, _height: i32, _border: i32, pixels: *mut JSObject) -> Fallible<()> {
-        let _data = try!(unsafe { fallible_array_buffer_view_to_vec::<u8>(pixels) });
+        let _data = try!(fallible_array_buffer_view_to_vec::<u8>(pixels) );
         // FIXME: No compressed texture format is currently supported, so error out as per
         // https://www.khronos.org/registry/webgl/specs/latest/1.0/#COMPRESSED_TEXTURE_SUPPORT
         self.webgl_error(InvalidEnum);
@@ -1016,10 +1010,10 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
-    fn CompressedTexSubImage2D(&self, _cx: *mut JSContext, _target: u32, _level: i32,
+    unsafe fn CompressedTexSubImage2D(&self, _cx: *mut JSContext, _target: u32, _level: i32,
                                _xoffset: i32, _yoffset: i32, _width: i32, _height: i32,
                                _format: u32, pixels: *mut JSObject) -> Fallible<()> {
-        let _data = try!(unsafe { fallible_array_buffer_view_to_vec::<u8>(pixels) });
+        let _data = try!(fallible_array_buffer_view_to_vec::<u8>(pixels));
         // FIXME: No compressed texture format is currently supported, so error out as per
         // https://www.khronos.org/registry/webgl/specs/latest/1.0/#COMPRESSED_TEXTURE_SUPPORT
         self.webgl_error(InvalidEnum);
@@ -1568,8 +1562,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         }
     }
 
+    #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
-    fn GetProgramParameter(&self, _: *mut JSContext, program: Option<&WebGLProgram>, param_id: u32) -> JSVal {
+    unsafe fn GetProgramParameter(&self, _: *mut JSContext, program: Option<&WebGLProgram>, param_id: u32) -> JSVal {
         if let Some(program) = program {
             match handle_potential_webgl_error!(self, program.parameter(param_id), WebGLParameter::Invalid) {
                 WebGLParameter::Int(val) => Int32Value(val),
@@ -1591,8 +1586,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         shader.and_then(|s| s.info_log()).map(DOMString::from)
     }
 
+    #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
-    fn GetShaderParameter(&self, _: *mut JSContext, shader: Option<&WebGLShader>, param_id: u32) -> JSVal {
+    unsafe fn GetShaderParameter(&self, _: *mut JSContext, shader: Option<&WebGLShader>, param_id: u32) -> JSVal {
         if let Some(shader) = shader {
             match handle_potential_webgl_error!(self, shader.parameter(param_id), WebGLParameter::Invalid) {
                 WebGLParameter::Int(val) => Int32Value(val),
@@ -1621,14 +1617,12 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
-    fn GetVertexAttrib(&self, cx: *mut JSContext, index: u32, pname: u32) -> JSVal {
+    unsafe fn GetVertexAttrib(&self, cx: *mut JSContext, index: u32, pname: u32) -> JSVal {
         if index == 0 && pname == constants::CURRENT_VERTEX_ATTRIB {
             rooted!(in(cx) let mut result = UndefinedValue());
             let (x, y, z, w) = self.current_vertex_attrib_0.get();
             let attrib = vec![x, y, z, w];
-            unsafe {
-                attrib.to_jsval(cx, result.handle_mut());
-            }
+            attrib.to_jsval(cx, result.handle_mut());
             return result.get()
         }
 
@@ -1642,9 +1636,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             WebGLParameter::Float(_) => panic!("Vertex attrib should not be float"),
             WebGLParameter::FloatArray(val) => {
                 rooted!(in(cx) let mut result = UndefinedValue());
-                unsafe {
-                    val.to_jsval(cx, result.handle_mut());
-                }
+                val.to_jsval(cx, result.handle_mut());
                 result.get()
             }
             WebGLParameter::Invalid => NullValue(),
@@ -1787,13 +1779,13 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12
-    fn ReadPixels(&self, _cx: *mut JSContext, x: i32, y: i32, width: i32, height: i32,
+    unsafe fn ReadPixels(&self, _cx: *mut JSContext, x: i32, y: i32, width: i32, height: i32,
                   format: u32, pixel_type: u32, pixels: *mut JSObject) -> Fallible<()> {
         if pixels.is_null() {
             return Ok(self.webgl_error(InvalidValue));
         }
 
-        let mut data = match unsafe { array_buffer_view_data::<u8>(pixels) } {
+        let mut data = match { array_buffer_view_data::<u8>(pixels) } {
             Some(data) => data,
             None => return Err(Error::Type("Not an ArrayBufferView".to_owned())),
         };
@@ -1802,7 +1794,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             return Ok(());
         }
 
-        match unsafe { JS_GetArrayBufferViewType(pixels) } {
+        match { JS_GetArrayBufferViewType(pixels) } {
             Type::Uint8 => (),
             _ => return Ok(self.webgl_error(InvalidOperation)),
         }
@@ -2035,12 +2027,12 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn Uniform1iv(&self,
+    unsafe fn Uniform1iv(&self,
                   cx: *mut JSContext,
                   uniform: Option<&WebGLUniformLocation>,
                   data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<i32>(cx, data, ConversionBehavior::Default) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<i32>(cx, data, ConversionBehavior::Default));
 
         if self.validate_uniform_parameters(uniform, UniformSetterType::Int, &data_vec) {
             self.ipc_renderer
@@ -2053,12 +2045,12 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn Uniform1fv(&self,
+    unsafe fn Uniform1fv(&self,
                   cx: *mut JSContext,
                   uniform: Option<&WebGLUniformLocation>,
                   data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<f32>(cx, data, ()) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<f32>(cx, data, ()));
 
         if self.validate_uniform_parameters(uniform, UniformSetterType::Float, &data_vec) {
             self.ipc_renderer
@@ -2082,12 +2074,12 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn Uniform2fv(&self,
+    unsafe fn Uniform2fv(&self,
                   cx: *mut JSContext,
                   uniform: Option<&WebGLUniformLocation>,
                   data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<f32>(cx, data, ()) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<f32>(cx, data, ()));
 
         if self.validate_uniform_parameters(uniform,
                                             UniformSetterType::FloatVec2,
@@ -2115,12 +2107,12 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn Uniform2iv(&self,
+    unsafe fn Uniform2iv(&self,
                   cx: *mut JSContext,
                   uniform: Option<&WebGLUniformLocation>,
                   data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<i32>(cx, data, ConversionBehavior::Default) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<i32>(cx, data, ConversionBehavior::Default));
 
         if self.validate_uniform_parameters(uniform,
                                             UniformSetterType::IntVec2,
@@ -2148,12 +2140,12 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn Uniform3fv(&self,
+    unsafe fn Uniform3fv(&self,
                   cx: *mut JSContext,
                   uniform: Option<&WebGLUniformLocation>,
                   data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<f32>(cx, data, ()) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<f32>(cx, data, ()));
 
         if self.validate_uniform_parameters(uniform,
                                             UniformSetterType::FloatVec3,
@@ -2181,12 +2173,12 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn Uniform3iv(&self,
+    unsafe fn Uniform3iv(&self,
                   cx: *mut JSContext,
                   uniform: Option<&WebGLUniformLocation>,
                   data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<i32>(cx, data, ConversionBehavior::Default) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<i32>(cx, data, ConversionBehavior::Default));
 
         if self.validate_uniform_parameters(uniform,
                                             UniformSetterType::IntVec3,
@@ -2215,12 +2207,12 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn Uniform4iv(&self,
+    unsafe fn Uniform4iv(&self,
                   cx: *mut JSContext,
                   uniform: Option<&WebGLUniformLocation>,
                   data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<i32>(cx, data, ConversionBehavior::Default) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<i32>(cx, data, ConversionBehavior::Default));
 
         if self.validate_uniform_parameters(uniform,
                                             UniformSetterType::IntVec4,
@@ -2248,12 +2240,12 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn Uniform4fv(&self,
+    unsafe fn Uniform4fv(&self,
                   cx: *mut JSContext,
                   uniform: Option<&WebGLUniformLocation>,
                   data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<f32>(cx, data, ()) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<f32>(cx, data, ()));
 
         if self.validate_uniform_parameters(uniform,
                                             UniformSetterType::FloatVec4,
@@ -2268,13 +2260,13 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn UniformMatrix2fv(&self,
+    unsafe fn UniformMatrix2fv(&self,
                         cx: *mut JSContext,
                         uniform: Option<&WebGLUniformLocation>,
                         transpose: bool,
                         data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<f32>(cx, data, ()) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<f32>(cx, data, ()));
         if self.validate_uniform_parameters(uniform,
                                             UniformSetterType::FloatMat2,
                                             &data_vec) {
@@ -2288,13 +2280,13 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn UniformMatrix3fv(&self,
+    unsafe fn UniformMatrix3fv(&self,
                         cx: *mut JSContext,
                         uniform: Option<&WebGLUniformLocation>,
                         transpose: bool,
                         data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<f32>(cx, data, ()) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<f32>(cx, data, ()));
         if self.validate_uniform_parameters(uniform,
                                             UniformSetterType::FloatMat3,
                                             &data_vec) {
@@ -2308,13 +2300,13 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn UniformMatrix4fv(&self,
+    unsafe fn UniformMatrix4fv(&self,
                         cx: *mut JSContext,
                         uniform: Option<&WebGLUniformLocation>,
                         transpose: bool,
                         data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<f32>(cx, data, ()) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<f32>(cx, data, ()));
         if self.validate_uniform_parameters(uniform,
                                             UniformSetterType::FloatMat4,
                                             &data_vec) {
@@ -2352,9 +2344,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn VertexAttrib1fv(&self, cx: *mut JSContext, indx: u32, data: *mut JSObject) -> Fallible<()> {
+    unsafe fn VertexAttrib1fv(&self, cx: *mut JSContext, indx: u32, data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<f32>(cx, data, ()) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<f32>(cx, data, ()));
         if data_vec.len() < 1 {
             return Ok(self.webgl_error(InvalidOperation));
         }
@@ -2369,9 +2361,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn VertexAttrib2fv(&self, cx: *mut JSContext, indx: u32, data: *mut JSObject) -> Fallible<()> {
+    unsafe fn VertexAttrib2fv(&self, cx: *mut JSContext, indx: u32, data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<f32>(cx, data, ()) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<f32>(cx, data, ()));
         if data_vec.len() < 2 {
             return Ok(self.webgl_error(InvalidOperation));
         }
@@ -2386,9 +2378,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn VertexAttrib3fv(&self, cx: *mut JSContext, indx: u32, data: *mut JSObject) -> Fallible<()> {
+    unsafe fn VertexAttrib3fv(&self, cx: *mut JSContext, indx: u32, data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<f32>(cx, data, ()) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<f32>(cx, data, ()));
         if data_vec.len() < 3 {
             return Ok(self.webgl_error(InvalidOperation));
         }
@@ -2403,9 +2395,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
     #[allow(unsafe_code)]
-    fn VertexAttrib4fv(&self, cx: *mut JSContext, indx: u32, data: *mut JSObject) -> Fallible<()> {
+    unsafe fn VertexAttrib4fv(&self, cx: *mut JSContext, indx: u32, data: *mut JSObject) -> Fallible<()> {
         assert!(!data.is_null());
-        let data_vec = try!(unsafe { typed_array_or_sequence_to_vec::<f32>(cx, data, ()) });
+        let data_vec = try!(typed_array_or_sequence_to_vec::<f32>(cx, data, ()));
         if data_vec.len() < 4 {
             return Ok(self.webgl_error(InvalidOperation));
         }
@@ -2468,7 +2460,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
     #[allow(unsafe_code)]
-    fn TexImage2D(&self,
+    unsafe fn TexImage2D(&self,
                   _cx: *mut JSContext,
                   target: u32,
                   level: i32,
@@ -2482,7 +2474,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         let data = if data_ptr.is_null() {
             None
         } else {
-            Some(try!(unsafe { fallible_array_buffer_view_to_vec::<u8>(data_ptr) }))
+            Some(try!(fallible_array_buffer_view_to_vec::<u8>(data_ptr)))
         };
 
         let validator = TexImage2DValidator::new(self, target, level,
@@ -2504,7 +2496,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         };
 
         let expected_byte_length =
-            match unsafe { self.validate_tex_image_2d_data(width, height,
+            match { self.validate_tex_image_2d_data(width, height,
                                                            format, data_type,
                                                            data_ptr) } {
                 Ok(byte_length) => byte_length,
@@ -2574,7 +2566,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
     #[allow(unsafe_code)]
-    fn TexSubImage2D(&self,
+    unsafe fn TexSubImage2D(&self,
                      _cx: *mut JSContext,
                      target: u32,
                      level: i32,
@@ -2588,7 +2580,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         let data = if data_ptr.is_null() {
             None
         } else {
-            Some(try!(unsafe { fallible_array_buffer_view_to_vec::<u8>(data_ptr) }))
+            Some(try!(fallible_array_buffer_view_to_vec::<u8>(data_ptr)))
         };
 
 
@@ -2610,7 +2602,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         };
 
         let expected_byte_length =
-            match unsafe { self.validate_tex_image_2d_data(width, height,
+            match { self.validate_tex_image_2d_data(width, height,
                                                            format, data_type,
                                                            data_ptr) } {
                 Ok(byte_length) => byte_length,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -483,8 +483,10 @@ impl WindowMethods for Window {
         self.navigator.or_init(|| Navigator::new(self))
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout
-    fn SetTimeout(&self, _cx: *mut JSContext, callback: Rc<Function>, timeout: i32, args: Vec<HandleValue>) -> i32 {
+    unsafe fn SetTimeout(&self, _cx: *mut JSContext, callback: Rc<Function>, timeout: i32,
+                         args: Vec<HandleValue>) -> i32 {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             TimerCallback::FunctionTimerCallback(callback),
             args,
@@ -492,8 +494,10 @@ impl WindowMethods for Window {
             IsInterval::NonInterval)
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout
-    fn SetTimeout_(&self, _cx: *mut JSContext, callback: DOMString, timeout: i32, args: Vec<HandleValue>) -> i32 {
+    unsafe fn SetTimeout_(&self, _cx: *mut JSContext, callback: DOMString,
+                          timeout: i32, args: Vec<HandleValue>) -> i32 {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             TimerCallback::StringTimerCallback(callback),
             args,
@@ -506,8 +510,10 @@ impl WindowMethods for Window {
         self.upcast::<GlobalScope>().clear_timeout_or_interval(handle);
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-setinterval
-    fn SetInterval(&self, _cx: *mut JSContext, callback: Rc<Function>, timeout: i32, args: Vec<HandleValue>) -> i32 {
+    unsafe fn SetInterval(&self, _cx: *mut JSContext, callback: Rc<Function>,
+                          timeout: i32, args: Vec<HandleValue>) -> i32 {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             TimerCallback::FunctionTimerCallback(callback),
             args,
@@ -515,8 +521,10 @@ impl WindowMethods for Window {
             IsInterval::Interval)
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-setinterval
-    fn SetInterval_(&self, _cx: *mut JSContext, callback: DOMString, timeout: i32, args: Vec<HandleValue>) -> i32 {
+    unsafe fn SetInterval_(&self, _cx: *mut JSContext, callback: DOMString,
+                           timeout: i32, args: Vec<HandleValue>) -> i32 {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             TimerCallback::StringTimerCallback(callback),
             args,
@@ -610,8 +618,9 @@ impl WindowMethods for Window {
         doc.cancel_animation_frame(ident);
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-window-postmessage
-    fn PostMessage(&self,
+    unsafe fn PostMessage(&self,
                    cx: *mut JSContext,
                    message: HandleValue,
                    origin: DOMString)
@@ -670,8 +679,8 @@ impl WindowMethods for Window {
     }
 
     #[allow(unsafe_code)]
-    fn WebdriverCallback(&self, cx: *mut JSContext, val: HandleValue) {
-        let rv = unsafe { jsval_to_webdriver(cx, val) };
+    unsafe fn WebdriverCallback(&self, cx: *mut JSContext, val: HandleValue) {
+        let rv = jsval_to_webdriver(cx, val);
         let opt_chan = self.webdriver_script_chan.borrow_mut().take();
         if let Some(chan) = opt_chan {
             chan.send(rv).unwrap();
@@ -1511,6 +1520,7 @@ impl Window {
 }
 
 impl Window {
+    #[allow(unsafe_code)]
     pub fn new(runtime: Rc<Runtime>,
                script_chan: MainThreadScriptChan,
                dom_task_source: DOMManipulationTaskSource,
@@ -1598,7 +1608,9 @@ impl Window {
             test_runner: Default::default(),
         };
 
-        WindowBinding::Wrap(runtime.cx(), win)
+        unsafe {
+            WindowBinding::Wrap(runtime.cx(), win)
+        }
     }
 }
 

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -164,8 +164,9 @@ impl Worker {
 }
 
 impl WorkerMethods for Worker {
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-worker-postmessage
-    fn PostMessage(&self, cx: *mut JSContext, message: HandleValue) -> ErrorResult {
+    unsafe fn PostMessage(&self, cx: *mut JSContext, message: HandleValue) -> ErrorResult {
         let data = try!(StructuredCloneData::write(cx, message));
         let address = Trusted::new(self);
 

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -268,8 +268,10 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
         base64_atob(atob)
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout
-    fn SetTimeout(&self, _cx: *mut JSContext, callback: Rc<Function>, timeout: i32, args: Vec<HandleValue>) -> i32 {
+    unsafe fn SetTimeout(&self, _cx: *mut JSContext, callback: Rc<Function>,
+                         timeout: i32, args: Vec<HandleValue>) -> i32 {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             TimerCallback::FunctionTimerCallback(callback),
             args,
@@ -277,8 +279,10 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
             IsInterval::NonInterval)
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout
-    fn SetTimeout_(&self, _cx: *mut JSContext, callback: DOMString, timeout: i32, args: Vec<HandleValue>) -> i32 {
+    unsafe fn SetTimeout_(&self, _cx: *mut JSContext, callback: DOMString,
+                          timeout: i32, args: Vec<HandleValue>) -> i32 {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             TimerCallback::StringTimerCallback(callback),
             args,
@@ -291,8 +295,10 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
         self.upcast::<GlobalScope>().clear_timeout_or_interval(handle);
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-setinterval
-    fn SetInterval(&self, _cx: *mut JSContext, callback: Rc<Function>, timeout: i32, args: Vec<HandleValue>) -> i32 {
+    unsafe fn SetInterval(&self, _cx: *mut JSContext, callback: Rc<Function>,
+                          timeout: i32, args: Vec<HandleValue>) -> i32 {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             TimerCallback::FunctionTimerCallback(callback),
             args,
@@ -300,8 +306,10 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
             IsInterval::Interval)
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-setinterval
-    fn SetInterval_(&self, _cx: *mut JSContext, callback: DOMString, timeout: i32, args: Vec<HandleValue>) -> i32 {
+    unsafe fn SetInterval_(&self, _cx: *mut JSContext, callback: DOMString,
+                           timeout: i32, args: Vec<HandleValue>) -> i32 {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             TimerCallback::StringTimerCallback(callback),
             args,

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -86,8 +86,9 @@ impl XMLDocumentMethods for XMLDocument {
         self.upcast::<Document>().SupportedPropertyNames()
     }
 
+    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter
-    fn NamedGetter(&self, _cx: *mut JSContext, name: DOMString) -> Option<NonZero<*mut JSObject>> {
+    unsafe fn NamedGetter(&self, _cx: *mut JSContext, name: DOMString) -> Option<NonZero<*mut JSObject>> {
         self.upcast::<Document>().NamedGetter(_cx, name)
     }
 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -761,47 +761,45 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
 
     #[allow(unsafe_code)]
     // https://xhr.spec.whatwg.org/#the-response-attribute
-    fn Response(&self, cx: *mut JSContext) -> JSVal {
-        unsafe {
-            rooted!(in(cx) let mut rval = UndefinedValue());
-            match self.response_type.get() {
-                XMLHttpRequestResponseType::_empty | XMLHttpRequestResponseType::Text => {
-                    let ready_state = self.ready_state.get();
-                    // Step 2
-                    if ready_state == XMLHttpRequestState::Done || ready_state == XMLHttpRequestState::Loading {
-                        self.text_response().to_jsval(cx, rval.handle_mut());
-                    } else {
-                    // Step 1
-                        "".to_jsval(cx, rval.handle_mut());
-                    }
-                },
-                // Step 1
-                _ if self.ready_state.get() != XMLHttpRequestState::Done => {
-                    return NullValue();
-                },
+    unsafe fn Response(&self, cx: *mut JSContext) -> JSVal {
+        rooted!(in(cx) let mut rval = UndefinedValue());
+        match self.response_type.get() {
+            XMLHttpRequestResponseType::_empty | XMLHttpRequestResponseType::Text => {
+                let ready_state = self.ready_state.get();
                 // Step 2
-                XMLHttpRequestResponseType::Document => {
-                    let op_doc = self.document_response();
-                    if let Some(doc) = op_doc {
-                        doc.to_jsval(cx, rval.handle_mut());
-                    } else {
-                    // Substep 1
-                        return NullValue();
-                    }
-                },
-                XMLHttpRequestResponseType::Json => {
-                    self.json_response(cx).to_jsval(cx, rval.handle_mut());
-                },
-                XMLHttpRequestResponseType::Blob => {
-                    self.blob_response().to_jsval(cx, rval.handle_mut());
-                },
-                _ => {
-                    // XXXManishearth handle other response types
-                    self.response.borrow().to_jsval(cx, rval.handle_mut());
+                if ready_state == XMLHttpRequestState::Done || ready_state == XMLHttpRequestState::Loading {
+                    self.text_response().to_jsval(cx, rval.handle_mut());
+                } else {
+                // Step 1
+                    "".to_jsval(cx, rval.handle_mut());
                 }
+            },
+            // Step 1
+            _ if self.ready_state.get() != XMLHttpRequestState::Done => {
+                return NullValue();
+            },
+            // Step 2
+            XMLHttpRequestResponseType::Document => {
+                let op_doc = self.document_response();
+                if let Some(doc) = op_doc {
+                    doc.to_jsval(cx, rval.handle_mut());
+                } else {
+                // Substep 1
+                    return NullValue();
+                }
+            },
+            XMLHttpRequestResponseType::Json => {
+                self.json_response(cx).to_jsval(cx, rval.handle_mut());
+            },
+            XMLHttpRequestResponseType::Blob => {
+                self.blob_response().to_jsval(cx, rval.handle_mut());
+            },
+            _ => {
+                // XXXManishearth handle other response types
+                self.response.borrow().to_jsval(cx, rval.handle_mut());
             }
-            rval.get()
         }
+        rval.get()
     }
 
     // https://xhr.spec.whatwg.org/#the-responsetext-attribute

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -173,11 +173,11 @@ pub fn init_service_workers(sw_senders: SWManagerSenders) {
 pub fn init() {
     unsafe {
         proxyhandler::init();
-    }
 
-    // Create the global vtables used by the (generated) DOM
-    // bindings to implement JS proxies.
-    RegisterBindings::RegisterProxyHandlers();
+        // Create the global vtables used by the (generated) DOM
+        // bindings to implement JS proxies.
+        RegisterBindings::RegisterProxyHandlers();
+    }
 
     perform_platform_specific_initialization();
 }


### PR DESCRIPTION
This is a rebased version of PR #11595


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #11485

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because: no code logic was changed

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14096)
<!-- Reviewable:end -->
