### PR TITLE
Fixed some typos in stopNotifications test.

### DIFF
--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/stopNotifications/disconnect-called-before.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/stopNotifications/disconnect-called-before.html.ini
@@ -1,0 +1,5 @@
+[disconnect-called-before.html]
+  type: testharness
+  [disconnect() called before stopNotifications. Reject with InvalidStateError.]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/stopNotifications/disconnect-called-during.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/stopNotifications/disconnect-called-during.html.ini
@@ -1,5 +1,5 @@
 [disconnect-called-during.html]
   type: testharness
-  [disconnect() called during stopNotifications. Reject with NetworkError.]
+  [disconnect() called during stopNotifications. Reject with InvalidStateError.]
     expected: FAIL
 

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/disconnect-called-before.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/disconnect-called-before.html
@@ -17,8 +17,8 @@ promise_test(t => {
         .then(characteristic => characteristic.startNotifications())
         .then(characteristic => {
             gattServer.disconnect();
-            return promise_rejects(t, 'NetworkError', characteristic.startNotifications());
+            return promise_rejects(t, 'InvalidStateError', characteristic.stopNotifications());
         });
     });
-}, 'disconnect() called before stopNotifications. Reject with NetworkError.');
+}, 'disconnect() called before stopNotifications. Reject with InvalidStateError.');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/disconnect-called-during.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/stopNotifications/disconnect-called-during.html
@@ -16,10 +16,10 @@ promise_test(t => {
         .then(service => service.getCharacteristic(heart_rate_measurement.name))
         .then(characteristic => characteristic.startNotifications())
         .then(characteristic => {
-            let promise = promise_rejects(t, 'NetworkError', characteristic.startNotifications());
+            let promise = promise_rejects(t, 'InvalidStateError', characteristic.stopNotifications());
             gattServer.disconnect();
             return promise;
         });
     });
-}, 'disconnect() called during stopNotifications. Reject with NetworkError.');
+}, 'disconnect() called during stopNotifications. Reject with InvalidStateError.');
 </script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
We called the startNotifications() method instead of stopNotifications() in the tests. According to the specification this method should return `InvalidStateError` and not `NetworkError`, so we changed that as well.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14493)
<!-- Reviewable:end -->
