### PR TITLE
stylo: Map more Gecko state bits to Servo state bits

### DIFF
--- a/components/style/element_state.rs
+++ b/components/style/element_state.rs
@@ -31,13 +31,13 @@ bitflags! {
         const IN_CHECKED_STATE = 0x20,
         #[doc = "https://html.spec.whatwg.org/multipage/#selector-indeterminate"]
         const IN_INDETERMINATE_STATE = 0x40,
-        #[doc = "https://html.spec.whatwg.org/multipage/#selector-read-write"]
-        const IN_READ_WRITE_STATE = 0x80,
         #[doc = "https://html.spec.whatwg.org/multipage/#selector-placeholder-shown"]
-        const IN_PLACEHOLDER_SHOWN_STATE = 0x0100,
+        const IN_PLACEHOLDER_SHOWN_STATE = 0x80,
         #[doc = "https://html.spec.whatwg.org/multipage/#selector-target"]
-        const IN_TARGET_STATE = 0x0200,
+        const IN_TARGET_STATE = 0x100,
         #[doc = "https://fullscreen.spec.whatwg.org/#%3Afullscreen-pseudo-class"]
-        const IN_FULLSCREEN_STATE = 0x0400,
+        const IN_FULLSCREEN_STATE = 0x200,
+        #[doc = "https://html.spec.whatwg.org/multipage/#selector-read-write"]
+        const IN_READ_WRITE_STATE = 0x400,
     }
 }

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -337,7 +337,7 @@ impl<'le> TElement for GeckoElement<'le> {
 
     fn get_state(&self) -> ElementState {
         unsafe {
-            ElementState::from_bits_truncate(Gecko_ElementState(self.0) as u16)
+            ElementState::from_bits_truncate(Gecko_ElementState(self.0))
         }
     }
 

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -349,7 +349,7 @@ extern "C" {
      -> RawGeckoNodeBorrowedOrNull;
 }
 extern "C" {
-    pub fn Gecko_ElementState(element: RawGeckoElementBorrowed) -> u8;
+    pub fn Gecko_ElementState(element: RawGeckoElementBorrowed) -> u16;
 }
 extern "C" {
     pub fn Gecko_IsHTMLElementInHTMLDocument(element: RawGeckoElementBorrowed)


### PR DESCRIPTION
This is the servo part of [bug 1328806](https://bugzilla.mozilla.org/show_bug.cgi?id=1328806) which has been reviewed by @bholley on Bugzilla.

r? @bholley

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14872)
<!-- Reviewable:end -->
