### PR TITLE
stylo: Avoid traversing children of XBL-bound elements during initial styling

### DIFF
--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -244,16 +244,6 @@ pub trait TElement : PartialEq + Debug + Sized + Copy + Clone + ElementExt + Pre
     /// traversal. Returns the number of children left to process.
     fn did_process_child(&self) -> isize;
 
-    /// Returns true if this element's style is display:none. Panics if
-    /// the element has no style.
-    fn is_display_none(&self) -> bool {
-        let data = self.borrow_data().unwrap();
-        // See the comment on `cascade_node` about getting the up-to-date parent
-        // style for why we allow this on Gecko.
-        debug_assert!(cfg!(feature = "gecko") || data.has_current_styles());
-        data.styles().is_display_none()
-    }
-
     /// Gets a reference to the ElementData container.
     fn get_data(&self) -> Option<&AtomicRefCell<ElementData>>;
 

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -353,6 +353,7 @@ impl<'le> TElement for GeckoElement<'le> {
     }
 
     unsafe fn set_dirty_descendants(&self) {
+        debug!("Setting dirty descendants: {:?}", self);
         self.set_flags(NODE_HAS_DIRTY_DESCENDANTS_FOR_SERVO as u32)
     }
 

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -170,6 +170,11 @@ impl ComputedValues {
         self.custom_properties.as_ref().map(|x| x.clone())
     }
 
+    #[allow(non_snake_case)]
+    pub fn has_moz_binding(&self) -> bool {
+        !self.get_box().gecko.mBinding.mRawPtr.is_null()
+    }
+
     pub fn root_font_size(&self) -> Au { self.root_font_size }
     pub fn set_root_font_size(&mut self, s: Au) { self.root_font_size = s; }
     pub fn set_writing_mode(&mut self, mode: WritingMode) { self.writing_mode = mode; }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1199,6 +1199,8 @@ impl ComputedValues {
         self.custom_properties.as_ref().map(|x| x.clone())
     }
 
+    pub fn has_moz_binding(&self) -> bool { false }
+
     pub fn root_font_size(&self) -> Au { self.root_font_size }
     pub fn set_root_font_size(&mut self, size: Au) { self.root_font_size = size }
     pub fn set_writing_mode(&mut self, mode: WritingMode) { self.writing_mode = mode; }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -131,7 +131,7 @@ fn traverse_subtree(element: GeckoElement, raw_data: RawServoStyleSetBorrowed,
     // When new content is inserted in a display:none subtree, we will call into
     // servo to try to style it. Detect that here and bail out.
     if let Some(parent) = element.parent_element() {
-        if parent.get_data().is_none() || parent.is_display_none() {
+        if parent.borrow_data().map_or(true, |d| d.styles().is_display_none()) {
             debug!("{:?} has unstyled parent - ignoring call to traverse_subtree", parent);
             return;
         }


### PR DESCRIPTION
Corresponding Gecko bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1294572

CC @heycam @emilio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14581)
<!-- Reviewable:end -->
