### PR TITLE
Update helper functions of StyleComplexColor

### DIFF
--- a/components/style/gecko_bindings/structs_debug.rs
+++ b/components/style/gecko_bindings/structs_debug.rs
@@ -3042,6 +3042,7 @@ pub mod root {
         pub struct StyleComplexColor {
             pub mColor: root::nscolor,
             pub mForegroundRatio: u8,
+            pub mIsAuto: bool,
         }
         #[test]
         fn bindgen_test_layout_StyleComplexColor() {

--- a/components/style/gecko_bindings/structs_release.rs
+++ b/components/style/gecko_bindings/structs_release.rs
@@ -3024,6 +3024,7 @@ pub mod root {
         pub struct StyleComplexColor {
             pub mColor: root::nscolor,
             pub mForegroundRatio: u8,
+            pub mIsAuto: bool,
         }
         #[test]
         fn bindgen_test_layout_StyleComplexColor() {

--- a/components/style/gecko_bindings/sugar/style_complex_color.rs
+++ b/components/style/gecko_bindings/sugar/style_complex_color.rs
@@ -11,6 +11,7 @@ impl From<nscolor> for StyleComplexColor {
         StyleComplexColor {
             mColor: other,
             mForegroundRatio: 0,
+            mIsAuto: false,
         }
     }
 }
@@ -20,6 +21,15 @@ impl StyleComplexColor {
         StyleComplexColor {
             mColor: 0,
             mForegroundRatio: 255,
+            mIsAuto: false,
+        }
+    }
+
+    pub fn auto() -> Self {
+        StyleComplexColor {
+            mColor: 0,
+            mForegroundRatio: 255,
+            mIsAuto: true,
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The definition of `StyleComplexColor` in the Gecko side was updated in [bug 1063162](https://bugzilla.mozilla.org/show_bug.cgi?id=1063162). The helper functions need update as well.

r? @Manishearth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14769)
<!-- Reviewable:end -->
