### PR TITLE
script: Fix the scroll to top behavior

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14690,6 +14690,12 @@
             "url": "/_mozilla/mozilla/scrollTo.html"
           }
         ],
+        "mozilla/scroll_top_null_target.html": [
+          {
+            "path": "mozilla/scroll_top_null_target.html",
+            "url": "/_mozilla/mozilla/scroll_top_null_target.html"
+          }
+        ],
         "mozilla/send-arraybuffer.htm": [
           {
             "path": "mozilla/send-arraybuffer.htm",

--- a/tests/wpt/mozilla/tests/mozilla/scroll_top_null_target.html
+++ b/tests/wpt/mozilla/tests/mozilla/scroll_top_null_target.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title></title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <a id="test"></a>
+    </body>
+    <script>
+     test(function() {
+         location.hash = "test";
+         assert_equals(document.querySelector(":target"), document.getElementById("test"),
+                       "Target shoud be the same with the test anchor!");
+         location.hash = "";
+         assert_equals(document.querySelector(":target"), null, "Target should be null!");
+     });
+    </script>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

When finding the indicated fragment, do not use the document element to indicate
the top of the Document, and when scrolling to the frament and we do not find a
element, scrolling the top if the fragment is empty or equal to "top".

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14341)
<!-- Reviewable:end -->
