### PR TITLE
Implement ToCss serialization for CSSRules

### DIFF
--- a/components/script/dom/cssfontfacerule.rs
+++ b/components/script/dom/cssfontfacerule.rs
@@ -12,6 +12,7 @@ use dom::window::Window;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use style::font_face::FontFaceRule;
+use style_traits::ToCss;
 
 #[dom_struct]
 pub struct CSSFontFaceRule {
@@ -44,7 +45,6 @@ impl SpecificCSSRule for CSSFontFaceRule {
     }
 
     fn get_css(&self) -> DOMString {
-        // self.fontfacerule.read().to_css_string().into()
-        "".into()
+        self.fontfacerule.read().to_css_string().into()
     }
 }

--- a/components/script/dom/csskeyframesrule.rs
+++ b/components/script/dom/csskeyframesrule.rs
@@ -12,6 +12,7 @@ use dom::window::Window;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use style::stylesheets::KeyframesRule;
+use style_traits::ToCss;
 
 #[dom_struct]
 pub struct CSSKeyframesRule {
@@ -44,7 +45,6 @@ impl SpecificCSSRule for CSSKeyframesRule {
     }
 
     fn get_css(&self) -> DOMString {
-        // self.keyframesrule.read().to_css_string().into()
-        "".into()
+        self.keyframesrule.read().to_css_string().into()
     }
 }

--- a/components/script/dom/cssmediarule.rs
+++ b/components/script/dom/cssmediarule.rs
@@ -13,6 +13,7 @@ use dom::window::Window;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use style::stylesheets::MediaRule;
+use style_traits::ToCss;
 
 #[dom_struct]
 pub struct CSSMediaRule {
@@ -45,7 +46,6 @@ impl SpecificCSSRule for CSSMediaRule {
     }
 
     fn get_css(&self) -> DOMString {
-        // self.mediarule.read().to_css_string().into()
-        "".into()
+        self.mediarule.read().to_css_string().into()
     }
 }

--- a/components/script/dom/cssnamespacerule.rs
+++ b/components/script/dom/cssnamespacerule.rs
@@ -12,6 +12,7 @@ use dom::window::Window;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use style::stylesheets::NamespaceRule;
+use style_traits::ToCss;
 
 #[dom_struct]
 pub struct CSSNamespaceRule {
@@ -44,7 +45,6 @@ impl SpecificCSSRule for CSSNamespaceRule {
     }
 
     fn get_css(&self) -> DOMString {
-        // self.namespacerule.read().to_css_string().into()
-        "".into()
+        self.namespacerule.read().to_css_string().into()
     }
 }

--- a/components/script/dom/cssviewportrule.rs
+++ b/components/script/dom/cssviewportrule.rs
@@ -12,6 +12,7 @@ use dom::window::Window;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use style::viewport::ViewportRule;
+use style_traits::ToCss;
 
 #[dom_struct]
 pub struct CSSViewportRule {
@@ -44,7 +45,6 @@ impl SpecificCSSRule for CSSViewportRule {
     }
 
     fn get_css(&self) -> DOMString {
-        // self.viewportrule.read().to_css_string().into()
-        "".into()
+        self.viewportrule.read().to_css_string().into()
     }
 }

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -10,7 +10,9 @@ use computed_values::font_family::FontFamily;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser};
 use parser::{ParserContext, log_css_error};
 use properties::longhands::font_family::parse_one_family;
+use std::fmt;
 use std::iter;
+use style_traits::ToCss;
 use values::specified::url::SpecifiedUrl;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -20,6 +22,22 @@ pub enum Source {
     Local(FontFamily),
 }
 
+impl ToCss for Source {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        match *self {
+            Source::Url(ref url) => {
+                try!(dest.write_str("local(\""));
+                try!(url.to_css(dest));
+            },
+            Source::Local(ref family) => {
+                try!(dest.write_str("url(\""));
+                try!(family.to_css(dest));
+            },
+        }
+        dest.write_str("\")")
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf, Deserialize, Serialize))]
 pub struct UrlSource {
@@ -27,11 +45,39 @@ pub struct UrlSource {
     pub format_hints: Vec<String>,
 }
 
+impl ToCss for UrlSource {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        dest.write_str(self.url.as_str())
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct FontFaceRule {
     pub family: FontFamily,
     pub sources: Vec<Source>,
+}
+
+impl ToCss for FontFaceRule {
+    // Serialization of FontFaceRule is not specced.
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        try!(dest.write_str("@font-face { font-family: "));
+        try!(self.family.to_css(dest));
+        try!(dest.write_str(";"));
+
+        if self.sources.len() > 0 {
+            try!(dest.write_str(" src: "));
+            let mut iter = self.sources.iter();
+            try!(iter.next().unwrap().to_css(dest));
+            for source in iter {
+                try!(dest.write_str(", "));
+                try!(source.to_css(dest));
+            }
+            try!(dest.write_str(";"));
+        }
+
+        dest.write_str(" }")
+    }
 }
 
 pub fn parse_font_face_block(context: &ParserContext, input: &mut Parser)

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -9,7 +9,9 @@ use parser::{ParserContext, log_css_error};
 use properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock};
 use properties::PropertyDeclarationParseResult;
 use properties::animated_properties::TransitionProperty;
+use std::fmt;
 use std::sync::Arc;
+use style_traits::ToCss;
 
 /// A number from 1 to 100, indicating the percentage of the animation where
 /// this keyframe should run.
@@ -80,6 +82,21 @@ pub struct Keyframe {
     /// by cloning an `Arc<_>` (incrementing a reference count) rather than re-creating a `Vec<_>`.
     #[cfg_attr(feature = "servo", ignore_heap_size_of = "Arc")]
     pub block: Arc<RwLock<PropertyDeclarationBlock>>,
+}
+
+impl ToCss for Keyframe {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        let mut iter = self.selector.percentages().iter();
+        try!(write!(dest, "{}%", iter.next().unwrap().0));
+        for percentage in iter {
+            try!(write!(dest, ", "));
+            try!(write!(dest, "{}%", percentage.0));
+        }
+        try!(dest.write_str(" { "));
+        try!(self.block.read().to_css(dest));
+        try!(dest.write_str(" }"));
+        Ok(())
+    }
 }
 
 /// A keyframes step value. This can be a synthetised keyframes animation, that

--- a/components/style/values/specified/url.rs
+++ b/components/style/values/specified/url.rs
@@ -104,6 +104,13 @@ impl SpecifiedUrl {
         self.resolved.as_ref()
     }
 
+    pub fn as_str(&self) -> &str {
+        match self.resolved {
+            Some(ref url) => url.as_str(),
+            None => "",
+        }
+    }
+
     /// Little helper for Gecko's ffi.
     pub fn as_slice_components(&self) -> (*const u8, usize) {
         match self.resolved {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implementation of ToCss serialization for CSSRules. It requires #14190 to merge first to uncomment `CssRule::Style` branch in CssRule's ToCss implementation.

r? @Manishearth 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14195 (github issue number if applicable).

- [X] These changes do not require tests because it's serialization changes and I'm not sure there is a test for that.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14238)
<!-- Reviewable:end -->
