### PR TITLE
Show the placeholder text for textarea elements.

### DIFF
--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -29,6 +29,7 @@ files = [
   "./tests/unit/net/parsable_mime/text",
   "./tests/wpt/mozilla/tests/css/fonts",
   "./tests/wpt/mozilla/tests/css/pre_with_tab.html",
+  "./tests/wpt/mozilla/tests/mozilla/textarea_placeholder.html",
   # FIXME(pcwalton, #11679): This is a workaround for a tidy error on the quoted string
   # `"__TEXT,_info_plist"` inside an attribute.
   "./components/servo/platform/macos/mod.rs",

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6498,6 +6498,18 @@
             "url": "/_mozilla/mozilla/table_valign_uneven_height.html"
           }
         ],
+        "mozilla/textarea_placeholder.html": [
+          {
+            "path": "mozilla/textarea_placeholder.html",
+            "references": [
+              [
+                "/_mozilla/mozilla/textarea_placeholder_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/mozilla/textarea_placeholder.html"
+          }
+        ],
         "mozilla/webgl/clearcolor.html": [
           {
             "path": "mozilla/webgl/clearcolor.html",
@@ -21544,6 +21556,18 @@
             ]
           ],
           "url": "/_mozilla/mozilla/table_valign_uneven_height.html"
+        }
+      ],
+      "mozilla/textarea_placeholder.html": [
+        {
+          "path": "mozilla/textarea_placeholder.html",
+          "references": [
+            [
+              "/_mozilla/mozilla/textarea_placeholder_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/mozilla/textarea_placeholder.html"
         }
       ],
       "mozilla/webgl/clearcolor.html": [

--- a/tests/wpt/mozilla/tests/mozilla/textarea_placeholder.html
+++ b/tests/wpt/mozilla/tests/mozilla/textarea_placeholder.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="match" href="textarea_placeholder_ref.html">
+
+<textarea placeholder=""></textarea>
+<textarea placeholder="    "></textarea>
+<textarea placeholder="foobar"></textarea>
+<textarea placeholder="  foo  bar  "></textarea>
+<textarea rows=5 placeholder="  foo
+ bar "></textarea>
+<textarea placeholder="foo bar">lorem ipsum</textarea>

--- a/tests/wpt/mozilla/tests/mozilla/textarea_placeholder_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/textarea_placeholder_ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+
+<textarea></textarea>
+<textarea></textarea>
+<textarea>foobar</textarea>
+<textarea>  foo  bar  </textarea>
+<textarea rows=5>
+
+ foo
+ bar
+</textarea>
+<textarea>lorem ipsum</textarea>


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/10552.

All this logic was taken from htmlinputelement.rs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14539)
<!-- Reviewable:end -->
