### PR TITLE
Avoid codesize impact of the pushing in PropertyDeclaration::parse

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1022,29 +1022,34 @@ impl PropertyDeclaration {
                         }
                     % endif
                     match input.try(|i| CSSWideKeyword::parse(context, i)) {
-                        Ok(CSSWideKeyword::InheritKeyword) => {
-                            % for sub_property in shorthand.sub_properties:
-                                result_list.push(
-                                    PropertyDeclaration::${sub_property.camel_case}(
-                                        DeclaredValue::Inherit));
-                            % endfor
-                            PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
-                        },
-                        Ok(CSSWideKeyword::InitialKeyword) => {
-                            % for sub_property in shorthand.sub_properties:
-                                result_list.push(
-                                    PropertyDeclaration::${sub_property.camel_case}(
-                                        DeclaredValue::Initial));
-                            % endfor
-                            PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
-                        },
-                        Ok(CSSWideKeyword::UnsetKeyword) => {
-                            % for sub_property in shorthand.sub_properties:
-                                result_list.push(PropertyDeclaration::${sub_property.camel_case}(
-                                        DeclaredValue::Unset));
-                            % endfor
-                            PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
-                        },
+                        Ok(keyword) => {
+                            result_list.reserve(${len(shorthand.sub_properties)});
+                            match keyword {
+                                CSSWideKeyword::InheritKeyword => {
+                                    % for sub_property in shorthand.sub_properties:
+                                        result_list.push(
+                                            PropertyDeclaration::${sub_property.camel_case}(
+                                                DeclaredValue::Inherit));
+                                    % endfor
+                                    PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
+                                },
+                                CSSWideKeyword::InitialKeyword => {
+                                    % for sub_property in shorthand.sub_properties:
+                                        result_list.push(
+                                            PropertyDeclaration::${sub_property.camel_case}(
+                                                DeclaredValue::Initial));
+                                    % endfor
+                                    PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
+                                },
+                                CSSWideKeyword::UnsetKeyword => {
+                                    % for sub_property in shorthand.sub_properties:
+                                        result_list.push(PropertyDeclaration::${sub_property.camel_case}(
+                                                DeclaredValue::Unset));
+                                    % endfor
+                                    PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
+                                },
+                            }
+                        }
                         Err(()) => match shorthands::${shorthand.ident}::parse(context, input, result_list) {
                             Ok(()) => PropertyDeclarationParseResult::ValidOrIgnoredDeclaration,
                             Err(()) => PropertyDeclarationParseResult::InvalidValue,

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -962,38 +962,45 @@ impl PropertyDeclaration {
                 result_list.push(PropertyDeclaration::Custom(name, value));
                 return PropertyDeclarationParseResult::ValidOrIgnoredDeclaration;
             }
-            PropertyId::Longhand(id) => match id {
-            % for property in data.longhands:
-                LonghandId::${property.camel_case} => {
-                    % if not property.derived_from:
-                        % if not property.allowed_in_keyframe_block:
-                            if in_keyframe_block {
-                                return PropertyDeclarationParseResult::AnimationPropertyInKeyframeBlock
+            PropertyId::Longhand(id) => {
+                let mut maybe_push = None;
+                let ret = match id {
+                % for property in data.longhands:
+                    LonghandId::${property.camel_case} => {
+                        % if not property.derived_from:
+                            % if not property.allowed_in_keyframe_block:
+                                if in_keyframe_block {
+                                    return PropertyDeclarationParseResult::AnimationPropertyInKeyframeBlock
+                                }
+                            % endif
+                            % if property.internal:
+                                if context.stylesheet_origin != Origin::UserAgent {
+                                    return PropertyDeclarationParseResult::UnknownProperty
+                                }
+                            % endif
+                            % if property.experimental and product == "servo":
+                                if !PREFS.get("${property.experimental}")
+                                    .as_boolean().unwrap_or(false) {
+                                    return PropertyDeclarationParseResult::ExperimentalProperty
+                                }
+                            % endif
+                            match longhands::${property.ident}::parse_declared(context, input) {
+                                Ok(value) => {
+                                    maybe_push = Some(PropertyDeclaration::${property.camel_case}(value));
+                                    PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
+                                },
+                                Err(()) => PropertyDeclarationParseResult::InvalidValue,
                             }
+                        % else:
+                            PropertyDeclarationParseResult::UnknownProperty
                         % endif
-                        % if property.internal:
-                            if context.stylesheet_origin != Origin::UserAgent {
-                                return PropertyDeclarationParseResult::UnknownProperty
-                            }
-                        % endif
-                        % if property.experimental and product == "servo":
-                            if !PREFS.get("${property.experimental}")
-                                .as_boolean().unwrap_or(false) {
-                                return PropertyDeclarationParseResult::ExperimentalProperty
-                            }
-                        % endif
-                        match longhands::${property.ident}::parse_declared(context, input) {
-                            Ok(value) => {
-                                result_list.push(PropertyDeclaration::${property.camel_case}(value));
-                                PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
-                            },
-                            Err(()) => PropertyDeclarationParseResult::InvalidValue,
-                        }
-                    % else:
-                        PropertyDeclarationParseResult::UnknownProperty
-                    % endif
+                    }
+                % endfor
+                };
+                if let Some(push) = maybe_push {
+                    result_list.push(push);
                 }
-            % endfor
+                ret
             },
             PropertyId::Shorthand(id) => match id {
             % for shorthand in data.shorthands:


### PR DESCRIPTION
While investigating https://bugzilla.mozilla.org/show_bug.cgi?id=1297322#c19, I realized that the asm generated for this function in release mode is abominable. LLVM, always wanting to please, inlines a bajillion things resulting in 100k lines of ASM with a lot of redundant bits. We have a thousand calls to `alloc::oom` at the end of the function alone. I'm told that LLVM doesn't hoist things out of switches that well, which might be the case here. The only common allocation here is the pushing (parsing may allocate but that's not common).

I thought I'd hoist the allocation calls out. All the longhands can share a single `push()` call.

Furthermore, the shorthands have a bunch of sequential push calls for CSS-wide keywords. I'm not sure how well LLVM optimizes those, but we should be `reserve()`ing early anyway; pretty sure `reserve(n)` followed by n `push()`es when inlined will make the push a trivial pointer-bump.

There's a further optimization which I have yet to implement that @dotdash pointed out that will let me hoist the push calls for all shorthands into one (not counting any pushes done by shorthand parsing). This should have no perf impact but reduce code size further.


I haven't yet measured the impact here (@mbrubeck if you have time would you be able to check how this impacts XUL?), but will do so later today.


r? @mbrubeck

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14950)
<!-- Reviewable:end -->
