### PR TITLE
Remove FrameChange::document_ready

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1920,15 +1920,15 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
     }
 
     fn handle_get_pipeline(&mut self, frame_id: Option<FrameId>,
-                           resp_chan: IpcSender<Option<(PipelineId, bool)>>) {
+                           resp_chan: IpcSender<Option<PipelineId>>) {
         let frame_id = frame_id.unwrap_or(self.root_frame_id);
         let current_pipeline_id = self.frames.get(&frame_id)
             .map(|frame| frame.current.pipeline_id);
         let current_pipeline_id_loaded = current_pipeline_id
-            .map(|id| (id, true));
+            .map(|id| id);
         let pipeline_id_loaded = self.pending_frames.iter().rev()
             .find(|x| x.old_pipeline_id == current_pipeline_id)
-            .map(|x| (x.new_pipeline_id, false))
+            .map(|x| x.new_pipeline_id)
             .or(current_pipeline_id_loaded);
         if let Err(e) = resp_chan.send(pipeline_id_loaded) {
             warn!("Failed get_pipeline response ({}).", e);

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -412,10 +412,6 @@ struct FrameChange {
     /// The pipeline for the document being loaded.
     new_pipeline_id: PipelineId,
 
-    /// Is this document ready to be activated?
-    /// TODO: this flag is never set, it can be removed.
-    document_ready: bool,
-
     /// Is the new document replacing the current document (e.g. a reload)
     /// or pushing it into the session history (e.g. a navigation)?
     replace: bool,
@@ -1446,7 +1442,6 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             frame_id: top_level_frame_id,
             old_pipeline_id: pipeline_id,
             new_pipeline_id: new_pipeline_id,
-            document_ready: false,
             replace: false,
         });
     }
@@ -1480,7 +1475,6 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             frame_id: self.root_frame_id,
             old_pipeline_id: None,
             new_pipeline_id: root_pipeline_id,
-            document_ready: false,
             replace: false,
         });
         self.compositor_proxy.send(ToCompositorMsg::ChangePageUrl(root_pipeline_id, url));
@@ -1585,7 +1579,6 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             frame_id: load_info.info.frame_id,
             old_pipeline_id: load_info.old_pipeline_id,
             new_pipeline_id: load_info.info.new_pipeline_id,
-            document_ready: false,
             replace: load_info.info.replace,
         });
     }
@@ -1630,7 +1623,6 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             frame_id: frame_id,
             old_pipeline_id: None,
             new_pipeline_id: new_pipeline_id,
-            document_ready: false,
             replace: replace,
         });
     }
@@ -1766,7 +1758,6 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                     frame_id: root_frame_id,
                     old_pipeline_id: Some(source_id),
                     new_pipeline_id: new_pipeline_id,
-                    document_ready: false,
                     replace: replace,
                 });
 
@@ -1937,7 +1928,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             .map(|id| (id, true));
         let pipeline_id_loaded = self.pending_frames.iter().rev()
             .find(|x| x.old_pipeline_id == current_pipeline_id)
-            .map(|x| (x.new_pipeline_id, x.document_ready))
+            .map(|x| (x.new_pipeline_id, false))
             .or(current_pipeline_id_loaded);
         if let Err(e) = resp_chan.send(pipeline_id_loaded) {
             warn!("Failed get_pipeline response ({}).", e);

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -686,7 +686,7 @@ pub enum ConstellationMsg {
     /// Request that the constellation send the current pipeline id for the provided frame
     /// id, or for the root frame if this is None, over a provided channel.
     /// Also returns a boolean saying whether the document has finished loading or not.
-    GetPipeline(Option<FrameId>, IpcSender<Option<(PipelineId, bool)>>),
+    GetPipeline(Option<FrameId>, IpcSender<Option<PipelineId>>),
     /// Requests that the constellation inform the compositor of the title of the pipeline
     /// immediately.
     GetPipelineTitle(PipelineId),

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -260,7 +260,7 @@ impl Handler {
             let msg = ConstellationMsg::GetPipeline(frame_id, sender.clone());
             self.constellation_chan.send(msg).unwrap();
             // Wait until the document is ready before returning the pipeline id.
-            if let Some((x, true)) = receiver.recv().unwrap() {
+            if let Some(x) = receiver.recv().unwrap() {
                 return Ok(x);
             }
             thread::sleep(Duration::from_millis(interval));


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Remove unused `FrameChange::document_ready` field and remove unused boolean in `ConstellationMsg::GetPipeline`'s second argument.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14693

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because compiler validates the field is not used anywhere

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14724)
<!-- Reviewable:end -->
