### PR TITLE
Warn when a timer event is processed for a discarded document.

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1049,8 +1049,11 @@ impl ScriptThread {
             TimerSource::FromWorker => panic!("Worker timeouts must not be sent to script thread"),
         };
 
-        let window = self.documents.borrow().find_window(pipeline_id)
-            .expect("ScriptThread: received fire timer msg for a pipeline not in this script thread. This is a bug.");
+        let window = self.documents.borrow().find_window(pipeline_id);
+        let window = match window {
+            Some(w) => w,
+            None => return warn!("Received fire timer msg for a closed pipeline {}.", pipeline_id),
+        };
 
         window.handle_fire_timer(id);
     }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14930,6 +14930,12 @@
             "url": "/_mozilla/mozilla/textcontent.html"
           }
         ],
+        "mozilla/timeout-in-discarded-document.html": [
+          {
+            "path": "mozilla/timeout-in-discarded-document.html",
+            "url": "/_mozilla/mozilla/timeout-in-discarded-document.html"
+          }
+        ],
         "mozilla/timer_eventInvalidation.html": [
           {
             "path": "mozilla/timer_eventInvalidation.html",

--- a/tests/wpt/mozilla/tests/mozilla/timeout-in-discarded-document.html
+++ b/tests/wpt/mozilla/tests/mozilla/timeout-in-discarded-document.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Timeout in a discarded document doesn't break the browser.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe></iframe>
+<script>
+  async_test(function(t) {
+    var i = document.querySelector('iframe');
+    i.contentWindow.setTimeout(function() {}, 10);
+    i.remove();
+    t.step_timeout(function() { t.done() }, 100);
+  });
+</script>


### PR DESCRIPTION
Turn a panic into a warning for a situation that is easy to hit in web content.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14677
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14679)
<!-- Reviewable:end -->
