### PR TITLE
stylo: Track the last restyle generation properly.

### DIFF
--- a/components/style/gecko/data.rs
+++ b/components/style/gecko/data.rs
@@ -25,6 +25,9 @@ pub struct PerDocumentStyleDataImpl {
     /// Rule processor.
     pub stylist: Arc<Stylist>,
 
+    /// Last restyle generation.
+    pub last_restyle_generation: u32,
+
     /// List of stylesheets, mirrored from Gecko.
     pub stylesheets: Vec<Arc<Stylesheet>>,
 
@@ -64,6 +67,7 @@ impl PerDocumentStyleData {
 
         PerDocumentStyleData(AtomicRefCell::new(PerDocumentStyleDataImpl {
             stylist: Arc::new(Stylist::new(device)),
+            last_restyle_generation: 0,
             stylesheets: vec![],
             stylesheets_changed: true,
             new_animations_sender: new_anims_sender,
@@ -100,6 +104,12 @@ impl PerDocumentStyleDataImpl {
                                                    .update(&self.stylesheets, None, true);
             self.stylesheets_changed = false;
         }
+    }
+
+    pub fn next_generation(&mut self) -> u32 {
+        self.last_restyle_generation =
+            self.last_restyle_generation.wrapping_add(1);
+        self.last_restyle_generation
     }
 }
 

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -106,7 +106,7 @@ fn create_shared_context(mut per_doc_data: &mut AtomicRefMut<PerDocumentStyleDat
         // FIXME (bug 1303229): Use the actual viewport size here
         viewport_size: Size2D::new(Au(0), Au(0)),
         screen_size_changed: false,
-        generation: 0,
+        generation: per_doc_data.next_generation(),
         goal: ReflowGoal::ForScriptQuery,
         stylist: per_doc_data.stylist.clone(),
         running_animations: per_doc_data.running_animations.clone(),


### PR DESCRIPTION
I couldn't reproduce locally, but I believe this fixes:

https://bugzilla.mozilla.org/show_bug.cgi?id=1323890

r? @heycam

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14622)
<!-- Reviewable:end -->
