### PR TITLE
Rework the way scroll roots are collected

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -42,8 +42,7 @@ use flow::IS_ABSOLUTELY_POSITIONED;
 use flow_list::FlowList;
 use fragment::{CoordinateSystem, Fragment, FragmentBorderBoxIterator, Overflow};
 use fragment::{IS_INLINE_FLEX_ITEM, IS_BLOCK_FLEX_ITEM};
-use gfx::display_list::{ClippingRegion, StackingContext};
-use gfx_traits::ScrollRootId;
+use gfx::display_list::ClippingRegion;
 use gfx_traits::print_tree::PrintTree;
 use layout_debug;
 use model::{AdjoiningMargins, CollapsibleMargins, IntrinsicISizes, MarginCollapseInfo, MaybeAuto};
@@ -2195,10 +2194,8 @@ impl Flow for BlockFlow {
         }
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.collect_stacking_contexts_for_block(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.collect_stacking_contexts_for_block(state);
     }
 
     fn build_display_list(&mut self, state: &mut DisplayListBuildState) {

--- a/components/layout/flex.rs
+++ b/components/layout/flex.rs
@@ -16,8 +16,6 @@ use flow;
 use flow::{Flow, FlowClass, ImmutableFlowUtils, OpaqueFlow};
 use flow::{INLINE_POSITION_IS_STATIC, IS_ABSOLUTELY_POSITIONED};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
-use gfx::display_list::StackingContext;
-use gfx_traits::ScrollRootId;
 use layout_debug;
 use model::{IntrinsicISizes, MaybeAuto, SizeConstraint};
 use model::{specified, specified_or_none};
@@ -967,10 +965,8 @@ impl Flow for FlexFlow {
         self.build_display_list_for_flex(state);
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.block_flow.collect_stacking_contexts(state);
     }
 
     fn repair_style(&mut self, new_style: &Arc<ServoComputedValues>) {

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -35,7 +35,7 @@ use floats::{Floats, SpeculatedFloatPlacement};
 use flow_list::{FlowList, MutFlowListIterator};
 use flow_ref::{FlowRef, WeakFlowRef};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
-use gfx::display_list::{ClippingRegion, StackingContext};
+use gfx::display_list::ClippingRegion;
 use gfx_traits::{ScrollRootId, StackingContextId};
 use gfx_traits::print_tree::PrintTree;
 use inline::InlineFlow;
@@ -221,9 +221,7 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
         None
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 _parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState);
 
     /// If this is a float, places it. The default implementation does nothing.
     fn place_float_if_applicable<'a>(&mut self) {}
@@ -1115,11 +1113,9 @@ impl BaseFlow {
         return self as *const BaseFlow as usize;
     }
 
-    pub fn collect_stacking_contexts_for_children(&mut self,
-                                                  parent: &mut StackingContext,
-                                                  parent_scroll_root_id: ScrollRootId) {
+    pub fn collect_stacking_contexts_for_children(&mut self, state: &mut DisplayListBuildState) {
         for kid in self.children.iter_mut() {
-            kid.collect_stacking_contexts(parent, parent_scroll_root_id);
+            kid.collect_stacking_contexts(state);
         }
     }
 

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -16,10 +16,9 @@ use flow::OpaqueFlow;
 use flow_ref::FlowRef;
 use fragment::{CoordinateSystem, Fragment, FragmentBorderBoxIterator, Overflow};
 use fragment::SpecificFragmentInfo;
-use gfx::display_list::{OpaqueNode, StackingContext};
+use gfx::display_list::OpaqueNode;
 use gfx::font::FontMetrics;
 use gfx::font_context::FontContext;
-use gfx_traits::ScrollRootId;
 use gfx_traits::print_tree::PrintTree;
 use layout_debug;
 use model::IntrinsicISizesContribution;
@@ -1622,10 +1621,8 @@ impl Flow for InlineFlow {
 
     fn update_late_computed_block_position_if_necessary(&mut self, _: Au) {}
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.collect_stacking_contexts_for_inline(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.collect_stacking_contexts_for_inline(state);
     }
 
     fn build_display_list(&mut self, state: &mut DisplayListBuildState) {

--- a/components/layout/list_item.rs
+++ b/components/layout/list_item.rs
@@ -17,8 +17,6 @@ use flow::{Flow, FlowClass, OpaqueFlow};
 use fragment::{CoordinateSystem, Fragment, FragmentBorderBoxIterator, GeneratedContentInfo};
 use fragment::Overflow;
 use generated_content;
-use gfx::display_list::StackingContext;
-use gfx_traits::ScrollRootId;
 use inline::InlineFlow;
 use std::sync::Arc;
 use style::computed_values::{list_style_type, position};
@@ -144,10 +142,8 @@ impl Flow for ListItemFlow {
         self.build_display_list_for_list_item(state);
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.block_flow.collect_stacking_contexts(state);
     }
 
     fn repair_style(&mut self, new_style: &Arc<ServoComputedValues>) {

--- a/components/layout/multicol.rs
+++ b/components/layout/multicol.rs
@@ -15,8 +15,6 @@ use euclid::Size2D;
 use floats::FloatKind;
 use flow::{Flow, FlowClass, OpaqueFlow, mut_base, FragmentationContext};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
-use gfx::display_list::StackingContext;
-use gfx_traits::ScrollRootId;
 use gfx_traits::print_tree::PrintTree;
 use std::cmp::{min, max};
 use std::fmt;
@@ -188,10 +186,8 @@ impl Flow for MulticolFlow {
         self.block_flow.build_display_list(state);
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.block_flow.collect_stacking_contexts(state);
     }
 
     fn repair_style(&mut self, new_style: &Arc<ServoComputedValues>) {
@@ -272,10 +268,8 @@ impl Flow for MulticolColumnFlow {
         self.block_flow.build_display_list(state);
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.block_flow.collect_stacking_contexts(state);
     }
 
     fn repair_style(&mut self, new_style: &Arc<ServoComputedValues>) {

--- a/components/layout/sequential.rs
+++ b/components/layout/sequential.rs
@@ -14,7 +14,6 @@ use flow::{PostorderFlowTraversal, PreorderFlowTraversal};
 use flow::IS_ABSOLUTELY_POSITIONED;
 use fragment::FragmentBorderBoxIterator;
 use generated_content::ResolveGeneratedContent;
-use gfx_traits::ScrollRootId;
 use servo_config::opts;
 use style::servo::restyle_damage::{REFLOW, STORE_OVERFLOW};
 use traversal::{AssignBSizes, AssignISizes, BubbleISizes, BuildDisplayList};
@@ -76,9 +75,8 @@ pub fn traverse_flow_tree_preorder(root: &mut Flow,
 pub fn build_display_list_for_subtree<'a>(flow_root: &mut Flow,
                                           shared_layout_context: &'a SharedLayoutContext)
                                           -> DisplayListBuildState<'a> {
-    let mut state = DisplayListBuildState::new(shared_layout_context,
-                                               flow::base(flow_root).stacking_context_id);
-    flow_root.collect_stacking_contexts(&mut state.root_stacking_context, ScrollRootId::root());
+    let mut state = DisplayListBuildState::new(shared_layout_context);
+    flow_root.collect_stacking_contexts(&mut state);
 
     let mut build_display_list = BuildDisplayList { state: state };
     build_display_list.traverse(flow_root);

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -16,8 +16,6 @@ use flow;
 use flow::{BaseFlow, EarlyAbsolutePositionInfo, Flow, FlowClass, ImmutableFlowUtils, OpaqueFlow};
 use flow_list::MutFlowListIterator;
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
-use gfx::display_list::StackingContext;
-use gfx_traits::ScrollRootId;
 use gfx_traits::print_tree::PrintTree;
 use layout_debug;
 use model::{IntrinsicISizes, IntrinsicISizesContribution, MaybeAuto};
@@ -501,10 +499,8 @@ impl Flow for TableFlow {
         self.block_flow.build_display_list_for_block(state, border_painting_mode);
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.block_flow.collect_stacking_contexts(state);
     }
 
     fn repair_style(&mut self, new_style: &Arc<ServoComputedValues>) {

--- a/components/layout/table_caption.rs
+++ b/components/layout/table_caption.rs
@@ -13,8 +13,6 @@ use display_list_builder::DisplayListBuildState;
 use euclid::Point2D;
 use flow::{Flow, FlowClass, OpaqueFlow};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
-use gfx::display_list::StackingContext;
-use gfx_traits::ScrollRootId;
 use gfx_traits::print_tree::PrintTree;
 use std::fmt;
 use std::sync::Arc;
@@ -83,10 +81,8 @@ impl Flow for TableCaptionFlow {
         self.block_flow.build_display_list(state);
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.block_flow.collect_stacking_contexts(state);
     }
 
     fn repair_style(&mut self, new_style: &Arc<ServoComputedValues>) {

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -14,8 +14,6 @@ use display_list_builder::{BlockFlowDisplayListBuilding, BorderPaintingMode, Dis
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
 use flow::{self, Flow, FlowClass, IS_ABSOLUTELY_POSITIONED, OpaqueFlow};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
-use gfx::display_list::StackingContext;
-use gfx_traits::ScrollRootId;
 use gfx_traits::print_tree::PrintTree;
 use layout_debug;
 use model::MaybeAuto;
@@ -262,10 +260,8 @@ impl Flow for TableCellFlow {
         self.block_flow.build_display_list_for_block(state, border_painting_mode)
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.block_flow.collect_stacking_contexts(state);
     }
 
     fn repair_style(&mut self, new_style: &Arc<ServoComputedValues>) {

--- a/components/layout/table_colgroup.rs
+++ b/components/layout/table_colgroup.rs
@@ -12,8 +12,6 @@ use display_list_builder::DisplayListBuildState;
 use euclid::Point2D;
 use flow::{BaseFlow, Flow, FlowClass, ForceNonfloatedFlag, OpaqueFlow};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow, SpecificFragmentInfo};
-use gfx::display_list::StackingContext;
-use gfx_traits::ScrollRootId;
 use layout_debug;
 use std::cmp::max;
 use std::fmt;
@@ -96,9 +94,7 @@ impl Flow for TableColGroupFlow {
     // Table columns are invisible.
     fn build_display_list(&mut self, _: &mut DisplayListBuildState) { }
 
-    fn collect_stacking_contexts(&mut self,
-                                 _parent: &mut StackingContext,
-                                 _parent_scroll_root_id: ScrollRootId) {}
+    fn collect_stacking_contexts(&mut self, _: &mut DisplayListBuildState) {}
 
     fn repair_style(&mut self, _: &Arc<ServoComputedValues>) {}
 

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -15,8 +15,6 @@ use euclid::Point2D;
 use flow::{self, EarlyAbsolutePositionInfo, Flow, FlowClass, ImmutableFlowUtils, OpaqueFlow};
 use flow_list::MutFlowListIterator;
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
-use gfx::display_list::StackingContext;
-use gfx_traits::ScrollRootId;
 use gfx_traits::print_tree::PrintTree;
 use layout_debug;
 use model::MaybeAuto;
@@ -481,10 +479,8 @@ impl Flow for TableRowFlow {
         self.block_flow.build_display_list_for_block(state, border_painting_mode);
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.block_flow.collect_stacking_contexts(state);
     }
 
     fn repair_style(&mut self, new_style: &Arc<ServoComputedValues>) {

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -13,8 +13,6 @@ use display_list_builder::DisplayListBuildState;
 use euclid::Point2D;
 use flow::{Flow, FlowClass, OpaqueFlow};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
-use gfx::display_list::StackingContext;
-use gfx_traits::ScrollRootId;
 use gfx_traits::print_tree::PrintTree;
 use layout_debug;
 use serde::{Serialize, Serializer};
@@ -184,10 +182,8 @@ impl Flow for TableRowGroupFlow {
         self.block_flow.build_display_list(state);
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.block_flow.collect_stacking_contexts(state);
     }
 
     fn repair_style(&mut self, new_style: &Arc<ServoComputedValues>) {

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -22,8 +22,6 @@ use euclid::Point2D;
 use floats::FloatKind;
 use flow::{Flow, FlowClass, ImmutableFlowUtils, INLINE_POSITION_IS_STATIC, OpaqueFlow};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
-use gfx::display_list::StackingContext;
-use gfx_traits::ScrollRootId;
 use gfx_traits::print_tree::PrintTree;
 use model::MaybeAuto;
 use std::cmp::{max, min};
@@ -462,10 +460,8 @@ impl Flow for TableWrapperFlow {
         self.block_flow.build_display_list(state);
     }
 
-    fn collect_stacking_contexts(&mut self,
-                                 parent: &mut StackingContext,
-                                 parent_scroll_root_id: ScrollRootId) {
-        self.block_flow.collect_stacking_contexts(parent, parent_scroll_root_id);
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.block_flow.collect_stacking_contexts(state);
     }
 
     fn repair_style(&mut self, new_style: &Arc<ServoComputedValues>) {

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -232,17 +232,11 @@ pub struct BuildDisplayList<'a> {
 impl<'a> BuildDisplayList<'a> {
     #[inline]
     pub fn traverse(&mut self, flow: &mut Flow) {
-        let new_stacking_context =
-            flow::base(flow).stacking_context_id != self.state.stacking_context_id();
-        if new_stacking_context {
-            self.state.push_stacking_context_id(flow::base(flow).stacking_context_id);
-        }
+        let parent_stacking_context_id = self.state.current_stacking_context_id;
+        self.state.current_stacking_context_id = flow::base(flow).stacking_context_id;
 
-        let new_scroll_root =
-            flow::base(flow).scroll_root_id != self.state.scroll_root_id();
-        if new_scroll_root {
-            self.state.push_scroll_root_id(flow::base(flow).scroll_root_id);
-        }
+        let parent_scroll_root_id = self.state.current_scroll_root_id;
+        self.state.current_scroll_root_id = flow::base(flow).scroll_root_id;
 
         if self.should_process() {
             flow.build_display_list(&mut self.state);
@@ -253,13 +247,8 @@ impl<'a> BuildDisplayList<'a> {
             self.traverse(kid);
         }
 
-        if new_stacking_context {
-            self.state.pop_stacking_context_id();
-        }
-
-        if new_scroll_root {
-            self.state.pop_scroll_root_id();
-        }
+        self.state.current_stacking_context_id = parent_stacking_context_id;
+        self.state.current_scroll_root_id = parent_scroll_root_id;
     }
 
     #[inline]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they should not change behavior.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

Collect scroll roots during the collect_stacking_context phase instead
of during display list construction. This will be useful in order to
collect containing block scroll roots as well as to give scroll roots
sequential ids in the future. This change also pulls stacking context
children out of the StackingContext struct itself, which should reduce
very slightly the memory used by the finished display list. This also
simplifies the DisplayListBuilder because it no longer has to maintain
a stack of ScrollRootIds and StackingContextIds and can instead just
rely on the program stack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14603)
<!-- Reviewable:end -->
