### PR TITLE
Implement home end key scrolling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,7 @@ dependencies = [
  "servo_geometry 0.0.1",
  "servo_url 0.0.1",
  "style_traits 0.0.1",
+ "webrender_traits 0.11.0 (git+https://github.com/servo/webrender)",
  "x11 2.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1037,6 +1038,7 @@ dependencies = [
  "servo_url 0.0.1",
  "style_traits 0.0.1",
  "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webrender_traits 0.11.0 (git+https://github.com/servo/webrender)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -16,6 +16,7 @@ use servo_geometry::ScreenPx;
 use servo_url::ServoUrl;
 use std::fmt::{Debug, Error, Formatter};
 use style_traits::cursor::Cursor;
+use webrender_traits::ScrollLocation;
 
 #[derive(Clone)]
 pub enum MouseWindowEvent {
@@ -62,7 +63,7 @@ pub enum WindowEvent {
     Touch(TouchEventType, TouchId, TypedPoint2D<f32, DevicePixel>),
     /// Sent when the user scrolls. The first point is the delta and the second point is the
     /// origin.
-    Scroll(TypedPoint2D<f32, DevicePixel>, TypedPoint2D<i32, DevicePixel>, TouchEventType),
+    Scroll(ScrollLocation, TypedPoint2D<i32, DevicePixel>, TouchEventType),
     /// Sent when the user zooms.
     Zoom(f32),
     /// Simulated "pinch zoom" gesture for non-touch platforms (e.g. ctrl-scrollwheel).

--- a/ports/cef/Cargo.toml
+++ b/ports/cef/Cargo.toml
@@ -35,6 +35,11 @@ servo_geometry = {path = "../../components/geometry"}
 servo_url = {path = "../../components/url"}
 style_traits = {path = "../../components/style_traits"}
 
+[dependencies.webrender_traits]
+git = "https://github.com/servo/webrender"
+default-features = false
+features = ["serde_derive", "ipc"]
+
 [target.'cfg(target_os="macos")'.dependencies]
 objc = "0.2"
 cocoa = "0.5"

--- a/ports/cef/browser_host.rs
+++ b/ports/cef/browser_host.rs
@@ -8,6 +8,7 @@ use interfaces::{CefBrowser, CefBrowserHost, CefClient, cef_browser_t, cef_brows
 use types::cef_event_flags_t::{EVENTFLAG_ALT_DOWN, EVENTFLAG_CONTROL_DOWN, EVENTFLAG_SHIFT_DOWN};
 use types::cef_key_event_type_t::{KEYEVENT_CHAR, KEYEVENT_KEYDOWN, KEYEVENT_KEYUP, KEYEVENT_RAWKEYDOWN};
 use types::{cef_mouse_button_type_t, cef_mouse_event, cef_rect_t, cef_key_event, cef_window_handle_t};
+use webrender_traits::ScrollLocation;
 use wrappers::CefWrap;
 
 use compositing::windowing::{WindowEvent, MouseWindowEvent};
@@ -471,7 +472,7 @@ full_cef_class_impl! {
             let delta_y: c_int = delta_y;
             let delta = TypedPoint2D::new(delta_x as f32, delta_y as f32);
             let origin = TypedPoint2D::new((*event).x as i32, (*event).y as i32);
-            this.downcast().send_window_event(WindowEvent::Scroll(delta,
+            this.downcast().send_window_event(WindowEvent::Scroll(ScrollLocation::Delta(delta),
                                                                   origin,
                                                                   TouchEventType::Move))
         }}

--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -28,6 +28,7 @@ extern crate style_traits;
 
 extern crate net_traits;
 extern crate msg;
+extern crate webrender_traits;
 
 extern crate libc;
 

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -23,6 +23,10 @@ servo_config = {path = "../../components/config"}
 servo_url = {path = "../../components/url"}
 style_traits = {path = "../../components/style_traits"}
 
+[dependencies.webrender_traits]
+git = "https://github.com/servo/webrender"
+default_features = false
+
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 osmesa-sys = "0.1.2"
 

--- a/ports/glutin/lib.rs
+++ b/ports/glutin/lib.rs
@@ -22,6 +22,8 @@ extern crate servo_config;
 extern crate servo_geometry;
 extern crate servo_url;
 extern crate style_traits;
+extern crate webrender_traits;
+
 #[cfg(target_os = "windows")] extern crate winapi;
 #[cfg(target_os = "windows")] extern crate user32;
 #[cfg(target_os = "windows")] extern crate gdi32;

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -42,6 +42,7 @@ use std::sync::mpsc::{Sender, channel};
 use style_traits::cursor::Cursor;
 #[cfg(target_os = "windows")]
 use user32;
+use webrender_traits::ScrollLocation;
 #[cfg(target_os = "windows")]
 use winapi;
 
@@ -425,8 +426,9 @@ impl Window {
                     MouseScrollDelta::LineDelta(dx, dy) => (dx, dy * LINE_HEIGHT),
                     MouseScrollDelta::PixelDelta(dx, dy) => (dx, dy),
                 };
+                let scroll_location = ScrollLocation::Delta(TypedPoint2D::new(dx, dy));
                 let phase = glutin_phase_to_touch_event_type(phase);
-                self.scroll_window(dx, dy, phase);
+                self.scroll_window(scroll_location, phase);
             },
             Event::Touch(touch) => {
                 use script_traits::TouchId;
@@ -461,16 +463,19 @@ impl Window {
     }
 
     /// Helper function to send a scroll event.
-    fn scroll_window(&self, mut dx: f32, mut dy: f32, phase: TouchEventType) {
+    fn scroll_window(&self, scroll_location: ScrollLocation, phase: TouchEventType) {
         // Scroll events snap to the major axis of movement, with vertical
         // preferred over horizontal.
-        if dy.abs() >= dx.abs() {
-            dx = 0.0;
-        } else {
-            dy = 0.0;
+        if let ScrollLocation::Delta(mut delta) = scroll_location {
+            if delta.y.abs() >= delta.x.abs() {
+                delta.x = 0.0;
+            } else {
+                delta.y = 0.0;
+            }
         }
+
         let mouse_pos = self.mouse_pos.get();
-        let event = WindowEvent::Scroll(TypedPoint2D::new(dx as f32, dy as f32),
+        let event = WindowEvent::Scroll(scroll_location,
                                         TypedPoint2D::new(mouse_pos.x as i32, mouse_pos.y as i32),
                                         phase);
         self.event_queue.borrow_mut().push(event);
@@ -1034,33 +1039,46 @@ impl WindowMethods for Window {
 
             (NONE, None, Key::PageDown) |
             (NONE, Some(' '), _) => {
-                self.scroll_window(0.0,
+               let scroll_location = ScrollLocation::Delta(TypedPoint2D::new(0.0,
                                    -self.framebuffer_size()
                                         .to_f32()
                                         .to_untyped()
-                                        .height + 2.0 * LINE_HEIGHT,
+                                        .height + 2.0 * LINE_HEIGHT));
+                self.scroll_window(scroll_location,
                                    TouchEventType::Move);
             }
             (NONE, None, Key::PageUp) |
             (SHIFT, Some(' '), _) => {
-                self.scroll_window(0.0,
+                let scroll_location = ScrollLocation::Delta(TypedPoint2D::new(0.0,
                                    self.framebuffer_size()
                                        .to_f32()
                                        .to_untyped()
-                                       .height - 2.0 * LINE_HEIGHT,
+                                       .height - 2.0 * LINE_HEIGHT));
+                self.scroll_window(scroll_location,
                                    TouchEventType::Move);
             }
+
+            (NONE, None, Key::Home) => {
+                self.scroll_window(ScrollLocation::Start, TouchEventType::Move);
+            }
+
+            (NONE, None, Key::End) => {
+                self.scroll_window(ScrollLocation::End, TouchEventType::Move);
+            }
+
             (NONE, None, Key::Up) => {
-                self.scroll_window(0.0, 3.0 * LINE_HEIGHT, TouchEventType::Move);
+                self.scroll_window(ScrollLocation::Delta(TypedPoint2D::new(0.0, 3.0 * LINE_HEIGHT)),
+                                   TouchEventType::Move);
             }
             (NONE, None, Key::Down) => {
-                self.scroll_window(0.0, -3.0 * LINE_HEIGHT, TouchEventType::Move);
+                self.scroll_window(ScrollLocation::Delta(TypedPoint2D::new(0.0, -3.0 * LINE_HEIGHT)),
+                                   TouchEventType::Move);
             }
             (NONE, None, Key::Left) => {
-                self.scroll_window(LINE_HEIGHT, 0.0, TouchEventType::Move);
+                self.scroll_window(ScrollLocation::Delta(TypedPoint2D::new(LINE_HEIGHT, 0.0)), TouchEventType::Move);
             }
             (NONE, None, Key::Right) => {
-                self.scroll_window(-LINE_HEIGHT, 0.0, TouchEventType::Move);
+                self.scroll_window(ScrollLocation::Delta(TypedPoint2D::new(-LINE_HEIGHT, 0.0)), TouchEventType::Move);
             }
             (CMD_OR_CONTROL, Some('r'), _) => {
                 if let Some(true) = PREFS.get("shell.builtin-key-shortcuts.enabled").as_boolean() {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
* Refactor all scroll related code to use a new `ScrollLocation` struct which can either be a `delta` (as before) or a `Start` or `End` request, to represent the desire to scroll to the start and end of the page.
Effectively, everywhere a delta was used, there is now a `ScrollLocation` struct instead.

* Add key press listeners for HOME and END keys so as to cause a scroll to be queued with `ScrollLocation::Start` (in HOME case) or `ScrollLocation::End` (in END case).

* These changes depend on added support for the new `ScrollLocation` in webrender and webrender_traits. See https://github.com/servo/webrender/pull/540.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ x] These changes fix #13082 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because scrolling I/O

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14141)
<!-- Reviewable:end -->
