### PR TITLE
Bump rust-openssl, add support for OpenSSL 1.1.0 [WIP]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
  "devtools_traits 0.0.1",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper_serde 0.2.0",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -570,7 +570,7 @@ dependencies = [
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper_serde 0.2.0",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1142,17 +1142,6 @@ dependencies = [
 
 [[package]]
 name = "hyper_serde"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hyper_serde"
 version = "0.2.0"
 dependencies = [
  "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1628,7 +1617,7 @@ dependencies = [
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-openssl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper_serde 0.2.0",
  "immeta 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1677,7 +1666,7 @@ dependencies = [
  "devtools_traits 0.0.1",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper_serde 0.2.0",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net 0.0.1",
@@ -2181,7 +2170,7 @@ dependencies = [
  "html5ever 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever-atoms 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper_serde 0.2.0",
  "image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js 0.1.3 (git+https://github.com/servo/rust-mozjs)",
@@ -3286,7 +3275,6 @@ dependencies = [
 "checksum httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46534074dbb80b070d60a5cb8ecadd8963a00a438ae1a95268850a7ef73b67ae"
 "checksum hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "86ea0c0ff7e6ef09eff72234800ddb48b6263277936e7ecd6ecd3250345d705f"
 "checksum hyper-openssl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f65182c46bc87621207a0b7238c18f350f325b7e970910aa4944165452b5b02e"
-"checksum hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "572d2168173019de312a050a24f2ad33ac2ac7895a2139fbf21ee6b6f470a24e"
 "checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
 "checksum image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "559d5ebbe9ec73111799e49c07717944b244f8accf5de33a8a8128bc3ecd2e00"
 "checksum immeta 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3e76ecb1d64979a91c7fc5b7c0495ef1467e3cbff759044f2b88878a5a845ef7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
  "devtools_traits 0.0.1",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
+ "hyper_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -570,7 +570,7 @@ dependencies = [
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
+ "hyper_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "hyper_serde"
 version = "0.2.0"
-source = "git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie#e5223ca3363fcc4098d24a50075a3fe6c37e31bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1617,7 +1617,7 @@ dependencies = [
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-openssl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
+ "hyper_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "immeta 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1666,7 +1666,7 @@ dependencies = [
  "devtools_traits 0.0.1",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
+ "hyper_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net 0.0.1",
@@ -1689,7 +1689,7 @@ dependencies = [
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
+ "hyper_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2170,7 +2170,7 @@ dependencies = [
  "html5ever 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever-atoms 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
+ "hyper_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js 0.1.3 (git+https://github.com/servo/rust-mozjs)",
@@ -2266,7 +2266,7 @@ dependencies = [
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
+ "hyper_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -3267,7 +3267,7 @@ dependencies = [
 "checksum httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46534074dbb80b070d60a5cb8ecadd8963a00a438ae1a95268850a7ef73b67ae"
 "checksum hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "86ea0c0ff7e6ef09eff72234800ddb48b6263277936e7ecd6ecd3250345d705f"
 "checksum hyper-openssl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f65182c46bc87621207a0b7238c18f350f325b7e970910aa4944165452b5b02e"
-"checksum hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)" = "<none>"
+"checksum hyper_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9aed306c437dec2690f0ebf7414e5c881005890768658884c2000cd97981e325"
 "checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
 "checksum image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "559d5ebbe9ec73111799e49c07717944b244f8accf5de33a8a8128bc3ecd2e00"
 "checksum immeta 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3e76ecb1d64979a91c7fc5b7c0495ef1467e3cbff759044f2b88878a5a845ef7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,23 +1143,23 @@ dependencies = [
 [[package]]
 name = "hyper_serde"
 version = "0.1.6"
-dependencies = [
- "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_test 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hyper_serde"
-version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper_serde"
+version = "0.2.0"
+dependencies = [
+ "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_test 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1699,7 +1699,7 @@ dependencies = [
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.1.6",
+ "hyper_serde 0.2.0",
  "image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2276,7 +2276,7 @@ dependencies = [
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.1.6",
+ "hyper_serde 0.2.0",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 name = "webdriver_server"
 version = "0.0.1"
 dependencies = [
- "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -47,6 +47,11 @@ dependencies = [
  "cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "app_units"
@@ -416,7 +421,16 @@ name = "cookie"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cookie"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "openssl 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -534,7 +548,7 @@ version = "0.0.1"
 dependencies = [
  "devtools_traits 0.0.1",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -554,7 +568,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -1097,7 +1111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1106,8 +1120,6 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1118,12 +1130,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-openssl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hyper_serde"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1389,14 +1411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libressl-pnacl-sys"
-version = "2.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "pnacl-build-helper 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "libservo"
 version = "0.0.1"
 dependencies = [
@@ -1597,10 +1611,11 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "brotli 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "content-blocker 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-openssl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "immeta 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1611,8 +1626,6 @@ dependencies = [
  "mime_guess 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
- "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "profile_traits 0.0.1",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1627,7 +1640,7 @@ dependencies = [
  "util 0.0.1",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_traits 0.11.0 (git+https://github.com/servo/webrender)",
- "websocket 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "websocket 0.17.1 (git+https://github.com/dten/rust-websocket.git?branch=openssl_0.9.1)",
 ]
 
 [[package]]
@@ -1647,10 +1660,10 @@ name = "net_tests"
 version = "0.0.1"
 dependencies = [
  "content-blocker 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -1670,10 +1683,10 @@ name = "net_traits"
 version = "0.0.1"
 dependencies = [
  "bluetooth_traits 0.0.1",
- "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1688,7 +1701,7 @@ dependencies = [
  "util 0.0.1",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_traits 0.11.0 (git+https://github.com/servo/webrender)",
- "websocket 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "websocket 0.17.1 (git+https://github.com/dten/rust-websocket.git?branch=openssl_0.9.1)",
 ]
 
 [[package]]
@@ -1844,45 +1857,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl"
-version = "0.7.14"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys-extras 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.7.17"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "openssl-sys-extras"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "openssl-verify"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1995,14 +1987,6 @@ name = "plugins"
 version = "0.0.1"
 dependencies = [
  "clippy_lints 0.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pnacl-build-helper"
-version = "1.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2172,7 +2156,7 @@ dependencies = [
  "canvas_traits 0.0.1",
  "caseless 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2183,7 +2167,7 @@ dependencies = [
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever-atoms 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2224,7 +2208,7 @@ dependencies = [
  "util 0.0.1",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_traits 0.11.0 (git+https://github.com/servo/webrender)",
- "websocket 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "websocket 0.17.1 (git+https://github.com/dten/rust-websocket.git?branch=openssl_0.9.1)",
  "xml5ever 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2273,13 +2257,13 @@ dependencies = [
  "app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bluetooth_traits 0.0.1",
  "canvas_traits 0.0.1",
- "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "euclid 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2753,14 +2737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tempfile"
 version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3044,7 +3020,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.76 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3098,13 +3074,13 @@ dependencies = [
 [[package]]
 name = "websocket"
 version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/dten/rust-websocket.git?branch=openssl_0.9.1#4fea855d4db04ab82e369e5709cd962dc766ed8f"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3200,6 +3176,7 @@ dependencies = [
 "checksum alloc-no-stdlib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b21f6ad9c9957eb5d70c3dee16d31c092b3cab339628f821766b05e6833d72b8"
 "checksum android_glue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e2b80445d331077679dfc6f3014f3e9ab7083e588423d35041d3fc017198189"
 "checksum angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)" = "<none>"
+"checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "636ee56f12e31dbc11dc0a1ac6004f08b04e6e6595963716fc8130e90d4e04cf"
 "checksum arrayvec 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "80a137392e2e92ce7387c063d98a11f0d47115426c5f8759657af3c7b385c860"
 "checksum audio-video-metadata 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "03da2550cb89fe3faf218c179261c26cf7891c4234707c15f5d09ebb32ae2400"
@@ -3229,6 +3206,7 @@ dependencies = [
 "checksum compiletest_rs 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "28d60af0dbee4912f00dda79ac3b06d1ca44b641d69359e6f1d4df7c985521d2"
 "checksum content-blocker 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0d86cb81505503bbfb0d47cf7e12be2e69205a75e70c4da84998e39b96b7f1"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
+"checksum cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24fcc697127e82832d93475e73ff2a020d371fadd45c43a0522c441095ef8846"
 "checksum core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "20a6d0448d3a99d977ae4a2aa5a98d886a923e863e81ad9ff814645b6feb3bbd"
 "checksum core-foundation-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "05eed248dc504a5391c63794fe4fb64f46f071280afaa1b73308f3c0ce4574c5"
 "checksum core-graphics 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "66e998abb8823fecd2a8a7205429b17a340d447d8c69b3bce86846dcdea3e33b"
@@ -3285,7 +3263,8 @@ dependencies = [
 "checksum html5ever 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "45815593feb142cf01121b9f413d8630c9902192d160e494a579c50628eef498"
 "checksum html5ever-atoms 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "daefa106438c66af58309c84842b5db1df2733fe35849f39adde6fdf63583d40"
 "checksum httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46534074dbb80b070d60a5cb8ecadd8963a00a438ae1a95268850a7ef73b67ae"
-"checksum hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "edd47c66782933e546a32ae89ca3c49263b2ba9bc29f3a0d5c52fff48e0ac67c"
+"checksum hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "86ea0c0ff7e6ef09eff72234800ddb48b6263277936e7ecd6ecd3250345d705f"
+"checksum hyper-openssl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f65182c46bc87621207a0b7238c18f350f325b7e970910aa4944165452b5b02e"
 "checksum hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "572d2168173019de312a050a24f2ad33ac2ac7895a2139fbf21ee6b6f470a24e"
 "checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
 "checksum image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "559d5ebbe9ec73111799e49c07717944b244f8accf5de33a8a8128bc3ecd2e00"
@@ -3305,7 +3284,6 @@ dependencies = [
 "checksum leaky-cow 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40a8225d44241fd324a8af2806ba635fc7c8a7e9a7de4d5cf3ef54e71f5926fc"
 "checksum libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "044d1360593a78f5c8e5e710beccdc24ab71d1f01bc19a29bcacdba22e8475d8"
 "checksum libloading 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "eceb2637ee9a27c7f19764048a9f377e40e3a70a322722f348e6bc7704d565f2"
-"checksum libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cbc058951ab6a3ef35ca16462d7642c4867e6403520811f28537a4e2f2db3e71"
 "checksum libz-sys 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "40f2df7730b5d29426c3e44ce4d088d8c5def6471c2c93ba98585b89fb201ce6"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
@@ -3339,10 +3317,8 @@ dependencies = [
 "checksum ogg 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "426d8dc59cdd206be1925461087350385c0a02f291d87625829c6d08e72b457b"
 "checksum ogg_metadata 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e755cc735fa6faa709cb23048433d9201d6caa85fa96215386ccdd5e9b40ad01"
 "checksum open 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c228597177bc4a6876e278f7c7948ac033bfcb4d163ccdd5a009557c8fe5fa1e"
-"checksum openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)" = "c4117b6244aac42ed0150a6019b4d953d28247c5dd6ae6f46ae469b5f2318733"
-"checksum openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)" = "89c47ee94c352eea9ddaf8e364be7f978a3bb6d66d73176572484238dd5a5c3f"
-"checksum openssl-sys-extras 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)" = "11c5e1dba7d3d03d80f045bf0d60111dc69213b67651e7c889527a3badabb9fa"
-"checksum openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ed86cce894f6b0ed4572e21eb34026f1dc8869cb9ee3869029131bc8c3feb2d"
+"checksum openssl 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c368aec980860439ea434b98dd622b1e09f720c6762308854ef4b9e2e82771ad"
+"checksum openssl-sys 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "58acf9d02ba8903c7c664df3037f4c04935e968d9f3932232400fa60364de62a"
 "checksum ordered-float 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cc511538298611a79d5a4ddfbb75315b866d942ed26a00bdc3590795c68b7279"
 "checksum osmesa-src 12.0.1 (git+https://github.com/servo/osmesa-src)" = "<none>"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
@@ -3355,7 +3331,6 @@ dependencies = [
 "checksum phf_macros 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "619b2c128703c63376de760377600b924fc0257487f51bc156f596cf8762e497"
 "checksum phf_shared 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "286385a0e50d4147bce15b2c19f0cf84c395b0e061aaf840898a7bf664c2cfb7"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
-"checksum pnacl-build-helper 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "61c9231d31aea845007443d62fcbb58bb6949ab9c18081ee1e09920e0cf1118b"
 "checksum png 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "06208e2ee243e3118a55dda9318f821f206d8563fb8d4df258767f8e62bb0997"
 "checksum quickersort 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e952ea7699262481636004bc4ab8afaccf2bc13f91b79d1aee6617bd8fc39651"
 "checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
@@ -3403,7 +3378,6 @@ dependencies = [
 "checksum syntex_pos 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a43abded5057c75bac8555e46ec913ce502efb418267b1ab8e9783897470c7db"
 "checksum syntex_syntax 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ef781e4b60f03431f1b5b59843546ce60ae029a787770cf8e0969ac1fd063a5"
 "checksum target_build_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a1be18d4d908e4e5697908de04fdd5099505463fc8eaf1ceb8133ae486936aa"
-"checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9270837a93bad1b1dac18fe67e786b3c960513af86231f6f4f57fddd594ff0c8"
 "checksum tendril 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cebf864c2d90394a1b66d6fe45963f9a177f2af81a0edea5060f77627f9c4587"
 "checksum term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3deff8a2b3b6607d6d7cc32ac25c0b33709453ca9cceac006caac51e963cf94a"
@@ -3437,7 +3411,7 @@ dependencies = [
 "checksum webdriver 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d43d9121a4d0313abca5fb621f094791300176cac493ce74ad2cc188bddac29"
 "checksum webrender 0.11.0 (git+https://github.com/servo/webrender)" = "<none>"
 "checksum webrender_traits 0.11.0 (git+https://github.com/servo/webrender)" = "<none>"
-"checksum websocket 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a1a6ea5ed0367f32eb3d94dcc58859ef4294b5f75ba983dbf56ac314af45d"
+"checksum websocket 0.17.1 (git+https://github.com/dten/rust-websocket.git?branch=openssl_0.9.1)" = "<none>"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7c47e9ca2f5c47d27f731b1bb9bb50cc05f9886bb84fbd52afa0ff97f4f61b06"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
  "devtools_traits 0.0.1",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0",
+ "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -570,7 +570,7 @@ dependencies = [
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0",
+ "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1143,12 +1143,12 @@ dependencies = [
 [[package]]
 name = "hyper_serde"
 version = "0.2.0"
+source = "git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie#e5223ca3363fcc4098d24a50075a3fe6c37e31bd"
 dependencies = [
  "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_test 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1617,7 +1617,7 @@ dependencies = [
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-openssl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0",
+ "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
  "immeta 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1666,7 +1666,7 @@ dependencies = [
  "devtools_traits 0.0.1",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0",
+ "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net 0.0.1",
@@ -1689,7 +1689,7 @@ dependencies = [
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0",
+ "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
  "image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2170,7 +2170,7 @@ dependencies = [
  "html5ever 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever-atoms 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0",
+ "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
  "image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js 0.1.3 (git+https://github.com/servo/rust-mozjs)",
@@ -2266,7 +2266,7 @@ dependencies = [
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.2.0",
+ "hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -2348,14 +2348,6 @@ dependencies = [
  "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_test"
-version = "0.8.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
  "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3275,6 +3267,7 @@ dependencies = [
 "checksum httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46534074dbb80b070d60a5cb8ecadd8963a00a438ae1a95268850a7ef73b67ae"
 "checksum hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "86ea0c0ff7e6ef09eff72234800ddb48b6263277936e7ecd6ecd3250345d705f"
 "checksum hyper-openssl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f65182c46bc87621207a0b7238c18f350f325b7e970910aa4944165452b5b02e"
+"checksum hyper_serde 0.2.0 (git+https://github.com/frewsxcv/hyper_serde.git?branch=bump-cookie)" = "<none>"
 "checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
 "checksum image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "559d5ebbe9ec73111799e49c07717944b244f8accf5de33a8a8128bc3ecd2e00"
 "checksum immeta 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3e76ecb1d64979a91c7fc5b7c0495ef1467e3cbff759044f2b88878a5a845ef7"
@@ -3362,7 +3355,6 @@ dependencies = [
 "checksum serde_codegen_internals 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "59933a62554548c690d2673c5164f0c4a46be7c5731edfd94b0ecb1048940732"
 "checksum serde_derive 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)" = "d91be8acdeb9128d3a074986a36b90fc8ad0a3001c6bd1231aea219ae790aa4a"
 "checksum serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e10f8a9d94b06cf5d3bef66475f04c8ff90950f1be7004c357ff9472ccbaebc"
-"checksum serde_test 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6c2122529606178685adf8f0f59d5975fafbad3cc3a5d92f8cd42ac9d02dda7c"
 "checksum servo-egl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21069a884c33fe6ee596975e1f3849ed88c4ec857fbaf11d33672d8ebe051217"
 "checksum servo-fontconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "93f799b649b4a2bf362398910eca35240704c7e765e780349b2bb1070d892262"
 "checksum servo-fontconfig-sys 4.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a0af4a4d7746467921486e5c5420f815cc016a6bf5574210d8e9c00f4afae224"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,6 +1638,7 @@ dependencies = [
  "mime_guess 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
+ "openssl 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugins 0.0.1",
  "profile_traits 0.0.1",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "openssl 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1142,6 +1143,17 @@ dependencies = [
 [[package]]
 name = "hyper_serde"
 version = "0.1.6"
+dependencies = [
+ "cookie 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_test 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper_serde"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1687,7 +1699,7 @@ dependencies = [
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper_serde 0.1.6",
  "image 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2264,7 +2276,7 @@ dependencies = [
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper_serde 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper_serde 0.1.6",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -2346,6 +2358,14 @@ dependencies = [
  "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_test"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
  "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3353,6 +3373,7 @@ dependencies = [
 "checksum serde_codegen_internals 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "59933a62554548c690d2673c5164f0c4a46be7c5731edfd94b0ecb1048940732"
 "checksum serde_derive 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)" = "d91be8acdeb9128d3a074986a36b90fc8ad0a3001c6bd1231aea219ae790aa4a"
 "checksum serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e10f8a9d94b06cf5d3bef66475f04c8ff90950f1be7004c357ff9472ccbaebc"
+"checksum serde_test 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6c2122529606178685adf8f0f59d5975fafbad3cc3a5d92f8cd42ac9d02dda7c"
 "checksum servo-egl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21069a884c33fe6ee596975e1f3849ed88c4ec857fbaf11d33672d8ebe051217"
 "checksum servo-fontconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "93f799b649b4a2bf362398910eca35240704c7e765e780349b2bb1070d892262"
 "checksum servo-fontconfig-sys 4.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a0af4a4d7746467921486e5c5420f815cc016a6bf5574210d8e9c00f4afae224"

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -13,8 +13,7 @@ path = "lib.rs"
 devtools_traits = {path = "../devtools_traits"}
 encoding = "0.2"
 hyper = {version = "0.9.9", default-features = false}
-# hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
+hyper_serde = "0.2"
 ipc-channel = "0.5"
 log = "0.3.5"
 msg = {path = "../msg"}

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -12,8 +12,8 @@ path = "lib.rs"
 [dependencies]
 devtools_traits = {path = "../devtools_traits"}
 encoding = "0.2"
-hyper = "0.9.9"
-hyper_serde = "0.1.4"
+hyper = {version = "0.9.9", default-features = false}
+hyper_serde = {version = "0.1.4", default-features = false}
 ipc-channel = "0.5"
 log = "0.3.5"
 msg = {path = "../msg"}

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -14,7 +14,7 @@ devtools_traits = {path = "../devtools_traits"}
 encoding = "0.2"
 hyper = {version = "0.9.9", default-features = false}
 # hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {path = "../../hyper_serde"}
+hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
 ipc-channel = "0.5"
 log = "0.3.5"
 msg = {path = "../msg"}

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -13,7 +13,8 @@ path = "lib.rs"
 devtools_traits = {path = "../devtools_traits"}
 encoding = "0.2"
 hyper = {version = "0.9.9", default-features = false}
-hyper_serde = {version = "0.1.4", default-features = false}
+# hyper_serde = {version = "0.1.4", default-features = false}
+hyper_serde = {path = "../../hyper_serde"}
 ipc-channel = "0.5"
 log = "0.3.5"
 msg = {path = "../msg"}

--- a/components/devtools_traits/Cargo.toml
+++ b/components/devtools_traits/Cargo.toml
@@ -15,7 +15,7 @@ heapsize = "0.3.0"
 heapsize_derive = "0.1"
 hyper = {version = "0.9.9", default-features = false}
 # hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {path = "../../hyper_serde"}
+hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
 ipc-channel = "0.5"
 msg = {path = "../msg"}
 serde = "0.8"

--- a/components/devtools_traits/Cargo.toml
+++ b/components/devtools_traits/Cargo.toml
@@ -13,8 +13,8 @@ path = "lib.rs"
 bitflags = "0.7"
 heapsize = "0.3.0"
 heapsize_derive = "0.1"
-hyper = "0.9.9"
-hyper_serde = "0.1.4"
+hyper = {version = "0.9.9", default-features = false}
+hyper_serde = {version = "0.1.4", default-features = false}
 ipc-channel = "0.5"
 msg = {path = "../msg"}
 serde = "0.8"

--- a/components/devtools_traits/Cargo.toml
+++ b/components/devtools_traits/Cargo.toml
@@ -14,7 +14,8 @@ bitflags = "0.7"
 heapsize = "0.3.0"
 heapsize_derive = "0.1"
 hyper = {version = "0.9.9", default-features = false}
-hyper_serde = {version = "0.1.4", default-features = false}
+# hyper_serde = {version = "0.1.4", default-features = false}
+hyper_serde = {path = "../../hyper_serde"}
 ipc-channel = "0.5"
 msg = {path = "../msg"}
 serde = "0.8"

--- a/components/devtools_traits/Cargo.toml
+++ b/components/devtools_traits/Cargo.toml
@@ -14,8 +14,7 @@ bitflags = "0.7"
 heapsize = "0.3.0"
 heapsize_derive = "0.1"
 hyper = {version = "0.9.9", default-features = false}
-# hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
+hyper_serde = "0.2"
 ipc-channel = "0.5"
 msg = {path = "../msg"}
 serde = "0.8"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -18,8 +18,7 @@ devtools_traits = {path = "../devtools_traits"}
 flate2 = "0.2.0"
 hyper = {version = "0.9.9", default-features = false}
 hyper-openssl = "0.1"
-# hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
+hyper_serde = "0.2"
 immeta = "0.3.1"
 ipc-channel = "0.5"
 lazy_static = "0.2"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -18,7 +18,8 @@ devtools_traits = {path = "../devtools_traits"}
 flate2 = "0.2.0"
 hyper = {version = "0.9.9", default-features = false}
 hyper-openssl = "0.1"
-hyper_serde = {version = "0.1.4", default-features = false}
+# hyper_serde = {version = "0.1.4", default-features = false}
+hyper_serde = {path = "../../hyper_serde"}
 immeta = "0.3.1"
 ipc-channel = "0.5"
 lazy_static = "0.2"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -19,7 +19,7 @@ flate2 = "0.2.0"
 hyper = {version = "0.9.9", default-features = false}
 hyper-openssl = "0.1"
 # hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {path = "../../hyper_serde"}
+hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
 immeta = "0.3.1"
 ipc-channel = "0.5"
 lazy_static = "0.2"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -28,6 +28,7 @@ mime = "0.2.1"
 mime_guess = "1.8.0"
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}
+openssl = "0.9"
 plugins = {path = "../plugins"}
 profile_traits = {path = "../profile_traits"}
 rustc-serialize = "0.3"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -16,8 +16,9 @@ content-blocker = "0.2.1"
 cookie = {version = "0.2.5", features = ["serialize-rustc"]}
 devtools_traits = {path = "../devtools_traits"}
 flate2 = "0.2.0"
-hyper = "0.9.9"
-hyper_serde = "0.1.4"
+hyper = {version = "0.9.9", default-features = false}
+hyper-openssl = "0.1"
+hyper_serde = {version = "0.1.4", default-features = false}
 immeta = "0.3.1"
 ipc-channel = "0.5"
 lazy_static = "0.2"
@@ -27,8 +28,6 @@ mime = "0.2.1"
 mime_guess = "1.8.0"
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}
-openssl = "0.7.6"
-openssl-verify = "0.1"
 plugins = {path = "../plugins"}
 profile_traits = {path = "../profile_traits"}
 rustc-serialize = "0.3"
@@ -41,7 +40,7 @@ unicase = "1.4.0"
 url = {version = "1.2", features = ["heap_size", "rustc-serialize"]}
 util = {path = "../util"}
 uuid = {version = "0.3.1", features = ["v4"]}
-websocket = "0.17"
+websocket = {git = "https://github.com/dten/rust-websocket.git", branch = "openssl_0.9.1" }
 
 [dependencies.webrender_traits]
 git = "https://github.com/servo/webrender"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 bitflags = "0.7"
 brotli = "1.0.6"
 content-blocker = "0.2.1"
-cookie = {version = "0.2.5", features = ["serialize-rustc"]}
+cookie = {version = "0.4", features = ["serialize-rustc"]}
 devtools_traits = {path = "../devtools_traits"}
 flate2 = "0.2.0"
 hyper = {version = "0.9.9", default-features = false}

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -34,13 +34,13 @@ pub fn create_http_connector() -> Arc<Pool<Connector>> {
         .join("certs");
     let mut ssl_connector_builder = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
     {
-        let ssl_context_builder = connector_builder.builder_mut();
+        let ssl_context_builder = ssl_connector_builder.builder_mut();
         ssl_context_builder.set_ca_file(ca_file).expect("could not set CA file");
         ssl_context_builder.set_cipher_list(DEFAULT_CIPHERS).expect("could not set ciphers");
         ssl_context_builder.set_options(SSL_OP_NO_SSLV2 | SSL_OP_NO_SSLV3 | SSL_OP_NO_COMPRESSION);
     }
-    let ssl_connector = connector_builder.build();
-    let ssl_client = OpensslClient::from(connector);
+    let ssl_connector = ssl_connector_builder.build();
+    let ssl_client = OpensslClient::from(ssl_connector);
     let https_connector = HttpsConnector::new(ssl_client);
     Arc::new(Pool::with_connector(Default::default(), https_connector))
 }

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -52,9 +52,6 @@ impl SslClient for ServoSslClient {
         let mut ssl = try!(Ssl::new(&self.context));
         try!(ssl.set_hostname(host));
         let host = host.to_owned();
-        ssl.set_verify_callback(SSL_VERIFY_PEER, move |p, x| {
-            ::openssl_verify::verify_callback(&host, p, x)
-        });
         SslStream::connect(ssl, stream).map_err(From::from)
     }
 }

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use hyper::client::Pool;
-use hyper::net::{HttpStream, HttpsConnector, SslClient};
+use hyper::net::HttpsConnector;
 use hyper_openssl::OpensslClient;
 use openssl::ssl::{SSL_OP_NO_COMPRESSION, SSL_OP_NO_SSLV2, SSL_OP_NO_SSLV3, SSL_VERIFY_PEER};
-use openssl::ssl::{Ssl, SslConnectorBuilder, SslContext, SslMethod, SslStream};
+use openssl::ssl::{SslConnectorBuilder, SslMethod};
 use std::sync::Arc;
 use util::resource_files::resources_dir_path;
 

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -37,7 +37,6 @@ pub fn create_http_connector() -> Arc<Pool<Connector>> {
         let ssl_context_builder = ssl_connector_builder.builder_mut();
         ssl_context_builder.set_ca_file(ca_file).expect("could not set CA file");
         ssl_context_builder.set_cipher_list(DEFAULT_CIPHERS).expect("could not set ciphers");
-        ssl_context_builder.set_options(SSL_OP_NO_SSLV2 | SSL_OP_NO_SSLV3 | SSL_OP_NO_COMPRESSION);
     }
     let ssl_connector = ssl_connector_builder.build();
     let ssl_client = OpensslClient::from(ssl_connector);

--- a/components/net/cookie.rs
+++ b/components/net/cookie.rs
@@ -6,6 +6,7 @@
 //! http://tools.ietf.org/html/rfc6265
 
 use cookie_rs;
+use hyper;
 use net_traits::CookieSource;
 use net_traits::pub_domains::is_pub_domain;
 use servo_url::ServoUrl;
@@ -87,6 +88,22 @@ impl Cookie {
             last_access: now(),
             expiry_time: expiry_time,
         })
+    }
+
+    pub fn new_wrapped_hyper(cookie: hyper::header::CookiePair, request: &ServoUrl,
+                             source: CookieSource) -> Option<Cookie> {
+        let cookie = cookie_rs::Cookie {
+            name: cookie.name,
+            value: cookie.value,
+            expires: cookie.expires,
+            max_age: cookie.max_age,
+            domain: cookie.domain,
+            path: cookie.path,
+            secure: cookie.secure,
+            httponly: cookie.httponly,
+            custom: cookie.custom,
+        };
+        Cookie::new_wrapped(cookie, request, source)
     }
 
     pub fn touch(&mut self) {

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -545,40 +545,22 @@ fn obtain_response(request_factory: &NetworkHttpRequestFactory,
 
 // FIXME: This incredibly hacky. Make it more robust, and at least test it.
 fn is_cert_verify_error(error: &OpensslError) -> bool {
-    /*
-    match error {
-        &OpensslError::UnknownError { ref library, ref function, ref reason } => {
-            library == "SSL routines" &&
-            function.to_uppercase() == "SSL3_GET_SERVER_CERTIFICATE" &&
-            reason == "certificate verify failed"
-        }
-    }
-    */
-    unimplemented!()
+    error.library() == Some("SSL routines") &&
+        error.function().map(|s| s.to_uppercase()) == Some("SSL3_GET_SERVER_CERTIFICATE".into()) &&
+        error.reason() == Some("certificate verify failed")
 }
 
 fn is_unknown_message_digest_err(error: &OpensslError) -> bool {
-    /*
-    match error {
-        &OpensslError::UnknownError { ref library, ref function, ref reason } => {
-            library == "asn1 encoding routines" &&
-            function == "ASN1_item_verify" &&
-            reason == "unknown message digest algorithm"
-        }
-    }
-    */
-    unimplemented!()
+    error.library() == Some("asn1 encoding routines") &&
+        error.function().map(|s| s.to_uppercase()) == Some("ASN1_item_verify".into()) &&
+        error.reason() == Some("unknown message digest algorithm")
 }
 
 fn format_ssl_error(error: &OpensslError) -> String {
-    /*
-    match error {
-        &OpensslError::UnknownError { ref library, ref function, ref reason } => {
-            format!("{}: {} - {}", library, function, reason)
-        }
-    }
-    */
-    unimplemented!()
+    format!("{}: {} - {}",
+            error.library().unwrap_or("<unknown library>"),
+            error.function().unwrap_or("<unknown function>"),
+            error.reason().unwrap_or("<unknown reason>"))
 }
 
 /// [HTTP fetch](https://fetch.spec.whatwg.org#http-fetch)

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -6,6 +6,7 @@ use brotli::Decompressor;
 use connector::{Connector, create_http_connector};
 use content_blocker_parser::RuleList;
 use cookie;
+use cookie_rs;
 use cookie_storage::CookieStorage;
 use devtools_traits::{ChromeToDevtoolsControlMsg, DevtoolsControlMsg, HttpRequest as DevtoolsHttpRequest};
 use devtools_traits::{HttpResponse as DevtoolsHttpResponse, NetworkEvent};
@@ -13,6 +14,7 @@ use fetch::cors_cache::CorsCache;
 use fetch::methods::{Data, DoneChannel, FetchContext, Target, is_simple_header, is_simple_method, main_fetch};
 use flate2::read::{DeflateDecoder, GzDecoder};
 use hsts::HstsList;
+use hyper;
 use hyper::Error as HttpError;
 use hyper::LanguageTag;
 use hyper::client::{Pool, Request as HyperRequest, Response as HyperResponse};
@@ -20,7 +22,7 @@ use hyper::header::{AcceptEncoding, AcceptLanguage, AccessControlAllowCredential
 use hyper::header::{AccessControlAllowOrigin, AccessControlAllowHeaders, AccessControlAllowMethods};
 use hyper::header::{AccessControlRequestHeaders, AccessControlMaxAge, AccessControlRequestMethod};
 use hyper::header::{Authorization, Basic, CacheControl, CacheDirective, ContentEncoding};
-use hyper::header::{ContentLength, Encoding, Header, Headers, Host, IfMatch, IfRange};
+use hyper::header::{ContentLength, CookiePair, Encoding, Header, Headers, Host, IfMatch, IfRange};
 use hyper::header::{IfUnmodifiedSince, IfModifiedSince, IfNoneMatch, Location, Pragma, Quality};
 use hyper::header::{QualityItem, Referer, SetCookie, UserAgent, qitem};
 use hyper::method::Method;
@@ -322,13 +324,25 @@ fn set_cookie_for_url(cookie_jar: &Arc<RwLock<CookieStorage>>,
 
     if let Ok(SetCookie(cookies)) = header {
         for bare_cookie in cookies {
-            unimplemented!()
-            /*
-            if let Some(cookie) = cookie::Cookie::new_wrapped(bare_cookie, request, source) {
+            let c = hyper_cookie_to_cookie_rs(bare_cookie);
+            if let Some(cookie) = cookie::Cookie::new_wrapped(c, request, source) {
                 cookie_jar.push(cookie, source);
             }
-            */
         }
+    }
+}
+
+fn hyper_cookie_to_cookie_rs(hyper_cookie: hyper::header::CookiePair) -> cookie_rs::Cookie {
+    cookie_rs::Cookie {
+        name: hyper_cookie.name,
+        value: hyper_cookie.value,
+        expires: hyper_cookie.expires,
+        max_age: hyper_cookie.max_age,
+        domain: hyper_cookie.domain,
+        path: hyper_cookie.path,
+        secure: hyper_cookie.secure,
+        httponly: hyper_cookie.httponly,
+        custom: hyper_cookie.custom,
     }
 }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -322,9 +322,12 @@ fn set_cookie_for_url(cookie_jar: &Arc<RwLock<CookieStorage>>,
 
     if let Ok(SetCookie(cookies)) = header {
         for bare_cookie in cookies {
+            unimplemented!()
+            /*
             if let Some(cookie) = cookie::Cookie::new_wrapped(bare_cookie, request, source) {
                 cookie_jar.push(cookie, source);
             }
+            */
         }
     }
 }
@@ -545,6 +548,7 @@ fn obtain_response(request_factory: &NetworkHttpRequestFactory,
 
 // FIXME: This incredibly hacky. Make it more robust, and at least test it.
 fn is_cert_verify_error(error: &OpensslError) -> bool {
+    /*
     match error {
         &OpensslError::UnknownError { ref library, ref function, ref reason } => {
             library == "SSL routines" &&
@@ -552,9 +556,12 @@ fn is_cert_verify_error(error: &OpensslError) -> bool {
             reason == "certificate verify failed"
         }
     }
+    */
+    unimplemented!()
 }
 
 fn is_unknown_message_digest_err(error: &OpensslError) -> bool {
+    /*
     match error {
         &OpensslError::UnknownError { ref library, ref function, ref reason } => {
             library == "asn1 encoding routines" &&
@@ -562,14 +569,19 @@ fn is_unknown_message_digest_err(error: &OpensslError) -> bool {
             reason == "unknown message digest algorithm"
         }
     }
+    */
+    unimplemented!()
 }
 
 fn format_ssl_error(error: &OpensslError) -> String {
+    /*
     match error {
         &OpensslError::UnknownError { ref library, ref function, ref reason } => {
             format!("{}: {} - {}", library, function, reason)
         }
     }
+    */
+    unimplemented!()
 }
 
 /// [HTTP fetch](https://fetch.spec.whatwg.org#http-fetch)

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -20,7 +20,7 @@ use hyper::header::{AcceptEncoding, AcceptLanguage, AccessControlAllowCredential
 use hyper::header::{AccessControlAllowOrigin, AccessControlAllowHeaders, AccessControlAllowMethods};
 use hyper::header::{AccessControlRequestHeaders, AccessControlMaxAge, AccessControlRequestMethod};
 use hyper::header::{Authorization, Basic, CacheControl, CacheDirective, ContentEncoding};
-use hyper::header::{ContentLength, CookiePair, Encoding, Header, Headers, Host, IfMatch, IfRange};
+use hyper::header::{ContentLength, Encoding, Header, Headers, Host, IfMatch, IfRange};
 use hyper::header::{IfUnmodifiedSince, IfModifiedSince, IfNoneMatch, Location, Pragma, Quality};
 use hyper::header::{QualityItem, Referer, SetCookie, UserAgent, qitem};
 use hyper::method::Method;

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -25,6 +25,7 @@ use hyper::header::{IfUnmodifiedSince, IfModifiedSince, IfNoneMatch, Location, P
 use hyper::header::{QualityItem, Referer, SetCookie, UserAgent, qitem};
 use hyper::method::Method;
 use hyper::net::Fresh;
+use hyper::net::HttpStream;
 use hyper::status::StatusCode;
 use hyper_serde::Serde;
 use log;
@@ -36,6 +37,7 @@ use net_traits::request::{RedirectMode, Referrer, Request, RequestMode, Response
 use net_traits::response::{HttpsState, Response, ResponseBody, ResponseType};
 use openssl;
 use openssl::error::Error as OpensslError;
+use openssl::ssl::SslStream;
 use resource_thread::AuthCache;
 use servo_url::ServoUrl;
 use std::collections::HashSet;
@@ -126,9 +128,6 @@ impl WrappedHttpResponse {
 struct NetworkHttpRequestFactory {
     pub connector: Arc<Pool<Connector>>,
 }
-
-use hyper::net::HttpStream;
-use openssl::ssl::SslStream;
 
 impl NetworkHttpRequestFactory {
     fn create(&self, url: ServoUrl, method: Method, headers: Headers)

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -30,7 +30,6 @@ extern crate mime_guess;
 extern crate msg;
 extern crate net_traits;
 extern crate openssl;
-extern crate openssl_verify;
 extern crate profile_traits;
 extern crate rustc_serialize;
 #[macro_use]

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -29,6 +29,7 @@ extern crate mime;
 extern crate mime_guess;
 extern crate msg;
 extern crate net_traits;
+extern crate openssl;
 extern crate profile_traits;
 extern crate rustc_serialize;
 #[macro_use]

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -29,7 +29,6 @@ extern crate mime;
 extern crate mime_guess;
 extern crate msg;
 extern crate net_traits;
-extern crate openssl;
 extern crate profile_traits;
 extern crate rustc_serialize;
 #[macro_use]

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -18,6 +18,7 @@ extern crate cookie as cookie_rs;
 extern crate devtools_traits;
 extern crate flate2;
 extern crate hyper;
+extern crate hyper_openssl;
 extern crate hyper_serde;
 extern crate immeta;
 extern crate ipc_channel;

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -399,10 +399,13 @@ impl CoreResourceManager {
         let header = Header::parse_header(&[cookie_list.into_bytes()]);
         if let Ok(SetCookie(cookies)) = header {
             for bare_cookie in cookies {
+                unimplemented!()
+                /*
                 if let Some(cookie) = cookie::Cookie::new_wrapped(bare_cookie, &request, source) {
                     let mut cookie_jar = resource_group.cookie_jar.write().unwrap();
                     cookie_jar.push(cookie, source);
                 }
+                */
             }
         }
     }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -398,14 +398,11 @@ impl CoreResourceManager {
                            resource_group: &ResourceGroup) {
         let header = Header::parse_header(&[cookie_list.into_bytes()]);
         if let Ok(SetCookie(cookies)) = header {
-            for bare_cookie in cookies {
-                unimplemented!()
-                /*
-                if let Some(cookie) = cookie::Cookie::new_wrapped(bare_cookie, &request, source) {
+            for cookie in cookies {
+                if let Some(cookie) = cookie::Cookie::new_wrapped_hyper(cookie, &request, source) {
                     let mut cookie_jar = resource_group.cookie_jar.write().unwrap();
                     cookie_jar.push(cookie, source);
                 }
-                */
             }
         }
     }

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -18,7 +18,7 @@ heapsize = "0.3.0"
 heapsize_derive = "0.1"
 hyper = {version = "0.9.9", default-features = false}
 # hyper_serde = {version = "0.1.4"}
-hyper_serde = {path = "../../hyper_serde"}
+hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
 image = "0.10"
 lazy_static = "0.2"
 log = "0.3.5"

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -16,8 +16,8 @@ msg = {path = "../msg"}
 ipc-channel = "0.5"
 heapsize = "0.3.0"
 heapsize_derive = "0.1"
-hyper = "0.9.9"
-hyper_serde = "0.1.4"
+hyper = {version = "0.9.9", default-features = false}
+hyper_serde = {version = "0.1.4", default-features = false}
 image = "0.10"
 lazy_static = "0.2"
 log = "0.3.5"
@@ -26,7 +26,7 @@ serde = "0.8"
 serde_derive = "0.8"
 servo_url = {path = "../url", features = ["servo"]}
 url = {version = "1.2", features = ["heap_size"]}
-websocket = "0.17"
+websocket = {git = "https://github.com/dten/rust-websocket.git", branch = "openssl_0.9.1" }
 uuid = { version = "0.3.1", features = ["v4", "serde"] }
 cookie = {version = "0.2.5", features = ["serialize-rustc"]}
 

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -17,7 +17,8 @@ ipc-channel = "0.5"
 heapsize = "0.3.0"
 heapsize_derive = "0.1"
 hyper = {version = "0.9.9", default-features = false}
-hyper_serde = {version = "0.1.4", default-features = false}
+# hyper_serde = {version = "0.1.4"}
+hyper_serde = {path = "../../hyper_serde"}
 image = "0.10"
 lazy_static = "0.2"
 log = "0.3.5"
@@ -28,7 +29,7 @@ servo_url = {path = "../url", features = ["servo"]}
 url = {version = "1.2", features = ["heap_size"]}
 websocket = {git = "https://github.com/dten/rust-websocket.git", branch = "openssl_0.9.1" }
 uuid = { version = "0.3.1", features = ["v4", "serde"] }
-cookie = {version = "0.2.5", features = ["serialize-rustc"]}
+cookie = {version = "0.4", features = ["serialize-serde"]}
 
 [dependencies.webrender_traits]
 git = "https://github.com/servo/webrender"

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -17,8 +17,7 @@ ipc-channel = "0.5"
 heapsize = "0.3.0"
 heapsize_derive = "0.1"
 hyper = {version = "0.9.9", default-features = false}
-# hyper_serde = {version = "0.1.4"}
-hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
+hyper_serde = "0.2"
 image = "0.10"
 lazy_static = "0.2"
 log = "0.3.5"

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -364,13 +364,7 @@ pub enum CoreResourceMsg {
     /// Store a set of cookies for a given originating URL
     SetCookiesForUrl(ServoUrl, String, CookieSource),
     /// Store a set of cookies for a given originating URL
-    SetCookiesForUrlWithData(
-        ServoUrl,
-        #[serde(deserialize_with = "::hyper_serde::deserialize",
-                serialize_with = "::hyper_serde::serialize")]
-        Cookie,
-        CookieSource
-    ),
+    SetCookiesForUrlWithData(ServoUrl, Cookie, CookieSource),
     /// Retrieve the stored cookies for a given URL
     GetCookiesForUrl(ServoUrl, IpcSender<Option<String>>, CookieSource),
     /// Get a cookie by name for a given originating URL

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -28,7 +28,7 @@ bitflags = "0.7"
 bluetooth_traits = {path = "../bluetooth_traits"}
 canvas_traits = {path = "../canvas_traits"}
 caseless = "0.1.0"
-cookie = {version = "0.2.5", features = ["serialize-rustc"]}
+cookie = "0.4"
 cssparser = {version = "0.7", features = ["heap_size", "serde-serialization"]}
 devtools_traits = {path = "../devtools_traits"}
 encoding = "0.2"
@@ -83,5 +83,5 @@ xml5ever = {version = "0.2", features = ["unstable"]}
 
 [dependencies.webrender_traits]
 git = "https://github.com/servo/webrender"
-default_features = false
+default-features = false
 features = ["nightly", "serde_derive", "ipc"]

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -40,7 +40,8 @@ heapsize_derive = "0.1"
 html5ever = {version = "0.10.2", features = ["heap_size", "unstable"]}
 html5ever-atoms = {version = "0.1", features = ["heap_size"]}
 hyper = {version = "0.9.9", default-features = false}
-hyper_serde = {version = "0.1.4", default-features = false}
+# hyper_serde = {version = "0.1.4", default-features = false}
+hyper_serde = {path = "../../hyper_serde"}
 image = "0.10"
 ipc-channel = "0.5"
 js = {git = "https://github.com/servo/rust-mozjs", features = ["promises"]}

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -39,8 +39,8 @@ heapsize = "0.3.6"
 heapsize_derive = "0.1"
 html5ever = {version = "0.10.2", features = ["heap_size", "unstable"]}
 html5ever-atoms = {version = "0.1", features = ["heap_size"]}
-hyper = "0.9.9"
-hyper_serde = "0.1.4"
+hyper = {version = "0.9.9", default-features = false}
+hyper_serde = {version = "0.1.4", default-features = false}
 image = "0.10"
 ipc-channel = "0.5"
 js = {git = "https://github.com/servo/rust-mozjs", features = ["promises"]}
@@ -78,7 +78,7 @@ time = "0.1.12"
 url = {version = "1.2", features = ["heap_size", "query_encoding"]}
 util = {path = "../util"}
 uuid = {version = "0.3.1", features = ["v4"]}
-websocket = "0.17"
+websocket = {git = "https://github.com/dten/rust-websocket.git", branch = "openssl_0.9.1" }
 xml5ever = {version = "0.2", features = ["unstable"]}
 
 [dependencies.webrender_traits]

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -41,7 +41,7 @@ html5ever = {version = "0.10.2", features = ["heap_size", "unstable"]}
 html5ever-atoms = {version = "0.1", features = ["heap_size"]}
 hyper = {version = "0.9.9", default-features = false}
 # hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {path = "../../hyper_serde"}
+hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
 image = "0.10"
 ipc-channel = "0.5"
 js = {git = "https://github.com/servo/rust-mozjs", features = ["promises"]}

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -40,8 +40,7 @@ heapsize_derive = "0.1"
 html5ever = {version = "0.10.2", features = ["heap_size", "unstable"]}
 html5ever-atoms = {version = "0.1", features = ["heap_size"]}
 hyper = {version = "0.9.9", default-features = false}
-# hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
+hyper_serde = "0.2"
 image = "0.10"
 ipc-channel = "0.5"
 js = {git = "https://github.com/servo/rust-mozjs", features = ["promises"]}

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -13,14 +13,15 @@ path = "lib.rs"
 app_units = "0.3"
 bluetooth_traits = {path = "../bluetooth_traits"}
 canvas_traits = {path = "../canvas_traits"}
-cookie = {version = "0.2.5", features = ["serialize-rustc"]}
+cookie = "0.4"
 devtools_traits = {path = "../devtools_traits"}
 euclid = "0.10.1"
 gfx_traits = {path = "../gfx_traits"}
 heapsize = "0.3.0"
 heapsize_derive = "0.1"
 hyper = {version = "0.9.9", default-features = false}
-hyper_serde = {version = "0.1.4", default-features = false}
+# hyper_serde = {version = "0.1.4", default-features = false}
+hyper_serde = {path = "../../hyper_serde"}
 ipc-channel = "0.5"
 libc = "0.2"
 msg = {path = "../msg"}

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -21,7 +21,7 @@ heapsize = "0.3.0"
 heapsize_derive = "0.1"
 hyper = {version = "0.9.9", default-features = false}
 # hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {path = "../../hyper_serde"}
+hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
 ipc-channel = "0.5"
 libc = "0.2"
 msg = {path = "../msg"}

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -20,8 +20,7 @@ gfx_traits = {path = "../gfx_traits"}
 heapsize = "0.3.0"
 heapsize_derive = "0.1"
 hyper = {version = "0.9.9", default-features = false}
-# hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
+hyper_serde = "0.2"
 ipc-channel = "0.5"
 libc = "0.2"
 msg = {path = "../msg"}

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -19,8 +19,8 @@ euclid = "0.10.1"
 gfx_traits = {path = "../gfx_traits"}
 heapsize = "0.3.0"
 heapsize_derive = "0.1"
-hyper = "0.9.9"
-hyper_serde = "0.1.4"
+hyper = {version = "0.9.9", default-features = false}
+hyper_serde = {version = "0.1.4", default-features = false}
 ipc-channel = "0.5"
 libc = "0.2"
 msg = {path = "../msg"}

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -63,7 +63,7 @@ features = ["serde_derive"]
 
 [dependencies.webrender_traits]
 git = "https://github.com/servo/webrender"
-default_features = false
+default-features = false
 features = ["serde_derive", "ipc"]
 
 [target.'cfg(not(target_os = "android"))'.dependencies]

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 [dependencies]
 cookie = {version = "0.2.5", features = ["serialize-rustc"]}
 euclid = "0.10.1"
-hyper = "0.9.9"
+hyper = {version = "0.9.9", default-features = false}
 image = "0.10"
 ipc-channel = "0.5"
 log = "0.3.5"

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -10,7 +10,7 @@ name = "webdriver_server"
 path = "lib.rs"
 
 [dependencies]
-cookie = "0.4"
+cookie = {version = "0.4", features = ["serialize-serde"]}
 euclid = "0.10.1"
 hyper = {version = "0.9.9", default-features = false}
 image = "0.10"

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -10,7 +10,7 @@ name = "webdriver_server"
 path = "lib.rs"
 
 [dependencies]
-cookie = {version = "0.2.5", features = ["serialize-rustc"]}
+cookie = "0.4"
 euclid = "0.10.1"
 hyper = {version = "0.9.9", default-features = false}
 image = "0.10"

--- a/tests/unit/net/Cargo.toml
+++ b/tests/unit/net/Cargo.toml
@@ -15,7 +15,8 @@ cookie = "0.4"
 devtools_traits = {path = "../../../components/devtools_traits"}
 flate2 = "0.2.0"
 hyper = {version = "0.9.9", default-features = false}
-hyper_serde = {version = "0.1.4", default-features = false}
+# hyper_serde = {version = "0.1.4", default-features = false}
+hyper_serde = {path = "../../../hyper_serde"}
 ipc-channel = "0.5"
 msg = {path = "../../../components/msg"}
 net = {path = "../../../components/net"}

--- a/tests/unit/net/Cargo.toml
+++ b/tests/unit/net/Cargo.toml
@@ -15,8 +15,7 @@ cookie = "0.4"
 devtools_traits = {path = "../../../components/devtools_traits"}
 flate2 = "0.2.0"
 hyper = {version = "0.9.9", default-features = false}
-# hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
+hyper_serde = "0.2"
 ipc-channel = "0.5"
 msg = {path = "../../../components/msg"}
 net = {path = "../../../components/net"}

--- a/tests/unit/net/Cargo.toml
+++ b/tests/unit/net/Cargo.toml
@@ -11,11 +11,11 @@ doctest = false
 
 [dependencies]
 content-blocker = "0.2.1"
-cookie = "0.2"
+cookie = "0.4"
 devtools_traits = {path = "../../../components/devtools_traits"}
 flate2 = "0.2.0"
-hyper = "0.9.9"
-hyper_serde = "0.1.4"
+hyper = {version = "0.9.9", default-features = false}
+hyper_serde = {version = "0.1.4", default-features = false}
 ipc-channel = "0.5"
 msg = {path = "../../../components/msg"}
 net = {path = "../../../components/net"}

--- a/tests/unit/net/Cargo.toml
+++ b/tests/unit/net/Cargo.toml
@@ -16,7 +16,7 @@ devtools_traits = {path = "../../../components/devtools_traits"}
 flate2 = "0.2.0"
 hyper = {version = "0.9.9", default-features = false}
 # hyper_serde = {version = "0.1.4", default-features = false}
-hyper_serde = {path = "../../../hyper_serde"}
+hyper_serde = {git = "https://github.com/frewsxcv/hyper_serde.git", branch = "bump-cookie"}
 ipc-channel = "0.5"
 msg = {path = "../../../components/msg"}
 net = {path = "../../../components/net"}


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/14203.

TODO:

* Stop using a git dep and use this published version: https://github.com/nox/hyper_serde/pull/2
 * Or maybe remove hyper_serde

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14484)
<!-- Reviewable:end -->
