### PR TITLE
Handle properly alternate stylesheet

### DIFF
--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -99,6 +99,17 @@ impl HTMLLinkElement {
             })
         })
     }
+
+    pub fn is_alternate(&self) -> bool {
+        let rel = get_attr(self.upcast(), &local_name!("rel"));
+        match rel {
+            Some(ref value) => {
+                value.split(HTML_SPACE_CHARACTERS)
+                    .any(|s| s.eq_ignore_ascii_case("alternate"))
+            },
+            None => false,
+        }
+    }
 }
 
 fn get_attr(element: &Element, local_name: &LocalName) -> Option<String> {
@@ -112,17 +123,8 @@ fn get_attr(element: &Element, local_name: &LocalName) -> Option<String> {
 fn string_is_stylesheet(value: &Option<String>) -> bool {
     match *value {
         Some(ref value) => {
-            let mut found_stylesheet = false;
-            for s in value.split(HTML_SPACE_CHARACTERS).into_iter() {
-                if s.eq_ignore_ascii_case("alternate") {
-                    return false;
-                }
-
-                if s.eq_ignore_ascii_case("stylesheet") {
-                    found_stylesheet = true;
-                }
-            }
-            found_stylesheet
+            value.split(HTML_SPACE_CHARACTERS)
+                .any(|s| s.eq_ignore_ascii_case("stylesheet"))
         },
         None => false,
     }

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -138,6 +138,9 @@ impl FetchResponseListener for StylesheetContext {
                                                         Some(&loader),
                                                         win.css_error_reporter(),
                                                         ParserContextExtraData::default()));
+                    if elem.downcast::<HTMLLinkElement>().unwrap().is_alternate() {
+                        sheet.set_disabled(true);
+                    }
                     elem.downcast::<HTMLLinkElement>()
                         .unwrap()
                         .set_stylesheet(sheet.clone());

--- a/tests/wpt/metadata/subresource-integrity/subresource-integrity.sub.html.ini
+++ b/tests/wpt/metadata/subresource-integrity/subresource-integrity.sub.html.ini
@@ -1,14 +1,11 @@
 [subresource-integrity.sub.html]
   type: testharness
-  expected: TIMEOUT
+  expected: OK
   [Style: <crossorigin='anonymous'> with correct hash, ACAO: *]
     expected: FAIL
 
   [Style: Same-origin with correct sha256 and sha512 hash, rel='alternate stylesheet' enabled]
-    expected: NOTRUN
-
-  [Style: Same-origin with incorrect sha256 and sha512 hash, rel='alternate stylesheet' enabled]
-    expected: NOTRUN
+    expected: FAIL
 
   [Style: Same-origin with incorrect hash.]
     expected: FAIL

--- a/tests/wpt/web-platform-tests/html/semantics/links/linktypes/alternate-import.css
+++ b/tests/wpt/web-platform-tests/html/semantics/links/linktypes/alternate-import.css
@@ -1,0 +1,3 @@
+body {
+    background-color: black;
+}

--- a/tests/wpt/web-platform-tests/html/semantics/links/linktypes/alternate.css
+++ b/tests/wpt/web-platform-tests/html/semantics/links/linktypes/alternate.css
@@ -1,3 +1,5 @@
+@import url("alternate-import.css");
+
 div {
     background-color: red;
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Alternate stylesheet are now fetched and then desactivated instead of ignoring them.

I don't know if tests are required to check if the stylesheet is correctly loaded and disabled ?
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14881 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14911)
<!-- Reviewable:end -->
