### PR TITLE
Update atoms when build geckolib with gecko

### DIFF
--- a/components/style/binding_tools/regen_atoms.py
+++ b/components/style/binding_tools/regen_atoms.py
@@ -34,14 +34,14 @@ def msvc32_symbolify(source, ident):
 
 class GkAtomSource:
     PATTERN = re.compile('^GK_ATOM\((?P<ident>.+),\s*"(?P<value>.*)"\)', re.M)
-    FILE = "dist/include/nsGkAtomList.h"
+    FILE = "include/nsGkAtomList.h"
     CLASS = "nsGkAtoms"
     TYPE = "nsIAtom"
 
 
 class CSSPseudoElementsAtomSource:
     PATTERN = re.compile('^CSS_PSEUDO_ELEMENT\((?P<ident>.+),\s*"(?P<value>.*)",', re.M)
-    FILE = "dist/include/nsCSSPseudoElementList.h"
+    FILE = "include/nsCSSPseudoElementList.h"
     CLASS = "nsCSSPseudoElements"
     # NB: nsICSSPseudoElement is effectively the same as a nsIAtom, but we need
     # this for MSVC name mangling.
@@ -50,14 +50,14 @@ class CSSPseudoElementsAtomSource:
 
 class CSSAnonBoxesAtomSource:
     PATTERN = re.compile('^CSS_ANON_BOX\((?P<ident>.+),\s*"(?P<value>.*)"\)', re.M)
-    FILE = "dist/include/nsCSSAnonBoxList.h"
+    FILE = "include/nsCSSAnonBoxList.h"
     CLASS = "nsCSSAnonBoxes"
     TYPE = "nsICSSAnonBoxPseudo"
 
 
 class CSSPropsAtomSource:
     PATTERN = re.compile('^CSS_PROP_[A-Z]+\(\s*(?P<value>[^,]+),\s*(?P<ident>[^,]+)', re.M)
-    FILE = "dist/include/nsCSSPropList.h"
+    FILE = "include/nsCSSPropList.h"
     CLASS = "nsCSSProps"
     TYPE = "nsICSSProperty"
 
@@ -232,10 +232,15 @@ def write_pseudo_element_helper(atoms, target_filename):
         f.write("}\n")
 
 
-if len(sys.argv) != 2:
-    print("Usage: {} objdir".format(sys.argv[0]))
-    exit(2)
+def generate_atoms(dist):
+    style_path = os.path.dirname(os.path.dirname(__file__))
+    atoms = collect_atoms(dist)
+    write_atom_macro(atoms, os.path.join(style_path, "gecko_string_cache/atom_macro.rs"))
+    write_pseudo_element_helper(atoms, os.path.join(style_path, "gecko/generated/gecko_pseudo_element_helper.rs"))
 
-atoms = collect_atoms(sys.argv[1])
-write_atom_macro(atoms, "../gecko_string_cache/atom_macro.rs")
-write_pseudo_element_helper(atoms, "../gecko/generated/gecko_pseudo_element_helper.rs")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: {} objdir".format(sys.argv[0]))
+        exit(2)
+    generate_atoms(os.path.join(sys.argv[1], "dist"))

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -416,6 +416,14 @@ class MachCommands(CommandBase):
         if release:
             opts += ["--release"]
 
+        if with_gecko is not None:
+            print("Generating atoms data...")
+            run_file = path.join(self.context.topdir, "components",
+                                 "style", "binding_tools", "regen_atoms.py")
+            run_globals = {"__file__": run_file}
+            execfile(run_file, run_globals)
+            run_globals["generate_atoms"](env["MOZ_DIST"])
+
         build_start = time()
         with cd(path.join("ports", "geckolib")):
             ret = call(["cargo", "build"] + opts, env=env, verbose=verbose)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This would automatically update the generated atom-related files in-tree before calling cargo to build geckolib. With this change, `./mach build-gecko --with-gecko` should be now the easiest way to update all in-tree bindings.

This isn't really a build-time generating, because it isn't invoked from the build script, but from mach. It isn't done the other way because
1. it doesn't seem to be a common practice for build script to write anything to the src directory
2. real build-time generated atom data wouldn't need to include atoms for multiple platforms, but we still want it so that we can build geckolib independently

cc @heycam 

r? @emilio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14609)
<!-- Reviewable:end -->
