### PR TITLE
Default is top-to-bottom if unset, not bottom-to-top

### DIFF
--- a/components/style/values/computed/image.rs
+++ b/components/style/values/computed/image.rs
@@ -470,7 +470,7 @@ impl ToComputedValue for specified::AngleOrCorner {
     fn to_computed_value(&self, _: &Context) -> AngleOrCorner {
         match *self {
             specified::AngleOrCorner::None => {
-                AngleOrCorner::Angle(Angle(0.0))
+                AngleOrCorner::Angle(Angle(PI))
             },
             specified::AngleOrCorner::Angle(angle) => {
                 AngleOrCorner::Angle(angle)

--- a/tests/unit/style/parsing/image.rs
+++ b/tests/unit/style/parsing/image.rs
@@ -2,10 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use app_units::Au;
 use cssparser::Parser;
+use euclid::size::Size2D;
 use media_queries::CSSErrorReporterTest;
+use std::f32::consts::PI;
 use style::parser::ParserContext;
 use style::stylesheets::Origin;
+use style::values::computed;
+use style::values::computed::{Angle, Context, ToComputedValue};
+use style::values::specified;
 use style::values::specified::image::*;
 use style_traits::ToCss;
 
@@ -32,6 +38,14 @@ fn test_linear_gradient() {
 
     // Parsing without <angle> and <side-or-corner>
     assert_roundtrip_with_context!(Image::parse, "linear-gradient(red, green)");
+
+    // AngleOrCorner::None should become AngleOrCorner::Angle(Angle(PI)) when parsed
+    // Note that Angle(PI) is correct for top-to-bottom rendering, whereas Angle(0) would render bottom-to-top.
+    // ref: https://developer.mozilla.org/en-US/docs/Web/CSS/angle
+    let container = Size2D::new(Au::default(), Au::default());
+    let specified_context = Context::initial(container, true);
+    assert_eq!(specified::AngleOrCorner::None.to_computed_value(&specified_context),
+               computed::AngleOrCorner::Angle(Angle(PI)));
 }
 
 #[test]

--- a/tests/wpt/mozilla/tests/css/linear_gradients_parsing_a.html
+++ b/tests/wpt/mozilla/tests/css/linear_gradients_parsing_a.html
@@ -19,11 +19,15 @@ section {
 #c {
     background: linear-gradient(90deg, violet, violet 1em, violet 2ex, violet 50%, blue 50%, blue, blue);
 }
+#d {
+    background: linear-gradient(red, green);
+}
 </style>
 </head>
 <body>
 <section id=a></section>
 <section id=b></section>
 <section id=c></section>
+<section id=d></section>
 </body>
 </html>

--- a/tests/wpt/mozilla/tests/css/linear_gradients_parsing_ref.html
+++ b/tests/wpt/mozilla/tests/css/linear_gradients_parsing_ref.html
@@ -30,6 +30,9 @@ nav {
     background: blue;
     right: 0;
 }
+#d {
+    background: linear-gradient(to bottom, red, green);
+}
 </style>
 </head>
 <body>
@@ -39,5 +42,6 @@ nav {
     <nav id=ca></nav>
     <nav id=cb></nav>
 </section>
+<section id=d></section>
 </body>
 </html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Reverse linear gradient direction if not explicitly specified to match expected default behavior

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14745 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14746)
<!-- Reviewable:end -->
