### PR TITLE
Bug 1292275 - Stylo: Fix crash after failed stylesheet load.

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -165,6 +165,22 @@ pub extern "C" fn Servo_Node_ClearNodeData(node: RawGeckoNodeBorrowed) -> () {
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_StyleSheet_Empty(mode: SheetParsingMode) -> RawServoStyleSheetStrong {
+    let url = Url::parse("about:blank").unwrap();
+    let extra_data = ParserContextExtraData::default();
+    let origin = match mode {
+        SheetParsingMode::eAuthorSheetFeatures => Origin::Author,
+        SheetParsingMode::eUserSheetFeatures => Origin::User,
+        SheetParsingMode::eAgentSheetFeatures => Origin::UserAgent,
+    };
+    let sheet = Arc::new(Stylesheet::from_str("", url, origin, Box::new(StdoutErrorReporter),
+                                              extra_data));
+    unsafe {
+        transmute(sheet)
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(data: *const nsACString,
                                                  mode: SheetParsingMode,
                                                  base_url: *const nsACString,


### PR DESCRIPTION
This is the Servo part of [bug 1292275](https://bugzilla.mozilla.org/show_bug.cgi?id=1292275), already reviewed there by @heycam.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14142)
<!-- Reviewable:end -->
