### PR TITLE
webgl: Validate enums for blendEquation.

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -788,11 +788,19 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
     fn BlendEquation(&self, mode: u32) {
+        if mode != constants::FUNC_ADD {
+            return self.webgl_error(InvalidEnum);
+        }
+
         self.ipc_renderer.send(CanvasMsg::WebGL(WebGLCommand::BlendEquation(mode))).unwrap();
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
     fn BlendEquationSeparate(&self, mode_rgb: u32, mode_alpha: u32) {
+        if mode_rgb != constants::FUNC_ADD || mode_alpha != constants::FUNC_ADD {
+            return self.webgl_error(InvalidEnum);
+        }
+
         self.ipc_renderer
             .send(CanvasMsg::WebGL(WebGLCommand::BlendEquationSeparate(mode_rgb, mode_alpha)))
             .unwrap();

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/state/gl-enum-tests.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/state/gl-enum-tests.html.ini
@@ -1,24 +1,6 @@
 [gl-enum-tests.html]
   type: testharness
   expected: ERROR
-  [WebGL test #3: getError expected: INVALID_ENUM. Was NO_ERROR : gl.blendEquation(desktopGL['MIN'\]) should return INVALID_ENUM.]
-    expected: FAIL
-
-  [WebGL test #4: getError expected: INVALID_ENUM. Was NO_ERROR : gl.blendEquation(desktopGL['MAX'\]) should return INVALID_ENUM.]
-    expected: FAIL
-
-  [WebGL test #5: getError expected: INVALID_ENUM. Was NO_ERROR : gl.blendEquationSeparate(desktopGL['MIN'\], gl.FUNC_ADD) should return INVALID_ENUM.]
-    expected: FAIL
-
-  [WebGL test #6: getError expected: INVALID_ENUM. Was NO_ERROR : gl.blendEquationSeparate(desktopGL['MAX'\], gl.FUNC_ADD) should return INVALID_ENUM.]
-    expected: FAIL
-
-  [WebGL test #7: getError expected: INVALID_ENUM. Was NO_ERROR : gl.blendEquationSeparate(gl.FUNC_ADD, desktopGL['MIN'\]) should return INVALID_ENUM.]
-    expected: FAIL
-
-  [WebGL test #8: getError expected: INVALID_ENUM. Was NO_ERROR : gl.blendEquationSeparate(gl.FUNC_ADD, desktopGL['MAX'\]) should return INVALID_ENUM.]
-    expected: FAIL
-
   [WebGL test #9: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 


### PR DESCRIPTION
Improves a conformance test that tried passing in desktop GL enums for
blending.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14809)
<!-- Reviewable:end -->
