### PR TITLE
Make tidy work on stylo trees

### DIFF
--- a/python/servo/lints/wpt_lint.py
+++ b/python/servo/lints/wpt_lint.py
@@ -26,6 +26,8 @@ class Lint(LintRunner):
                 yield f[len(working_dir):]
 
     def run(self):
+        if self.stylo:
+            return
         wpt_working_dir = os.path.abspath(os.path.join(WPT_PATH, "web-platform-tests"))
         for suite in SUITES:
             files = self._get_wpt_files(suite)

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -381,11 +381,13 @@ class MachCommands(CommandBase):
                      help="Don't show progress for tidy")
     @CommandArgument('--self-test', default=False, action="store_true",
                      help="Run unit tests for tidy")
-    def test_tidy(self, all_files, no_progress, self_test):
+    @CommandArgument('--stylo', default=False, action="store_true",
+                     help="Only handle files in the stylo tree")
+    def test_tidy(self, all_files, no_progress, self_test, stylo):
         if self_test:
             return test_tidy.do_tests()
         else:
-            return tidy.scan(not all_files, not no_progress)
+            return tidy.scan(not all_files, not no_progress, stylo=stylo)
 
     @Command('test-webidl',
              description='Run the WebIDL parser tests',


### PR DESCRIPTION
This adds `./mach test-tidy --stylo`, which turns off the usage of git to search for files to check (fixes #14855), and also turns off the wpt lint, making it possible to run tidy in a stylo tree.


r? @jdm @wafflespeanut

cc @bzbarsky

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14853)
<!-- Reviewable:end -->
