### PR TITLE
style: Don't pop too much in the bloom filter.

### DIFF
--- a/components/style/bloom.rs
+++ b/components/style/bloom.rs
@@ -181,7 +181,7 @@ impl StyleBloom {
 
         // If the filter represents an element too deep in the dom, we need to
         // pop ancestors.
-        while current_depth >= element_depth - 1 {
+        while current_depth > element_depth - 1 {
             self.pop::<E>().expect("Emilio is bad at math");
             current_depth -= 1;
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is not a problem for Servo, because we recovered it without much problem a
few lines below, and we never reached the pathological case where the filter has
one element (the root), and we restyled another element with depth 1.

Fixes [bug 1321725](https://bugzil.la/1321725).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14439)
<!-- Reviewable:end -->
