### PR TITLE
Implement parsing/serialization and/or gecko glue for some properties

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -810,7 +810,7 @@ fn static_assert() {
 
 <% skip_position_longhands = " ".join(x.ident for x in SIDES) %>
 <%self:impl_trait style_struct_name="Position"
-                  skip_longhands="${skip_position_longhands} z-index box-sizing">
+                  skip_longhands="${skip_position_longhands} z-index box-sizing order">
 
     % for side in SIDES:
     <% impl_split_style_coord("%s" % side.ident,
@@ -859,6 +859,16 @@ fn static_assert() {
         }
     }
     ${impl_simple_copy('box_sizing', 'mBoxSizing')}
+
+    pub fn set_order(&mut self, v: longhands::order::computed_value::T) {
+        self.gecko.mOrder = v;
+    }
+
+    pub fn clone_order(&self) -> longhands::order::computed_value::T {
+        self.gecko.mOrder
+    }
+
+    ${impl_simple_copy('order', 'mOrder')}
 
 </%self:impl_trait>
 
@@ -2244,7 +2254,7 @@ clip-path
 </%self:impl_trait>
 
 <%self:impl_trait style_struct_name="Column"
-                  skip_longhands="column-width column-count -moz-column-rule-width">
+                  skip_longhands="column-width column-count column-gap -moz-column-rule-width">
 
     pub fn set_column_width(&mut self, v: longhands::column_width::computed_value::T) {
         match v.0 {
@@ -2268,6 +2278,15 @@ clip-path
     }
 
     ${impl_simple_copy('column_count', 'mColumnCount')}
+
+    pub fn set_column_gap(&mut self, v: longhands::column_gap::computed_value::T) {
+        match v.0 {
+            Some(len) => self.gecko.mColumnGap.set(len),
+            None => self.gecko.mColumnGap.set_value(CoordDataValue::Normal),
+        }
+    }
+
+    <%call expr="impl_coord_copy('column_gap', 'mColumnGap')"></%call>
 
     <% impl_app_units("_moz_column_rule_width", "mColumnRuleWidth", need_clone=True,
                       round_to_pixels=True) %>

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -2244,7 +2244,7 @@ clip-path
 </%self:impl_trait>
 
 <%self:impl_trait style_struct_name="Column"
-                  skip_longhands="column-width column-count">
+                  skip_longhands="column-width column-count -moz-column-rule-width">
 
     pub fn set_column_width(&mut self, v: longhands::column_width::computed_value::T) {
         match v.0 {
@@ -2268,6 +2268,9 @@ clip-path
     }
 
     ${impl_simple_copy('column_count', 'mColumnCount')}
+
+    <% impl_app_units("_moz_column_rule_width", "mColumnRuleWidth", need_clone=True,
+                      round_to_pixels=True) %>
 </%self:impl_trait>
 
 <%self:impl_trait style_struct_name="Counters"

--- a/components/style/properties/longhand/column.mako.rs
+++ b/components/style/properties/longhand/column.mako.rs
@@ -169,7 +169,7 @@
 </%helpers:longhand>
 
 // FIXME: This prop should be animatable.
-<%helpers:longhand name="column-gap" experimental="True" products="servo" animatable="False">
+<%helpers:longhand name="column-gap" experimental="True" animatable="False">
     use std::fmt;
     use style_traits::ToCss;
     use values::HasViewportPercentage;

--- a/components/style/properties/longhand/column.mako.rs
+++ b/components/style/properties/longhand/column.mako.rs
@@ -252,3 +252,39 @@
 
 ${helpers.single_keyword("column-fill", "auto balance",
                          products="gecko", animatable=False)}
+
+// https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-width
+<%helpers:longhand name="-moz-column-rule-width" products="gecko" animatable="True">
+    use app_units::Au;
+    use std::fmt;
+    use style_traits::ToCss;
+    use values::HasViewportPercentage;
+    use values::specified::BorderWidth;
+
+    pub mod computed_value {
+        use app_units::Au;
+        pub type T = Au;
+    }
+
+    pub type SpecifiedValue = BorderWidth;
+
+    #[inline]
+    pub fn get_initial_value() -> computed_value::T {
+        Au::from_px(3) // medium
+    }
+
+    pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
+        BorderWidth::parse(input)
+    }
+</%helpers:longhand>
+
+// https://drafts.csswg.org/css-multicol-1/#crc
+${helpers.predefined_type("-moz-column-rule-color", "CSSColor",
+                          "::cssparser::Color::CurrentColor",
+                          products="gecko", gecko_ffi_name="mColumnRuleColor",
+                          animatable=True, complex_color=True, need_clone=True)}
+
+// It's not implemented in servo or gecko yet.
+// https://drafts.csswg.org/css-multicol-1/#column-span
+${helpers.single_keyword("column-span", "none all",
+                         products="none", animatable=False)}

--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -866,6 +866,11 @@ ${helpers.single_keyword("text-align-last",
         computed_value::T::None
     }
 
+    #[inline]
+    pub fn get_initial_specified_value() -> SpecifiedValue {
+        SpecifiedValue::None
+    }
+
     impl ToComputedValue for SpecifiedValue {
         type ComputedValue = computed_value::T;
 
@@ -984,6 +989,12 @@ ${helpers.single_keyword("text-align-last",
         }
     }
 </%helpers:longhand>
+
+// https://drafts.csswg.org/css-text-decor-3/#text-emphasis-color-property
+${helpers.predefined_type("text-emphasis-color", "CSSColor",
+                          "::cssparser::Color::CurrentColor",
+                          products="gecko",animatable=True,
+                          complex_color=True, need_clone=True)}
 
 // TODO(pcwalton): `full-width`
 ${helpers.single_keyword("text-transform",

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -107,7 +107,7 @@ ${helpers.single_keyword("align-self", "auto stretch flex-start flex-end center 
                          animatable=False)}
 
 // https://drafts.csswg.org/css-flexbox/#propdef-order
-<%helpers:longhand name="order" products="servo" animatable="True">
+<%helpers:longhand name="order" animatable="True">
     use values::computed::ComputedValueAsSpecified;
 
     impl ComputedValueAsSpecified for SpecifiedValue {}

--- a/components/style/properties/shorthand/inherited_text.mako.rs
+++ b/components/style/properties/shorthand/inherited_text.mako.rs
@@ -21,3 +21,60 @@
         }
     }
 </%helpers:shorthand>
+
+// https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property
+<%helpers:shorthand name="text-emphasis" products="gecko" sub_properties="text-emphasis-color
+    text-emphasis-style">
+    use properties::longhands::{text_emphasis_color, text_emphasis_style};
+
+    pub fn parse_value(context: &ParserContext, input: &mut Parser) -> Result<Longhands, ()> {
+        let mut color = None;
+        let mut style = None;
+
+        loop {
+            if color.is_none() {
+                if let Ok(value) = input.try(|input| text_emphasis_color::parse(context, input)) {
+                    color = Some(value);
+                    continue
+                }
+            }
+            if style.is_none() {
+                if let Ok(value) = input.try(|input| text_emphasis_style::parse(context, input)) {
+                    style = Some(value);
+                    continue
+                }
+            }
+            break
+        }
+        if color.is_some() || style.is_some() {
+            if style.is_none() {
+                style = Some(text_emphasis_style::get_initial_specified_value());
+            }
+
+            Ok(Longhands {
+                text_emphasis_color: color,
+                text_emphasis_style: style,
+            })
+        } else {
+            Err(())
+        }
+    }
+
+    impl<'a> LonghandsToSerialize<'a>  {
+        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            let mut style_present = false;
+            if let DeclaredValue::Value(ref value) = *self.text_emphasis_style {
+                style_present = true;
+                try!(value.to_css(dest));
+            }
+
+            if let DeclaredValue::Value(ref color) = *self.text_emphasis_color {
+                if style_present {
+                    try!(write!(dest, " "));
+                }
+                try!(color.to_css(dest));
+            }
+            Ok(())
+        }
+    }
+</%helpers:shorthand>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The PR covers implementation and/or gecko glue for these properties:

1. Implemented parsing/serialization and gecko glue for column-rule-width, column-rule-color and column-span longhand properties (column-span is not implemented in gecko yet but I wanted to complete column properties :) )
2.  Implemented parsing/serialization and gecko glue for text-emphasis-color longhand and text-emphasis shorthand properties.
3. Implemented gecko glue for column-gap and order properties

I implemented column-rule-width and column-rule-color properties with `-moz-` prefixes, but I can remove them if it's not right.
I coudn't test them in full stylo build yet (LLVM messed up my current clang). But I'll test them soon.

r? @Manishearth or @emilio 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14316)
<!-- Reviewable:end -->
