### PR TITLE
stylo: Use impl_app_units for -webkit-text-stroke-width property.

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1992,12 +1992,8 @@ fn static_assert() {
         self.gecko.mTextEmphasisStyle = other.gecko.mTextEmphasisStyle;
     }
 
-    #[allow(non_snake_case)]
-    pub fn set__webkit_text_stroke_width(&mut self, v: longhands::_webkit_text_stroke_width::computed_value::T) {
-        self.gecko.mWebkitTextStrokeWidth.set_value(CoordDataValue::Coord(v.0));
-    }
-
-    <%call expr="impl_coord_copy('_webkit_text_stroke_width', 'mWebkitTextStrokeWidth')"></%call>
+    <% impl_app_units("_webkit_text_stroke_width", "mWebkitTextStrokeWidth", need_clone=False,
+                      round_to_pixels=False) %>
 
 </%self:impl_trait>
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is a follow up for #14358.

After [gecko bug 1320239](https://bugzilla.mozilla.org/show_bug.cgi?id=1320239), we now use nscoord for -webkit-text-stroke-width
property. So, we can use impl_app_units for the gecko glue code.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

After gecko bug 1320239, we now use nscoord for -webkit-text-stroke-width
property. So, we can use impl_app_units for the gecko glue code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14449)
<!-- Reviewable:end -->
