### PR TITLE
Make style parsing always take ref of ServoUrl

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1518,7 +1518,7 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
         let res = try!(read_resource_file(filename).map_err(|_| filename));
         Ok(Stylesheet::from_bytes(
             &res,
-            ServoUrl::parse(&format!("chrome://resources/{:?}", filename)).unwrap(),
+            &ServoUrl::parse(&format!("chrome://resources/{:?}", filename)).unwrap(),
             None,
             None,
             Origin::UserAgent,
@@ -1535,7 +1535,7 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
     }
     for &(ref contents, ref url) in &opts::get().user_stylesheets {
         user_or_user_agent_stylesheets.push(Stylesheet::from_bytes(
-            &contents, url.clone(), None, None, Origin::User, Default::default(),
+            &contents, url, None, None, Origin::User, Default::default(),
             Box::new(StdoutErrorReporter), ParserContextExtraData::default()));
     }
 

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -87,7 +87,7 @@ impl CSSRuleList {
         let doc = window.Document();
         let index = idx as usize;
 
-        let new_rule = css_rules.insert_rule(rule, doc.url().clone(), index, nested)?;
+        let new_rule = css_rules.insert_rule(rule, &doc.url(), index, nested)?;
 
         let sheet = self.sheet.get();
         let sheet = sheet.as_ref().map(|sheet| &**sheet);

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -373,7 +373,7 @@ impl FetchResponseListener for StylesheetContext {
             let win = window_from_node(&*elem);
 
             let sheet = Arc::new(Stylesheet::from_bytes(
-                &data, final_url, protocol_encoding_label, Some(environment_encoding),
+                &data, &final_url, protocol_encoding_label, Some(environment_encoding),
                 Origin::Author, self.media.take().unwrap(), win.css_error_reporter(),
                 ParserContextExtraData::default()));
 

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -68,7 +68,7 @@ impl HTMLStyleElement {
 
         let data = node.GetTextContent().expect("Element.textContent must be a string");
         let mq = parse_media_query_list(&mut CssParser::new(&mq_str));
-        let sheet = Stylesheet::from_str(&data, url, Origin::Author, mq, win.css_error_reporter(),
+        let sheet = Stylesheet::from_str(&data, &url, Origin::Author, mq, win.css_error_reporter(),
                                          ParserContextExtraData::default());
         let sheet = Arc::new(sheet);
 

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -211,7 +211,7 @@ pub extern "C" fn Servo_StyleSheet_Empty(mode: SheetParsingMode) -> RawServoStyl
         SheetParsingMode::eAgentSheetFeatures => Origin::UserAgent,
     };
     let sheet = Arc::new(Stylesheet::from_str(
-        "", url, origin, Default::default(), Box::new(StdoutErrorReporter), extra_data));
+        "", &url, origin, Default::default(), Box::new(StdoutErrorReporter), extra_data));
     unsafe {
         transmute(sheet)
     }
@@ -241,7 +241,7 @@ pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(data: *const nsACString,
         principal: Some(GeckoArcPrincipal::new(principal)),
     }};
     let sheet = Arc::new(Stylesheet::from_str(
-        input, url, origin, Default::default(), Box::new(StdoutErrorReporter), extra_data));
+        input, &url, origin, Default::default(), Box::new(StdoutErrorReporter), extra_data));
     unsafe {
         transmute(sheet)
     }

--- a/tests/unit/style/media_queries.rs
+++ b/tests/unit/style/media_queries.rs
@@ -28,7 +28,7 @@ impl ParseErrorReporter for CSSErrorReporterTest {
 fn test_media_rule<F>(css: &str, callback: F) where F: Fn(&MediaList, &str) {
     let url = ServoUrl::parse("http://localhost").unwrap();
     let stylesheet = Stylesheet::from_str(
-        css, url, Origin::Author, Default::default(),
+        css, &url, Origin::Author, Default::default(),
         Box::new(CSSErrorReporterTest), ParserContextExtraData::default());
     let mut rule_count = 0;
     media_queries(&stylesheet.rules.0.read(), &mut |mq| {
@@ -52,7 +52,7 @@ fn media_queries<F>(rules: &[CssRule], f: &mut F) where F: FnMut(&MediaList) {
 fn media_query_test(device: &Device, css: &str, expected_rule_count: usize) {
     let url = ServoUrl::parse("http://localhost").unwrap();
     let ss = Stylesheet::from_str(
-        css, url, Origin::Author, Default::default(),
+        css, &url, Origin::Author, Default::default(),
         Box::new(CSSErrorReporterTest), ParserContextExtraData::default());
     let mut rule_count = 0;
     ss.effective_style_rules(device, |_| rule_count += 1);

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -50,7 +50,7 @@ fn test_parse_stylesheet() {
             }
         }";
     let url = ServoUrl::parse("about::test").unwrap();
-    let stylesheet = Stylesheet::from_str(css, url, Origin::UserAgent, Default::default(),
+    let stylesheet = Stylesheet::from_str(css, &url, Origin::UserAgent, Default::default(),
                                           Box::new(CSSErrorReporterTest),
                                           ParserContextExtraData::default());
     let expected = Stylesheet {
@@ -322,7 +322,7 @@ fn test_report_error_stylesheet() {
 
     let errors = error_reporter.errors.clone();
 
-    Stylesheet::from_str(css, url, Origin::UserAgent, Default::default(), error_reporter,
+    Stylesheet::from_str(css, &url, Origin::UserAgent, Default::default(), error_reporter,
                          ParserContextExtraData::default());
 
     let mut errors = errors.lock().unwrap();

--- a/tests/unit/style/viewport.rs
+++ b/tests/unit/style/viewport.rs
@@ -21,7 +21,7 @@ macro_rules! stylesheet {
     ($css:expr, $origin:ident, $error_reporter:expr) => {
         Box::new(Stylesheet::from_str(
             $css,
-            ServoUrl::parse("http://localhost").unwrap(),
+            &ServoUrl::parse("http://localhost").unwrap(),
             Origin::$origin,
             Default::default(),
             $error_reporter,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
It doesn't seem to me there is any reason why the parsing functions need to take the ownership of a `ServoUrl`. A reference to that should be enough.

This should remove some unnecessary refcount manipulcation.

r? @SimonSapin 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14385)
<!-- Reviewable:end -->
