### PR TITLE
CSSOM: Make Stylesheet fields have their own synchronization

### DIFF
--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -24,7 +24,6 @@ lazy_static = "0.2"
 log = "0.3.5"
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}
-style_traits = {path = "../style_traits"}
 parking_lot = {version = "0.3.3", features = ["nightly"]}
 plugins = {path = "../plugins"}
 profile_traits = {path = "../profile_traits"}

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -42,7 +42,6 @@ extern crate selectors;
 extern crate serde_json;
 extern crate servo_url;
 extern crate style;
-extern crate style_traits;
 extern crate util;
 extern crate webrender_traits;
 

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1531,6 +1531,7 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
             None,
             None,
             Origin::UserAgent,
+            Default::default(),
             Box::new(StdoutErrorReporter),
             ParserContextExtraData::default()))
     }
@@ -1543,8 +1544,8 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
     }
     for &(ref contents, ref url) in &opts::get().user_stylesheets {
         user_or_user_agent_stylesheets.push(Stylesheet::from_bytes(
-            &contents, url.clone(), None, None, Origin::User, Box::new(StdoutErrorReporter),
-            ParserContextExtraData::default()));
+            &contents, url.clone(), None, None, Origin::User, Default::default(),
+            Box::new(StdoutErrorReporter), ParserContextExtraData::default()));
     }
 
     let quirks_mode_stylesheet = try!(parse_ua_stylesheet("quirks-mode.css"));

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1055,7 +1055,7 @@ impl LayoutThread {
                        .send(ConstellationMsg::ViewportConstrained(self.id, constraints))
                        .unwrap();
             }
-            if data.document_stylesheets.iter().any(|sheet| sheet.dirty_on_viewport_size_change) {
+            if data.document_stylesheets.iter().any(|sheet| sheet.dirty_on_viewport_size_change()) {
                 let mut iter = node.traverse_preorder();
 
                 let mut next = iter.next();

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -370,12 +370,10 @@ impl FetchResponseListener for StylesheetContext {
 
             let win = window_from_node(&*elem);
 
-            let mut sheet = Stylesheet::from_bytes(&data, final_url, protocol_encoding_label,
-                                                   Some(environment_encoding), Origin::Author,
-                                                   win.css_error_reporter(),
-                                                   ParserContextExtraData::default());
-            sheet.set_media(self.media.take().unwrap());
-            let sheet = Arc::new(sheet);
+            let sheet = Arc::new(Stylesheet::from_bytes(
+                &data, final_url, protocol_encoding_label, Some(environment_encoding),
+                Origin::Author, self.media.take().unwrap(), win.css_error_reporter(),
+                ParserContextExtraData::default()));
 
             let win = window_from_node(&*elem);
             win.layout_chan().send(Msg::AddStylesheet(sheet.clone())).unwrap();

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -21,6 +21,7 @@ use html5ever_atoms::LocalName;
 use parking_lot::RwLock;
 use std::ascii::AsciiExt;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use style::attr::AttrValue;
 use style::str::HTML_SPACE_CHARACTERS;
 use style::stylesheets::{Stylesheet, CssRule, Origin};
@@ -101,7 +102,7 @@ impl HTMLMetaElement {
                         media: Default::default(),
                         // Viewport constraints are always recomputed on resize; they don't need to
                         // force all styles to be recomputed.
-                        dirty_on_viewport_size_change: false,
+                        dirty_on_viewport_size_change: AtomicBool::new(false),
                     }));
                     let doc = document_from_node(self);
                     doc.invalidate_stylesheets();

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -65,10 +65,9 @@ impl HTMLStyleElement {
         };
 
         let data = node.GetTextContent().expect("Element.textContent must be a string");
-        let mut sheet = Stylesheet::from_str(&data, url, Origin::Author, win.css_error_reporter(),
-                                             ParserContextExtraData::default());
-        let mut css_parser = CssParser::new(&mq_str);
-        sheet.set_media(parse_media_query_list(&mut css_parser));
+        let mq = parse_media_query_list(&mut CssParser::new(&mq_str));
+        let sheet = Stylesheet::from_str(&data, url, Origin::Author, mq, win.css_error_reporter(),
+                                         ParserContextExtraData::default());
         let sheet = Arc::new(sheet);
 
         win.layout_chan().send(Msg::AddStylesheet(sheet.clone())).unwrap();

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -174,15 +174,17 @@ impl Stylesheet {
                       base_url: ServoUrl,
                       protocol_encoding_label: Option<&str>,
                       environment_encoding: Option<EncodingRef>,
-                      origin: Origin, error_reporter: Box<ParseErrorReporter + Send>,
+                      origin: Origin,
+                      media: MediaList,
+                      error_reporter: Box<ParseErrorReporter + Send>,
                       extra_data: ParserContextExtraData)
                       -> Stylesheet {
         let (string, _) = decode_stylesheet_bytes(
             bytes, protocol_encoding_label, environment_encoding);
-        Stylesheet::from_str(&string, base_url, origin, error_reporter, extra_data)
+        Stylesheet::from_str(&string, base_url, origin, media, error_reporter, extra_data)
     }
 
-    pub fn from_str(css: &str, base_url: ServoUrl, origin: Origin,
+    pub fn from_str(css: &str, base_url: ServoUrl, origin: Origin, media: MediaList,
                     error_reporter: Box<ParseErrorReporter + Send>,
                     extra_data: ParserContextExtraData) -> Stylesheet {
         let rule_parser = TopLevelRuleParser {
@@ -212,15 +214,10 @@ impl Stylesheet {
         Stylesheet {
             origin: origin,
             rules: rules.into(),
-            media: Arc::new(RwLock::new(Default::default())),
+            media: Arc::new(RwLock::new(media)),
             dirty_on_viewport_size_change:
                 input.seen_viewport_percentages(),
         }
-    }
-
-    /// Set the MediaList associated with the style-sheet.
-    pub fn set_media(&mut self, media: MediaList) {
-        *self.media.write() = media;
     }
 
     /// Returns whether the style-sheet applies for the current device depending

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -57,7 +57,7 @@ pub struct Stylesheet {
     /// cascading order)
     pub rules: CssRules,
     /// List of media associated with the Stylesheet.
-    pub media: MediaList,
+    pub media: Arc<RwLock<MediaList>>,
     pub origin: Origin,
     pub dirty_on_viewport_size_change: bool,
 }
@@ -228,7 +228,7 @@ impl Stylesheet {
         Stylesheet {
             origin: origin,
             rules: rules.into(),
-            media: Default::default(),
+            media: Arc::new(RwLock::new(Default::default())),
             dirty_on_viewport_size_change:
                 input.seen_viewport_percentages(),
         }
@@ -236,7 +236,7 @@ impl Stylesheet {
 
     /// Set the MediaList associated with the style-sheet.
     pub fn set_media(&mut self, media: MediaList) {
-        self.media = media;
+        *self.media.write() = media;
     }
 
     /// Returns whether the style-sheet applies for the current device depending
@@ -244,7 +244,7 @@ impl Stylesheet {
     ///
     /// Always true if no associated MediaList exists.
     pub fn is_effective_for_device(&self, device: &Device) -> bool {
-        self.media.evaluate(device)
+        self.media.read().evaluate(device)
     }
 
     /// Return an iterator over the effective rules within the style-sheet, as

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -170,21 +170,6 @@ impl ToCss for StyleRule {
 
 
 impl Stylesheet {
-    pub fn from_bytes_iter<I: Iterator<Item=Vec<u8>>>(
-            input: I, base_url: ServoUrl, protocol_encoding_label: Option<&str>,
-            environment_encoding: Option<EncodingRef>, origin: Origin,
-            error_reporter: Box<ParseErrorReporter + Send>,
-            extra_data: ParserContextExtraData) -> Stylesheet {
-        let mut bytes = vec![];
-        // TODO: incremental decoding and tokenization/parsing
-        for chunk in input {
-            bytes.extend_from_slice(&chunk)
-        }
-        Stylesheet::from_bytes(&bytes, base_url, protocol_encoding_label,
-                               environment_encoding, origin, error_reporter,
-                               extra_data)
-    }
-
     pub fn from_bytes(bytes: &[u8],
                       base_url: ServoUrl,
                       protocol_encoding_label: Option<&str>,
@@ -192,7 +177,6 @@ impl Stylesheet {
                       origin: Origin, error_reporter: Box<ParseErrorReporter + Send>,
                       extra_data: ParserContextExtraData)
                       -> Stylesheet {
-        // TODO: bytes.as_slice could be bytes.container_as_bytes()
         let (string, _) = decode_stylesheet_bytes(
             bytes, protocol_encoding_label, environment_encoding);
         Stylesheet::from_str(&string, base_url, origin, error_reporter, extra_data)

--- a/ports/cef/Cargo.lock
+++ b/ports/cef/Cargo.lock
@@ -1203,7 +1203,6 @@ dependencies = [
  "serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_url 0.0.1",
  "style 0.0.1",
- "style_traits 0.0.1",
  "util 0.0.1",
  "webrender_traits 0.9.0 (git+https://github.com/servo/webrender)",
 ]

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -174,8 +174,8 @@ pub extern "C" fn Servo_StyleSheet_Empty(mode: SheetParsingMode) -> RawServoStyl
         SheetParsingMode::eUserSheetFeatures => Origin::User,
         SheetParsingMode::eAgentSheetFeatures => Origin::UserAgent,
     };
-    let sheet = Arc::new(Stylesheet::from_str("", url, origin, Box::new(StdoutErrorReporter),
-                                              extra_data));
+    let sheet = Arc::new(Stylesheet::from_str(
+        "", url, origin, Default::default(), Box::new(StdoutErrorReporter), extra_data));
     unsafe {
         transmute(sheet)
     }
@@ -204,8 +204,8 @@ pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(data: *const nsACString,
         referrer: Some(GeckoArcURI::new(referrer)),
         principal: Some(GeckoArcPrincipal::new(principal)),
     }};
-    let sheet = Arc::new(Stylesheet::from_str(input, url, origin, Box::new(StdoutErrorReporter),
-                                              extra_data));
+    let sheet = Arc::new(Stylesheet::from_str(
+        input, url, origin, Default::default(), Box::new(StdoutErrorReporter), extra_data));
     unsafe {
         transmute(sheet)
     }

--- a/ports/servo/Cargo.lock
+++ b/ports/servo/Cargo.lock
@@ -1289,7 +1289,6 @@ dependencies = [
  "serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_url 0.0.1",
  "style 0.0.1",
- "style_traits 0.0.1",
  "util 0.0.1",
  "webrender_traits 0.9.0 (git+https://github.com/servo/webrender)",
 ]

--- a/tests/unit/style/media_queries.rs
+++ b/tests/unit/style/media_queries.rs
@@ -26,8 +26,9 @@ impl ParseErrorReporter for CSSErrorReporterTest {
 
 fn test_media_rule<F>(css: &str, callback: F) where F: Fn(&MediaList, &str) {
     let url = ServoUrl::parse("http://localhost").unwrap();
-    let stylesheet = Stylesheet::from_str(css, url, Origin::Author, Box::new(CSSErrorReporterTest),
-                                          ParserContextExtraData::default());
+    let stylesheet = Stylesheet::from_str(
+        css, url, Origin::Author, Default::default(),
+        Box::new(CSSErrorReporterTest), ParserContextExtraData::default());
     let mut rule_count = 0;
     media_queries(&stylesheet.rules.0.read(), &mut |mq| {
         rule_count += 1;
@@ -49,8 +50,9 @@ fn media_queries<F>(rules: &[CssRule], f: &mut F) where F: FnMut(&MediaList) {
 
 fn media_query_test(device: &Device, css: &str, expected_rule_count: usize) {
     let url = ServoUrl::parse("http://localhost").unwrap();
-    let ss = Stylesheet::from_str(css, url, Origin::Author, Box::new(CSSErrorReporterTest),
-                                  ParserContextExtraData::default());
+    let ss = Stylesheet::from_str(
+        css, url, Origin::Author, Default::default(),
+        Box::new(CSSErrorReporterTest), ParserContextExtraData::default());
     let mut rule_count = 0;
     ss.effective_style_rules(device, |_| rule_count += 1);
     assert!(rule_count == expected_rule_count, css.to_owned());

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -12,6 +12,7 @@ use servo_url::ServoUrl;
 use std::borrow::ToOwned;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
 use style::error_reporting::ParseErrorReporter;
 use style::keyframes::{Keyframe, KeyframeSelector, KeyframePercentage};
 use style::parser::ParserContextExtraData;
@@ -55,7 +56,7 @@ fn test_parse_stylesheet() {
     let expected = Stylesheet {
         origin: Origin::UserAgent,
         media: Default::default(),
-        dirty_on_viewport_size_change: false,
+        dirty_on_viewport_size_change: AtomicBool::new(false),
         rules: vec![
             CssRule::Namespace(Arc::new(RwLock::new(NamespaceRule {
                 prefix: None,

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -49,7 +49,7 @@ fn test_parse_stylesheet() {
             }
         }";
     let url = ServoUrl::parse("about::test").unwrap();
-    let stylesheet = Stylesheet::from_str(css, url, Origin::UserAgent,
+    let stylesheet = Stylesheet::from_str(css, url, Origin::UserAgent, Default::default(),
                                           Box::new(CSSErrorReporterTest),
                                           ParserContextExtraData::default());
     let expected = Stylesheet {
@@ -320,7 +320,7 @@ fn test_report_error_stylesheet() {
 
     let errors = error_reporter.errors.clone();
 
-    Stylesheet::from_str(css, url, Origin::UserAgent, error_reporter,
+    Stylesheet::from_str(css, url, Origin::UserAgent, Default::default(), error_reporter,
                          ParserContextExtraData::default());
 
     let mut errors = errors.lock().unwrap();

--- a/tests/unit/style/viewport.rs
+++ b/tests/unit/style/viewport.rs
@@ -23,6 +23,7 @@ macro_rules! stylesheet {
             $css,
             ServoUrl::parse("http://localhost").unwrap(),
             Origin::$origin,
+            Default::default(),
             $error_reporter,
             ParserContextExtraData::default()
         ))


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

r? @upsuper 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix bug 1314208.

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14232)
<!-- Reviewable:end -->
