### PR TITLE
Share script threads by tab and by eTLD+1

### DIFF
--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -162,19 +162,20 @@ impl LoadData {
     }
 }
 
-/// The initial data associated with a newly-created framed pipeline.
+/// The initial data required to create a new layout attached to an existing script thread.
 #[derive(Deserialize, Serialize)]
 pub struct NewLayoutInfo {
-    /// Id of the parent of this new pipeline.
-    pub parent_pipeline_id: PipelineId,
+    /// The ID of the parent pipeline and frame type, if any.
+    /// If `None`, this is a root pipeline.
+    pub parent_info: Option<(PipelineId, FrameType)>,
     /// Id of the newly-created pipeline.
     pub new_pipeline_id: PipelineId,
     /// Id of the frame associated with this pipeline.
     pub frame_id: FrameId,
-    /// Type of the frame associated with this pipeline.
-    pub frame_type: FrameType,
     /// Network request data which will be initiated by the script thread.
     pub load_data: LoadData,
+    /// Information about the initial window size.
+    pub window_size: Option<WindowSizeData>,
     /// A port on which layout can receive messages from the pipeline.
     pub pipeline_port: IpcReceiver<LayoutControlMsg>,
     /// A sender for the layout thread to communicate to the constellation.

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html.ini
@@ -1,8 +1,0 @@
-[cross_origin_parentage.html]
-  type: testharness
-  [Check the frame heriarchy 1]
-    expected: FAIL
-
-  [Check the frame heriarchy 2]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR shares script threads among all similar-origin documents in the same tab. This allows DOM object to be shared among same-origin same-tab documents.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #633.
- [X] These changes do not require tests because refactoring.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14211)
<!-- Reviewable:end -->
