### PR TITLE
Add asserts to make failure clearer

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -42,7 +42,13 @@ mod bindings {
 
     lazy_static! {
         static ref INCLUDE_RE: Regex = Regex::new(r#"#include\s*"(.+?)""#).unwrap();
-        static ref DISTDIR_PATH: PathBuf = PathBuf::from(env::var("MOZ_DIST").unwrap());
+        static ref DISTDIR_PATH: PathBuf = {
+            let path = PathBuf::from(env::var("MOZ_DIST").unwrap());
+            if !path.is_absolute() || !path.is_dir() {
+                panic!("MOZ_DIST must be an absolute directory, was: {}", path.display());
+            }
+            path
+        };
         static ref SEARCH_PATHS: Vec<PathBuf> = vec![
             DISTDIR_PATH.join("include"),
             DISTDIR_PATH.join("include/nspr"),


### PR DESCRIPTION
Gecko currently doesn't pass absolute path for `MOZ_DIST`, which leads to obscure panic when running the build script. This patch adds some assertions so that failures around this would be clearer.

r? @emilio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14563)
<!-- Reviewable:end -->
