### PR TITLE
Return `KeyReaction::Nothing` for a Tab event

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -35,7 +35,6 @@ use dom::virtualmethods::VirtualMethods;
 use html5ever_atoms::LocalName;
 use ipc_channel::ipc::{self, IpcSender};
 use mime_guess;
-use msg::constellation_msg::Key;
 use net_traits::{CoreResourceMsg, IpcSend};
 use net_traits::blob_url_store::get_blob_origin;
 use net_traits::filemanager_thread::{FileManagerThreadMsg, FilterPattern};
@@ -1097,18 +1096,10 @@ impl VirtualMethods for HTMLInputElement {
                     let action = self.textinput.borrow_mut().handle_keydown(keyevent);
                     match action {
                         TriggerDefaultAction => {
-                            if let Some(key) = keyevent.get_key() {
-                                match key {
-                                    Key::Enter | Key::KpEnter =>
-                                        self.implicit_submission(keyevent.CtrlKey(),
-                                                                 keyevent.ShiftKey(),
-                                                                 keyevent.AltKey(),
-                                                                 keyevent.MetaKey()),
-                                    // Issue #12071: Tab should not submit forms
-                                    // TODO(3982): Implement form keyboard navigation
-                                    _ => (),
-                                }
-                            };
+                            self.implicit_submission(keyevent.CtrlKey(),
+                                                     keyevent.ShiftKey(),
+                                                     keyevent.AltKey(),
+                                                     keyevent.MetaKey());
                         },
                         DispatchInput => {
                             self.value_changed.set(true);

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -544,7 +544,6 @@ impl<T: ClipboardProvider> TextInput<T> {
                 self.adjust_vertical(28, maybe_select);
                 KeyReaction::RedrawSelection
             }
-            (None, Key::Tab) => KeyReaction::TriggerDefaultAction,
             _ => KeyReaction::Nothing,
         }
     }


### PR DESCRIPTION
Do nothing instead of triggering the default action for a tab event.

Hitting the tab key in an html text input shouldn't submit the form, and for any text input, the tab key should have a particular action associated, not the default action.
This cleans up #12701.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14184)
<!-- Reviewable:end -->
