### PR TITLE
webgl: test expectation updates

### DIFF
--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-vertex-attrib-zero-issues.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/attribs/gl-vertex-attrib-zero-issues.html.ini
@@ -1,33 +1,3 @@
 [gl-vertex-attrib-zero-issues.html]
   type: testharness
   expected: TIMEOUT
-  [WebGL test #5: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #7: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #11: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #13: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #17: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #19: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #23: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #25: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #29: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #31: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/buffers/element-array-buffer-delete-recreate.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/buffers/element-array-buffer-delete-recreate.html.ini
@@ -3,9 +3,6 @@
   [WebGL test #0: getError expected: NO_ERROR. Was INVALID_ENUM : no errors from draw]
     expected: FAIL
 
-  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-
   [WebGL test #1: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/bad-arguments-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/bad-arguments-test.html.ini
@@ -1,45 +1,9 @@
 [bad-arguments-test.html]
   type: testharness
-  [WebGL test #59: context.detachShader(program, argument) should be undefined. Threw exception TypeError: context.detachShader is not a function]
-    expected: FAIL
-
-  [WebGL test #60: context.detachShader(argument, shader) should be undefined. Threw exception TypeError: context.detachShader is not a function]
-    expected: FAIL
-
-  [WebGL test #70: context.uniform2fv(argument, new Float32Array([0.0, 0.0\])) should be undefined. Threw exception TypeError: context.uniform2fv is not a function]
-    expected: FAIL
-
-  [WebGL test #71: context.uniform2iv(argument, new Int32Array([0, 0\])) should be undefined. Threw exception TypeError: context.uniform2iv is not a function]
-    expected: FAIL
-
-  [WebGL test #72: context.uniformMatrix2fv(argument, false, new Float32Array([0.0, 0.0, 0.0, 0.0\])) should be undefined. Threw exception TypeError: context.uniformMatrix2fv is not a function]
-    expected: FAIL
-
-  [WebGL test #73: context.getProgramInfoLog(argument) should be null. Threw exception TypeError: context.getProgramInfoLog is not a function]
-    expected: FAIL
-
   [WebGL test #78: context.getUniform(argument, loc) should be null. Threw exception TypeError: context.getUniform is not a function]
     expected: FAIL
 
   [WebGL test #79: context.getUniform(program, argument) should be null. Threw exception TypeError: context.getUniform is not a function]
-    expected: FAIL
-
-  [WebGL test #85: context.detachShader(program, argument) should be undefined. Threw exception TypeError: context.detachShader is not a function]
-    expected: FAIL
-
-  [WebGL test #86: context.detachShader(argument, shader) should be undefined. Threw exception TypeError: context.detachShader is not a function]
-    expected: FAIL
-
-  [WebGL test #96: context.uniform2fv(argument, new Float32Array([0.0, 0.0\])) should be undefined. Threw exception TypeError: context.uniform2fv is not a function]
-    expected: FAIL
-
-  [WebGL test #97: context.uniform2iv(argument, new Int32Array([0, 0\])) should be undefined. Threw exception TypeError: context.uniform2iv is not a function]
-    expected: FAIL
-
-  [WebGL test #98: context.uniformMatrix2fv(argument, false, new Float32Array([0.0, 0.0, 0.0, 0.0\])) should be undefined. Threw exception TypeError: context.uniformMatrix2fv is not a function]
-    expected: FAIL
-
-  [WebGL test #99: context.getProgramInfoLog(argument) should be null. Threw exception TypeError: context.getProgramInfoLog is not a function]
     expected: FAIL
 
   [WebGL test #104: context.getUniform(argument, loc) should be null. Threw exception TypeError: context.getUniform is not a function]

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/functions-returning-strings.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/functions-returning-strings.html.ini
@@ -12,9 +12,3 @@
   [WebGL test #5: gl.getShaderInfoLog(fs) should return a string.  Returns: "null"]
     expected: FAIL
 
-  [WebGL test #8: gl.getProgramInfoLog(prog) should return a string. Threw exception TypeError: gl.getProgramInfoLog is not a function]
-    expected: FAIL
-
-  [WebGL test #9: gl.getProgramInfoLog(prog) should return a string. Threw exception TypeError: gl.getProgramInfoLog is not a function]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/webgl-specific.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/misc/webgl-specific.html.ini
@@ -48,40 +48,13 @@
   [WebGL test #16: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: gl.blendFuncSeparate(gl.ONE_MINUS_CONSTANT_ALPHA, gl.ONE_MINUS_CONSTANT_COLOR, gl.ONE, gl.ZERO)]
     expected: FAIL
 
-  [WebGL test #17: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: gl.depthRange(20, 10)]
-    expected: FAIL
-
-  [WebGL test #18: gl.stencilMask(255) threw exception TypeError: gl.stencilMask is not a function]
-    expected: FAIL
-
-  [WebGL test #20: gl.stencilMaskSeparate(gl.FRONT, 1) threw exception TypeError: gl.stencilMaskSeparate is not a function]
-    expected: FAIL
-
   [WebGL test #21: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: gl.drawArrays(gl.TRIANGLES, 0, 0)]
-    expected: FAIL
-
-  [WebGL test #22: gl.stencilMaskSeparate(gl.BACK, 1) threw exception TypeError: gl.stencilMaskSeparate is not a function]
-    expected: FAIL
-
-  [WebGL test #24: gl.stencilFunc(gl.ALWAYS, 0, 255) threw exception TypeError: gl.stencilFunc is not a function]
-    expected: FAIL
-
-  [WebGL test #26: gl.stencilFuncSeparate(gl.BACK, gl.ALWAYS, 1, 255) threw exception TypeError: gl.stencilFuncSeparate is not a function]
     expected: FAIL
 
   [WebGL test #27: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: gl.drawArrays(gl.TRIANGLES, 0, 0)]
     expected: FAIL
 
-  [WebGL test #28: gl.stencilFuncSeparate(gl.FRONT, gl.ALWAYS, 1, 255) threw exception TypeError: gl.stencilFuncSeparate is not a function]
-    expected: FAIL
-
-  [WebGL test #30: gl.stencilFuncSeparate(gl.BACK, gl.ALWAYS, 1, 1) threw exception TypeError: gl.stencilFuncSeparate is not a function]
-    expected: FAIL
-
   [WebGL test #31: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: gl.drawArrays(gl.TRIANGLES, 0, 0)]
-    expected: FAIL
-
-  [WebGL test #32: gl.stencilFuncSeparate(gl.FRONT, gl.ALWAYS, 1, 1) threw exception TypeError: gl.stencilFuncSeparate is not a function]
     expected: FAIL
 
   [WebGL test #39: gl.getParameter(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL) should be 37444 (of type number). Was null (of type object).]

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-scissor-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-scissor-test.html.ini
@@ -1,8 +1,5 @@
 [gl-scissor-test.html]
   type: testharness
-  [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-
   [WebGL test #50: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-viewport-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/rendering/gl-viewport-test.html.ini
@@ -1,8 +1,5 @@
 [gl-viewport-test.html]
   type: testharness
-  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-
   [WebGL test #1: at (16, 32) expected: 0,0,255,255 was 0,0,0,0]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/copy-tex-image-2d-formats.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/copy-tex-image-2d-formats.html.ini
@@ -1,8 +1,5 @@
 [copy-tex-image-2d-formats.html]
   type: testharness
-  [WebGL test #16: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-
   [WebGL test #16: Creating framebuffer from ALPHA texture succeeded even though it is not a renderable format]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-copying-feedback-loops.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-copying-feedback-loops.html.ini
@@ -1,8 +1,5 @@
 [texture-copying-feedback-loops.html]
   type: testharness
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-
   [WebGL test #3: getError expected: INVALID_OPERATION. Was NO_ERROR : after copyTexImage2D to same texture same level, invalid feedback loop]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-fakeblack.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-fakeblack.html.ini
@@ -1,8 +1,5 @@
 [texture-fakeblack.html]
   type: testharness
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-
   [WebGL test #1: at (0, 0) expected: 0,0,0,255 was 255,0,0,255]
     expected: FAIL
 

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-sub-image-cube-maps.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-sub-image-cube-maps.html.ini
@@ -1,12 +1,6 @@
 [texture-sub-image-cube-maps.html]
   type: testharness
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-
   [WebGL test #0: unexpected gl error: INVALID_VALUE]
-    expected: FAIL
-
-  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
   [WebGL test #1: at (0, 0) expected: 255,0,0,255 was 0,0,0,0]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This series cherry-picks some diffs from a full 

    ./mach update-wpt --ignore-existing

on the webgl conformance tests, all of which I think are just leftovers from previous fixes.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14875)
<!-- Reviewable:end -->
