### PR TITLE
Updating GATTServer's  Connect/Disconnect calls

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -65,3 +65,4 @@ fetch
 characteristicvaluechanged
 fullscreenchange
 fullscreenerror
+gattserverdisconnected

--- a/components/bluetooth/test.rs
+++ b/components/bluetooth/test.rs
@@ -222,21 +222,23 @@ fn create_heart_rate_service(device: &BluetoothDevice,
         try!(create_characteristic_with_value(&heart_rate_service,
                                               HEART_RATE_MEASUREMENT_CHARACTERISTIC_UUID.to_owned(),
                                               vec![0]));
-    try!(heart_rate_measurement_characteristic.set_flags(vec![NOTIFY_FLAG.to_string()]));
+    try!(heart_rate_measurement_characteristic.set_flags(vec![NOTIFY_FLAG.to_string(),
+                                                              READ_FLAG.to_string(),
+                                                              WRITE_FLAG.to_string()]));
 
     // Body Sensor Location Characteristic 1
     let body_sensor_location_characteristic_1 =
         try!(create_characteristic_with_value(&heart_rate_service,
                                               BODY_SENSOR_LOCATION_CHARACTERISTIC_UUID.to_owned(),
                                               vec![49]));
-    try!(body_sensor_location_characteristic_1.set_flags(vec![READ_FLAG.to_string()]));
+    try!(body_sensor_location_characteristic_1.set_flags(vec![READ_FLAG.to_string(), WRITE_FLAG.to_string()]));
 
     // Body Sensor Location Characteristic 2
     let body_sensor_location_characteristic_2 =
         try!(create_characteristic_with_value(&heart_rate_service,
                                               BODY_SENSOR_LOCATION_CHARACTERISTIC_UUID.to_owned(),
                                               vec![50]));
-    try!(body_sensor_location_characteristic_2.set_flags(vec![READ_FLAG.to_string()]));
+    try!(body_sensor_location_characteristic_2.set_flags(vec![READ_FLAG.to_string(), WRITE_FLAG.to_string()]));
     Ok(heart_rate_service)
 }
 

--- a/components/bluetooth_traits/lib.rs
+++ b/components/bluetooth_traits/lib.rs
@@ -85,12 +85,14 @@ pub type BluetoothResponseResult = Result<BluetoothResponse, BluetoothError>;
 pub enum BluetoothRequest {
     RequestDevice(RequestDeviceoptions, IpcSender<BluetoothResponseResult>),
     GATTServerConnect(String, IpcSender<BluetoothResponseResult>),
-    GATTServerDisconnect(String, IpcSender<BluetoothResult<bool>>),
+    GATTServerDisconnect(String, IpcSender<BluetoothResult<()>>),
     GetGATTChildren(String, Option<String>, bool, GATTType, IpcSender<BluetoothResponseResult>),
     ReadValue(String, IpcSender<BluetoothResponseResult>),
     WriteValue(String, Vec<u8>, IpcSender<BluetoothResponseResult>),
     EnableNotification(String, bool, IpcSender<BluetoothResponseResult>),
     WatchAdvertisements(String, IpcSender<BluetoothResponseResult>),
+    SetRepresentedToNull(Vec<String>, Vec<String>, Vec<String>),
+    IsRepresentedDeviceNull(String, IpcSender<bool>),
     Test(String, IpcSender<BluetoothResult<()>>),
     Exit,
 }

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -106,6 +106,10 @@ impl Bluetooth {
         self.global().as_window().bluetooth_thread()
     }
 
+    pub fn get_device_map(&self) -> &DOMRefCell<HashMap<String, MutJS<BluetoothDevice>>> {
+        &self.device_instance_map
+    }
+
     // https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices
     fn request_bluetooth_devices(&self,
                                  p: &Rc<Promise>,

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6794,6 +6794,12 @@
             "url": "/_mozilla/mozilla/bluetooth/disconnect/disconnect-twice-in-a-row.html"
           }
         ],
+        "mozilla/bluetooth/disconnect/event-is-fired.html": [
+          {
+            "path": "mozilla/bluetooth/disconnect/event-is-fired.html",
+            "url": "/_mozilla/mozilla/bluetooth/disconnect/event-is-fired.html"
+          }
+        ],
         "mozilla/bluetooth/getCharacteristic/blocklisted-characteristic.html": [
           {
             "path": "mozilla/bluetooth/getCharacteristic/blocklisted-characteristic.html",
@@ -6828,6 +6834,18 @@
           {
             "path": "mozilla/bluetooth/getCharacteristic/disconnect-called-during.html",
             "url": "/_mozilla/mozilla/bluetooth/getCharacteristic/disconnect-called-during.html"
+          }
+        ],
+        "mozilla/bluetooth/getCharacteristic/disconnect-invalidates-object.html": [
+          {
+            "path": "mozilla/bluetooth/getCharacteristic/disconnect-invalidates-object.html",
+            "url": "/_mozilla/mozilla/bluetooth/getCharacteristic/disconnect-invalidates-object.html"
+          }
+        ],
+        "mozilla/bluetooth/getCharacteristic/get-different-characteristic-after-reconnection.html": [
+          {
+            "path": "mozilla/bluetooth/getCharacteristic/get-different-characteristic-after-reconnection.html",
+            "url": "/_mozilla/mozilla/bluetooth/getCharacteristic/get-different-characteristic-after-reconnection.html"
           }
         ],
         "mozilla/bluetooth/getCharacteristic/get-same-characteristic.html": [
@@ -6926,6 +6944,18 @@
             "url": "/_mozilla/mozilla/bluetooth/getCharacteristics/disconnect-called-during.html"
           }
         ],
+        "mozilla/bluetooth/getCharacteristics/disconnect-invalidates-objects.html": [
+          {
+            "path": "mozilla/bluetooth/getCharacteristics/disconnect-invalidates-objects.html",
+            "url": "/_mozilla/mozilla/bluetooth/getCharacteristics/disconnect-invalidates-objects.html"
+          }
+        ],
+        "mozilla/bluetooth/getCharacteristics/get-different-characteristics-after-reconnection.html": [
+          {
+            "path": "mozilla/bluetooth/getCharacteristics/get-different-characteristics-after-reconnection.html",
+            "url": "/_mozilla/mozilla/bluetooth/getCharacteristics/get-different-characteristics-after-reconnection.html"
+          }
+        ],
         "mozilla/bluetooth/getCharacteristics/get-same-characteristics.html": [
           {
             "path": "mozilla/bluetooth/getCharacteristics/get-same-characteristics.html",
@@ -6990,6 +7020,18 @@
           {
             "path": "mozilla/bluetooth/getDescriptor/disconnect-called-during.html",
             "url": "/_mozilla/mozilla/bluetooth/getDescriptor/disconnect-called-during.html"
+          }
+        ],
+        "mozilla/bluetooth/getDescriptor/disconnect-invalidates-object.html": [
+          {
+            "path": "mozilla/bluetooth/getDescriptor/disconnect-invalidates-object.html",
+            "url": "/_mozilla/mozilla/bluetooth/getDescriptor/disconnect-invalidates-object.html"
+          }
+        ],
+        "mozilla/bluetooth/getDescriptor/get-different-descriptor-after-reconnection.html": [
+          {
+            "path": "mozilla/bluetooth/getDescriptor/get-different-descriptor-after-reconnection.html",
+            "url": "/_mozilla/mozilla/bluetooth/getDescriptor/get-different-descriptor-after-reconnection.html"
           }
         ],
         "mozilla/bluetooth/getDescriptor/get-same-descriptor.html": [
@@ -7094,6 +7136,18 @@
             "url": "/_mozilla/mozilla/bluetooth/getDescriptors/disconnect-called-during.html"
           }
         ],
+        "mozilla/bluetooth/getDescriptors/disconnect-invalidates-objects.html": [
+          {
+            "path": "mozilla/bluetooth/getDescriptors/disconnect-invalidates-objects.html",
+            "url": "/_mozilla/mozilla/bluetooth/getDescriptors/disconnect-invalidates-objects.html"
+          }
+        ],
+        "mozilla/bluetooth/getDescriptors/get-different-descriptors-after-reconnection.html": [
+          {
+            "path": "mozilla/bluetooth/getDescriptors/get-different-descriptors-after-reconnection.html",
+            "url": "/_mozilla/mozilla/bluetooth/getDescriptors/get-different-descriptors-after-reconnection.html"
+          }
+        ],
         "mozilla/bluetooth/getDescriptors/get-same-descriptors.html": [
           {
             "path": "mozilla/bluetooth/getDescriptors/get-same-descriptors.html",
@@ -7124,10 +7178,22 @@
             "url": "/_mozilla/mozilla/bluetooth/getPrimaryService/disconnect-called-during.html"
           }
         ],
+        "mozilla/bluetooth/getPrimaryService/disconnect-invalidates-object.html": [
+          {
+            "path": "mozilla/bluetooth/getPrimaryService/disconnect-invalidates-object.html",
+            "url": "/_mozilla/mozilla/bluetooth/getPrimaryService/disconnect-invalidates-object.html"
+          }
+        ],
         "mozilla/bluetooth/getPrimaryService/disconnected-device.html": [
           {
             "path": "mozilla/bluetooth/getPrimaryService/disconnected-device.html",
             "url": "/_mozilla/mozilla/bluetooth/getPrimaryService/disconnected-device.html"
+          }
+        ],
+        "mozilla/bluetooth/getPrimaryService/get-different-service-after-reconnection.html": [
+          {
+            "path": "mozilla/bluetooth/getPrimaryService/get-different-service-after-reconnection.html",
+            "url": "/_mozilla/mozilla/bluetooth/getPrimaryService/get-different-service-after-reconnection.html"
           }
         ],
         "mozilla/bluetooth/getPrimaryService/get-same-service.html": [
@@ -7220,6 +7286,12 @@
             "url": "/_mozilla/mozilla/bluetooth/getPrimaryServices/disconnect-called-during.html"
           }
         ],
+        "mozilla/bluetooth/getPrimaryServices/disconnect-invalidates-objects.html": [
+          {
+            "path": "mozilla/bluetooth/getPrimaryServices/disconnect-invalidates-objects.html",
+            "url": "/_mozilla/mozilla/bluetooth/getPrimaryServices/disconnect-invalidates-objects.html"
+          }
+        ],
         "mozilla/bluetooth/getPrimaryServices/disconnected-device-with-uuid.html": [
           {
             "path": "mozilla/bluetooth/getPrimaryServices/disconnected-device-with-uuid.html",
@@ -7230,6 +7302,12 @@
           {
             "path": "mozilla/bluetooth/getPrimaryServices/disconnected-device.html",
             "url": "/_mozilla/mozilla/bluetooth/getPrimaryServices/disconnected-device.html"
+          }
+        ],
+        "mozilla/bluetooth/getPrimaryServices/get-different-services-after-reconnection.html": [
+          {
+            "path": "mozilla/bluetooth/getPrimaryServices/get-different-services-after-reconnection.html",
+            "url": "/_mozilla/mozilla/bluetooth/getPrimaryServices/get-different-services-after-reconnection.html"
           }
         ],
         "mozilla/bluetooth/getPrimaryServices/get-same-service.html": [

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/disconnect-invalidates-object.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristic/disconnect-invalidates-object.html.ini
@@ -1,0 +1,5 @@
+[disconnect-invalidates-object.html]
+  type: testharness
+  [Calls on a characteristic after we disconnect and connect again. Should reject with InvalidStateError.]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-invalidates-objects.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/getCharacteristics/disconnect-invalidates-objects.html.ini
@@ -1,0 +1,5 @@
+[disconnect-invalidates-objects.html]
+  type: testharness
+  [Calls on characteristics after we disconnect and connect again. Should reject with InvalidStateError.]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/stopNotifications/disconnect-called-before.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/stopNotifications/disconnect-called-before.html.ini
@@ -1,5 +1,0 @@
-[disconnect-called-before.html]
-  type: testharness
-  [disconnect() called before stopNotifications. Reject with InvalidStateError.]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/disconnect/event-is-fired.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/disconnect/event-is-fired.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(() => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+        optionalServices: [generic_access.name]
+    })
+    .then(device => {
+        return device.gatt.connect()
+        .then(gattServer => {
+            let event = 'gattserverdisconnected';
+            let disconnected = new Promise((resolve, reject) => {
+                let event_listener = (e) => {
+                    device.removeEventListener(event, event_listener);
+                    resolve(e);
+                };
+                device.addEventListener(event, event_listener);
+            });
+            gattServer.disconnect();
+            return disconnected
+        })
+        .then(disconnected => {
+            assert_equals(disconnected.target.name, mock_device_name.heart_rate);
+            assert_true(disconnected.bubbles);
+        });
+    });
+}, 'A device disconnecting while connected should fire the gattserverdisconnected event.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/disconnect-invalidates-object.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/disconnect-invalidates-object.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.two_heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [generic_access.name]}]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        return gattServer.getPrimaryService(generic_access.name)
+        .then(service => service.getCharacteristic(device_name.name))
+        .then(c => {
+            let characteristic = c;
+            gattServer.disconnect();
+            return gattServer.connect()
+            .then(() => characteristic);
+        });
+    })
+    .then(characteristic => {
+        let promises = [];
+        promises.push(promise_rejects(t, 'InvalidStateError', characteristic.getDescriptor(number_of_digitals.name)));
+        promises.push(promise_rejects(t, 'InvalidStateError', characteristic.getDescriptors(number_of_digitals.name)));
+        promises.push(promise_rejects(t, 'InvalidStateError', characteristic.getDescriptors()));
+        promises.push(promise_rejects(t, 'InvalidStateError', characteristic.readValue()));
+        promises.push(promise_rejects(t, 'InvalidStateError', characteristic.writeValue(new Uint8Array(1))));
+        promises.push(promise_rejects(t, 'InvalidStateError', characteristic.startNotifications()));
+        promises.push(promise_rejects(t, 'InvalidStateError', characteristic.stopNotifications()));
+        return Promise.all(promises);
+    });
+}, 'Calls on a characteristic after we disconnect and connect again. Should reject with InvalidStateError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/get-different-characteristic-after-reconnection.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristic/get-different-characteristic-after-reconnection.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.two_heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [generic_access.name]}]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        let characteristic1;
+        return gattServer.getPrimaryService(generic_access.name)
+        .then(service => service.getCharacteristic(device_name.name))
+        .then(characteristic => characteristic1 = characteristic)
+        .then(() => gattServer.disconnect())
+        .then(() => gattServer.connect())
+        .then(() => gattServer.getPrimaryService(generic_access.name))
+        .then(service => service.getCharacteristic(device_name.name))
+        .then(characteristic2 => [characteristic1, characteristic2])
+    })
+    .then(characteristics_array => {
+        assert_not_equals(characteristics_array[0], characteristics_array[1]);
+    });
+}, 'Calls to getCharacteristic after a disconnection should return a different object.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-invalidates-objects.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/disconnect-invalidates-objects.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        return gattServer.getPrimaryService(heart_rate.name)
+        .then(service => service.getCharacteristics())
+        .then(c => {
+            let characteristics = c;
+            assert_greater_than(characteristics.length, 1);
+            gattServer.disconnect();
+            return gattServer.connect()
+            .then(() => characteristics);
+        });
+    })
+    .then(characteristics => {
+        let promises = [];
+        for (let characteristic of characteristics) {
+            promises.push(promise_rejects(t, 'InvalidStateError', characteristic.getDescriptor(number_of_digitals.name)));
+            promises.push(promise_rejects(t, 'InvalidStateError', characteristic.getDescriptors(number_of_digitals.name)));
+            promises.push(promise_rejects(t, 'InvalidStateError', characteristic.getDescriptors()));
+            promises.push(promise_rejects(t, 'InvalidStateError', characteristic.readValue()));
+            promises.push(promise_rejects(t, 'InvalidStateError', characteristic.writeValue(new Uint8Array(1))));
+            promises.push(promise_rejects(t, 'InvalidStateError', characteristic.startNotifications()));
+            promises.push(promise_rejects(t, 'InvalidStateError', characteristic.stopNotifications()));
+        }
+        return Promise.all(promises);
+    });
+}, 'Calls on characteristics after we disconnect and connect again. Should reject with InvalidStateError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/get-different-characteristics-after-reconnection.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getCharacteristics/get-different-characteristics-after-reconnection.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        let characteristics1;
+        return gattServer.getPrimaryService(heart_rate.name)
+        .then(service => service.getCharacteristics())
+        .then(characteristics => characteristics1 = characteristics)
+        .then(() => gattServer.disconnect())
+        .then(() => gattServer.connect())
+        .then(() => gattServer.getPrimaryService(heart_rate.name))
+        .then(service => service.getCharacteristics())
+        .then(characteristics2 => [characteristics1, characteristics2])
+    })
+    .then(characteristics_arrays => {
+        for (let i = 1; i < characteristics_arrays.length; i++) {
+            assert_equals(characteristics_arrays[0].length, characteristics_arrays[i].length);
+        }
+        let base_set = new Set(characteristics_arrays.shift());
+        for (let characteristics of characteristics_arrays) {
+            characteristics.forEach(characteristic => assert_false(base_set.has(characteristic)));
+        }
+    });
+}, 'Calls to getCharacteristics after a disconnection should return different objects.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/disconnect-invalidates-object.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/disconnect-invalidates-object.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [generic_access.name]}]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        return gattServer.getPrimaryService(generic_access.name)
+        .then(service => service.getCharacteristic(device_name.name))
+        .then(characteristic => characteristic.getDescriptor(number_of_digitals.name))
+        .then(d => {
+            let descriptor = d;
+            gattServer.disconnect();
+            return gattServer.connect()
+            .then(() => descriptor);
+        });
+    })
+    .then(descriptor => {
+        let promises = [];
+        promises.push(promise_rejects(t, 'InvalidStateError', descriptor.readValue()));
+        promises.push(promise_rejects(t, 'InvalidStateError', descriptor.writeValue(new Uint8Array(1))));
+        return Promise.all(promises);
+    });
+}, 'Calls on a descriptor after we disconnect and connect again. Should reject with InvalidStateError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/get-different-descriptor-after-reconnection.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptor/get-different-descriptor-after-reconnection.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.two_heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [generic_access.name]}]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        let descriptor1;
+        return gattServer.getPrimaryService(generic_access.name)
+        .then(service => service.getCharacteristic(device_name.name))
+        .then(characteristic => characteristic.getDescriptor(number_of_digitals.name))
+        .then(descriptor => descriptor1 = descriptor)
+        .then(() => gattServer.disconnect())
+        .then(() => gattServer.connect())
+        .then(() => gattServer.getPrimaryService(generic_access.name))
+        .then(service => service.getCharacteristic(device_name.name))
+        .then(characteristic => characteristic.getDescriptor(number_of_digitals.name))
+        .then(descriptor2 => [descriptor1, descriptor2])
+    })
+    .then(descriptors_array => {
+        assert_not_equals(descriptors_array[0], descriptors_array[1]);
+    });
+}, 'Calls to getDescriptor after a disconnection should return a different object.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-invalidates-objects.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/disconnect-invalidates-objects.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [generic_access.name]}]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        return gattServer.getPrimaryService(generic_access.name)
+        .then(service => service.getCharacteristic(device_name.name))
+        .then(characteristic => characteristic.getDescriptors())
+        .then(d => {
+            let descriptors = d;
+            gattServer.disconnect();
+            return gattServer.connect()
+            .then(() => descriptors);
+        });
+    })
+    .then(descriptors => {
+        let promises = [];
+        for (let descriptor of descriptors) {
+            promises.push(promise_rejects(t, 'InvalidStateError', descriptor.readValue()));
+            if (descriptor.uuid != client_characteristic_configuration.uuid)
+                promises.push(promise_rejects(t, 'InvalidStateError', descriptor.writeValue(new Uint8Array(1))));
+        }
+        return Promise.all(promises);
+    });
+}, 'Calls on descriptors after we disconnect and connect again. Should reject with InvalidStateError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/get-different-descriptors-after-reconnection.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getDescriptors/get-different-descriptors-after-reconnection.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.two_heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [generic_access.name]}]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        let descriptors1;
+        return gattServer.getPrimaryService(generic_access.name)
+        .then(service => service.getCharacteristic(device_name.name))
+        .then(characteristic => characteristic.getDescriptors(number_of_digitals.name))
+        .then(descriptors => descriptors1 = descriptors)
+        .then(() => gattServer.disconnect())
+        .then(() => gattServer.connect())
+        .then(() => gattServer.getPrimaryService(generic_access.name))
+        .then(service => service.getCharacteristic(device_name.name))
+        .then(characteristic => characteristic.getDescriptors(number_of_digitals.name))
+        .then(descriptors2 => [descriptors1, descriptors2])
+    })
+    .then(descriptors_arrays => {
+        for (let i = 1; i < descriptors_arrays.length; i++) {
+            assert_equals(descriptors_arrays[0].length, descriptors_arrays[i].length);
+        }
+        let base_set = new Set(descriptors_arrays.shift());
+        for (let descriptors of descriptors_arrays) {
+            descriptors.forEach(descriptor => assert_false(base_set.has(descriptor)));
+        }
+    });
+}, 'Calls to getDescriptors after a disconnection should return a different object.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/disconnect-invalidates-object.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/disconnect-invalidates-object.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.two_heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        return gattServer.getPrimaryService(heart_rate.name)
+        .then(s => {
+            let service = s;
+            gattServer.disconnect();
+            return gattServer.connect()
+            .then(() => service);
+        });
+    })
+    .then(service => {
+        let promises = [];
+        promises.push(promise_rejects(t, 'InvalidStateError', service.getCharacteristic(body_sensor_location.name)));
+        promises.push(promise_rejects(t, 'InvalidStateError', service.getCharacteristics(body_sensor_location.name)));
+        promises.push(promise_rejects(t, 'InvalidStateError', service.getCharacteristics()));
+        return Promise.all(promises);
+    });
+}, 'Calls on a service after we disconnect and connect again. Should reject with InvalidStateError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/get-different-service-after-reconnection.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryService/get-different-service-after-reconnection.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.two_heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [generic_access.name]}]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        let service1;
+        return gattServer.getPrimaryService(generic_access.name)
+        .then(service => service1 = service)
+        .then(() => gattServer.disconnect())
+        .then(() => gattServer.connect())
+        .then(() => gattServer.getPrimaryService(generic_access.name))
+        .then(service2 => [service1, service2])
+    })
+    .then(services_array => {
+        assert_not_equals(services_array[0], services_array[1]);
+    });
+}, 'Calls to getPrimaryService after a disconnection should return a different object.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-invalidates-objects.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/disconnect-invalidates-objects.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.two_heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        return gattServer.getPrimaryServices()
+        .then(s => {
+            let services = s;
+            assert_greater_than(services.length, 1);
+            gattServer.disconnect();
+            return gattServer.connect()
+            .then(() => services);
+        });
+    })
+    .then(services => {
+        let promises = [];
+        for (let service of services) {
+            promises.push(promise_rejects(t, 'InvalidStateError', service.getCharacteristic(body_sensor_location.name)));
+            promises.push(promise_rejects(t, 'InvalidStateError', service.getCharacteristics(body_sensor_location.name)));
+            promises.push(promise_rejects(t, 'InvalidStateError', service.getCharacteristics()));
+        }
+        return Promise.all(promises);
+    });
+}, 'Calls on services after we disconnect and connect again. Should reject with InvalidStateError.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/get-different-services-after-reconnection.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getPrimaryServices/get-different-services-after-reconnection.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(t => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.two_heart_rate);
+    return window.navigator.bluetooth.requestDevice({
+        filters: [{services: [heart_rate.name]}],
+        optionalServices: [generic_access.name]
+    })
+    .then(device => device.gatt.connect())
+    .then(gattServer => {
+        let services1;
+        return gattServer.getPrimaryServices()
+        .then(services => services1 = services)
+        .then(() => gattServer.disconnect())
+        .then(() => gattServer.connect())
+        .then(() => gattServer.getPrimaryServices())
+        .then(services2 => [services1, services2])
+    })
+    .then(services_arrays => {
+        for (let i = 1; i < services_arrays.length; i++) {
+            assert_equals(services_arrays[0].length, services_arrays[i].length);
+        }
+        let base_set = new Set(services_arrays.shift());
+        for (let services of services_arrays) {
+            services.forEach(service => assert_false(base_set.has(service)));
+        }
+    });
+}, 'Calls to getPrimaryServices after a disconnection should return different objects.');
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Added the missing [Step 5.2.3](https://github.com/servo/servo/compare/master...szeged:connect-disconnect-update#diff-1dbe29f87740f5aec93f37adbecace6cR213) to the `connect` function.
Updated the [disconnect](https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-disconnect) function to its current state in the specification, including the `clean_up_disconnected_device` and the `garbage_collect_the connection` functions.
Added new tests for checking the invalid state of JS objects after disconnection.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14612)
<!-- Reviewable:end -->
