### PR TITLE
Use single_value_to_css in Servo_DeclarationBlock_SerializeOneValue

### DIFF
--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1073,6 +1073,8 @@ extern "C" {
 extern "C" {
     pub fn Servo_DeclarationBlock_SerializeOneValue(declarations:
                                                         RawServoDeclarationBlockBorrowed,
+                                                    property: *mut nsIAtom,
+                                                    is_custom: bool,
                                                     buffer: *mut nsString);
 }
 extern "C" {


### PR DESCRIPTION
These are the servo-side changes for [bug 1317178](https://bugzilla.mozilla.org/show_bug.cgi?id=1317178). @Manishearth has already reviewed them there. Please merge these patches until the gecko-side changes for [bug 1317178](https://bugzilla.mozilla.org/show_bug.cgi?id=1317178) is landed.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [bug 1317178](https://bugzilla.mozilla.org/show_bug.cgi?id=1317178).
- [X] These changes do not require tests because there are existing tests for this in mozilla-central

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14357)
<!-- Reviewable:end -->
