### PR TITLE
Use `android-rs-injected-glue` on Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,11 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "android_injected_glue"
+version = "0.2.1"
+source = "git+https://github.com/mmatyas/android-rs-injected-glue#d3223d1273d0dafcf06d6a6405fedfffbf257300"
+
+[[package]]
 name = "angle"
 version = "0.1.2"
 source = "git+https://github.com/servo/angle?branch=servo#99128001400771ee9c8a74dcf54cf6fe11b1e532"
@@ -2377,6 +2382,7 @@ name = "servo"
 version = "0.0.1"
 dependencies = [
  "android_glue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "android_injected_glue 0.2.1 (git+https://github.com/mmatyas/android-rs-injected-glue)",
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "browserhtml 0.1.17 (git+https://github.com/browserhtml/browserhtml?branch=crate)",
  "compiletest_helper 0.0.1",
@@ -3206,6 +3212,7 @@ dependencies = [
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum alloc-no-stdlib 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b21f6ad9c9957eb5d70c3dee16d31c092b3cab339628f821766b05e6833d72b8"
 "checksum android_glue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e2b80445d331077679dfc6f3014f3e9ab7083e588423d35041d3fc017198189"
+"checksum android_injected_glue 0.2.1 (git+https://github.com/mmatyas/android-rs-injected-glue)" = "<none>"
 "checksum angle 0.1.2 (git+https://github.com/servo/angle?branch=servo)" = "<none>"
 "checksum app_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "636ee56f12e31dbc11dc0a1ac6004f08b04e6e6595963716fc8130e90d4e04cf"
 "checksum arrayvec 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "80a137392e2e92ce7387c063d98a11f0d47115426c5f8759657af3c7b385c860"

--- a/ports/servo/Cargo.toml
+++ b/ports/servo/Cargo.toml
@@ -54,3 +54,4 @@ sig = "0.1"
 [target.'cfg(target_os = "android")'.dependencies]
 libc = "0.2"
 android_glue = "0.2"
+android_injected_glue = {git = "https://github.com/mmatyas/android-rs-injected-glue"}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Due to changes in `android-rs-glue`, currently the Android build fails to start. As discussed [here](https://github.com/servo/servo/issues/13154), other than the `android-glue`, we now also have to inject some additional code too. This task is usually done by a helper program of `android-glue`, `cargo-apk`, but since Servo's build system is somewhat more complex than a regular small application, at the moment it'd be more clean to move the required internal `injected-glue` lib to a new repository, and add it as a dependency.

This patch adds a new dependency, `android-rs-injected-glue`, and integrates it into Servo. After applying this commit and #14528, Servo can be launched on Android. (It doesn't *work* yet as expected, though.)

Part of #13154.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14530)
<!-- Reviewable:end -->
