### PR TITLE
Report meaningful line numbers for inline script errors

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -145,8 +145,23 @@ impl fmt::Debug for Element {
 
 #[derive(PartialEq, HeapSizeOf)]
 pub enum ElementCreator {
-    ParserCreated,
+    ParserCreated(u64),
     ScriptCreated,
+}
+
+impl ElementCreator {
+    pub fn is_parser_created(&self) -> bool {
+        match *self {
+            ElementCreator::ParserCreated(_) => true,
+            ElementCreator::ScriptCreated => false,
+        }
+    }
+    pub fn return_line_number(&self) -> u64 {
+        match *self {
+            ElementCreator::ParserCreated(l) => l,
+            ElementCreator::ScriptCreated => 1,
+        }
+    }
 }
 
 pub enum AdjacentPosition {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -339,13 +339,13 @@ impl GlobalScope {
     /// Evaluate JS code on this global scope.
     pub fn evaluate_js_on_global_with_result(
             &self, code: &str, rval: MutableHandleValue) {
-        self.evaluate_script_on_global_with_result(code, "", rval)
+        self.evaluate_script_on_global_with_result(code, "", rval, 1)
     }
 
     /// Evaluate a JS script on this global scope.
     #[allow(unsafe_code)]
     pub fn evaluate_script_on_global_with_result(
-            &self, code: &str, filename: &str, rval: MutableHandleValue) {
+            &self, code: &str, filename: &str, rval: MutableHandleValue, line_number: u32) {
         let metadata = time::TimerMetadata {
             url: if filename.is_empty() {
                 self.get_url().as_str().into()
@@ -367,7 +367,7 @@ impl GlobalScope {
 
                 let _ac = JSAutoCompartment::new(cx, globalhandle.get());
                 let _aes = AutoEntryScript::new(self);
-                let options = CompileOptionsWrapper::new(cx, filename.as_ptr(), 1);
+                let options = CompileOptionsWrapper::new(cx, filename.as_ptr(), line_number);
                 unsafe {
                     if !Evaluate2(cx, options.ptr, code.as_ptr(),
                                   code.len() as libc::size_t,

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -59,7 +59,7 @@ impl HTMLLinkElement {
         HTMLLinkElement {
             htmlelement: HTMLElement::new_inherited(local_name, prefix, document),
             rel_list: Default::default(),
-            parser_inserted: Cell::new(creator == ElementCreator::ParserCreated),
+            parser_inserted: Cell::new(creator.is_parser_created()),
             stylesheet: DOMRefCell::new(None),
             cssom_stylesheet: MutNullableJS::new(None),
             pending_loads: Cell::new(0),

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -50,8 +50,8 @@ impl HTMLStyleElement {
             htmlelement: HTMLElement::new_inherited(local_name, prefix, document),
             stylesheet: DOMRefCell::new(None),
             cssom_stylesheet: MutNullableJS::new(None),
-            parser_inserted: Cell::new(creator == ElementCreator::ParserCreated),
-            in_stack_of_open_elements: Cell::new(creator == ElementCreator::ParserCreated),
+            parser_inserted: Cell::new(creator.is_parser_created()),
+            in_stack_of_open_elements: Cell::new(creator.is_parser_created()),
             pending_loads: Cell::new(0),
             any_failed_load: Cell::new(false),
         }

--- a/components/script/dom/servoparser/xml.rs
+++ b/components/script/dom/servoparser/xml.rs
@@ -134,8 +134,9 @@ impl TreeSink for Sink {
             ns: name.namespace_url,
             local: name.local,
         };
+        //TODO: Add ability to track lines to API of xml5ever
         let elem = Element::create(name, prefix, &*self.document,
-                                   ElementCreator::ParserCreated);
+                                   ElementCreator::ParserCreated(1));
 
         for attr in attrs {
             let name = QualName {

--- a/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/window-onerror-parse-error.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/window-onerror-parse-error.html.ini
@@ -1,5 +1,0 @@
-[window-onerror-parse-error.html]
-  type: testharness
-  [correct line number passed to window.onerror]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/window-onerror-runtime-error.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/window-onerror-runtime-error.html.ini
@@ -1,5 +1,0 @@
-[window-onerror-runtime-error.html]
-  type: testharness
-  [correct line number passed to window.onerror]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -15200,6 +15200,12 @@
             "url": "/_mozilla/mozilla/trace_null.html"
           }
         ],
+        "mozilla/track_line.html": [
+          {
+            "path": "mozilla/track_line.html",
+            "url": "/_mozilla/mozilla/track_line.html"
+          }
+        ],
         "mozilla/union.html": [
           {
             "path": "mozilla/union.html",

--- a/tests/wpt/mozilla/tests/mozilla/track_line.html
+++ b/tests/wpt/mozilla/tests/mozilla/track_line.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test that errors from inline scripts report meaningful line numbers</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({allow_uncaught_exception:true});
+var t = async_test("error event has proper line number");
+window.addEventListener('error', t.step_func(function(e) {
+    assert_true(e instanceof ErrorEvent);
+    assert_equals(e.lineno, 16);
+    t.done();
+}), true);
+</script>
+<script>
+this_is_a_js_error
+</script>


### PR DESCRIPTION
Rebased from #14661.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12744 and partially #9604
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14963)
<!-- Reviewable:end -->
