### PR TITLE
Track stylesheet load's document instead of using element's current document

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6474,6 +6474,18 @@
             "url": "/_mozilla/mozilla/sslfail.html"
           }
         ],
+        "mozilla/stylesheet-adopt-panic.html": [
+          {
+            "path": "mozilla/stylesheet-adopt-panic.html",
+            "references": [
+              [
+                "/_mozilla/mozilla/stylesheet-adopt-panic-ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/mozilla/stylesheet-adopt-panic.html"
+          }
+        ],
         "mozilla/svg/svg.html": [
           {
             "path": "mozilla/svg/svg.html",
@@ -21754,6 +21766,18 @@
             ]
           ],
           "url": "/_mozilla/mozilla/sslfail.html"
+        }
+      ],
+      "mozilla/stylesheet-adopt-panic.html": [
+        {
+          "path": "mozilla/stylesheet-adopt-panic.html",
+          "references": [
+            [
+              "/_mozilla/mozilla/stylesheet-adopt-panic-ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/mozilla/stylesheet-adopt-panic.html"
         }
       ],
       "mozilla/svg/svg.html": [

--- a/tests/wpt/mozilla/tests/mozilla/adopt-panic.css
+++ b/tests/wpt/mozilla/tests/mozilla/adopt-panic.css
@@ -1,0 +1,3 @@
+body {
+    background-color: green;
+}

--- a/tests/wpt/mozilla/tests/mozilla/blank.html
+++ b/tests/wpt/mozilla/tests/mozilla/blank.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<title>Blank document</title>

--- a/tests/wpt/mozilla/tests/mozilla/stylesheet-adopt-panic-ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/stylesheet-adopt-panic-ref.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<iframe src="blank.html"></iframe>
+<style>
+  body {
+      background-color: green;
+  }
+</style>

--- a/tests/wpt/mozilla/tests/mozilla/stylesheet-adopt-panic.html
+++ b/tests/wpt/mozilla/tests/mozilla/stylesheet-adopt-panic.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Verify that adopting a stylesheet with an import applies its styles and doesn't panic</title>
+<link rel="match" href="stylesheet-adopt-panic-ref.html">
+<iframe src="blank.html" onload="foo()"></iframe>
+<script>
+  function foo() {
+    var i = document.querySelector('iframe');
+    i.contentDocument.documentElement.innerHTML = "<style>@import 'adopt-panic.css';</style>";
+    var e = i.contentDocument.querySelector('style');
+    document.body.appendChild(e);
+  }
+</script>


### PR DESCRIPTION
For cases where a stylesheet load finishes in a different document than it started, we need to be more careful about which document we report the completion to. In this case we actually have separate requests for each document involved, but they previously used the same element to determine which document to interact with.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14641
- [X] There are tests for these changes OR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14841)
<!-- Reviewable:end -->
