### PR TITLE
Do not use the script element's line number for external scripts.

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -510,9 +510,10 @@ impl HTMLScriptElement {
 
         // Step 5.a.2.
         let window = window_from_node(self);
+        let line_number = if script.external { 1 } else { self.line_number as u32 };
         rooted!(in(window.get_cx()) let mut rval = UndefinedValue());
         window.upcast::<GlobalScope>().evaluate_script_on_global_with_result(
-            &script.text, script.url.as_str(), rval.handle_mut(), self.line_number as u32);
+            &script.text, script.url.as_str(), rval.handle_mut(), line_number);
 
         // Step 6.
         document.set_current_script(old_script.r());

--- a/tests/wpt/mozilla/tests/mozilla/resources/external.js
+++ b/tests/wpt/mozilla/tests/mozilla/resources/external.js
@@ -1,0 +1,4 @@
+
+
+
+this_is_a_js_error

--- a/tests/wpt/mozilla/tests/mozilla/track_line.html
+++ b/tests/wpt/mozilla/tests/mozilla/track_line.html
@@ -6,12 +6,18 @@
 <script>
 setup({allow_uncaught_exception:true});
 var t = async_test("error event has proper line number");
+var errors = 0;
+var expected_lines = [21, 4];
 window.addEventListener('error', t.step_func(function(e) {
     assert_true(e instanceof ErrorEvent);
-    assert_equals(e.lineno, 16);
-    t.done();
+    assert_equals(e.lineno, expected_lines[errors]);
+    errors++;
+    if (errors == 2) {
+        t.done();
+    }
 }), true);
 </script>
 <script>
 this_is_a_js_error
 </script>
+<script src="resources/external.js"></script>


### PR DESCRIPTION
This was yielding incorrect line numbers when looking at JS backtraces in gdb.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15020)
<!-- Reviewable:end -->
