### PR TITLE
Implement 3 more properties for stylo

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1571,7 +1571,8 @@ fn static_assert() {
 <% skip_background_longhands = """background-repeat
                                   background-image background-clip
                                   background-origin background-attachment
-                                  background-size background-position""" %>
+                                  background-size background-position
+                                  background-blend-mode""" %>
 <%self:impl_trait style_struct_name="Background"
                   skip_longhands="${skip_background_longhands}"
                   skip_additionals="*">
@@ -1584,6 +1585,29 @@ fn static_assert() {
             T::scroll => structs::NS_STYLE_IMAGELAYER_ATTACHMENT_SCROLL as u8,
             T::fixed => structs::NS_STYLE_IMAGELAYER_ATTACHMENT_FIXED as u8,
             T::local => structs::NS_STYLE_IMAGELAYER_ATTACHMENT_LOCAL as u8,
+        }
+    </%self:simple_image_array_property>
+
+    <%self:simple_image_array_property name="blend_mode" shorthand="background" field_name="mBlendMode">
+        use properties::longhands::background_blend_mode::single_value::computed_value::T;
+
+        match servo {
+            T::normal => structs::NS_STYLE_BLEND_NORMAL as u8,
+            T::multiply => structs::NS_STYLE_BLEND_MULTIPLY as u8,
+            T::screen => structs::NS_STYLE_BLEND_SCREEN as u8,
+            T::overlay => structs::NS_STYLE_BLEND_OVERLAY as u8,
+            T::darken => structs::NS_STYLE_BLEND_DARKEN as u8,
+            T::lighten => structs::NS_STYLE_BLEND_LIGHTEN as u8,
+            T::color_dodge => structs::NS_STYLE_BLEND_COLOR_DODGE as u8,
+            T::color_burn => structs::NS_STYLE_BLEND_COLOR_BURN as u8,
+            T::hard_light => structs::NS_STYLE_BLEND_HARD_LIGHT as u8,
+            T::soft_light => structs::NS_STYLE_BLEND_SOFT_LIGHT as u8,
+            T::difference => structs::NS_STYLE_BLEND_DIFFERENCE as u8,
+            T::exclusion => structs::NS_STYLE_BLEND_EXCLUSION as u8,
+            T::hue => structs::NS_STYLE_BLEND_HUE as u8,
+            T::saturation => structs::NS_STYLE_BLEND_SATURATION as u8,
+            T::color => structs::NS_STYLE_BLEND_COLOR as u8,
+            T::luminosity => structs::NS_STYLE_BLEND_LUMINOSITY as u8,
         }
     </%self:simple_image_array_property>
 </%self:impl_trait>

--- a/components/style/properties/longhand/background.mako.rs
+++ b/components/style/properties/longhand/background.mako.rs
@@ -339,3 +339,10 @@ ${helpers.single_keyword("background-origin",
         }))
     }
 </%helpers:vector_longhand>
+
+// https://drafts.fxtf.org/compositing/#background-blend-mode
+${helpers.single_keyword("background-blend-mode",
+                         """normal multiply screen overlay darken lighten color-dodge
+                            color-burn hard-light soft-light difference exclusion hue
+                            saturation color luminosity""",
+                         vector="true", products="gecko", animatable=False)}

--- a/components/style/properties/longhand/column.mako.rs
+++ b/components/style/properties/longhand/column.mako.rs
@@ -273,6 +273,11 @@ ${helpers.single_keyword("column-fill", "auto balance",
         Au::from_px(3) // medium
     }
 
+    #[inline]
+    pub fn get_initial_specified_value() -> SpecifiedValue {
+        BorderWidth::Medium
+    }
+
     pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
         BorderWidth::parse(context, input)
     }
@@ -289,8 +294,9 @@ ${helpers.predefined_type("-moz-column-rule-color", "CSSColor",
 ${helpers.single_keyword("column-span", "none all",
                          products="none", animatable=False)}
 
-${helpers.single_keyword("column-rule-style",
+${helpers.single_keyword("-moz-column-rule-style",
                          "none hidden dotted dashed solid double groove ridge inset outset",
                          products="gecko",
+                         gecko_ffi_name="mColumnRuleStyle",
                          gecko_constant_prefix="NS_STYLE_BORDER_STYLE",
                          animatable=False)}

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -79,13 +79,13 @@ ${helpers.single_keyword("justify-content", "flex-start flex-end center space-be
                          products="servo",
                          animatable=False)}
 
-// FIXME(heycam): Disable align-items in geckolib since we don't support the Gecko initial value
-// 'normal' yet.
-${helpers.single_keyword("align-items", "stretch flex-start flex-end center baseline",
+// https://drafts.csswg.org/css-flexbox/#propdef-align-items
+// FIXME: This is a workaround for 'normal' value. We don't support the Gecko initial value 'normal' yet.
+${helpers.single_keyword("align-items", "stretch flex-start flex-end center baseline" if product == "servo"
+                         else "normal stretch flex-start flex-end center baseline",
                          need_clone=True,
                          gecko_constant_prefix="NS_STYLE_ALIGN",
-                         animatable=False,
-                         products="servo")}
+                         animatable=False)}
 
 ${helpers.single_keyword("align-content", "stretch flex-start flex-end center space-between space-around",
                          gecko_constant_prefix="NS_STYLE_ALIGN",
@@ -103,8 +103,11 @@ ${helpers.predefined_type("flex-shrink", "Number",
                           needs_context=False,
                           animatable=True)}
 
+// https://drafts.csswg.org/css-align/#align-self-property
+// FIXME: We don't support the Gecko value 'normal' yet.
 ${helpers.single_keyword("align-self", "auto stretch flex-start flex-end center baseline",
                          need_clone=True,
+                         extra_gecko_values="normal",
                          gecko_constant_prefix="NS_STYLE_ALIGN",
                          animatable=False)}
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1687,6 +1687,9 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
                     align_items::flex_start => align_self::flex_start,
                     align_items::flex_end => align_self::flex_end,
                     align_items::center => align_self::center,
+                    % if product == "gecko":
+                        align_items::normal => align_self::normal,
+                    % endif
                 };
             style.mutate_position().set_align_self(self_align);
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implemented these new properties:

1. Implemented parsing/serialization and stylo glue for `background-blend-mode`.
2. Made `align-items` work for stylo.
3. Implemented parsing/serialization for `-moz-column-rule`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because it's stylo changes.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14410)
<!-- Reviewable:end -->
