### PR TITLE
Use MSVC toolchain if PLATFORM is defined

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,9 +35,6 @@ branches:
   only:
     - master
 
-platform:
-  - x64
-
 cache:
   - .servo -> rust-nightly-date, cargo-nightly-build
   - .cargo -> rust-nightly-date, cargo-nightly-build

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -108,10 +108,12 @@ def host_triple():
         os_type = "linux-androideabi"
     elif os_type == "windows":
         # If we are in a Visual Studio environment, use msvc
-        if os.getenv("VSInstallDir") is not None:
+        if os.getenv("PLATFORM") is not None:
             os_type = "pc-windows-msvc"
-        else:
+        elif os.getenv("MSYSTEM") is not None:
             os_type = "pc-windows-gnu"
+        else:
+            os_type = "unknown"
     elif os_type.startswith("mingw64_nt-") or os_type.startswith("cygwin_nt-"):
         os_type = "pc-windows-gnu"
     elif os_type == "freebsd":


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`VSInstallDir` exists only when Visual Studio is installed.
`VS140COMNTOOLS` is defined by installing either Visual Studio or [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools)

It will allow to build MSVC based Servo without having to install whole Visual Studio (few GiB).

EDIT: Another (maybe cleaner) solution would be reverting https://github.com/servo/servo/commit/63ec96a57d4772a961bea63111c927ccd7c85a91

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because `VS140COMNTOOLS` variable is already used in [mach.bat](https://github.com/servo/servo/blob/master/mach.bat)

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14346)
<!-- Reviewable:end -->
