### PR TITLE
animation-iteration-count property is a number instead of integer.

### DIFF
--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -32,7 +32,7 @@ pub enum KeyframesIterationState {
     /// Infinite iterations, so no need to track a state.
     Infinite,
     /// Current and max iterations.
-    Finite(u32, u32),
+    Finite(f32, f32),
 }
 
 /// This structure represents wether an animation is actually running.
@@ -92,7 +92,7 @@ impl KeyframesAnimationState {
         }
 
         if let KeyframesIterationState::Finite(ref mut current, ref max) = self.iteration_state {
-            *current += 1;
+            *current += 1.0;
             // NB: This prevent us from updating the direction, which might be
             // needed for the correct handling of animation-fill-mode.
             if *current >= *max {
@@ -473,7 +473,7 @@ pub fn maybe_start_animations(context: &SharedStyleContext,
             let duration = box_style.animation_duration_mod(i).seconds();
             let iteration_state = match box_style.animation_iteration_count_mod(i) {
                 AnimationIterationCount::Infinite => KeyframesIterationState::Infinite,
-                AnimationIterationCount::Number(n) => KeyframesIterationState::Finite(0, n),
+                AnimationIterationCount::Number(n) => KeyframesIterationState::Finite(0.0, n),
             };
 
             let animation_direction = box_style.animation_direction_mod(i);

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -828,10 +828,11 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
 
         pub use self::AnimationIterationCount as SingleComputedValue;
 
+        // https://drafts.csswg.org/css-animations/#animation-iteration-count
         #[derive(Debug, Clone, PartialEq)]
         #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
         pub enum AnimationIterationCount {
-            Number(u32),
+            Number(f32),
             Infinite,
         }
 
@@ -841,12 +842,12 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
                     return Ok(AnimationIterationCount::Infinite)
                 }
 
-                let number = try!(input.expect_integer());
-                if number < 0 {
+                let number = try!(input.expect_number());
+                if number < 0.0 {
                     return Err(());
                 }
 
-                Ok(AnimationIterationCount::Number(number as u32))
+                Ok(AnimationIterationCount::Number(number))
             }
         }
 
@@ -886,7 +887,7 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
 
     #[inline]
     pub fn get_initial_single_value() -> AnimationIterationCount {
-        AnimationIterationCount::Number(1)
+        AnimationIterationCount::Number(1.0)
     }
 
     #[inline]

--- a/tests/unit/style/parsing/animation.rs
+++ b/tests/unit/style/parsing/animation.rs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use cssparser::Parser;
+use media_queries::CSSErrorReporterTest;
+use parsing::parse;
+use style::parser::{Parse, ParserContext};
+use style::properties::longhands::animation_iteration_count::computed_value::AnimationIterationCount;
+use style::stylesheets::Origin;
+use style_traits::ToCss;
+
+#[test]
+fn test_animation_iteration() {
+    assert_roundtrip_with_context!(AnimationIterationCount::parse, "0", "0");
+    assert_roundtrip_with_context!(AnimationIterationCount::parse, "0.1", "0.1");
+    assert_roundtrip_with_context!(AnimationIterationCount::parse, "infinite", "infinite");
+
+    // Negative numbers are invalid
+    assert!(parse(AnimationIterationCount::parse, "-1").is_err());
+}

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -47,6 +47,7 @@ macro_rules! parse_longhand {
     }};
 }
 
+mod animation;
 mod background;
 mod basic_shape;
 mod border;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is a revised PR  for #14732.
@emilio?
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14851)
<!-- Reviewable:end -->
