### PR TITLE
Remove misleading section from non-toplevel Cargo.toml.

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -20,12 +20,6 @@ testing = ["style/testing"]
 clippy = ["plugins/clippy"]
 debugmozjs = ["script/debugmozjs"]
 
-[profile.release]
-opt-level = 3
-# Uncomment to profile on Linux:
-# debug = true
-# lto = false
-
 [dependencies]
 backtrace = "0.2"
 bluetooth_traits = {path = "../bluetooth_traits"}


### PR DESCRIPTION
This made me waste some time trying to figure out why my builds were no longer getting debug information after #14381.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14413)
<!-- Reviewable:end -->
