### PR TITLE
Reuse box-shadow code for drop-shadow filter

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1809,7 +1809,7 @@ fn static_assert() {
                 Sepia(factor)      => fill_filter(NS_STYLE_FILTER_SEPIA,
                                                   CoordDataValue::Factor(factor),
                                                   gecko_filter),
-                DropShadow(offset_x, offset_y, blur_radius, ref color) => {
+                DropShadow(shadow) => {
                     gecko_filter.mType = NS_STYLE_FILTER_DROP_SHADOW;
 
                     fn init_shadow(filter: &mut nsStyleFilter) -> &mut nsCSSShadowArray {
@@ -1823,13 +1823,13 @@ fn static_assert() {
                     }
 
                     let mut gecko_shadow = init_shadow(gecko_filter);
-                    gecko_shadow.mArray[0].mXOffset = offset_x.0;
-                    gecko_shadow.mArray[0].mYOffset = offset_y.0;
-                    gecko_shadow.mArray[0].mRadius = blur_radius.0;
+                    gecko_shadow.mArray[0].mXOffset = shadow.offset_x.0;
+                    gecko_shadow.mArray[0].mYOffset = shadow.offset_y.0;
+                    gecko_shadow.mArray[0].mRadius = shadow.blur_radius.0;
                     // mSpread is not supported in the spec, so we leave it as 0
                     gecko_shadow.mArray[0].mInset = false; // Not supported in spec level 1
 
-                    gecko_shadow.mArray[0].mColor = match *color {
+                    gecko_shadow.mArray[0].mColor = match shadow.color {
                         Color::RGBA(rgba) => {
                             gecko_shadow.mArray[0].mHasColor = true;
                             convert_rgba_to_nscolor(&rgba)

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -167,5 +167,16 @@ impl ToCss for BorderRadiusSize {
     }
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub struct Shadow {
+    pub offset_x: Au,
+    pub offset_y: Au,
+    pub blur_radius: Au,
+    pub spread_radius: Au,
+    pub color: CSSColor,
+    pub inset: bool,
+}
+
 pub type Number = CSSFloat;
 pub type Opacity = CSSFloat;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Followup for #14218. Extracted the `Shadow` struct and methods into `values::*`, and make `box-shadow` and `drop-shadow` share the new `Shadow` type. The `ToCss` trait is not reused because they behave different in the two properties.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14219  (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14359)
<!-- Reviewable:end -->
