### PR TITLE
Allow sharing non-common style affecting attribute selectors.

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -30,6 +30,17 @@ use std::slice::IterMut;
 use std::sync::Arc;
 use stylist::ApplicableDeclarationBlock;
 
+/// Determines the amount of relations where we're going to share style.
+#[inline]
+fn relations_are_shareable(relations: &StyleRelations) -> bool {
+    use selectors::matching::*;
+    !relations.intersects(AFFECTED_BY_ID_SELECTOR |
+                          AFFECTED_BY_PSEUDO_ELEMENTS | AFFECTED_BY_STATE |
+                          AFFECTED_BY_NON_COMMON_STYLE_AFFECTING_ATTRIBUTE_SELECTOR |
+                          AFFECTED_BY_STYLE_ATTRIBUTE |
+                          AFFECTED_BY_PRESENTATIONAL_HINTS)
+}
+
 fn create_common_style_affecting_attributes_from_element<E: TElement>(element: &E)
                                                          -> CommonStyleAffectingAttributes {
     let mut flags = CommonStyleAffectingAttributes::empty();
@@ -72,7 +83,6 @@ pub struct MatchResults {
 impl MatchResults {
     /// Returns true if the primary rule node is shareable with other nodes.
     pub fn primary_is_shareable(&self) -> bool {
-        use traversal::relations_are_shareable;
         relations_are_shareable(&self.relations)
     }
 }
@@ -375,8 +385,6 @@ impl<E: TElement> StyleSharingCandidateCache<E> {
                               element: &E,
                               style: &Arc<ComputedValues>,
                               relations: StyleRelations) {
-        use traversal::relations_are_shareable;
-
         let parent = match element.parent_element() {
             Some(element) => element,
             None => {

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -36,7 +36,6 @@ fn relations_are_shareable(relations: &StyleRelations) -> bool {
     use selectors::matching::*;
     !relations.intersects(AFFECTED_BY_ID_SELECTOR |
                           AFFECTED_BY_PSEUDO_ELEMENTS | AFFECTED_BY_STATE |
-                          AFFECTED_BY_NON_COMMON_STYLE_AFFECTING_ATTRIBUTE_SELECTOR |
                           AFFECTED_BY_STYLE_ATTRIBUTE |
                           AFFECTED_BY_PRESENTATIONAL_HINTS)
 }

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -14,7 +14,6 @@ use matching::{MatchMethods, StyleSharingResult};
 use restyle_hints::{RESTYLE_DESCENDANTS, RESTYLE_SELF};
 use selector_parser::RestyleDamage;
 use selectors::Element;
-use selectors::matching::StyleRelations;
 use servo_config::opts;
 use std::mem;
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
@@ -274,17 +273,6 @@ pub trait DomTraversal<N: TNode> : Sync {
 
     /// Create a thread-local context.
     fn create_thread_local_context(&self) -> Self::ThreadLocalContext;
-}
-
-/// Determines the amount of relations where we're going to share style.
-#[inline]
-pub fn relations_are_shareable(relations: &StyleRelations) -> bool {
-    use selectors::matching::*;
-    !relations.intersects(AFFECTED_BY_ID_SELECTOR |
-                          AFFECTED_BY_PSEUDO_ELEMENTS | AFFECTED_BY_STATE |
-                          AFFECTED_BY_NON_COMMON_STYLE_AFFECTING_ATTRIBUTE_SELECTOR |
-                          AFFECTED_BY_STYLE_ATTRIBUTE |
-                          AFFECTED_BY_PRESENTATIONAL_HINTS)
 }
 
 /// Helper for the function below.


### PR DESCRIPTION
Something I just noticed while re-reading that code is that we prevent sharing among siblings with different non-common attributes, even though we already have the infra to match those selectors:

```rust
    if !match_same_not_common_style_affecting_attributes_rules(element,
                                                               candidate_element,
                                                               shared_context) {
        miss!(NonCommonAttrRules)
    }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14904)
<!-- Reviewable:end -->
