### PR TITLE
Remove-ResponseAction

### DIFF
--- a/components/net/image_cache_thread.rs
+++ b/components/net/image_cache_thread.rs
@@ -225,17 +225,8 @@ impl ImageListener {
     }
 }
 
-/// A legacy type that's mostly redundant with FetchResponseMsg.
-// FIXME(#13717): remove this type.
-#[derive(Deserialize, Serialize)]
-enum ResponseAction {
-    HeadersAvailable(Result<Metadata, NetworkError>),
-    DataAvailable(Vec<u8>),
-    ResponseComplete(Result<(), NetworkError>)
-}
-
 struct ResourceLoadInfo {
-    action: ResponseAction,
+    action: FetchResponseMsg,
     key: LoadKey,
 }
 
@@ -417,8 +408,10 @@ impl ImageCache {
     // Handle progress messages from the resource thread
     fn handle_progress(&mut self, msg: ResourceLoadInfo) {
         match (msg.action, msg.key) {
-            (ResponseAction::HeadersAvailable(_), _) => {}
-            (ResponseAction::DataAvailable(data), _) => {
+            (FetchResponseMsg::ProcessRequestBody, _) |
+            (FetchResponseMsg::ProcessRequestEOF, _) => return,
+            (FetchResponseMsg::ProcessResponse(_), _) => {}
+            (FetchResponseMsg::ProcessResponseChunk(data), _) => {
                 let pending_load = self.pending_loads.get_by_key_mut(&msg.key).unwrap();
                 pending_load.bytes.extend_from_slice(&data);
                 //jmr0 TODO: possibly move to another task?
@@ -434,7 +427,7 @@ impl ImageCache {
                     }
                 }
             }
-            (ResponseAction::ResponseComplete(result), key) => {
+            (FetchResponseMsg::ProcessResponseEOF(result), key) => {
                 match result {
                     Ok(()) => {
                         let pending_load = self.pending_loads.get_by_key_mut(&msg.key).unwrap();
@@ -550,20 +543,7 @@ impl ImageCache {
                             let action = match action {
                                 FetchResponseMsg::ProcessRequestBody |
                                 FetchResponseMsg::ProcessRequestEOF => return,
-                                FetchResponseMsg::ProcessResponse(meta_result) => {
-                                    ResponseAction::HeadersAvailable(meta_result.map(|m| {
-                                        match m {
-                                            FetchMetadata::Unfiltered(m) => m,
-                                            FetchMetadata::Filtered { unsafe_, .. } => unsafe_
-                                        }
-                                    }))
-                                }
-                                FetchResponseMsg::ProcessResponseChunk(new_bytes) => {
-                                    ResponseAction::DataAvailable(new_bytes)
-                                }
-                                FetchResponseMsg::ProcessResponseEOF(response) => {
-                                    ResponseAction::ResponseComplete(response)
-                                }
+                                a => a
                             };
                             progress_sender.send(ResourceLoadInfo {
                                 action: action,
@@ -630,12 +610,12 @@ impl ImageCache {
                           loaded_bytes: Vec<u8>) {
         let (cache_result, load_key, _) = self.pending_loads.get_cached(ref_url.clone());
         assert!(cache_result == CacheResult::Miss);
-        let action = ResponseAction::DataAvailable(loaded_bytes);
+        let action = FetchResponseMsg::ProcessResponseChunk(loaded_bytes);
         let _ = self.progress_sender.send(ResourceLoadInfo {
             action: action,
             key: load_key,
         });
-        let action = ResponseAction::ResponseComplete(Ok(()));
+        let action = FetchResponseMsg::ProcessResponseEOF(Ok(()));
         let _ = self.progress_sender.send(ResourceLoadInfo {
             action: action,
             key: load_key,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Remove the old Enum ResponseAction and use net_traits::FetchResponseMsg instead.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13717 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because @KiChjang said so.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14586)
<!-- Reviewable:end -->
