### PR TITLE
Remove the network.http.redirection-limit preference.

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -53,7 +53,6 @@ use time::Tm;
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 use tinyfiledialogs;
 use url::{Position, Url, Origin};
-use util::prefs::PREFS;
 use util::thread::spawn_named;
 use uuid;
 
@@ -890,7 +889,6 @@ pub fn load<A, B>(load_data: &LoadData,
                   cancel_listener: &CancellationListener,
                   swmanager_chan: Option<IpcSender<CustomResponseMediator>>)
                   -> Result<StreamedResponse, LoadError> where A: HttpRequest + 'static, B: UIProvider {
-    let max_redirects = PREFS.get("network.http.redirection-limit").as_i64().unwrap() as u32;
     let mut iters = 0;
     // URL of the document being loaded, as seen by all the higher-level code.
     let mut doc_url = load_data.url.clone();
@@ -939,7 +937,7 @@ pub fn load<A, B>(load_data: &LoadData,
             doc_url = secure_url(&doc_url);
         }
 
-        if iters > max_redirects {
+        if iters > 20 {
             return Err(LoadError::new(doc_url, LoadErrorType::MaxRedirects(iters - 1)));
         }
 

--- a/resources/package-prefs.json
+++ b/resources/package-prefs.json
@@ -52,7 +52,6 @@
   "layout.text-orientation.enabled": false,
   "layout.viewport.enabled": false,
   "layout.writing-mode.enabled": false,
-  "network.http.redirection-limit": 20,
   "network.mime.sniff": false,
   "shell.builtin-key-shortcuts.enabled": false,
   "shell.homepage": "https://servo.org",

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -53,7 +53,6 @@
   "layout.text-orientation.enabled": false,
   "layout.viewport.enabled": false,
   "layout.writing-mode.enabled": false,
-  "network.http.redirection-limit": 20,
   "network.mime.sniff": false,
   "shell.builtin-key-shortcuts.enabled": true,
   "shell.homepage": "http://servo.org",


### PR DESCRIPTION
The Fetch standard defines this value as twenty; there is no good reason to
allow changing that at runtime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14204)
<!-- Reviewable:end -->
