### PR TITLE
Support property aliases

### DIFF
--- a/components/style/properties/build.py
+++ b/components/style/properties/build.py
@@ -70,13 +70,17 @@ def write(directory, filename, content):
     open(os.path.join(directory, filename), "wb").write(content)
 
 
+def static_id_generator(properties):
+    for kind, props in [("Longhand", properties.longhands),
+                        ("Shorthand", properties.shorthands)]:
+        for p in props:
+            yield "%s\tStaticId::%s(%sId::%s)" % (p.name, kind, kind, p.camel_case)
+            for alias in p.alias:
+                yield "%s\tStaticId::%s(%sId::%s)" % (alias, kind, kind, p.camel_case)
+
+
 def static_ids(properties):
-    return '\n'.join(
-        "%s\tStaticId::%s(%sId::%s)" % (p.name, kind, kind, p.camel_case)
-        for kind, props in [("Longhand", properties.longhands),
-                            ("Shorthand", properties.shorthands)]
-        for p in props
-    )
+    return '\n'.join(static_id_generator(properties))
 
 
 def write_html(properties):

--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -88,7 +88,7 @@ class Longhand(object):
                  predefined_type=None, custom_cascade=False, experimental=False, internal=False,
                  need_clone=False, need_index=False, gecko_ffi_name=None, depend_on_viewport_size=False,
                  allowed_in_keyframe_block=True, complex_color=False, cast_type='u8',
-                 has_uncacheable_values=False, logical=False):
+                 has_uncacheable_values=False, logical=False, alias=None):
         self.name = name
         if not spec:
             raise TypeError("Spec should be specified for %s" % name)
@@ -109,6 +109,7 @@ class Longhand(object):
         self.complex_color = complex_color
         self.cast_type = cast_type
         self.logical = arg_to_bool(logical)
+        self.alias = alias.split() if alias else []
 
         # https://drafts.csswg.org/css-animations/#keyframes
         # > The <declaration-list> inside of <keyframe-block> accepts any CSS property
@@ -134,7 +135,7 @@ class Longhand(object):
 
 class Shorthand(object):
     def __init__(self, name, sub_properties, spec=None, experimental=False, internal=False,
-                 allowed_in_keyframe_block=True):
+                 allowed_in_keyframe_block=True, alias=None):
         self.name = name
         if not spec:
             raise TypeError("Spec should be specified for %s" % name)
@@ -145,6 +146,7 @@ class Shorthand(object):
         self.experimental = ("layout.%s.enabled" % name) if experimental else None
         self.sub_properties = sub_properties
         self.internal = internal
+        self.alias = alias.split() if alias else []
 
         # https://drafts.csswg.org/css-animations/#keyframes
         # > The <declaration-list> inside of <keyframe-block> accepts any CSS property

--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -170,7 +170,8 @@ ${helpers.single_keyword("overflow-wrap",
                          "normal break-word",
                          gecko_constant_prefix="NS_STYLE_OVERFLOWWRAP",
                          animatable=False,
-                         spec="https://drafts.csswg.org/css-text/#propdef-overflow-wrap")}
+                         spec="https://drafts.csswg.org/css-text/#propdef-overflow-wrap",
+                         alias="word-wrap")}
 
 // TODO(pcwalton): Support `word-break: keep-all` once we have better CJK support.
 ${helpers.single_keyword("word-break",

--- a/components/style/properties/shorthand/inherited_text.mako.rs
+++ b/components/style/properties/shorthand/inherited_text.mako.rs
@@ -4,25 +4,6 @@
 
 <%namespace name="helpers" file="/helpers.mako.rs" />
 
-// Per CSS-TEXT 6.2, "for legacy reasons, UAs must treat `word-wrap` as an alternate name for
-// the `overflow-wrap` property, as if it were a shorthand of `overflow-wrap`."
-<%helpers:shorthand name="word-wrap" sub_properties="overflow-wrap"
-                    spec="https://drafts.csswg.org/css-text/#propdef-word-wrap">
-    use properties::longhands::overflow_wrap;
-
-    pub fn parse_value(context: &ParserContext, input: &mut Parser) -> Result<Longhands, ()> {
-        Ok(Longhands {
-            overflow_wrap: Some(try!(overflow_wrap::parse(context, input))),
-        })
-    }
-
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            self.overflow_wrap.to_css(dest)
-        }
-    }
-</%helpers:shorthand>
-
 <%helpers:shorthand name="text-emphasis" products="gecko" sub_properties="text-emphasis-color
     text-emphasis-style"
     spec="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -457,24 +457,6 @@ mod shorthand_serialization {
         }
     }
 
-    #[test]
-    fn overflow_wrap_should_only_serialize_with_a_single_property() {
-        use style::properties::longhands::overflow_wrap::computed_value::T as OverflowWrap;
-
-        let value = DeclaredValue::Value(OverflowWrap::break_word);
-
-        let properties = vec![
-            PropertyDeclaration::OverflowWrap(value)
-        ];
-
-        let serialization = shorthand_properties_to_string(properties);
-
-        // word-wrap is considered an outdated alternative to overflow-wrap, but it is currently
-        // what servo is using in its naming conventions:
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap
-        assert_eq!(serialization, "word-wrap: break-word;");
-    }
-
     mod outline {
         use style::properties::longhands::outline_width::SpecifiedValue as WidthContainer;
         use super::*;


### PR DESCRIPTION
Aliases now get forwarded to their "original" property name at parse time. CSSOM continues to provide access through alias getters.

We'll need to probably add `${"-webkit-foo -moz-foo" if gecko else ""}` all over the place. Might want to come up with a convenient attibute name for that (`gecko_prefix="mw"`) or something.


r? @heycam or @bholley 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14893)
<!-- Reviewable:end -->
