### PR TITLE
Rewrite Crypto::GetRandomValues to use typed array API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.3"
-source = "git+https://github.com/servo/rust-mozjs#342f304a455080acf64f5ceb40a7f8059481ca01"
+source = "git+https://github.com/servo/rust-mozjs#15ff1e83446e998112dcde731610e8b60cc32abf"
 dependencies = [
  "cmake 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -6,7 +6,6 @@ use core::nonzero::NonZero;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::CryptoBinding;
 use dom::bindings::codegen::Bindings::CryptoBinding::CryptoMethods;
-use dom::bindings::conversions::array_buffer_view_data;
 use dom::bindings::error::{Error, Fallible};
 use dom::bindings::js::Root;
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
@@ -46,9 +45,10 @@ impl CryptoMethods for Crypto {
                        input: *mut JSObject)
                        -> Fallible<NonZero<*mut JSObject>> {
         assert!(!input.is_null());
-        let mut data = match array_buffer_view_data::<u8>(input) {
-            Some(data) => data,
-            None => {
+        typedarray!(in(_cx) let mut array_buffer_view: ArrayBufferView = input);
+        let mut data = match array_buffer_view.as_mut() {
+            Ok(x) => x.as_mut_slice(),
+            Err(_) => {
                 return Err(Error::Type("Argument to Crypto.getRandomValues is not an ArrayBufferView"
                                        .to_owned()));
             }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Rewrite Crypto::GetRandomValues to use typed array API

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #14673  (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14730)
<!-- Reviewable:end -->
