### PR TITLE
Remove reflow status from browsing context.

### DIFF
--- a/components/script/dom/browsingcontext.rs
+++ b/components/script/dom/browsingcontext.rs
@@ -33,9 +33,6 @@ use std::cell::Cell;
 pub struct BrowsingContext {
     reflector: Reflector,
 
-    /// Indicates if reflow is required when reloading.
-    needs_reflow: Cell<bool>,
-
     /// Has this browsing context been discarded?
     discarded: Cell<bool>,
 
@@ -47,7 +44,6 @@ impl BrowsingContext {
     pub fn new_inherited(frame_element: Option<&Element>) -> BrowsingContext {
         BrowsingContext {
             reflector: Reflector::new(),
-            needs_reflow: Cell::new(true),
             discarded:  Cell::new(false),
             frame_element: frame_element.map(JS::from_ref),
         }
@@ -94,12 +90,6 @@ impl BrowsingContext {
         let window_proxy = self.reflector.get_jsobject();
         assert!(!window_proxy.get().is_null());
         window_proxy.get()
-    }
-
-    pub fn set_reflow_status(&self, status: bool) -> bool {
-        let old = self.needs_reflow.get();
-        self.needs_reflow.set(status);
-        old
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR removes the reflow status from each browsing context. Previously, we were only using it to avoid reflowing on traversal, which is rare enough it doesn't seem worth the complexity.

This is a first step towards #14843.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because reflows aren't visible from script

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14990)
<!-- Reviewable:end -->
