### PR TITLE
style: Simplify Debug impl for PropertyDeclaration reusing to_css.

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -842,17 +842,7 @@ impl fmt::Debug for PropertyDeclaration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(self.id().to_css(f));
         try!(f.write_str(": "));
-        match *self {
-            % for property in data.longhands:
-                % if not property.derived_from:
-                    PropertyDeclaration::${property.camel_case}(ref value) => value.to_css(f),
-                % endif
-            % endfor
-            PropertyDeclaration::Custom(_, ref value) => value.to_css(f),
-            % if any(property.derived_from for property in data.longhands):
-                _ => Err(fmt::Error),
-            % endif
-        }
+        self.to_css(f)
     }
 }
 


### PR DESCRIPTION
These two functions appear in the data from bug 1328497, and the second part of one is identical to the other.

I think the way to fix this is another one (either using static arrays to get
the interesting data, or making rust generate the equivalent code).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14844)
<!-- Reviewable:end -->
