### PR TITLE
Add -Z wr-record

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -165,7 +165,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
                 enable_msaa: opts.use_msaa,
                 enable_profiler: opts.webrender_stats,
                 debug: opts.webrender_debug,
-                enable_recording: false,
+                enable_recording: opts.webrender_record,
                 precache_shaders: opts.precache_shaders,
                 enable_scrollbars: opts.output_file.is_none(),
                 renderer_kind: renderer_kind,

--- a/components/util/opts.rs
+++ b/components/util/opts.rs
@@ -206,6 +206,9 @@ pub struct Opts {
     /// True to show webrender debug on screen.
     pub webrender_debug: bool,
 
+    /// True if webrender recording should be enabled.
+    pub webrender_record: bool,
+
     /// True to compile all webrender shaders at init time. This is mostly
     /// useful when modifying the shaders, to ensure they all compile
     /// after each change is made.
@@ -325,6 +328,9 @@ pub struct DebugOptions {
     /// Show webrender debug on screen.
     pub webrender_debug: bool,
 
+    /// Enable webrender recording.
+    pub webrender_record: bool,
+
     /// Use multisample antialiasing in WebRender.
     pub use_msaa: bool,
 
@@ -377,6 +383,7 @@ impl DebugOptions {
                 "disable-vsync" => debug_options.disable_vsync = true,
                 "wr-stats" => debug_options.webrender_stats = true,
                 "wr-debug" => debug_options.webrender_debug = true,
+                "wr-record" => debug_options.webrender_record = true,
                 "msaa" => debug_options.use_msaa = true,
                 "full-backtraces" => debug_options.full_backtraces = true,
                 "precache-shaders" => debug_options.precache_shaders = true,
@@ -558,6 +565,7 @@ pub fn default_opts() -> Opts {
         full_backtraces: false,
         is_printing_version: false,
         webrender_debug: false,
+        webrender_record: false,
         precache_shaders: false,
         signpost: false,
     }
@@ -861,6 +869,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         full_backtraces: debug_options.full_backtraces,
         is_printing_version: is_printing_version,
         webrender_debug: debug_options.webrender_debug,
+        webrender_record: debug_options.webrender_record,
         precache_shaders: debug_options.precache_shaders,
         signpost: debug_options.signpost,
     };


### PR DESCRIPTION
This adds `-Z wr-record`, which flips `enable_recording` to true for Webrender.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14249)
<!-- Reviewable:end -->
