### PR TITLE
Remove unnecessary Flow::column_sizes methods

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -56,7 +56,7 @@ use style::properties::ServoComputedValues;
 use style::selector_impl::RestyleDamage;
 use style::servo::restyle_damage::{RECONSTRUCT_FLOW, REFLOW, REFLOW_OUT_OF_FLOW, REPAINT, REPOSITION};
 use style::values::computed::LengthOrPercentageOrAuto;
-use table::{ColumnComputedInlineSize, ColumnIntrinsicInlineSize, TableFlow};
+use table::TableFlow;
 use table_caption::TableCaptionFlow;
 use table_cell::TableCellFlow;
 use table_colgroup::TableColGroupFlow;
@@ -178,18 +178,6 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
     /// If this is a table cell flow, returns the underlying object. Fails otherwise.
     fn as_table_cell(&self) -> &TableCellFlow {
         panic!("called as_table_cell() on a non-tablecell flow")
-    }
-
-    /// If this is a table row, table rowgroup, or table flow, returns column intrinsic
-    /// inline-sizes. Fails otherwise.
-    fn column_intrinsic_inline_sizes(&mut self) -> &mut Vec<ColumnIntrinsicInlineSize> {
-        panic!("called column_intrinsic_inline_sizes() on non-table flow")
-    }
-
-    /// If this is a table row, table rowgroup, or table flow, returns column computed
-    /// inline-sizes. Fails otherwise.
-    fn column_computed_inline_sizes(&mut self) -> &mut Vec<ColumnComputedInlineSize> {
-        panic!("called column_intrinsic_inline_sizes() on non-table flow")
     }
 
     // Main methods

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -217,14 +217,6 @@ impl Flow for TableFlow {
         self.block_flow.mark_as_root();
     }
 
-    fn column_intrinsic_inline_sizes(&mut self) -> &mut Vec<ColumnIntrinsicInlineSize> {
-        &mut self.column_intrinsic_inline_sizes
-    }
-
-    fn column_computed_inline_sizes(&mut self) -> &mut Vec<ColumnComputedInlineSize> {
-        &mut self.column_computed_inline_sizes
-    }
-
     /// The specified column inline-sizes are set from column group and the first row for the fixed
     /// table layout calculation.
     /// The maximum min/pref inline-sizes of each column are set from the rows for the automatic

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -235,14 +235,6 @@ impl Flow for TableRowFlow {
         &self.block_flow
     }
 
-    fn column_intrinsic_inline_sizes(&mut self) -> &mut Vec<ColumnIntrinsicInlineSize> {
-        panic!("can't call column_intrinsic_inline_sizes() on table row")
-    }
-
-    fn column_computed_inline_sizes(&mut self) -> &mut Vec<ColumnComputedInlineSize> {
-        &mut self.column_computed_inline_sizes
-    }
-
     /// Recursively (bottom-up) determines the context's preferred and minimum inline-sizes. When
     /// called on this context, all child contexts have had their min/pref inline-sizes set. This
     /// function must decide min/pref inline-sizes based on child context inline-sizes and

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -123,14 +123,6 @@ impl Flow for TableRowGroupFlow {
         &self.block_flow
     }
 
-    fn column_intrinsic_inline_sizes(&mut self) -> &mut Vec<ColumnIntrinsicInlineSize> {
-        &mut self.column_intrinsic_inline_sizes
-    }
-
-    fn column_computed_inline_sizes(&mut self) -> &mut Vec<ColumnComputedInlineSize> {
-        &mut self.column_computed_inline_sizes
-    }
-
     fn bubble_inline_sizes(&mut self) {
         let _scope = layout_debug_scope!("table_rowgroup::bubble_inline_sizes {:x}",
                                          self.block_flow.base.debug_id());

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -328,7 +328,8 @@ impl Flow for TableWrapperFlow {
         for kid in self.block_flow.base.child_iter_mut() {
             debug_assert!(kid.is_table_caption() || kid.is_table());
             if kid.is_table() {
-                self.column_intrinsic_inline_sizes = kid.column_intrinsic_inline_sizes().clone()
+                let table = kid.as_table();
+                self.column_intrinsic_inline_sizes = table.column_intrinsic_inline_sizes.clone();
             }
         }
 


### PR DESCRIPTION
One of these methods is never called. The other is used only on TableFlow and doesn't need to be implemented for all Flow types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14424)
<!-- Reviewable:end -->
