### PR TITLE
rule tree: Avoid yet another dumb assertion when dropping the rule tree.

### DIFF
--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -410,10 +410,12 @@ impl StrongRuleNode {
         debug_assert!(thread_state::get().is_layout() &&
                       !thread_state::get().is_worker());
 
+        // NB: This can run from the root node destructor, so we can't use
+        // `get()`, since it asserts the refcount is bigger than zero.
         let me = &*self.ptr;
         debug_assert!(me.is_root());
 
-        let current = self.get().next_free.load(Ordering::SeqCst);
+        let current = me.next_free.load(Ordering::SeqCst);
         if current == FREE_LIST_SENTINEL {
             return None;
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

There's a comment in the caller (where we do the same) saying why this can assert (if this runs from the rule tree root destructor).

This doesn't happen in servo's ci because we gc all the time, but can happen when abruptly shutting down the document.

r? @SimonSapin or @heycam or @Manishearth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14233)
<!-- Reviewable:end -->
