### PR TITLE
Implement tidy commit message test

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -942,6 +942,21 @@ def run_lint_scripts(only_changed_files=False, progress=True):
             yield error
 
 
+def check_commits(path='.'):
+    """Gets all commits since the last merge."""
+    args = ['git', 'log', '-n1', '--merges', '--format=%H']
+    last_merge = subprocess.check_output(args, cwd=path).strip()
+    args = ['git', 'log', '{}..HEAD'.format(last_merge), '--format=%s']
+    commits = subprocess.check_output(args, cwd=path).lower().splitlines()
+
+    for commit in commits:
+        # .split() to only match entire words
+        if 'wip' in commit.split():
+            yield ('.', 0, 'no commits should contain WIP')
+
+    raise StopIteration
+
+
 def scan(only_changed_files=False, progress=True):
     # check config file for errors
     config_errors = check_config_file(CONFIG_FILE_PATH)
@@ -957,8 +972,11 @@ def scan(only_changed_files=False, progress=True):
     dep_license_errors = check_dep_license_errors(get_dep_toml_files(only_changed_files), progress)
     # other lint checks
     lint_errors = run_lint_scripts(only_changed_files, progress)
+    # check commits for WIP
+    commit_errors = check_commits()
     # chain all the iterators
-    errors = itertools.chain(config_errors, directory_errors, file_errors, dep_license_errors, lint_errors)
+    errors = itertools.chain(config_errors, directory_errors, file_errors, dep_license_errors, lint_errors,
+                             commit_errors)
 
     error = None
     for error in errors:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Makes tidy check commit messages since the latest merge, failing if one of them contains the string "WIP".

I have written a test for my changes, although it is a bit hacky.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14388.

<!-- Either: -->
- [x] These changes do not require tests because this would require playing with a new/existing git repo

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14450)
<!-- Reviewable:end -->
