### PR TITLE
Request a definition for "Fragment" be added to the glossary.

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -18,6 +18,9 @@ The thread that controls a collection of related web content. This could be thou
 
 A list of concrete rendering instructions. The display list is post-layout, so all items have stacking-context-relative pixel positions, and z-index has already been applied, so items later in the display list will always be on top of items earlier in it.
 
+### Fragment ###
+`TODO`
+
 ### Layout thread ###
 
 A thread that is responsible for laying out a DOM tree into layers of boxes for a particular document. Receives commands from the script thread to lay out a page and either generate a new display list for use by the renderer thread, or return the results of querying the layout of the page for use by script.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -19,7 +19,8 @@ The thread that controls a collection of related web content. This could be thou
 A list of concrete rendering instructions. The display list is post-layout, so all items have stacking-context-relative pixel positions, and z-index has already been applied, so items later in the display list will always be on top of items earlier in it.
 
 ### Fragment ###
-`TODO`
+
+The most primitive thing Servo knows how to layout. Servo fragments have no direct or simple correspondence with CSS fragments (i.e. serveral fragments may coressponed to the same CSS box/DOM node, while some CSS fragments are not created at all).
 
 ### Layout thread ###
 


### PR DESCRIPTION
"Fragment" is used with relative frequency in the layout component. It seems to represent something like a unit of layout work (i.e. a div that needs its size and contents computed?) but I'm not entirely sure. A definition in the glossary would greatly ease the process of diving in to layout code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14624)
<!-- Reviewable:end -->
