### PR TITLE
Add Start/Stop notifications

### DIFF
--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -238,6 +238,9 @@ impl BluetoothManager {
                 BluetoothRequest::WriteValue(id, value, sender) => {
                     self.write_value(id, value, sender)
                 },
+                BluetoothRequest::EnableNotification(id, enable, sender) => {
+                    self.enable_notification(id, enable, sender)
+                },
                 BluetoothRequest::Test(data_set_name, sender) => {
                     self.test(data_set_name, sender)
                 }
@@ -937,6 +940,27 @@ impl BluetoothManager {
                 Ok(_) => return drop(sender.send(Ok(BluetoothResponse::WriteValue(value)))),
                 Err(_) => return drop(sender.send(Err(BluetoothError::NotSupported))),
             },
+            None => return drop(sender.send(Err(BluetoothError::InvalidState))),
+        }
+    }
+
+    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-startnotifications
+    fn enable_notification(&mut self, id: String, enable: bool, sender: IpcSender<BluetoothResponseResult>) {
+        let mut adapter = get_adapter_or_return_error!(self, sender);
+        match self.get_gatt_characteristic(&mut adapter, &id) {
+            Some(c) => {
+                let result = match enable {
+                    true => c.start_notify(),
+                    false => c.stop_notify(),
+                };
+                match result {
+                    // Step 11.
+                    Ok(_) => return drop(sender.send(Ok(BluetoothResponse::EnableNotification(())))),
+                    // Step 4.
+                    Err(_) => return drop(sender.send(Err(BluetoothError::NotSupported))),
+                }
+            },
+            // Step 3.
             None => return drop(sender.send(Err(BluetoothError::InvalidState))),
         }
     }

--- a/components/bluetooth/test.rs
+++ b/components/bluetooth/test.rs
@@ -18,6 +18,7 @@ const ADAPTER_ERROR: &'static str = "No adapter found";
 const WRONG_DATA_SET_ERROR: &'static str = "Wrong data set name was provided";
 const READ_FLAG: &'static str = "read";
 const WRITE_FLAG: &'static str = "write";
+const NOTIFY_FLAG: &'static str = "notify";
 
 // Adapter names
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=65
@@ -217,10 +218,11 @@ fn create_heart_rate_service(device: &BluetoothDevice,
     }
 
     // Heart Rate Measurement Characteristic
-    let _heart_rate_measurement_characteristic =
+    let heart_rate_measurement_characteristic =
         try!(create_characteristic_with_value(&heart_rate_service,
                                               HEART_RATE_MEASUREMENT_CHARACTERISTIC_UUID.to_owned(),
                                               vec![0]));
+    try!(heart_rate_measurement_characteristic.set_flags(vec![NOTIFY_FLAG.to_string()]));
 
     // Body Sensor Location Characteristic 1
     let body_sensor_location_characteristic_1 =
@@ -357,10 +359,11 @@ fn create_two_heart_rate_services_device(adapter: &BluetoothAdapter) -> Result<(
 
     let heart_rate_service_empty_2 = try!(create_heart_rate_service(&heart_rate_device_empty, true));
 
-    let _heart_rate_measurement_characteristic =
+    let heart_rate_measurement_characteristic =
         try!(create_characteristic_with_value(&heart_rate_service_empty_1,
                                               HEART_RATE_MEASUREMENT_CHARACTERISTIC_UUID.to_owned(),
                                               vec![0]));
+    try!(heart_rate_measurement_characteristic.set_flags(vec![NOTIFY_FLAG.to_string()]));
 
     let _body_sensor_location_characteristic_1 =
         try!(create_characteristic_with_value(&heart_rate_service_empty_1,

--- a/components/bluetooth_traits/lib.rs
+++ b/components/bluetooth_traits/lib.rs
@@ -92,6 +92,7 @@ pub enum BluetoothRequest {
     GetDescriptors(String, Option<String>, IpcSender<BluetoothResponseResult>),
     ReadValue(String, IpcSender<BluetoothResponseResult>),
     WriteValue(String, Vec<u8>, IpcSender<BluetoothResponseResult>),
+    EnableNotification(String, bool, IpcSender<BluetoothResponseResult>),
     Test(String, IpcSender<BluetoothResult<()>>),
     Exit,
 }
@@ -110,6 +111,7 @@ pub enum BluetoothResponse {
     GetDescriptors(BluetoothDescriptorsMsg),
     ReadValue(Vec<u8>),
     WriteValue(Vec<u8>),
+    EnableNotification(()),
 }
 
 pub trait BluetoothResponseListener {

--- a/components/script/dom/webidls/BluetoothRemoteGATTCharacteristic.webidl
+++ b/components/script/dom/webidls/BluetoothRemoteGATTCharacteristic.webidl
@@ -17,8 +17,8 @@ interface BluetoothRemoteGATTCharacteristic {
   //Promise<DataView> readValue();
   Promise<void> writeValue(sequence<octet> value);
   //Promise<void> writeValue(BufferSource value);
-  //Promise<void> startNotifications();
-  //Promise<void> stopNotifications();
+  Promise<BluetoothRemoteGATTCharacteristic> startNotifications();
+  Promise<BluetoothRemoteGATTCharacteristic> stopNotifications();
 };
 
 //BluetootRemoteGATTCharacteristic implements EventTarget;

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7592,6 +7592,66 @@
             "url": "/_mozilla/mozilla/bluetooth/requestDevice/two-filters.html"
           }
         ],
+        "mozilla/bluetooth/startNotifications/blocklisted-characteristic.html": [
+          {
+            "path": "mozilla/bluetooth/startNotifications/blocklisted-characteristic.html",
+            "url": "/_mozilla/mozilla/bluetooth/startNotifications/blocklisted-characteristic.html"
+          }
+        ],
+        "mozilla/bluetooth/startNotifications/characteristic-is-removed.html": [
+          {
+            "path": "mozilla/bluetooth/startNotifications/characteristic-is-removed.html",
+            "url": "/_mozilla/mozilla/bluetooth/startNotifications/characteristic-is-removed.html"
+          }
+        ],
+        "mozilla/bluetooth/startNotifications/disconnect-called-before.html": [
+          {
+            "path": "mozilla/bluetooth/startNotifications/disconnect-called-before.html",
+            "url": "/_mozilla/mozilla/bluetooth/startNotifications/disconnect-called-before.html"
+          }
+        ],
+        "mozilla/bluetooth/startNotifications/disconnect-called-during.html": [
+          {
+            "path": "mozilla/bluetooth/startNotifications/disconnect-called-during.html",
+            "url": "/_mozilla/mozilla/bluetooth/startNotifications/disconnect-called-during.html"
+          }
+        ],
+        "mozilla/bluetooth/startNotifications/notify-failure.html": [
+          {
+            "path": "mozilla/bluetooth/startNotifications/notify-failure.html",
+            "url": "/_mozilla/mozilla/bluetooth/startNotifications/notify-failure.html"
+          }
+        ],
+        "mozilla/bluetooth/startNotifications/notify-succeeds.html": [
+          {
+            "path": "mozilla/bluetooth/startNotifications/notify-succeeds.html",
+            "url": "/_mozilla/mozilla/bluetooth/startNotifications/notify-succeeds.html"
+          }
+        ],
+        "mozilla/bluetooth/stopNotifications/characteristic-is-removed.html": [
+          {
+            "path": "mozilla/bluetooth/stopNotifications/characteristic-is-removed.html",
+            "url": "/_mozilla/mozilla/bluetooth/stopNotifications/characteristic-is-removed.html"
+          }
+        ],
+        "mozilla/bluetooth/stopNotifications/disconnect-called-before.html": [
+          {
+            "path": "mozilla/bluetooth/stopNotifications/disconnect-called-before.html",
+            "url": "/_mozilla/mozilla/bluetooth/stopNotifications/disconnect-called-before.html"
+          }
+        ],
+        "mozilla/bluetooth/stopNotifications/disconnect-called-during.html": [
+          {
+            "path": "mozilla/bluetooth/stopNotifications/disconnect-called-during.html",
+            "url": "/_mozilla/mozilla/bluetooth/stopNotifications/disconnect-called-during.html"
+          }
+        ],
+        "mozilla/bluetooth/stopNotifications/notify-succeeds.html": [
+          {
+            "path": "mozilla/bluetooth/stopNotifications/notify-succeeds.html",
+            "url": "/_mozilla/mozilla/bluetooth/stopNotifications/notify-succeeds.html"
+          }
+        ],
         "mozilla/bluetooth/writeValue/characteristic/blocklisted-characteristic.html": [
           {
             "path": "mozilla/bluetooth/writeValue/characteristic/blocklisted-characteristic.html",

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/startNotifications/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/startNotifications/disconnect-called-during.html.ini
@@ -1,0 +1,4 @@
+[disconnect-called-during.html]
+  type: testharness
+  [disconnect() called during startNotifications. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/stopNotifications/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/stopNotifications/disconnect-called-during.html.ini
@@ -1,0 +1,4 @@
+[disconnect-called-during.html]
+  type: testharness
+  [disconnect() called during stopNotifications. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/blocklisted-characteristic.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/blocklisted-characteristic.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.blocklist);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [blocklist_test_service_uuid]}]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => gattServer.getPrimaryService(blocklist_test_service_uuid))
+    .then(service => service.getCharacteristic(blocklist_exclude_reads_characteristic_uuid))
+    .then(characteristic => promise_rejects(t, 'SecurityError', characteristic.startNotifications()));
+}, 'Characteristic with exclude-reads rejects startNotifications.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/characteristic-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/characteristic-is-removed.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+        optionalServices: [generic_access.name]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => gattServer.getPrimaryService(heart_rate.name))
+    .then(service => service.getCharacteristic(heart_rate_measurement.name))
+    .then(characteristic => {
+        window.testRunner.setBluetoothMockDataSet(adapter_type.missing_characteristic_heart_rate);
+        return promise_rejects(t, 'InvalidStateError', characteristic.startNotifications());
+    });
+}, 'Characteristic gets removed. Reject with InvalidStateError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/disconnect-called-before.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+        optionalServices: [generic_access.name]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        return gattServer.getPrimaryService(heart_rate.name)
+        .then(service => service.getCharacteristic(heart_rate_measurement.name))
+        .then(characteristic => {
+            gattServer.disconnect();
+            return promise_rejects(t, 'NetworkError', characteristic.startNotifications());
+        });
+    });
+}, 'disconnect() called before startNotifications. Reject with NetworkError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/disconnect-called-during.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+        optionalServices: [generic_access.name]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        return gattServer.getPrimaryService(heart_rate.name)
+        .then(service => service.getCharacteristic(heart_rate_measurement.name))
+        .then(characteristic => {
+            let promise = promise_rejects(t, 'NetworkError', characteristic.startNotifications());
+            gattServer.disconnect();
+            return promise;
+        });
+    });
+}, 'disconnect() called during startNotifications. Reject with NetworkError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/notify-failure.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/notify-failure.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+        optionalServices: [generic_access.name]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        return gattServer.getPrimaryService(generic_access.name)
+        .then(service => service.getCharacteristic(device_name.name))
+        .then(characteristic => promise_rejects(t, 'NotSupportedError', characteristic.startNotifications()));
+    });
+}, 'startNotifications should throw NotSupportedError without Notify or Indicate flag.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/notify-succeeds.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/startNotifications/notify-succeeds.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(() => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+        optionalServices: [generic_access.name]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => gattServer.getPrimaryService(heart_rate.name))
+    .then(service => service.getCharacteristic(heart_rate_measurement.name))
+    .then(characteristic => {
+        return characteristic.startNotifications()
+        .then(result => assert_equals(result, characteristic));
+    });
+}, 'startNotifications should return the caller object.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/characteristic-is-removed.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/characteristic-is-removed.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+        optionalServices: [generic_access.name]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => gattServer.getPrimaryService(heart_rate.name))
+    .then(service => service.getCharacteristic(heart_rate_measurement.name))
+    .then(characteristic => characteristic.startNotifications())
+    .then(characteristic => {
+        window.testRunner.setBluetoothMockDataSet(adapter_type.missing_characteristic_heart_rate);
+        return promise_rejects(t, 'InvalidStateError', characteristic.stopNotifications());
+    });
+}, 'Characteristic gets removed. Reject with InvalidStateError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/disconnect-called-before.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+        optionalServices: [generic_access.name]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        return gattServer.getPrimaryService(heart_rate.name)
+        .then(service => service.getCharacteristic(heart_rate_measurement.name))
+        .then(characteristic => characteristic.startNotifications())
+        .then(characteristic => {
+            gattServer.disconnect();
+            return promise_rejects(t, 'NetworkError', characteristic.startNotifications());
+        });
+    });
+}, 'disconnect() called before stopNotifications. Reject with NetworkError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/disconnect-called-during.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+        optionalServices: [generic_access.name]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        return gattServer.getPrimaryService(heart_rate.name)
+        .then(service => service.getCharacteristic(heart_rate_measurement.name))
+        .then(characteristic => characteristic.startNotifications())
+        .then(characteristic => {
+            let promise = promise_rejects(t, 'NetworkError', characteristic.startNotifications());
+            gattServer.disconnect();
+            return promise;
+        });
+    });
+}, 'disconnect() called during stopNotifications. Reject with NetworkError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/notify-succeeds.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/notify-succeeds.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(() => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+        optionalServices: [generic_access.name]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => gattServer.getPrimaryService(heart_rate.name))
+    .then(service => service.getCharacteristic(heart_rate_measurement.name))
+    .then(characteristic => characteristic.startNotifications())
+    .then(characteristic => {
+        return characteristic.stopNotifications()
+        .then(result => assert_equals(result, characteristic));
+    });
+}, 'stopNotifications should return the caller object.');
+</script>


### PR DESCRIPTION
Add support for Start and Stop Notifications for WebBluetooth

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14276)
<!-- Reviewable:end -->
