### PR TITLE
Add keyword "auto" to flexbox min-size property

### DIFF
--- a/components/layout/flex.rs
+++ b/components/layout/flex.rs
@@ -20,7 +20,7 @@ use gfx::display_list::StackingContext;
 use gfx_traits::ScrollRootId;
 use layout_debug;
 use model::{IntrinsicISizes, MaybeAuto, MinMaxConstraint};
-use model::{specified, specified_or_none};
+use model::{specified_or_auto, specified_or_none};
 use std::cmp::{max, min};
 use std::ops::Range;
 use std::sync::Arc;
@@ -30,8 +30,8 @@ use style::context::{SharedStyleContext, StyleContext};
 use style::logical_geometry::{Direction, LogicalSize};
 use style::properties::ServoComputedValues;
 use style::servo::restyle_damage::{REFLOW, REFLOW_OUT_OF_FLOW};
-use style::values::computed::{LengthOrPercentage, LengthOrPercentageOrAuto};
-use style::values::computed::{LengthOrPercentageOrAutoOrContent, LengthOrPercentageOrNone};
+use style::values::computed::{LengthOrPercentageOrAuto, LengthOrPercentageOrAutoOrContent};
+use style::values::computed::LengthOrPercentageOrNone;
 
 /// The size of an axis. May be a specified size, a min/max
 /// constraint, or an unlimited size
@@ -45,8 +45,8 @@ enum AxisSize {
 impl AxisSize {
     /// Generate a new available cross or main axis size from the specified size of the container,
     /// containing block size, min constraint, and max constraint
-    pub fn new(size: LengthOrPercentageOrAuto, content_size: Option<Au>, min: LengthOrPercentage,
-               max: LengthOrPercentageOrNone) -> AxisSize {
+    pub fn new(size: LengthOrPercentageOrAuto, content_size: Option<Au>,
+               min: LengthOrPercentageOrAuto, max: LengthOrPercentageOrNone) -> AxisSize {
         match size {
             LengthOrPercentageOrAuto::Length(length) => AxisSize::Definite(length),
             LengthOrPercentageOrAuto::Percentage(percent) => {
@@ -177,8 +177,7 @@ impl FlexItem {
                 self.base_size = basis.specified_or_default(content_size);
                 self.max_size = specified_or_none(block.fragment.style.max_inline_size(),
                                                   containing_length).unwrap_or(MAX_AU);
-                self.min_size = specified(block.fragment.style.min_inline_size(),
-                                          containing_length);
+                self.min_size = specified_or_auto(block.fragment.style.min_inline_size(), containing_length);
             }
             Direction::Block => {
                 let basis = from_flex_basis(block.fragment.style.get_position().flex_basis,
@@ -190,8 +189,7 @@ impl FlexItem {
                 self.base_size = basis.specified_or_default(content_size);
                 self.max_size = specified_or_none(block.fragment.style.max_block_size(),
                                                   containing_length).unwrap_or(MAX_AU);
-                self.min_size = specified(block.fragment.style.min_block_size(),
-                                          containing_length);
+                self.min_size = specified_or_auto(block.fragment.style.min_block_size(), containing_length);
             }
         }
     }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -250,11 +250,11 @@ impl fmt::Debug for SpecificFragmentInfo {
 
 /// Clamp a value obtained from style_length, based on min / max lengths.
 fn clamp_size(size: Au,
-              min_size: LengthOrPercentage,
+              min_size: LengthOrPercentageOrAuto,
               max_size: LengthOrPercentageOrNone,
               container_size: Au)
               -> Au {
-    let min_size = model::specified(min_size, container_size);
+    let min_size = model::specified_or_auto(min_size, container_size);
     let max_size = model::specified_or_none(max_size, container_size);
 
     max(min_size, match max_size {
@@ -729,7 +729,7 @@ impl IframeFragmentInfo {
     }
 
     fn calculate_replaced_size(content_size: LengthOrPercentageOrAuto,
-                               style_min_size: LengthOrPercentage,
+                               style_min_size: LengthOrPercentageOrAuto,
                                style_max_size: LengthOrPercentageOrNone,
                                containing_size: Option<Au>,
                                default_size: Au) -> Au {
@@ -1184,7 +1184,7 @@ impl Fragment {
         if flags.contains(INTRINSIC_INLINE_SIZE_INCLUDES_SPECIFIED) {
             specified = MaybeAuto::from_style(style.content_inline_size(),
                                               Au(0)).specified_or_zero();
-            specified = max(model::specified(style.min_inline_size(), Au(0)), specified);
+            specified = max(model::specified_or_auto(style.min_inline_size(), Au(0)), specified);
             if let Some(max) = model::specified_or_none(style.max_inline_size(), Au(0)) {
                 specified = min(specified, max)
             }
@@ -1559,7 +1559,8 @@ impl Fragment {
                     LengthOrPercentageOrAuto::Calc(calc) => calc.length(),
                 };
 
-                image_inline_size = max(model::specified(self.style.min_inline_size(), Au(0)), image_inline_size);
+                image_inline_size = max(model::specified_or_auto(self.style.min_inline_size(), Au(0)),
+                                        image_inline_size);
                 if let Some(max) = model::specified_or_none(self.style.max_inline_size(), Au(0)) {
                     image_inline_size = min(image_inline_size, max)
                 }
@@ -1579,7 +1580,8 @@ impl Fragment {
                     LengthOrPercentageOrAuto::Calc(calc) => calc.length(),
                 };
 
-                canvas_inline_size = max(model::specified(self.style.min_inline_size(), Au(0)), canvas_inline_size);
+                canvas_inline_size = max(model::specified_or_auto(self.style.min_inline_size(), Au(0)),
+                                         canvas_inline_size);
                 if let Some(max) = model::specified_or_none(self.style.max_inline_size(), Au(0)) {
                     canvas_inline_size = min(canvas_inline_size, max)
                 }
@@ -1599,7 +1601,7 @@ impl Fragment {
                     LengthOrPercentageOrAuto::Calc(calc) => calc.length(),
                 };
 
-                svg_inline_size = max(model::specified(self.style.min_inline_size(), Au(0)), svg_inline_size);
+                svg_inline_size = max(model::specified_or_auto(self.style.min_inline_size(), Au(0)), svg_inline_size);
                 if let Some(max) = model::specified_or_none(self.style.max_inline_size(), Au(0)) {
                     svg_inline_size = min(svg_inline_size, max)
                 }

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -144,8 +144,8 @@ ${helpers.predefined_type("flex-basis",
 
     // min-width, min-height, min-block-size, min-inline-size
     ${helpers.predefined_type("min-%s" % size,
-                              "LengthOrPercentage",
-                              "computed::LengthOrPercentage::Length(Au(0))",
+                              "LengthOrPercentageOrAuto",
+                              "computed::LengthOrPercentageOrAuto::Auto",
                               "parse_non_negative",
                               animatable=True, logical = logical)}
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1177,13 +1177,13 @@ impl ComputedValues {
     }
 
     #[inline]
-    pub fn min_inline_size(&self) -> computed::LengthOrPercentage {
+    pub fn min_inline_size(&self) -> computed::LengthOrPercentageOrAuto {
         let position_style = self.get_position();
         if self.writing_mode.is_vertical() { position_style.min_height } else { position_style.min_width }
     }
 
     #[inline]
-    pub fn min_block_size(&self) -> computed::LengthOrPercentage {
+    pub fn min_block_size(&self) -> computed::LengthOrPercentageOrAuto {
         let position_style = self.get_position();
         if self.writing_mode.is_vertical() { position_style.min_width } else { position_style.min_height }
     }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1700,6 +1700,16 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
         }
     % endfor
 
+    % for direction in ["width", "height"]:
+        // Like calling to_computed_value, which wouldn't type check.
+        if let (false, computed::LengthOrPercentageOrAuto::Auto) = (
+            is_flex_item, style.get_position().clone_min_${direction}()
+        ){
+            style.mutate_position().set_min_${direction}(
+                computed::LengthOrPercentageOrAuto::Length(Au(0))
+            );
+        }
+    % endfor
 
     % if product == "gecko":
         style.mutate_background().fill_arrays();

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_min-height-auto.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_min-height-auto.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_min-height-auto.htm]
-  type: testharness
-  [flexbox | computed style | min-height: auto]
-    expected: FAIL
-

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_min-width-auto.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_min-width-auto.htm.ini
@@ -1,5 +1,0 @@
-[flexbox_computedstyle_min-width-auto.htm]
-  type: testharness
-  [flexbox | computed style | min-width: auto]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6590,6 +6590,12 @@
             "url": "/_mozilla/css/empty-keyframes.html"
           }
         ],
+        "css/flex-auto-min-size-fallback.html": [
+          {
+            "path": "css/flex-auto-min-size-fallback.html",
+            "url": "/_mozilla/css/flex-auto-min-size-fallback.html"
+          }
+        ],
         "css/flex-item-assign-inline-size.html": [
           {
             "path": "css/flex-item-assign-inline-size.html",

--- a/tests/wpt/mozilla/tests/css/flex-auto-min-size-fallback.html
+++ b/tests/wpt/mozilla/tests/css/flex-auto-min-size-fallback.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html><head><title>non-flexbox | computed style | min-width: auto</title>
+<link href="http://www.w3.org/TR/css-flexbox-1/#min-size-auto" rel="help">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta content="dom" name="flags">
+<meta name="assert" content="Even with the new flexbox 'auto' keyword, non-flexitem elements should still return '0px' for their min-width/height" />
+<style>
+body {
+  min-width: auto;
+  min-height: auto;
+}
+</style>
+</head><body><div id="log"></div>
+<script>
+test(function() {
+  var body = document.body;
+
+  assert_equals(getComputedStyle(body).getPropertyValue("min-width"), "0px");
+  assert_equals(getComputedStyle(body).getPropertyValue("min-height"), "0px");
+});
+</script>
+</body></html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is the first patch for #12610, the algorithm itself took longer than I expected, so I'm landing this foundational work first.

This adds a new initial value `auto` to the `min-width` and `min-height` specified on a flexitem. It also provides a fallback of "0px" if we try to get the `min-width/height` on a non-flexitem box using `getComputedStyle`. 

The `auto` resolution algorithm is not ready yet, so we fall back to `0px` during layout.

r?@stshine

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14332)
<!-- Reviewable:end -->
