### PR TITLE
Allow passing --nocapture argument to test-unit mach command

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -193,12 +193,14 @@ class MachCommands(CommandBase):
     @Command('test-unit',
              description='Run unit tests',
              category='testing')
+    @CommandArgument('test_name', nargs=argparse.REMAINDER,
+                     help="Only run tests that match this pattern or file path")
     @CommandArgument('--package', '-p', default=None, help="Specific package to test")
     @CommandArgument('--bench', default=False, action="store_true",
                      help="Run in bench mode")
-    @CommandArgument('test_name', nargs=argparse.REMAINDER,
-                     help="Only run tests that match this pattern or file path")
-    def test_unit(self, test_name=None, package=None, bench=False):
+    @CommandArgument('--nocapture', default=False, action="store_true",
+                     help="Run tests with nocapture ( show test stdout )")
+    def test_unit(self, test_name=None, package=None, bench=False, nocapture=False):
         if test_name is None:
             test_name = []
 
@@ -259,6 +261,10 @@ class MachCommands(CommandBase):
 
             if features:
                 args += ["--features", "%s" % ' '.join(features)]
+
+            if nocapture:
+                args += ["--", "--nocapture"]
+
             err = call(args, env=env, cwd=self.servo_crate())
             if err is not 0:
                 return err


### PR DESCRIPTION
This adds the ` --nocapture` argument to the test-unit mach command.
Defaulting to false, when given it passes `-- --nocapture` to cargo test to show stdout during test-unit runs.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14595

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14706)
<!-- Reviewable:end -->
