### PR TITLE
Fix rowspan handling for rows that span to the end of the rowgroup

### DIFF
--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -752,6 +752,7 @@ pub fn propagate_column_inline_sizes_to_child(
     // FIXME(pcwalton): This seems inefficient. Reference count it instead?
     match child_flow.class() {
         FlowClass::TableRowGroup => {
+            incoming_rowspan.clear();
             let child_table_rowgroup_flow = child_flow.as_mut_table_rowgroup();
             child_table_rowgroup_flow.spacing = *border_spacing;
             for kid in child_table_rowgroup_flow.block_flow.base.child_iter_mut() {
@@ -789,7 +790,11 @@ pub fn propagate_column_inline_sizes_to_child(
                         if incoming_rowspan.len() < col + 1 {
                             incoming_rowspan.resize(col + 1, 1);
                         }
-                        incoming_rowspan[col] = max(cell.row_span, incoming_rowspan[col]);
+                        // HTML § 4.9.11: For rowspan, the value 0 means the cell is to span all
+                        // the remaining rows in the rowgroup.
+                        if cell.row_span > incoming_rowspan[col] || cell.row_span == 0 {
+                            incoming_rowspan[col] = cell.row_span;
+                        }
                     }
                     col += 1;
                 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5292,6 +5292,18 @@
             "url": "/_mozilla/css/table_row_direction_a.html"
           }
         ],
+        "css/table_rowspan_rowgroup_a.html": [
+          {
+            "path": "css/table_rowspan_rowgroup_a.html",
+            "references": [
+              [
+                "/_mozilla/css/table_rowspan_rowgroup_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/table_rowspan_rowgroup_a.html"
+          }
+        ],
         "css/table_rowspan_simple_a.html": [
           {
             "path": "css/table_rowspan_simple_a.html",
@@ -20550,6 +20562,18 @@
           "url": "/_mozilla/css/table_row_direction_a.html"
         }
       ],
+      "css/table_rowspan_rowgroup_a.html": [
+        {
+          "path": "css/table_rowspan_rowgroup_a.html",
+          "references": [
+            [
+              "/_mozilla/css/table_rowspan_rowgroup_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/table_rowspan_rowgroup_a.html"
+        }
+      ],
       "css/table_rowspan_simple_a.html": [
         {
           "path": "css/table_rowspan_simple_a.html",
@@ -20560,18 +20584,6 @@
             ]
           ],
           "url": "/_mozilla/css/table_rowspan_simple_a.html"
-        }
-      ],
-      "css/table_rowspan_simple_ref.html": [
-        {
-          "path": "css/table_rowspan_simple_ref.html",
-          "references": [
-            [
-              "/_mozilla/css/table_rowspan_simple_ref.html",
-              "=="
-            ]
-          ],
-          "url": "/_mozilla/css/table_rowspan_simple_ref.html"
         }
       ],
       "css/table_specified_width_a.html": [

--- a/tests/wpt/mozilla/tests/css/table_rowspan_rowgroup_a.html
+++ b/tests/wpt/mozilla/tests/css/table_rowspan_rowgroup_a.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="UTF-8">
+  <link rel="match" href="table_rowspan_rowgroup_ref.html">
+  <link rel="spec" href="https://html.spec.whatwg.org/multipage/#attributes-common-to-td-and-th-elements">
+  <style>
+    td {
+      width: 100px;
+    }
+  </style>
+  <body>
+    <table border="1">
+      <tbody>
+        <tr><td rowspan="0">A</td><td>B</td></tr>
+        <tr><td>C</td></tr>
+        <tr><td>D</td></tr>
+      </tbody>
+      <tbody>
+        <tr><td>E</td><td>F</td></tr>
+      </tbody>
+    </table>
+  </body>
+</html>
+

--- a/tests/wpt/mozilla/tests/css/table_rowspan_rowgroup_ref.html
+++ b/tests/wpt/mozilla/tests/css/table_rowspan_rowgroup_ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="UTF-8">
+  <style>
+    td {
+      width: 100px;
+    }
+  </style>
+  <body>
+    <table border="1">
+      <tbody>
+        <tr><td rowspan="3">A</td><td>B</td></tr>
+        <tr><td>C</td></tr>
+        <tr><td>D</td></tr>
+      </tbody>
+      <tbody>
+        <tr><td>E</td><td>F</td></tr>
+      </tbody>
+    </table>
+  </body>
+</html>
+

--- a/tests/wpt/mozilla/tests/css/table_rowspan_simple_ref.html
+++ b/tests/wpt/mozilla/tests/css/table_rowspan_simple_ref.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <meta charset="UTF-8">
-  <link rel="match" href="table_rowspan_simple_ref.html">
   <style>
     td {
       width: 100px;


### PR DESCRIPTION
This fixes `rowspan="0"` to behave as described in [the HTML spec](https://html.spec.whatwg.org/multipage/tables.html#attributes-common-to-td-and-th-elements):

> For this attribute, the value zero means that the cell is to span all the remaining rows in the row group.

It also prevents any `rowspan` from overlapping into another rowgroup, as required by [HTML § 4.9.12](https://html.spec.whatwg.org/multipage/tables.html#table-processing-model):

> Row groups cannot overlap each other. Similarly, column groups cannot overlap each other. A cell cannot cover slots that are from two or more row groups.

r? @notriddle or @pcwalton 

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14798)
<!-- Reviewable:end -->
