### PR TITLE
Support build.rustflags in .servobuild

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -276,6 +276,7 @@ class CommandBase(object):
         self.config["build"].setdefault("mode", "")
         self.config["build"].setdefault("debug-mozjs", False)
         self.config["build"].setdefault("ccache", "")
+        self.config["build"].setdefault("rustflags", "")
 
         self.config.setdefault("android", {})
         self.config["android"].setdefault("sdk", "")
@@ -466,6 +467,9 @@ class CommandBase(object):
             env['HOST_FILE'] = hosts_file_path
 
         env['RUSTDOC'] = path.join(self.context.topdir, 'etc', 'rustdoc-with-private')
+
+        if self.config["build"]["rustflags"]:
+            env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " " + self.config["build"]["rustflags"]
 
         # Don't run the gold linker if on Windows https://github.com/servo/servo/issues/9499
         if self.config["tools"]["rustc-with-gold"] and sys.platform not in ("win32", "msys"):

--- a/servobuild.example
+++ b/servobuild.example
@@ -38,6 +38,8 @@ android = false
 debug-mozjs = false
 # Set to the path to your ccache binary to enable caching of compiler outputs
 #ccache = "/usr/local/bin/ccache"
+# Any optional flags that will be added to $RUSTFLAGS
+#rustflags = ""
 
 # Android information
 [android]


### PR DESCRIPTION
Add ability to specify rustflags in .servobuild.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14251)
<!-- Reviewable:end -->
