### PR TITLE
Stylo: implement column-rule-style

### DIFF
--- a/components/style/properties/longhand/column.mako.rs
+++ b/components/style/properties/longhand/column.mako.rs
@@ -288,3 +288,9 @@ ${helpers.predefined_type("-moz-column-rule-color", "CSSColor",
 // https://drafts.csswg.org/css-multicol-1/#column-span
 ${helpers.single_keyword("column-span", "none all",
                          products="none", animatable=False)}
+
+${helpers.single_keyword("column-rule-style",
+                         "none hidden dotted dashed solid double groove ridge inset outset",
+                         products="gecko",
+                         gecko_constant_prefix="NS_STYLE_BORDER_STYLE",
+                         animatable=False)}


### PR DESCRIPTION
Implemented `column-rule-style` in stylo.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13868

- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it's a style addition and I added the screenshot.

Screenshot:
![screenshot from 2016-11-27 21-59-38](https://cloud.githubusercontent.com/assets/597469/20652731/0a7ccbfc-b4ff-11e6-8e4c-1547897bcf25.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14383)
<!-- Reviewable:end -->
