### PR TITLE
 stylo: Coordinate stylist flushing with gecko, and clean up pseudo-element resolution

### DIFF
--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1184,17 +1184,6 @@ extern "C" {
      -> ServoComputedValuesStrong;
 }
 extern "C" {
-    pub fn Servo_ComputedValues_GetForPseudoElement(parent_style:
-                                                        ServoComputedValuesBorrowed,
-                                                    match_element:
-                                                        RawGeckoElementBorrowed,
-                                                    pseudo_tag: *mut nsIAtom,
-                                                    set:
-                                                        RawServoStyleSetBorrowed,
-                                                    is_probe: bool)
-     -> ServoComputedValuesStrong;
-}
-extern "C" {
     pub fn Servo_ComputedValues_Inherit(parent_style:
                                             ServoComputedValuesBorrowedOrNull)
      -> ServoComputedValuesStrong;
@@ -1223,6 +1212,12 @@ extern "C" {
                               set: RawServoStyleSetBorrowed,
                               consume: ConsumeStyleBehavior,
                               compute: LazyComputeBehavior)
+     -> ServoComputedValuesStrong;
+}
+extern "C" {
+    pub fn Servo_ResolvePseudoStyle(element: RawGeckoElementBorrowed,
+                                    pseudo_tag: *mut nsIAtom, is_probe: bool,
+                                    set: RawServoStyleSetBorrowed)
      -> ServoComputedValuesStrong;
 }
 extern "C" {

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -991,16 +991,18 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_StyleSet_AppendStyleSheet(set: RawServoStyleSetBorrowed,
-                                           sheet: RawServoStyleSheetBorrowed);
+                                           sheet: RawServoStyleSheetBorrowed,
+                                           flush: bool);
 }
 extern "C" {
     pub fn Servo_StyleSet_PrependStyleSheet(set: RawServoStyleSetBorrowed,
-                                            sheet:
-                                                RawServoStyleSheetBorrowed);
+                                            sheet: RawServoStyleSheetBorrowed,
+                                            flush: bool);
 }
 extern "C" {
     pub fn Servo_StyleSet_RemoveStyleSheet(set: RawServoStyleSetBorrowed,
-                                           sheet: RawServoStyleSheetBorrowed);
+                                           sheet: RawServoStyleSheetBorrowed,
+                                           flush: bool);
 }
 extern "C" {
     pub fn Servo_StyleSet_InsertStyleSheetBefore(set:
@@ -1008,7 +1010,11 @@ extern "C" {
                                                  sheet:
                                                      RawServoStyleSheetBorrowed,
                                                  reference:
-                                                     RawServoStyleSheetBorrowed);
+                                                     RawServoStyleSheetBorrowed,
+                                                 flush: bool);
+}
+extern "C" {
+    pub fn Servo_StyleSet_FlushStyleSheets(set: RawServoStyleSetBorrowed);
 }
 extern "C" {
     pub fn Servo_StyleSet_NoteStyleSheetsChanged(set:


### PR DESCRIPTION
Corresponding gecko bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1325728

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14711)
<!-- Reviewable:end -->
