### PR TITLE
stylo: don't match native anonymous content to user/author rules

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -28,6 +28,7 @@ use gecko_bindings::bindings::Gecko_StoreStyleDifference;
 use gecko_bindings::structs;
 use gecko_bindings::structs::{NODE_HAS_DIRTY_DESCENDANTS_FOR_SERVO, NODE_IS_DIRTY_FOR_SERVO};
 use gecko_bindings::structs::{nsIAtom, nsIContent, nsStyleContext};
+use gecko_bindings::structs::NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE;
 use parking_lot::RwLock;
 use parser::ParserContextExtraData;
 use properties::{ComputedValues, parse_style_attribute};
@@ -623,5 +624,10 @@ impl<'le> ElementExt for GeckoElement<'le> {
     #[inline]
     fn is_link(&self) -> bool {
         self.match_non_ts_pseudo_class(NonTSPseudoClass::AnyLink)
+    }
+
+    #[inline]
+    fn matches_user_and_author_rules(&self) -> bool {
+        self.flags() & (NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE as u32) == 0
     }
 }

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -106,6 +106,7 @@ pub enum CacheMiss {
     LocalName,
     Namespace,
     Link,
+    UserAndAuthorRules,
     State,
     IdAttr,
     StyleAttr,
@@ -141,6 +142,10 @@ fn element_matches_candidate<E: TElement>(element: &E,
 
     if element.is_link() != candidate_element.is_link() {
         miss!(Link)
+    }
+
+    if element.matches_user_and_author_rules() != candidate_element.matches_user_and_author_rules() {
+        miss!(UserAndAuthorRules)
     }
 
     if element.get_state() != candidate_element.get_state() {

--- a/components/style/selector_parser.rs
+++ b/components/style/selector_parser.rs
@@ -101,6 +101,8 @@ impl PseudoElementCascadeType {
 
 pub trait ElementExt: Element<Impl=SelectorImpl> {
     fn is_link(&self) -> bool;
+
+    fn matches_user_and_author_rules(&self) -> bool;
 }
 
 impl SelectorImpl {

--- a/components/style/servo/selector_parser.rs
+++ b/components/style/servo/selector_parser.rs
@@ -398,4 +398,9 @@ impl<E: Element<Impl=SelectorImpl>> ElementExt for E {
     fn is_link(&self) -> bool {
         self.match_non_ts_pseudo_class(NonTSPseudoClass::AnyLink)
     }
+
+    #[inline]
+    fn matches_user_and_author_rules(&self) -> bool {
+        true
+    }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This makes us skip user and document style sheets when performing the cascade for Gecko native anonymous content.  It was reviewed in https://bugzilla.mozilla.org/show_bug.cgi?id=1293809 by @emilio.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14356)
<!-- Reviewable:end -->
