### PR TITLE
Only create scrolling overflow regions when necessary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,6 +1330,7 @@ dependencies = [
  "serde_json 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_atoms 0.0.1",
  "servo_config 0.0.1",
+ "servo_geometry 0.0.1",
  "servo_url 0.0.1",
  "smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -25,7 +25,7 @@ use ipc_channel::ipc::IpcSharedMemory;
 use msg::constellation_msg::PipelineId;
 use net_traits::image::base::{Image, PixelFormat};
 use range::Range;
-use servo_geometry::{au_rect_to_f32_rect, f32_rect_to_au_rect, max_rect};
+use servo_geometry::max_rect;
 use std::cmp::{self, Ordering};
 use std::collections::HashMap;
 use std::fmt;
@@ -411,24 +411,6 @@ impl StackingContext {
                              true,
                              ScrollPolicy::Scrollable,
                              ScrollRootId::root())
-    }
-
-    pub fn overflow_rect_in_parent_space(&self) -> Rect<Au> {
-        // Transform this stacking context to get it into the same space as
-        // the parent stacking context.
-        //
-        // TODO: Take into account 3d transforms, even though it's a fairly
-        // uncommon case.
-        let origin_x = self.bounds.origin.x.to_f32_px();
-        let origin_y = self.bounds.origin.y.to_f32_px();
-
-        let transform = Matrix4D::identity().pre_translated(origin_x, origin_y, 0.0)
-                                            .pre_mul(&self.transform);
-        let transform_2d = transform.to_2d();
-
-        let overflow = au_rect_to_f32_rect(self.overflow);
-        let overflow = transform_2d.transform_rect(&overflow);
-        f32_rect_to_au_rect(overflow)
     }
 
     pub fn to_display_list_items(self) -> (DisplayItem, DisplayItem) {

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -38,6 +38,7 @@ script_traits = {path = "../script_traits"}
 selectors = "0.15"
 serde = "0.8"
 serde_derive = "0.8"
+servo_geometry = {path = "../geometry"}
 serde_json = "0.8"
 servo_atoms = {path = "../atoms"}
 servo_config = {path = "../config"}

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -518,6 +518,8 @@ bitflags! {
     flags BlockFlowFlags: u8 {
         #[doc = "If this is set, then this block flow is the root flow."]
         const IS_ROOT = 0b0000_0001,
+        #[doc = "If this is set, then this block flow has overflow and it will scroll."]
+        const HAS_SCROLLING_OVERFLOW = 0b0000_0010,
     }
 }
 
@@ -1675,7 +1677,7 @@ impl BlockFlow {
         }
     }
 
-    pub fn has_scrolling_overflow(&self) -> bool {
+    pub fn style_permits_scrolling_overflow(&self) -> bool {
         match (self.fragment.style().get_box().overflow_x,
                self.fragment.style().get_box().overflow_y.0) {
             (overflow_x::T::auto, _) | (overflow_x::T::scroll, _) |
@@ -1823,6 +1825,19 @@ impl BlockFlow {
                                               Au::from_f32_px(clip_rect.size.height)));
         self.base.clip = ClippingRegion::from_rect(&clip_rect)
     }
+
+    pub fn mark_scrolling_overflow(&mut self, has_scrolling_overflow: bool) {
+        if has_scrolling_overflow {
+            self.flags.insert(HAS_SCROLLING_OVERFLOW);
+        } else {
+            self.flags.remove(HAS_SCROLLING_OVERFLOW);
+        }
+    }
+
+    pub fn has_scrolling_overflow(&mut self) -> bool {
+        self.flags.contains(HAS_SCROLLING_OVERFLOW)
+    }
+
 }
 
 impl Flow for BlockFlow {

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -128,14 +128,7 @@ impl<'a> DisplayListBuildState<'a> {
 
     fn add_stacking_context(&mut self,
                             parent_id: StackingContextId,
-                            mut stacking_context: StackingContext) {
-        self.update_overflow_for_stacking_context(&mut stacking_context);
-        self.add_stacking_context_without_calcuating_overflow(parent_id, stacking_context);
-    }
-
-    fn add_stacking_context_without_calcuating_overflow(&mut self,
-                                                        parent_id: StackingContextId,
-                                                        stacking_context: StackingContext) {
+                            stacking_context: StackingContext) {
         let contexts = self.stacking_context_children.entry(parent_id).or_insert(Vec::new());
         contexts.push(stacking_context);
     }
@@ -191,24 +184,6 @@ impl<'a> DisplayListBuildState<'a> {
 
         DisplayList {
             list: list,
-        }
-    }
-
-    fn update_overflow_for_stacking_context(&mut self, stacking_context: &mut StackingContext) {
-        if stacking_context.context_type != StackingContextType::Real {
-            return;
-        }
-
-        let children = self.stacking_context_children.get_mut(&stacking_context.id);
-        if let Some(children) = children {
-            for child in children {
-                if child.context_type == StackingContextType::Real {
-                    // This child might be transformed, so we need to take into account
-                    // its transformed overflow rect too, but at the correct position.
-                    let overflow = child.overflow_rect_in_parent_space();
-                    stacking_context.overflow = stacking_context.overflow.union(&overflow);
-                }
-            }
         }
     }
 
@@ -1842,12 +1817,10 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
     }
 
     fn collect_scroll_root_for_block(&mut self, state: &mut DisplayListBuildState) -> ScrollRootId {
-        if !self.has_scrolling_overflow() {
+        if !self.style_permits_scrolling_overflow() {
             return state.current_scroll_root_id;
         }
 
-        let scroll_root_id = ScrollRootId::new_of_type(self.fragment.node.id() as usize,
-                                                       self.fragment.fragment_type());
         let coordinate_system = if self.fragment.establishes_stacking_context() {
             CoordinateSystem::Own
         } else {
@@ -1859,13 +1832,24 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
             &self.base.early_absolute_position_info.relative_containing_block_size,
             self.base.early_absolute_position_info.relative_containing_block_mode,
             coordinate_system);
+        let clip = self.fragment.stacking_relative_content_box(&border_box);
 
+        let has_scrolling_overflow = self.base.overflow.scroll.origin != Point2D::zero() ||
+                                     self.base.overflow.scroll.size.width > clip.size.width ||
+                                     self.base.overflow.scroll.size.height > clip.size.height;
+        self.mark_scrolling_overflow(has_scrolling_overflow);
+        if !has_scrolling_overflow {
+            return state.current_scroll_root_id;
+        }
+
+        let scroll_root_id = ScrollRootId::new_of_type(self.fragment.node.id() as usize,
+                                                       self.fragment.fragment_type());
         let parent_scroll_root_id = state.current_scroll_root_id;
         state.add_scroll_root(
             ScrollRoot {
                 id: scroll_root_id,
                 parent_id: parent_scroll_root_id,
-                clip: self.fragment.stacking_relative_content_box(&border_box),
+                clip: clip,
                 size: self.base.overflow.scroll.size,
             }
         );
@@ -1898,10 +1882,9 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
             state.stacking_context_children.remove(&stacking_context_id).unwrap_or_else(Vec::new);
         for child in new_children {
             if child.context_type == StackingContextType::PseudoFloat {
-                state.add_stacking_context_without_calcuating_overflow(stacking_context_id, child);
+                state.add_stacking_context(stacking_context_id, child);
             } else {
-                state.add_stacking_context_without_calcuating_overflow(parent_stacking_context_id,
-                                                                       child);
+                state.add_stacking_context(parent_stacking_context_id, child);
             }
         }
     }
@@ -1942,9 +1925,7 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
             DisplayListSection::BlockBackgroundsAndBorders
         };
 
-        if self.has_scrolling_overflow() {
-            state.processing_scroll_root_element = true;
-        }
+        state.processing_scroll_root_element = self.has_scrolling_overflow();
 
         // Add the box that starts the block context.
         self.fragment

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -50,6 +50,7 @@ extern crate serde_derive;
 extern crate serde_json;
 #[macro_use] extern crate servo_atoms;
 extern crate servo_config;
+extern crate servo_geometry;
 extern crate servo_url;
 extern crate smallvec;
 extern crate style;

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5232,6 +5232,18 @@
             "url": "/_mozilla/css/table_margin_auto_a.html"
           }
         ],
+        "css/table_overflow.html": [
+          {
+            "path": "css/table_overflow.html",
+            "references": [
+              [
+                "/_mozilla/css/table_overflow_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/table_overflow.html"
+          }
+        ],
         "css/table_padding_a.html": [
           {
             "path": "css/table_padding_a.html",
@@ -20554,6 +20566,18 @@
             ]
           ],
           "url": "/_mozilla/css/table_margin_auto_a.html"
+        }
+      ],
+      "css/table_overflow.html": [
+        {
+          "path": "css/table_overflow.html",
+          "references": [
+            [
+              "/_mozilla/css/table_overflow_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/table_overflow.html"
         }
       ],
       "css/table_padding_a.html": [

--- a/tests/wpt/mozilla/tests/css/table_overflow.html
+++ b/tests/wpt/mozilla/tests/css/table_overflow.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Ensure that table overflow:auto and overflow:scroll do not crash</title>
+<link rel="match" href="table_overflow_ref.html">
+
+<style>
+    div {
+        height: 100px;
+        width: 100px;
+        background: green;
+    }
+</style>
+
+<body>
+
+<table style="overflow: scroll;"><tr><td><div></div></td></tr></table>
+<table style="overflow: auto;"><tr><td><div></div></td></tr></table>
+
+</body>

--- a/tests/wpt/mozilla/tests/css/table_overflow_ref.html
+++ b/tests/wpt/mozilla/tests/css/table_overflow_ref.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Ensure that table overflow:auto and overflow:scroll do not crash</title>
+<style>
+    div {
+        height: 100px;
+        width: 100px;
+        background: green;
+    }
+</style>
+
+<body>
+
+<table><tr><td><div></div></td></tr></table>
+<table><tr><td><div></div></td></tr></table>
+
+</body>


### PR DESCRIPTION
Only create scroll roots for overflow regions when the overflow region
is actually larger than the container size. This prevents creating
scrolling roots for elements that do not have overflow scroll as a
side-effect of the way their height and width is defined. For example,
tables should never respect overflow:scroll since their height and
width should always be large enough to prevent overflow. This also
decreases the size and complexity of the display list in many other
circumstances.

As part of this change, transformed overflow calculation is moved from
display list construction to layout. This should mean that overflow is
handled more accurately earlier.

Fixes #14574.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14574 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14979)
<!-- Reviewable:end -->
