### PR TITLE
Keep same timestamp when replacing frame state

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -236,6 +236,14 @@ impl FrameState {
             frame_id: frame_id,
         }
     }
+
+    fn new_with_instant(instant: Instant, pipeline_id: PipelineId, frame_id: FrameId) -> FrameState {
+        FrameState {
+            instant: instant,
+            pipeline_id: pipeline_id,
+            frame_id: frame_id,
+        }
+    }
 }
 
 /// Stores the navigation context for a single frame in the frame tree.
@@ -266,7 +274,8 @@ impl Frame {
     }
 
     fn replace_current(&mut self, pipeline_id: PipelineId) -> FrameState {
-        replace(&mut self.current, FrameState::new(pipeline_id, self.id))
+        let instant = self.current.instant;
+        replace(&mut self.current, FrameState::new_with_instant(instant, pipeline_id, self.id))
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14664)
<!-- Reviewable:end -->
