### PR TITLE
Index the session past correctly when discarding.

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -521,7 +521,7 @@ pub fn default_opts() -> Opts {
         userscripts: None,
         user_stylesheets: Vec::new(),
         output_file: None,
-        max_session_history: 16,
+        max_session_history: 20,
         replace_surrogates: false,
         gc_profile: false,
         load_webfonts_synchronously: false,
@@ -615,7 +615,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
                 "Probability of randomly closing a pipeline (for testing constellation hardening).",
                 "0.0");
     opts.optopt("", "random-pipeline-closure-seed", "A fixed seed for repeatbility of random pipeline closure.", "");
-    opts.optopt("", "max-session-history", "Maximum amount of session history to store in each tab.", "16");
+    opts.optopt("", "max-session-history", "Maximum amount of session history to store in each tab.", "20");
     opts.optmulti("Z", "debug",
                   "A comma-separated string of debug options. Pass help to show available options.", "");
     opts.optflag("h", "help", "Print this message");
@@ -786,7 +786,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
 
     let max_session_history = opt_match.opt_str("max-session-history").map(|max| {
         max.parse().unwrap_or_else(|err| args_fail(&format!("Error parsing option: --max-session-history ({})", err)))
-    }).unwrap_or(16);
+    }).unwrap_or(20);
 
     if opt_match.opt_present("M") {
         MULTIPROCESS.store(true, Ordering::SeqCst)

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2110,7 +2110,8 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         } else if let Some(frame) = self.frames.get_mut(&frame_change.frame_id) {
             debug!("Adding pipeline to existing frame.");
             frame.load(frame_change.new_pipeline_id, frame_change.url.clone());
-            let evicted_id = frame.prev.get_mut(opts::get().max_session_history)
+            let evicted_id = frame.prev.len().checked_sub(opts::get().max_session_history)
+                .and_then(|index| frame.prev.get_mut(index))
                 .and_then(|entry| entry.pipeline_id.take());
             (evicted_id, false, true, true)
         } else {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -15128,6 +15128,12 @@
             "url": "/_mozilla/mozilla/service-workers/service-worker-registration.html"
           }
         ],
+        "mozilla/servo-max-session-history.html": [
+          {
+            "path": "mozilla/servo-max-session-history.html",
+            "url": "/_mozilla/mozilla/servo-max-session-history.html"
+          }
+        ],
         "mozilla/sigsegv.html": [
           {
             "path": "mozilla/sigsegv.html",

--- a/tests/wpt/mozilla/tests/mozilla/servo-max-session-history.html
+++ b/tests/wpt/mozilla/tests/mozilla/servo-max-session-history.html
@@ -1,0 +1,36 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body></body>
+<script>
+  // This test goes forward by X pages, then back by Y pages,
+  // then checks to see if that triggered a reload.
+  // If it did, the document must have been discarded,
+
+  // The current page number (stored in the URL search string)
+  var page_number = location.search.substring(1) | 0;
+
+  // The number of pages to go forward by.
+  // This should be more than go_back_by, to ensure that
+  // we actually do more than one back traversal.
+  var go_forward_by = 24;
+
+  // The number of pages to go back by.
+  // This should be more than the default --max-session-history,
+  // to ensure that going back reloads the page.
+  var go_back_by = Math.min(page_number, 20);
+
+  if (history.length < go_forward_by) {
+    // Keep loading new pages until we have loaded enough of them.
+    location.assign("?" + (page_number + 1));
+  } else if (page_number === 0) {
+    // If we got back to the beginning, we must have triggered reloads.
+    test(function() {}, "Forward then back triggered a reload.");
+  } else {
+    // Otherwise, go back.
+    history.go(-go_back_by);
+  }
+</script>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Oops, indexed from the wrong end when discarding documents in #14312.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because we're not testing document discarding

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14860)
<!-- Reviewable:end -->
