### PR TITLE
stylo - implement -webkit-text-fill-color and -webkit-text-stroke.

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1817,7 +1817,8 @@ fn static_assert() {
 
 
 <%self:impl_trait style_struct_name="InheritedText"
-                  skip_longhands="text-align text-emphasis-style text-shadow line-height letter-spacing word-spacing">
+                  skip_longhands="text-align text-emphasis-style text-shadow line-height letter-spacing word-spacing
+                                  -webkit-text-stroke-width">
 
     <% text_align_keyword = Keyword("text-align", "start end left right center justify -moz-center -moz-left " +
                                                   "-moz-right match-parent") %>
@@ -1963,6 +1964,13 @@ fn static_assert() {
         }
         self.gecko.mTextEmphasisStyle = other.gecko.mTextEmphasisStyle;
     }
+
+    #[allow(non_snake_case)]
+    pub fn set__webkit_text_stroke_width(&mut self, v: longhands::_webkit_text_stroke_width::computed_value::T) {
+        self.gecko.mWebkitTextStrokeWidth.set_value(CoordDataValue::Coord(v.0));
+    }
+
+    <%call expr="impl_coord_copy('_webkit_text_stroke_width', 'mWebkitTextStrokeWidth')"></%call>
 
 </%self:impl_trait>
 

--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -996,6 +996,48 @@ ${helpers.predefined_type("text-emphasis-color", "CSSColor",
                           products="gecko",animatable=True,
                           complex_color=True, need_clone=True)}
 
+// CSS Compatibility
+// https://compat.spec.whatwg.org/#the-webkit-text-fill-color
+${helpers.predefined_type(
+    "-webkit-text-fill-color", "CSSColor",
+    "CSSParserColor::CurrentColor",
+    products="gecko", animatable=True,
+    complex_color=True, need_clone=True)}
+
+// CSS Compatibility
+// https://compat.spec.whatwg.org/#the-webkit-text-stroke-color
+${helpers.predefined_type(
+    "-webkit-text-stroke-color", "CSSColor",
+    "CSSParserColor::CurrentColor",
+    products="gecko", animatable=True,
+    complex_color=True, need_clone=True)}
+
+// CSS Compatibility
+// https://compat.spec.whatwg.org/#the-webkit-text-stroke-width
+<%helpers:longhand products="gecko" name="-webkit-text-stroke-width" animatable="False">
+    use app_units::Au;
+    use std::fmt;
+    use style_traits::ToCss;
+    use values::HasViewportPercentage;
+    use values::specified::BorderWidth;
+
+    pub type SpecifiedValue = BorderWidth;
+
+    #[inline]
+    pub fn parse(_context: &ParserContext, input: &mut Parser)
+                 -> Result<SpecifiedValue, ()> {
+        BorderWidth::parse(input)
+    }
+
+    pub mod computed_value {
+        use app_units::Au;
+        pub type T = Au;
+    }
+    #[inline] pub fn get_initial_value() -> computed_value::T {
+        Au::from_px(0)
+    }
+</%helpers:longhand>
+
 // TODO(pcwalton): `full-width`
 ${helpers.single_keyword("text-transform",
                          "none capitalize uppercase lowercase",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Implement -webkit-text-fill-color property.
Implement -webkit-text-stroke property, along with -webkit-text-stroke-width and -webkit-text-stroke-color longhand properties.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13849 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14358)
<!-- Reviewable:end -->
