### PR TITLE
Fix filling of two vector fields for geckolib

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1774,9 +1774,9 @@ fn static_assert() {
     }
 
     <%
-        fill_fields = "mRepeat mClip mOrigin mPositionX mPositionY mImage"
+        fill_fields = "mRepeat mClip mOrigin mPositionX mPositionY mImage mSize"
         if shorthand == "background":
-            fill_fields += " mAttachment"
+            fill_fields += " mAttachment mBlendMode"
         else:
             # mSourceURI uses mImageCount
             fill_fields += " mMaskMode mComposite"

--- a/components/style/properties/longhand/background.mako.rs
+++ b/components/style/properties/longhand/background.mako.rs
@@ -416,5 +416,5 @@ ${helpers.single_keyword("background-blend-mode",
                          """normal multiply screen overlay darken lighten color-dodge
                             color-burn hard-light soft-light difference exclusion hue
                             saturation color luminosity""",
-                         vector="true", products="gecko", animatable=False,
+                         vector=True, products="gecko", animatable=False,
                          spec="https://drafts.fxtf.org/compositing/#background-blend-mode")}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This fixes a crash of stylo when you do the following:
```javascript
p.setAttribute("style", "background-blend-mode: multiply");
alert(getComputedStyle(p).backgroundBlendMode);
p.setAttribute("style", "background-blend-mode: normal, normal");
alert(getComputedStyle(p).backgroundBlendMode);
```

r? @Manishearth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15002)
<!-- Reviewable:end -->
