### PR TITLE
Allow cli prefs to have numerical value

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -889,14 +889,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     prefs::add_user_prefs();
 
     for pref in opt_match.opt_strs("pref").iter() {
-        let split: Vec<&str> = pref.splitn(2, '=').collect();
-        let pref_name = split[0];
-        let value = split.get(1);
-        match value {
-            Some(&"false") => PREFS.set(pref_name, PrefValue::Boolean(false)),
-            Some(&"true") | None => PREFS.set(pref_name, PrefValue::Boolean(true)),
-            _ => PREFS.set(pref_name, PrefValue::String(value.unwrap().to_string()))
-        };
+        parse_pref_from_command_line(pref);
     }
 
     if let Some(layout_threads) = layout_threads {
@@ -944,6 +937,20 @@ pub fn set_defaults(opts: Opts) {
         let box_opts = Box::new(opts);
         DEFAULT_OPTIONS = Box::into_raw(box_opts);
     }
+}
+
+pub fn parse_pref_from_command_line(pref: &str) {
+    let split: Vec<&str> = pref.splitn(2, '=').collect();
+    let pref_name = split[0];
+    let value = split.get(1);
+    match value {
+        Some(&"false") => PREFS.set(pref_name, PrefValue::Boolean(false)),
+        Some(&"true") | None => PREFS.set(pref_name, PrefValue::Boolean(true)),
+        Some(value) => match value.parse::<f64>() {
+            Ok(v) => PREFS.set(pref_name, PrefValue::Number(v)),
+            Err(_) => PREFS.set(pref_name, PrefValue::String(value.to_string()))
+        }
+    };
 }
 
 #[inline]

--- a/tests/unit/servo_config/opts.rs
+++ b/tests/unit/servo_config/opts.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use servo_config::opts::parse_url_or_filename;
+use servo_config::opts::{parse_url_or_filename, parse_pref_from_command_line};
+use servo_config::prefs::{PrefValue, PREFS};
 use std::path::Path;
 
 #[cfg(not(target_os = "windows"))]
@@ -66,4 +67,27 @@ fn test_argument_parsing_special() {
                ["fake", "cwd", "bar%3Fbaz%23buzz.html"]);
     assert_eq!(url.query(), None);
     assert_eq!(url.fragment(), None);
+}
+
+#[test]
+fn test_parse_pref_from_command_line() {
+    // Test with boolean values.
+    parse_pref_from_command_line("testtrue=true");
+    assert_eq!(*PREFS.get("testtrue"), PrefValue::Boolean(true));
+    parse_pref_from_command_line("testfalse=false");
+    assert_eq!(*PREFS.get("testfalse"), PrefValue::Boolean(false));
+
+    // Test with numbers.
+    parse_pref_from_command_line("testint=42");
+    assert_eq!(*PREFS.get("testint"), PrefValue::Number(42 as f64));
+    parse_pref_from_command_line("testfloat=4.2");
+    assert_eq!(*PREFS.get("testfloat"), PrefValue::Number(4.2));
+
+    // Test default (string).
+    parse_pref_from_command_line("teststr=str");
+    assert_eq!(*PREFS.get("teststr"), PrefValue::String("str".to_owned()));
+
+    // Test with no value.
+    parse_pref_from_command_line("testempty");
+    assert_eq!(*PREFS.get("testempty"), PrefValue::Boolean(true));
 }


### PR DESCRIPTION
I'm not sure as I'm new with servo but shouldn't the new function ```parse_opt_prefs``` be in ```prefs.rs``` instead of ```opts.rs``` ?

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14842 

<!-- Either: -->
- [X] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14863)
<!-- Reviewable:end -->
