### PR TITLE
stylo: Don't keep around cached style after one-off style resolutions.

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -807,6 +807,8 @@ pub extern "C" fn Servo_ResolveStyle(element: RawGeckoElementBorrowed,
                                      consume: structs::ConsumeStyleBehavior,
                                      compute: structs::LazyComputeBehavior) -> ServoComputedValuesStrong
 {
+    use style::context::StyleContext;
+
     let element = GeckoElement(element);
     debug!("Servo_ResolveStyle: {:?}, consume={:?}, compute={:?}", element, consume, compute);
 
@@ -832,6 +834,9 @@ pub extern "C" fn Servo_ResolveStyle(element: RawGeckoElementBorrowed,
             };
 
             recalc_style_at::<_, _, RecalcStyleOnly>(&context, &mut traversal_data, element, &mut data);
+
+            // We don't want to keep any cached style around after this one-off style resolution.
+            context.local_context().style_sharing_candidate_cache.borrow_mut().clear();
 
             // The element was either unstyled or needed restyle. If it was unstyled, it may have
             // additional unstyled children that subsequent traversals won't find now that the style


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

r? @bholley 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14599)
<!-- Reviewable:end -->
