### PR TITLE
Use system rust by default for geckolib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - sudo: 9000
       dist: trusty
       script:
+         - cp servobuild.example .servobuild
          - ./mach build -d --verbose
          - ./mach test-compiletest
          - ./mach test-unit

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -394,6 +394,7 @@ class MachCommands(CommandBase):
                      action='store_true',
                      help='Build in release mode')
     def build_geckolib(self, jobs=None, verbose=False, release=False):
+        self.set_use_system_rust_by_default()
         self.set_use_stable_rust()
         self.ensure_bootstrapped()
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
For stylo, we use the system rust to compile geckolib. I think geckolib itself should probably use that as well. That also avoids explicit environment detection for this case.

This was motivated by 8e8519d which breaks building geckolib in MozillaBuild environment.

I guess some additional work is needed to make Travis happy...

r? @metajack

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14302)
<!-- Reviewable:end -->
