### PR TITLE
Stylo: Disable regex feature of env_logger

### DIFF
--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -16,7 +16,7 @@ bindgen = ["style/bindgen"]
 app_units = "0.3"
 atomic_refcell = "0.1"
 cssparser = {version = "0.7"}
-env_logger = "0.3"
+env_logger = {version = "0.3", default-features = false} # disable `regex` to reduce code size
 euclid = "0.10.1"
 lazy_static = "0.2"
 libc = "0.2"


### PR DESCRIPTION
To reduce binary size.  See [bug 1328497](https://bugzilla.mozilla.org/show_bug.cgi?id=1328497) for details.  r? @bholley

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14866)
<!-- Reviewable:end -->
