### PR TITLE
Appveyor: Use ccache on Windows GNU builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 version: 1.0.{build}
 
 environment:
+  CCACHE_DIR: "%APPVEYOR_BUILD_FOLDER%\\.ccache"
   RUST_BACKTRACE: 1
   # The appveyor image we use has a pretty huge set of things installed... we make the
   # initial PATH something sane so we know what to expect
@@ -38,6 +39,7 @@ branches:
 cache:
   - .servo -> rust-nightly-date, cargo-commit-hash
   - .cargo -> rust-nightly-date, cargo-commit-hash
+  - .ccache
 
 install:
   - if %TARGET:*-msvc=msvc%==msvc set BUILD_ENV=msvc
@@ -47,10 +49,7 @@ install:
   - if %BUILD_ENV%==gnu  set MSYS=winsymlinks=lnk
   - if %BUILD_ENV%==gnu  bash -lc "echo $MSYSTEM; pacman --needed --noconfirm -Sy pacman-mirrors"
   - if %BUILD_ENV%==gnu  bash -lc "pacman --noconfirm -Sy"
-  - if %BUILD_ENV%==gnu  bash -lc "pacman -Sy --needed --noconfirm mingw-w64-x86_64-toolchain mingw-w64-x86_64-freetype mingw-w64-x86_64-icu mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates mingw-w64-x86_64-expat mingw-w64-x86_64-cmake tar diffutils patch patchutils make python2-setuptools"
-  - if %BUILD_ENV%==gnu  bash -lc "easy_install-2.7 pip virtualenv"
-  - if %BUILD_ENV%==gnu  bash -lc "mv /mingw64/bin/python2.exe /mingw64/bin/python2-mingw64.exe"
-  - if %BUILD_ENV%==gnu  bash -lc "mv /mingw64/bin/python2.7.exe /mingw64/bin/python2.7-mingw64.exe"
+  - if %BUILD_ENV%==gnu  bash -lc "pacman -Sy --needed --noconfirm mingw-w64-x86_64-ccache mingw-w64-x86_64-toolchain mingw-w64-x86_64-freetype mingw-w64-x86_64-icu mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates mingw-w64-x86_64-expat mingw-w64-x86_64-cmake tar diffutils patch patchutils make python2-setuptools"
   # Downgrade msys2 build GCC to 5.4.0-1 - https://github.com/servo/servo/issues/12512
   - if %BUILD_ENV%==gnu  set GCC_URL=http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc
   - if %BUILD_ENV%==gnu  set GCC_EXT=5.4.0-1-any.pkg.tar.xz
@@ -64,7 +63,9 @@ install:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 build_script:
+  - if %BUILD_ENV%==gnu  bash -lc "ccache -s"
   - if %BUILD_ENV%==msvc mach build -d -v && mach test-unit
-  - if %BUILD_ENV%==gnu  bash -lc "export PATH=/c/Python27:$PATH; cd $APPVEYOR_BUILD_FOLDER; ./mach build -d -v && ./mach test-unit"
+  - if %BUILD_ENV%==gnu  bash -lc "export PATH=/c/Python27:$PATH; export CCACHE=/mingw64/bin/ccache; cd $APPVEYOR_BUILD_FOLDER; ./mach build -d -v && ./mach test-unit"
+  - if %BUILD_ENV%==gnu  bash -lc "ccache -s"
 
 test: off


### PR DESCRIPTION
r? @larsbergstrom 

Locally tested:

First run: (Build time: 26:27)
```
cache directory                     C:/github/servo/.servo/.ccache
primary config                      C:/github/servo/.servo/.ccache/ccache.conf
secondary config      (readonly)    C:/building/msys64/mingw64/etc/ccache.conf
cache hit (direct)                     0
cache hit (preprocessed)               0
cache miss                           953
called for link                        5
called for preprocessing               9
compile failed                         6
preprocessor error                    30
unsupported source language            1
autoconf compile/link                 43
no input file                          6
files in cache                      2523
cache size                         443.0 MB
max cache size                       5.0 GB
```

Second run: (Build time: 15:30)

```
cache directory                     C:/github/servo/.servo/.ccache
primary config                      C:/github/servo/.servo/.ccache/ccache.conf
secondary config      (readonly)    C:/building/msys64/mingw64/etc/ccache.conf
cache hit (direct)                   922
cache hit (preprocessed)              31
cache miss                           953
called for link                       10
called for preprocessing              18
compile failed                        12
preprocessor error                    60
unsupported source language            2
autoconf compile/link                 86
no input file                         12
files in cache                      2523
cache size                         443.0 MB
max cache size                       5.0 GB

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14850)
<!-- Reviewable:end -->
