### PR TITLE
Don't inherit all properties for eagerly computed pseudos if there are no matching rules.

### DIFF
--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -394,7 +394,7 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
                                     &context.default_computed_values,
                                     false);
                             data.styles_mut().pseudos
-                                .insert(style_pseudo.clone(), new_style.unwrap());
+                                .insert(style_pseudo.clone(), new_style);
                         }
                     }
                     PseudoElementCascadeType::Lazy => {

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -521,10 +521,10 @@ pub extern "C" fn Servo_ComputedValues_GetForAnonymousBox(parent_style_or_null: 
 
 
     let maybe_parent = ComputedValues::arc_from_borrowed(&parent_style_or_null);
-    let new_computed = data.stylist.precomputed_values_for_pseudo(&pseudo, maybe_parent,
-                                                                  &data.default_computed_values, false)
-                           .map(|styles| styles.values);
-    new_computed.map_or(Strong::null(), |c| c.into_strong())
+    data.stylist.precomputed_values_for_pseudo(&pseudo, maybe_parent,
+                                               &data.default_computed_values, false)
+        .values
+        .into_strong()
 }
 
 #[no_mangle]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

When we resolve style for an eagerly computed pseudo-element, such as an anonymous box, if there are no matching rules we currently just clone the parent's style.  We should only do that if `inherit_all` is true, otherwise we should inherit only the inherited properties from the parent.

I was going to use `.unwrap_or_default()` on the result of looking up `precomputed_pseudo_element_decls`, but that didn't seem to work since that map lookup returns a reference and not a `Vec` itself.

r? @emilio 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://bugzilla.mozilla.org/show_bug.cgi?id=1329121

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14922)
<!-- Reviewable:end -->
