### PR TITLE
Add config to do desktop notifications by running an abitrary command.

### DIFF
--- a/servobuild.example
+++ b/servobuild.example
@@ -27,6 +27,12 @@ system-cargo = false
 # Defaults to true
 rustc-with-gold = true
 
+# If uncommented, this command is used instead of the platform’s default
+# to notify at the end of a compilation that took a long time.
+# This is the name or path of an executable called with two arguments:
+# the summary and content of the notification.
+#notify-command = "notify-send"
+
 [build]
 # Set "mode = dev" or use `mach build --dev` to build the project with warning.
 # or Set "mode = release" or use `mach build --release` for optimized build.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

I now have an usual setup where I use a (fast) remote machine for building, and I’m adding a hack to forward end-of-build notifications back to my laptop. This is the motivation for this change, but I kept it general enough that it could be used in other situations.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15013)
<!-- Reviewable:end -->
