### PR TITLE
Use tinyfiledialogs from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
  "device 0.0.1 (git+https://github.com/servo/devices)",
  "ipc-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_rand 0.0.1",
- "tinyfiledialogs 2.5.9 (git+https://github.com/jdm/tinyfiledialogs)",
+ "tinyfiledialogs 2.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1683,7 +1683,7 @@ dependencies = [
  "servo_url 0.0.1",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "tinyfiledialogs 2.5.9 (git+https://github.com/jdm/tinyfiledialogs)",
+ "tinyfiledialogs 2.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2303,7 +2303,7 @@ dependencies = [
  "style 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "tinyfiledialogs 2.5.9 (git+https://github.com/jdm/tinyfiledialogs)",
+ "tinyfiledialogs 2.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_traits 0.11.0 (git+https://github.com/servo/webrender)",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "tinyfiledialogs"
 version = "2.5.9"
-source = "git+https://github.com/jdm/tinyfiledialogs#4bf666ab49bf9aafcbbc34b6d4383db00d737654"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3545,7 +3545,7 @@ dependencies = [
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59f6d3eff89920113dac9db44dde461d71d01e88a5b57b258a0466c32b5d7fe1"
 "checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
-"checksum tinyfiledialogs 2.5.9 (git+https://github.com/jdm/tinyfiledialogs)" = "<none>"
+"checksum tinyfiledialogs 2.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d401358cd71aca93d5f4fccd3db5b87d970ae70fe457911929d99f4a87f7531"
 "checksum toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "0590d72182e50e879c4da3b11c6488dae18fccb1ae0c7a3eda18e16795844796"
 "checksum traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07eaeb7689bb7fca7ce15628319635758eda769fed481ecfe6686ddef2600616"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -18,4 +18,4 @@ servo_rand = {path = "../rand"}
 uuid = {version = "0.3.1", features = ["v4"]}
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tinyfiledialogs = {git = "https://github.com/jdm/tinyfiledialogs"}
+tinyfiledialogs = "2.5.9"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -49,4 +49,4 @@ default_features = false
 features = ["serde_derive", "ipc"]
 
 [target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))'.dependencies]
-tinyfiledialogs = {git = "https://github.com/jdm/tinyfiledialogs"}
+tinyfiledialogs = "2.5.9"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -18,7 +18,7 @@ debugmozjs = ['js/debugmozjs']
 cmake = "0.1"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))'.dependencies]
-tinyfiledialogs = {git = "https://github.com/jdm/tinyfiledialogs"}
+tinyfiledialogs = "2.5.9"
 
 [dependencies]
 angle = {git = "https://github.com/servo/angle", branch = "servo"}


### PR DESCRIPTION
Use the crates.io version of tinyfiledialogs instead of pulling directly from the git repository.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14862 (github issue number if applicable).

<!-- Either: -->
- [X] These changes do not require tests because no code was changed

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14871)
<!-- Reviewable:end -->
