### PR TITLE
FIX for Implement scroll transactions

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1081,6 +1081,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                               delta: TypedPoint2D<f32, DevicePixel>,
                               cursor: TypedPoint2D<i32, DevicePixel>) {
         let event_phase = match (self.scroll_in_progress, self.in_scroll_transaction) {
+            (false, None) => ScrollEventPhase::Start,
             (false, Some(last_scroll)) if last_scroll.elapsed() > Duration::from_millis(80) =>
                 ScrollEventPhase::Start,
             (_, _) => ScrollEventPhase::Move(self.scroll_in_progress),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Follow up on https://github.com/servo/servo/pull/14470

@mbrubeck @KiChjang @glennw I just found out in the context of https://github.com/servo/webrender/pull/600 I forgot to add a case for the very first scroll event, or else the scrolling on that PR, in a non-Mac OS environment, will only start after an 80ms pause following the initial scroll event...

Sorry this slipped through my initial testing...

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14597)
<!-- Reviewable:end -->
