### PR TITLE
Added parsing/serialization for text-emphasis-position

### DIFF
--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -936,6 +936,55 @@ ${helpers.single_keyword("text-align-last",
     }
 </%helpers:longhand>
 
+<%helpers:longhand name="text-emphasis-position" animatable="False" products="none">
+    use std::fmt;
+    use values::computed::ComputedValueAsSpecified;
+    use values::NoViewportPercentage;
+    use style_traits::ToCss;
+
+    define_css_keyword_enum!(HorizontalWritingModeValue:
+                             "over" => Over,
+                             "under" => Under);
+    define_css_keyword_enum!(VerticalWritingModeValue:
+                             "right" => Right,
+                             "left" => Left);
+
+    #[derive(Debug, Clone, PartialEq)]
+    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+    pub struct SpecifiedValue(pub HorizontalWritingModeValue, pub VerticalWritingModeValue);
+
+    pub mod computed_value {
+        pub type T = super::SpecifiedValue;
+    }
+
+    impl ComputedValueAsSpecified for SpecifiedValue {}
+    impl NoViewportPercentage for SpecifiedValue {}
+
+    pub fn get_initial_value() -> computed_value::T {
+        SpecifiedValue(HorizontalWritingModeValue::Over, VerticalWritingModeValue::Right)
+    }
+
+    pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
+       if let Ok(horizontal) = input.try(|input| HorizontalWritingModeValue::parse(input)) {
+            let vertical = try!(VerticalWritingModeValue::parse(input));
+            Ok(SpecifiedValue(horizontal, vertical))
+        } else {
+            let vertical = try!(VerticalWritingModeValue::parse(input));
+            let horizontal = try!(HorizontalWritingModeValue::parse(input));
+            Ok(SpecifiedValue(horizontal, vertical))
+        }
+    }
+
+    impl ToCss for SpecifiedValue {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            let SpecifiedValue(horizontal, vertical) = *self;
+            try!(horizontal.to_css(dest));
+            try!(dest.write_char(' '));
+            vertical.to_css(dest)
+        }
+    }
+</%helpers:longhand>
+
 // TODO(pcwalton): `full-width`
 ${helpers.single_keyword("text-transform",
                          "none capitalize uppercase lowercase",

--- a/tests/unit/style/parsing/inherited_text.rs
+++ b/tests/unit/style/parsing/inherited_text.rs
@@ -48,3 +48,34 @@ fn text_emphasis_style_longhand_should_parse_properly() {
     let devanagari_string_struct = SpecifiedValue::String("षि".to_string());
     assert_eq!(devanagari_string, devanagari_string_struct);
 }
+
+#[test]
+fn test_text_emphasis_position() {
+    use style::properties::longhands::text_emphasis_position;
+    use style::properties::longhands::text_emphasis_position::{HorizontalWritingModeValue, VerticalWritingModeValue };
+    use style::properties::longhands::text_emphasis_position::SpecifiedValue;
+
+    let over_right = parse_longhand!(text_emphasis_position, "over right");
+    assert_eq!(over_right, SpecifiedValue(HorizontalWritingModeValue::Over, VerticalWritingModeValue::Right));
+
+    let over_left = parse_longhand!(text_emphasis_position, "over left");
+    assert_eq!(over_left, SpecifiedValue(HorizontalWritingModeValue::Over, VerticalWritingModeValue::Left));
+
+    let under_right = parse_longhand!(text_emphasis_position, "under right");
+    assert_eq!(under_right, SpecifiedValue(HorizontalWritingModeValue::Under, VerticalWritingModeValue::Right));
+
+    let under_left = parse_longhand!(text_emphasis_position, "under left");
+    assert_eq!(under_left, SpecifiedValue(HorizontalWritingModeValue::Under, VerticalWritingModeValue::Left));
+
+    let right_over = parse_longhand!(text_emphasis_position, "right over");
+    assert_eq!(right_over, SpecifiedValue(HorizontalWritingModeValue::Over, VerticalWritingModeValue::Right));
+
+    let left_over = parse_longhand!(text_emphasis_position, "left over");
+    assert_eq!(left_over, SpecifiedValue(HorizontalWritingModeValue::Over, VerticalWritingModeValue::Left));
+
+    let right_under = parse_longhand!(text_emphasis_position, "right under");
+    assert_eq!(right_under, SpecifiedValue(HorizontalWritingModeValue::Under, VerticalWritingModeValue::Right));
+
+    let left_under = parse_longhand!(text_emphasis_position, "left under");
+    assert_eq!(left_under, SpecifiedValue(HorizontalWritingModeValue::Under, VerticalWritingModeValue::Left));
+}


### PR DESCRIPTION
Implemented parsing/serialization for text-emphasis-position

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #13850 
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14188)
<!-- Reviewable:end -->
