### PR TITLE
script: Ensure script is initialized before running script.

### DIFF
--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -163,14 +163,16 @@ fn perform_platform_specific_initialization() {
 #[cfg(not(target_os = "linux"))]
 fn perform_platform_specific_initialization() {}
 
+pub fn init_service_workers(sw_senders: SWManagerSenders) {
+    // Spawn the service worker manager passing the constellation sender
+    ServiceWorkerManager::spawn_manager(sw_senders);
+}
+
 #[allow(unsafe_code)]
-pub fn init(sw_senders: SWManagerSenders) {
+pub fn init() {
     unsafe {
         proxyhandler::init();
     }
-
-    // Spawn the service worker manager passing the constellation sender
-    ServiceWorkerManager::spawn_manager(sw_senders);
 
     // Create the global vtables used by the (generated) DOM
     // bindings to implement JS proxies.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fixes the race causing #14154. Service workers are ok because they contain explicit synchronization.

r? @asajeffrey or @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14179)
<!-- Reviewable:end -->
