### PR TITLE
[WIP] Fix namespaces of elements created in XML documents

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2296,10 +2296,15 @@ impl DocumentMethods for Document {
             debug!("Not a valid element name");
             return Err(Error::InvalidCharacter);
         }
-        if self.is_html_document {
+
+        let ns = if self.is_html_document {
             local_name.make_ascii_lowercase();
-        }
-        let name = QualName::new(ns!(html), LocalName::from(local_name));
+            ns!(html)
+        } else {
+            ns!()
+        };
+
+        let name = QualName::new(ns, LocalName::from(local_name));
         Ok(Element::create(name, None, self, ElementCreator::ScriptCreated))
     }
 

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -75,11 +75,22 @@ impl DOMImplementationMethods for DOMImplementation {
             _ => "application/xml"
         };
 
+        // @TODO What's the right thing to do for this? Without this, tests in DOMImplementation-createDocument.html
+        // and Node-properties.html fail.
+        //
+        // Before, the call to XMLDocument::new was hardcoded to pass in NonHTMLDocument as the doc type. That means
+        // that document.is_html_document is false for documents that are actually HTML. That makes the tests fail
+        // because I use that property in document.createElement to decide whether to use the HTML namespace or not.
+        let doc_type = match maybe_doctype {
+            Some(dt) if dt.name() == "html" && content_type != "application/xml"  => IsHTMLDocument::HTMLDocument,
+            _ => IsHTMLDocument::NonHTMLDocument,
+        };
+
         // Step 1.
         let doc = XMLDocument::new(win,
                                    None,
                                    None,
-                                   IsHTMLDocument::NonHTMLDocument,
+                                   doc_type,
                                    Some(DOMString::from(content_type)),
                                    None,
                                    DocumentSource::NotFromParser,

--- a/tests/wpt/metadata/dom/nodes/Node-properties.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Node-properties.html.ini
@@ -1,8 +1,0 @@
-[Node-properties.html]
-  type: testharness
-  [xmlElement.namespaceURI]
-    expected: FAIL
-
-  [detachedXmlElement.namespaceURI]
-    expected: FAIL
-


### PR DESCRIPTION
This is a work in progress.

Without this PR, all elements are created using the HTML namespace, even when createElement is called in an XML document. To fix this, I check `self.is_html_document` and assign the namespace based on that.

However, there were two problems with this approach:

1. It seems some documents that I would think are HTML documents aren't currently handled as such. See the condition I added in the second commit.
2. The last test in `Document-constructor.html` fails. I'm not sure whether the test is correct, though. I tried running something similar in Firefox DevEdition (replacing `assert_equals` with `console.log`) and it looks to me like that test would fail in Firefox as well.

```
  var doc = new Document();
  var a = doc.createElement("a");
  a.href = "http://example.org/?\u00E4";
  console.log(a.href, "http://example.org/?%C3%A4");
```

Result:
```
"http://example.org/?ä" "http://example.org/?%C3%A4"
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14095 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there are already tests which were being ignored.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14401)
<!-- Reviewable:end -->
