### PR TITLE
style: Make some removed assertions Servo-only instead.

### DIFF
--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -248,6 +248,9 @@ pub trait TElement : PartialEq + Debug + Sized + Copy + Clone + ElementExt + Pre
     /// the element has no style.
     fn is_display_none(&self) -> bool {
         let data = self.borrow_data().unwrap();
+        // See the comment on `cascade_node` about getting the up-to-date parent
+        // style for why we allow this on Gecko.
+        debug_assert!(cfg!(gecko) || data.has_current_styles());
         data.styles().is_display_none()
     }
 

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -733,6 +733,13 @@ pub trait MatchMethods : TElement {
         // Get our parent's style.
         let parent_data = parent.as_ref().map(|x| x.borrow_data().unwrap());
         let parent_style = parent_data.as_ref().map(|d| {
+            // Sometimes Gecko eagerly styles things without processing pending
+            // restyles first. In general we'd like to avoid this, but there can
+            // be good reasons (for example, needing to construct a frame for
+            // some small piece of newly-added content in order to do something
+            // specific with that frame, but not wanting to flush all of
+            // layout).
+            debug_assert!(cfg!(gecko) || d.has_current_styles());
             &d.styles().primary.values
         });
 


### PR DESCRIPTION
These were removed in #14560.

r? @heycam or @bholley

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14565)
<!-- Reviewable:end -->
