### PR TITLE
Create windows-gnu and windows-msvc builds

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -106,7 +106,27 @@ windows-dev:
   - ./mach test-unit
   - ./mach build-geckolib
 
+windows-gnu-dev:
+  - ./mach build --dev
+  - ./mach test-unit
+  - ./mach build-geckolib
+
+windows-msvc-dev:
+  - mach.bat build --dev
+  - mach.bat test-unit
+  - mach.bat build-geckolib
+
 windows-nightly:
   - ./mach build --release
   - ./mach package --release
-  - ./etc/ci/upload_nightly.sh windows
+  - ./etc/ci/upload_nightly.sh windows-gnu
+
+windows-nightly-gnu:
+  - ./mach build --release
+  - ./mach package --release
+  - ./etc/ci/upload_nightly.sh windows-gnu
+
+windows-nightly-msvc:
+  - mach.bat build --release
+  - mach.bat package --release
+  - .\etc\ci\upload_nightly.sh windows-msvc

--- a/etc/ci/upload_nightly.sh
+++ b/etc/ci/upload_nightly.sh
@@ -11,7 +11,7 @@ shopt -s failglob
 
 
 usage() {
-    printf "usage: ${0} android|linux|mac|macbrew|windows\n"
+    printf "usage: ${0} android|linux|mac|macbrew|windows-gnu|windows-msvc\n"
 }
 
 
@@ -48,7 +48,8 @@ main() {
     elif [[ "${platform}" == "macbrew" ]]; then
         extension=tar.gz
         package=target/release/brew/*."${extension}"
-    elif [[ "${platform}" == "windows" ]]; then
+    elif [[ "${platform}" == "windows-gnu" ||
+            "${platform}" == "windows-msvc" ]]; then
         extension=msi
         package=target/release/msi/*.msi
     else


### PR DESCRIPTION
r? @metajack @edunham 

The idea here is that I'm adding `-gnu` and `-msvc` variants in advance of the buildbot changes (in https://github.com/servo/saltfs/pull/491). Once those land and are pushed out to the buildbot master, it'll pick up these changed files and then we can remove the unsuffixed `windows-dev` and `windows-nightly`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14651)
<!-- Reviewable:end -->
