### PR TITLE
Disable the debugger on Android until mio works on Android

### DIFF
--- a/components/debugger/Cargo.toml
+++ b/components/debugger/Cargo.toml
@@ -13,4 +13,6 @@ crate_type = ["rlib"]
 [dependencies]
 log = "0.3.5"
 util = {path = "../util"}
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
 ws = "0.5.3"

--- a/components/debugger/lib.rs
+++ b/components/debugger/lib.rs
@@ -5,11 +5,13 @@
 #[macro_use]
 extern crate log;
 extern crate util;
+#[cfg(not(target_os = "android"))]
 extern crate ws;
 
 use std::sync::mpsc;
 use std::sync::mpsc::channel;
 use util::thread::spawn_named;
+#[cfg(not(target_os = "android"))]
 use ws::{Builder, CloseCode, Handler, Handshake};
 
 enum Message {
@@ -18,10 +20,12 @@ enum Message {
 
 pub struct Sender(mpsc::Sender<Message>);
 
+#[cfg(not(target_os = "android"))]
 struct Connection {
     sender: ws::Sender
 }
 
+#[cfg(not(target_os = "android"))]
 impl Handler for Connection {
     fn on_open(&mut self, _: Handshake) -> ws::Result<()> {
         debug!("Connection opened.");
@@ -37,6 +41,7 @@ impl Handler for Connection {
     }
 }
 
+#[cfg(not(target_os = "android"))]
 pub fn start_server(port: u16) -> Sender {
     debug!("Starting server.");
     let (sender, receiver) = channel();
@@ -60,10 +65,21 @@ pub fn start_server(port: u16) -> Sender {
     Sender(sender)
 }
 
+#[cfg(target_os = "android")]
+pub fn start_server(_: u16) -> Sender {
+    panic!("Debugger is not supported on Android");
+}
+
+#[cfg(not(target_os = "android"))]
 pub fn shutdown_server(sender: &Sender) {
     debug!("Shutting down server.");
     let &Sender(ref sender) = sender;
     if let Err(_) = sender.send(Message::ShutdownServer) {
         warn!("Failed to shut down server.");
     }
+}
+
+#[cfg(target_os = "android")]
+pub fn shutdown_server(_: &Sender) {
+    panic!("Debugger is not supported on Android");
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
r? @nox 

The recent change to `ws-rs` introduced a dependency on `mio`, which depends on `nix`, which does not build on Android (https://github.com/nix-rust/nix/issues/313). I've disabled the debugger in this change.

Fixes #14171

cc @mmatyas 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14270)
<!-- Reviewable:end -->
