### PR TITLE
Remove libloading from the list of packages that can have duplicated versions.

### DIFF
--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -30,7 +30,7 @@ rand = [
 
 [ignore]
 # Ignored packages with duplicated versions
-packages = ["bitflags", "byteorder", "lazy_static", "semver", "libloading"]
+packages = ["bitflags", "byteorder", "lazy_static", "semver"]
 # Files that are ignored for all tidy and lint checks.
 files = [
   # Generated and upstream code combined with our own. Could use cleanup


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15046)
<!-- Reviewable:end -->
