### PR TITLE
#14514 Implement port-based blocking

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -143,6 +143,18 @@ pub fn main_fetch(request: Rc<Request>,
 
     // Step 5
     // TODO this step (CSP port/content blocking)
+    if let Some(port) = request.url().port() {
+        let is_ftp = request.url().scheme() == "ftp" && (port == 20 || port == 21);
+        static BAD_PORTS: [u16; 64] = [1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42,
+                                       43, 53, 77, 79, 87, 95, 101, 102, 103, 104, 109, 110, 111,
+                                       113, 115, 117, 119, 123, 135, 139, 143, 179, 389, 465, 512,
+                                       513, 514, 515, 526, 530, 531, 532, 540, 556, 563, 587, 601,
+                                       636, 993, 995, 2049, 3659, 4045, 6000, 6665, 6666, 6667,
+                                       6668, 6669];
+        if !is_ftp && BAD_PORTS.binary_search(&port).is_ok() {
+            response = Some(Response::network_error(NetworkError::Internal("Request attempted on bad port".into())));
+        }
+    }
 
     // Step 6
     // TODO this step (referrer policy)

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -39719,6 +39719,12 @@
             "url": "/cssom/shorthand-serialization.html"
           }
         ],
+        "fetch/api/request/request-bad-port.html": [
+          {
+            "path": "fetch/api/request/request-bad-port.html",
+            "url": "/fetch/api/request/request-bad-port.html"
+          }
+        ],
         "html/semantics/forms/form-submission-0/submit-entity-body.html": [
           {
             "path": "html/semantics/forms/form-submission-0/submit-entity-body.html",

--- a/tests/wpt/web-platform-tests/fetch/api/request/request-bad-port.html
+++ b/tests/wpt/web-platform-tests/fetch/api/request/request-bad-port.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+    // list of bad ports according to
+    // https://fetch.spec.whatwg.org/#port-blocking
+    var BLOCKED_PORTS_LIST = [
+        1,    // tcpmux
+        7,    // echo
+        9,    // discard
+        11,   // systat
+        13,   // daytime
+        15,   // netstat
+        17,   // qotd
+        19,   // chargen
+        20,   // ftp-data
+        21,   // ftp
+        22,   // ssh
+        23,   // telnet
+        25,   // smtp
+        37,   // time
+        42,   // name
+        43,   // nicname
+        53,   // domain
+        77,   // priv-rjs
+        79,   // finger
+        87,   // ttylink
+        95,   // supdup
+        101,  // hostriame
+        102,  // iso-tsap
+        103,  // gppitnp
+        104,  // acr-nema
+        109,  // pop2
+        110,  // pop3
+        111,  // sunrpc
+        113,  // auth
+        115,  // sftp
+        117,  // uucp-path
+        119,  // nntp
+        123,  // ntp
+        135,  // loc-srv / epmap
+        139,  // netbios
+        143,  // imap2
+        179,  // bgp
+        389,  // ldap
+        465,  // smtp+ssl
+        512,  // print / exec
+        513,  // login
+        514,  // shell
+        515,  // printer
+        526,  // tempo
+        530,  // courier
+        531,  // chat
+        532,  // netnews
+        540,  // uucp
+        556,  // remotefs
+        563,  // nntp+ssl
+        587,  // smtp
+        601,  // syslog-conn
+        636,  // ldap+ssl
+        993,  // imap+ssl
+        995,  // pop3+ssl
+        2049, // nfs
+        3659, // apple-sasl
+        4045, // lockd
+        6000, // x11
+        6665, // irc (alternate)
+        6666, // irc (alternate)
+        6667, // irc (default)
+        6668, // irc (alternate)
+        6669, // irc (alternate)
+    ];
+
+    BLOCKED_PORTS_LIST.map(function(a){
+    	promise_test(function(t){
+            return promise_rejects(t, new TypeError(), fetch("http://example.com:" + a))
+        }, 'Request on bad port ' + a + ' should throw TypeError.');
+    });
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Add check for bad ports to http_fetch(), return NetworkError::Internal if bad port/schema combination is seen.

Test added

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14514 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14623)
<!-- Reviewable:end -->
