### PR TITLE
Fix `overflow` serialization with CSS-wide keywords

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -467,6 +467,21 @@ impl ShorthandId {
         }
     }
 
+    // Overflow does not behave like a normal shorthand. When overflow-x and overflow-y are not of equal
+    // values, they no longer use the shared property name "overflow".
+    pub fn overflow_longhands_to_css<'a, W, I>(&self, declarations: I, dest: &mut W) -> fmt::Result
+        where W: fmt::Write, I: Iterator<Item=&'a PropertyDeclaration> {
+        match *self {
+            ShorthandId::Overflow => {
+                match shorthands::overflow::LonghandsToSerialize::from_iter(declarations) {
+                    Ok(longhands) => longhands.to_css_declared_with_name(dest),
+                    Err(_) => Err(fmt::Error)
+                }
+            },
+            _ => Err(fmt::Error)
+        }
+    }
+
     /// Serializes the possible shorthand name with value to input buffer given
     /// a list of longhand declarations.
     ///

--- a/components/style/properties/shorthand/box.mako.rs
+++ b/components/style/properties/shorthand/box.mako.rs
@@ -15,10 +15,6 @@
         })
     }
 
-
-    // Overflow does not behave like a normal shorthand. When overflow-x and overflow-y are not of equal
-    // values, they no longer use the shared property name "overflow".
-    // Other shorthands do not include their name in the to_css method
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             let x_and_y_equal = match (self.overflow_x, self.overflow_y) {
@@ -26,6 +22,31 @@
                     *x_value == y_container.0
                 },
                 (&DeclaredValue::WithVariables { .. }, &DeclaredValue::WithVariables { .. }) => true,
+                (&DeclaredValue::Initial, &DeclaredValue::Initial) => true,
+                (&DeclaredValue::Inherit, &DeclaredValue::Inherit) => true,
+                (&DeclaredValue::Unset, &DeclaredValue::Unset) => true,
+                _ => false
+            };
+
+            if x_and_y_equal {
+                try!(self.overflow_x.to_css(dest));
+            }
+            Ok(())
+        }
+
+        // Overflow does not behave like a normal shorthand. When overflow-x and overflow-y are not of equal
+        // values, they no longer use the shared property name "overflow".
+        // Other shorthands do not include their name in the to_css method
+        pub fn to_css_declared_with_name<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            let x_and_y_equal = match (self.overflow_x, self.overflow_y) {
+                (&DeclaredValue::Value(ref x_value), &DeclaredValue::Value(ref y_container)) => {
+                    *x_value == y_container.0
+                },
+                (_, &DeclaredValue::WithVariables { .. }) |
+                (&DeclaredValue::WithVariables { .. }, _) => {
+                    // We don't serialize shorthands with variables
+                    return dest.write_str("");
+                },
                 (&DeclaredValue::Initial, &DeclaredValue::Initial) => true,
                 (&DeclaredValue::Inherit, &DeclaredValue::Inherit) => true,
                 (&DeclaredValue::Unset, &DeclaredValue::Unset) => true,

--- a/tests/wpt/metadata/MANIFEST.json
+++ b/tests/wpt/metadata/MANIFEST.json
@@ -45845,7 +45845,16 @@
   "local_changes": {
     "deleted": [],
     "deleted_reftests": {},
-    "items": {},
+    "items": {
+      "testharness": {
+        "cssom/overflow-serialization.html": [
+          {
+            "path": "cssom/overflow-serialization.html",
+            "url": "/cssom/overflow-serialization.html"
+          }
+        ]
+      }
+    },
     "reftest_nodes": {}
   },
   "reftest_nodes": {

--- a/tests/wpt/web-platform-tests/cssom/overflow-serialization.html
+++ b/tests/wpt/web-platform-tests/cssom/overflow-serialization.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSSOM - Overlow property has different serialization than other shorthands.</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style>
+        div { overflow: inherit; }
+        div { overflow: hidden; }
+        div { overflow-x: initial; overflow-y: initial; }
+        div { overflow-x: scroll; overflow-y: scroll; }
+        div { overflow-x: inherit; overflow-y: unset; }
+    </style>
+
+    <script>
+    test(function () {
+        var styleSheet = document.styleSheets[0];
+
+        assert_equals(styleSheet.cssRules[0].style.cssText, "overflow: inherit;", "Single value overflow with CSS-wide keyword should serialize correctly.");
+        assert_equals(styleSheet.cssRules[1].style.cssText, "overflow: hidden;", "Single value overflow with non-CSS-wide keyword should serialize correctly.");
+        assert_equals(styleSheet.cssRules[2].style.cssText, "overflow: initial;", "Overflow-x/y longhands with same CSS-wide keyword should serialize correctly.");
+        assert_equals(styleSheet.cssRules[3].style.cssText, "overflow: scroll;", "Overflow-x/y longhands with same non-CSS-wide keyword should serialize correctly.");
+        assert_equals(styleSheet.cssRules[4].style.cssText, "overflow-x: inherit; overflow-y: unset;", "Overflow-x/y longhands with different keywords should serialize correctly.");
+
+        var div = document.createElement('div');
+        div.style.overflow = "inherit";
+        assert_equals(div.style.overflow, "inherit", "Single value overflow with CSS-wide keyword should serialize correctly.");
+
+        div.style.overflow = "hidden";
+        assert_equals(div.style.overflow, "hidden", "Single value overflow with non-CSS-wide keyword should serialize correctly.");
+
+        div.style.overflow = "";
+        div.style.overflowX = "initial";
+        div.style.overflowY = "initial";
+        assert_equals(div.style.overflow, "initial", "Overflow-x/y longhands with same CSS-wide keyword should serialize correctly.");
+
+        div.style.overflowX = "scroll";
+        div.style.overflowY = "scroll";
+        assert_equals(div.style.overflow, "scroll", "Overflow-x/y longhands with same non-CSS-wide keyword should serialize correctly.");
+
+        div.style.overflowX = "inherit";
+        div.style.overflowY = "unset";
+        assert_equals(div.style.overflow, "", "Overflow-x/y longhands with different keywords shouldn't serialize.");
+    });
+    </script>
+</head>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Overflow does not behave like a normal shorthand. CSS-wide keywords were handled in their `to_css_declared` method. So I had to bypass this check to make it work.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14752 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14757)
<!-- Reviewable:end -->
