### PR TITLE
style: Refactor and add infrastructure for font metrics in style.

### DIFF
--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -403,6 +403,7 @@ fn compute_style_for_animation_step(context: &SharedStyleContext,
                                                previous_style,
                                                /* cascade_info = */ None,
                                                context.error_reporter.clone(),
+                                               /* Metrics provider */ None,
                                                CascadeFlags::empty());
             computed
         }

--- a/components/style/font_metrics.rs
+++ b/components/style/font_metrics.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use Atom;
+use app_units::Au;
+use euclid::Size2D;
+use std::fmt;
+
+/// Represents the font metrics that style needs from a font to compute the
+/// value of certain CSS units like `ex`.
+#[derive(Debug, PartialEq, Clone)]
+pub struct FontMetrics {
+    pub x_height: Au,
+    pub zero_advance_measure: Size2D<Au>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum FontMetricsQueryResult {
+    Available(Option<FontMetrics>),
+    NotAvailable,
+}
+
+/// A trait used to represent something capable of providing us font metrics.
+pub trait FontMetricsProvider: Send + Sync + fmt::Debug {
+    /// Obtain the metrics for given font family.
+    ///
+    /// TODO: We could make this take the full list, I guess, and save a few
+    /// virtual calls.
+    ///
+    /// This is not too common in practice though.
+    fn query(&self, _font_name: &Atom) -> FontMetricsQueryResult {
+        FontMetricsQueryResult::NotAvailable
+    }
+}

--- a/components/style/gecko/conversions.rs
+++ b/components/style/gecko/conversions.rs
@@ -38,7 +38,7 @@ impl From<CalcLengthOrPercentage> for nsStyleCoord_CalcValue {
     fn from(other: CalcLengthOrPercentage) -> nsStyleCoord_CalcValue {
         let has_percentage = other.percentage.is_some();
         nsStyleCoord_CalcValue {
-            mLength: other.length.map_or(0, |l| l.0),
+            mLength: other.length.0,
             mPercent: other.percentage.unwrap_or(0.0),
             mHasPercent: has_percentage,
         }
@@ -53,7 +53,7 @@ impl From<nsStyleCoord_CalcValue> for CalcLengthOrPercentage {
             None
         };
         CalcLengthOrPercentage {
-            length: Some(Au(other.mLength)),
+            length: Au(other.mLength),
             percentage: percentage,
         }
     }

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -103,6 +103,7 @@ pub mod dom;
 pub mod element_state;
 pub mod error_reporting;
 pub mod font_face;
+pub mod font_metrics;
 #[cfg(feature = "gecko")] #[allow(unsafe_code)] pub mod gecko;
 #[cfg(feature = "gecko")] #[allow(unsafe_code)] pub mod gecko_bindings;
 pub mod keyframes;

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -916,6 +916,14 @@ fn static_assert() {
         }
     }
 
+    pub fn font_family_count(&self) -> usize {
+        0
+    }
+
+    pub fn font_family_at(&self, _: usize) -> longhands::font_family::computed_value::FontFamily {
+        unimplemented!()
+    }
+
     pub fn copy_font_family_from(&mut self, other: &Self) {
         unsafe { Gecko_CopyFontFamilyFrom(&mut self.gecko.mFont, &other.gecko.mFont); }
     }

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -418,7 +418,7 @@ impl Interpolate for CalcLengthOrPercentage {
         }
 
         Ok(CalcLengthOrPercentage {
-            length: try!(interpolate_half(self.length, other.length, progress)),
+            length: try!(self.length.interpolate(&other.length, progress)),
             percentage: try!(interpolate_half(self.percentage, other.percentage, progress)),
         })
     }

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -8,7 +8,7 @@
 <% data.new_style_struct("Font",
                          inherited=True,
                          additional_methods=[Method("compute_font_hash", is_mut=True)]) %>
-<%helpers:longhand name="font-family" animatable="False">
+<%helpers:longhand name="font-family" animatable="False" need_index="True">
     use self::computed_value::FontFamily;
     use values::NoViewportPercentage;
     use values::computed::ComputedValueAsSpecified;
@@ -21,6 +21,7 @@
         use std::fmt;
         use Atom;
         use style_traits::ToCss;
+        pub use self::FontFamily as SingleComputedValue;
 
         #[derive(Debug, PartialEq, Eq, Clone, Hash)]
         #[cfg_attr(feature = "servo", derive(HeapSizeOf, Deserialize, Serialize))]
@@ -28,8 +29,8 @@
             FamilyName(Atom),
             Generic(Atom),
         }
-        impl FontFamily {
 
+        impl FontFamily {
             #[inline]
             pub fn atom(&self) -> &Atom {
                 match *self {
@@ -67,11 +68,13 @@
                 FontFamily::FamilyName(input)
             }
         }
+
         impl ToCss for FontFamily {
             fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
                 self.atom().with_str(|s| dest.write_str(s))
             }
         }
+
         impl ToCss for T {
             fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
                 let mut iter = self.0.iter();
@@ -83,6 +86,7 @@
                 Ok(())
             }
         }
+
         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
         pub struct T(pub Vec<FontFamily>);
@@ -307,8 +311,7 @@ ${helpers.single_keyword("font-variant",
         fn to_computed_value(&self, context: &Context) -> computed_value::T {
             match self.0 {
                 LengthOrPercentage::Length(Length::FontRelative(value)) => {
-                    value.to_computed_value(context.inherited_style().get_font().clone_font_size(),
-                                            context.style().root_font_size())
+                    value.to_computed_value(context, /* use inherited */ true)
                 }
                 LengthOrPercentage::Length(Length::ServoCharacterWidth(value)) => {
                     value.to_computed_value(context.inherited_style().get_font().clone_font_size())

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -25,6 +25,7 @@ use url::Url;
 #[cfg(feature = "servo")] use euclid::side_offsets::SideOffsets2D;
 use euclid::size::Size2D;
 use computed_values;
+use font_metrics::FontMetricsProvider;
 #[cfg(feature = "servo")] use logical_geometry::{LogicalMargin, PhysicalSide};
 use logical_geometry::WritingMode;
 use parser::{Parse, ParserContext, ParserContextExtraData};
@@ -1464,6 +1465,7 @@ pub fn cascade(viewport_size: Size2D<Au>,
                        inherited_style,
                        cascade_info,
                        error_reporter,
+                       None,
                        flags)
 }
 
@@ -1475,6 +1477,7 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
                                     inherited_style: &ComputedValues,
                                     mut cascade_info: Option<<&mut CascadeInfo>,
                                     mut error_reporter: StdBox<ParseErrorReporter + Send>,
+                                    font_metrics_provider: Option<<&FontMetricsProvider>,
                                     flags: CascadeFlags)
                                     -> ComputedValues
     where F: Fn() -> I, I: Iterator<Item = &'a PropertyDeclaration>
@@ -1528,6 +1531,7 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
         viewport_size: viewport_size,
         inherited_style: inherited_style,
         style: starting_style,
+        font_metrics_provider: font_metrics_provider,
     };
 
     // Set computed values, overwriting earlier declarations for the same
@@ -1562,6 +1566,7 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
                 // classification is correct.
                 let is_early_property = matches!(*declaration,
                     PropertyDeclaration::FontSize(_) |
+                    PropertyDeclaration::FontFamily(_) |
                     PropertyDeclaration::Color(_) |
                     PropertyDeclaration::Position(_) |
                     PropertyDeclaration::Float(_) |

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -5,6 +5,7 @@
 use app_units::Au;
 use cssparser::{Parser, Token};
 use euclid::size::Size2D;
+use font_metrics::FontMetrics;
 use parser::Parse;
 use std::ascii::AsciiExt;
 use std::cmp;
@@ -13,7 +14,8 @@ use std::ops::Mul;
 use style_traits::ToCss;
 use style_traits::values::specified::AllowedNumericType;
 use super::{Angle, Number, SimplifiedValueNode, SimplifiedSumNode, Time};
-use values::{CSSFloat, Either, FONT_MEDIUM_PX, HasViewportPercentage, None_, computed};
+use values::{CSSFloat, Either, FONT_MEDIUM_PX, HasViewportPercentage, None_};
+use values::computed::Context;
 
 pub use super::image::{AngleOrCorner, ColorStop, EndingShape as GradientEndingShape, Gradient};
 pub use super::image::{GradientKind, HorizontalDirection, Image, LengthOrKeyword, LengthOrPercentageOrKeyword};
@@ -40,18 +42,78 @@ impl ToCss for FontRelativeLength {
 }
 
 impl FontRelativeLength {
-    pub fn to_computed_value(&self,
-                             reference_font_size: Au,
-                             root_font_size: Au)
-                             -> Au
-    {
+    pub fn find_first_available_font_metrics(context: &Context) -> Option<FontMetrics> {
+        use font_metrics::FontMetricsQueryResult::*;
+        if let Some(ref metrics_provider) = context.font_metrics_provider {
+            for family in context.style().get_font().font_family_iter() {
+                if let Available(metrics) = metrics_provider.query(family.atom()) {
+                    return metrics;
+                }
+            }
+        }
+
+        None
+    }
+
+    // NB: The use_inherited flag is used to special-case the computation of
+    // font-family.
+    pub fn to_computed_value(&self, context: &Context, use_inherited: bool) -> Au {
+        let reference_font_size = if use_inherited {
+            context.inherited_style().get_font().clone_font_size()
+        } else {
+            context.style().get_font().clone_font_size()
+        };
+
+        let root_font_size = context.style().root_font_size;
         match *self {
             FontRelativeLength::Em(length) => reference_font_size.scale_by(length),
-            FontRelativeLength::Ex(length) | FontRelativeLength::Ch(length) => {
-                // https://github.com/servo/servo/issues/7462
-                let em_factor = 0.5;
-                reference_font_size.scale_by(length * em_factor)
+            FontRelativeLength::Ex(length) => {
+                match Self::find_first_available_font_metrics(context) {
+                    Some(metrics) => metrics.x_height,
+                    // https://drafts.csswg.org/css-values/#ex
+                    //
+                    //     In the cases where it is impossible or impractical to
+                    //     determine the x-height, a value of 0.5em must be
+                    //     assumed.
+                    //
+                    None => reference_font_size.scale_by(0.5 * length),
+                }
             },
+            FontRelativeLength::Ch(length) => {
+                let wm = context.style().writing_mode;
+
+                // TODO(emilio, #14144): Compute this properly once we support
+                // all the relevant writing-mode related properties, this should
+                // be equivalent to "is the text in the block direction?".
+                let vertical = wm.is_vertical();
+
+                match Self::find_first_available_font_metrics(context) {
+                    Some(metrics) => {
+                        if vertical {
+                            metrics.zero_advance_measure.height
+                        } else {
+                            metrics.zero_advance_measure.width
+                        }
+                    }
+                    // https://drafts.csswg.org/css-values/#ch
+                    //
+                    //     In the cases where it is impossible or impractical to
+                    //     determine the measure of the “0” glyph, it must be
+                    //     assumed to be 0.5em wide by 1em tall. Thus, the ch
+                    //     unit falls back to 0.5em in the general case, and to
+                    //     1em when it would be typeset upright (i.e.
+                    //     writing-mode is vertical-rl or vertical-lr and
+                    //     text-orientation is upright).
+                    //
+                    None => {
+                        if vertical {
+                            reference_font_size.scale_by(length)
+                        } else {
+                            reference_font_size.scale_by(0.5 * length)
+                        }
+                    }
+                }
+            }
             FontRelativeLength::Rem(length) => root_font_size.scale_by(length)
         }
     }
@@ -610,38 +672,6 @@ impl CalcLengthOrPercentage {
             (Some(angle), None) => Ok(Angle(angle)),
             (None, Some(value)) if value == 0. => Ok(Angle(0.)),
             _ => Err(())
-        }
-    }
-
-    pub fn compute_from_viewport_and_font_size(&self,
-                                               viewport_size: Size2D<Au>,
-                                               font_size: Au,
-                                               root_font_size: Au)
-                                               -> computed::CalcLengthOrPercentage
-    {
-        let mut length = None;
-
-        if let Some(absolute) = self.absolute {
-            length = Some(length.unwrap_or(Au(0)) + absolute);
-        }
-
-        for val in &[self.vw, self.vh, self.vmin, self.vmax] {
-            if let Some(val) = *val {
-                length = Some(length.unwrap_or(Au(0)) +
-                    val.to_computed_value(viewport_size));
-            }
-        }
-
-        for val in &[self.ch, self.em, self.ex, self.rem] {
-            if let Some(val) = *val {
-                length = Some(length.unwrap_or(Au(0)) + val.to_computed_value(
-                    font_size, root_font_size));
-            }
-        }
-
-        computed::CalcLengthOrPercentage {
-            length: length,
-            percentage: self.percentage.map(|p| p.0),
         }
     }
 }

--- a/components/style/values/specified/position.rs
+++ b/components/style/values/specified/position.rs
@@ -7,6 +7,7 @@
 //!
 //! [position]: https://drafts.csswg.org/css-backgrounds-3/#position
 
+use app_units::Au;
 use cssparser::{Parser, Token};
 use parser::Parse;
 use std::fmt;
@@ -290,9 +291,9 @@ impl ToComputedValue for Position {
             Keyword::Right => {
                 if let Some(x) = self.horiz_position {
                     let (length, percentage) = match x {
-                        LengthOrPercentage::Percentage(Percentage(y)) => (None, Some(1.0 - y)),
-                        LengthOrPercentage::Length(y) => (Some(-y.to_computed_value(context)), Some(1.0)),
-                        _ => (None, None),
+                        LengthOrPercentage::Percentage(Percentage(y)) => (Au(0), Some(1.0 - y)),
+                        LengthOrPercentage::Length(y) => (-y.to_computed_value(context), Some(1.0)),
+                        _ => (Au(0), None),
                     };
                     ComputedLengthOrPercentage::Calc(CalcLengthOrPercentage {
                         length: length,
@@ -316,9 +317,9 @@ impl ToComputedValue for Position {
             Keyword::Bottom => {
                 if let Some(x) = self.vert_position {
                     let (length, percentage) = match x {
-                        LengthOrPercentage::Percentage(Percentage(y)) => (None, Some(1.0 - y)),
-                        LengthOrPercentage::Length(y) => (Some(-y.to_computed_value(context)), Some(1.0)),
-                        _ => (None, None),
+                        LengthOrPercentage::Percentage(Percentage(y)) => (Au(0), Some(1.0 - y)),
+                        LengthOrPercentage::Length(y) => (-y.to_computed_value(context), Some(1.0)),
+                        _ => (Au(0), None),
                     };
                     ComputedLengthOrPercentage::Calc(CalcLengthOrPercentage {
                         length: length,

--- a/components/style/viewport.rs
+++ b/components/style/viewport.rs
@@ -633,6 +633,7 @@ impl MaybeNew for ViewportConstraints {
             viewport_size: initial_viewport,
             inherited_style: ComputedValues::initial_values(),
             style: ComputedValues::initial_values().clone(),
+            font_metrics_provider: None, // TODO: Should have!
         };
 
         // DEVICE-ADAPT § 9.3 Resolving 'extend-to-zoom'

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -148,6 +148,7 @@ pub extern "C" fn Servo_RestyleWithAddedDeclaration(declarations: RawServoDeclar
                                       previous_style,
                                       None,
                                       Box::new(StdoutErrorReporter),
+                                      None,
                                       CascadeFlags::empty());
     Arc::new(computed).into_strong()
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because moves stuff around without adding functionality.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

This commit itself only moves things around and adds an extra parameter to the
`apply_declarations` function to eventually handle #14079 correctly.

Probably needs a more granular API to query fonts, á la nsFontMetrics, but
that's trivial to do once this is landed.

Then we should make the font provider mandatory, and implement the missing stylo
bits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14174)
<!-- Reviewable:end -->
