### PR TITLE
Make datetime just reflect

### DIFF
--- a/components/script/dom/htmltimeelement.rs
+++ b/components/script/dom/htmltimeelement.rs
@@ -2,14 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use dom::bindings::codegen::Bindings::ElementBinding::ElementBinding::ElementMethods;
 use dom::bindings::codegen::Bindings::HTMLTimeElementBinding;
 use dom::bindings::codegen::Bindings::HTMLTimeElementBinding::HTMLTimeElementMethods;
-use dom::bindings::inheritance::Castable;
 use dom::bindings::js::Root;
 use dom::bindings::str::DOMString;
 use dom::document::Document;
-use dom::element::Element;
 use dom::htmlelement::HTMLElement;
 use dom::node::Node;
 use html5ever_atoms::LocalName;
@@ -38,18 +35,7 @@ impl HTMLTimeElement {
 
 impl HTMLTimeElementMethods for HTMLTimeElement {
     // https://html.spec.whatwg.org/multipage/#dom-time-datetime
-    //make_getter!(DateTime, "datetime");
-    fn DateTime(&self) -> DOMString {
-        let element = self.upcast::<Element>();
-        if element.has_attribute(&local_name!("datetime")) {
-            return element.get_string_attribute(&local_name!("datetime"))
-        } else {
-            match element.GetInnerHTML() {
-                Ok(x) => x,
-                _ => DOMString::new(),
-            }
-        }
-    }
+    make_getter!(DateTime, "datetime");
 
     // https://html.spec.whatwg.org/multipage/#dom-time-datetime
     make_setter!(SetDateTime, "datetime");

--- a/tests/wpt/web-platform-tests/html/semantics/text-level-semantics/the-time-element/001.html
+++ b/tests/wpt/web-platform-tests/html/semantics/text-level-semantics/the-time-element/001.html
@@ -58,12 +58,9 @@ test(function () {
 test(function () {
   assert_equals( makeTime('go fish').dateTime, 'go fish' );
 }, 'the datetime attribute should be reflected by the .dateTime property even if it is invalid');
-test(function () {
-  assert_equals( makeTime(false,'2000-02-01T03:04:05Z', '2000-02-01').dateTime, '2000-02-01' );
-}, 'the datetime content attribute should not reflect the textContent when datetime attribute is present.');
-test(function () {
-  assert_equals( makeTime(false,'2000-02-01T03:04:05Z').dateTime, '2000-02-01T03:04:05Z' );
-}, 'the datetime content attribute should reflect the textContent when datetime attribute is absent.');
+test(function() {
+  assert_equals( makeTime(false,'2000-02-01T03:04:05Z').dateTime, '' );
+}, 'the datetime attribute should not reflect the textContent');
     </script>
 
   </body>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This just uses `make_getter!` for `datetime` rather than checking if `datetime` has data and falling back to the child data if `datetime` has no data.

I reverted 2 of the test changes and added back an old test that makes sure that child content is not returned when `datetime` is empty.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14611 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14631)
<!-- Reviewable:end -->
