### PR TITLE
Rewrite determine_request_referrer() to explicitly limit it to the checks it can do.

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -276,27 +276,28 @@ fn strip_url(mut referrer_url: ServoUrl, origin_only: bool) -> Option<ServoUrl> 
 }
 
 /// https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer
+/// Steps 4-6.
 pub fn determine_request_referrer(headers: &mut Headers,
                                   referrer_policy: ReferrerPolicy,
-                                  referrer_url: Option<ServoUrl>,
-                                  url: ServoUrl) -> Option<ServoUrl> {
-    //TODO - algorithm step 2 not addressed
+                                  referrer_source: ServoUrl,
+                                  current_url: ServoUrl)
+                                  -> Option<ServoUrl> {
     assert!(!headers.has::<Referer>());
-    if let Some(ref_url) = referrer_url {
-        let cross_origin = ref_url.origin() != url.origin();
-        return match referrer_policy {
-            ReferrerPolicy::NoReferrer => None,
-            ReferrerPolicy::Origin => strip_url(ref_url, true),
-            ReferrerPolicy::SameOrigin => if cross_origin { None } else { strip_url(ref_url, false) },
-            ReferrerPolicy::UnsafeUrl => strip_url(ref_url, false),
-            ReferrerPolicy::OriginWhenCrossOrigin => strip_url(ref_url, cross_origin),
-            ReferrerPolicy::StrictOrigin => strict_origin(ref_url, url),
-            ReferrerPolicy::StrictOriginWhenCrossOrigin => strict_origin_when_cross_origin(ref_url, url),
-            ReferrerPolicy::NoReferrerWhenDowngrade =>
-                no_referrer_when_downgrade_header(ref_url, url),
-        };
+    // FIXME(#14505): this does not seem to be the correct way of checking for
+    //                same-origin requests.
+    let cross_origin = referrer_source.origin() != current_url.origin();
+    // FIXME(#14506): some of these cases are expected to consider whether the
+    //                request's client is "TLS-protected", whatever that means.
+    match referrer_policy {
+        ReferrerPolicy::NoReferrer => None,
+        ReferrerPolicy::Origin => strip_url(referrer_source, true),
+        ReferrerPolicy::SameOrigin => if cross_origin { None } else { strip_url(referrer_source, false) },
+        ReferrerPolicy::UnsafeUrl => strip_url(referrer_source, false),
+        ReferrerPolicy::OriginWhenCrossOrigin => strip_url(referrer_source, cross_origin),
+        ReferrerPolicy::StrictOrigin => strict_origin(referrer_source, current_url),
+        ReferrerPolicy::StrictOriginWhenCrossOrigin => strict_origin_when_cross_origin(referrer_source, current_url),
+        ReferrerPolicy::NoReferrerWhenDowngrade => no_referrer_when_downgrade_header(referrer_source, current_url),
     }
-    return None;
 }
 
 pub fn set_request_cookies(url: &ServoUrl, headers: &mut Headers, cookie_jar: &Arc<RwLock<CookieStorage>>) {

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -9,7 +9,6 @@ use msg::constellation_msg::PipelineId;
 use servo_url::ServoUrl;
 use std::cell::{Cell, RefCell};
 use std::default::Default;
-use std::mem::swap;
 use url::{Origin as UrlOrigin};
 
 /// An [initiator](https://fetch.spec.whatwg.org/#concept-request-initiator)
@@ -306,21 +305,6 @@ impl Referrer {
         match *self {
             Referrer::NoReferrer | Referrer::Client => None,
             Referrer::ReferrerUrl(ref url) => Some(url)
-        }
-    }
-    pub fn from_url(url: Option<ServoUrl>) -> Self {
-        if let Some(url) = url {
-            Referrer::ReferrerUrl(url)
-        } else {
-            Referrer::NoReferrer
-        }
-    }
-    pub fn take(&mut self) -> Option<ServoUrl> {
-        let mut new = Referrer::Client;
-        swap(self, &mut new);
-        match new {
-            Referrer::NoReferrer | Referrer::Client => None,
-            Referrer::ReferrerUrl(url) => Some(url)
         }
     }
 }


### PR DESCRIPTION
Checks for the Client value should reside in the script thread.

I also noted some other issues in this code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14508)
<!-- Reviewable:end -->
