### PR TITLE
layout: Mark flex items properly during construction

### DIFF
--- a/components/layout/flex.rs
+++ b/components/layout/flex.rs
@@ -395,6 +395,10 @@ impl FlexFlow {
         }
     }
 
+    pub fn main_mode(&self) -> Direction {
+        self.main_mode
+    }
+
     /// Returns a line start after the last item that is already in a line.
     /// Note that when the container main size is infinite(i.e. A column flexbox with auto height),
     /// we do not need to do flex resolving and this can be considered as a fast-path, so the
@@ -613,8 +617,6 @@ impl FlexFlow {
                 //
                 // TODO(#2265, pcwalton): Do this in the cascade instead.
                 block.base.flags.set_text_align(containing_block_text_align);
-                // FIXME(stshine): should this be done during construction?
-                block.mark_as_flex();
 
                 let margin = block.fragment.style().logical_margin();
                 let auto_len =
@@ -808,6 +810,14 @@ impl FlexFlow {
 impl Flow for FlexFlow {
     fn class(&self) -> FlowClass {
         FlowClass::Flex
+    }
+
+    fn as_mut_flex(&mut self) -> &mut FlexFlow {
+        self
+    }
+
+    fn as_flex(&self) -> &FlexFlow {
+        self
     }
 
     fn as_block(&self) -> &BlockFlow {

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -30,6 +30,7 @@ use block::{BlockFlow, FormattingContextType};
 use context::{LayoutContext, SharedLayoutContext};
 use display_list_builder::DisplayListBuildState;
 use euclid::{Point2D, Size2D};
+use flex::FlexFlow;
 use floats::{Floats, SpeculatedFloatPlacement};
 use flow_list::{FlowList, MutFlowListIterator};
 use flow_ref::{FlowRef, WeakFlowRef};
@@ -84,6 +85,16 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
     fn as_mut_block(&mut self) -> &mut BlockFlow {
         debug!("called as_mut_block() on a flow of type {:?}", self.class());
         panic!("called as_mut_block() on a non-block flow")
+    }
+
+    /// If this is a flex flow, returns the underlying object. Fails otherwise.
+    fn as_flex(&self) -> &FlexFlow {
+        panic!("called as_flex() on a non-flex flow")
+    }
+
+    /// If this is a flex flow, returns the underlying object, borrowed mutably. Fails otherwise.
+    fn as_mut_flex(&mut self) -> &mut FlexFlow {
+        panic!("called as_mut_flex() on a non-flex flow")
     }
 
     /// If this is an inline flow, returns the underlying object. Fails otherwise.

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -123,6 +123,9 @@ pub struct Fragment {
     /// The pseudo-element that this fragment represents.
     pub pseudo: PseudoElementType<()>,
 
+    /// Various flags for this fragment.
+    pub flags: FragmentFlags,
+
     /// A debug ID that is consistent for the life of this fragment (via transform etc).
     /// This ID should not be considered stable across multiple layouts or fragment
     /// manipulations.
@@ -917,6 +920,7 @@ impl Fragment {
             specific: specific,
             inline_context: None,
             pseudo: node.get_pseudo_element_type().strip(),
+            flags: FragmentFlags::empty(),
             debug_id: DebugId::new(),
             stacking_context_id: StackingContextId::new(0),
         }
@@ -945,6 +949,7 @@ impl Fragment {
             specific: specific,
             inline_context: None,
             pseudo: pseudo,
+            flags: FragmentFlags::empty(),
             debug_id: DebugId::new(),
             stacking_context_id: StackingContextId::new(0),
         }
@@ -969,6 +974,7 @@ impl Fragment {
             specific: specific,
             inline_context: None,
             pseudo: self.pseudo,
+            flags: FragmentFlags::empty(),
             debug_id: DebugId::new(),
             stacking_context_id: StackingContextId::new(0),
         }
@@ -996,6 +1002,7 @@ impl Fragment {
             specific: info,
             inline_context: self.inline_context.clone(),
             pseudo: self.pseudo.clone(),
+            flags: FragmentFlags::empty(),
             debug_id: self.debug_id.clone(),
             stacking_context_id: StackingContextId::new(0),
         }
@@ -3108,6 +3115,16 @@ impl Overflow {
     pub fn translate(&mut self, point: &Point2D<Au>) {
         self.scroll = self.scroll.translate(point);
         self.paint = self.paint.translate(point);
+    }
+}
+
+bitflags! {
+    pub flags FragmentFlags: u8 {
+        // TODO(stshine): find a better name since these flags can also be used for grid item.
+        /// Whether this fragment represents a child in a row flex container.
+        const IS_INLINE_FLEX_ITEM = 0b0000_0001,
+        /// Whether this fragment represents a child in a column flex container.
+        const IS_BLOCK_FLEX_ITEM = 0b0000_0010,
     }
 }
 

--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -505,7 +505,7 @@ impl ToGfxMatrix for ComputedMatrix {
 }
 
 // Used to specify the logical direction.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Direction {
     Inline,
     Block


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


Set the flag of the fragment of children in a flex container according
to the direction of the container. The mark is done on the fragment
because flex item enstablish a stacking context when its z-index is
non-zero ,despite its `position' property.

Part of #14123.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because refactoring

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

r? @pcwalton

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14130)
<!-- Reviewable:end -->
