### PR TITLE
ensure RuleNodes are dropped when Gecko drops the Stylist

### DIFF
--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -440,8 +440,7 @@ impl StrongRuleNode {
         // script.
         debug_assert!(!thread_state::get().is_worker() &&
                       (thread_state::get().is_layout() ||
-                       (thread_state::get().is_script() &&
-                        me.refcount.load(Ordering::SeqCst) == 0)));
+                       thread_state::get().is_script()));
         let current = me.next_free.load(Ordering::SeqCst);
 
         if current == FREE_LIST_SENTINEL {

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -624,6 +624,18 @@ impl Stylist {
     }
 }
 
+impl Drop for Stylist {
+    fn drop(&mut self) {
+        // This is the last chance to GC the rule tree.  If we have dropped all
+        // strong rule node references before the Stylist is dropped, then this
+        // will cause the rule tree to be destroyed correctly.  If we haven't
+        // dropped all strong rule node references before now, then we will
+        // leak them, since there will be no way to call gc() on the rule tree
+        // after this point.
+        unsafe { self.rule_tree.gc(); }
+    }
+}
+
 
 /// Map that contains the CSS rules for a specific PseudoElement
 /// (or lack of PseudoElement).

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -46,6 +46,7 @@ use style::selector_parser::PseudoElementCascadeType;
 use style::sequential;
 use style::string_cache::Atom;
 use style::stylesheets::{Origin, Stylesheet};
+use style::thread_state;
 use style::timer::Timer;
 use style_traits::ToCss;
 
@@ -66,6 +67,9 @@ pub extern "C" fn Servo_Initialize() -> () {
 
     // Allocate our default computed values.
     unsafe { ComputedValues::initialize(); }
+
+    // Pretend that we're a Servo Layout thread, to make some assertions happy.
+    thread_state::initialize(thread_state::LAYOUT);
 }
 
 #[no_mangle]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

These are the Servo-side patches from https://bugzilla.mozilla.org/show_bug.cgi?id=1318238, which already have been reviewed by @bholley and @emilio there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14273)
<!-- Reviewable:end -->
