### PR TITLE
Make restyle tracking more granular

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -13,7 +13,6 @@ use script_traits::{AnimationState, ConstellationControlMsg, LayoutMsg as Conste
 use std::collections::HashMap;
 use std::sync::mpsc::Receiver;
 use style::animation::{Animation, update_style_for_animation};
-use style::dom::TRestyleDamage;
 use style::selector_parser::RestyleDamage;
 use style::timer::Timer;
 

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -18,6 +18,7 @@ use net_traits::image_cache_thread::{ImageCacheChan, ImageCacheThread, ImageResp
 use net_traits::image_cache_thread::{ImageOrMetadataAvailable, UsePlaceholder};
 use parking_lot::RwLock;
 use servo_url::ServoUrl;
+use std::borrow::Borrow;
 use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
@@ -86,6 +87,12 @@ pub struct SharedLayoutContext {
     pub webrender_image_cache: Arc<RwLock<HashMap<(ServoUrl, UsePlaceholder),
                                                   WebRenderImageInfo,
                                                   BuildHasherDefault<FnvHasher>>>>,
+}
+
+impl Borrow<SharedStyleContext> for SharedLayoutContext {
+    fn borrow(&self) -> &SharedStyleContext {
+        &self.style_context
+    }
 }
 
 pub struct LayoutContext<'a> {

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -50,7 +50,6 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use style::computed_values::{clear, float, overflow_x, position, text_align};
 use style::context::SharedStyleContext;
-use style::dom::TRestyleDamage;
 use style::logical_geometry::{LogicalRect, LogicalSize, WritingMode};
 use style::properties::ServoComputedValues;
 use style::selector_parser::RestyleDamage;

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -44,7 +44,6 @@ use style::computed_values::{overflow_wrap, overflow_x, position, text_decoratio
 use style::computed_values::{transform_style, vertical_align, white_space, word_break, z_index};
 use style::computed_values::content::ContentItem;
 use style::context::SharedStyleContext;
-use style::dom::TRestyleDamage;
 use style::logical_geometry::{Direction, LogicalMargin, LogicalRect, LogicalSize, WritingMode};
 use style::properties::ServoComputedValues;
 use style::selector_parser::RestyleDamage;

--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -19,7 +19,6 @@ use std::collections::{HashMap, LinkedList};
 use std::sync::Arc;
 use style::computed_values::{display, list_style_type};
 use style::computed_values::content::ContentItem;
-use style::dom::TRestyleDamage;
 use style::properties::ServoComputedValues;
 use style::selector_parser::RestyleDamage;
 use style::servo::restyle_damage::RESOLVE_GENERATED_CONTENT;

--- a/components/layout/incremental.rs
+++ b/components/layout/incremental.rs
@@ -4,7 +4,6 @@
 
 use flow::{self, AFFECTS_COUNTERS, Flow, HAS_COUNTER_AFFECTING_CHILDREN, IS_ABSOLUTELY_POSITIONED};
 use style::computed_values::float;
-use style::dom::TRestyleDamage;
 use style::selector_parser::RestyleDamage;
 use style::servo::restyle_damage::{REFLOW, RECONSTRUCT_FLOW};
 

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -106,7 +106,7 @@ use std::sync::mpsc::{Receiver, Sender, channel};
 use style::animation::Animation;
 use style::context::{LocalStyleContextCreationInfo, ReflowGoal, SharedStyleContext};
 use style::data::StoredRestyleHint;
-use style::dom::{StylingMode, TElement, TNode};
+use style::dom::{TElement, TNode};
 use style::error_reporting::{ParseErrorReporter, StdoutErrorReporter};
 use style::logical_geometry::LogicalPoint;
 use style::media_queries::{Device, MediaType};
@@ -116,6 +116,7 @@ use style::stylesheets::{Origin, Stylesheet, UserAgentStylesheets};
 use style::stylist::Stylist;
 use style::thread_state;
 use style::timer::Timer;
+use style::traversal::DomTraversalContext;
 use util::geometry::max_rect;
 use util::opts;
 use util::prefs::PREFS;
@@ -1122,7 +1123,7 @@ impl LayoutThread {
                     None => continue,
                 };
                 let mut style_data = &mut data.base.style_data;
-                debug_assert!(!style_data.is_restyle());
+                debug_assert!(style_data.has_current_styles());
                 let mut restyle_data = match style_data.restyle() {
                     Some(d) => d,
                     None => continue,
@@ -1131,7 +1132,9 @@ impl LayoutThread {
                 // Stash the data on the element for processing by the style system.
                 restyle_data.hint = restyle.hint.into();
                 restyle_data.damage = restyle.damage;
-                restyle_data.snapshot = restyle.snapshot;
+                if let Some(s) = restyle.snapshot {
+                    restyle_data.snapshot.ensure(move || s);
+                }
                 debug!("Noting restyle for {:?}: {:?}", el, restyle_data);
             }
         }
@@ -1142,7 +1145,9 @@ impl LayoutThread {
                                                                          data.reflow_info.goal);
 
         let dom_depth = Some(0); // This is always the root node.
-        if element.styling_mode() != StylingMode::Stop {
+        let token = <RecalcStyleAndConstructFlows as DomTraversalContext<ServoLayoutNode>>
+            ::pre_traverse(element, &shared_layout_context.style_context.stylist, /* skip_root = */ false);
+        if token.should_traverse() {
             // Recalculate CSS styles and rebuild flows and fragments.
             profile(time::ProfilerCategory::LayoutStyleRecalc,
                     self.profiler_metadata(),
@@ -1152,11 +1157,11 @@ impl LayoutThread {
                 if let (true, Some(traversal)) = (self.parallel_flag, self.parallel_traversal.as_mut()) {
                     // Parallel mode
                     parallel::traverse_dom::<ServoLayoutNode, RecalcStyleAndConstructFlows>(
-                        element.as_node(), dom_depth, &shared_layout_context, traversal);
+                        element, dom_depth, &shared_layout_context, token, traversal);
                 } else {
                     // Sequential mode
                     sequential::traverse_dom::<ServoLayoutNode, RecalcStyleAndConstructFlows>(
-                        element.as_node(), &shared_layout_context);
+                        element, &shared_layout_context, token);
                 }
             });
             // TODO(pcwalton): Measure energy usage of text shaping, perhaps?

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -97,7 +97,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use style::context::ReflowGoal;
-use style::dom::TRestyleDamage;
 use style::element_state::*;
 use style::matching::{common_style_affecting_attributes, rare_style_affecting_attributes};
 use style::parser::ParserContextExtraData;

--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -816,7 +816,7 @@ impl<'ln> ThreadSafeLayoutNode for ServoThreadSafeLayoutNode<'ln> {
         debug_assert!(self.is_text_node());
         let parent = self.node.parent_node().unwrap().as_element().unwrap();
         let parent_data = parent.get_data().unwrap().borrow();
-        parent_data.current_styles().primary.values.clone()
+        parent_data.styles().primary.values.clone()
     }
 
     fn debug_id(self) -> usize {

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -317,7 +317,7 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
         if self.get_style_data()
                .unwrap()
                .borrow()
-               .current_styles().pseudos
+               .styles().pseudos
                .contains_key(&PseudoElement::Before) {
             Some(self.with_pseudo(PseudoElementType::Before(None)))
         } else {
@@ -330,7 +330,7 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
         if self.get_style_data()
                .unwrap()
                .borrow()
-               .current_styles().pseudos
+               .styles().pseudos
                .contains_key(&PseudoElement::After) {
             Some(self.with_pseudo(PseudoElementType::After(None)))
         } else {
@@ -371,7 +371,7 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
     fn style(&self, context: &SharedStyleContext) -> Arc<ServoComputedValues> {
         match self.get_pseudo_element_type() {
             PseudoElementType::Normal => self.get_style_data().unwrap().borrow()
-                                             .current_styles().primary.values.clone(),
+                                             .styles().primary.values.clone(),
             other => {
                 // Precompute non-eagerly-cascaded pseudo-element styles if not
                 // cached before.
@@ -383,14 +383,14 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
                         if !self.get_style_data()
                                 .unwrap()
                                 .borrow()
-                                .current_styles().pseudos.contains_key(&style_pseudo) {
+                                .styles().pseudos.contains_key(&style_pseudo) {
                             let mut data = self.get_style_data().unwrap().borrow_mut();
                             let new_style =
                                 context.stylist.precomputed_values_for_pseudo(
                                     &style_pseudo,
-                                    Some(&data.current_styles().primary.values),
+                                    Some(&data.styles().primary.values),
                                     false);
-                            data.current_styles_mut().pseudos
+                            data.styles_mut().pseudos
                                 .insert(style_pseudo.clone(), new_style.unwrap());
                         }
                     }
@@ -398,22 +398,22 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
                         if !self.get_style_data()
                                 .unwrap()
                                 .borrow()
-                                .current_styles().pseudos.contains_key(&style_pseudo) {
+                                .styles().pseudos.contains_key(&style_pseudo) {
                             let mut data = self.get_style_data().unwrap().borrow_mut();
                             let new_style =
                                 context.stylist
                                        .lazily_compute_pseudo_element_style(
                                            self,
                                            &style_pseudo,
-                                           &data.current_styles().primary.values);
-                            data.current_styles_mut().pseudos
+                                           &data.styles().primary.values);
+                            data.styles_mut().pseudos
                                 .insert(style_pseudo.clone(), new_style.unwrap());
                         }
                     }
                 }
 
                 self.get_style_data().unwrap().borrow()
-                    .current_styles().pseudos.get(&style_pseudo)
+                    .styles().pseudos.get(&style_pseudo)
                     .unwrap().values.clone()
             }
         }
@@ -422,9 +422,9 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
     #[inline]
     fn selected_style(&self) -> Arc<ServoComputedValues> {
         let data = self.get_style_data().unwrap().borrow();
-        data.current_styles().pseudos
+        data.styles().pseudos
             .get(&PseudoElement::Selection).map(|s| s)
-            .unwrap_or(&data.current_styles().primary)
+            .unwrap_or(&data.styles().primary)
             .values.clone()
     }
 
@@ -440,9 +440,9 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
         let data = self.get_style_data().unwrap().borrow();
         match self.get_pseudo_element_type() {
             PseudoElementType::Normal
-                => data.current_styles().primary.values.clone(),
+                => data.styles().primary.values.clone(),
             other
-                => data.current_styles().pseudos
+                => data.styles().pseudos
                        .get(&other.style_pseudo_element()).unwrap().values.clone(),
         }
     }

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -38,14 +38,6 @@ pub struct SharedStyleContext {
     /// Screen sized changed?
     pub screen_size_changed: bool,
 
-    /// Skip the root during traversal?
-    ///
-    /// This is used in Gecko to style newly-appended children without restyling
-    /// the parent. It would be cleaner to add an API to allow us to enqueue the
-    /// children directly from glue.rs.
-    #[cfg(feature = "gecko")]
-    pub skip_root: bool,
-
     /// The CSS selector stylist.
     pub stylist: Arc<Stylist>,
 

--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -4,10 +4,10 @@
 
 //! Per-node data used in style calculation.
 
-use dom::TRestyleDamage;
+use dom::TElement;
 use properties::ComputedValues;
 use properties::longhands::display::computed_value as display;
-use restyle_hints::RestyleHint;
+use restyle_hints::{RESTYLE_LATER_SIBLINGS, RestyleHint};
 use rule_tree::StrongRuleNode;
 use selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use std::collections::HashMap;
@@ -16,6 +16,8 @@ use std::hash::BuildHasherDefault;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
+use stylist::Stylist;
+use thread_state;
 
 #[derive(Clone)]
 pub struct ComputedStyle {
@@ -133,7 +135,7 @@ impl StoredRestyleHint {
     /// Propagates this restyle hint to a child element.
     pub fn propagate(&self) -> Self {
         StoredRestyleHint {
-            restyle_self: self.descendants == DescendantRestyleHint::Empty,
+            restyle_self: self.descendants != DescendantRestyleHint::Empty,
             descendants: self.descendants.propagate(),
         }
     }
@@ -183,10 +185,50 @@ impl From<RestyleHint> for StoredRestyleHint {
     }
 }
 
+// We really want to store an Option<Snapshot> here, but we can't drop Gecko
+// Snapshots off-main-thread. So we make a convenient little wrapper to provide
+// the semantics of Option<Snapshot>, while deferring the actual drop.
+static NO_SNAPSHOT: Option<Snapshot> = None;
+
 #[derive(Debug)]
-pub enum RestyleDataStyles {
-    Previous(ElementStyles),
-    New(ElementStyles),
+pub struct SnapshotOption {
+    snapshot: Option<Snapshot>,
+    destroyed: bool,
+}
+
+impl SnapshotOption {
+    pub fn empty() -> Self {
+        SnapshotOption {
+            snapshot: None,
+            destroyed: false,
+        }
+    }
+
+    pub fn destroy(&mut self) {
+        self.destroyed = true;
+        debug_assert!(self.is_none());
+    }
+
+    pub fn ensure<F: FnOnce() -> Snapshot>(&mut self, create: F) -> &mut Snapshot {
+        debug_assert!(thread_state::get().is_layout());
+        if self.is_none() {
+            self.snapshot = Some(create());
+            self.destroyed = false;
+        }
+
+        self.snapshot.as_mut().unwrap()
+    }
+}
+
+impl Deref for SnapshotOption {
+    type Target = Option<Snapshot>;
+    fn deref(&self) -> &Option<Snapshot> {
+        if self.destroyed {
+            &NO_SNAPSHOT
+        } else {
+            &self.snapshot
+        }
+    }
 }
 
 /// Transient data used by the restyle algorithm. This structure is instantiated
@@ -194,54 +236,71 @@ pub enum RestyleDataStyles {
 /// processing.
 #[derive(Debug)]
 pub struct RestyleData {
-    pub styles: RestyleDataStyles,
+    pub styles: ElementStyles,
     pub hint: StoredRestyleHint,
+    pub recascade: bool,
     pub damage: RestyleDamage,
-    pub snapshot: Option<Snapshot>,
+    pub snapshot: SnapshotOption,
 }
 
 impl RestyleData {
-    fn new(previous: ElementStyles) -> Self {
+    fn new(styles: ElementStyles) -> Self {
         RestyleData {
-            styles: RestyleDataStyles::Previous(previous),
+            styles: styles,
             hint: StoredRestyleHint::default(),
+            recascade: false,
             damage: RestyleDamage::empty(),
-            snapshot: None,
+            snapshot: SnapshotOption::empty(),
         }
     }
 
-    pub fn get_current_styles(&self) -> Option<&ElementStyles> {
-        use self::RestyleDataStyles::*;
-        match self.styles {
-            Previous(_) => None,
-            New(ref x) => Some(x),
+    /// Expands the snapshot (if any) into a restyle hint. Returns true if later siblings
+    /// must be restyled.
+    pub fn expand_snapshot<E: TElement>(&mut self, element: E, stylist: &Stylist) -> bool {
+        if self.snapshot.is_none() {
+            return false;
         }
+
+        // Compute the hint.
+        let state = element.get_state();
+        let mut hint = stylist.compute_restyle_hint(&element,
+                                                    self.snapshot.as_ref().unwrap(),
+                                                    state);
+
+        // If the hint includes a directive for later siblings, strip it out and
+        // notify the caller to modify the base hint for future siblings.
+        let later_siblings = hint.contains(RESTYLE_LATER_SIBLINGS);
+        hint.remove(RESTYLE_LATER_SIBLINGS);
+
+        // Insert the hint.
+        self.hint.insert(&hint.into());
+
+        // Destroy the snapshot.
+        self.snapshot.destroy();
+
+        later_siblings
     }
 
-    pub fn current_styles(&self) -> &ElementStyles {
-        self.get_current_styles().unwrap()
+    pub fn has_current_styles(&self) -> bool {
+        !(self.hint.restyle_self || self.recascade || self.snapshot.is_some())
     }
 
-    pub fn current_styles_mut(&mut self) -> &mut ElementStyles {
-        use self::RestyleDataStyles::*;
-        match self.styles {
-            New(ref mut x) => x,
-            Previous(_) => panic!("Calling current_styles_mut before styling"),
-        }
+    pub fn styles(&self) -> &ElementStyles {
+        &self.styles
     }
 
-    pub fn current_or_previous_styles(&self) -> &ElementStyles {
-        use self::RestyleDataStyles::*;
-        match self.styles {
-            Previous(ref x) => x,
-            New(ref x) => x,
-        }
+    pub fn styles_mut(&mut self) -> &mut ElementStyles {
+        &mut self.styles
     }
 
     fn finish_styling(&mut self, styles: ElementStyles, damage: RestyleDamage) {
-        debug_assert!(self.get_current_styles().is_none());
-        self.styles = RestyleDataStyles::New(styles);
+        debug_assert!(!self.has_current_styles());
+        debug_assert!(self.snapshot.is_none(), "Traversal should have expanded snapshots");
+        self.styles = styles;
         self.damage |= damage;
+        // The hint and recascade bits get cleared by the traversal code. This
+        // is a bit confusing, and we should simplify it when we separate matching
+        // from cascading.
     }
 }
 
@@ -363,10 +422,7 @@ impl ElementData {
         let old = mem::replace(self, ElementData::new(None));
         let styles = match old {
             ElementData::Initial(i) => i.unwrap(),
-            ElementData::Restyle(r) => match r.styles {
-                RestyleDataStyles::New(n) => n,
-                RestyleDataStyles::Previous(_) => panic!("Never restyled element"),
-            },
+            ElementData::Restyle(r) => r.styles,
             ElementData::Persistent(_) => unreachable!(),
         };
         *self = ElementData::Persistent(styles);
@@ -380,7 +436,7 @@ impl ElementData {
                 RestyleDamage::rebuild_and_reflow()
             },
             Restyle(ref r) => {
-                debug_assert!(r.get_current_styles().is_some());
+                debug_assert!(r.has_current_styles());
                 r.damage
             },
             Persistent(_) => RestyleDamage::empty(),
@@ -400,7 +456,7 @@ impl ElementData {
                 RestyleDamage::rebuild_and_reflow()
             },
             Restyle(ref r) => {
-                if r.get_current_styles().is_none() {
+                if !r.has_current_styles() {
                     error!("Accessing damage on dirty element");
                 }
                 r.damage
@@ -409,61 +465,41 @@ impl ElementData {
         }
     }
 
-    pub fn current_styles(&self) -> &ElementStyles {
-        self.get_current_styles().unwrap()
+    /// Returns true if this element's style is up-to-date and has no potential
+    /// invalidation.
+    pub fn has_current_styles(&self) -> bool {
+        use self::ElementData::*;
+        match *self {
+            Initial(ref x) => x.is_some(),
+            Restyle(ref x) => x.has_current_styles(),
+            Persistent(_) => true,
+        }
     }
 
-    pub fn get_current_styles(&self) -> Option<&ElementStyles> {
+    pub fn get_styles(&self) -> Option<&ElementStyles> {
         use self::ElementData::*;
         match *self {
             Initial(ref x) => x.as_ref(),
-            Restyle(ref x) => x.get_current_styles(),
+            Restyle(ref x) => Some(x.styles()),
             Persistent(ref x) => Some(x),
         }
     }
 
-    pub fn current_styles_mut(&mut self) -> &mut ElementStyles {
+    pub fn styles(&self) -> &ElementStyles {
+        self.get_styles().expect("Calling styles() on unstyled ElementData")
+    }
+
+    pub fn get_styles_mut(&mut self) -> Option<&mut ElementStyles> {
         use self::ElementData::*;
         match *self {
-            Initial(ref mut x) => x.as_mut().unwrap(),
-            Restyle(ref mut x) => x.current_styles_mut(),
-            Persistent(ref mut x) => x,
+            Initial(ref mut x) => x.as_mut(),
+            Restyle(ref mut x) => Some(x.styles_mut()),
+            Persistent(ref mut x) => Some(x),
         }
     }
 
-    pub fn previous_styles(&self) -> Option<&ElementStyles> {
-        use self::ElementData::*;
-        use self::RestyleDataStyles::*;
-        match *self {
-            Initial(_) => None,
-            Restyle(ref x) => match x.styles {
-                Previous(ref styles) => Some(styles),
-                New(_) => panic!("Calling previous_styles after finish_styling"),
-            },
-            Persistent(_) => panic!("Calling previous_styles on Persistent ElementData"),
-        }
-    }
-
-    pub fn previous_styles_mut(&mut self) -> Option<&mut ElementStyles> {
-        use self::ElementData::*;
-        use self::RestyleDataStyles::*;
-        match *self {
-            Initial(_) => None,
-            Restyle(ref mut x) => match x.styles {
-                Previous(ref mut styles) => Some(styles),
-                New(_) => panic!("Calling previous_styles after finish_styling"),
-            },
-            Persistent(_) => panic!("Calling previous_styles on Persistent ElementData"),
-        }
-    }
-
-    pub fn current_or_previous_styles(&self) -> &ElementStyles {
-        use self::ElementData::*;
-        match *self {
-            Initial(ref x) => x.as_ref().unwrap(),
-            Restyle(ref x) => x.current_or_previous_styles(),
-            Persistent(ref x) => x,
-        }
+    pub fn styles_mut(&mut self) -> &mut ElementStyles {
+        self.get_styles_mut().expect("Calling styles_mut() on unstyled ElementData")
     }
 
     pub fn finish_styling(&mut self, styles: ElementStyles, damage: RestyleDamage) {

--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::TRestyleDamage;
 use gecko_bindings::bindings;
 use gecko_bindings::structs;
 use gecko_bindings::structs::{nsChangeHint, nsStyleContext};
@@ -22,17 +21,17 @@ impl GeckoRestyleDamage {
     pub fn as_change_hint(&self) -> nsChangeHint {
         self.0
     }
-}
 
-impl TRestyleDamage for GeckoRestyleDamage {
-    type PreExistingComputedValues = nsStyleContext;
-
-    fn empty() -> Self {
+    pub fn empty() -> Self {
         GeckoRestyleDamage(nsChangeHint(0))
     }
 
-    fn compute(source: &nsStyleContext,
-               new_style: &Arc<ComputedValues>) -> Self {
+    pub fn is_empty(&self) -> bool {
+        self.0 == nsChangeHint(0)
+    }
+
+    pub fn compute(source: &nsStyleContext,
+                   new_style: &Arc<ComputedValues>) -> Self {
         let context = source as *const nsStyleContext as *mut nsStyleContext;
         let hint = unsafe {
             bindings::Gecko_CalcStyleDifference(context,
@@ -41,7 +40,7 @@ impl TRestyleDamage for GeckoRestyleDamage {
         GeckoRestyleDamage(hint)
     }
 
-    fn rebuild_and_reflow() -> Self {
+    pub fn rebuild_and_reflow() -> Self {
         GeckoRestyleDamage(structs::nsChangeHint_nsChangeHint_ReconstructFrame)
     }
 }

--- a/components/style/gecko/snapshot.rs
+++ b/components/style/gecko/snapshot.rs
@@ -17,6 +17,10 @@ use string_cache::Atom;
 #[derive(Debug)]
 pub struct GeckoElementSnapshot(bindings::ServoElementSnapshotOwned);
 
+// FIXME(bholley): Add support for *OwnedConst type, and then we get Sync
+// automatically.
+unsafe impl Sync for GeckoElementSnapshot {}
+
 impl Drop for GeckoElementSnapshot {
     fn drop(&mut self) {
         unsafe {

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -260,10 +260,10 @@ impl<'le> GeckoElement<'le> {
     }
 
     pub fn get_pseudo_style(&self, pseudo: &PseudoElement) -> Option<Arc<ComputedValues>> {
-        // NB: Gecko sometimes resolves pseudos after an element has already been
-        // marked for restyle. We should consider fixing this, but for now just allow
-        // it with current_or_previous_styles.
-        self.borrow_data().and_then(|data| data.current_or_previous_styles().pseudos
+        // FIXME(bholley): Gecko sometimes resolves pseudos after an element has
+        // already been marked for restyle. We should consider fixing this, and
+        // then assert has_current_styles here.
+        self.borrow_data().and_then(|data| data.styles().pseudos
                                                .get(pseudo).map(|c| c.values.clone()))
     }
 
@@ -273,8 +273,7 @@ impl<'le> GeckoElement<'le> {
             Some(x) => x,
             None => {
                 debug!("Creating ElementData for {:?}", self);
-                let existing = self.get_styles_from_frame();
-                let ptr = Box::into_raw(Box::new(AtomicRefCell::new(ElementData::new(existing))));
+                let ptr = Box::into_raw(Box::new(AtomicRefCell::new(ElementData::new(None))));
                 self.0.mServoData.set(ptr);
                 unsafe { &* ptr }
             },

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -13,7 +13,7 @@ use cache::LRUCache;
 use cascade_info::CascadeInfo;
 use context::{SharedStyleContext, StyleContext};
 use data::{ComputedStyle, ElementData, ElementStyles, PseudoStyles};
-use dom::{TElement, TNode, TRestyleDamage, UnsafeNode};
+use dom::{TElement, TNode, UnsafeNode};
 use properties::{CascadeFlags, ComputedValues, SHAREABLE, SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP, cascade};
 use properties::longhands::display::computed_value as display;
 use rule_tree::StrongRuleNode;
@@ -186,7 +186,8 @@ fn element_matches_candidate<E: TElement>(element: &E,
     }
 
     let data = candidate_element.borrow_data().unwrap();
-    let current_styles = data.current_styles();
+    debug_assert!(data.has_current_styles());
+    let current_styles = data.styles();
 
     Ok(current_styles.primary.clone())
 }
@@ -600,7 +601,8 @@ pub trait MatchMethods : TElement {
                     // can decide more easily if it knows that it's a child of
                     // replaced content, or similar stuff!
                     let damage = {
-                        let previous_values = data.previous_styles().map(|x| &x.primary.values);
+                        debug_assert!(!data.has_current_styles());
+                        let previous_values = data.get_styles().map(|x| &x.primary.values);
                         match self.existing_style_for_restyle_damage(previous_values, None) {
                             Some(ref source) => RestyleDamage::compute(source, &shared_style.values),
                             None => RestyleDamage::rebuild_and_reflow(),
@@ -730,13 +732,17 @@ pub trait MatchMethods : TElement {
     {
         // Get our parent's style.
         let parent_data = parent.as_ref().map(|x| x.borrow_data().unwrap());
-        let parent_style = parent_data.as_ref().map(|x| &x.current_styles().primary.values);
+        let parent_style = parent_data.as_ref().map(|d| {
+            debug_assert!(d.has_current_styles());
+            &d.styles().primary.values
+        });
 
         let mut new_styles;
         let mut possibly_expired_animations = vec![];
 
         let damage = {
-            let (old_primary, old_pseudos) = match data.previous_styles_mut() {
+            debug_assert!(!data.has_current_styles());
+            let (old_primary, old_pseudos) = match data.get_styles_mut() {
                 None => (None, None),
                 Some(previous) => {
                     // Update animations before the cascade. This may modify the

--- a/components/style/selector_parser.rs
+++ b/components/style/selector_parser.rs
@@ -8,6 +8,7 @@ use cssparser::Parser as CssParser;
 use matching::{common_style_affecting_attributes, CommonStyleAffectingAttributeMode};
 use selectors::Element;
 use selectors::parser::{AttrSelector, SelectorList};
+use std::fmt::Debug;
 use stylesheets::{Origin, Namespaces};
 
 pub type AttrValue = <SelectorImpl as ::selectors::SelectorImpl>::AttrValue;
@@ -29,6 +30,12 @@ pub use servo::restyle_damage::ServoRestyleDamage as RestyleDamage;
 
 #[cfg(feature = "gecko")]
 pub use gecko::restyle_damage::GeckoRestyleDamage as RestyleDamage;
+
+#[cfg(feature = "servo")]
+pub type PreExistingComputedValues = ::std::sync::Arc<::properties::ServoComputedValues>;
+
+#[cfg(feature = "gecko")]
+pub type PreExistingComputedValues = ::gecko_bindings::structs::nsStyleContext;
 
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct SelectorParser<'a> {
@@ -99,7 +106,7 @@ impl PseudoElementCascadeType {
     }
 }
 
-pub trait ElementExt: Element<Impl=SelectorImpl> {
+pub trait ElementExt: Element<Impl=SelectorImpl> + Debug {
     fn is_link(&self) -> bool;
 
     fn matches_user_and_author_rules(&self) -> bool;

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use computed_values::display;
-use dom::TRestyleDamage;
 use heapsize::HeapSizeOf;
 use properties::ServoComputedValues;
 use std::fmt;
@@ -53,16 +52,9 @@ impl HeapSizeOf for ServoRestyleDamage {
     fn heap_size_of_children(&self) -> usize { 0 }
 }
 
-impl TRestyleDamage for ServoRestyleDamage {
-    /// For Servo the style source is always the computed values.
-    type PreExistingComputedValues = Arc<ServoComputedValues>;
-
-    fn empty() -> Self {
-        ServoRestyleDamage::empty()
-    }
-
-    fn compute(old: &Arc<ServoComputedValues>,
-               new: &Arc<ServoComputedValues>) -> ServoRestyleDamage {
+impl ServoRestyleDamage {
+    pub fn compute(old: &Arc<ServoComputedValues>,
+                   new: &Arc<ServoComputedValues>) -> ServoRestyleDamage {
         compute_damage(old, new)
     }
 
@@ -72,13 +64,11 @@ impl TRestyleDamage for ServoRestyleDamage {
     /// Use this instead of `ServoRestyleDamage::all()` because
     /// `ServoRestyleDamage::all()` will result in unnecessary sequential resolution
     /// of generated content.
-    fn rebuild_and_reflow() -> ServoRestyleDamage {
+    pub fn rebuild_and_reflow() -> ServoRestyleDamage {
         REPAINT | REPOSITION | STORE_OVERFLOW | BUBBLE_ISIZES | REFLOW_OUT_OF_FLOW | REFLOW |
             RECONSTRUCT_FLOW
     }
-}
 
-impl ServoRestyleDamage {
     /// Supposing a flow has the given `position` property and this damage,
     /// returns the damage that we should add to the *parent* of this flow.
     pub fn damage_for_parent(self, child_is_absolutely_positioned: bool) -> ServoRestyleDamage {

--- a/components/style/servo/selector_parser.rs
+++ b/components/style/servo/selector_parser.rs
@@ -13,6 +13,7 @@ use selectors::{Element, MatchAttrGeneric};
 use selectors::parser::AttrSelector;
 use std::borrow::Cow;
 use std::fmt;
+use std::fmt::Debug;
 
 /// NB: If you add to this list, be sure to update `each_pseudo_element` too.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -398,7 +399,7 @@ impl MatchAttrGeneric for ServoElementSnapshot {
     }
 }
 
-impl<E: Element<Impl=SelectorImpl>> ElementExt for E {
+impl<E: Element<Impl=SelectorImpl> + Debug> ElementExt for E {
     fn is_link(&self) -> bool {
         self.match_non_ts_pseudo_class(NonTSPseudoClass::AnyLink)
     }

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -7,14 +7,18 @@
 use atomic_refcell::{AtomicRefCell, AtomicRefMut};
 use bloom::StyleBloom;
 use context::{LocalStyleContext, SharedStyleContext, StyleContext};
-use data::{ElementData, RestyleData, StoredRestyleHint};
-use dom::{OpaqueNode, StylingMode, TElement, TNode};
+use data::{ElementData, StoredRestyleHint};
+use dom::{OpaqueNode, TElement, TNode};
 use matching::{MatchMethods, StyleSharingResult};
-use restyle_hints::{RESTYLE_DESCENDANTS, RESTYLE_LATER_SIBLINGS, RESTYLE_SELF};
+use restyle_hints::{RESTYLE_DESCENDANTS, RESTYLE_SELF};
+use selector_parser::RestyleDamage;
+use selectors::Element;
 use selectors::matching::StyleRelations;
+use std::borrow::Borrow;
 use std::cell::RefCell;
-use std::marker::PhantomData;
+use std::mem;
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use stylist::Stylist;
 use util::opts;
 
 /// Every time we do another layout, the old bloom filters are invalid. This is
@@ -36,7 +40,7 @@ thread_local!(
 pub fn take_thread_local_bloom_filter(context: &SharedStyleContext)
                                       -> StyleBloom
 {
-    debug!("{} taking bf", ::tid::tid());
+    trace!("{} taking bf", ::tid::tid());
 
     STYLE_BLOOM.with(|style_bloom| {
         style_bloom.borrow_mut().take()
@@ -45,7 +49,7 @@ pub fn take_thread_local_bloom_filter(context: &SharedStyleContext)
 }
 
 pub fn put_thread_local_bloom_filter(bf: StyleBloom) {
-    debug!("[{}] putting bloom filter back", ::tid::tid());
+    trace!("[{}] putting bloom filter back", ::tid::tid());
 
     STYLE_BLOOM.with(move |style_bloom| {
         debug_assert!(style_bloom.borrow().is_none(),
@@ -64,7 +68,7 @@ pub fn remove_from_bloom_filter<'a, E, C>(context: &C, root: OpaqueNode, element
     where E: TElement,
           C: StyleContext<'a>
 {
-    debug!("[{}] remove_from_bloom_filter", ::tid::tid());
+    trace!("[{}] remove_from_bloom_filter", ::tid::tid());
 
     // We may have arrived to `reconstruct_flows` without entering in style
     // recalc at all due to our optimizations, nor that it's up to date, so we
@@ -96,8 +100,25 @@ pub struct PerLevelTraversalData {
     pub current_dom_depth: Option<usize>,
 }
 
+/// This structure exists to enforce that callers invoke pre_traverse, and also
+/// to pass information from the pre-traversal into the primary traversal.
+pub struct PreTraverseToken {
+    traverse: bool,
+    skip_root: bool,
+}
+
+impl PreTraverseToken {
+    pub fn should_traverse(&self) -> bool {
+        self.traverse
+    }
+
+    pub fn should_skip_root(&self) -> bool {
+        self.skip_root
+    }
+}
+
 pub trait DomTraversalContext<N: TNode> {
-    type SharedContext: Sync + 'static;
+    type SharedContext: Sync + 'static + Borrow<SharedStyleContext>;
 
     fn new<'a>(&'a Self::SharedContext, OpaqueNode) -> Self;
 
@@ -113,24 +134,113 @@ pub trait DomTraversalContext<N: TNode> {
     /// performed.
     ///
     /// If it's false, then process_postorder has no effect at all.
-    fn needs_postorder_traversal(&self) -> bool { true }
+    fn needs_postorder_traversal() -> bool { true }
 
-    /// Returns true if traversal should visit the given child.
-    fn should_traverse_child(child: N) -> bool;
+    /// Must be invoked before traversing the root element to determine whether
+    /// a traversal is needed. Returns a token that allows the caller to prove
+    /// that the call happened.
+    ///
+    /// The skip_root parameter is used in Gecko to style newly-appended children
+    /// without restyling the parent.
+    fn pre_traverse(root: N::ConcreteElement, stylist: &Stylist, skip_root: bool)
+                    -> PreTraverseToken
+    {
+        // If we should skip the root, traverse unconditionally.
+        if skip_root {
+            return PreTraverseToken {
+                traverse: true,
+                skip_root: true,
+            };
+        }
+
+        // Expand the snapshot, if any. This is normally handled by the parent, so
+        // we need a special case for the root.
+        //
+        // Expanding snapshots here may create a LATER_SIBLINGS restyle hint, which
+        // we will drop on the floor. This is fine, because we don't traverse roots
+        // with siblings.
+        debug_assert!(root.next_sibling_element().is_none());
+        if let Some(mut data) = root.mutate_data() {
+            if let Some(r) = data.as_restyle_mut() {
+                let _later_siblings = r.expand_snapshot(root, stylist);
+            }
+        }
+
+        PreTraverseToken {
+            traverse: Self::node_needs_traversal(root.as_node()),
+            skip_root: false,
+        }
+    }
+
+    /// Returns true if traversal should visit a text node. The style system never
+    /// processes text nodes, but Servo overrides this to visit them for flow
+    /// construction when necessary.
+    fn text_node_needs_traversal(node: N) -> bool { debug_assert!(node.is_text_node()); false }
+
+    /// Returns true if traversal is needed for the given node and subtree.
+    fn node_needs_traversal(node: N) -> bool {
+        // Non-incremental layout visits every node.
+        if cfg!(feature = "servo") && opts::get().nonincremental_layout {
+            return true;
+        }
+
+        match node.as_element() {
+            None => Self::text_node_needs_traversal(node),
+            Some(el) => {
+                // If the dirty descendants bit is set, we need to traverse no
+                // matter what. Skip examining the ElementData.
+                if el.has_dirty_descendants() {
+                    return true;
+                }
+
+                // Check the element data. If it doesn't exist, we need to visit
+                // the element.
+                let data = match el.borrow_data() {
+                    Some(d) => d,
+                    None => return true,
+                };
+
+                // Check what kind of element data we have. If it's Initial or Persistent,
+                // we're done.
+                let restyle = match *data {
+                    ElementData::Initial(ref i) => return i.is_none(),
+                    ElementData::Persistent(_) => return false,
+                    ElementData::Restyle(ref r) => r,
+                };
+
+                // Check whether we have any selector matching or re-cascading to
+                // do in this subtree.
+                debug_assert!(restyle.snapshot.is_none(), "Snapshots should already be expanded");
+                if !restyle.hint.is_empty() || restyle.recascade {
+                    return true;
+                }
+
+                // Servo uses the post-order traversal for flow construction, so
+                // we need to traverse any element with damage so that we can perform
+                // fixup / reconstruction on our way back up the tree.
+                if cfg!(feature = "servo") && restyle.damage != RestyleDamage::empty() {
+                    return true;
+                }
+
+                false
+            },
+        }
+    }
 
     /// Helper for the traversal implementations to select the children that
     /// should be enqueued for processing.
     fn traverse_children<F: FnMut(N)>(parent: N::ConcreteElement, mut f: F)
     {
-        use dom::StylingMode::Restyle;
-
         if parent.is_display_none() {
             return;
         }
 
         for kid in parent.as_node().children() {
-            if Self::should_traverse_child(kid) {
-                if kid.as_element().map_or(false, |el| el.styling_mode() == Restyle) {
+            if Self::node_needs_traversal(kid) {
+                let el = kid.as_element();
+                if el.as_ref().and_then(|el| el.borrow_data())
+                              .map_or(false, |d| d.is_restyle())
+                {
                     unsafe { parent.set_dirty_descendants(); }
                 }
                 f(kid);
@@ -206,60 +316,74 @@ pub fn style_element_in_display_none_subtree<'a, E, C, F>(element: E,
 #[inline]
 #[allow(unsafe_code)]
 pub fn recalc_style_at<'a, E, C, D>(context: &'a C,
-                                    data: &mut PerLevelTraversalData,
-                                    element: E)
+                                    traversal_data: &mut PerLevelTraversalData,
+                                    element: E,
+                                    mut data: &mut AtomicRefMut<ElementData>)
     where E: TElement,
           C: StyleContext<'a>,
           D: DomTraversalContext<E::ConcreteNode>
 {
-    let mode = element.styling_mode();
-    let should_compute = element.borrow_data().map_or(true, |d| d.get_current_styles().is_none());
-    debug!("recalc_style_at: {:?} (should_compute={:?} mode={:?}, data={:?})",
-           element, should_compute, mode, element.borrow_data());
+    debug_assert!(data.as_restyle().map_or(true, |r| r.snapshot.is_none()),
+                  "Snapshots should be expanded by the caller");
 
-    let (computed_display_none, propagated_hint) = if should_compute {
-        compute_style::<_, _, D>(context, data, element)
-    } else {
-        (false, StoredRestyleHint::empty())
+    let compute_self = !data.has_current_styles();
+    let mut inherited_style_changed = false;
+
+    debug!("recalc_style_at: {:?} (compute_self={:?}, dirty_descendants={:?}, data={:?})",
+           element, compute_self, element.has_dirty_descendants(), data);
+
+    // Compute style for this element if necessary.
+    if compute_self {
+        inherited_style_changed = compute_style::<_, _, D>(context, &mut data, traversal_data, element);
+    }
+
+    // Now that matching and cascading is done, clear the bits corresponding to
+    // those operations and compute the propagated restyle hint.
+    let empty_hint = StoredRestyleHint::empty();
+    let propagated_hint = match data.as_restyle_mut() {
+        None => empty_hint,
+        Some(r) => {
+            r.recascade = false;
+            mem::replace(&mut r.hint, empty_hint).propagate()
+        },
     };
+    debug_assert!(data.has_current_styles());
+    trace!("propagated_hint={:?}, inherited_style_changed={:?}", propagated_hint, inherited_style_changed);
 
-    // Preprocess children, computing restyle hints and handling sibling relationships.
-    //
-    // We don't need to do this if we're not traversing children, or if we're performing
-    // initial styling.
-    let will_traverse_children = !computed_display_none &&
-                                 (mode == StylingMode::Restyle ||
-                                  mode == StylingMode::Traverse);
-    if will_traverse_children {
-        preprocess_children::<_, _, D>(context, element, propagated_hint,
-                                       mode == StylingMode::Restyle);
+    // Preprocess children, propagating restyle hints and handling sibling relationships.
+    if !data.styles().is_display_none() &&
+       (element.has_dirty_descendants() || !propagated_hint.is_empty() || inherited_style_changed) {
+        preprocess_children::<_, _, D>(context, element, propagated_hint, inherited_style_changed);
     }
 }
 
+// Computes style, returning true if the inherited styles changed for this
+// element.
+//
+// FIXME(bholley): This should differentiate between matching and cascading,
+// since we have separate bits for each now.
 fn compute_style<'a, E, C, D>(context: &'a C,
-                              data: &mut PerLevelTraversalData,
-                              element: E) -> (bool, StoredRestyleHint)
+                              mut data: &mut AtomicRefMut<ElementData>,
+                              traversal_data: &mut PerLevelTraversalData,
+                              element: E) -> bool
     where E: TElement,
           C: StyleContext<'a>,
-          D: DomTraversalContext<E::ConcreteNode>
+          D: DomTraversalContext<E::ConcreteNode>,
 {
     let shared_context = context.shared_context();
     let mut bf = take_thread_local_bloom_filter(shared_context);
     // Ensure the bloom filter is up to date.
     let dom_depth = bf.insert_parents_recovering(element,
-                                                 data.current_dom_depth,
+                                                 traversal_data.current_dom_depth,
                                                  shared_context.generation);
 
     // Update the dom depth with the up-to-date dom depth.
     //
     // Note that this is always the same than the pre-existing depth, but it can
     // change from unknown to known at this step.
-    data.current_dom_depth = Some(dom_depth);
+    traversal_data.current_dom_depth = Some(dom_depth);
 
     bf.assert_complete(element);
-
-    let mut data = unsafe { D::ensure_element_data(&element).borrow_mut() };
-    debug_assert!(!data.is_persistent());
 
     // Check to see whether we can share a style with someone.
     let style_sharing_candidate_cache =
@@ -304,7 +428,7 @@ fn compute_style<'a, E, C, D>(context: &'a C,
             // Add ourselves to the LRU cache.
             if let Some(element) = shareable_element {
                 style_sharing_candidate_cache.insert_if_possible(&element,
-                                                                 &data.current_styles().primary.values,
+                                                                 &data.styles().primary.values,
                                                                  relations);
             }
         }
@@ -318,7 +442,7 @@ fn compute_style<'a, E, C, D>(context: &'a C,
 
     // If we're restyling this element to display:none, throw away all style data
     // in the subtree, notify the caller to early-return.
-    let display_none = data.current_styles().is_display_none();
+    let display_none = data.styles().is_display_none();
     if display_none {
         debug!("New element style is display:none - clearing data from descendants.");
         clear_descendant_data(element, &|e| unsafe { D::clear_element_data(&e) });
@@ -331,13 +455,16 @@ fn compute_style<'a, E, C, D>(context: &'a C,
     // complexity.
     put_thread_local_bloom_filter(bf);
 
-    (display_none, data.as_restyle().map_or(StoredRestyleHint::empty(), |r| r.hint.propagate()))
+    // FIXME(bholley): Compute this accurately from the call to CalcStyleDifference.
+    let inherited_styles_changed = true;
+
+    inherited_styles_changed
 }
 
 fn preprocess_children<'a, E, C, D>(context: &'a C,
                                     element: E,
                                     mut propagated_hint: StoredRestyleHint,
-                                    restyled_parent: bool)
+                                    parent_inherited_style_changed: bool)
     where E: TElement,
           C: StyleContext<'a>,
           D: DomTraversalContext<E::ConcreteNode>
@@ -350,41 +477,33 @@ fn preprocess_children<'a, E, C, D>(context: &'a C,
             None => continue,
         };
 
-        // Set up our lazy child restyle data.
-        let mut child_data = unsafe { LazyRestyleData::<E, D>::new(&child) };
+        let mut child_data = unsafe { D::ensure_element_data(&child).borrow_mut() };
+        if child_data.is_unstyled_initial() {
+            continue;
+        }
+
+        let mut restyle_data = match child_data.restyle() {
+            Some(d) => d,
+            None => continue,
+        };
 
         // Propagate the parent and sibling restyle hint.
         if !propagated_hint.is_empty() {
-            child_data.ensure().map(|d| d.hint.insert(&propagated_hint));
+            restyle_data.hint.insert(&propagated_hint);
         }
 
-        // Handle element snashots.
-        if child_data.has_snapshot() {
-            // Compute the restyle hint.
-            let mut restyle_data = child_data.ensure().unwrap();
-            let mut hint = context.shared_context().stylist
-                                  .compute_restyle_hint(&child,
-                                                        restyle_data.snapshot.as_ref().unwrap(),
-                                                        child.get_state());
-
-            // If the hint includes a directive for later siblings, strip
-            // it out and modify the base hint for future siblings.
-            if hint.contains(RESTYLE_LATER_SIBLINGS) {
-                hint.remove(RESTYLE_LATER_SIBLINGS);
-                propagated_hint.insert(&(RESTYLE_SELF | RESTYLE_DESCENDANTS).into());
-            }
-
-            // Insert the hint.
-            if !hint.is_empty() {
-                restyle_data.hint.insert(&hint.into());
-            }
+        // Handle element snapshots.
+        let stylist = &context.shared_context().stylist;
+        let later_siblings = restyle_data.expand_snapshot(child, stylist);
+        if later_siblings {
+            propagated_hint.insert(&(RESTYLE_SELF | RESTYLE_DESCENDANTS).into());
         }
 
-        // If we restyled this node, conservatively mark all our children as
-        // needing a re-cascade. Once we have the rule tree, we will be able
-        // to distinguish between re-matching and re-cascading.
-        if restyled_parent {
-            child_data.ensure();
+        // If properties that we inherited from the parent changed, we need to recascade.
+        //
+        // FIXME(bholley): Need to handle explicitly-inherited reset properties somewhere.
+        if parent_inherited_style_changed {
+            restyle_data.recascade = true;
         }
     }
 }
@@ -403,61 +522,4 @@ pub fn clear_descendant_data<E: TElement, F: Fn(E)>(el: E, clear_data: &F) {
     }
 
     unsafe { el.unset_dirty_descendants(); }
-}
-
-/// Various steps in the child preparation algorithm above may cause us to lazily
-/// instantiate the ElementData on the child. Encapsulate that logic into a
-/// convenient abstraction.
-struct LazyRestyleData<'b, E: TElement + 'b, D: DomTraversalContext<E::ConcreteNode>> {
-    data: Option<AtomicRefMut<'b, ElementData>>,
-    element: &'b E,
-    phantom: PhantomData<D>,
-}
-
-impl<'b, E: TElement, D: DomTraversalContext<E::ConcreteNode>> LazyRestyleData<'b, E, D> {
-    /// This may lazily instantiate ElementData, and is therefore only safe to
-    /// call on an element for which we have exclusive access.
-    unsafe fn new(element: &'b E) -> Self {
-        LazyRestyleData {
-            data: None,
-            element: element,
-            phantom: PhantomData,
-        }
-    }
-
-    fn ensure(&mut self) -> Option<&mut RestyleData> {
-        if self.data.is_none() {
-            let mut d = unsafe { D::ensure_element_data(self.element).borrow_mut() };
-            d.restyle();
-            self.data = Some(d);
-        }
-
-        self.data.as_mut().unwrap().as_restyle_mut()
-    }
-
-    /// Checks for the existence of an element snapshot without lazily instantiating
-    /// anything. This allows the traversal to cheaply pass through already-styled
-    /// nodes when they don't need a restyle.
-    fn has_snapshot(&self) -> bool {
-        // If there's no element data, we're done.
-        let raw_data = self.element.get_data();
-        if raw_data.is_none() {
-            debug_assert!(self.data.is_none());
-            return false;
-        }
-
-        // If there is element data, we still may not have committed to processing
-        // the node. Carefully get a reference to the data.
-        let maybe_tmp_borrow;
-        let borrow_ref = match self.data {
-            Some(ref d) => d,
-            None => {
-                maybe_tmp_borrow = raw_data.unwrap().borrow_mut();
-                &maybe_tmp_borrow
-            }
-        };
-
-        // Check for a snapshot.
-        borrow_ref.as_restyle().map_or(false, |d| d.snapshot.is_some())
-    }
 }


### PR DESCRIPTION
The primary idea of this patch is to ditch the rigid enum of Previous/Current
styles, and replace it with a series of indicators for the various types of
work that needs to be performed (expanding snapshots, rematching, recascading,
and damage processing). This loses us a little bit of sanity checking (since
the up-to-date-ness of our style is no longer baked into the type system), but 
gives us a lot more flexibility that we'll need going forward (especially when
we separate matching from cascading). We also eliminate get_styling_mode in
favor of a method on the traversal.

This patch does a few other things as ridealongs:
* Temporarily eliminates the handling for transfering ownership of styles to the 
  frame. We'll need this again at some point, but for now it's causing too much
  complexity for a half-implemented feature.
* Ditches TRestyleDamage, which is no longer necessary post-crate-merge, and is
  a constant source of compilation failures from either needing to be imported
  or being unnecessarily imported (which varies between gecko and servo).
* Expands Snapshots for the traversal root, which was missing before.
* Fixes up the skip_root stuff to avoid visiting the skipped root.
* Unifies parallel traversal and avoids spawning for a single work item.
* Adds an explicit pre_traverse step do any pre-processing and determine whether
      we need to traverse at all.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14436)
<!-- Reviewable:end -->
