### PR TITLE
style: Avoid ending up with an invalid keyframe when inf or NaN are a…

### DIFF
--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -50,10 +50,11 @@ impl KeyframePercentage {
             KeyframePercentage::new(1.)
         } else {
             let percentage = try!(input.expect_percentage());
-            if percentage > 1. || percentage < 0. {
+            if percentage >= 0. && percentage <= 1. {
+                KeyframePercentage::new(percentage)
+            } else {
                 return Err(());
             }
-            KeyframePercentage::new(percentage)
         };
 
         Ok(percentage)

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -8294,6 +8294,12 @@
             "url": "/_mozilla/mozilla/iterable.html"
           }
         ],
+        "mozilla/keyframe-infinite-percentage.html": [
+          {
+            "path": "mozilla/keyframe-infinite-percentage.html",
+            "url": "/_mozilla/mozilla/keyframe-infinite-percentage.html"
+          }
+        ],
         "mozilla/lenient_this.html": [
           {
             "path": "mozilla/lenient_this.html",

--- a/tests/wpt/mozilla/tests/mozilla/keyframe-infinite-percentage.html
+++ b/tests/wpt/mozilla/tests/mozilla/keyframe-infinite-percentage.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Shouldn't end up with an invalid keyframe when inf or nan are at play.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@keyframes anim {
+  0e309% {}
+}
+</style>
+<script>
+test(function() {
+  assert_true(true, "Doesn't crash");
+}, "Doesn't crash");
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fixes: https://bugzilla.mozilla.org/show_bug.cgi?id=1323717

r? @SimonSapin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14605)
<!-- Reviewable:end -->
