### PR TITLE
Remove -w flag now that WebRender is always used

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -573,8 +573,6 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     let (app_name, args) = args.split_first().unwrap();
 
     let mut opts = Options::new();
-    opts.optflag("c", "cpu", "CPU painting");
-    opts.optflag("g", "gpu", "GPU painting");
     opts.optopt("o", "output", "Output file", "output.png");
     opts.optopt("s", "size", "Size of tiles", "512");
     opts.optopt("", "device-pixel-ratio", "Device pixels per px", "");
@@ -620,7 +618,6 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     opts.optmulti("", "pref",
                   "A preference to set to enable", "dom.mozbrowser.enabled");
     opts.optflag("b", "no-native-titlebar", "Do not use native titlebar");
-    opts.optflag("w", "webrender", "Use webrender backend");
     opts.optopt("G", "graphics", "Select graphics backend (gl or es2)", "gl");
     opts.optopt("", "config-dir",
                     "config directory following xdg spec on linux platform", "");

--- a/tests/heartbeats/characterize.py
+++ b/tests/heartbeats/characterize.py
@@ -210,9 +210,6 @@ def main():
     parser.add_argument("-d", "--debug",
                         action='store_true',
                         help="Use debug build instead of release build")
-    parser.add_argument("-w", "--webrender",
-                        action='store_true',
-                        help="Use webrender backend")
     parser.add_argument("-l", "--max_layout_threads",
                         help="Specify the maximum number of threads for layout, for example \"-l 5\"")
     parser.add_argument("-o", "--output",
@@ -233,8 +230,6 @@ def main():
         benchmark = args.benchmark
     if args.debug:
         build_target = "debug"
-    if args.webrender:
-        renderer = "-w"
     if args.max_layout_threads:
         max_layout_threads = int(args.max_layout_threads)
     if args.output:

--- a/tests/heartbeats/characterize_android.py
+++ b/tests/heartbeats/characterize_android.py
@@ -85,9 +85,6 @@ def main():
     parser.add_argument("-b", "--benchmark",
                         default=benchmark,
                         help="Gets the benchmark, for example \"-b http://www.example.com\"")
-    parser.add_argument("-w", "--webrender",
-                        action='store_true',
-                        help="Use webrender backend")
     parser.add_argument("-l", "--layout_threads",
                         help="Specify the number of threads for layout, for example \"-l 5\"")
     parser.add_argument("-o", "--output",
@@ -99,8 +96,6 @@ def main():
     args = parser.parse_args()
     if args.benchmark:
         benchmark = args.benchmark
-    if args.webrender:
-        renderer = "-w"
     if args.layout_threads:
         layout_threads = int(args.layout_threads)
     if args.output:

--- a/tests/wpt/harness/wptrunner/browsers/servo.py
+++ b/tests/wpt/harness/wptrunner/browsers/servo.py
@@ -10,17 +10,20 @@ from ..executors.executorservo import ServoTestharnessExecutor, ServoRefTestExec
 
 here = os.path.join(os.path.split(__file__)[0])
 
-__wptrunner__ = {"product": "servo",
-                 "check_args": "check_args",
-                 "browser": "ServoBrowser",
-                 "executor": {"testharness": "ServoTestharnessExecutor",
-                              "reftest": "ServoRefTestExecutor",
-                              "wdspec": "ServoWdspecExecutor"},
-                 "browser_kwargs": "browser_kwargs",
-                 "executor_kwargs": "executor_kwargs",
-                 "env_options": "env_options",
-                 "run_info_extras": "run_info_extras",
-                 "update_properties": "update_properties"}
+__wptrunner__ = {
+    "product": "servo",
+    "check_args": "check_args",
+    "browser": "ServoBrowser",
+    "executor": {
+        "testharness": "ServoTestharnessExecutor",
+        "reftest": "ServoRefTestExecutor",
+        "wdspec": "ServoWdspecExecutor",
+    },
+    "browser_kwargs": "browser_kwargs",
+    "executor_kwargs": "executor_kwargs",
+    "env_options": "env_options",
+    "update_properties": "update_properties",
+}
 
 
 def check_args(**kwargs):
@@ -28,11 +31,12 @@ def check_args(**kwargs):
 
 
 def browser_kwargs(**kwargs):
-    return {"binary": kwargs["binary"],
-            "debug_info": kwargs["debug_info"],
-            "binary_args": kwargs["binary_args"],
-            "user_stylesheets": kwargs.get("user_stylesheets"),
-            "render_backend": kwargs.get("servo_backend")}
+    return {
+        "binary": kwargs["binary"],
+        "debug_info": kwargs["debug_info"],
+        "binary_args": kwargs["binary_args"],
+        "user_stylesheets": kwargs.get("user_stylesheets"),
+    }
 
 
 def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
@@ -51,31 +55,23 @@ def env_options():
             "supports_debugger": True}
 
 
-def run_info_extras(**kwargs):
-    return {"backend": kwargs["servo_backend"]}
-
-
 def update_properties():
-    return ["debug", "os", "version", "processor", "bits", "backend"], None
-
-
-def render_arg(render_backend):
-    return {"cpu": "--cpu", "webrender": "-w"}[render_backend]
+    return ["debug", "os", "version", "processor", "bits"], None
 
 
 class ServoBrowser(NullBrowser):
     def __init__(self, logger, binary, debug_info=None, binary_args=None,
-                 user_stylesheets=None, render_backend="webrender"):
+                 user_stylesheets=None):
         NullBrowser.__init__(self, logger)
         self.binary = binary
         self.debug_info = debug_info
         self.binary_args = binary_args or []
         self.user_stylesheets = user_stylesheets or []
-        self.render_backend = render_backend
 
     def executor_browser(self):
-        return ExecutorBrowser, {"binary": self.binary,
-                                 "debug_info": self.debug_info,
-                                 "binary_args": self.binary_args,
-                                 "user_stylesheets": self.user_stylesheets,
-                                 "render_backend": self.render_backend}
+        return ExecutorBrowser, {
+            "binary": self.binary,
+            "debug_info": self.debug_info,
+            "binary_args": self.binary_args,
+            "user_stylesheets": self.user_stylesheets,
+        }

--- a/tests/wpt/harness/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/harness/wptrunner/browsers/servodriver.py
@@ -9,23 +9,25 @@ import tempfile
 from mozprocess import ProcessHandler
 
 from .base import Browser, require_arg, get_free_port, browser_command, ExecutorBrowser
-from .servo import render_arg
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorservodriver import (ServoWebDriverTestharnessExecutor,
                                              ServoWebDriverRefTestExecutor)
 
 here = os.path.join(os.path.split(__file__)[0])
 
-__wptrunner__ = {"product": "servodriver",
-                 "check_args": "check_args",
-                 "browser": "ServoWebDriverBrowser",
-                 "executor": {"testharness": "ServoWebDriverTestharnessExecutor",
-                              "reftest": "ServoWebDriverRefTestExecutor"},
-                 "browser_kwargs": "browser_kwargs",
-                 "executor_kwargs": "executor_kwargs",
-                 "env_options": "env_options",
-                 "run_info_extras": "run_info_extras",
-                 "update_properties": "update_properties"}
+__wptrunner__ = {
+    "product": "servodriver",
+    "check_args": "check_args",
+    "browser": "ServoWebDriverBrowser",
+    "executor": {
+        "testharness": "ServoWebDriverTestharnessExecutor",
+        "reftest": "ServoWebDriverRefTestExecutor",
+    },
+    "browser_kwargs": "browser_kwargs",
+    "executor_kwargs": "executor_kwargs",
+    "env_options": "env_options",
+    "update_properties": "update_properties",
+}
 
 hosts_text = """127.0.0.1 web-platform.test
 127.0.0.1 www.web-platform.test
@@ -41,10 +43,11 @@ def check_args(**kwargs):
 
 
 def browser_kwargs(**kwargs):
-    return {"binary": kwargs["binary"],
-            "debug_info": kwargs["debug_info"],
-            "user_stylesheets": kwargs.get("user_stylesheets"),
-            "render_backend": kwargs.get("servo_backend")}
+    return {
+        "binary": kwargs["binary"],
+        "debug_info": kwargs["debug_info"],
+        "user_stylesheets": kwargs.get("user_stylesheets"),
+    }
 
 
 def executor_kwargs(test_type, server_config, cache_manager, run_info_data, **kwargs):
@@ -61,12 +64,8 @@ def env_options():
             "supports_debugger": True}
 
 
-def run_info_extras(**kwargs):
-    return {"backend": kwargs["servo_backend"]}
-
-
 def update_properties():
-    return ["debug", "os", "version", "processor", "bits", "backend"], None
+    return ["debug", "os", "version", "processor", "bits"], None
 
 
 def make_hosts_file():
@@ -80,7 +79,7 @@ class ServoWebDriverBrowser(Browser):
     used_ports = set()
 
     def __init__(self, logger, binary, debug_info=None, webdriver_host="127.0.0.1",
-                 user_stylesheets=None, render_backend="webrender"):
+                 user_stylesheets=None):
         Browser.__init__(self, logger)
         self.binary = binary
         self.webdriver_host = webdriver_host
@@ -90,7 +89,6 @@ class ServoWebDriverBrowser(Browser):
         self.hosts_path = make_hosts_file()
         self.command = None
         self.user_stylesheets = user_stylesheets if user_stylesheets else []
-        self.render_backend = render_backend
 
     def start(self):
         self.webdriver_port = get_free_port(4444, exclude=self.used_ports)
@@ -100,11 +98,15 @@ class ServoWebDriverBrowser(Browser):
         env["HOST_FILE"] = self.hosts_path
         env["RUST_BACKTRACE"] = "1"
 
-        debug_args, command = browser_command(self.binary,
-                                              [render_arg(self.render_backend), "--hard-fail",
-                                               "--webdriver", str(self.webdriver_port),
-                                               "about:blank"],
-                                              self.debug_info)
+        debug_args, command = browser_command(
+            self.binary,
+            [
+                "--hard-fail",
+                "--webdriver", str(self.webdriver_port),
+                "about:blank",
+            ],
+            self.debug_info
+        )
 
         for stylesheet in self.user_stylesheets:
             command += ["--user-stylesheet", stylesheet]

--- a/tests/wpt/harness/wptrunner/executors/executorservo.py
+++ b/tests/wpt/harness/wptrunner/executors/executorservo.py
@@ -30,14 +30,9 @@ from ..webdriver_server import ServoDriverServer
 from .executormarionette import WdspecRun
 
 pytestrunner = None
-render_arg = None
 webdriver = None
 
 extra_timeout = 5 # seconds
-
-def do_delayed_imports():
-    global render_arg
-    from ..browsers.servo import render_arg
 
 hosts_text = """127.0.0.1 web-platform.test
 127.0.0.1 www.web-platform.test
@@ -80,8 +75,10 @@ class ServoTestharnessExecutor(ProcessTestExecutor):
         self.result_data = None
         self.result_flag = threading.Event()
 
-        args = [render_arg(self.browser.render_backend), "--hard-fail", "-u", "Servo/wptrunner",
-                "-Z", "replace-surrogates", "-z", self.test_url(test)]
+        args = [
+            "--hard-fail", "-u", "Servo/wptrunner",
+            "-Z", "replace-surrogates", "-z", self.test_url(test),
+        ]
         for stylesheet in self.browser.user_stylesheets:
             args += ["--user-stylesheet", stylesheet]
         for pref, value in test.environment.get('prefs', {}).iteritems():
@@ -213,9 +210,12 @@ class ServoRefTestExecutor(ProcessTestExecutor):
         with TempFilename(self.tempdir) as output_path:
             debug_args, command = browser_command(
                 self.binary,
-                [render_arg(self.browser.render_backend), "--hard-fail", "--exit",
-                 "-u", "Servo/wptrunner", "-Z", "disable-text-aa,load-webfonts-synchronously,replace-surrogates",
-                 "--output=%s" % output_path, full_url] + self.browser.binary_args,
+                [
+                    "--hard-fail", "--exit",
+                    "-u", "Servo/wptrunner",
+                    "-Z", "disable-text-aa,load-webfonts-synchronously,replace-surrogates",
+                    "--output=%s" % output_path, full_url
+                ] + self.browser.binary_args,
                 self.debug_info)
 
             for stylesheet in self.browser.user_stylesheets:
@@ -295,7 +295,7 @@ class ServoWdspecProtocol(Protocol):
 
     def setup(self, runner):
         try:
-            self.server = ServoDriverServer(self.logger, binary=self.browser.binary, binary_args=self.browser.binary_args, render_backend=self.browser.render_backend)
+            self.server = ServoDriverServer(self.logger, binary=self.browser.binary, binary_args=self.browser.binary_args)
             self.server.start(block=False)
             self.logger.info(
                 "WebDriver HTTP server listening at %s" % self.server.url)

--- a/tests/wpt/harness/wptrunner/webdriver_server.py
+++ b/tests/wpt/harness/wptrunner/webdriver_server.py
@@ -165,12 +165,11 @@ class GeckoDriverServer(WebDriverServer):
 
 
 class ServoDriverServer(WebDriverServer):
-    def __init__(self, logger, binary="servo", binary_args=None, host="127.0.0.1", port=None, render_backend=None):
+    def __init__(self, logger, binary="servo", binary_args=None, host="127.0.0.1", port=None):
         env = os.environ.copy()
         env["RUST_BACKTRACE"] = "1"
         WebDriverServer.__init__(self, logger, binary, host=host, port=port, env=env)
         self.binary_args = binary_args
-        self.render_backend = render_backend
 
     def make_command(self):
         command = [self.binary,
@@ -179,10 +178,6 @@ class ServoDriverServer(WebDriverServer):
                    "--headless"]
         if self.binary_args:
             command += self.binary_args
-        if self.render_backend == "cpu":
-            command += ["--cpu"]
-        elif self.render_backend == "webrender":
-            command += ["--webrender"]
         return command
 
 

--- a/tests/wpt/harness/wptrunner/wptcommandline.py
+++ b/tests/wpt/harness/wptrunner/wptcommandline.py
@@ -178,10 +178,6 @@ scheme host and port.""")
     servo_group.add_argument("--user-stylesheet",
                              default=[], action="append", dest="user_stylesheets",
                              help="Inject a user CSS stylesheet into every test.")
-    servo_group.add_argument("--servo-backend",
-                             default="webrender", choices=["cpu", "webrender"],
-                             help="Rendering backend to use with Servo.")
-
 
     parser.add_argument("test_list", nargs="*",
                         help="List of URLs for tests to run, or paths including tests to run. "

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/canvas/to-data-url-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/canvas/to-data-url-test.html.ini
@@ -3,4 +3,3 @@
   expected:
     if os == "linux": TIMEOUT
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/constants-and-properties.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/constants-and-properties.html.ini
@@ -2,4 +2,3 @@
   type: testharness
   expected:
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-attribute-preserve-drawing-buffer.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-attribute-preserve-drawing-buffer.html.ini
@@ -3,4 +3,3 @@
   expected:
     if os == "linux": TIMEOUT
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-creation-and-destruction.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-creation-and-destruction.html.ini
@@ -3,4 +3,3 @@
   expected:
     if os == "linux": TIMEOUT
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-creation.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-creation.html.ini
@@ -3,4 +3,3 @@
   expected:
     if os == "linux": TIMEOUT
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-hidden-alpha.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-hidden-alpha.html.ini
@@ -2,4 +2,3 @@
   type: testharness
   expected:
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-lost-restored.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-lost-restored.html.ini
@@ -2,4 +2,3 @@
   type: testharness
   expected:
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-release-upon-reload.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-release-upon-reload.html.ini
@@ -3,4 +3,3 @@
   expected:
     if os == "linux": TIMEOUT
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-release-with-workers.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-release-with-workers.html.ini
@@ -3,4 +3,3 @@
   expected:
     if os == "linux": TIMEOUT
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-type-test.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/context/context-type-test.html.ini
@@ -2,4 +2,3 @@
   type: testharness
   expected:
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/extensions/angle-instanced-arrays-out-of-bounds.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/extensions/angle-instanced-arrays-out-of-bounds.html.ini
@@ -2,4 +2,3 @@
   type: testharness
   expected:
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/extensions/angle-instanced-arrays.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/extensions/angle-instanced-arrays.html.ini
@@ -2,4 +2,3 @@
   type: testharness
   expected:
     if os == "mac": CRASH
-    if not debug and (os == "mac") and (version == "OS X 10.10.5") and (processor == "x86_64") and (bits == 64) and (backend == "cpu"): CRASH


### PR DESCRIPTION
Also remove the obsolete `--cpu` and `--gpu` renderer flags,
which also are no longer used.

Update tests and wptrunner to not pass these flags.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13761 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the tests are updated to no longer pass these flags

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15064)
<!-- Reviewable:end -->
