### PR TITLE
Added Websocket to RequestMode enum

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -330,6 +330,7 @@ impl CoreResourceManager {
         let ua = self.user_agent.clone();
         let dc = self.devtools_chan.clone();
         let filemanager = self.filemanager.clone();
+
         thread::Builder::new().name(format!("fetch thread for {}", init.url)).spawn(move || {
             let request = Request::from_init(init);
             // XXXManishearth: Check origin against pipeline id (also ensure that the mode is allowed)

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -77,6 +77,7 @@ pub enum RequestMode {
     SameOrigin,
     NoCors,
     CorsMode,
+    WebSocket
 }
 
 /// Request [credentials mode](https://fetch.spec.whatwg.org/#concept-request-credentials-mode)

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -826,6 +826,7 @@ impl Into<RequestMode> for NetTraitsRequestMode {
             NetTraitsRequestMode::SameOrigin => RequestMode::Same_origin,
             NetTraitsRequestMode::NoCors => RequestMode::No_cors,
             NetTraitsRequestMode::CorsMode => RequestMode::Cors,
+            NetTraitsRequestMode::WebSocket => unreachable!("Websocket request mode should never be exposed to JS"),
         }
     }
 }


### PR DESCRIPTION
Added Websocket to RequestMode enum
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14785  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because matching the enum should have default control flow.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14895)
<!-- Reviewable:end -->
