### PR TITLE
Rename media_queries::MediaQueryList to MediaList

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -92,7 +92,7 @@ use std::sync::mpsc::{Receiver, Sender};
 use std::time::{SystemTime, Instant};
 use style::attr::{AttrIdentifier, AttrValue, LengthOrPercentageOrAuto};
 use style::element_state::*;
-use style::media_queries::MediaQueryList;
+use style::media_queries::MediaList;
 use style::properties::PropertyDeclarationBlock;
 use style::selector_impl::{PseudoElement, Snapshot};
 use style::values::specified::Length;
@@ -369,7 +369,7 @@ no_jsmanaged_fields!(WebGLProgramId);
 no_jsmanaged_fields!(WebGLRenderbufferId);
 no_jsmanaged_fields!(WebGLShaderId);
 no_jsmanaged_fields!(WebGLTextureId);
-no_jsmanaged_fields!(MediaQueryList);
+no_jsmanaged_fields!(MediaList);
 
 impl JSTraceable for Box<ScriptChan + Send> {
     #[inline]

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -42,7 +42,7 @@ use std::default::Default;
 use std::mem;
 use std::sync::{Arc, Mutex};
 use style::attr::AttrValue;
-use style::media_queries::{MediaQueryList, parse_media_query_list};
+use style::media_queries::{MediaList, parse_media_query_list};
 use style::parser::ParserContextExtraData;
 use style::str::HTML_SPACE_CHARACTERS;
 use style::stylesheets::{Stylesheet, Origin};
@@ -297,7 +297,7 @@ impl HTMLLinkElement {
 struct StylesheetContext {
     /// The element that initiated the request.
     elem: Trusted<HTMLLinkElement>,
-    media: Option<MediaQueryList>,
+    media: Option<MediaList>,
     /// The response body received to date.
     data: Vec<u8>,
     /// The response metadata received to date.

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -19,8 +19,7 @@ use euclid::scale_factor::ScaleFactor;
 use js::jsapi::JSTracer;
 use std::cell::Cell;
 use std::rc::Rc;
-use style;
-use style::media_queries::{Device, MediaType};
+use style::media_queries::{Device, MediaList, MediaType};
 use style_traits::{PagePx, ToCss, ViewportPx};
 
 pub enum MediaQueryListMatchState {
@@ -32,13 +31,12 @@ pub enum MediaQueryListMatchState {
 pub struct MediaQueryList {
     eventtarget: EventTarget,
     document: JS<Document>,
-    media_query_list: style::media_queries::MediaQueryList,
+    media_query_list: MediaList,
     last_match_state: Cell<Option<bool>>
 }
 
 impl MediaQueryList {
-    fn new_inherited(document: &Document,
-                     media_query_list: style::media_queries::MediaQueryList) -> MediaQueryList {
+    fn new_inherited(document: &Document, media_query_list: MediaList) -> MediaQueryList {
         MediaQueryList {
             eventtarget: EventTarget::new_inherited(),
             document: JS::from_ref(document),
@@ -47,8 +45,7 @@ impl MediaQueryList {
         }
     }
 
-    pub fn new(document: &Document,
-               media_query_list: style::media_queries::MediaQueryList) -> Root<MediaQueryList> {
+    pub fn new(document: &Document, media_query_list: MediaList) -> Root<MediaQueryList> {
         reflect_dom_object(box MediaQueryList::new_inherited(document, media_query_list),
                            document.window(),
                            MediaQueryListBinding::Wrap)

--- a/components/style/media_queries.rs
+++ b/components/style/media_queries.rs
@@ -19,11 +19,11 @@ use values::specified;
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-pub struct MediaQueryList {
+pub struct MediaList {
     pub media_queries: Vec<MediaQuery>
 }
 
-impl ToCss for MediaQueryList {
+impl ToCss for MediaList {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result
         where W: fmt::Write
     {
@@ -252,7 +252,7 @@ impl MediaQuery {
     }
 }
 
-pub fn parse_media_query_list(input: &mut Parser) -> MediaQueryList {
+pub fn parse_media_query_list(input: &mut Parser) -> MediaList {
     let queries = if input.is_exhausted() {
         vec![MediaQuery::new(None, MediaQueryType::All, vec!())]
     } else {
@@ -271,10 +271,10 @@ pub fn parse_media_query_list(input: &mut Parser) -> MediaQueryList {
         }
         media_queries
     };
-    MediaQueryList { media_queries: queries }
+    MediaList { media_queries: queries }
 }
 
-impl MediaQueryList {
+impl MediaList {
     pub fn evaluate(&self, device: &Device) -> bool {
         let viewport_size = device.au_viewport_size();
 

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -11,7 +11,7 @@ use encoding::EncodingRef;
 use error_reporting::ParseErrorReporter;
 use font_face::{FontFaceRule, parse_font_face_block};
 use keyframes::{Keyframe, parse_keyframe_list};
-use media_queries::{Device, MediaQueryList, parse_media_query_list};
+use media_queries::{Device, MediaList, parse_media_query_list};
 use parking_lot::RwLock;
 use parser::{ParserContext, ParserContextExtraData, log_css_error};
 use properties::{PropertyDeclarationBlock, parse_property_declaration_list};
@@ -46,7 +46,7 @@ pub struct Stylesheet {
     /// cascading order)
     pub rules: Vec<CSSRule>,
     /// List of media associated with the Stylesheet, if any.
-    pub media: Option<MediaQueryList>,
+    pub media: Option<MediaList>,
     pub origin: Origin,
     pub dirty_on_viewport_size_change: bool,
 }
@@ -77,7 +77,7 @@ impl CSSRule {
     ///
     /// Note that only some types of rules can contain rules. An empty slice is used for others.
     pub fn with_nested_rules_and_mq<F, R>(&self, mut f: F) -> R
-    where F: FnMut(&[CSSRule], Option<&MediaQueryList>) -> R {
+    where F: FnMut(&[CSSRule], Option<&MediaList>) -> R {
         match *self {
             CSSRule::Namespace(_) |
             CSSRule::Style(_) |
@@ -111,7 +111,7 @@ pub struct KeyframesRule {
 
 #[derive(Debug)]
 pub struct MediaRule {
-    pub media_queries: Arc<RwLock<MediaQueryList>>,
+    pub media_queries: Arc<RwLock<MediaList>>,
     pub rules: Vec<CSSRule>,
 }
 
@@ -187,15 +187,15 @@ impl Stylesheet {
         }
     }
 
-    /// Set the MediaQueryList associated with the style-sheet.
-    pub fn set_media(&mut self, media: Option<MediaQueryList>) {
+    /// Set the MediaList associated with the style-sheet.
+    pub fn set_media(&mut self, media: Option<MediaList>) {
         self.media = media;
     }
 
     /// Returns whether the style-sheet applies for the current device depending
-    /// on the associated MediaQueryList.
+    /// on the associated MediaList.
     ///
-    /// Always true if no associated MediaQueryList exists.
+    /// Always true if no associated MediaList exists.
     pub fn is_effective_for_device(&self, device: &Device) -> bool {
         self.media.as_ref().map_or(true, |ref media| media.evaluate(device))
     }
@@ -287,7 +287,7 @@ enum AtRulePrelude {
     /// A @font-face rule prelude.
     FontFace,
     /// A @media rule prelude, with its media queries.
-    Media(Arc<RwLock<MediaQueryList>>),
+    Media(Arc<RwLock<MediaList>>),
     /// A @viewport rule prelude.
     Viewport,
     /// A @keyframes rule, with its animation name.

--- a/tests/unit/style/media_queries.rs
+++ b/tests/unit/style/media_queries.rs
@@ -24,7 +24,7 @@ impl ParseErrorReporter for CSSErrorReporterTest {
      }
 }
 
-fn test_media_rule<F>(css: &str, callback: F) where F: Fn(&MediaQueryList, &str) {
+fn test_media_rule<F>(css: &str, callback: F) where F: Fn(&MediaList, &str) {
     let url = Url::parse("http://localhost").unwrap();
     let stylesheet = Stylesheet::from_str(css, url, Origin::Author, Box::new(CSSErrorReporterTest),
                                           ParserContextExtraData::default());
@@ -36,7 +36,7 @@ fn test_media_rule<F>(css: &str, callback: F) where F: Fn(&MediaQueryList, &str)
     assert!(rule_count > 0);
 }
 
-fn media_queries<F>(rules: &[CSSRule], f: &mut F) where F: FnMut(&MediaQueryList) {
+fn media_queries<F>(rules: &[CSSRule], f: &mut F) where F: FnMut(&MediaList) {
     for rule in rules {
         rule.with_nested_rules_and_mq(|rules, mq| {
             if let Some(mq) = mq {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`MediaList` is the name of the interface for "collection of media queries" used in [CSSOM spec](https://drafts.csswg.org/cssom/#the-medialist-interface), `MediaQueryList` happens to mean something different in [CSSOM View spec](https://drafts.csswg.org/cssom-view/#the-mediaquerylist-interface), which also leads to naming conflict in dom code. So I think it's better renaming it to `MediaList`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14121)
<!-- Reviewable:end -->
