### PR TITLE
Run cargo doc on libservo crate

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -217,7 +217,7 @@ class PostBuildCommands(CommandBase):
                         copy2(full_name, destination)
 
         return call(["cargo", "doc"] + params,
-                    env=self.build_env(), cwd=self.servo_crate())
+                    env=self.build_env(), cwd=path.join('components', 'servo'))
 
     @Command('browse-doc',
              description='Generate documentation and open it in a web browser',


### PR DESCRIPTION
Fixes `./mach doc` regression caused by #14172.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14254)
<!-- Reviewable:end -->
