### PR TITLE
Store unset keyword as specified value

### DIFF
--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -345,6 +345,7 @@ pub fn cascade<'a>(custom_properties: &mut Option<HashMap<&'a Name, BorrowedSpec
             DeclaredValue::Initial => {
                 map.remove(&name);
             }
+            DeclaredValue::Unset | // Custom properties are inherited by default.
             DeclaredValue::Inherit => {}  // The inherited value is what we already have.
         }
     }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -90,6 +90,14 @@ pub mod shorthands {
     use parser::{Parse, ParserContext};
     use values::specified;
 
+    bitflags! {
+        flags SerializeFlags: u8 {
+            const ALL_INHERIT = 0b001,
+            const ALL_INITIAL = 0b010,
+            const ALL_UNSET   = 0b100,
+        }
+    }
+
     pub fn parse_four_sides<F, T>(input: &mut Parser, parse_one: F) -> Result<(T, T, T, T), ()>
         where F: Fn(&mut Parser) -> Result<T, ()>, T: Clone
     {
@@ -520,9 +528,7 @@ pub enum DeclaredValue<T> {
     },
     Initial,
     Inherit,
-    // There is no Unset variant here.
-    // The 'unset' keyword is represented as either Initial or Inherit,
-    // depending on whether the property is inherited.
+    Unset,
 }
 
 impl<T: HasViewportPercentage> HasViewportPercentage for DeclaredValue<T> {
@@ -533,7 +539,8 @@ impl<T: HasViewportPercentage> HasViewportPercentage for DeclaredValue<T> {
             DeclaredValue::WithVariables { .. }
                 => panic!("DeclaredValue::has_viewport_percentage without resolving variables!"),
             DeclaredValue::Initial |
-            DeclaredValue::Inherit => false,
+            DeclaredValue::Inherit |
+            DeclaredValue::Unset => false,
         }
     }
 }
@@ -549,6 +556,7 @@ impl<T: ToCss> ToCss for DeclaredValue<T> {
             DeclaredValue::WithVariables { .. } => Ok(()),
             DeclaredValue::Initial => dest.write_str("initial"),
             DeclaredValue::Inherit => dest.write_str("inherit"),
+            DeclaredValue::Unset => dest.write_str("unset"),
         }
     }
 }
@@ -821,7 +829,7 @@ impl PropertyDeclaration {
         match id {
             PropertyId::Custom(name) => {
                 let value = match input.try(|i| CSSWideKeyword::parse(context, i)) {
-                    Ok(CSSWideKeyword::UnsetKeyword) |  // Custom properties are alawys inherited
+                    Ok(CSSWideKeyword::UnsetKeyword) => DeclaredValue::Unset,
                     Ok(CSSWideKeyword::InheritKeyword) => DeclaredValue::Inherit,
                     Ok(CSSWideKeyword::InitialKeyword) => DeclaredValue::Initial,
                     Err(()) => match ::custom_properties::SpecifiedValue::parse(context, input) {
@@ -904,8 +912,7 @@ impl PropertyDeclaration {
                         Ok(CSSWideKeyword::UnsetKeyword) => {
                             % for sub_property in shorthand.sub_properties:
                                 result_list.push(PropertyDeclaration::${sub_property.camel_case}(
-                                    DeclaredValue::${"Inherit" if sub_property.style_struct.inherited else "Initial"}
-                                ));
+                                        DeclaredValue::Unset));
                             % endfor
                             PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
                         },

--- a/components/style/properties/shorthand/border.mako.rs
+++ b/components/style/properties/shorthand/border.mako.rs
@@ -40,6 +40,7 @@ ${helpers.four_sides_shorthand("border-style", "border-%s-style",
                     },
                     &DeclaredValue::Initial => DeclaredValue::Initial,
                     &DeclaredValue::Inherit => DeclaredValue::Inherit,
+                    &DeclaredValue::Unset => DeclaredValue::Unset,
                 };
             % endfor
 

--- a/components/style/properties/shorthand/box.mako.rs
+++ b/components/style/properties/shorthand/box.mako.rs
@@ -28,6 +28,7 @@
                 (&DeclaredValue::WithVariables { .. }, &DeclaredValue::WithVariables { .. }) => true,
                 (&DeclaredValue::Initial, &DeclaredValue::Initial) => true,
                 (&DeclaredValue::Inherit, &DeclaredValue::Inherit) => true,
+                (&DeclaredValue::Unset, &DeclaredValue::Unset) => true,
                 _ => false
             };
 
@@ -331,6 +332,7 @@ macro_rules! try_parse_one {
                 },
                 (&DeclaredValue::Initial, &DeclaredValue::Initial) => true,
                 (&DeclaredValue::Inherit, &DeclaredValue::Inherit) => true,
+                (&DeclaredValue::Unset, &DeclaredValue::Unset) => true,
                 (x, y) => { *x == *y },
             };
 

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -39677,6 +39677,12 @@
     "deleted_reftests": {},
     "items": {
       "testharness": {
+        "css-values/unset-value-storage.html": [
+          {
+            "path": "css-values/unset-value-storage.html",
+            "url": "/css-values/unset-value-storage.html"
+          }
+        ],
         "cssom/CSSKeyframesRule.html": [
           {
             "path": "cssom/CSSKeyframesRule.html",

--- a/tests/wpt/web-platform-tests/css-values/unset-value-storage.html
+++ b/tests/wpt/web-platform-tests/css-values/unset-value-storage.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Storage of "unset" value</title>
+<meta name="author" title="Xidorn Quan" href="https://www.upsuper.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  div {
+    color: unset;
+    border: unset;
+  }
+</style>
+<body>
+  <div id="log"></div>
+  <script>
+    test(function() {
+      let properties = ["color", "border", "border-left", "border-color", "border-right-style"];
+      let style = document.styleSheets[0].cssRules[0].style;
+      for (let prop of properties) {
+        assert_equals(style.getPropertyValue(prop), "unset", `${prop} is expected to be "unset"`);
+      }
+    });
+  </script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`unset` keyword value should *not* be converted to something else during parsing. It is a specified-value time value, which should be preserved until computation.

WIP patch for seeing what tests would be broken and / or if there is necessary to add any new test.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14640)
<!-- Reviewable:end -->
