### PR TITLE
Implement scroll transactions

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -31,6 +31,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::rc::Rc;
 use std::sync::mpsc::Sender;
+use std::time::{Duration, Instant};
 use style_traits::{PagePx, ViewportPx};
 use style_traits::viewport::ViewportConstraints;
 use time::{precise_time_ns, precise_time_s};
@@ -197,6 +198,8 @@ pub struct IOCompositor<Window: WindowMethods> {
 
     /// Whether a scroll is in progress; i.e. whether the user's fingers are down.
     scroll_in_progress: bool,
+
+    in_scroll_transaction: Option<Instant>,
 
     /// The webrender renderer.
     webrender: webrender::Renderer,
@@ -396,6 +399,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             last_composite_time: 0,
             ready_to_save_state: ReadyState::Unknown,
             scroll_in_progress: false,
+            in_scroll_transaction: None,
             webrender: state.webrender,
             webrender_api: state.webrender_api_sender.create_api(),
         }
@@ -1068,11 +1072,17 @@ impl<Window: WindowMethods> IOCompositor<Window> {
     fn on_scroll_window_event(&mut self,
                               delta: TypedPoint2D<f32, DevicePixel>,
                               cursor: TypedPoint2D<i32, DevicePixel>) {
+        let event_phase = match (self.scroll_in_progress, self.in_scroll_transaction) {
+            (false, Some(last_scroll)) if last_scroll.elapsed() > Duration::from_millis(80) =>
+                ScrollEventPhase::Start,
+            (_, _) => ScrollEventPhase::Move(self.scroll_in_progress),
+        };
+        self.in_scroll_transaction = Some(Instant::now());
         self.pending_scroll_zoom_events.push(ScrollZoomEvent {
             magnification: 1.0,
             delta: delta,
             cursor: cursor,
-            phase: ScrollEventPhase::Move(self.scroll_in_progress),
+            phase: event_phase,
             event_count: 1,
         });
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
@glennw Here is a first pass at faking Start scroll events by way of 'transactions', as suggested by @mstange at https://github.com/servo/webrender/pull/599#issuecomment-263323105

Since I still don't have a Linux environment available for testing(and my Mac doesn't have enough resources to run a VM at the moment), I tested this with both https://github.com/servo/webrender/pull/599 and https://github.com/servo/webrender/pull/600 on a Mac by:

* disabling start and end events by removing the content of these two functions: https://github.com/servo/servo/blob/master/components/compositing/compositor.rs#L1080 and https://github.com/servo/servo/blob/master/components/compositing/compositor.rs#L1093

* Setting `CAN_OVERSCROLL` to false for Mac OS in Webrender https://github.com/servo/webrender/blob/master/webrender/src/frame.rs#L29

* This PR also requires a `./mach update-cargo -a`

The desired behavior of both Webrender PR's, based on my manual testing, now also works when there are no end or start scroll events provided by the os. The scroll transactions do not affect normal scrolling on Mac OS, and both PR still work as before on that platform.

Both PR in Webrender need some re-basing and cleaning up, as does this one, and I first wanted to put this proposal forward, and also ask if someone has the time to do some testing in a real Linux environment...

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13249 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14470)
<!-- Reviewable:end -->
