### PR TITLE
font-variant-caps implemented in font.mako.rs

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -140,6 +140,21 @@ ${helpers.single_keyword("font-variant",
                          "normal small-caps",
                          animatable=False)}
 
+
+<% font_variant_caps_custom_consts= { "small-caps": "SMALLCAPS",
+                                      "all-small": "ALLSMALL",
+                                      "petite-caps": "PETITECAPS",
+                                      "all-petite": "ALLPETITE",
+                                      "titling-caps": "TITLING" } %>
+
+${helpers.single_keyword("font-variant-caps",
+                         "normal small-caps all-small petite-caps unicase titling-caps",
+                         gecko_constant_prefix="NS_FONT_VARIANT_CAPS",
+                         gecko_ffi_name="mFont.variantCaps",
+                         products="gecko",
+                         custom_consts=font_variant_caps_custom_consts,
+                         animatable=False)}
+
 <%helpers:longhand name="font-weight" need_clone="True" animatable="True">
     use std::fmt;
     use style_traits::ToCss;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implemented font-variant-caps for gecko library

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13668  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____
Not sure.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
Before Change:

<img width="261" alt="beforechange" src="https://cloud.githubusercontent.com/assets/9249887/21127332/03487fbc-c0c0-11e6-8667-bb1e60d5c754.PNG">

After Change:

<img width="174" alt="afterchange" src="https://cloud.githubusercontent.com/assets/9249887/21127345/0cc8860e-c0c0-11e6-96cf-16b77c14c5a7.png">

Pictures are rendering of example from [font-variant-caps](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14561)
<!-- Reviewable:end -->
