### PR TITLE
Fix loss of response type information in Fetch API

### DIFF
--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -173,8 +173,10 @@ pub trait FetchTaskTarget {
 
 #[derive(Serialize, Deserialize)]
 pub enum FilteredMetadata {
+    Basic(Metadata),
+    Cors(Metadata),
     Opaque,
-    Transparent(Metadata),
+    OpaqueRedirect
 }
 
 #[derive(Serialize, Deserialize)]

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -835,8 +835,10 @@ impl XMLHttpRequest {
             Ok(meta) => match meta {
                 FetchMetadata::Unfiltered(m) => m,
                 FetchMetadata::Filtered { filtered, .. } => match filtered {
+                    FilteredMetadata::Basic(m) => m,
+                    FilteredMetadata::Cors(m) => m,
                     FilteredMetadata::Opaque => return Err(Error::Network),
-                    FilteredMetadata::Transparent(m) => m
+                    FilteredMetadata::OpaqueRedirect => return Err(Error::Network)
                 }
             },
             Err(_) => {

--- a/tests/unit/net/data_loader.rs
+++ b/tests/unit/net/data_loader.rs
@@ -32,7 +32,7 @@ fn assert_parse(url:          &'static str,
             assert_eq!(header_content_type, content_type.as_ref());
 
             let metadata = match response.metadata() {
-                Ok(FetchMetadata::Filtered { filtered: FilteredMetadata::Transparent(m), .. }) => m,
+                Ok(FetchMetadata::Filtered { filtered: FilteredMetadata::Basic(m), .. }) => m,
                 result => panic!(result),
             };
             assert_eq!(metadata.content_type.map(Serde::into_inner), content_type);

--- a/tests/wpt/metadata/fetch/api/basic/accept-header-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/accept-header-worker.html.ini
@@ -1,12 +1,6 @@
 [accept-header-worker.html]
   type: testharness
-  [Request through fetch should have 'accept' header with value '*/*']
-    expected: FAIL
-
   [Request through fetch should have 'accept' header with value 'custom/*']
-    expected: FAIL
-
-  [Request through fetch should have a 'accept-language' header]
     expected: FAIL
 
   [Request through fetch should have 'accept-language' header with value 'bzh']

--- a/tests/wpt/metadata/fetch/api/basic/accept-header.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/accept-header.html.ini
@@ -1,12 +1,6 @@
 [accept-header.html]
   type: testharness
-  [Request through fetch should have 'accept' header with value '*/*']
-    expected: FAIL
-
   [Request through fetch should have 'accept' header with value 'custom/*']
-    expected: FAIL
-
-  [Request through fetch should have a 'accept-language' header]
     expected: FAIL
 
   [Request through fetch should have 'accept-language' header with value 'bzh']

--- a/tests/wpt/metadata/fetch/api/basic/mode-no-cors-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/mode-no-cors-worker.html.ini
@@ -1,11 +1,5 @@
 [mode-no-cors-worker.html]
   type: testharness
-  [Fetch ../resources/top.txt with no-cors mode]
-    expected: FAIL
-
-  [Fetch http://web-platform.test:8000/fetch/api/resources/top.txt with no-cors mode]
-    expected: FAIL
-
   [Fetch https://web-platform.test:8443/fetch/api/resources/top.txt with no-cors mode]
     expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/mode-no-cors.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/mode-no-cors.html.ini
@@ -1,11 +1,5 @@
 [mode-no-cors.html]
   type: testharness
-  [Fetch ../resources/top.txt with no-cors mode]
-    expected: FAIL
-
-  [Fetch http://web-platform.test:8000/fetch/api/resources/top.txt with no-cors mode]
-    expected: FAIL
-
   [Fetch https://web-platform.test:8443/fetch/api/resources/top.txt with no-cors mode]
     expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/mode-same-origin-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/mode-same-origin-worker.html.ini
@@ -1,17 +1,5 @@
 [mode-same-origin-worker.html]
   type: testharness
-  [Fetch ../resources/top.txt with same-origin mode]
-    expected: FAIL
-
-  [Fetch http://web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
-    expected: FAIL
-
   [Fetch http://www1.web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
-    expected: FAIL
-
-  [Fetch /fetch/api/basic/../resources/redirect.py?location=../resources/top.txt with same-origin mode]
-    expected: FAIL
-
-  [Fetch /fetch/api/basic/../resources/redirect.py?location=http://web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
     expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/mode-same-origin.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/mode-same-origin.html.ini
@@ -1,17 +1,5 @@
 [mode-same-origin.html]
   type: testharness
-  [Fetch ../resources/top.txt with same-origin mode]
-    expected: FAIL
-
-  [Fetch http://web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
-    expected: FAIL
-
   [Fetch http://www1.web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
-    expected: FAIL
-
-  [Fetch /fetch/api/basic/../resources/redirect.py?location=../resources/top.txt with same-origin mode]
-    expected: FAIL
-
-  [Fetch /fetch/api/basic/../resources/redirect.py?location=http://web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode]
     expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/request-forbidden-headers-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-forbidden-headers-worker.html.ini
@@ -1,8 +1,5 @@
 [request-forbidden-headers-worker.html]
   type: testharness
-  [Accept-Charset is a forbidden request header]
-    expected: FAIL
-
   [Accept-Encoding is a forbidden request header]
     expected: FAIL
 
@@ -10,65 +7,5 @@
     expected: FAIL
 
   [Access-Control-Request-Method is a forbidden request header]
-    expected: FAIL
-
-  [Connection is a forbidden request header]
-    expected: FAIL
-
-  [Content-Length is a forbidden request header]
-    expected: FAIL
-
-  [Cookie is a forbidden request header]
-    expected: FAIL
-
-  [Cookie2 is a forbidden request header]
-    expected: FAIL
-
-  [Date is a forbidden request header]
-    expected: FAIL
-
-  [DNT is a forbidden request header]
-    expected: FAIL
-
-  [Expect is a forbidden request header]
-    expected: FAIL
-
-  [Host is a forbidden request header]
-    expected: FAIL
-
-  [Keep-Alive is a forbidden request header]
-    expected: FAIL
-
-  [Origin is a forbidden request header]
-    expected: FAIL
-
-  [Referer is a forbidden request header]
-    expected: FAIL
-
-  [TE is a forbidden request header]
-    expected: FAIL
-
-  [Trailer is a forbidden request header]
-    expected: FAIL
-
-  [Transfer-Encoding is a forbidden request header]
-    expected: FAIL
-
-  [Upgrade is a forbidden request header]
-    expected: FAIL
-
-  [Via is a forbidden request header]
-    expected: FAIL
-
-  [Proxy- is a forbidden request header]
-    expected: FAIL
-
-  [Proxy-Test is a forbidden request header]
-    expected: FAIL
-
-  [Sec- is a forbidden request header]
-    expected: FAIL
-
-  [Sec-Test is a forbidden request header]
     expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/request-forbidden-headers.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-forbidden-headers.html.ini
@@ -1,8 +1,5 @@
 [request-forbidden-headers.html]
   type: testharness
-  [Accept-Charset is a forbidden request header]
-    expected: FAIL
-
   [Accept-Encoding is a forbidden request header]
     expected: FAIL
 
@@ -10,65 +7,5 @@
     expected: FAIL
 
   [Access-Control-Request-Method is a forbidden request header]
-    expected: FAIL
-
-  [Connection is a forbidden request header]
-    expected: FAIL
-
-  [Content-Length is a forbidden request header]
-    expected: FAIL
-
-  [Cookie is a forbidden request header]
-    expected: FAIL
-
-  [Cookie2 is a forbidden request header]
-    expected: FAIL
-
-  [Date is a forbidden request header]
-    expected: FAIL
-
-  [DNT is a forbidden request header]
-    expected: FAIL
-
-  [Expect is a forbidden request header]
-    expected: FAIL
-
-  [Host is a forbidden request header]
-    expected: FAIL
-
-  [Keep-Alive is a forbidden request header]
-    expected: FAIL
-
-  [Origin is a forbidden request header]
-    expected: FAIL
-
-  [Referer is a forbidden request header]
-    expected: FAIL
-
-  [TE is a forbidden request header]
-    expected: FAIL
-
-  [Trailer is a forbidden request header]
-    expected: FAIL
-
-  [Transfer-Encoding is a forbidden request header]
-    expected: FAIL
-
-  [Upgrade is a forbidden request header]
-    expected: FAIL
-
-  [Via is a forbidden request header]
-    expected: FAIL
-
-  [Proxy- is a forbidden request header]
-    expected: FAIL
-
-  [Proxy-Test is a forbidden request header]
-    expected: FAIL
-
-  [Sec- is a forbidden request header]
-    expected: FAIL
-
-  [Sec-Test is a forbidden request header]
     expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/request-headers-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-headers-worker.html.ini
@@ -1,11 +1,5 @@
 [request-headers-worker.html]
   type: testharness
-  [Fetch with GET]
-    expected: FAIL
-
-  [Fetch with HEAD]
-    expected: FAIL
-
   [Fetch with PUT without body]
     expected: FAIL
 
@@ -52,9 +46,6 @@
     expected: FAIL
 
   [Fetch with POST with URLSearchParams body]
-    expected: FAIL
-
-  [Fetch with GET and mode "cors" does not need an Origin header]
     expected: FAIL
 
   [Fetch with POST and mode "same-origin" needs an Origin header]

--- a/tests/wpt/metadata/fetch/api/basic/request-headers.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-headers.html.ini
@@ -1,11 +1,5 @@
 [request-headers.html]
   type: testharness
-  [Fetch with GET]
-    expected: FAIL
-
-  [Fetch with HEAD]
-    expected: FAIL
-
   [Fetch with PUT without body]
     expected: FAIL
 
@@ -52,9 +46,6 @@
     expected: FAIL
 
   [Fetch with POST with URLSearchParams body]
-    expected: FAIL
-
-  [Fetch with GET and mode "cors" does not need an Origin header]
     expected: FAIL
 
   [Fetch with POST and mode "same-origin" needs an Origin header]

--- a/tests/wpt/metadata/fetch/api/basic/scheme-blob-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-blob-worker.html.ini
@@ -1,6 +1,0 @@
-[scheme-blob-worker.html]
-  type: testharness
-  [Fetching [GET\] URL.createObjectURL(blob) is OK]
-    bug: https://github.com/servo/servo/issues/13766
-    expected: FAIL
-

--- a/tests/wpt/metadata/fetch/api/basic/scheme-blob.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-blob.html.ini
@@ -1,6 +1,0 @@
-[scheme-blob.html]
-  type: testharness
-  [Fetching [GET\] URL.createObjectURL(blob) is OK]
-    bug: https://github.com/servo/servo/issues/13766
-    expected: FAIL
-

--- a/tests/wpt/metadata/fetch/api/basic/scheme-data-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-data-worker.html.ini
@@ -9,12 +9,6 @@
   [Fetching data:,response%27s%20body is OK (cors)]
     expected: FAIL
 
-  [Fetching data:text/plain;base64,cmVzcG9uc2UncyBib[...\] is OK]
-    expected: FAIL
-
-  [Fetching data:image/png;base64,cmVzcG9uc2UncyBib2[...\] is OK]
-    expected: FAIL
-
   [Fetching [POST\] data:,response%27s%20body is OK]
     expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/basic/scheme-data.html.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-data.html.ini
@@ -9,12 +9,6 @@
   [Fetching data:,response%27s%20body is OK (cors)]
     expected: FAIL
 
-  [Fetching data:text/plain;base64,cmVzcG9uc2UncyBib[...\] is OK]
-    expected: FAIL
-
-  [Fetching data:image/png;base64,cmVzcG9uc2UncyBib2[...\] is OK]
-    expected: FAIL
-
   [Fetching [POST\] data:,response%27s%20body is OK]
     expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/credentials/cookies-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/credentials/cookies-worker.html.ini
@@ -1,18 +1,9 @@
 [cookies-worker.html]
   type: testharness
-  [Include mode: 1 cookie]
-    expected: FAIL
-
   [Include mode: 2 cookies]
     expected: FAIL
 
-  [Omit mode: discard cookies]
-    expected: FAIL
-
   [Omit mode: no cookie is stored]
-    expected: FAIL
-
-  [Omit mode: no cookie is sent]
     expected: FAIL
 
   [Same-origin mode: 1 cookie]

--- a/tests/wpt/metadata/fetch/api/credentials/cookies.html.ini
+++ b/tests/wpt/metadata/fetch/api/credentials/cookies.html.ini
@@ -1,18 +1,9 @@
 [cookies.html]
   type: testharness
-  [Include mode: 1 cookie]
-    expected: FAIL
-
   [Include mode: 2 cookies]
     expected: FAIL
 
-  [Omit mode: discard cookies]
-    expected: FAIL
-
   [Omit mode: no cookie is stored]
-    expected: FAIL
-
-  [Omit mode: no cookie is sent]
     expected: FAIL
 
   [Same-origin mode: 1 cookie]

--- a/tests/wpt/metadata/fetch/api/policies/referrer-no-referrer-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/referrer-no-referrer-worker.html.ini
@@ -1,5 +1,0 @@
-[referrer-no-referrer-worker.html]
-  type: testharness
-  [Request's referrer is empty]
-    expected: FAIL
-

--- a/tests/wpt/metadata/fetch/api/policies/referrer-no-referrer.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/referrer-no-referrer.html.ini
@@ -1,5 +1,0 @@
-[referrer-no-referrer.html]
-  type: testharness
-  [Request's referrer is empty]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Avoids mapping response types that are distinct according to [the spec](https://fetch.spec.whatwg.org/#concept-response-type) to fewer response types. Also updates test expectations to match that we now pass tests that check the response type.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14068

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14868)
<!-- Reviewable:end -->
