### PR TITLE
Don't unnecessarily clone entire `opts::Opt` structure.

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -87,9 +87,11 @@ use profile::time as profile_time;
 use profile_traits::mem;
 use profile_traits::time;
 use script_traits::{ConstellationMsg, SWManagerSenders, ScriptMsg};
+use std::borrow::Cow;
 use std::cmp::max;
 use std::rc::Rc;
 use std::sync::mpsc::Sender;
+use url::Url;
 use util::opts;
 use util::prefs::PREFS;
 use util::resource_files::resources_dir_path;
@@ -173,7 +175,9 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
         // Create the constellation, which maintains the engine
         // pipelines, including the script and layout threads, as well
         // as the navigation context.
-        let (constellation_chan, sw_senders) = create_constellation(opts.clone(),
+        let (constellation_chan, sw_senders) = create_constellation(opts.user_agent.clone(),
+                                                                    opts.config_dir.clone(),
+                                                                    opts.url.clone(),
                                                                     compositor_proxy.clone_compositor_proxy(),
                                                                     time_profiler_chan.clone(),
                                                                     mem_profiler_chan.clone(),
@@ -238,7 +242,9 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
     }
 }
 
-fn create_constellation(opts: opts::Opts,
+fn create_constellation(user_agent: Cow<'static, str>,
+                        config_dir: Option<String>,
+                        url: Option<Url>,
                         compositor_proxy: Box<CompositorProxy + Send>,
                         time_profiler_chan: time::ProfilerChan,
                         mem_profiler_chan: mem::ProfilerChan,
@@ -250,10 +256,10 @@ fn create_constellation(opts: opts::Opts,
     let bluetooth_thread: IpcSender<BluetoothRequest> = BluetoothThreadFactory::new();
 
     let (public_resource_threads, private_resource_threads) =
-        new_resource_threads(opts.user_agent,
+        new_resource_threads(user_agent,
                              devtools_chan.clone(),
                              time_profiler_chan.clone(),
-                             opts.config_dir.map(Into::into));
+                             config_dir.map(Into::into));
     let image_cache_thread = new_image_cache_thread(public_resource_threads.sender(),
                                                     webrender_api_sender.create_api());
     let font_cache_thread = FontCacheThread::new(public_resource_threads.sender(),
@@ -280,7 +286,7 @@ fn create_constellation(opts: opts::Opts,
                         layout_thread::LayoutThread,
                         script::script_thread::ScriptThread>::start(initial_state);
 
-    if let Some(url) = opts.url {
+    if let Some(url) = url {
         constellation_chan.send(ConstellationMsg::InitLoadUrl(url)).unwrap();
     };
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -89,6 +89,7 @@ use profile_traits::time;
 use script_traits::{ConstellationMsg, SWManagerSenders, ScriptMsg};
 use std::borrow::Cow;
 use std::cmp::max;
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::mpsc::Sender;
 use url::Url;
@@ -243,7 +244,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
 }
 
 fn create_constellation(user_agent: Cow<'static, str>,
-                        config_dir: Option<String>,
+                        config_dir: Option<PathBuf>,
                         url: Option<Url>,
                         compositor_proxy: Box<CompositorProxy + Send>,
                         time_profiler_chan: time::ProfilerChan,
@@ -259,7 +260,7 @@ fn create_constellation(user_agent: Cow<'static, str>,
         new_resource_threads(user_agent,
                              devtools_chan.clone(),
                              time_profiler_chan.clone(),
-                             config_dir.map(Into::into));
+                             config_dir);
     let image_cache_thread = new_image_cache_thread(public_resource_threads.sender(),
                                                     webrender_api_sender.create_api());
     let font_cache_thread = FontCacheThread::new(public_resource_threads.sender(),

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -215,7 +215,7 @@ pub struct Opts {
     pub use_msaa: bool,
 
     /// Directory for a default config directory
-    pub config_dir: Option<String>,
+    pub config_dir: Option<PathBuf>,
 
     // don't skip any backtraces on panic
     pub full_backtraces: bool,
@@ -857,7 +857,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         enable_vsync: !debug_options.disable_vsync,
         webrender_stats: debug_options.webrender_stats,
         use_msaa: debug_options.use_msaa,
-        config_dir: opt_match.opt_str("config-dir"),
+        config_dir: opt_match.opt_str("config-dir").map(Into::into),
         full_backtraces: debug_options.full_backtraces,
         is_printing_version: is_printing_version,
         webrender_debug: debug_options.webrender_debug,


### PR DESCRIPTION
`opts::Opt` is a pretty big structure, so cloning everything is
excessive when we only need a few items.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14181)
<!-- Reviewable:end -->
