### PR TITLE
Make default linear-gradient() direction 'to bottom', not 'to top'.

### DIFF
--- a/components/style/values/computed/image.rs
+++ b/components/style/values/computed/image.rs
@@ -470,7 +470,7 @@ impl ToComputedValue for specified::AngleOrCorner {
     fn to_computed_value(&self, _: &Context) -> AngleOrCorner {
         match *self {
             specified::AngleOrCorner::None => {
-                AngleOrCorner::Angle(Angle(0.0))
+                AngleOrCorner::Angle(Angle(PI))
             },
             specified::AngleOrCorner::Angle(angle) => {
                 AngleOrCorner::Angle(angle)


### PR DESCRIPTION
Found this while looking at failing Firefox reftests with stylo.  If a `linear-gradient()` value doesn't specify a direction, then it should go from top to bottom.

r? @shinglyu 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14748)
<!-- Reviewable:end -->
