### PR TITLE
Delegate logical bitfield setters to physical to fix cascade

### DIFF
--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -207,11 +207,17 @@
                 }
                 _ => panic!("entered the wrong cascade_property() implementation"),
             };
+
+            % if property.logical:
+                let wm = context.style.writing_mode;
+            % endif
+            <% maybe_wm = "wm" if property.logical else "" %>
+            <% maybe_physical = "_physical" if property.logical else "" %>
             % if not property.derived_from:
-                if seen.get_${property.ident}() {
+                if seen.get${maybe_physical}_${property.ident}(${maybe_wm}) {
                     return
                 }
-                seen.set_${property.ident}();
+                seen.set${maybe_physical}_${property.ident}(${maybe_wm});
                 {
                     let custom_props = context.style().custom_properties();
                     ::properties::substitute_variables_${property.ident}(
@@ -221,9 +227,6 @@
                             cascade_info.on_cascade_property(&declaration,
                                                              &value);
                         }
-                        % if property.logical:
-                            let wm = context.style.writing_mode;
-                        % endif
                         <% maybe_wm = ", wm" if property.logical else "" %>
                         match *value {
                             DeclaredValue::Value(ref specified_value) => {

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -149,6 +149,7 @@ pub mod animated_properties {
 // TODO(SimonSapin): Convert this to a syntax extension rather than a Mako template.
 // Maybe submit for inclusion in libstd?
 mod property_bit_field {
+    use logical_geometry::WritingMode;
 
     pub struct PropertyBitField {
         storage: [u32; (${len(data.longhands)} - 1 + 32) / 32]
@@ -179,6 +180,24 @@ mod property_bit_field {
                 #[inline]
                 pub fn set_${property.ident}(&mut self) {
                     self.set(${i})
+                }
+            % endif
+            % if property.logical:
+                #[allow(non_snake_case)]
+                pub fn get_physical_${property.ident}(&self, wm: WritingMode) -> bool {
+                    <%helpers:logical_setter_helper name="${property.name}">
+                        <%def name="inner(physical_ident)">
+                            self.get_${physical_ident}()
+                        </%def>
+                    </%helpers:logical_setter_helper>
+                }
+                #[allow(non_snake_case)]
+                pub fn set_physical_${property.ident}(&mut self, wm: WritingMode) {
+                    <%helpers:logical_setter_helper name="${property.name}">
+                        <%def name="inner(physical_ident)">
+                            self.set_${physical_ident}()
+                        </%def>
+                    </%helpers:logical_setter_helper>
                 }
             % endif
         % endfor


### PR DESCRIPTION
(fixes #14222)

Five minutes early for "tomorrow", _shrug_.

I'm not entirely sure of this fix. It depends on properties going through the cascade in source order all else being the same. I think that's the case.

Fixes wikipedia though.

r? @emilio or @SimonSapin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14223)
<!-- Reviewable:end -->
