### PR TITLE
Implement Sub-resource integrity fetch step

### DIFF
--- a/tests/unit/net/fetch.rs
+++ b/tests/unit/net/fetch.rs
@@ -233,7 +233,6 @@ fn test_cors_preflight_fetch() {
     let _ = server.close();
 
     assert!(!fetch_response.is_network_error());
-
     match *fetch_response.body.lock().unwrap() {
         ResponseBody::Done(ref body) => assert_eq!(&**body, ACK),
         _ => panic!()
@@ -556,6 +555,58 @@ fn test_fetch_with_hsts() {
                "https");
 }
 
+#[test]
+fn test_fetch_with_sri_sucess() {
+    static MESSAGE: &'static [u8] = b"alert('Hello, world.');";
+    let handler = move |_: HyperRequest, response: HyperResponse| {
+        response.send(MESSAGE).unwrap();
+    };
+    let (mut server, server_url) = make_server(handler);
+    let do_fetch = |url: ServoUrl| {
+        let origin = Origin::Origin(url.origin());
+        let mut request = Request::new(url, Some(origin), false, None);
+        *request.referrer.borrow_mut() = Referrer::NoReferrer;
+        *request.integrity_metadata.borrow_mut()
+             = "sha384-H8BRh8j48O9oYatfu5AZzq6A9RINhZO5H16dQZngK7T62em8MUt1FLm52t+eX6xO".to_owned();
+        // Set the flag.
+        request.local_urls_only = false;
+
+        fetch(request, None)
+    };
+
+    let response = do_fetch(server_url);
+
+    let _ = server.close();
+    assert_eq!(response_is_done(&response), true);
+}
+
+#[test]
+fn test_fetch_with_sri_network_error() {
+    static MESSAGE: &'static [u8] = b"alert('Hello, Network Error');";
+    let handler = move |_: HyperRequest, response: HyperResponse| {
+        response.send(MESSAGE).unwrap();
+    };
+    let (mut server, server_url) = make_server(handler);
+
+    let do_fetch = |url: ServoUrl| {
+        let origin = Origin::Origin(url.origin());
+        let mut request = Request::new(url, Some(origin), false, None);
+        *request.referrer.borrow_mut() = Referrer::NoReferrer;
+        *request.integrity_metadata.borrow_mut()
+             = "sha384-H8BRh8j48O9oYatfu5AZzq6A9RINhZO5H16dQZngK7T62em8MUt1FLm52t+eX6xO".to_owned();
+        // Set the flag.
+        request.local_urls_only = false;
+
+        fetch(request, None)
+    };
+
+    let response = do_fetch(server_url);
+
+    let _ = server.close();
+    assert!(response.is_network_error());
+    assert!(response.internal_response.unwrap().is_network_error());
+}
+
 fn setup_server_and_fetch(message: &'static [u8], redirect_cap: u32) -> Response {
     let handler = move |request: HyperRequest, mut response: HyperResponse| {
         let redirects = match request.uri {
@@ -742,7 +793,6 @@ fn test_fetch_async_returns_complete_response() {
     let fetch_response = fetch(request, None);
 
     let _ = server.close();
-
     assert_eq!(response_is_done(&fetch_response), true);
 }
 


### PR DESCRIPTION
Implemented step eighteen of the main fetch. If a request has integrity metadata, then following steps are performed

1) Wait for response body
2) If the response does not have a termination reason and response does not match request’s integrity metadata, set response and internalResponse to a network error. 

SRI document specifies that user-agent should support SHA256,384 and 512. Validation using unsupported hash functions acts like no integrity value was provided for this reason validate_response_integrity method returns true if hashing algorithm specified is not SHA256, 384, 512.Validation is performed on the response this is specified in fetch specification.

SRI document specified there could be multiple Integrity metadata in integrity attribute. I believe the best algorithm would have been selected and set in integrity metadata before the main fetch is called. Is my assumption correct here?

This will not completely fix #14523, It will implement changes related fetch part.

r? @jdm 
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
.

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14816)
<!-- Reviewable:end -->
