### PR TITLE
Use software rendering when running servo in headless mode

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -209,6 +209,26 @@ def is_macosx():
     return sys.platform == 'darwin'
 
 
+def is_linux():
+    return sys.platform.startswith('linux')
+
+
+def set_osmesa_env(bin_path, env):
+    """Set proper LD_LIBRARY_PATH and DRIVE for software rendering on Linux and OSX"""
+    if is_linux():
+        osmesa_path = path.join(find_dep_path_newest('osmesa-src', bin_path), "out", "lib", "gallium")
+        env["LD_LIBRARY_PATH"] = osmesa_path
+        env["GALLIUM_DRIVER"] = "softpipe"
+    elif is_macosx():
+        osmesa_path = path.join(find_dep_path_newest('osmesa-src', bin_path),
+                                "out", "src", "gallium", "targets", "osmesa", ".libs")
+        glapi_path = path.join(find_dep_path_newest('osmesa-src', bin_path),
+                               "out", "src", "mapi", "shared-glapi", ".libs")
+        env["DYLD_LIBRARY_PATH"] = osmesa_path + ":" + glapi_path
+        env["GALLIUM_DRIVER"] = "softpipe"
+    return env
+
+
 class BuildNotFound(Exception):
     def __init__(self, message):
         self.message = message

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -22,7 +22,11 @@ from mach.decorators import (
     Command,
 )
 
-from servo.command_base import CommandBase, call, check_call, find_dep_path_newest, is_windows, is_macosx
+from servo.command_base import (
+    CommandBase,
+    call, check_call, find_dep_path_newest,
+    is_windows, is_macosx, set_osmesa_env,
+)
 
 
 def read_file(filename, if_exists=False):
@@ -52,10 +56,13 @@ class PostBuildCommands(CommandBase):
                      help='Name of debugger to use.')
     @CommandArgument('--browserhtml', '-b', action='store_true',
                      help='Launch with Browser.html')
+    @CommandArgument('--headless', '-z', action='store_true',
+                     help='Launch in headless mode')
     @CommandArgument(
         'params', nargs='...',
         help="Command-line arguments to be passed through to Servo")
-    def run(self, params, release=False, dev=False, android=None, debug=False, debugger=None, browserhtml=False):
+    def run(self, params, release=False, dev=False, android=None, debug=False, debugger=None, browserhtml=False,
+            headless=False):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 
@@ -106,6 +113,10 @@ class PostBuildCommands(CommandBase):
                            '--pref', 'dom.forcetouch.enabled',
                            '--pref', 'shell.builtin-key-shortcuts.enabled=false',
                            path.join(browserhtml_path, 'out', 'index.html')]
+
+        if headless:
+            set_osmesa_env(args[0], env)
+            args.append('-z')
 
         # Borrowed and modified from:
         # http://hg.mozilla.org/mozilla-central/file/c9cfa9b91dea/python/mozbuild/mozbuild/mach_commands.py#l883

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -25,7 +25,11 @@ from mach.decorators import (
     Command,
 )
 
-from servo.command_base import BuildNotFound, CommandBase, call, cd, check_call, find_dep_path_newest, host_triple
+from servo.command_base import (
+    BuildNotFound, CommandBase,
+    call, cd, check_call, host_triple, set_osmesa_env,
+)
+
 from wptrunner import wptcommandline
 from update import updatecommandline
 from servo_tidy import tidy
@@ -637,29 +641,13 @@ class MachCommands(CommandBase):
     def set_software_rendering_env(self, use_release):
         # On Linux and mac, find the OSMesa software rendering library and
         # add it to the dynamic linker search path.
-        if sys.platform.startswith('linux'):
-            try:
-                args = [self.get_binary_path(use_release, not use_release)]
-                osmesa_path = path.join(find_dep_path_newest('osmesa-src', args[0]), "out", "lib", "gallium")
-                os.environ["LD_LIBRARY_PATH"] = osmesa_path
-                os.environ["GALLIUM_DRIVER"] = "softpipe"
-            except BuildNotFound:
-                # This can occur when cross compiling (e.g. arm64), in which case
-                # we won't run the tests anyway so can safely ignore this step.
-                pass
-        elif sys.platform.startswith('darwin'):
-            try:
-                args = [self.get_binary_path(use_release, not use_release)]
-                osmesa_path = path.join(find_dep_path_newest('osmesa-src', args[0]),
-                                        "out", "src", "gallium", "targets", "osmesa", ".libs")
-                glapi_path = path.join(find_dep_path_newest('osmesa-src', args[0]),
-                                       "out", "src", "mapi", "shared-glapi", ".libs")
-                os.environ["DYLD_LIBRARY_PATH"] = osmesa_path + ":" + glapi_path
-                os.environ["GALLIUM_DRIVER"] = "softpipe"
-            except BuildNotFound:
-                # This can occur when cross compiling (e.g. arm64), in which case
-                # we won't run the tests anyway so can safely ignore this step.
-                pass
+        try:
+            args = [self.get_binary_path(use_release, not use_release)]
+            set_osmesa_env(args[0], os.environ)
+        except BuildNotFound:
+            # This can occur when cross compiling (e.g. arm64), in which case
+            # we won't run the tests anyway so can safely ignore this step.
+            pass
 
 
 def create_parser_create():


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Properly setting environment to use OsMesa in headless mode.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13515

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because I manually ran: `./mach run -d tests/html/about-mozilla.html -z`

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14379)
<!-- Reviewable:end -->
