### PR TITLE
Check all constellation files for panics

### DIFF
--- a/components/constellation/timer_scheduler.rs
+++ b/components/constellation/timer_scheduler.rs
@@ -39,7 +39,7 @@ impl PartialEq for ScheduledEvent {
 
 impl TimerScheduler {
     pub fn start() -> IpcSender<TimerEventRequest> {
-        let (req_ipc_sender, req_ipc_receiver) = ipc::channel().unwrap();
+        let (req_ipc_sender, req_ipc_receiver) = ipc::channel().expect("Channel creation failed.");
         let (req_sender, req_receiver) = mpsc::sync_channel(1);
 
         // We could do this much more directly with recv_timeout
@@ -92,7 +92,7 @@ impl TimerScheduler {
                 // This thread can terminate if the req_ipc_sender is dropped.
                 warn!("TimerScheduler thread terminated.");
             })
-            .unwrap()
+            .expect("Thread creation failed.")
             .thread()
             .clone();
 
@@ -105,13 +105,13 @@ impl TimerScheduler {
             .name(String::from("TimerProxy"))
             .spawn(move || {
                 while let Ok(req) = req_ipc_receiver.recv() {
-                    req_sender.send(req).unwrap();
+                    let _ = req_sender.send(req);
                     timeout_thread.unpark();
                 }
                 // This thread can terminate if the req_ipc_sender is dropped.
                 warn!("TimerProxy thread terminated.");
             })
-            .unwrap();
+            .expect("Thread creation failed.");
 
         // Return the IPC sender
         req_ipc_sender

--- a/etc/ci/check_no_panic.sh
+++ b/etc/ci/check_no_panic.sh
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Make sure listed files do not use unwrap() or panic!()
+# Make sure listed paths do not use unwrap() or panic!()
 
 set -o errexit
 set -o nounset
@@ -13,14 +13,21 @@ set -o pipefail
 # cd into repo root to make sure paths work in any case
 cd "$(git rev-parse --show-toplevel)"
 
-FILES=("components/compositing/compositor.rs"
-       "components/constellation/constellation.rs"
-       "components/constellation/pipeline.rs"
-       "ports/glutin/lib.rs"
-       "ports/glutin/window.rs")
+# Each path can be either a single file or a directory
+PATHS=(
+    "components/compositing/compositor.rs"
+    "components/constellation/"
+    "ports/glutin/lib.rs"
+    "ports/glutin/window.rs"
+)
 
-# make sure the files exist
-ls -1 "${FILES[@]}"
+# Make sure the paths exist
+ls -1 "${PATHS[@]}"
 
-# make sure the files do not contain "unwrap" or "panic!"
-! grep --line-number --with-filename "unwrap(\|panic!(" "${FILES[@]}"
+# Make sure the files do not contain "unwrap" or "panic!"
+! grep \
+    --dereference-recursive \
+    --line-number \
+    --with-filename \
+    "unwrap(\|panic!(" \
+    "${PATHS[@]}"


### PR DESCRIPTION
Teaches the `etc/ci/check_no_panic.sh` script to handle directories,
so it can check all constellation files for panics.

<!-- Please describe your changes on the following line: -->

r? @asajeffrey 
There are currently 4 `unwrap()`s in `components/constellation/timer_scheduler.rs`; I'm not sure how you want to handle those.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14976 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it adds more testing coverage

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15029)
<!-- Reviewable:end -->
