### PR TITLE
Parallelize build-time bindgen

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -617,8 +617,14 @@ mod bindings {
 pub fn generate() {
     use self::common::*;
     use std::fs;
+    use std::thread;
     fs::create_dir_all(&*OUTDIR_PATH).unwrap();
-    bindings::generate_structs(BuildType::Debug);
-    bindings::generate_structs(BuildType::Release);
-    bindings::generate_bindings();
+    let threads = vec![
+        thread::spawn(|| bindings::generate_structs(BuildType::Debug)),
+        thread::spawn(|| bindings::generate_structs(BuildType::Release)),
+        thread::spawn(|| bindings::generate_bindings()),
+    ];
+    for t in threads.into_iter() {
+        t.join().unwrap();
+    }
 }


### PR DESCRIPTION
When there is nothing else is being compiled, this cuts the time consumption of running the bindgen part by more than half.

r? @emilio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14600)
<!-- Reviewable:end -->
