### PR TITLE
Don't fire a load event on inline scripts

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -528,8 +528,6 @@ impl HTMLScriptElement {
         // Step 8.
         if script.external {
             self.dispatch_load_event();
-        } else {
-            window.dom_manipulation_task_source().queue_simple_event(self.upcast(), atom!("load"), &window);
         }
     }
 

--- a/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/load-event.html.ini
+++ b/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/load-event.html.ini
@@ -1,5 +1,0 @@
-[load-event.html]
-  type: testharness
-  [load events should not be fired for inline scripts]
-    expected: FAIL
-

--- a/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/019.html.ini
+++ b/tests/wpt/metadata/old-tests/submission/Opera/script_scheduling/019.html.ini
@@ -1,5 +1,0 @@
-[019.html]
-  type: testharness
-  [ scheduler: DOM added scripts and event handling ]
-    expected: FAIL
-


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15009)
<!-- Reviewable:end -->
