### PR TITLE
Store blink value for text-decoration-line

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -2315,6 +2315,9 @@ fn static_assert() {
         if v.line_through {
             bits |= structs::NS_STYLE_TEXT_DECORATION_LINE_LINE_THROUGH as u8;
         }
+        if v.blink {
+            bits |= structs::NS_STYLE_TEXT_DECORATION_LINE_BLINK as u8;
+        }
         self.gecko.mTextDecorationLine = bits;
     }
 


### PR DESCRIPTION
The spec does say user agents may not blink, but it doesn't say this
value can be ignored during parsing.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15038)
<!-- Reviewable:end -->
