### PR TITLE
Only allow border-image-outset to use non-negative numbers.

### DIFF
--- a/components/style/properties/longhand/border.mako.rs
+++ b/components/style/properties/longhand/border.mako.rs
@@ -242,7 +242,7 @@ ${helpers.single_keyword("-moz-float-edge", "content-box margin-box",
     pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
         let mut values = vec![];
         for _ in 0..4 {
-            let value = input.try(|input| LengthOrNumber::parse(input));
+            let value = input.try(|input| LengthOrNumber::parse_non_negative(input));
             match value {
                 Ok(val) => values.push(val),
                 Err(_) => break,

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -1009,3 +1009,13 @@ impl Parse for LengthOrPercentageOrAutoOrContent {
 }
 
 pub type LengthOrNumber = Either<Length, Number>;
+
+impl LengthOrNumber {
+    pub fn parse_non_negative(input: &mut Parser) -> Result<Self, ()> {
+        if let Ok(v) = input.try(|i| Length::parse_non_negative(i)) {
+            Ok(Either::First(v))
+        } else {
+            Number::parse_non_negative(input).map(Either::Second)
+        }
+    }
+}

--- a/tests/unit/style/parsing/border.rs
+++ b/tests/unit/style/parsing/border.rs
@@ -12,7 +12,7 @@ use style::properties::shorthands::border_image;
 use style::stylesheets::Origin;
 
 #[test]
-fn border_image_shorhand_should_parse_when_all_properties_specified() {
+fn border_image_shorthand_should_parse_when_all_properties_specified() {
     let url = ServoUrl::parse("http://localhost").unwrap();
     let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
     let mut parser = Parser::new("linear-gradient(red, blue) 30 30% 45 fill / 20px 40px / 10px \
@@ -28,7 +28,7 @@ fn border_image_shorhand_should_parse_when_all_properties_specified() {
 }
 
 #[test]
-fn border_image_shorhand_should_parse_without_width() {
+fn border_image_shorthand_should_parse_without_width() {
     let url = ServoUrl::parse("http://localhost").unwrap();
     let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
     let mut parser = Parser::new("linear-gradient(red, blue) 30 30% 45 fill / / 10px round stretch");
@@ -43,7 +43,7 @@ fn border_image_shorhand_should_parse_without_width() {
 }
 
 #[test]
-fn border_image_shorhand_should_parse_without_outset() {
+fn border_image_shorthand_should_parse_without_outset() {
     let url = ServoUrl::parse("http://localhost").unwrap();
     let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
     let mut parser = Parser::new("linear-gradient(red, blue) 30 30% 45 fill / 20px 40px round");
@@ -58,7 +58,7 @@ fn border_image_shorhand_should_parse_without_outset() {
 }
 
 #[test]
-fn border_image_shorhand_should_parse_without_width_or_outset() {
+fn border_image_shorthand_should_parse_without_width_or_outset() {
     let url = ServoUrl::parse("http://localhost").unwrap();
     let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
     let mut parser = Parser::new("linear-gradient(red, blue) 30 30% 45 fill round");
@@ -73,7 +73,7 @@ fn border_image_shorhand_should_parse_without_width_or_outset() {
 }
 
 #[test]
-fn border_image_shorhand_should_parse_with_just_source() {
+fn border_image_shorthand_should_parse_with_just_source() {
     let url = ServoUrl::parse("http://localhost").unwrap();
     let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
     let mut parser = Parser::new("linear-gradient(red, blue)");
@@ -85,4 +85,22 @@ fn border_image_shorhand_should_parse_with_just_source() {
     assert_eq!(result.border_image_width.unwrap(), border_image_width::get_initial_specified_value());
     assert_eq!(result.border_image_outset.unwrap(), border_image_outset::get_initial_specified_value());
     assert_eq!(result.border_image_repeat.unwrap(), border_image_repeat::get_initial_specified_value());
+}
+
+#[test]
+fn border_image_outset_should_error_on_negative_length() {
+    let url = ServoUrl::parse("http://localhost").unwrap();
+    let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+    let mut parser = Parser::new("-1em");
+    let result = border_image_outset::parse(&context, &mut parser);
+    assert_eq!(result, Err(()));
+}
+
+#[test]
+fn border_image_outset_should_error_on_negative_number() {
+    let url = ServoUrl::parse("http://localhost").unwrap();
+    let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+    let mut parser = Parser::new("-15");
+    let result = border_image_outset::parse(&context, &mut parser);
+    assert_eq!(result, Err(()));
 }


### PR DESCRIPTION
Restricts border-image-outline to only allow positive values.  

Fixes #14295 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14295.

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14347)
<!-- Reviewable:end -->
