### PR TITLE
Convert column-width to use Either

### DIFF
--- a/components/layout/multicol.rs
+++ b/components/layout/multicol.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use style::context::{StyleContext, SharedStyleContext};
 use style::logical_geometry::LogicalSize;
 use style::properties::ServoComputedValues;
+use style::values::Either;
 use style::values::computed::{LengthOrPercentageOrAuto, LengthOrPercentageOrNone};
 
 pub struct MulticolFlow {
@@ -102,7 +103,7 @@ impl Flow for MulticolFlow {
             let column_gap = column_style.column_gap.0.unwrap_or_else(||
                 self.block_flow.fragment.style.get_font().font_size);
             let mut column_count;
-            if let Some(column_width) = column_style.column_width.0 {
+            if let Either::First(column_width) = column_style.column_width {
                 column_count =
                     max(1, (content_inline_size + column_gap).0 / (column_width + column_gap).0);
                 if let Some(specified_column_count) = column_style.column_count.0 {

--- a/components/style/gecko/values.rs
+++ b/components/style/gecko/values.rs
@@ -10,7 +10,7 @@ use gecko_bindings::structs::{NS_RADIUS_CLOSEST_SIDE, NS_RADIUS_FARTHEST_SIDE};
 use gecko_bindings::structs::nsStyleCoord;
 use gecko_bindings::sugar::ns_style_coord::{CoordData, CoordDataMut, CoordDataValue};
 use std::cmp::max;
-use values::Either;
+use values::{Auto, Either};
 use values::computed::{Angle, LengthOrPercentageOrNone, Number};
 use values::computed::{LengthOrPercentage, LengthOrPercentageOrAuto};
 use values::computed::basic_shape::ShapeRadius;
@@ -181,6 +181,20 @@ impl GeckoStyleCoordConvertible for Angle {
         if let CoordDataValue::Radian(r) = coord.as_value() {
             Some(Angle::from_radians(r))
             // XXXManishearth should this handle Degree too?
+        } else {
+            None
+        }
+    }
+}
+
+impl GeckoStyleCoordConvertible for Auto {
+    fn to_gecko_style_coord<T: CoordDataMut>(&self, coord: &mut T) {
+        coord.set_value(CoordDataValue::Auto)
+    }
+
+    fn from_gecko_style_coord<T: CoordData>(coord: &T) -> Option<Self> {
+        if let CoordDataValue::Auto = coord.as_value() {
+            Some(Auto)
         } else {
             None
         }

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -493,6 +493,7 @@ impl Debug for ${style_struct.gecko_struct_name} {
 
     # Types used with predefined_type()-defined properties that we can auto-generate.
     predefined_types = {
+        "length::LengthOrAuto": impl_style_coord,
         "Length": impl_style_coord,
         "LengthOrPercentage": impl_style_coord,
         "LengthOrPercentageOrAuto": impl_style_coord,
@@ -2326,16 +2327,7 @@ clip-path
 </%self:impl_trait>
 
 <%self:impl_trait style_struct_name="Column"
-                  skip_longhands="column-width column-count column-gap -moz-column-rule-width">
-
-    pub fn set_column_width(&mut self, v: longhands::column_width::computed_value::T) {
-        match v.0 {
-            Some(au) => self.gecko.mColumnWidth.set(au),
-            None => self.gecko.mColumnWidth.set_value(CoordDataValue::Auto),
-        }
-    }
-
-    ${impl_coord_copy('column_width', 'mColumnWidth')}
+                  skip_longhands="column-count column-gap -moz-column-rule-width">
 
     #[allow(unused_unsafe)]
     pub fn set_column_count(&mut self, v: longhands::column_count::computed_value::T) {

--- a/components/style/properties/longhand/column.mako.rs
+++ b/components/style/properties/longhand/column.mako.rs
@@ -7,86 +7,13 @@
 <% data.new_style_struct("Column", inherited=False) %>
 
 // FIXME: This prop should be animatable.
-<%helpers:longhand name="column-width" experimental="True" animatable="False">
-    use std::fmt;
-    use style_traits::ToCss;
-    use values::HasViewportPercentage;
+${helpers.predefined_type("column-width",
+                          "length::LengthOrAuto",
+                          "Either::Second(Auto)",
+                          parse_method="parse_non_negative_length",
+                          animatable=False,
+                          experimental=True)}
 
-    impl HasViewportPercentage for SpecifiedValue {
-        fn has_viewport_percentage(&self) -> bool {
-            match *self {
-                SpecifiedValue::Specified(length) => length.has_viewport_percentage(),
-                _ => false
-            }
-        }
-    }
-
-    #[derive(Debug, Clone, Copy, PartialEq)]
-    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    pub enum SpecifiedValue {
-        Auto,
-        Specified(specified::Length),
-    }
-
-    impl ToCss for SpecifiedValue {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match *self {
-                SpecifiedValue::Auto => dest.write_str("auto"),
-                SpecifiedValue::Specified(l) => l.to_css(dest),
-            }
-        }
-    }
-
-    pub mod computed_value {
-        use app_units::Au;
-        #[derive(Debug, Clone, PartialEq)]
-        #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-        pub struct T(pub Option<Au>);
-    }
-
-    impl ToCss for computed_value::T {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match self.0 {
-                None => dest.write_str("auto"),
-                Some(l) => l.to_css(dest),
-            }
-        }
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        computed_value::T(None)
-    }
-
-    impl ToComputedValue for SpecifiedValue {
-        type ComputedValue = computed_value::T;
-
-        #[inline]
-        fn to_computed_value(&self, context: &Context) -> computed_value::T {
-            match *self {
-                SpecifiedValue::Auto => computed_value::T(None),
-                SpecifiedValue::Specified(l) =>
-                    computed_value::T(Some(l.to_computed_value(context)))
-            }
-        }
-        #[inline]
-        fn from_computed_value(computed: &computed_value::T) -> Self {
-            match *computed {
-                computed_value::T(None) => SpecifiedValue::Auto,
-                computed_value::T(Some(l)) =>
-                    SpecifiedValue::Specified(ToComputedValue::from_computed_value(&l))
-            }
-        }
-    }
-
-    pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-        if input.try(|input| input.expect_ident_matching("auto")).is_ok() {
-            Ok(SpecifiedValue::Auto)
-        } else {
-            specified::Length::parse_non_negative(input).map(SpecifiedValue::Specified)
-        }
-    }
-</%helpers:longhand>
 
 // FIXME: This prop should be animatable.
 <%helpers:longhand name="column-count" experimental="True" animatable="False">

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1145,7 +1145,10 @@ impl ComputedValues {
     #[inline]
     pub fn is_multicol(&self) -> bool {
         let style = self.get_column();
-        style.column_count.0.is_some() || style.column_width.0.is_some()
+        match style.column_width {
+            Either::First(_width) => true,
+            Either::Second(_auto) => style.column_count.0.is_some(),
+        }
     }
 
     /// Resolves the currentColor keyword.

--- a/components/style/values/computed/length.rs
+++ b/components/style/values/computed/length.rs
@@ -7,7 +7,7 @@ use ordered_float::NotNaN;
 use std::fmt;
 use style_traits::ToCss;
 use super::{Number, ToComputedValue, Context};
-use values::{CSSFloat, Either, None_, specified};
+use values::{Auto, CSSFloat, Either, None_, specified};
 
 pub use cssparser::Color as CSSColor;
 pub use super::image::{EndingShape as GradientShape, Gradient, GradientKind, Image};
@@ -470,6 +470,8 @@ impl ToCss for LengthOrPercentageOrNone {
 }
 
 pub type LengthOrNone = Either<Length, None_>;
+
+pub type LengthOrAuto = Either<Length, Auto>;
 
 pub type LengthOrNumber = Either<Length, Number>;
 

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -14,7 +14,7 @@ use std::ops::Mul;
 use style_traits::ToCss;
 use style_traits::values::specified::AllowedNumericType;
 use super::{Angle, Number, SimplifiedValueNode, SimplifiedSumNode, Time};
-use values::{CSSFloat, Either, FONT_MEDIUM_PX, HasViewportPercentage, None_};
+use values::{Auto, CSSFloat, Either, FONT_MEDIUM_PX, HasViewportPercentage, None_};
 use values::computed::Context;
 
 pub use super::image::{AngleOrCorner, ColorStop, EndingShape as GradientEndingShape, Gradient};
@@ -345,7 +345,7 @@ impl Parse for Length {
 
 impl<T> Either<Length, T> {
     #[inline]
-    pub fn parse_non_negative_length(input: &mut Parser) -> Result<Either<Length, T>, ()> {
+    pub fn parse_non_negative_length(_context: &ParserContext, input: &mut Parser) -> Result<Self, ()> {
         Length::parse_internal(input, AllowedNumericType::NonNegative).map(Either::First)
     }
 }
@@ -952,6 +952,8 @@ impl Parse for LengthOrPercentageOrNone {
 }
 
 pub type LengthOrNone = Either<Length, None_>;
+
+pub type LengthOrAuto = Either<Length, Auto>;
 
 #[derive(Clone, PartialEq, Copy, Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -536,11 +536,11 @@ mod shorthand_serialization {
     #[test]
     fn columns_should_serialize_correctly() {
         use style::properties::longhands::column_count::SpecifiedValue as ColumnCount;
-        use style::properties::longhands::column_width::SpecifiedValue as ColumnWidth;
+        use style::values::{Auto, Either};
 
         let mut properties = Vec::new();
 
-        let width = DeclaredValue::Value(ColumnWidth::Auto);
+        let width = DeclaredValue::Value(Either::Second(Auto));
         let count = DeclaredValue::Value(ColumnCount::Auto);
 
         properties.push(PropertyDeclaration::ColumnWidth(width));


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

* Converted column-width to use `Either<Length, Auto>`
* Added gecko glue code
* Cleaned up old column-width glue code

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14350 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because tests already surround the refactored code.
<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14394)
<!-- Reviewable:end -->
