### PR TITLE
Rename Windows nightly builders for consistency

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -121,12 +121,12 @@ windows-nightly:
   - ./mach package --release
   - ./etc/ci/upload_nightly.sh windows-gnu
 
-windows-nightly-gnu:
+windows-gnu-nightly:
   - ./mach build --release
   - ./mach package --release
   - ./etc/ci/upload_nightly.sh windows-gnu
 
-windows-nightly-msvc:
+windows-msvc-nightly:
   - mach.bat build --release
   - mach.bat package --release
   - .\etc\ci\upload_nightly.sh windows-msvc


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fixup for #14651. r? @larsbergstrom 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because these builders aren't used yet

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14670)
<!-- Reviewable:end -->
