### PR TITLE
Update CORS naming from 'CORS' to 'Cors'.

### DIFF
--- a/components/net/fetch/cors_cache.rs
+++ b/components/net/fetch/cors_cache.rs
@@ -42,7 +42,7 @@ impl HeaderOrMethod {
 
 /// An entry in the CORS cache
 #[derive(Clone, Debug)]
-pub struct CORSCacheEntry {
+pub struct CorsCacheEntry {
     pub origin: Origin,
     pub url: Url,
     pub max_age: u32,
@@ -51,10 +51,10 @@ pub struct CORSCacheEntry {
     created: Timespec
 }
 
-impl CORSCacheEntry {
+impl CorsCacheEntry {
     fn new(origin: Origin, url: Url, max_age: u32, credentials: bool,
-            header_or_method: HeaderOrMethod) -> CORSCacheEntry {
-        CORSCacheEntry {
+            header_or_method: HeaderOrMethod) -> CorsCacheEntry {
+        CorsCacheEntry {
             origin: origin,
             url: url,
             max_age: max_age,
@@ -65,7 +65,7 @@ impl CORSCacheEntry {
     }
 }
 
-fn match_headers(cors_cache: &CORSCacheEntry, cors_req: &Request) -> bool {
+fn match_headers(cors_cache: &CorsCacheEntry, cors_req: &Request) -> bool {
     cors_cache.origin == *cors_req.origin.borrow() &&
         cors_cache.url == cors_req.current_url() &&
         (cors_cache.credentials || cors_req.credentials_mode != CredentialsMode::Include)
@@ -73,43 +73,43 @@ fn match_headers(cors_cache: &CORSCacheEntry, cors_req: &Request) -> bool {
 
 /// A simple, vector-based CORS Cache
 #[derive(Clone)]
-pub struct CORSCache(Vec<CORSCacheEntry>);
+pub struct CorsCache(Vec<CorsCacheEntry>);
 
-impl CORSCache {
-    pub fn new() -> CORSCache {
-        CORSCache(vec![])
+impl CorsCache {
+    pub fn new() -> CorsCache {
+        CorsCache(vec![])
     }
 
     fn find_entry_by_header<'a>(&'a mut self, request: &Request,
-                                header_name: &str) -> Option<&'a mut CORSCacheEntry> {
+                                header_name: &str) -> Option<&'a mut CorsCacheEntry> {
         self.cleanup();
         self.0.iter_mut().find(|e| match_headers(e, request) && e.header_or_method.match_header(header_name))
     }
 
     fn find_entry_by_method<'a>(&'a mut self, request: &Request,
-                                method: Method) -> Option<&'a mut CORSCacheEntry> {
-        // we can take the method from CORSRequest itself
+                                method: Method) -> Option<&'a mut CorsCacheEntry> {
+        // we can take the method from CorSRequest itself
         self.cleanup();
         self.0.iter_mut().find(|e| match_headers(e, request) && e.header_or_method.match_method(&method))
     }
 
     /// [Clear the cache](https://fetch.spec.whatwg.org/#concept-cache-clear)
     pub fn clear(&mut self, request: &Request) {
-        let CORSCache(buf) = self.clone();
-        let new_buf: Vec<CORSCacheEntry> =
+        let CorsCache(buf) = self.clone();
+        let new_buf: Vec<CorsCacheEntry> =
             buf.into_iter().filter(|e| e.origin == *request.origin.borrow() &&
                                        request.current_url() == e.url).collect();
-        *self = CORSCache(new_buf);
+        *self = CorsCache(new_buf);
     }
 
     /// Remove old entries
     pub fn cleanup(&mut self) {
-        let CORSCache(buf) = self.clone();
+        let CorsCache(buf) = self.clone();
         let now = time::now().to_timespec();
-        let new_buf: Vec<CORSCacheEntry> = buf.into_iter()
+        let new_buf: Vec<CorsCacheEntry> = buf.into_iter()
                                               .filter(|e| now.sec < e.created.sec + e.max_age as i64)
                                               .collect();
-        *self = CORSCache(new_buf);
+        *self = CorsCache(new_buf);
     }
 
     /// Returns true if an entry with a
@@ -127,7 +127,7 @@ impl CORSCache {
         match self.find_entry_by_header(&request, header_name).map(|e| e.max_age = new_max_age) {
             Some(_) => true,
             None => {
-                self.insert(CORSCacheEntry::new(request.origin.borrow().clone(), request.current_url(), new_max_age,
+                self.insert(CorsCacheEntry::new(request.origin.borrow().clone(), request.current_url(), new_max_age,
                                                 request.credentials_mode == CredentialsMode::Include,
                                                 HeaderOrMethod::HeaderData(header_name.to_owned())));
                 false
@@ -149,7 +149,7 @@ impl CORSCache {
         match self.find_entry_by_method(&request, method.clone()).map(|e| e.max_age = new_max_age) {
             Some(_) => true,
             None => {
-                self.insert(CORSCacheEntry::new(request.origin.borrow().clone(), request.current_url(), new_max_age,
+                self.insert(CorsCacheEntry::new(request.origin.borrow().clone(), request.current_url(), new_max_age,
                                                 request.credentials_mode == CredentialsMode::Include,
                                                 HeaderOrMethod::MethodData(method)));
                 false
@@ -158,7 +158,7 @@ impl CORSCache {
     }
 
     /// Insert an entry
-    pub fn insert(&mut self, entry: CORSCacheEntry) {
+    pub fn insert(&mut self, entry: CorsCacheEntry) {
         self.cleanup();
         self.0.push(entry);
     }

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -6,7 +6,7 @@ use blob_loader::load_blob_sync;
 use connector::create_http_connector;
 use data_loader::decode;
 use devtools_traits::DevtoolsControlMsg;
-use fetch::cors_cache::CORSCache;
+use fetch::cors_cache::CorsCache;
 use filemanager_thread::{FileManager, UIProvider};
 use http_loader::{HttpState, set_default_accept_encoding, set_default_accept_language, set_request_cookies};
 use http_loader::{NetworkHttpRequestFactory, ReadResult, StreamedResponse, obtain_response, read_block};
@@ -65,11 +65,11 @@ pub fn fetch<UI: 'static + UIProvider>(request: Rc<Request>,
                                        target: &mut Target,
                                        context: &FetchContext<UI>)
                                        -> Response {
-    fetch_with_cors_cache(request, &mut CORSCache::new(), target, context)
+    fetch_with_cors_cache(request, &mut CorsCache::new(), target, context)
 }
 
 pub fn fetch_with_cors_cache<UI: 'static + UIProvider>(request: Rc<Request>,
-                                                       cache: &mut CORSCache,
+                                                       cache: &mut CorsCache,
                                                        target: &mut Target,
                                                        context: &FetchContext<UI>)
                                                        -> Response {
@@ -136,7 +136,7 @@ pub fn fetch_with_cors_cache<UI: 'static + UIProvider>(request: Rc<Request>,
 
 /// [Main fetch](https://fetch.spec.whatwg.org/#concept-main-fetch)
 fn main_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
-                                        cache: &mut CORSCache,
+                                        cache: &mut CorsCache,
                                         cors_flag: bool,
                                         recursive_flag: bool,
                                         target: &mut Target,
@@ -213,7 +213,7 @@ fn main_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
             } else if request.mode == RequestMode::SameOrigin {
                 Response::network_error(NetworkError::Internal("Cross-origin response".into()))
 
-            } else if request.mode == RequestMode::NoCORS {
+            } else if request.mode == RequestMode::NoCors {
                 request.response_tainting.set(ResponseTainting::Opaque);
                 basic_fetch(request.clone(), cache, target, done_chan, context)
 
@@ -224,7 +224,7 @@ fn main_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
                 (request.unsafe_request &&
                  (!is_simple_method(&request.method.borrow()) ||
                   request.headers.borrow().iter().any(|h| !is_simple_header(&h)))) {
-                request.response_tainting.set(ResponseTainting::CORSTainting);
+                request.response_tainting.set(ResponseTainting::CorsTainting);
                 request.redirect_mode.set(RedirectMode::Error);
                 let response = http_fetch(request.clone(), cache, true, true, false,
                                           target, done_chan, context);
@@ -234,7 +234,7 @@ fn main_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
                 response
 
             } else {
-                request.response_tainting.set(ResponseTainting::CORSTainting);
+                request.response_tainting.set(ResponseTainting::CorsTainting);
                 http_fetch(request.clone(), cache, true, false, false, target, done_chan, context)
             }
         }
@@ -250,7 +250,7 @@ fn main_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
     let response = if response.response_type == ResponseType::Default {
         let response_type = match request.response_tainting.get() {
             ResponseTainting::Basic => ResponseType::Basic,
-            ResponseTainting::CORSTainting => ResponseType::CORS,
+            ResponseTainting::CorsTainting => ResponseType::Cors,
             ResponseTainting::Opaque => ResponseType::Opaque,
         };
         response.to_filtered(response_type)
@@ -400,7 +400,7 @@ fn main_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
 
 /// [Basic fetch](https://fetch.spec.whatwg.org#basic-fetch)
 fn basic_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
-                                         cache: &mut CORSCache,
+                                         cache: &mut CorsCache,
                                          target: &mut Target,
                                          done_chan: &mut DoneChannel,
                                          context: &FetchContext<UI>)
@@ -499,7 +499,7 @@ fn basic_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
 
 /// [HTTP fetch](https://fetch.spec.whatwg.org#http-fetch)
 fn http_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
-                                        cache: &mut CORSCache,
+                                        cache: &mut CorsCache,
                                         cors_flag: bool,
                                         cors_preflight_flag: bool,
                                         authentication_fetch_flag: bool,
@@ -526,7 +526,7 @@ fn http_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
 
             // Substep 3
             if (res.response_type == ResponseType::Opaque &&
-                request.mode != RequestMode::NoCORS) ||
+                request.mode != RequestMode::NoCors) ||
                (res.response_type == ResponseType::OpaqueRedirect &&
                 request.redirect_mode.get() != RedirectMode::Manual) ||
                (res.url_list.borrow().len() > 1 &&
@@ -674,7 +674,7 @@ fn http_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
 
 /// [HTTP redirect fetch](https://fetch.spec.whatwg.org#http-redirect-fetch)
 fn http_redirect_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
-                                                 cache: &mut CORSCache,
+                                                 cache: &mut CorsCache,
                                                  response: Response,
                                                  cors_flag: bool,
                                                  target: &mut Target,
@@ -720,7 +720,7 @@ fn http_redirect_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
     };
     let has_credentials = has_credentials(&location_url);
 
-    if request.mode == RequestMode::CORSMode && !same_origin && has_credentials {
+    if request.mode == RequestMode::CorsMode && !same_origin && has_credentials {
         return Response::network_error(NetworkError::Internal("Cross-origin credentials check failed".into()));
     }
 
@@ -1166,7 +1166,7 @@ fn http_network_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
 
 /// [CORS preflight fetch](https://fetch.spec.whatwg.org#cors-preflight-fetch)
 fn cors_preflight_fetch<UI: 'static + UIProvider>(request: Rc<Request>,
-                                                  cache: &mut CORSCache,
+                                                  cache: &mut CorsCache,
                                                   context: &FetchContext<UI>)
                                                   -> Response {
     // Step 1

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -152,7 +152,7 @@ pub struct LoadData {
     /// Unused in fetch
     pub preserved_headers: Headers,
     pub data: Option<Vec<u8>>,
-    pub cors: Option<ResourceCORSData>,
+    pub cors: Option<ResourceCorsData>,
     pub pipeline_id: Option<PipelineId>,
     // https://fetch.spec.whatwg.org/#concept-http-fetch step 4.3
     pub credentials_flag: bool,
@@ -472,7 +472,7 @@ pub struct LoadResponse {
 }
 
 #[derive(Clone, Deserialize, Serialize, HeapSizeOf)]
-pub struct ResourceCORSData {
+pub struct ResourceCorsData {
     /// CORS Preflight flag
     pub preflight: bool,
     /// Origin of CORS Request

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -57,8 +57,8 @@ pub enum Referrer {
 pub enum RequestMode {
     Navigate,
     SameOrigin,
-    NoCORS,
-    CORSMode
+    NoCors,
+    CorsMode
 }
 
 /// Request [credentials mode](https://fetch.spec.whatwg.org/#concept-request-credentials-mode)
@@ -92,7 +92,7 @@ pub enum RedirectMode {
 #[derive(Copy, Clone, PartialEq, HeapSizeOf)]
 pub enum ResponseTainting {
     Basic,
-    CORSTainting,
+    CorsTainting,
     Opaque
 }
 
@@ -106,7 +106,7 @@ pub enum Window {
 
 /// [CORS settings attribute](https://html.spec.whatwg.org/multipage/#attr-crossorigin-anonymous)
 #[derive(Copy, Clone, PartialEq, Serialize, Deserialize)]
-pub enum CORSSettings {
+pub enum CorsSettings {
     Anonymous,
     UseCredentials
 }
@@ -150,7 +150,7 @@ impl Default for RequestInit {
             type_: Type::None,
             destination: Destination::None,
             synchronous: false,
-            mode: RequestMode::NoCORS,
+            mode: RequestMode::NoCors,
             use_cors_preflight: false,
             credentials_mode: CredentialsMode::Omit,
             use_url_credentials: false,
@@ -230,7 +230,7 @@ impl Request {
             referrer_policy: Cell::new(None),
             pipeline_id: Cell::new(pipeline_id),
             synchronous: false,
-            mode: RequestMode::NoCORS,
+            mode: RequestMode::NoCors,
             use_cors_preflight: false,
             credentials_mode: CredentialsMode::Omit,
             use_url_credentials: false,

--- a/components/net_traits/response.rs
+++ b/components/net_traits/response.rs
@@ -17,7 +17,7 @@ use url::Url;
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize, HeapSizeOf)]
 pub enum ResponseType {
     Basic,
-    CORS,
+    Cors,
     Default,
     Error(NetworkError),
     Opaque,
@@ -198,7 +198,7 @@ impl Response {
                 response.headers = headers;
             },
 
-            ResponseType::CORS => {
+            ResponseType::Cors => {
                 let access = old_headers.get::<AccessControlExposeHeaders>();
                 let allowed_headers = access.as_ref().map(|v| &v[..]).unwrap_or(&[]);
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -33,7 +33,7 @@ use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use js::jsval::UndefinedValue;
 use net_traits::{FetchMetadata, FetchResponseListener, Metadata, NetworkError};
-use net_traits::request::{CORSSettings, CredentialsMode, Destination, RequestInit, RequestMode, Type as RequestType};
+use net_traits::request::{CorsSettings, CredentialsMode, Destination, RequestInit, RequestMode, Type as RequestType};
 use network_listener::{NetworkListener, PreInvoke};
 use servo_atoms::Atom;
 use std::ascii::AsciiExt;
@@ -221,7 +221,7 @@ impl PreInvoke for ScriptContext {}
 /// https://html.spec.whatwg.org/multipage/#fetch-a-classic-script
 fn fetch_a_classic_script(script: &HTMLScriptElement,
                           url: Url,
-                          cors_setting: Option<CORSSettings>,
+                          cors_setting: Option<CorsSettings>,
                           character_encoding: EncodingRef) {
     let doc = document_from_node(script);
 
@@ -233,13 +233,13 @@ fn fetch_a_classic_script(script: &HTMLScriptElement,
         // https://html.spec.whatwg.org/multipage/#create-a-potential-cors-request
         // Step 1
         mode: match cors_setting {
-            Some(_) => RequestMode::CORSMode,
-            None => RequestMode::NoCORS,
+            Some(_) => RequestMode::CorsMode,
+            None => RequestMode::NoCors,
         },
         // https://html.spec.whatwg.org/multipage/#create-a-potential-cors-request
         // Step 3-4
         credentials_mode: match cors_setting {
-            Some(CORSSettings::Anonymous) => CredentialsMode::CredentialsSameOrigin,
+            Some(CorsSettings::Anonymous) => CredentialsMode::CredentialsSameOrigin,
             _ => CredentialsMode::Include,
         },
         origin: doc.url().clone(),
@@ -358,8 +358,8 @@ impl HTMLScriptElement {
 
         // Step 14.
         let cors_setting = match self.GetCrossOrigin() {
-            Some(ref s) if *s == "anonymous" => Some(CORSSettings::Anonymous),
-            Some(ref s) if *s == "use-credentials" => Some(CORSSettings::UseCredentials),
+            Some(ref s) if *s == "anonymous" => Some(CorsSettings::Anonymous),
+            Some(ref s) if *s == "use-credentials" => Some(CorsSettings::UseCredentials),
             None => None,
             _ => unreachable!()
         };

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -114,7 +114,7 @@ impl Request {
                                                             url,
                                                             false);
                 // Step 5.5
-                fallback_mode = Some(NetTraitsRequestMode::CORSMode);
+                fallback_mode = Some(NetTraitsRequestMode::CorsMode);
                 // Step 5.6
                 fallback_credentials = Some(NetTraitsRequestCredentials::Omit);
             }
@@ -325,7 +325,7 @@ impl Request {
         r.Headers().empty_header_list();
 
         // Step 30
-        if r.request.borrow().mode == NetTraitsRequestMode::NoCORS {
+        if r.request.borrow().mode == NetTraitsRequestMode::NoCors {
             let borrowed_request = r.request.borrow();
             // Step 30.1
             if !is_cors_safelisted_method(&borrowed_request.method.borrow()) {
@@ -793,8 +793,8 @@ impl Into<NetTraitsRequestMode> for RequestMode {
         match self {
             RequestMode::Navigate => NetTraitsRequestMode::Navigate,
             RequestMode::Same_origin => NetTraitsRequestMode::SameOrigin,
-            RequestMode::No_cors => NetTraitsRequestMode::NoCORS,
-            RequestMode::Cors => NetTraitsRequestMode::CORSMode,
+            RequestMode::No_cors => NetTraitsRequestMode::NoCors,
+            RequestMode::Cors => NetTraitsRequestMode::CorsMode,
         }
     }
 }
@@ -804,8 +804,8 @@ impl Into<RequestMode> for NetTraitsRequestMode {
         match self {
             NetTraitsRequestMode::Navigate => RequestMode::Navigate,
             NetTraitsRequestMode::SameOrigin => RequestMode::Same_origin,
-            NetTraitsRequestMode::NoCORS => RequestMode::No_cors,
-            NetTraitsRequestMode::CORSMode => RequestMode::Cors,
+            NetTraitsRequestMode::NoCors => RequestMode::No_cors,
+            NetTraitsRequestMode::CorsMode => RequestMode::Cors,
         }
     }
 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -590,7 +590,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
             // https://github.com/whatwg/xhr/issues/71
             destination: Destination::None,
             synchronous: self.sync.get(),
-            mode: RequestMode::CORSMode,
+            mode: RequestMode::CorsMode,
             use_cors_preflight: has_handlers,
             credentials_mode: credentials_mode,
             use_url_credentials: use_url_credentials,

--- a/tests/unit/net/fetch.rs
+++ b/tests/unit/net/fetch.rs
@@ -20,7 +20,7 @@ use hyper::server::{Request as HyperRequest, Response as HyperResponse};
 use hyper::status::StatusCode;
 use hyper::uri::RequestUri;
 use msg::constellation_msg::TEST_PIPELINE_ID;
-use net::fetch::cors_cache::CORSCache;
+use net::fetch::cors_cache::CorsCache;
 use net::fetch::methods::{fetch, fetch_with_cors_cache};
 use net_traits::ReferrerPolicy;
 use net_traits::request::{Origin, RedirectMode, Referrer, Request, RequestMode};
@@ -189,7 +189,7 @@ fn test_cors_preflight_fetch() {
     *request.referrer.borrow_mut() = Referrer::ReferrerUrl(target_url);
     *request.referrer_policy.get_mut() = Some(ReferrerPolicy::Origin);
     request.use_cors_preflight = true;
-    request.mode = RequestMode::CORSMode;
+    request.mode = RequestMode::CorsMode;
     let fetch_response = fetch_sync(request, None);
     let _ = server.close();
 
@@ -206,7 +206,7 @@ fn test_cors_preflight_cache_fetch() {
     static ACK: &'static [u8] = b"ACK";
     let state = Arc::new(AtomicUsize::new(0));
     let counter = state.clone();
-    let mut cache = CORSCache::new();
+    let mut cache = CorsCache::new();
     let handler = move |request: HyperRequest, mut response: HyperResponse| {
         if request.method == Method::Options && state.clone().fetch_add(1, Ordering::SeqCst) == 0 {
             assert!(request.headers.has::<AccessControlRequestMethod>());
@@ -226,7 +226,7 @@ fn test_cors_preflight_cache_fetch() {
     let mut request = Request::new(url.clone(), Some(origin.clone()), false, None);
     *request.referrer.borrow_mut() = Referrer::NoReferrer;
     request.use_cors_preflight = true;
-    request.mode = RequestMode::CORSMode;
+    request.mode = RequestMode::CorsMode;
     let wrapped_request0 = Rc::new(request.clone());
     let wrapped_request1 = Rc::new(request);
 
@@ -278,7 +278,7 @@ fn test_cors_preflight_fetch_network_error() {
     *request.method.borrow_mut() = Method::Extension("CHICKEN".to_owned());
     *request.referrer.borrow_mut() = Referrer::NoReferrer;
     request.use_cors_preflight = true;
-    request.mode = RequestMode::CORSMode;
+    request.mode = RequestMode::CorsMode;
     let fetch_response = fetch_sync(request, None);
     let _ = server.close();
 
@@ -345,12 +345,12 @@ fn test_fetch_response_is_cors_filtered() {
     let origin = Origin::Origin(UrlOrigin::new_opaque());
     let mut request = Request::new(url, Some(origin), false, None);
     *request.referrer.borrow_mut() = Referrer::NoReferrer;
-    request.mode = RequestMode::CORSMode;
+    request.mode = RequestMode::CorsMode;
     let fetch_response = fetch_sync(request, None);
     let _ = server.close();
 
     assert!(!fetch_response.is_network_error());
-    assert_eq!(fetch_response.response_type, ResponseType::CORS);
+    assert_eq!(fetch_response.response_type, ResponseType::Cors);
 
     let headers = fetch_response.headers;
     assert!(headers.has::<CacheControl>());
@@ -630,7 +630,7 @@ fn test_fetch_redirect_updates_method() {
 
 fn response_is_done(response: &Response) -> bool {
     let response_complete = match response.response_type {
-        ResponseType::Default | ResponseType::Basic | ResponseType::CORS => {
+        ResponseType::Default | ResponseType::Basic | ResponseType::Cors => {
             (*response.body.lock().unwrap()).is_done()
         }
         // if the internal response cannot have a body, it shouldn't block the "done" state


### PR DESCRIPTION
As per:

https://aturon.github.io/style/naming/README.html#general-conventions-[rfc-#430]

Acronyms should be considered one word and not all caps.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14156)
<!-- Reviewable:end -->
