### PR TITLE
Allow `nightly-x86_64-pc-windows-gnu` to fail on AppVeyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,10 @@ environment:
   - TARGET: nightly-x86_64-pc-windows-msvc
   - TARGET: nightly-x86_64-pc-windows-gnu
 
+matrix:
+  allow_failures:
+    - TARGET: nightly-x86_64-pc-windows-gnu
+
 branches:
   only:
     - master


### PR DESCRIPTION
Been failing for a while. Doesn't seem helpful to have it result in every PR getting a ❌

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14139)
<!-- Reviewable:end -->
