### PR TITLE
layout: Dramatically improve performance of layout queries and `requestAnimationFrame()`.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -85,11 +85,7 @@ pub enum ConstructionResult {
 }
 
 impl ConstructionResult {
-    pub fn swap_out(&mut self) -> ConstructionResult {
-        if opts::get().nonincremental_layout {
-            return mem::replace(self, ConstructionResult::None)
-        }
-
+    pub fn get(&mut self) -> ConstructionResult {
         // FIXME(pcwalton): Stop doing this with inline fragments. Cloning fragments is very
         // inefficient!
         (*self).clone()
@@ -478,7 +474,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
             inline_fragment_accumulator: &mut InlineFragmentsAccumulator,
             abs_descendants: &mut AbsoluteDescendants,
             legalizer: &mut Legalizer) {
-        match kid.swap_out_construction_result() {
+        match kid.get_construction_result() {
             ConstructionResult::None => {}
             ConstructionResult::Flow(kid_flow, kid_abs_descendants) => {
                 // If kid_flow is TableCaptionFlow, kid_flow should be added under
@@ -776,7 +772,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
             if kid.get_pseudo_element_type() != PseudoElementType::Normal {
                 self.process(&kid);
             }
-            match kid.swap_out_construction_result() {
+            match kid.get_construction_result() {
                 ConstructionResult::None => {}
                 ConstructionResult::Flow(flow, kid_abs_descendants) => {
                     if !flow::base(&*flow).flags.contains(IS_ABSOLUTELY_POSITIONED) {
@@ -1022,7 +1018,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                                                        side: caption_side::T) {
         // Only flows that are table captions are matched here.
         for kid in node.children() {
-            match kid.swap_out_construction_result() {
+            match kid.get_construction_result() {
                 ConstructionResult::Flow(kid_flow, _) => {
                     if kid_flow.is_table_caption() &&
                         kid_flow.as_block()
@@ -1288,8 +1284,8 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
         for kid in node.children() {
             // CSS 2.1 § 17.2.1. Treat all non-column child fragments of `table-column-group`
             // as `display: none`.
-            if let ConstructionResult::ConstructionItem(ConstructionItem::TableColumnFragment(fragment))
-                   = kid.swap_out_construction_result() {
+            if let ConstructionResult::ConstructionItem(ConstructionItem::TableColumnFragment(
+                    fragment)) = kid.get_construction_result() {
                 col_fragments.push(fragment)
             }
         }
@@ -1619,9 +1615,8 @@ trait NodeUtils {
     /// Sets the construction result of a flow.
     fn set_flow_construction_result(self, result: ConstructionResult);
 
-    /// Replaces the flow construction result in a node with `ConstructionResult::None` and returns
-    /// the old value.
-    fn swap_out_construction_result(self) -> ConstructionResult;
+    /// Returns the construction result for this node.
+    fn get_construction_result(self) -> ConstructionResult;
 }
 
 impl<ConcreteThreadSafeLayoutNode> NodeUtils for ConcreteThreadSafeLayoutNode
@@ -1664,9 +1659,9 @@ impl<ConcreteThreadSafeLayoutNode> NodeUtils for ConcreteThreadSafeLayoutNode
     }
 
     #[inline(always)]
-    fn swap_out_construction_result(self) -> ConstructionResult {
+    fn get_construction_result(self) -> ConstructionResult {
         let mut layout_data = self.mutate_layout_data().unwrap();
-        self.construction_result_mut(&mut *layout_data).swap_out()
+        self.construction_result_mut(&mut *layout_data).get()
     }
 }
 

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -921,6 +921,8 @@ impl LayoutThread {
                         build_state.root_stacking_context.bounds = origin;
                         build_state.root_stacking_context.overflow = origin;
                         rw_data.display_list = Some(Arc::new(build_state.to_display_list()));
+
+                        debug_assert!(!flow::base(layout_root).restyle_damage.contains(REPAINT));
                     }
                     (ReflowGoal::ForScriptQuery, false) => {}
                 }

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1328,7 +1328,8 @@ impl LayoutThread {
                                                      &mut layout_context);
     }
 
-    fn reflow_with_newly_loaded_web_font<'a, 'b>(&mut self, possibly_locked_rw_data: &mut RwData<'a, 'b>) {
+    fn reflow_with_newly_loaded_web_font<'a, 'b>(&mut self,
+                                                 possibly_locked_rw_data: &mut RwData<'a, 'b>) {
         let mut rw_data = possibly_locked_rw_data.lock();
         font_context::invalidate_font_caches();
 
@@ -1397,7 +1398,10 @@ impl LayoutThread {
             profile(time::ProfilerCategory::LayoutGeneratedContent,
                     self.profiler_metadata(),
                     self.time_profiler_chan.clone(),
-                    || sequential::resolve_generated_content(FlowRef::deref_mut(&mut root_flow), &layout_context));
+                    || {
+                        sequential::resolve_generated_content(FlowRef::deref_mut(&mut root_flow),
+                                                              &layout_context)
+                    });
 
             // Guess float placement.
             profile(time::ProfilerCategory::LayoutFloatPlacementSpeculation,
@@ -1416,15 +1420,17 @@ impl LayoutThread {
                     match self.parallel_traversal {
                         None => {
                             // Sequential mode.
-                            LayoutThread::solve_constraints(FlowRef::deref_mut(&mut root_flow), &layout_context)
+                            LayoutThread::solve_constraints(FlowRef::deref_mut(&mut root_flow),
+                                                            &layout_context)
                         }
                         Some(ref mut parallel) => {
                             // Parallel mode.
-                            LayoutThread::solve_constraints_parallel(parallel,
-                                                                     FlowRef::deref_mut(&mut root_flow),
-                                                                     profiler_metadata,
-                                                                     self.time_profiler_chan.clone(),
-                                                                     &*layout_context);
+                            LayoutThread::solve_constraints_parallel(
+                                parallel,
+                                FlowRef::deref_mut(&mut root_flow),
+                                profiler_metadata,
+                                self.time_profiler_chan.clone(),
+                                &*layout_context);
                         }
                     }
                 });

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -815,7 +815,7 @@ impl LayoutThread {
             Some(x) => x,
             None => return None,
         };
-        let result = data.flow_construction_result.swap_out();
+        let result = data.flow_construction_result.get();
 
         let mut flow = match result {
             ConstructionResult::Flow(mut flow, abs_descendants) => {

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -616,6 +616,7 @@ impl LayoutThread {
         self.perform_post_style_recalc_layout_passes(&reflow_info,
                                                      None,
                                                      None,
+                                                     FlowTreeDamage::Dirty,
                                                      &mut *rw_data,
                                                      &mut layout_context);
 
@@ -946,8 +947,6 @@ impl LayoutThread {
                 println!("{}", serde_json::to_string_pretty(&display_list).unwrap());
             }
 
-            debug!("Layout done!");
-
             // TODO: Avoid the temporary conversion and build webrender sc/dl directly!
             let builder = rw_data.display_list.as_ref().unwrap().convert_to_webrender(self.id);
 
@@ -962,6 +961,8 @@ impl LayoutThread {
                 webrender_traits::Epoch(epoch_number),
                 viewport_size,
                 builder);
+
+            debug!("Layout done!");
         });
     }
 
@@ -1128,8 +1129,14 @@ impl LayoutThread {
                                                                          viewport_size_changed,
                                                                          data.reflow_info.goal);
 
+        let flow_tree_damage = if element.styling_mode() == StylingMode::Stop {
+            FlowTreeDamage::Clean
+        } else {
+            FlowTreeDamage::Dirty
+        };
+
         let dom_depth = Some(0); // This is always the root node.
-        if element.styling_mode() != StylingMode::Stop {
+        if flow_tree_damage == FlowTreeDamage::Dirty {
             // Recalculate CSS styles and rebuild flows and fragments.
             profile(time::ProfilerCategory::LayoutStyleRecalc,
                     self.profiler_metadata(),
@@ -1179,6 +1186,7 @@ impl LayoutThread {
         self.perform_post_style_recalc_layout_passes(&data.reflow_info,
                                                      Some(&data.query_type),
                                                      Some(&document),
+                                                     flow_tree_damage,
                                                      &mut rw_data,
                                                      &mut shared_layout_context);
 
@@ -1313,6 +1321,7 @@ impl LayoutThread {
         self.perform_post_style_recalc_layout_passes(&reflow_info,
                                                      None,
                                                      None,
+                                                     FlowTreeDamage::Dirty,
                                                      &mut *rw_data,
                                                      &mut layout_context);
     }
@@ -1337,6 +1346,7 @@ impl LayoutThread {
         self.perform_post_style_recalc_layout_passes(&reflow_info,
                                                      None,
                                                      None,
+                                                     FlowTreeDamage::Dirty,
                                                      &mut *rw_data,
                                                      &mut layout_context);
     }
@@ -1345,27 +1355,34 @@ impl LayoutThread {
                                                data: &Reflow,
                                                query_type: Option<&ReflowQueryType>,
                                                document: Option<&ServoLayoutDocument>,
+                                               flow_tree_damage: FlowTreeDamage,
                                                rw_data: &mut LayoutThreadData,
                                                layout_context: &mut SharedLayoutContext) {
-        if let Some(mut root_flow) = self.root_flow.clone() {
-            // Kick off animations if any were triggered, expire completed ones.
-            animation::update_animation_state(&self.constellation_chan,
-                                              &self.script_chan,
-                                              &mut *self.running_animations.write(),
-                                              &mut *self.expired_animations.write(),
-                                              &self.new_animations_receiver,
-                                              self.id,
-                                              &self.timer);
+        let mut root_flow = match self.root_flow.clone() {
+            Some(root_flow) => root_flow,
+            None => return,
+        };
 
+        // Kick off animations if any were triggered, expire completed ones.
+        animation::update_animation_state(&self.constellation_chan,
+                                          &self.script_chan,
+                                          &mut *self.running_animations.write(),
+                                          &mut *self.expired_animations.write(),
+                                          &self.new_animations_receiver,
+                                          self.id,
+                                          &self.timer);
+
+        if flow_tree_damage == FlowTreeDamage::Dirty {
             profile(time::ProfilerCategory::LayoutRestyleDamagePropagation,
                     self.profiler_metadata(),
                     self.time_profiler_chan.clone(),
                     || {
-                // Call `compute_layout_damage` even in non-incremental mode, because it sets flags
-                // that are needed in both incremental and non-incremental traversals.
+                // Call `compute_layout_damage` even in non-incremental mode, because it sets
+                // flags that are needed in both incremental and non-incremental traversals.
                 let damage = FlowRef::deref_mut(&mut root_flow).compute_layout_damage();
 
-                if opts::get().nonincremental_layout || damage.contains(REFLOW_ENTIRE_DOCUMENT) {
+                if opts::get().nonincremental_layout ||
+                        damage.contains(REFLOW_ENTIRE_DOCUMENT) {
                     FlowRef::deref_mut(&mut root_flow).reflow_entire_document()
                 }
             });
@@ -1419,13 +1436,13 @@ impl LayoutThread {
                 sequential::store_overflow(&layout_context,
                                            FlowRef::deref_mut(&mut root_flow) as &mut Flow);
             });
-
-            self.perform_post_main_layout_passes(data,
-                                                 query_type,
-                                                 document,
-                                                 rw_data,
-                                                 layout_context);
         }
+
+        self.perform_post_main_layout_passes(data,
+                                             query_type,
+                                             document,
+                                             rw_data,
+                                             layout_context);
     }
 
     fn perform_post_main_layout_passes(&mut self,
@@ -1573,3 +1590,14 @@ lazy_static! {
         }
     };
 }
+
+/// Whether the flow tree has been modified *at all* during restyling.
+///
+/// Tracking this allows us to skip running passes entirely if they are trivially proven to be
+/// no-ops.
+#[derive(Clone, Copy, PartialEq)]
+enum FlowTreeDamage {
+    Clean,
+    Dirty,
+}
+

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -104,7 +104,7 @@ use origin::Origin;
 use script_layout_interface::message::{Msg, ReflowQueryType};
 use script_thread::{MainThreadScriptMsg, Runnable};
 use script_traits::{AnimationState, CompositorEvent, MouseButton, MouseEventType, MozBrowserEvent};
-use script_traits::{ScriptMsg as ConstellationMsg, TouchpadPressurePhase};
+use script_traits::{MsDuration, ScriptMsg as ConstellationMsg, TouchpadPressurePhase};
 use script_traits::{TouchEventType, TouchId};
 use script_traits::UntrustedNodeAddress;
 use servo_atoms::Atom;
@@ -128,8 +128,18 @@ use style::selector_parser::{RestyleDamage, Snapshot};
 use style::str::{split_html_space_chars, str_join};
 use style::stylesheets::Stylesheet;
 use time;
+use timers::OneshotTimerCallback;
 use url::percent_encoding::percent_decode;
 use util::prefs::PREFS;
+
+/// The number of times we are allowed to see spurious `requestAnimationFrame()` calls before
+/// falling back to fake ones.
+///
+/// A spurious `requestAnimationFrame()` call is defined as one that does not change the DOM.
+const SPURIOUS_ANIMATION_FRAME_THRESHOLD: u8 = 5;
+
+/// The amount of time between fake `requestAnimationFrame()`s.
+const FAKE_REQUEST_ANIMATION_FRAME_DELAY: u64 = 16;
 
 pub enum TouchEventResult {
     Processed(bool),
@@ -283,6 +293,11 @@ pub struct Document {
     last_click_info: DOMRefCell<Option<(Instant, Point2D<f32>)>>,
     /// https://html.spec.whatwg.org/multipage/#ignore-destructive-writes-counter
     ignore_destructive_writes_counter: Cell<u32>,
+    /// The number of spurious `requestAnimationFrame()` requests we've received.
+    ///
+    /// A rAF request is considered spurious if nothing was actually reflowed.
+    spurious_animation_frames: Cell<u8>,
+
 }
 
 #[derive(JSTraceable, HeapSizeOf)]
@@ -1471,11 +1486,20 @@ impl Document {
         //
         // TODO: Should tick animation only when document is visible
         if !self.running_animation_callbacks.get() {
-            let global_scope = self.window.upcast::<GlobalScope>();
-            let event = ConstellationMsg::ChangeRunningAnimationsState(
-                global_scope.pipeline_id(),
-                AnimationState::AnimationCallbacksPresent);
-            global_scope.constellation_chan().send(event).unwrap();
+            if !self.is_faking_animation_frames() {
+                let global_scope = self.window.upcast::<GlobalScope>();
+                let event = ConstellationMsg::ChangeRunningAnimationsState(
+                    global_scope.pipeline_id(),
+                    AnimationState::AnimationCallbacksPresent);
+                global_scope.constellation_chan().send(event).unwrap();
+            } else {
+                let callback = FakeRequestAnimationFrameCallback {
+                    document: Trusted::new(self),
+                };
+                self.global()
+                    .schedule_callback(OneshotTimerCallback::FakeRequestAnimationFrame(callback),
+                                       MsDuration::new(FAKE_REQUEST_ANIMATION_FRAME_DELAY));
+            }
         }
 
         ident
@@ -1494,6 +1518,7 @@ impl Document {
         let mut animation_frame_list =
             mem::replace(&mut *self.animation_frame_list.borrow_mut(), vec![]);
         self.running_animation_callbacks.set(true);
+        let was_faking_animation_frames = self.is_faking_animation_frames();
         let timing = self.window.Performance().Now();
 
         for (_, callback) in animation_frame_list.drain(..) {
@@ -1502,24 +1527,40 @@ impl Document {
             }
         }
 
+        self.running_animation_callbacks.set(false);
+
+        let spurious = !self.window.reflow(ReflowGoal::ForDisplay,
+                                           ReflowQueryType::NoQuery,
+                                           ReflowReason::RequestAnimationFrame);
+
         // Only send the animation change state message after running any callbacks.
         // This means that if the animation callback adds a new callback for
         // the next frame (which is the common case), we won't send a NoAnimationCallbacksPresent
         // message quickly followed by an AnimationCallbacksPresent message.
-        if self.animation_frame_list.borrow().is_empty() {
+        //
+        // If this frame was spurious and we've seen too many spurious frames in a row, tell the
+        // constellation to stop giving us video refresh callbacks, to save energy. (A spurious
+        // animation frame is one in which the callback did not mutate the DOM—that is, an
+        // animation frame that wasn't actually used for animation.)
+        if self.animation_frame_list.borrow().is_empty() ||
+                (!was_faking_animation_frames && self.is_faking_animation_frames()) {
             mem::swap(&mut *self.animation_frame_list.borrow_mut(),
                       &mut animation_frame_list);
             let global_scope = self.window.upcast::<GlobalScope>();
-            let event = ConstellationMsg::ChangeRunningAnimationsState(global_scope.pipeline_id(),
-                                                                       AnimationState::NoAnimationCallbacksPresent);
+            let event = ConstellationMsg::ChangeRunningAnimationsState(
+                global_scope.pipeline_id(),
+                AnimationState::NoAnimationCallbacksPresent);
             global_scope.constellation_chan().send(event).unwrap();
         }
 
-        self.running_animation_callbacks.set(false);
-
-        self.window.reflow(ReflowGoal::ForDisplay,
-                           ReflowQueryType::NoQuery,
-                           ReflowReason::RequestAnimationFrame);
+        // Update the counter of spurious animation frames.
+        if spurious {
+            if self.spurious_animation_frames.get() < SPURIOUS_ANIMATION_FRAME_THRESHOLD {
+                self.spurious_animation_frames.set(self.spurious_animation_frames.get() + 1)
+            }
+        } else {
+            self.spurious_animation_frames.set(0)
+        }
     }
 
     pub fn fetch_async(&self, load: LoadType,
@@ -1880,6 +1921,7 @@ impl Document {
             target_element: MutNullableHeap::new(None),
             last_click_info: DOMRefCell::new(None),
             ignore_destructive_writes_counter: Default::default(),
+            spurious_animation_frames: Cell::new(0),
         }
     }
 
@@ -2064,6 +2106,12 @@ impl Document {
     pub fn decr_ignore_destructive_writes_counter(&self) {
         self.ignore_destructive_writes_counter.set(
             self.ignore_destructive_writes_counter.get() - 1);
+    }
+
+    /// Whether we've seen so many spurious animation frames (i.e. animation frames that didn't
+    /// mutate the DOM) that we've decided to fall back to fake ones.
+    fn is_faking_animation_frames(&self) -> bool {
+        self.spurious_animation_frames.get() >= SPURIOUS_ANIMATION_FRAME_THRESHOLD
     }
 }
 
@@ -3178,3 +3226,25 @@ pub enum FocusEventType {
     Focus,      // Element gained focus. Doesn't bubble.
     Blur,       // Element lost focus. Doesn't bubble.
 }
+
+/// A fake `requestAnimationFrame()` callback—"fake" because it is not triggered by the video
+/// refresh but rather a simple timer.
+///
+/// If the page is observed to be using `requestAnimationFrame()` for non-animation purposes (i.e.
+/// without mutating the DOM), then we fall back to simple timeouts to save energy over video
+/// refresh.
+#[derive(JSTraceable, HeapSizeOf)]
+pub struct FakeRequestAnimationFrameCallback {
+    /// The document.
+    #[ignore_heap_size_of = "non-owning"]
+    document: Trusted<Document>,
+}
+
+impl FakeRequestAnimationFrameCallback {
+    #[allow(unrooted_must_root)]
+    pub fn invoke(self) {
+        let document = self.document.root();
+        document.run_the_animation_frame_callbacks();
+    }
+}
+

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -7,6 +7,7 @@ use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use dom::bindings::reflector::Reflectable;
 use dom::bindings::str::DOMString;
+use dom::document::FakeRequestAnimationFrameCallback;
 use dom::eventsource::EventSourceTimeoutCallback;
 use dom::globalscope::GlobalScope;
 use dom::testbinding::TestBindingCallback;
@@ -71,6 +72,7 @@ pub enum OneshotTimerCallback {
     EventSourceTimeout(EventSourceTimeoutCallback),
     JsTimer(JsTimerTask),
     TestBindingCallback(TestBindingCallback),
+    FakeRequestAnimationFrame(FakeRequestAnimationFrameCallback),
 }
 
 impl OneshotTimerCallback {
@@ -80,6 +82,7 @@ impl OneshotTimerCallback {
             OneshotTimerCallback::EventSourceTimeout(callback) => callback.invoke(),
             OneshotTimerCallback::JsTimer(task) => task.invoke(this, js_timers),
             OneshotTimerCallback::TestBindingCallback(callback) => callback.invoke(),
+            OneshotTimerCallback::FakeRequestAnimationFrame(callback) => callback.invoke(),
         }
     }
 }

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -60,7 +60,9 @@ impl<T> PseudoElementType<T> {
 
     pub fn style_pseudo_element(&self) -> PseudoElement {
         match *self {
-            PseudoElementType::Normal => unreachable!("style_pseudo_element called with PseudoElementType::Normal"),
+            PseudoElementType::Normal => {
+                unreachable!("style_pseudo_element called with PseudoElementType::Normal")
+            }
             PseudoElementType::Before(_) => PseudoElement::Before,
             PseudoElementType::After(_) => PseudoElement::After,
             PseudoElementType::DetailsSummary(_) => PseudoElement::DetailsSummary,
@@ -150,7 +152,8 @@ impl<ConcreteNode> Iterator for TreeIterator<ConcreteNode>
 
 /// A thread-safe version of `LayoutNode`, used during flow construction. This type of layout
 /// node does not allow any parents or siblings of nodes to be accessed, to avoid races.
-pub trait ThreadSafeLayoutNode: Clone + Copy + Debug + GetLayoutData + NodeInfo + PartialEq + Sized {
+pub trait ThreadSafeLayoutNode: Clone + Copy + Debug + GetLayoutData + NodeInfo + PartialEq +
+                                Sized {
     type ConcreteThreadSafeLayoutElement:
         ThreadSafeLayoutElement<ConcreteThreadSafeLayoutNode = Self>
         + ::selectors::Element<Impl=SelectorImpl>;


### PR DESCRIPTION
See individual commits for details. This improves nytimes.com CPU usage and gets it within the ballpark of Firefox.

r? @emilio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14442)
<!-- Reviewable:end -->
