### PR TITLE
Run cargo doc in the ports/servo directory

### DIFF
--- a/ports/servo/Cargo.toml
+++ b/ports/servo/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 name = "servo"
 path = "main.rs"
 test = false
-doc = false
 bench = false
 
 [dev-dependencies]

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -217,7 +217,7 @@ class PostBuildCommands(CommandBase):
                         copy2(full_name, destination)
 
         return call(["cargo", "doc"] + params,
-                    env=self.build_env(), cwd=path.join('components', 'servo'))
+                    env=self.build_env(), cwd=self.servo_crate())
 
     @Command('browse-doc',
              description='Generate documentation and open it in a web browser',


### PR DESCRIPTION
Running it in components/servo isn't guaranteed to work because there's no Cargo.lock checked in there.  Followup to #14254.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14281)
<!-- Reviewable:end -->
