### PR TITLE
Interpolate colors with premultiplied alpha.

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -390,12 +390,23 @@ impl Interpolate for BackgroundSize {
 impl Interpolate for RGBA {
     #[inline]
     fn interpolate(&self, other: &RGBA, progress: f64) -> Result<Self, ()> {
-        Ok(RGBA {
-            red: try!(self.red.interpolate(&other.red, progress)),
-            green: try!(self.green.interpolate(&other.green, progress)),
-            blue: try!(self.blue.interpolate(&other.blue, progress)),
-            alpha: try!(self.alpha.interpolate(&other.alpha, progress)),
-        })
+        fn clamp(val: f32) -> f32 {
+            val.max(0.).min(1.)
+        }
+
+        let alpha = clamp(try!(self.alpha.interpolate(&other.alpha, progress)));
+        if alpha == 0. {
+            Ok(RGBA { red: 0., green: 0., blue: 0., alpha: 0. })
+        } else {
+            Ok(RGBA { red: clamp(try!((self.red * self.alpha).interpolate(&(other.red * other.alpha), progress))
+                                 * 1. / alpha),
+                      green: clamp(try!((self.green * self.alpha).interpolate(&(other.green * other.alpha), progress))
+                                   * 1. / alpha),
+                      blue: clamp(try!((self.blue * self.alpha).interpolate(&(other.blue * other.alpha), progress))
+                                  * 1. / alpha),
+                      alpha: alpha
+            })
+        }
     }
 }
 

--- a/tests/unit/style/animated_properties.rs
+++ b/tests/unit/style/animated_properties.rs
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use cssparser::{Color, RGBA};
+use style::properties::animated_properties::Interpolate;
+
+#[test]
+fn test_rgba_color_interepolation() {
+    assert_eq!(Color::RGBA(RGBA { red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0 }).interpolate(
+              &Color::RGBA(RGBA { red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0 }), 1.0).unwrap(),
+               Color::RGBA(RGBA { red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0 }));
+
+    assert_eq!(Color::RGBA(RGBA { red: 1.0, green: 0.0, blue: 0.0, alpha: 0.6 }).interpolate(
+              &Color::RGBA(RGBA { red: 0.0, green: 1.0, blue: 0.0, alpha: 0.4 }), 0.5).unwrap(),
+               Color::RGBA(RGBA { red: 0.6, green: 0.4, blue: 0.0, alpha: 0.5 }));
+
+    // Some cubic-bezier functions produce values that are out of range [0, 1].
+    // Unclamped cases.
+    assert_eq!(Color::RGBA(RGBA { red: 0.3, green: 0.0, blue: 0.0, alpha: 0.4 }).interpolate(
+              &Color::RGBA(RGBA { red: 0.0, green: 1.0, blue: 0.0, alpha: 0.6 }), -0.5).unwrap(),
+               Color::RGBA(RGBA { red: 0.6, green: 0.0, blue: 0.0, alpha: 0.3 }));
+
+    assert_eq!(Color::RGBA(RGBA { red: 1.0, green: 0.0, blue: 0.0, alpha: 0.6 }).interpolate(
+              &Color::RGBA(RGBA { red: 0.0, green: 0.3, blue: 0.0, alpha: 0.4 }), 1.5).unwrap(),
+               Color::RGBA(RGBA { red: 0.0, green: 0.6, blue: 0.0, alpha: 0.3 }));
+
+    // Clamped cases.
+    assert_eq!(Color::RGBA(RGBA { red: 1.0, green: 0.0, blue: 0.0, alpha: 0.8 }).interpolate(
+              &Color::RGBA(RGBA { red: 0.0, green: 1.0, blue: 0.0, alpha: 0.2 }), -0.5).unwrap(),
+               Color::RGBA(RGBA { red: 1.0, green: 0.0, blue: 0.0, alpha: 1.0 }));
+
+    assert_eq!(Color::RGBA(RGBA { red: 1.0, green: 0.0, blue: 0.0, alpha: 0.8 }).interpolate(
+              &Color::RGBA(RGBA { red: 0.0, green: 1.0, blue: 0.0, alpha: 0.2 }), 1.5).unwrap(),
+               Color::RGBA(RGBA { red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0 }));
+}

--- a/tests/unit/style/lib.rs
+++ b/tests/unit/style/lib.rs
@@ -22,6 +22,7 @@ extern crate style;
 extern crate style_traits;
 extern crate test;
 
+mod animated_properties;
 mod atomic_refcell;
 mod attr;
 mod cache;


### PR DESCRIPTION
We need to clamp each interpolated values because some cubic-bezier functions
produce values that are out of range [0, 1].

r? @emilio 

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14747)
<!-- Reviewable:end -->
