### PR TITLE
Exempt __cxa_type_match as an allowed dynamic symbol

### DIFF
--- a/etc/ci/check_dynamic_symbols.py
+++ b/etc/ci/check_dynamic_symbols.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 
 symbol_regex = re.compile(b"D  \*UND\*\t(.*) (.*)$")
-allowed_symbols = frozenset([b'unshare', b'malloc_usable_size'])
+allowed_symbols = frozenset([b'unshare', b'malloc_usable_size', b'__cxa_type_match'])
 actual_symbols = set()
 
 objdump_output = subprocess.check_output([


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This symbol is present in the new LLVM C++ stdlib, which is loaded dynamically from a .so file during startup.

Fixes #14571

r? @Ms2ger 
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14587)
<!-- Reviewable:end -->
