### PR TITLE
Ensure env vars for subprocess are str

### DIFF
--- a/tests/wpt/web-platform-tests/tools/sslutils/openssl.py
+++ b/tests/wpt/web-platform-tests/tools/sslutils/openssl.py
@@ -57,7 +57,7 @@ class OpenSSL(object):
             self.cmd += ["-config", self.conf_path]
         self.cmd += list(args)
 
-        env = os.environ.copy()
+        env = {k.encode('utf8'): v.encode('utf8') for k, v in os.environ.iteritems()}
         if self.base_conf_path is not None:
             env["OPENSSL_CONF"] = self.base_conf_path.encode("utf8")
 


### PR DESCRIPTION
There are several places in Servo's Python code to inject environment variables into os.environ. Those places usually have unicode_literals feature enabled, which makes the added environment variables unicodes rather than str, which leads to "TypeError: environment can only contain strings" error when running "mach test-wpt" at least on Windows.

The error I get without this commit is:
```text
Error running mach:

    ['test-wpt', 'tests/wpt/web-platform-tests/cssom/shorthand-serialization.html']

The error occurred in code that was called by the mach command. This is either
a bug in the called code itself or in the way that mach is calling it.

You should consider filing a bug for this issue.

If filing a bug, please include the full output of mach, including this error
message.

The details of the failure are as follows:

TypeError: environment can only contain strings

  File "C:\mozilla-source\servo\python\servo\testing_commands.py", line 425, in test_wpt
    ret = self.run_test_list_or_dispatch(kwargs["test_list"], "wpt", self._test_wpt, **kwargs)
  File "C:\mozilla-source\servo\python\servo\testing_commands.py", line 449, in run_test_list_or_dispatch
    return correct_function(**kwargs)
  File "C:\mozilla-source\servo\python\servo\testing_commands.py", line 435, in _test_wpt
    return self.wptrunner(run_file, **kwargs)
  File "C:\mozilla-source\servo\python\servo\testing_commands.py", line 473, in wptrunner
    return run_globals["run_tests"](**kwargs)
  File "C:\mozilla-source\servo\tests\wpt\run_wpt.py", line 13, in run_tests
    return run.run_tests(paths=paths, **kwargs)
  File "C:\mozilla-source\servo\tests\wpt\run.py", line 36, in run_tests
    success = wptrunner.run_tests(**kwargs)
  File "C:\mozilla-source\servo\tests\wpt\harness\wptrunner\wptrunner.py", line 155, in run_tests
    env_options) as test_environment:
  File "C:\mozilla-source\servo\tests\wpt\harness\wptrunner\environment.py", line 104, in __enter__
    self.config = self.load_config()
  File "C:\mozilla-source\servo\tests\wpt\harness\wptrunner\environment.py", line 152, in load_config
    key_file, certificate = self.ssl_env.host_cert_path(hosts)
  File "C:\mozilla-source\servo\tests\wpt\web-platform-tests\tools\sslutils\openssl.py", line 356, in host_cert_path
    key, cert = self._generate_host_cert(hosts)
  File "C:\mozilla-source\servo\tests\wpt\web-platform-tests\tools\sslutils\openssl.py", line 376, in _generate_host_cert
    self._generate_ca()
  File "C:\mozilla-source\servo\tests\wpt\web-platform-tests\tools\sslutils\openssl.py", line 327, in _generate_ca
    "-passout", "pass:%s" % self.password)
  File "C:\mozilla-source\servo\tests\wpt\web-platform-tests\tools\sslutils\openssl.py", line 67, in __call__
    env=env)
  File "C:\Python27\lib\subprocess.py", line 710, in __init__
    errread, errwrite)
  File "C:\Python27\lib\subprocess.py", line 958, in _execute_child
    startupinfo)
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14921)
<!-- Reviewable:end -->
