### PR TITLE
layout: Fix some particularly bad cases of spurious reflows leading to script thread unresponsiveness.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1191,10 +1191,13 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             }
         }
 
-        // We still need to tick layout unfortunately, see things like #12749.
-        let msg = ConstellationMsg::TickAnimation(pipeline_id, AnimationTickType::Layout);
-        if let Err(e) = self.constellation_chan.send(msg) {
-            warn!("Sending tick to constellation failed ({}).", e);
+        // We may need to tick animations in layout. (See #12749.)
+        let animations_running = self.pipeline_details(pipeline_id).animations_running;
+        if animations_running {
+            let msg = ConstellationMsg::TickAnimation(pipeline_id, AnimationTickType::Layout);
+            if let Err(e) = self.constellation_chan.send(msg) {
+                warn!("Sending tick to constellation failed ({}).", e);
+            }
         }
     }
 

--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -88,7 +88,8 @@ pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
 
             if let Animation::Transition(_, unsafe_node, _, ref frame, _) = running_animation {
                 script_chan.send(ConstellationControlMsg::TransitionEnd(unsafe_node,
-                                                                        frame.property_animation.property_name(),
+                                                                        frame.property_animation
+                                                                             .property_name(),
                                                                         frame.duration))
                            .unwrap();
             }
@@ -113,7 +114,7 @@ pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
     for new_running_animation in new_running_animations {
         running_animations.entry(*new_running_animation.node())
                           .or_insert_with(Vec::new)
-                          .push(new_running_animation);
+                          .push(new_running_animation)
     }
 
     let animation_state = if running_animations.is_empty() {
@@ -122,7 +123,8 @@ pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
         AnimationState::AnimationsPresent
     };
 
-    constellation_chan.send(ConstellationMsg::ChangeRunningAnimationsState(pipeline_id, animation_state))
+    constellation_chan.send(ConstellationMsg::ChangeRunningAnimationsState(pipeline_id,
+                                                                           animation_state))
                       .unwrap();
 }
 

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1091,7 +1091,7 @@ impl LayoutThread {
         }
 
         let restyles = document.drain_pending_restyles();
-        debug!("Draining restyles: {}", restyles.len());
+        debug!("Draining restyles: {} (needs dirtying? {:?})", restyles.len(), needs_dirtying);
         if !needs_dirtying {
             for (el, restyle) in restyles {
                 // Propagate the descendant bit up the ancestors. Do this before

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1282,6 +1282,10 @@ impl LayoutThread {
     }
 
     fn tick_animations(&mut self, rw_data: &mut LayoutThreadData) {
+        if opts::get().relayout_event {
+            println!("**** pipeline={}\tForDisplay\tSpecial\tAnimationTick", self.id);
+        }
+
         let reflow_info = Reflow {
             goal: ReflowGoal::ForDisplay,
             page_clip_rect: max_rect(),

--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -359,7 +359,9 @@ pub fn start_transitions_if_applicable(new_animations_sender: &Sender<Animation>
     let mut had_animations = false;
     for i in 0..new_style.get_box().transition_property_count() {
         // Create any property animations, if applicable.
-        let property_animations = PropertyAnimation::from_transition(i, old_style, Arc::make_mut(new_style));
+        let property_animations = PropertyAnimation::from_transition(i,
+                                                                     old_style,
+                                                                     Arc::make_mut(new_style));
         for property_animation in property_animations {
             // Per [1], don't trigger a new transition if the end state for that transition is
             // the same as that of a transition that's already running on the same node.

--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -335,6 +335,11 @@ impl PropertyAnimation {
     fn does_animate(&self) -> bool {
         self.property.does_animate() && self.duration != Time(0.0)
     }
+
+    #[inline]
+    pub fn has_the_same_end_value_as(&self, other: &PropertyAnimation) -> bool {
+        self.property.has_the_same_end_value_as(&other.property)
+    }
 }
 
 /// Inserts transitions into the queue of running animations as applicable for
@@ -348,13 +353,24 @@ pub fn start_transitions_if_applicable(new_animations_sender: &Sender<Animation>
                                        unsafe_node: UnsafeNode,
                                        old_style: &ComputedValues,
                                        new_style: &mut Arc<ComputedValues>,
-                                       timer: &Timer)
+                                       timer: &Timer,
+                                       possibly_expired_animations: &[PropertyAnimation])
                                        -> bool {
     let mut had_animations = false;
     for i in 0..new_style.get_box().transition_property_count() {
         // Create any property animations, if applicable.
         let property_animations = PropertyAnimation::from_transition(i, old_style, Arc::make_mut(new_style));
         for property_animation in property_animations {
+            // Per [1], don't trigger a new transition if the end state for that transition is
+            // the same as that of a transition that's already running on the same node.
+            //
+            // [1]: https://drafts.csswg.org/css-transitions/#starting
+            if possibly_expired_animations.iter().any(|animation| {
+                    animation.has_the_same_end_value_as(&property_animation)
+               }) {
+                continue
+            }
+
             // Set the property to the initial value.
             // NB: get_mut is guaranteed to succeed since we called make_mut()
             // above.

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -124,6 +124,20 @@ impl AnimatedProperty {
         }
     }
 
+    pub fn has_the_same_end_value_as(&self, other: &AnimatedProperty) -> bool {
+        match (self, other) {
+            % for prop in data.longhands:
+                % if prop.animatable:
+                    (&AnimatedProperty::${prop.camel_case}(_, ref this_end_value),
+                     &AnimatedProperty::${prop.camel_case}(_, ref other_end_value)) => {
+                        this_end_value == other_end_value
+                    }
+                % endif
+            % endfor
+            _ => false,
+        }
+    }
+
     pub fn update(&self, style: &mut ComputedValues, progress: f64) {
         match *self {
             % for prop in data.longhands:


### PR DESCRIPTION
See commits for details. This improves nytimes.com quite a bit.

r? @notriddle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14418)
<!-- Reviewable:end -->
