### PR TITLE
Minor fixes for the WebBluetooth implementation

### DIFF
--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -465,13 +465,13 @@ impl BluetoothManager {
             match flag.as_ref() {
                 "broadcast" => props.insert(BROADCAST),
                 "read" => props.insert(READ),
-                "write_without_response" => props.insert(WRITE_WITHOUT_RESPONSE),
+                "write-without-response" => props.insert(WRITE_WITHOUT_RESPONSE),
                 "write" => props.insert(WRITE),
                 "notify" => props.insert(NOTIFY),
                 "indicate" => props.insert(INDICATE),
-                "authenticated_signed_writes" => props.insert(AUTHENTICATED_SIGNED_WRITES),
-                "reliable_write" => props.insert(RELIABLE_WRITE),
-                "writable_auxiliaries" => props.insert(WRITABLE_AUXILIARIES),
+                "authenticated-signed-writes" => props.insert(AUTHENTICATED_SIGNED_WRITES),
+                "reliable-write" => props.insert(RELIABLE_WRITE),
+                "writable-auxiliaries" => props.insert(WRITABLE_AUXILIARIES),
                 _ => (),
             }
         }

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -337,11 +337,7 @@ impl BluetoothMethods for Bluetooth {
             return p;
         }
         // Step 2.
-        if !option.acceptAllDevices {
-            self.request_bluetooth_devices(&p, &option.filters, &option.optionalServices);
-        } else {
-            self.request_bluetooth_devices(&p, &None, &option.optionalServices);
-        }
+        self.request_bluetooth_devices(&p, &option.filters, &option.optionalServices);
         // TODO(#4282): Step 3-5: Reject and resolve promise.
         return p;
     }

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -194,7 +194,7 @@ fn convert_request_device_options(filters: &Option<Vec<BluetoothRequestDeviceFil
 
             // Step 2.7.
             // Note: What we are doing here is adding the not blacklisted UUIDs to the result vector,
-            // insted of removing them from an already filled vector.
+            // instead of removing them from an already filled vector.
             if !uuid_is_blacklisted(uuid.as_ref(), Blacklist::All) {
                 optional_services_uuids.push(uuid);
             }

--- a/components/script/dom/webidls/Navigator.webidl
+++ b/components/script/dom/webidls/Navigator.webidl
@@ -7,7 +7,6 @@ interface Navigator {
   // objects implementing this interface also implement the interfaces given below
 };
 Navigator implements NavigatorID;
-Navigator implements NavigatorBluetooth;
 Navigator implements NavigatorLanguage;
 //Navigator implements NavigatorOnLine;
 //Navigator implements NavigatorContentUtils;
@@ -27,9 +26,9 @@ interface NavigatorID {
   readonly attribute DOMString userAgent;
 };
 
-[NoInterfaceObject]
-interface NavigatorBluetooth {
-    readonly attribute Bluetooth bluetooth;
+// https://webbluetoothcg.github.io/web-bluetooth/#navigator-extensions
+partial interface Navigator {
+  readonly attribute Bluetooth bluetooth;
 };
 
 // https://w3c.github.io/ServiceWorker/#navigator-service-worker


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
1. Fix for a comment typo in `bluetooth.rs `.
2. Simplify caling `self.request_bluetooth_devices` in `bluetooth.rs` in `Step 2`.
We already have a check in `Step 1` to prevent calling `request_bluetooth_devices` with a `Some` value if `option.acceptAllDevices` is true, and `option.filters` is already an `Option`, so there is no need for the `None` in the else branch.
3. Updating the bluetooth extension in `Navigator.webidl `, to match the [specification](https://webbluetoothcg.github.io/web-bluetooth/#navigator-extensions).
4. Replace the `_` separating the characteristic property strings with `-` as described  [here](http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/gatt-api.txt#n142) 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14205)
<!-- Reviewable:end -->
