### PR TITLE
Remove useless call to map() in constellation.rs

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1735,12 +1735,10 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         let frame_id = frame_id.unwrap_or(self.root_frame_id);
         let current_pipeline_id = self.frames.get(&frame_id)
             .map(|frame| frame.current.pipeline_id);
-        let current_pipeline_id_loaded = current_pipeline_id
-            .map(|id| id);
         let pipeline_id_loaded = self.pending_frames.iter().rev()
             .find(|x| x.old_pipeline_id == current_pipeline_id)
             .map(|x| x.new_pipeline_id)
-            .or(current_pipeline_id_loaded);
+            .or(current_pipeline_id);
         if let Err(e) = resp_chan.send(pipeline_id_loaded) {
             warn!("Failed get_pipeline response ({}).", e);
         }


### PR DESCRIPTION
Remove a little bit useless call to map() in constellation.rs :)

Context: https://github.com/servo/servo/pull/14724/files#r94317893

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix [this remark](https://github.com/servo/servo/pull/14724/files#r94317893)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because these are minor changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14825)
<!-- Reviewable:end -->
