### PR TITLE
Make WebIDL callbacks permanently rooted

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -776,7 +776,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         if descriptor.interface.isCallback():
             name = descriptor.nativeType
             declType = CGWrapper(CGGeneric(name), pre="Rc<", post=">")
-            template = "%s::new(${val}.get().to_object())" % name
+            template = "%s::new(cx, ${val}.get().to_object())" % name
             if type.nullable():
                 declType = CGWrapper(declType, pre="Option<", post=">")
                 template = wrapObjectTemplate("Some(%s)" % template, "None",
@@ -2195,7 +2195,7 @@ class CGGeneric(CGThing):
 
 class CGCallbackTempRoot(CGGeneric):
     def __init__(self, name):
-        CGGeneric.__init__(self, "%s::new(${val}.get().to_object())" % name)
+        CGGeneric.__init__(self, "%s::new(cx, ${val}.get().to_object())" % name)
 
 
 def getAllTypes(descriptors, dictionaries, callbacks, typedefs):
@@ -4444,10 +4444,11 @@ class ClassConstructor(ClassItem):
                 "});\n"
                 "// Note: callback cannot be moved after calling init.\n"
                 "match Rc::get_mut(&mut ret) {\n"
-                "    Some(ref mut callback) => callback.parent.init(%s),\n"
+                "    Some(ref mut callback) => unsafe { callback.parent.init(%s, %s) },\n"
                 "    None => unreachable!(),\n"
                 "};\n"
-                "ret") % (cgClass.name, '\n'.join(initializers), self.args[0].name))
+                "ret") % (cgClass.name, '\n'.join(initializers),
+                          self.args[0].name, self.args[1].name))
 
     def declare(self, cgClass):
         args = ', '.join([a.declare() for a in self.args])
@@ -6236,11 +6237,11 @@ class CGCallback(CGClass):
                          bases=[ClassBase(baseName)],
                          constructors=self.getConstructors(),
                          methods=realMethods + getters + setters,
-                         decorators="#[derive(JSTraceable, PartialEq)]")
+                         decorators="#[derive(JSTraceable, PartialEq)]\n#[allow_unrooted_interior]")
 
     def getConstructors(self):
         return [ClassConstructor(
-            [Argument("*mut JSObject", "aCallback")],
+            [Argument("*mut JSContext", "aCx"), Argument("*mut JSObject", "aCallback")],
             bodyInHeader=True,
             visibility="pub",
             explicit=False,
@@ -6336,8 +6337,8 @@ class CGCallbackFunctionImpl(CGGeneric):
     def __init__(self, callback):
         impl = string.Template("""\
 impl CallbackContainer for ${type} {
-    fn new(callback: *mut JSObject) -> Rc<${type}> {
-        ${type}::new(callback)
+    unsafe fn new(cx: *mut JSContext, callback: *mut JSObject) -> Rc<${type}> {
+        ${type}::new(cx, callback)
     }
 
     fn callback_holder(&self) -> &CallbackObject {

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -441,13 +441,13 @@ impl EventTarget {
         assert!(!funobj.is_null());
         // Step 1.14
         if is_error {
-            Some(CommonEventHandler::ErrorEventHandler(OnErrorEventHandlerNonNull::new(funobj)))
+            Some(CommonEventHandler::ErrorEventHandler(OnErrorEventHandlerNonNull::new(cx, funobj)))
         } else {
             if ty == &atom!("beforeunload") {
                 Some(CommonEventHandler::BeforeUnloadEventHandler(
-                        OnBeforeUnloadEventHandlerNonNull::new(funobj)))
+                        OnBeforeUnloadEventHandlerNonNull::new(cx, funobj)))
             } else {
-                Some(CommonEventHandler::EventHandler(EventHandlerNonNull::new(funobj)))
+                Some(CommonEventHandler::EventHandler(EventHandlerNonNull::new(cx, funobj)))
             }
         }
     }
@@ -455,36 +455,47 @@ impl EventTarget {
     pub fn set_event_handler_common<T: CallbackContainer>(
         &self, ty: &str, listener: Option<Rc<T>>)
     {
+        let cx = self.global().get_cx();
+
         let event_listener = listener.map(|listener|
                                           InlineEventListener::Compiled(
                                               CommonEventHandler::EventHandler(
-                                                  EventHandlerNonNull::new(listener.callback()))));
+                                                  EventHandlerNonNull::new(cx, listener.callback()))));
         self.set_inline_event_listener(Atom::from(ty), event_listener);
     }
 
     pub fn set_error_event_handler<T: CallbackContainer>(
         &self, ty: &str, listener: Option<Rc<T>>)
     {
+        let cx = self.global().get_cx();
+
         let event_listener = listener.map(|listener|
                                           InlineEventListener::Compiled(
                                               CommonEventHandler::ErrorEventHandler(
-                                                  OnErrorEventHandlerNonNull::new(listener.callback()))));
+                                                  OnErrorEventHandlerNonNull::new(cx, listener.callback()))));
         self.set_inline_event_listener(Atom::from(ty), event_listener);
     }
 
     pub fn set_beforeunload_event_handler<T: CallbackContainer>(&self, ty: &str,
-            listener: Option<Rc<T>>) {
+                                                                listener: Option<Rc<T>>) {
+        let cx = self.global().get_cx();
+
         let event_listener = listener.map(|listener|
             InlineEventListener::Compiled(
                 CommonEventHandler::BeforeUnloadEventHandler(
-                    OnBeforeUnloadEventHandlerNonNull::new(listener.callback())))
+                    OnBeforeUnloadEventHandlerNonNull::new(cx, listener.callback())))
         );
         self.set_inline_event_listener(Atom::from(ty), event_listener);
     }
 
+    #[allow(unsafe_code)]
     pub fn get_event_handler_common<T: CallbackContainer>(&self, ty: &str) -> Option<Rc<T>> {
+        let cx = self.global().get_cx();
         let listener = self.get_inline_event_listener(&Atom::from(ty));
-        listener.map(|listener| CallbackContainer::new(listener.parent().callback_holder().get()))
+        unsafe {
+            listener.map(|listener|
+                         CallbackContainer::new(cx, listener.parent().callback_holder().get()))
+        }
     }
 
     pub fn has_handlers(&self) -> bool {

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -176,7 +176,7 @@ impl PromiseJobQueue {
 /// promise job queue, and enqueues a runnable to perform a microtask checkpoint if one
 /// is not already pending.
 #[allow(unsafe_code)]
-unsafe extern "C" fn enqueue_job(_cx: *mut JSContext,
+unsafe extern "C" fn enqueue_job(cx: *mut JSContext,
                                  job: HandleObject,
                                  _allocation_site: HandleObject,
                                  _data: *mut c_void) -> bool {
@@ -184,7 +184,7 @@ unsafe extern "C" fn enqueue_job(_cx: *mut JSContext,
         let global = GlobalScope::from_object(job.get());
         let pipeline = global.pipeline_id();
         global.enqueue_promise_job(EnqueuedPromiseCallback {
-            callback: PromiseJobCallback::new(job.get()),
+            callback: PromiseJobCallback::new(cx, job.get()),
             pipeline: pipeline,
         });
         true


### PR DESCRIPTION
This replicates the same model that Promise uses right now, because it requires less thinking than coming up with something else.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14447
- [ ] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14994)
<!-- Reviewable:end -->
