### PR TITLE
Fix current_dom_depth in sequential traversal. (fixes #14414)

### DIFF
--- a/components/style/sequential.rs
+++ b/components/style/sequential.rs
@@ -24,8 +24,9 @@ pub fn traverse_dom<N, C>(root: N,
 
             C::traverse_children(el, |kid| doit::<N, C>(context, kid, data));
 
-            // NB: Data is unused now, but we can always decrement the count
-            // here if we need it for the post-order one :)
+            if let Some(ref mut depth) = data.current_dom_depth {
+                *depth -= 1;
+            }
         }
 
         if context.needs_postorder_traversal() {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Since we pass around a reference to the one `PerLevelTraversalData` object in sequential traversal, we must update it after we process children.  Alternatively, we could switch to what the parallel traversal is doing and clone the object when passing it down.

r? @emilio 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14414 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14459)
<!-- Reviewable:end -->
