### PR TITLE
Added image-orientation property

### DIFF
--- a/tests/unit/style/parsing/inherited_box.rs
+++ b/tests/unit/style/parsing/inherited_box.rs
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use cssparser::Parser;
+use media_queries::CSSErrorReporterTest;
+use style::parser::ParserContext;
+use style::stylesheets::Origin;
+
+#[test]
+fn image_orientation_longhand_should_parse_properly() {
+    use std::f32::consts::PI;
+    use style::properties::longhands::image_orientation;
+    use style::properties::longhands::image_orientation::SpecifiedValue;
+    use style::values::specified::Angle;
+
+    let from_image = parse_longhand!(image_orientation, "from-image");
+    assert_eq!(from_image, SpecifiedValue { angle: None, flipped: false });
+
+    let flip = parse_longhand!(image_orientation, "flip");
+    assert_eq!(flip, SpecifiedValue { angle: None, flipped: true });
+
+    let zero = parse_longhand!(image_orientation, "0deg");
+    assert_eq!(zero, SpecifiedValue { angle: Some(Angle::from_radians(0.0)), flipped: false });
+
+    let negative_rad = parse_longhand!(image_orientation, "-1rad");
+    assert_eq!(negative_rad, SpecifiedValue { angle: Some(Angle::from_radians(-1.0)), flipped: false });
+
+    let flip_with_180 = parse_longhand!(image_orientation, "180deg flip");
+    assert_eq!(flip_with_180, SpecifiedValue { angle: Some(Angle::from_radians(PI)), flipped: true });
+}

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -52,6 +52,7 @@ mod basic_shape;
 mod border;
 mod font;
 mod image;
+mod inherited_box;
 mod inherited_text;
 mod mask;
 mod position;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Implemented as per the MDN documentation—I could not find a current CSS draft. I am not sure if this is the complete correct metadata for the longhand helper:
```
<%helpers:longhand name="image-orientation”
                   experimental=“True”
                   animatable=“False”>
```
Also I am not sure how to test this and would appreciate help in creating a testing strategy.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13877.

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14498)
<!-- Reviewable:end -->
