### PR TITLE
Expand ~ in --with-gecko for ./mach build-geckolib

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -408,7 +408,7 @@ class MachCommands(CommandBase):
         opts = []
         if with_gecko is not None:
             opts += ["--features", "bindgen"]
-            env["MOZ_DIST"] = path.abspath(with_gecko)
+            env["MOZ_DIST"] = path.abspath(path.expanduser(with_gecko))
         if jobs is not None:
             opts += ["-j", jobs]
         if verbose:


### PR DESCRIPTION
Otherwise `~/foo` expands to `/local/folder/~/foo`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14932)
<!-- Reviewable:end -->
