### PR TITLE
WIP: Add support for keyword values for min-width, min-height, max-width, and max-height

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -497,6 +497,7 @@ impl Debug for ${style_struct.gecko_struct_name} {
         "LengthOrPercentage": impl_style_coord,
         "LengthOrPercentageOrAuto": impl_style_coord,
         "LengthOrPercentageOrNone": impl_style_coord,
+        "MinLength": impl_style_coord,
         "Number": impl_simple,
         "Opacity": impl_simple,
         "CSSColor": impl_color,

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -26,6 +26,7 @@ use values::Either;
 use values::computed::{Angle, LengthOrPercentageOrAuto, LengthOrPercentageOrNone};
 use values::computed::{BorderRadiusSize, LengthOrNone};
 use values::computed::{CalcLengthOrPercentage, LengthOrPercentage};
+use values::computed::{MinLength};
 use values::computed::position::Position;
 use values::computed::ToComputedValue;
 
@@ -492,6 +493,20 @@ impl Interpolate for LengthOrPercentageOrNone {
                 Ok(LengthOrPercentageOrNone::None)
             }
             _ => Err(())
+        }
+    }
+}
+
+/// https://drafts.csswg.org/css-transitions/#animtype-lpcalc
+impl Interpolate for MinLength {
+    #[inline]
+    fn interpolate(&self, other: &Self, progress: f64) -> Result<Self, ()> {
+        match (*self, *other) {
+            (MinLength::LengthOrPercentage(ref this),
+             MinLength::LengthOrPercentage(ref other)) => {
+                this.interpolate(other, progress).map(MinLength::LengthOrPercentage)
+            }
+            _ => Err(()),
         }
     }
 }

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -157,10 +157,8 @@ ${helpers.predefined_type("flex-basis",
 
     // min-width, min-height, min-block-size, min-inline-size
     ${helpers.predefined_type("min-%s" % size,
-                              "LengthOrPercentage",
-                              "computed::LengthOrPercentage::Length(Au(0))",
-                              "parse_non_negative",
-                              needs_context=False,
+                              "MinLength",
+                              "computed::MinLength::LengthOrPercentage(computed::LengthOrPercentage::Length(Au(0)))",
                               animatable=True, logical = logical)}
 
     // max-width, max-height, max-block-size, max-inline-size

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1181,13 +1181,21 @@ impl ComputedValues {
     #[inline]
     pub fn min_inline_size(&self) -> computed::LengthOrPercentage {
         let position_style = self.get_position();
-        if self.writing_mode.is_vertical() { position_style.min_height } else { position_style.min_width }
+        let size = if self.writing_mode.is_vertical() { position_style.min_height } else { position_style.min_width };
+        match size {
+            computed::MinLength::LengthOrPercentage(lop) => lop,
+            _ => panic!("layout doesn't work!")
+        }
     }
 
     #[inline]
     pub fn min_block_size(&self) -> computed::LengthOrPercentage {
         let position_style = self.get_position();
-        if self.writing_mode.is_vertical() { position_style.min_width } else { position_style.min_height }
+        let size = if self.writing_mode.is_vertical() { position_style.min_width } else { position_style.min_height };
+        match size {
+            computed::MinLength::LengthOrPercentage(lop) => lop,
+            _ => panic!("layout doesn't work!")
+        }
     }
 
     #[inline]

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -18,6 +18,7 @@ pub use super::specified::{Angle, BorderStyle, Time, UrlOrNone};
 pub use super::specified::url::UrlExtraData;
 pub use self::length::{CalcLengthOrPercentage, Length, LengthOrNumber, LengthOrPercentage, LengthOrPercentageOrAuto};
 pub use self::length::{LengthOrPercentageOrAutoOrContent, LengthOrPercentageOrNone, LengthOrNone};
+pub use self::length::{MinLength};
 
 pub mod basic_shape;
 pub mod image;

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -21,6 +21,7 @@ pub use self::image::{SizeKeyword, VerticalDirection};
 pub use self::length::{FontRelativeLength, ViewportPercentageLength, CharacterWidth, Length, CalcLengthOrPercentage};
 pub use self::length::{Percentage, LengthOrNone, LengthOrNumber, LengthOrPercentage, LengthOrPercentageOrAuto};
 pub use self::length::{LengthOrPercentageOrNone, LengthOrPercentageOrAutoOrContent, CalcUnit};
+pub use self::length::{MinLength};
 
 pub mod basic_shape;
 pub mod image;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR aims to add support for keyword-values `max-content`, `min-content`, `fit-content`, and `fill-available` to the properties that use them, namely `min-width`, `min-height`, `max-width`, and `max-height`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #13821 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14432)
<!-- Reviewable:end -->
