### PR TITLE
script: Ban `FnBox<()>` and lock down the dangerous generic `no_jsmanaged_fields!` implementations.

### DIFF
--- a/components/script/dom/bindings/weakref.rs
+++ b/components/script/dom/bindings/weakref.rs
@@ -133,8 +133,6 @@ impl<T: WeakReferenceable> PartialEq<T> for WeakRef<T> {
     }
 }
 
-no_jsmanaged_fields!(WeakRef<T: WeakReferenceable>);
-
 impl<T: WeakReferenceable> Drop for WeakRef<T> {
     fn drop(&mut self) {
         unsafe {

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -15,8 +15,6 @@ use js::jsapi::{JSContext, JSObject};
 use js::jsapi::{JS_GetArrayBufferViewType, Type};
 use rand::{OsRng, Rng};
 
-no_jsmanaged_fields!(OsRng);
-
 // https://developer.mozilla.org/en-US/docs/Web/API/Crypto
 #[dom_struct]
 pub struct Crypto {

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -16,9 +16,6 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 use style::stylesheets::{CssRules, KeyframesRule, RulesMutateError};
 
-no_jsmanaged_fields!(RulesSource);
-no_jsmanaged_fields!(CssRules);
-
 impl From<RulesMutateError> for Error {
     fn from(other: RulesMutateError) -> Self {
         match other {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3,9 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use core::nonzero::NonZero;
+use devtools_traits::ScriptToDevtoolsControlMsg;
 use document_loader::{DocumentLoader, LoadType};
 use dom::activation::{ActivationSource, synthetic_click_activation};
 use dom::attr::Attr;
+use dom::bindings::callback::ExceptionHandling;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
 use dom::bindings::codegen::Bindings::DocumentBinding;
@@ -18,6 +20,7 @@ use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::Bindings::NodeFilterBinding::NodeFilter;
 use dom::bindings::codegen::Bindings::PerformanceBinding::PerformanceMethods;
 use dom::bindings::codegen::Bindings::TouchBinding::TouchMethods;
+use dom::bindings::codegen::Bindings::WindowBinding::FrameRequestCallback;
 use dom::bindings::codegen::Bindings::WindowBinding::{ScrollBehavior, WindowMethods};
 use dom::bindings::codegen::UnionTypes::NodeOrString;
 use dom::bindings::error::{Error, ErrorResult, Fallible};
@@ -111,7 +114,6 @@ use servo_atoms::Atom;
 use servo_url::ServoUrl;
 use std::ascii::AsciiExt;
 use std::borrow::ToOwned;
-use std::boxed::FnBox;
 use std::cell::{Cell, Ref, RefMut};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
@@ -232,8 +234,7 @@ pub struct Document {
     animation_frame_ident: Cell<u32>,
     /// https://html.spec.whatwg.org/multipage/#list-of-animation-frame-callbacks
     /// List of animation frame callbacks
-    #[ignore_heap_size_of = "closures are hard"]
-    animation_frame_list: DOMRefCell<Vec<(u32, Option<Box<FnBox(f64)>>)>>,
+    animation_frame_list: DOMRefCell<Vec<(u32, AnimationFrameCallback)>>,
     /// Whether we're in the process of running animation callbacks.
     ///
     /// Tracking this is not necessary for correctness. Instead, it is an optimization to avoid
@@ -1457,11 +1458,11 @@ impl Document {
     }
 
     /// https://html.spec.whatwg.org/multipage/#dom-window-requestanimationframe
-    pub fn request_animation_frame(&self, callback: Box<FnBox(f64)>) -> u32 {
+    pub fn request_animation_frame(&self, callback: AnimationFrameCallback) -> u32 {
         let ident = self.animation_frame_ident.get() + 1;
 
         self.animation_frame_ident.set(ident);
-        self.animation_frame_list.borrow_mut().push((ident, Some(callback)));
+        self.animation_frame_list.borrow_mut().push((ident, callback));
 
         // No need to send a `ChangeRunningAnimationsState` if we're running animation callbacks:
         // we're guaranteed to already be in the "animation callbacks present" state.
@@ -1485,7 +1486,7 @@ impl Document {
     pub fn cancel_animation_frame(&self, ident: u32) {
         let mut list = self.animation_frame_list.borrow_mut();
         if let Some(mut pair) = list.iter_mut().find(|pair| pair.0 == ident) {
-            pair.1 = None;
+            pair.1 = AnimationFrameCallback::None
         }
     }
 
@@ -1496,10 +1497,8 @@ impl Document {
         self.running_animation_callbacks.set(true);
         let timing = self.window.Performance().Now();
 
-        for (_, callback) in animation_frame_list.drain(..) {
-            if let Some(callback) = callback {
-                callback(*timing);
-            }
+        for (_, mut callback) in animation_frame_list.drain(..) {
+            callback.call(*timing)
         }
 
         // Only send the animation change state message after running any callbacks.
@@ -3178,3 +3177,41 @@ pub enum FocusEventType {
     Focus,      // Element gained focus. Doesn't bubble.
     Blur,       // Element lost focus. Doesn't bubble.
 }
+
+#[derive(JSTraceable, HeapSizeOf)]
+pub enum AnimationFrameCallback {
+    None,
+    DevtoolsFramerateTick(DevtoolsFramerateTick),
+    FrameRequestCallback(FrameRequestCallbackWrapper),
+}
+
+impl AnimationFrameCallback {
+    pub fn call(&mut self, now: f64) {
+        match *self {
+            AnimationFrameCallback::None => {}
+            AnimationFrameCallback::DevtoolsFramerateTick(ref tick) => {
+                let msg = ScriptToDevtoolsControlMsg::FramerateTick(tick.actor_name.clone(), now);
+                tick.devtools_sender.send(msg).unwrap();
+            }
+            AnimationFrameCallback::FrameRequestCallback(ref callback) => {
+                // TODO(jdm): The spec says that any exceptions should be suppressed:
+                // https://github.com/servo/servo/issues/6928
+                let _ = callback.callback.Call__(Finite::wrap(now), ExceptionHandling::Report);
+            }
+        }
+    }
+}
+
+#[derive(JSTraceable, HeapSizeOf)]
+pub struct DevtoolsFramerateTick {
+    pub actor_name: String,
+    #[ignore_heap_size_of = "channels are hard"]
+    pub devtools_sender: IpcSender<ScriptToDevtoolsControlMsg>,
+}
+
+#[derive(JSTraceable, HeapSizeOf)]
+pub struct FrameRequestCallbackWrapper {
+    #[ignore_heap_size_of = "refcounted"]
+    pub callback: Rc<FrameRequestCallback>,
+}
+

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -50,8 +50,6 @@ use style::parser::ParserContextExtraData;
 use style::str::HTML_SPACE_CHARACTERS;
 use style::stylesheets::{Stylesheet, Origin};
 
-no_jsmanaged_fields!(Stylesheet);
-
 #[dom_struct]
 pub struct HTMLLinkElement {
     htmlelement: HTMLElement,

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -19,8 +19,6 @@ use msg::constellation_msg::{Key, KeyModifiers};
 use std::borrow::Cow;
 use std::cell::Cell;
 
-no_jsmanaged_fields!(Key);
-
 #[dom_struct]
 pub struct KeyboardEvent {
     uievent: UIEvent,

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -302,6 +302,7 @@ macro_rules! make_nonzero_dimension_setter(
 
 /// For use on non-jsmanaged types
 /// Use #[derive(JSTraceable)] on JS managed types
+/// Keep use of this scoped to `script/dom/bindings/trace.rs`.
 macro_rules! no_jsmanaged_fields(
     ([$ty:ident; $count:expr]) => (
         impl $crate::dom::bindings::trace::JSTraceable for [$ty; $count] {
@@ -320,22 +321,6 @@ macro_rules! no_jsmanaged_fields(
                 }
             }
         )+
-    );
-    ($ty:ident<$($gen:ident),+>) => (
-        impl<$($gen),+> $crate::dom::bindings::trace::JSTraceable for $ty<$($gen),+> {
-            #[inline]
-            fn trace(&self, _: *mut ::js::jsapi::JSTracer) {
-                // Do nothing
-            }
-        }
-    );
-    ($ty:ident<$($gen:ident: $bound:ident),+>) => (
-        impl<$($gen: $bound),+> $crate::dom::bindings::trace::JSTraceable for $ty<$($gen),+> {
-            #[inline]
-            fn trace(&self, _: *mut ::js::jsapi::JSTracer) {
-                // Do nothing
-            }
-        }
     );
 );
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2562,11 +2562,9 @@ impl<'a> UnbindContext<'a> {
 }
 
 /// A node's unique ID, for devtools.
-struct UniqueId {
+pub struct UniqueId {
     cell: UnsafeCell<Option<Box<Uuid>>>,
 }
-
-no_jsmanaged_fields!(UniqueId);
 
 impl HeapSizeOf for UniqueId {
     #[allow(unsafe_code)]

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -23,10 +23,8 @@ pub enum TexParameterValue {
     Int(i32),
 }
 
-const MAX_LEVEL_COUNT: usize = 31;
-const MAX_FACE_COUNT: usize = 6;
-
-no_jsmanaged_fields!([ImageInfo; MAX_LEVEL_COUNT * MAX_FACE_COUNT]);
+pub const MAX_LEVEL_COUNT: usize = 31;
+pub const MAX_FACE_COUNT: usize = 6;
 
 #[dom_struct]
 pub struct WebGLTexture {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -6,7 +6,6 @@ use app_units::Au;
 use bluetooth_traits::BluetoothRequest;
 use cssparser::Parser;
 use devtools_traits::{ScriptToDevtoolsControlMsg, TimelineMarker, TimelineMarkerType};
-use dom::bindings::callback::ExceptionHandling;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::DocumentBinding::{DocumentMethods, DocumentReadyState};
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
@@ -30,7 +29,7 @@ use dom::bindings::utils::{GlobalStaticData, WindowProxyHandler};
 use dom::browsingcontext::BrowsingContext;
 use dom::crypto::Crypto;
 use dom::cssstyledeclaration::{CSSModificationAccess, CSSStyleDeclaration};
-use dom::document::Document;
+use dom::document::{AnimationFrameCallback, Document, FrameRequestCallbackWrapper};
 use dom::element::Element;
 use dom::event::Event;
 use dom::globalscope::GlobalScope;
@@ -197,7 +196,7 @@ pub struct Window {
 
     /// A handle to perform RPC calls into the layout, quickly.
     #[ignore_heap_size_of = "trait objects are hard"]
-    layout_rpc: Box<LayoutRPC + 'static>,
+    layout_rpc: Box<LayoutRPC + Send + 'static>,
 
     /// The current size of the window, in pixels.
     window_size: Cell<Option<WindowSizeData>>,
@@ -600,14 +599,10 @@ impl WindowMethods for Window {
     /// https://html.spec.whatwg.org/multipage/#dom-window-requestanimationframe
     fn RequestAnimationFrame(&self, callback: Rc<FrameRequestCallback>) -> u32 {
         let doc = self.Document();
-
-        let callback = move |now: f64| {
-            // TODO: @jdm The spec says that any exceptions should be suppressed;
-            // https://github.com/servo/servo/issues/6928
-            let _ = callback.Call__(Finite::wrap(now), ExceptionHandling::Report);
+        let wrapper = FrameRequestCallbackWrapper {
+            callback: callback,
         };
-
-        doc.request_animation_frame(Box::new(callback))
+        doc.request_animation_frame(AnimationFrameCallback::FrameRequestCallback(wrapper))
     }
 
     /// https://html.spec.whatwg.org/multipage/#dom-window-cancelanimationframe
@@ -1546,7 +1541,7 @@ impl Window {
                parent_info: Option<(PipelineId, FrameType)>,
                window_size: Option<WindowSizeData>)
                -> Root<Window> {
-        let layout_rpc: Box<LayoutRPC> = {
+        let layout_rpc: Box<LayoutRPC + Send> = {
             let (rpc_send, rpc_recv) = channel();
             layout_chan.send(Msg::GetRPC(rpc_send)).unwrap();
             rpc_recv.recv().unwrap()

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -6,7 +6,6 @@
 #![feature(conservative_impl_trait)]
 #![feature(const_fn)]
 #![feature(core_intrinsics)]
-#![feature(fnbox)]
 #![feature(mpsc_select)]
 #![feature(nonzero)]
 #![feature(on_unimplemented)]


### PR DESCRIPTION
Closes #14416.

The basic cause for that UAF was the unsafe use of `FnBox<()>` in the rooting protocol for the JS engine integration. This patch fixes that bug and removes all generics and existentials from the no-op tracing, as they were all dangerous. There should be no more ways to get UAF from DOM heap rooting without writing custom trace hooks.

r? @nox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14443)
<!-- Reviewable:end -->
