### PR TITLE
Separate the async bluetooth handling from networking code.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,7 +1729,6 @@ dependencies = [
 name = "net_traits"
 version = "0.0.1"
 dependencies = [
- "bluetooth_traits 0.0.1",
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/bluetooth_traits/lib.rs
+++ b/components/bluetooth_traits/lib.rs
@@ -108,7 +108,3 @@ pub enum BluetoothResponse {
     EnableNotification(()),
     WatchAdvertisements(()),
 }
-
-pub trait BluetoothResponseListener {
-    fn response(&mut self, response: BluetoothResponseResult);
-}

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -10,7 +10,6 @@ name = "net_traits"
 path = "lib.rs"
 
 [dependencies]
-bluetooth_traits = {path = "../bluetooth_traits"}
 msg = {path = "../msg"}
 ipc-channel = "0.5"
 heapsize = "0.3.0"

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -9,7 +9,6 @@
 
 #![deny(unsafe_code)]
 
-extern crate bluetooth_traits;
 extern crate cookie as cookie_rs;
 extern crate heapsize;
 #[macro_use] extern crate heapsize_derive;
@@ -34,7 +33,6 @@ extern crate uuid;
 extern crate webrender_traits;
 extern crate websocket;
 
-use bluetooth_traits::{BluetoothResponseListener, BluetoothResponseResult};
 use cookie_rs::Cookie;
 use filemanager_thread::FileManagerThreadMsg;
 use heapsize::HeapSizeOf;
@@ -235,13 +233,6 @@ impl<T: FetchResponseListener> Action<T> for FetchResponseMsg {
             FetchResponseMsg::ProcessResponseChunk(data) => listener.process_response_chunk(data),
             FetchResponseMsg::ProcessResponseEOF(data) => listener.process_response_eof(data),
         }
-    }
-}
-
-impl<T: BluetoothResponseListener> Action<T> for BluetoothResponseResult {
-    /// Execute the default action on a provided listener.
-    fn process(self, listener: &mut T) {
-        listener.response(self)
     }
 }
 

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use bluetooth_traits::{BluetoothResponseListener, BluetoothResponseResult};
 use net_traits::{Action, FetchResponseListener, FetchResponseMsg};
 use script_thread::{Runnable, RunnableWrapper};
 use std::sync::{Arc, Mutex};
@@ -37,13 +36,6 @@ impl<Listener: PreInvoke + Send + 'static> NetworkListener<Listener> {
 // helps type inference
 impl<Listener: FetchResponseListener + PreInvoke + Send + 'static> NetworkListener<Listener> {
     pub fn notify_fetch(&self, action: FetchResponseMsg) {
-        self.notify(action);
-    }
-}
-
-// helps type inference
-impl<Listener: BluetoothResponseListener + PreInvoke + Send + 'static> NetworkListener<Listener> {
-    pub fn notify_response(&self, action: BluetoothResponseResult) {
         self.notify(action);
     }
 }


### PR DESCRIPTION
They're not at all related, besides both being asynchronous. This change adds
a little extra code in response_async(), but makes this code more readable
and reduces the unnecessary indirection.

This change also makes the build system slightly more parallel, by dropping
the dependency on bluetooth_traits from net_traits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14658)
<!-- Reviewable:end -->
