### PR TITLE
Disable test-stylo on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ matrix:
          - ./mach test-compiletest
          - ./mach test-unit
          - ./mach build-geckolib
-         - ./mach test-stylo
+         # disabled due to #14723
+         #- ./mach test-stylo
          - bash etc/ci/check_no_panic.sh
          - bash etc/ci/lockfile_changed.sh
          - bash etc/ci/manifest_changed.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ matrix:
          - ./mach build -d --verbose
          - ./mach test-compiletest
          - ./mach test-unit
-         - ./mach build-geckolib
          # disabled due to #14723
+         #- ./mach build-geckolib
          #- ./mach test-stylo
          - bash etc/ci/check_no_panic.sh
          - bash etc/ci/lockfile_changed.sh


### PR DESCRIPTION
Nobody knows what to do about #14723 and Travis always showing failed builds isn't useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14973)
<!-- Reviewable:end -->
