### PR TITLE
Workaround for intermittent failure in img_width_attribute_intrinsic_width_a.html

### DIFF
--- a/tests/wpt/mozilla/tests/css/img_width_attribute_intrinsic_width_a.html
+++ b/tests/wpt/mozilla/tests/css/img_width_attribute_intrinsic_width_a.html
@@ -6,7 +6,7 @@
 <body>
 <table>
     <tr>
-        <td><img src=smiling.png width=300></td>
+        <td><img src=green.png width=300></td>
         <td>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus molestie orci euismod metus sodales, at varius odio luctus. Nunc vehicula sagittis interdum. Aenean fringilla ipsum et fermentum commodo. Sed dui orci, egestas sit amet augue quis, rutrum imperdiet tortor. Aenean congue ac odio in semper. Nullam sit amet libero at tortor feugiat mollis. Vivamus semper lacus ac erat luctus, ac ullamcorper metus scelerisque. Ut molestie libero nec tortor auctor consectetur. Nullam sagittis ipsum ut tellus tempor venenatis id sit amet augue.</td>
     </tr>
 </table>

--- a/tests/wpt/mozilla/tests/css/img_width_attribute_intrinsic_width_ref.html
+++ b/tests/wpt/mozilla/tests/css/img_width_attribute_intrinsic_width_ref.html
@@ -5,7 +5,7 @@
 <body>
 <table>
     <tr>
-        <td><img src=smiling.png style="width: 300px"></td>
+        <td><img src=green.png style="width: 300px"></td>
         <td>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus molestie orci euismod metus sodales, at varius odio luctus. Nunc vehicula sagittis interdum. Aenean fringilla ipsum et fermentum commodo. Sed dui orci, egestas sit amet augue quis, rutrum imperdiet tortor. Aenean congue ac odio in semper. Nullam sit amet libero at tortor feugiat mollis. Vivamus semper lacus ac erat luctus, ac ullamcorper metus scelerisque. Ut molestie libero nec tortor auctor consectetur. Nullam sagittis ipsum ut tellus tempor venenatis id sit amet augue.</td>
     </tr>
 </table>


### PR DESCRIPTION
This test previously used smiling.png as the image reference.

The OSMesa rasterizer occasionally has a very small difference
(1-2 pixels off by 1/255) when rendering this reftest.

Instead, change to use green.png which doesn't suffer from this
inaccuracy during bilinear sampling and upscaling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14435)
<!-- Reviewable:end -->
