### PR TITLE
Build with debugmozjs to run automated tests

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -1,28 +1,28 @@
 mac-rel-wpt1:
-  - ./mach build --release
+  - ./mach build --release --debug-mozjs
   - ./mach test-wpt-failure
   - ./mach test-wpt --release --processes 8 --total-chunks 2 --this-chunk 1 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --use-tracker
   - ./mach test-wpt --release --binary-arg=--multiprocess --processes 8 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
-  - ./mach build-cef --release
+  - ./mach build-cef --release --debug-mozjs
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 
 mac-rel-wpt2:
-  - ./mach build --release
+  - ./mach build --release --debug-mozjs
   - ./mach test-wpt --release --processes 8 --total-chunks 2 --this-chunk 2 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --use-tracker
 
 mac-dev-unit:
-  - ./mach build --dev
+  - ./mach build --dev --debug-mozjs
   - ./mach test-unit
-  - ./mach build-cef
+  - ./mach build-cef --debug-mozjs
   - ./mach build-geckolib
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 
 mac-rel-css:
-  - ./mach build --release
+  - ./mach build --release --debug-mozjs
   - ./mach test-css --release --processes 4 --log-raw test-css.log --log-errorsummary css-errorsummary.log --always-succeed
   - ./mach filter-intermittents css-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-css-errorsummary.log --use-tracker
   - ./mach build-geckolib --release
@@ -37,20 +37,20 @@ mac-nightly:
   - ./etc/ci/update_brew.sh
 
 linux-rel-intermittent:
-  - ./mach build --release
+  - ./mach build --release --debug-mozjs
   - ./etc/ci/check_intermittents.sh --log-raw intermittents.log
 
 mac-rel-intermittent:
-  - ./mach build --release
+  - ./mach build --release --debug-mozjs
   - ./etc/ci/check_intermittents.sh --log-raw intermittents.log
 
 linux-dev:
   - ./mach test-tidy --no-progress --all
   - ./mach test-tidy --no-progress --self-test
-  - ./mach build --dev
+  - ./mach build --dev --debug-mozjs
   - ./mach test-compiletest
   - ./mach test-unit
-  - ./mach build-cef
+  - ./mach build-cef --debug-mozjs
   - ./mach build-geckolib
   - ./mach test-stylo
   - bash ./etc/ci/lockfile_changed.sh
@@ -58,17 +58,17 @@ linux-dev:
   - bash ./etc/ci/check_no_panic.sh
 
 linux-rel-wpt:
-  - ./mach build --release --with-debug-assertions
+  - ./mach build --release --debug-mozjs --with-debug-assertions
   - ./mach test-wpt-failure
   - ./mach test-wpt --release --processes 24 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --use-tracker
   - ./mach test-wpt --release --binary-arg=--multiprocess --processes 24 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
 
 linux-rel-css:
-  - ./mach build --release --with-debug-assertions
+  - ./mach build --release --debug-mozjs --with-debug-assertions
   - ./mach test-css --release --processes 16 --log-raw test-css.log --log-errorsummary css-errorsummary.log --always-succeed
   - ./mach filter-intermittents css-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-css-errorsummary.log --use-tracker
-  - ./mach build-cef --release --with-debug-assertions
+  - ./mach build-cef --release --debug-mozjs --with-debug-assertions
   - ./mach build-geckolib --release
   - ./mach test-stylo --release
   - bash ./etc/ci/lockfile_changed.sh
@@ -102,17 +102,17 @@ arm64:
   - bash ./etc/ci/manifest_changed.sh
 
 windows-dev:
-  - ./mach build --dev
+  - ./mach build --dev --debug-mozjs
   - ./mach test-unit
   - ./mach build-geckolib
 
 windows-gnu-dev:
-  - ./mach build --dev
+  - ./mach build --dev --debug-mozjs
   - ./mach test-unit
   - ./mach build-geckolib
 
 windows-msvc-dev:
-  - mach.bat build --dev
+  - mach.bat build --dev --debug-mozjs
   - mach.bat test-unit
   - mach.bat build-geckolib
 

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -341,12 +341,16 @@ class MachCommands(CommandBase):
     @CommandArgument('--release', '-r',
                      action='store_true',
                      help='Build in release mode')
+    @CommandArgument('--debug-mozjs',
+                     default=None,
+                     action='store_true',
+                     help='Enable debug assertions in mozjs')
     @CommandArgument('--with-debug-assertions',
                      default=None,
                      action='store_true',
                      help='Enable debug assertions in release')
     def build_cef(self, jobs=None, verbose=False, release=False,
-                  with_debug_assertions=False):
+                  debug_mozjs=False, with_debug_assertions=False):
         self.ensure_bootstrapped()
 
         ret = None
@@ -359,6 +363,10 @@ class MachCommands(CommandBase):
             opts += ["--release"]
 
         servo_features = self.servo_features()
+
+        if debug_mozjs:
+            servo_features += ["debugmozjs"]
+
         if servo_features:
             opts += ["--features", "%s" % ' '.join(servo_features)]
 


### PR DESCRIPTION
This will enable many safety checks which will ease diagnosing problems.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #14759 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because changes the build steps

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

I've only enabled it for builds that are followed by `test-wpt` or `test-css` steps.
I'm not sure if this also needs to be enabled for subsequent `build-cef` and `build-geckolib` steps on the same builder to avoid rebuilding crates due to a feature mismatch.
r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14766)
<!-- Reviewable:end -->
