### PR TITLE
Use XPCOM string bindings instead of Gecko_Utf8SliceToString

### DIFF
--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -86,7 +86,6 @@ use gecko_bindings::structs::nsIPrincipal;
 use gecko_bindings::structs::nsIURI;
 use gecko_bindings::structs::nsMainThreadPtrHolder;
 use gecko_bindings::structs::nsRestyleHint;
-use gecko_bindings::structs::nsString;
 use gecko_bindings::structs::nsStyleBackground;
 unsafe impl Send for nsStyleBackground {}
 unsafe impl Sync for nsStyleBackground {}
@@ -487,10 +486,6 @@ extern "C" {
                                           aString:
                                               *const ::std::os::raw::c_char,
                                           aLength: u32) -> bool;
-}
-extern "C" {
-    pub fn Gecko_Utf8SliceToString(aString: *mut nsString, aBuffer: *const u8,
-                                   aBufferLen: usize);
 }
 extern "C" {
     pub fn Gecko_FontFamilyList_Clear(aList: *mut FontFamilyList);
@@ -1095,7 +1090,7 @@ extern "C" {
                                                         RawServoDeclarationBlockBorrowed,
                                                     property: *mut nsIAtom,
                                                     is_custom: bool,
-                                                    buffer: *mut nsString);
+                                                    buffer: *mut nsAString_internal);
 }
 extern "C" {
     pub fn Servo_DeclarationBlock_Count(declarations:

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -37,14 +37,12 @@ use style::gecko_bindings::bindings::{RawServoStyleSheetStrong, ServoComputedVal
 use style::gecko_bindings::bindings::{ServoCssRulesBorrowed, ServoCssRulesStrong};
 use style::gecko_bindings::bindings::{ThreadSafePrincipalHolder, ThreadSafeURIHolder};
 use style::gecko_bindings::bindings::{nsACString, nsAString};
-use style::gecko_bindings::bindings::Gecko_Utf8SliceToString;
 use style::gecko_bindings::bindings::RawGeckoElementBorrowed;
 use style::gecko_bindings::bindings::ServoComputedValuesBorrowedOrNull;
 use style::gecko_bindings::bindings::nsTArrayBorrowed_uintptr_t;
 use style::gecko_bindings::structs;
 use style::gecko_bindings::structs::{SheetParsingMode, nsIAtom};
 use style::gecko_bindings::structs::{nsRestyleHint, nsChangeHint};
-use style::gecko_bindings::structs::nsString;
 use style::gecko_bindings::sugar::ownership::{FFIArcHelpers, HasArcFFI, HasBoxFFI};
 use style::gecko_bindings::sugar::ownership::{HasSimpleFFI, Strong};
 use style::gecko_bindings::sugar::refptr::{GeckoArcPrincipal, GeckoArcURI};
@@ -565,7 +563,7 @@ pub extern "C" fn Servo_DeclarationBlock_GetCssText(declarations: RawServoDeclar
 pub extern "C" fn Servo_DeclarationBlock_SerializeOneValue(
     declarations: RawServoDeclarationBlockBorrowed,
     property: *mut nsIAtom, is_custom: bool,
-    buffer: *mut nsString)
+    buffer: *mut nsAString)
 {
     let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
     let property = get_property_name_from_atom(property, is_custom);
@@ -573,11 +571,7 @@ pub extern "C" fn Servo_DeclarationBlock_SerializeOneValue(
     let rv = declarations.read().single_value_to_css(&property, &mut string);
     debug_assert!(rv.is_ok());
 
-    // FIXME: Once we have nsString bindings for Servo (bug 1294742), we should be able to drop
-    // this and fill in |buffer| directly.
-    unsafe {
-        Gecko_Utf8SliceToString(buffer, string.as_ptr(), string.len());
-    }
+    write!(unsafe { &mut *buffer }, "{}", string).expect("Failed to copy string");
 }
 
 #[no_mangle]


### PR DESCRIPTION
These are the servo-side changes for [bug 1317179](https://bugzilla.mozilla.org/show_bug.cgi?id=1317179). @Manishearth has already reviewed them there. I'd like to merge these patches until the gecko-side changes for [bug 1317179](https://bugzilla.mozilla.org/show_bug.cgi?id=1317179) is landed.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [bug 1317179](https://bugzilla.mozilla.org/show_bug.cgi?id=1317179).
- [X] These changes do not require tests because there are existing tests for this in mozilla-central

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14404)
<!-- Reviewable:end -->
