### PR TITLE
Enable codegen-units=4 in debug mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,12 @@ members = [
     "ports/servo",
     "support/android/build-apk",
 ]
+
+[profile.dev]
+codegen-units = 4
+
+[profile.release]
+opt-level = 3
+# Uncomment to profile on Linux:
+# debug = true
+# lto = false

--- a/ports/servo/Cargo.toml
+++ b/ports/servo/Cargo.toml
@@ -35,12 +35,6 @@ testing = ["libservo/testing"]
 clippy = ["libservo/clippy"]
 debugmozjs = ["libservo/debugmozjs"]
 
-[profile.release]
-opt-level = 3
-# Uncomment to profile on Linux:
-# debug = true
-# lto = false
-
 [dependencies]
 backtrace = "0.2"
 browserhtml = {git = "https://github.com/browserhtml/browserhtml", branch = "crate"}


### PR DESCRIPTION
We previously had this and removed it because it caused runtime slowdowns
(discussion in #11102), but that was in release mode.

Debug mode is already very slow at runtime.
In my opinion, debug mode is mostly for the edit-compile-test cycle
which is currently dominated by compile times, so sacrificing runtime for compile time makes sense.

I’ve observed a ~30% improvement of compile times with this. This figure is consistent between a very fast desktop with 4 cores / 8 threads and a not-as-fast laptop with 2 cores / 4 threads.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/14995)
<!-- Reviewable:end -->
