### PR TITLE
Implement access to CSSStyleRule for stylo

### DIFF
--- a/components/style/binding_tools/regen.py
+++ b/components/style/binding_tools/regen.py
@@ -335,7 +335,8 @@ COMPILATION_TARGETS = {
             "ServoComputedValues",
             "ServoCssRules",
             "RawServoStyleSheet",
-            "RawServoDeclarationBlock"
+            "RawServoDeclarationBlock",
+            "RawServoStyleRule",
         ],
         "servo_owned_types": [
             "RawServoStyleSet",

--- a/components/style/binding_tools/regen.py
+++ b/components/style/binding_tools/regen.py
@@ -328,8 +328,13 @@ COMPILATION_TARGETS = {
             "nsStyleVisibility",
             "nsStyleXUL",
         ],
+        "array_types": {
+            "uintptr_t": "usize",
+        },
         "servo_nullable_arc_types": [
-            "ServoComputedValues", "RawServoStyleSheet",
+            "ServoComputedValues",
+            "ServoCssRules",
+            "RawServoStyleSheet",
             "RawServoDeclarationBlock"
         ],
         "servo_owned_types": [
@@ -534,6 +539,14 @@ def build(objdir, target_name, debug, debugger, kind_name=None,
         for ty in current_target["opaque_types"]:
             flags.append("--opaque-type")
             flags.append(ty)
+
+    if "array_types" in current_target:
+        for cpp_type, rust_type in current_target["array_types"].items():
+            flags.append("--blacklist-type")
+            flags.append("nsTArrayBorrowed_{}".format(cpp_type))
+            flags.append("--raw-line")
+            flags.append("pub type nsTArrayBorrowed_{0}<'a> = &'a mut ::gecko_bindings::structs::nsTArray<{1}>;"
+                         .format(cpp_type, rust_type))
 
     if "blacklist_types" in current_target:
         for ty in current_target["blacklist_types"]:

--- a/components/style/gecko/conversions.rs
+++ b/components/style/gecko/conversions.rs
@@ -11,13 +11,13 @@
 use app_units::Au;
 use gecko::values::{convert_rgba_to_nscolor, StyleCoordHelpers};
 use gecko_bindings::bindings::{Gecko_CreateGradient, Gecko_SetGradientImageValue, Gecko_SetUrlImageValue};
-use gecko_bindings::bindings::{RawServoStyleSheet, RawServoDeclarationBlock, ServoComputedValues};
+use gecko_bindings::bindings::{RawServoStyleSheet, RawServoDeclarationBlock, ServoComputedValues, ServoCssRules};
 use gecko_bindings::structs::{nsStyleCoord_CalcValue, nsStyleImage};
 use gecko_bindings::sugar::ns_style_coord::{CoordDataValue, CoordDataMut};
 use gecko_bindings::sugar::ownership::{HasArcFFI, HasFFI};
 use parking_lot::RwLock;
 use properties::{ComputedValues, PropertyDeclarationBlock};
-use stylesheets::Stylesheet;
+use stylesheets::{CssRule, Stylesheet};
 use values::computed::{CalcLengthOrPercentage, Gradient, Image, LengthOrPercentage, LengthOrPercentageOrAuto};
 
 unsafe impl HasFFI for Stylesheet {
@@ -33,6 +33,11 @@ unsafe impl HasFFI for RwLock<PropertyDeclarationBlock> {
     type FFIType = RawServoDeclarationBlock;
 }
 unsafe impl HasArcFFI for RwLock<PropertyDeclarationBlock> {}
+
+unsafe impl HasFFI for RwLock<Vec<CssRule>> {
+    type FFIType = ServoCssRules;
+}
+unsafe impl HasArcFFI for RwLock<Vec<CssRule>> {}
 
 impl From<CalcLengthOrPercentage> for nsStyleCoord_CalcValue {
     fn from(other: CalcLengthOrPercentage) -> nsStyleCoord_CalcValue {

--- a/components/style/gecko/conversions.rs
+++ b/components/style/gecko/conversions.rs
@@ -11,13 +11,14 @@
 use app_units::Au;
 use gecko::values::{convert_rgba_to_nscolor, StyleCoordHelpers};
 use gecko_bindings::bindings::{Gecko_CreateGradient, Gecko_SetGradientImageValue, Gecko_SetUrlImageValue};
-use gecko_bindings::bindings::{RawServoStyleSheet, RawServoDeclarationBlock, ServoComputedValues, ServoCssRules};
+use gecko_bindings::bindings::{RawServoStyleSheet, RawServoDeclarationBlock, RawServoStyleRule};
+use gecko_bindings::bindings::{ServoComputedValues, ServoCssRules};
 use gecko_bindings::structs::{nsStyleCoord_CalcValue, nsStyleImage};
 use gecko_bindings::sugar::ns_style_coord::{CoordDataValue, CoordDataMut};
 use gecko_bindings::sugar::ownership::{HasArcFFI, HasFFI};
 use parking_lot::RwLock;
 use properties::{ComputedValues, PropertyDeclarationBlock};
-use stylesheets::{CssRule, Stylesheet};
+use stylesheets::{CssRule, Stylesheet, StyleRule};
 use values::computed::{CalcLengthOrPercentage, Gradient, Image, LengthOrPercentage, LengthOrPercentageOrAuto};
 
 unsafe impl HasFFI for Stylesheet {
@@ -38,6 +39,11 @@ unsafe impl HasFFI for RwLock<Vec<CssRule>> {
     type FFIType = ServoCssRules;
 }
 unsafe impl HasArcFFI for RwLock<Vec<CssRule>> {}
+
+unsafe impl HasFFI for RwLock<StyleRule> {
+    type FFIType = RawServoStyleRule;
+}
+unsafe impl HasArcFFI for RwLock<StyleRule> {}
 
 impl From<CalcLengthOrPercentage> for nsStyleCoord_CalcValue {
     fn from(other: CalcLengthOrPercentage) -> nsStyleCoord_CalcValue {

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1011,6 +1011,14 @@ extern "C" {
      -> RawServoStyleRuleStrong;
 }
 extern "C" {
+    pub fn Servo_StyleRule_GetCssText(rule: RawServoStyleRuleBorrowed,
+                                      result: *mut nsAString_internal);
+}
+extern "C" {
+    pub fn Servo_StyleRule_GetSelectorText(rule: RawServoStyleRuleBorrowed,
+                                           result: *mut nsAString_internal);
+}
+extern "C" {
     pub fn Servo_ParseProperty(property: *const nsACString_internal,
                                value: *const nsACString_internal,
                                base_url: *const nsACString_internal,

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1011,6 +1011,15 @@ extern "C" {
      -> RawServoStyleRuleStrong;
 }
 extern "C" {
+    pub fn Servo_StyleRule_GetStyle(rule: RawServoStyleRuleBorrowed)
+     -> RawServoDeclarationBlockStrong;
+}
+extern "C" {
+    pub fn Servo_StyleRule_SetStyle(rule: RawServoStyleRuleBorrowed,
+                                    declarations:
+                                        RawServoDeclarationBlockBorrowed);
+}
+extern "C" {
     pub fn Servo_StyleRule_GetCssText(rule: RawServoStyleRuleBorrowed,
                                       result: *mut nsAString_internal);
 }

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1011,6 +1011,10 @@ extern "C" {
      -> RawServoStyleRuleStrong;
 }
 extern "C" {
+    pub fn Servo_StyleRule_Debug(rule: RawServoStyleRuleBorrowed,
+                                 result: *mut nsACString_internal);
+}
+extern "C" {
     pub fn Servo_StyleRule_GetStyle(rule: RawServoStyleRuleBorrowed)
      -> RawServoDeclarationBlockStrong;
 }

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -24,6 +24,11 @@ pub type RawServoDeclarationBlockBorrowedOrNull<'a> = Option<&'a RawServoDeclara
 pub type RawServoDeclarationBlockBorrowed<'a> = &'a RawServoDeclarationBlock;
 enum RawServoDeclarationBlockVoid{ }
 pub struct RawServoDeclarationBlock(RawServoDeclarationBlockVoid);
+pub type RawServoStyleRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoStyleRule>;
+pub type RawServoStyleRuleBorrowedOrNull<'a> = Option<&'a RawServoStyleRule>;
+pub type RawServoStyleRuleBorrowed<'a> = &'a RawServoStyleRule;
+enum RawServoStyleRuleVoid{ }
+pub struct RawServoStyleRule(RawServoStyleRuleVoid);
 pub type RawGeckoNodeBorrowed<'a> = &'a RawGeckoNode;
 pub type RawGeckoNodeBorrowedOrNull<'a> = Option<&'a RawGeckoNode>;
 pub type RawGeckoElementBorrowed<'a> = &'a RawGeckoElement;
@@ -219,6 +224,12 @@ extern "C" {
 extern "C" {
     pub fn Servo_DeclarationBlock_Release(ptr:
                                               RawServoDeclarationBlockBorrowed);
+}
+extern "C" {
+    pub fn Servo_StyleRule_AddRef(ptr: RawServoStyleRuleBorrowed);
+}
+extern "C" {
+    pub fn Servo_StyleRule_Release(ptr: RawServoStyleRuleBorrowed);
 }
 extern "C" {
     pub fn Servo_StyleSet_Drop(ptr: RawServoStyleSetOwned);
@@ -993,6 +1004,11 @@ extern "C" {
 extern "C" {
     pub fn Servo_CssRules_ListTypes(rules: ServoCssRulesBorrowed,
                                     result: nsTArrayBorrowed_uintptr_t);
+}
+extern "C" {
+    pub fn Servo_CssRules_GetStyleRuleAt(rules: ServoCssRulesBorrowed,
+                                         index: u32)
+     -> RawServoStyleRuleStrong;
 }
 extern "C" {
     pub fn Servo_ParseProperty(property: *const nsACString_internal,

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -3,11 +3,17 @@
 pub use nsstring::{nsACString, nsAString};
 type nsACString_internal = nsACString;
 type nsAString_internal = nsAString;
+pub type nsTArrayBorrowed_uintptr_t<'a> = &'a mut ::gecko_bindings::structs::nsTArray<usize>;
 pub type ServoComputedValuesStrong = ::gecko_bindings::sugar::ownership::Strong<ServoComputedValues>;
 pub type ServoComputedValuesBorrowedOrNull<'a> = Option<&'a ServoComputedValues>;
 pub type ServoComputedValuesBorrowed<'a> = &'a ServoComputedValues;
 enum ServoComputedValuesVoid{ }
 pub struct ServoComputedValues(ServoComputedValuesVoid);
+pub type ServoCssRulesStrong = ::gecko_bindings::sugar::ownership::Strong<ServoCssRules>;
+pub type ServoCssRulesBorrowedOrNull<'a> = Option<&'a ServoCssRules>;
+pub type ServoCssRulesBorrowed<'a> = &'a ServoCssRules;
+enum ServoCssRulesVoid{ }
+pub struct ServoCssRules(ServoCssRulesVoid);
 pub type RawServoStyleSheetStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoStyleSheet>;
 pub type RawServoStyleSheetBorrowedOrNull<'a> = Option<&'a RawServoStyleSheet>;
 pub type RawServoStyleSheetBorrowed<'a> = &'a RawServoStyleSheet;
@@ -188,6 +194,12 @@ unsafe impl Sync for nsStyleXUL {}
 pub type RawGeckoNode = nsINode;
 pub type RawGeckoElement = Element;
 pub type RawGeckoDocument = nsIDocument;
+extern "C" {
+    pub fn Servo_CssRules_AddRef(ptr: ServoCssRulesBorrowed);
+}
+extern "C" {
+    pub fn Servo_CssRules_Release(ptr: ServoCssRulesBorrowed);
+}
 extern "C" {
     pub fn Servo_StyleSheet_AddRef(ptr: RawServoStyleSheetBorrowed);
 }
@@ -951,6 +963,10 @@ extern "C" {
      -> bool;
 }
 extern "C" {
+    pub fn Servo_StyleSheet_GetRules(sheet: RawServoStyleSheetBorrowed)
+     -> ServoCssRulesStrong;
+}
+extern "C" {
     pub fn Servo_StyleSet_Init() -> RawServoStyleSetOwned;
 }
 extern "C" {
@@ -973,6 +989,10 @@ extern "C" {
                                                      RawServoStyleSheetBorrowed,
                                                  reference:
                                                      RawServoStyleSheetBorrowed);
+}
+extern "C" {
+    pub fn Servo_CssRules_ListTypes(rules: ServoCssRulesBorrowed,
+                                    result: nsTArrayBorrowed_uintptr_t);
 }
 extern "C" {
     pub fn Servo_ParseProperty(property: *const nsACString_internal,

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -136,6 +136,30 @@ pub enum CssRule {
     Keyframes(Arc<RwLock<KeyframesRule>>),
 }
 
+pub enum CssRuleType {
+    // https://drafts.csswg.org/cssom/#the-cssrule-interface
+    Style               = 1,
+    Charset             = 2,
+    Import              = 3,
+    Media               = 4,
+    FontFace            = 5,
+    Page                = 6,
+    // https://drafts.csswg.org/css-animations-1/#interface-cssrule-idl
+    Keyframes           = 7,
+    Keyframe            = 8,
+    // https://drafts.csswg.org/cssom/#the-cssrule-interface
+    Margin              = 9,
+    Namespace           = 10,
+    // https://drafts.csswg.org/css-counter-styles-3/#extentions-to-cssrule-interface
+    CounterStyle        = 11,
+    // https://drafts.csswg.org/css-conditional-3/#extentions-to-cssrule-interface
+    Supports            = 12,
+    // https://drafts.csswg.org/css-fonts-3/#om-fontfeaturevalues
+    FontFeatureValues   = 14,
+    // https://drafts.csswg.org/css-device-adapt/#css-rule-interface
+    Viewport            = 15,
+}
+
 /// Error reporter which silently forgets errors
 pub struct MemoryHoleReporter;
 
@@ -157,6 +181,17 @@ pub enum SingleRuleParseError {
 }
 
 impl CssRule {
+    pub fn rule_type(&self) -> CssRuleType {
+        match *self {
+            CssRule::Style(_)     => CssRuleType::Style,
+            CssRule::Media(_)     => CssRuleType::Media,
+            CssRule::FontFace(_)  => CssRuleType::FontFace,
+            CssRule::Keyframes(_) => CssRuleType::Keyframes,
+            CssRule::Namespace(_) => CssRuleType::Namespace,
+            CssRule::Viewport(_)  => CssRuleType::Viewport,
+        }
+    }
+
     /// Call `f` with the slice of rules directly contained inside this rule.
     ///
     /// Note that only some types of rules can contain rules. An empty slice is used for others.

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -4,6 +4,7 @@
 
 use app_units::Au;
 use cssparser::Parser;
+use cssparser::ToCss as ParserToCss;
 use env_logger;
 use euclid::Size2D;
 use parking_lot::RwLock;
@@ -321,6 +322,18 @@ pub extern "C" fn Servo_StyleRule_AddRef(rule: RawServoStyleRuleBorrowed) -> () 
 #[no_mangle]
 pub extern "C" fn Servo_StyleRule_Release(rule: RawServoStyleRuleBorrowed) -> () {
     unsafe { RwLock::<StyleRule>::release(rule) };
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_StyleRule_GetCssText(rule: RawServoStyleRuleBorrowed, result: *mut nsAString) -> () {
+    let rule = RwLock::<StyleRule>::as_arc(&rule);
+    rule.read().to_css(unsafe { result.as_mut().unwrap() }).unwrap();
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_StyleRule_GetSelectorText(rule: RawServoStyleRuleBorrowed, result: *mut nsAString) -> () {
+    let rule = RwLock::<StyleRule>::as_arc(&rule);
+    rule.read().selectors.to_css(unsafe { result.as_mut().unwrap() }).unwrap();
 }
 
 #[no_mangle]

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -325,6 +325,13 @@ pub extern "C" fn Servo_StyleRule_Release(rule: RawServoStyleRuleBorrowed) -> ()
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_StyleRule_Debug(rule: RawServoStyleRuleBorrowed, result: *mut nsACString) -> () {
+    let rule = RwLock::<StyleRule>::as_arc(&rule);
+    let result = unsafe { result.as_mut().unwrap() };
+    write!(result, "{:?}", *rule.read()).unwrap();
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_StyleRule_GetStyle(rule: RawServoStyleRuleBorrowed) -> RawServoDeclarationBlockStrong {
     let rule = RwLock::<StyleRule>::as_arc(&rule);
     rule.read().block.clone().into_strong()

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -23,6 +23,7 @@ use style::gecko::wrapper::{GeckoElement, GeckoNode};
 use style::gecko::wrapper::DUMMY_BASE_URL;
 use style::gecko_bindings::bindings::{RawGeckoElementBorrowed, RawGeckoNodeBorrowed};
 use style::gecko_bindings::bindings::{RawServoDeclarationBlockBorrowed, RawServoDeclarationBlockStrong};
+use style::gecko_bindings::bindings::{RawServoStyleRuleBorrowed, RawServoStyleRuleStrong};
 use style::gecko_bindings::bindings::{RawServoStyleSetBorrowed, RawServoStyleSetOwned};
 use style::gecko_bindings::bindings::{RawServoStyleSheetBorrowed, ServoComputedValuesBorrowed};
 use style::gecko_bindings::bindings::{RawServoStyleSheetStrong, ServoComputedValuesStrong};
@@ -47,7 +48,7 @@ use style::properties::{apply_declarations, parse_one_declaration};
 use style::selector_parser::PseudoElementCascadeType;
 use style::sequential;
 use style::string_cache::Atom;
-use style::stylesheets::{CssRule, Origin, Stylesheet};
+use style::stylesheets::{CssRule, Origin, Stylesheet, StyleRule};
 use style::thread_state;
 use style::timer::Timer;
 use style_traits::ToCss;
@@ -291,6 +292,18 @@ pub extern "C" fn Servo_CssRules_ListTypes(rules: ServoCssRulesBorrowed,
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_CssRules_GetStyleRuleAt(rules: ServoCssRulesBorrowed, index: u32)
+                                                -> RawServoStyleRuleStrong {
+    let rules = RwLock::<Vec<CssRule>>::as_arc(&rules).read();
+    match rules[index as usize] {
+        CssRule::Style(ref rule) => rule.clone().into_strong(),
+        _ => {
+            unreachable!("GetStyleRuleAt should only be called on a style rule");
+        }
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_CssRules_AddRef(rules: ServoCssRulesBorrowed) -> () {
     unsafe { RwLock::<Vec<CssRule>>::addref(rules) };
 }
@@ -298,6 +311,16 @@ pub extern "C" fn Servo_CssRules_AddRef(rules: ServoCssRulesBorrowed) -> () {
 #[no_mangle]
 pub extern "C" fn Servo_CssRules_Release(rules: ServoCssRulesBorrowed) -> () {
     unsafe { RwLock::<Vec<CssRule>>::release(rules) };
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_StyleRule_AddRef(rule: RawServoStyleRuleBorrowed) -> () {
+    unsafe { RwLock::<StyleRule>::addref(rule) };
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_StyleRule_Release(rule: RawServoStyleRuleBorrowed) -> () {
+    unsafe { RwLock::<StyleRule>::release(rule) };
 }
 
 #[no_mangle]

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -325,6 +325,20 @@ pub extern "C" fn Servo_StyleRule_Release(rule: RawServoStyleRuleBorrowed) -> ()
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_StyleRule_GetStyle(rule: RawServoStyleRuleBorrowed) -> RawServoDeclarationBlockStrong {
+    let rule = RwLock::<StyleRule>::as_arc(&rule);
+    rule.read().block.clone().into_strong()
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_StyleRule_SetStyle(rule: RawServoStyleRuleBorrowed,
+                                           declarations: RawServoDeclarationBlockBorrowed) -> () {
+    let rule = RwLock::<StyleRule>::as_arc(&rule);
+    let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
+    rule.write().block = declarations.clone();
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_StyleRule_GetCssText(rule: RawServoStyleRuleBorrowed, result: *mut nsAString) -> () {
     let rule = RwLock::<StyleRule>::as_arc(&rule);
     rule.read().to_css(unsafe { result.as_mut().unwrap() }).unwrap();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is the servo part of [bug 1307357](https://bugzilla.mozilla.org/show_bug.cgi?id=1307357) which has been reviewed by @heycam, @Manishearth and @SimonSapin.

r? @heycam 

(`./mach test-tidy` reports several issues on bindings.rs... which I don't think is introduced by my patch... so I have no idea what to do here...)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14330)
<!-- Reviewable:end -->
