### PR TITLE
Use Box<CalcLengthOrPercentage> in specified values to avoid bloating inline sizes

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -480,7 +480,7 @@ impl LayoutElementHelpers for LayoutJS<Element> {
             hints.push(from_declaration(
                 PropertyDeclaration::BorderSpacing(DeclaredValue::Value(
                     border_spacing::SpecifiedValue {
-                        horizontal: width_value,
+                        horizontal: width_value.clone(),
                         vertical: width_value,
                     }))));
         }
@@ -625,11 +625,11 @@ impl LayoutElementHelpers for LayoutJS<Element> {
             let width_value = specified::BorderWidth::from_length(
                 specified::Length::Absolute(Au::from_px(border as i32)));
             hints.push(from_declaration(
-                PropertyDeclaration::BorderTopWidth(DeclaredValue::Value(width_value))));
+                PropertyDeclaration::BorderTopWidth(DeclaredValue::Value(width_value.clone()))));
             hints.push(from_declaration(
-                PropertyDeclaration::BorderLeftWidth(DeclaredValue::Value(width_value))));
+                PropertyDeclaration::BorderLeftWidth(DeclaredValue::Value(width_value.clone()))));
             hints.push(from_declaration(
-                PropertyDeclaration::BorderBottomWidth(DeclaredValue::Value(width_value))));
+                PropertyDeclaration::BorderBottomWidth(DeclaredValue::Value(width_value.clone()))));
             hints.push(from_declaration(
                 PropertyDeclaration::BorderRightWidth(DeclaredValue::Value(width_value))));
         }

--- a/components/style/properties/longhand/border.mako.rs
+++ b/components/style/properties/longhand/border.mako.rs
@@ -427,7 +427,7 @@ ${helpers.single_keyword("-moz-float-edge", "content-box margin-box",
     impl ToCss for computed_value::SingleComputedValue {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self {
-                computed_value::SingleComputedValue::LengthOrPercentage(len) => len.to_css(dest),
+                computed_value::SingleComputedValue::LengthOrPercentage(ref len) => len.to_css(dest),
                 computed_value::SingleComputedValue::Number(number) => number.to_css(dest),
                 computed_value::SingleComputedValue::Auto => dest.write_str("auto"),
             }
@@ -436,7 +436,7 @@ ${helpers.single_keyword("-moz-float-edge", "content-box margin-box",
     impl ToCss for SingleSpecifiedValue {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self {
-                SingleSpecifiedValue::LengthOrPercentage(len) => len.to_css(dest),
+                SingleSpecifiedValue::LengthOrPercentage(ref len) => len.to_css(dest),
                 SingleSpecifiedValue::Number(number) => number.to_css(dest),
                 SingleSpecifiedValue::Auto => dest.write_str("auto"),
             }
@@ -449,7 +449,7 @@ ${helpers.single_keyword("-moz-float-edge", "content-box margin-box",
         #[inline]
         fn to_computed_value(&self, context: &Context) -> computed_value::SingleComputedValue {
             match *self {
-                SingleSpecifiedValue::LengthOrPercentage(len) => {
+                SingleSpecifiedValue::LengthOrPercentage(ref len) => {
                     computed_value::SingleComputedValue::LengthOrPercentage(
                         len.to_computed_value(context))
                 },

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -258,7 +258,7 @@ ${helpers.single_keyword("-moz-top-layer", "none top",
     impl HasViewportPercentage for SpecifiedValue {
         fn has_viewport_percentage(&self) -> bool {
             match *self {
-                SpecifiedValue::LengthOrPercentage(length) => length.has_viewport_percentage(),
+                SpecifiedValue::LengthOrPercentage(ref length) => length.has_viewport_percentage(),
                 _ => false
             }
         }
@@ -266,7 +266,7 @@ ${helpers.single_keyword("-moz-top-layer", "none top",
 
     /// The `vertical-align` value.
     #[allow(non_camel_case_types)]
-    #[derive(Debug, Clone, PartialEq, Copy)]
+    #[derive(Debug, Clone, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum SpecifiedValue {
         % for keyword in vertical_align_keywords:
@@ -281,7 +281,7 @@ ${helpers.single_keyword("-moz-top-layer", "none top",
                 % for keyword in vertical_align_keywords:
                     SpecifiedValue::${to_rust_ident(keyword)} => dest.write_str("${keyword}"),
                 % endfor
-                SpecifiedValue::LengthOrPercentage(value) => value.to_css(dest),
+                SpecifiedValue::LengthOrPercentage(ref value) => value.to_css(dest),
             }
         }
     }
@@ -324,7 +324,7 @@ ${helpers.single_keyword("-moz-top-layer", "none top",
                     % for keyword in vertical_align_keywords:
                         T::${to_rust_ident(keyword)} => dest.write_str("${keyword}"),
                     % endfor
-                    T::LengthOrPercentage(value) => value.to_css(dest),
+                    T::LengthOrPercentage(ref value) => value.to_css(dest),
                 }
             }
         }
@@ -347,7 +347,7 @@ ${helpers.single_keyword("-moz-top-layer", "none top",
                         computed_value::T::${to_rust_ident(keyword)}
                     }
                 % endfor
-                SpecifiedValue::LengthOrPercentage(value) =>
+                SpecifiedValue::LengthOrPercentage(ref value) =>
                     computed_value::T::LengthOrPercentage(value.to_computed_value(context)),
             }
         }
@@ -954,7 +954,7 @@ ${helpers.single_keyword("animation-fill-mode",
     impl HasViewportPercentage for SpecifiedValue {
         fn has_viewport_percentage(&self) -> bool {
             match *self {
-                SpecifiedValue::Repeat(length) => length.has_viewport_percentage(),
+                SpecifiedValue::Repeat(ref length) => length.has_viewport_percentage(),
                 _ => false
             }
         }
@@ -968,7 +968,7 @@ ${helpers.single_keyword("animation-fill-mode",
         pub struct T(pub Option<LengthOrPercentage>);
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq)]
+    #[derive(Debug, Clone, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum SpecifiedValue {
         None,
@@ -979,7 +979,7 @@ ${helpers.single_keyword("animation-fill-mode",
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match self.0 {
                 None => dest.write_str("none"),
-                Some(l) => {
+                Some(ref l) => {
                     try!(dest.write_str("repeat("));
                     try!(l.to_css(dest));
                     dest.write_str(")")
@@ -1012,7 +1012,7 @@ ${helpers.single_keyword("animation-fill-mode",
         fn to_computed_value(&self, context: &Context) -> computed_value::T {
             match *self {
                 SpecifiedValue::None => computed_value::T(None),
-                SpecifiedValue::Repeat(l) =>
+                SpecifiedValue::Repeat(ref l) =>
                     computed_value::T(Some(l.to_computed_value(context))),
             }
         }
@@ -1167,12 +1167,12 @@ ${helpers.single_keyword("animation-fill-mode",
     impl HasViewportPercentage for SpecifiedOperation {
         fn has_viewport_percentage(&self) -> bool {
             match *self {
-                SpecifiedOperation::Translate(_, l1, l2, l3) => {
+                SpecifiedOperation::Translate(_, ref l1, ref l2, ref l3) => {
                     l1.has_viewport_percentage() ||
                     l2.has_viewport_percentage() ||
                     l3.has_viewport_percentage()
                 },
-                SpecifiedOperation::Perspective(length) => length.has_viewport_percentage(),
+                SpecifiedOperation::Perspective(ref length) => length.has_viewport_percentage(),
                 _ => false
             }
         }
@@ -1183,13 +1183,13 @@ ${helpers.single_keyword("animation-fill-mode",
             match *self {
                 // todo(gw): implement serialization for transform
                 // types other than translate.
-                SpecifiedOperation::Matrix(_m) => {
+                SpecifiedOperation::Matrix(..) => {
                     Ok(())
                 }
-                SpecifiedOperation::Skew(_sx, _sy) => {
+                SpecifiedOperation::Skew(..) => {
                     Ok(())
                 }
-                SpecifiedOperation::Translate(kind, tx, ty, tz) => {
+                SpecifiedOperation::Translate(kind, ref tx, ref ty, ref tz) => {
                     match kind {
                         TranslateKind::Translate => {
                             try!(dest.write_str("translate("));
@@ -1224,13 +1224,13 @@ ${helpers.single_keyword("animation-fill-mode",
                         }
                     }
                 }
-                SpecifiedOperation::Scale(_sx, _sy, _sz) => {
+                SpecifiedOperation::Scale(..) => {
                     Ok(())
                 }
-                SpecifiedOperation::Rotate(_ax, _ay, _az, _angle) => {
+                SpecifiedOperation::Rotate(..) => {
                     Ok(())
                 }
-                SpecifiedOperation::Perspective(_p) => {
+                SpecifiedOperation::Perspective(_) => {
                     Ok(())
                 }
             }
@@ -1525,7 +1525,7 @@ ${helpers.single_keyword("animation-fill-mode",
                     SpecifiedOperation::Skew(theta_x, theta_y) => {
                         result.push(computed_value::ComputedOperation::Skew(theta_x, theta_y));
                     }
-                    SpecifiedOperation::Perspective(d) => {
+                    SpecifiedOperation::Perspective(ref d) => {
                         result.push(computed_value::ComputedOperation::Perspective(d.to_computed_value(context)));
                     }
                 };
@@ -1674,7 +1674,7 @@ ${helpers.predefined_type("perspective",
         }
     }
 
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub struct SpecifiedValue {
         horizontal: LengthOrPercentage,
@@ -1788,7 +1788,7 @@ ${helpers.single_keyword("transform-style",
         }
     }
 
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub struct SpecifiedValue {
         horizontal: LengthOrPercentage,

--- a/components/style/properties/longhand/effects.mako.rs
+++ b/components/style/properties/longhand/effects.mako.rs
@@ -150,13 +150,13 @@ ${helpers.predefined_type("opacity",
     impl HasViewportPercentage for SpecifiedClipRect {
         fn has_viewport_percentage(&self) -> bool {
             self.top.has_viewport_percentage() ||
-            self.right.map_or(false, |x| x.has_viewport_percentage()) ||
-            self.bottom.map_or(false, |x| x.has_viewport_percentage()) ||
+            self.right.as_ref().map_or(false, |x| x.has_viewport_percentage()) ||
+            self.bottom.as_ref().map_or(false, |x| x.has_viewport_percentage()) ||
             self.left.has_viewport_percentage()
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, Copy)]
+    #[derive(Clone, Debug, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub struct SpecifiedClipRect {
         pub top: specified::Length,
@@ -167,12 +167,11 @@ ${helpers.predefined_type("opacity",
 
     impl HasViewportPercentage for SpecifiedValue {
         fn has_viewport_percentage(&self) -> bool {
-            let &SpecifiedValue(clip) = self;
-            clip.map_or(false, |x| x.has_viewport_percentage())
+            self.0.as_ref().map_or(false, |x| x.has_viewport_percentage())
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, Copy)]
+    #[derive(Clone, Debug, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub struct SpecifiedValue(Option<SpecifiedClipRect>);
 
@@ -183,14 +182,14 @@ ${helpers.predefined_type("opacity",
             try!(self.top.to_css(dest));
             try!(dest.write_str(", "));
 
-            if let Some(right) = self.right {
+            if let Some(ref right) = self.right {
                 try!(right.to_css(dest));
                 try!(dest.write_str(", "));
             } else {
                 try!(dest.write_str("auto, "));
             }
 
-            if let Some(bottom) = self.bottom {
+            if let Some(ref bottom) = self.bottom {
                 try!(bottom.to_css(dest));
                 try!(dest.write_str(", "));
             } else {
@@ -224,10 +223,10 @@ ${helpers.predefined_type("opacity",
 
         #[inline]
         fn to_computed_value(&self, context: &Context) -> computed_value::T {
-            computed_value::T(self.0.map(|value| computed_value::ClipRect {
+            computed_value::T(self.0.as_ref().map(|value| computed_value::ClipRect {
                 top: value.top.to_computed_value(context),
-                right: value.right.map(|right| right.to_computed_value(context)),
-                bottom: value.bottom.map(|bottom| bottom.to_computed_value(context)),
+                right: value.right.as_ref().map(|right| right.to_computed_value(context)),
+                bottom: value.bottom.as_ref().map(|bottom| bottom.to_computed_value(context)),
                 left: value.left.to_computed_value(context),
             }))
         }
@@ -302,8 +301,7 @@ ${helpers.predefined_type("opacity",
 
     impl HasViewportPercentage for SpecifiedValue {
         fn has_viewport_percentage(&self) -> bool {
-            let &SpecifiedValue(ref vec) = self;
-            vec.iter().any(|ref x| x.has_viewport_percentage())
+            self.0.iter().any(|ref x| x.has_viewport_percentage())
         }
     }
 
@@ -314,7 +312,7 @@ ${helpers.predefined_type("opacity",
     impl HasViewportPercentage for SpecifiedFilter {
         fn has_viewport_percentage(&self) -> bool {
             match *self {
-                SpecifiedFilter::Blur(length) => length.has_viewport_percentage(),
+                SpecifiedFilter::Blur(ref length) => length.has_viewport_percentage(),
                 _ => false
             }
         }
@@ -439,7 +437,7 @@ ${helpers.predefined_type("opacity",
     impl ToCss for computed_value::Filter {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self {
-                computed_value::Filter::Blur(value) => {
+                computed_value::Filter::Blur(ref value) => {
                     try!(dest.write_str("blur("));
                     try!(value.to_css(dest));
                     try!(dest.write_str(")"));
@@ -477,7 +475,7 @@ ${helpers.predefined_type("opacity",
     impl ToCss for SpecifiedFilter {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self {
-                SpecifiedFilter::Blur(value) => {
+                SpecifiedFilter::Blur(ref value) => {
                     try!(dest.write_str("blur("));
                     try!(value.to_css(dest));
                     try!(dest.write_str(")"));
@@ -567,7 +565,7 @@ ${helpers.predefined_type("opacity",
         fn to_computed_value(&self, context: &Context) -> computed_value::T {
             computed_value::T{ filters: self.0.iter().map(|value| {
                 match *value {
-                    SpecifiedFilter::Blur(factor) =>
+                    SpecifiedFilter::Blur(ref factor) =>
                         computed_value::Filter::Blur(factor.to_computed_value(context)),
                     SpecifiedFilter::Brightness(factor) => computed_value::Filter::Brightness(factor),
                     SpecifiedFilter::Contrast(factor) => computed_value::Filter::Contrast(factor),

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -309,8 +309,7 @@ ${helpers.single_keyword("font-variant-caps",
 
     impl HasViewportPercentage for SpecifiedValue {
         fn has_viewport_percentage(&self) -> bool {
-            let &SpecifiedValue(length) = self;
-            return length.has_viewport_percentage()
+            return self.0.has_viewport_percentage()
         }
     }
 
@@ -340,13 +339,13 @@ ${helpers.single_keyword("font-variant-caps",
                 LengthOrPercentage::Length(Length::ServoCharacterWidth(value)) => {
                     value.to_computed_value(context.inherited_style().get_font().clone_font_size())
                 }
-                LengthOrPercentage::Length(l) => {
+                LengthOrPercentage::Length(ref l) => {
                     l.to_computed_value(context)
                 }
                 LengthOrPercentage::Percentage(Percentage(value)) => {
                     context.inherited_style().get_font().clone_font_size().scale_by(value)
                 }
-                LengthOrPercentage::Calc(calc) => {
+                LengthOrPercentage::Calc(ref calc) => {
                     let calc = calc.to_computed_value(context);
                     calc.length() + context.inherited_style().get_font().clone_font_size()
                                            .scale_by(calc.percentage())

--- a/components/style/properties/longhand/inherited_table.mako.rs
+++ b/components/style/properties/longhand/inherited_table.mako.rs
@@ -107,21 +107,26 @@ ${helpers.single_keyword("caption-side", "top bottom",
     }
 
     pub fn parse(_: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue,()> {
-        let mut lengths = [ None, None ];
-        for i in 0..2 {
-            match specified::Length::parse_non_negative(input) {
-                Err(()) => break,
-                Ok(length) => lengths[i] = Some(length),
+        let mut first = None;
+        let mut second = None;
+        match specified::Length::parse_non_negative(input) {
+            Err(()) => (),
+            Ok(length) => {
+                first = Some(length);
+                match specified::Length::parse_non_negative(input) {
+                    Err(()) => (),
+                    Ok(length) => second = Some(length),
+                }
             }
         }
         if input.next().is_ok() {
             return Err(())
         }
-        match (lengths[0], lengths[1]) {
+        match (first, second) {
             (None, None) => Err(()),
             (Some(length), None) => {
                 Ok(SpecifiedValue {
-                    horizontal: length,
+                    horizontal: length.clone(),
                     vertical: length,
                 })
             }

--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -15,13 +15,13 @@
     impl HasViewportPercentage for SpecifiedValue {
         fn has_viewport_percentage(&self) -> bool {
             match *self {
-                SpecifiedValue::LengthOrPercentage(length) => length.has_viewport_percentage(),
+                SpecifiedValue::LengthOrPercentage(ref length) => length.has_viewport_percentage(),
                 _ => false
             }
         }
     }
 
-    #[derive(Debug, Clone, PartialEq, Copy)]
+    #[derive(Debug, Clone, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum SpecifiedValue {
         Normal,
@@ -39,7 +39,7 @@
                 % if product == "gecko":
                     SpecifiedValue::MozBlockHeight => dest.write_str("-moz-block-height"),
                 % endif
-                SpecifiedValue::LengthOrPercentage(value) => value.to_css(dest),
+                SpecifiedValue::LengthOrPercentage(ref value) => value.to_css(dest),
                 SpecifiedValue::Number(number) => write!(dest, "{}", number),
             }
         }
@@ -108,15 +108,15 @@
                     SpecifiedValue::MozBlockHeight => computed_value::T::MozBlockHeight,
                 % endif
                 SpecifiedValue::Number(value) => computed_value::T::Number(value),
-                SpecifiedValue::LengthOrPercentage(value) => {
-                    match value {
-                        specified::LengthOrPercentage::Length(value) =>
+                SpecifiedValue::LengthOrPercentage(ref value) => {
+                    match *value {
+                        specified::LengthOrPercentage::Length(ref value) =>
                             computed_value::T::Length(value.to_computed_value(context)),
                         specified::LengthOrPercentage::Percentage(specified::Percentage(value)) => {
                             let fr = specified::Length::FontRelative(specified::FontRelativeLength::Em(value));
                             computed_value::T::Length(fr.to_computed_value(context))
                         },
-                        specified::LengthOrPercentage::Calc(calc) => {
+                        specified::LengthOrPercentage::Calc(ref calc) => {
                             let calc = calc.to_computed_value(context);
                             let fr = specified::FontRelativeLength::Em(calc.percentage());
                             let fr = specified::Length::FontRelative(fr);
@@ -267,13 +267,13 @@ ${helpers.single_keyword("text-align-last",
     impl HasViewportPercentage for SpecifiedValue {
         fn has_viewport_percentage(&self) -> bool {
             match *self {
-                SpecifiedValue::Specified(length) => length.has_viewport_percentage(),
+                SpecifiedValue::Specified(ref length) => length.has_viewport_percentage(),
                 _ => false
             }
         }
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq)]
+    #[derive(Debug, Clone, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum SpecifiedValue {
         Normal,
@@ -284,7 +284,7 @@ ${helpers.single_keyword("text-align-last",
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self {
                 SpecifiedValue::Normal => dest.write_str("normal"),
-                SpecifiedValue::Specified(l) => l.to_css(dest),
+                SpecifiedValue::Specified(ref l) => l.to_css(dest),
             }
         }
     }
@@ -317,7 +317,7 @@ ${helpers.single_keyword("text-align-last",
         fn to_computed_value(&self, context: &Context) -> computed_value::T {
             match *self {
                 SpecifiedValue::Normal => computed_value::T(None),
-                SpecifiedValue::Specified(l) =>
+                SpecifiedValue::Specified(ref l) =>
                     computed_value::T(Some(l.to_computed_value(context)))
             }
         }
@@ -348,13 +348,13 @@ ${helpers.single_keyword("text-align-last",
     impl HasViewportPercentage for SpecifiedValue {
         fn has_viewport_percentage(&self) -> bool {
             match *self {
-                SpecifiedValue::Specified(length) => length.has_viewport_percentage(),
+                SpecifiedValue::Specified(ref length) => length.has_viewport_percentage(),
                 _ => false
             }
         }
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq)]
+    #[derive(Debug, Clone, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum SpecifiedValue {
         Normal,
@@ -365,7 +365,7 @@ ${helpers.single_keyword("text-align-last",
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self {
                 SpecifiedValue::Normal => dest.write_str("normal"),
-                SpecifiedValue::Specified(l) => l.to_css(dest),
+                SpecifiedValue::Specified(ref l) => l.to_css(dest),
             }
         }
     }
@@ -398,7 +398,7 @@ ${helpers.single_keyword("text-align-last",
         fn to_computed_value(&self, context: &Context) -> computed_value::T {
             match *self {
                 SpecifiedValue::Normal => computed_value::T(None),
-                SpecifiedValue::Specified(l) =>
+                SpecifiedValue::Specified(ref l) =>
                     computed_value::T(Some(l.to_computed_value(context))),
             }
         }
@@ -681,7 +681,9 @@ ${helpers.single_keyword("text-align-last",
 
     fn parse_one_text_shadow(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedTextShadow,()> {
         use app_units::Au;
-        let mut lengths = [specified::Length::Absolute(Au(0)); 3];
+        let mut lengths = [specified::Length::Absolute(Au(0)),
+                           specified::Length::Absolute(Au(0)),
+                           specified::Length::Absolute(Au(0))];
         let mut lengths_parsed = false;
         let mut color = None;
 
@@ -723,9 +725,9 @@ ${helpers.single_keyword("text-align-last",
         }
 
         Ok(SpecifiedTextShadow {
-            offset_x: lengths[0],
-            offset_y: lengths[1],
-            blur_radius: lengths[2],
+            offset_x: lengths[0].take(),
+            offset_y: lengths[1].take(),
+            blur_radius: lengths[2].take(),
             color: color,
         })
     }

--- a/components/style/properties/longhand/outline.mako.rs
+++ b/components/style/properties/longhand/outline.mako.rs
@@ -48,7 +48,7 @@ ${helpers.predefined_type("outline-color", "CSSColor", "::cssparser::Color::Curr
 
     impl HasViewportPercentage for SpecifiedValue {
         fn has_viewport_percentage(&self) -> bool {
-            let &SpecifiedValue(length) = self;
+            let &SpecifiedValue(ref length) = self;
             length.has_viewport_percentage()
         }
     }

--- a/components/style/properties/shorthand/border.mako.rs
+++ b/components/style/properties/shorthand/border.mako.rs
@@ -33,18 +33,7 @@ ${helpers.four_sides_shorthand("border-style", "border-%s-style",
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             % for side in ["top", "right", "bottom", "left"]:
-                let ${side} = match self.border_${side}_width {
-                    &DeclaredValue::Value(ref value) => DeclaredValue::Value(*value),
-                    &DeclaredValue::WithVariables {
-                        css: ref a, first_token_type: ref b, base_url: ref c, from_shorthand: ref d
-                    } => DeclaredValue::WithVariables {
-                        // WithVariables should not be reachable during serialization
-                        css: a.clone(), first_token_type: b.clone(), base_url: c.clone(), from_shorthand: d.clone()
-                    },
-                    &DeclaredValue::Initial => DeclaredValue::Initial,
-                    &DeclaredValue::Inherit => DeclaredValue::Inherit,
-                    &DeclaredValue::Unset => DeclaredValue::Unset,
-                };
+                let ${side} = self.border_${side}_width.clone();
             % endfor
 
             super::serialize_four_sides(dest, &top, &right, &bottom, &left)
@@ -136,7 +125,7 @@ pub fn parse_border(context: &ParserContext, input: &mut Parser)
             % for side in ["top", "right", "bottom", "left"]:
                 border_${side}_color: color.clone(),
                 border_${side}_style: style,
-                border_${side}_width: width,
+                border_${side}_width: width.clone(),
             % endfor
         })
     }

--- a/components/style/servo/media_queries.rs
+++ b/components/style/servo/media_queries.rs
@@ -100,7 +100,7 @@ impl Device {
 /// A expression kind servo understands and parses.
 ///
 /// Only `pub` for unit testing, please don't use it directly!
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum ExpressionKind {
     /// http://dev.w3.org/csswg/mediaqueries-3/#width

--- a/components/style/values/computed/image.rs
+++ b/components/style/values/computed/image.rs
@@ -190,7 +190,7 @@ impl ToComputedValue for specified::GradientKind {
             specified::GradientKind::Linear(angle_or_corner) => {
                 GradientKind::Linear(angle_or_corner.to_computed_value(context))
             },
-            specified::GradientKind::Radial(ref shape, position) => {
+            specified::GradientKind::Radial(ref shape, ref position) => {
                 GradientKind::Radial(shape.to_computed_value(context),
                                      position.to_computed_value(context))
             },
@@ -253,7 +253,7 @@ impl ToComputedValue for specified::ColorStop {
             color: self.color.parsed,
             position: match self.position {
                 None => None,
-                Some(value) => Some(value.to_computed_value(context)),
+                Some(ref value) => Some(value.to_computed_value(context)),
             },
         }
     }
@@ -374,7 +374,7 @@ impl ToComputedValue for specified::LengthOrKeyword {
     #[inline]
     fn to_computed_value(&self, context: &Context) -> LengthOrKeyword {
         match *self {
-            specified::LengthOrKeyword::Length(length) => {
+            specified::LengthOrKeyword::Length(ref length) => {
                 LengthOrKeyword::Length(length.to_computed_value(context))
             },
             specified::LengthOrKeyword::Keyword(keyword) => {
@@ -437,7 +437,7 @@ impl ToComputedValue for specified::LengthOrPercentageOrKeyword {
     #[inline]
     fn to_computed_value(&self, context: &Context) -> LengthOrPercentageOrKeyword {
         match *self {
-            specified::LengthOrPercentageOrKeyword::LengthOrPercentage(first_len, second_len) => {
+            specified::LengthOrPercentageOrKeyword::LengthOrPercentage(ref first_len, ref second_len) => {
                 LengthOrPercentageOrKeyword::LengthOrPercentage(first_len.to_computed_value(context),
                                                                 second_len.to_computed_value(context))
             },

--- a/components/style/values/computed/length.rs
+++ b/components/style/values/computed/length.rs
@@ -187,13 +187,13 @@ impl ToComputedValue for specified::LengthOrPercentage {
 
     fn to_computed_value(&self, context: &Context) -> LengthOrPercentage {
         match *self {
-            specified::LengthOrPercentage::Length(value) => {
+            specified::LengthOrPercentage::Length(ref value) => {
                 LengthOrPercentage::Length(value.to_computed_value(context))
             }
             specified::LengthOrPercentage::Percentage(value) => {
                 LengthOrPercentage::Percentage(value.0)
             }
-            specified::LengthOrPercentage::Calc(calc) => {
+            specified::LengthOrPercentage::Calc(ref calc) => {
                 LengthOrPercentage::Calc(calc.to_computed_value(context))
             }
         }
@@ -209,9 +209,9 @@ impl ToComputedValue for specified::LengthOrPercentage {
             LengthOrPercentage::Percentage(value) => {
                 specified::LengthOrPercentage::Percentage(specified::Percentage(value))
             }
-            LengthOrPercentage::Calc(calc) => {
+            LengthOrPercentage::Calc(ref calc) => {
                 specified::LengthOrPercentage::Calc(
-                    ToComputedValue::from_computed_value(&calc)
+                    Box::new(ToComputedValue::from_computed_value(calc))
                 )
             }
         }
@@ -270,7 +270,7 @@ impl ToComputedValue for specified::LengthOrPercentageOrAuto {
     #[inline]
     fn to_computed_value(&self, context: &Context) -> LengthOrPercentageOrAuto {
         match *self {
-            specified::LengthOrPercentageOrAuto::Length(value) => {
+            specified::LengthOrPercentageOrAuto::Length(ref value) => {
                 LengthOrPercentageOrAuto::Length(value.to_computed_value(context))
             }
             specified::LengthOrPercentageOrAuto::Percentage(value) => {
@@ -279,7 +279,7 @@ impl ToComputedValue for specified::LengthOrPercentageOrAuto {
             specified::LengthOrPercentageOrAuto::Auto => {
                 LengthOrPercentageOrAuto::Auto
             }
-            specified::LengthOrPercentageOrAuto::Calc(calc) => {
+            specified::LengthOrPercentageOrAuto::Calc(ref calc) => {
                 LengthOrPercentageOrAuto::Calc(calc.to_computed_value(context))
             }
         }
@@ -299,7 +299,7 @@ impl ToComputedValue for specified::LengthOrPercentageOrAuto {
             }
             LengthOrPercentageOrAuto::Calc(calc) => {
                 specified::LengthOrPercentageOrAuto::Calc(
-                    ToComputedValue::from_computed_value(&calc)
+                    Box::new(ToComputedValue::from_computed_value(&calc))
                 )
             }
         }
@@ -347,13 +347,13 @@ impl ToComputedValue for specified::LengthOrPercentageOrAutoOrContent {
     #[inline]
     fn to_computed_value(&self, context: &Context) -> LengthOrPercentageOrAutoOrContent {
         match *self {
-            specified::LengthOrPercentageOrAutoOrContent::Length(value) => {
+            specified::LengthOrPercentageOrAutoOrContent::Length(ref value) => {
                 LengthOrPercentageOrAutoOrContent::Length(value.to_computed_value(context))
             },
             specified::LengthOrPercentageOrAutoOrContent::Percentage(value) => {
                 LengthOrPercentageOrAutoOrContent::Percentage(value.0)
             },
-            specified::LengthOrPercentageOrAutoOrContent::Calc(calc) => {
+            specified::LengthOrPercentageOrAutoOrContent::Calc(ref calc) => {
                 LengthOrPercentageOrAutoOrContent::Calc(calc.to_computed_value(context))
             },
             specified::LengthOrPercentageOrAutoOrContent::Auto => {
@@ -385,7 +385,7 @@ impl ToComputedValue for specified::LengthOrPercentageOrAutoOrContent {
             }
             LengthOrPercentageOrAutoOrContent::Calc(calc) => {
                 specified::LengthOrPercentageOrAutoOrContent::Calc(
-                    ToComputedValue::from_computed_value(&calc)
+                    Box::new(ToComputedValue::from_computed_value(&calc))
                 )
             }
         }
@@ -432,13 +432,13 @@ impl ToComputedValue for specified::LengthOrPercentageOrNone {
     #[inline]
     fn to_computed_value(&self, context: &Context) -> LengthOrPercentageOrNone {
         match *self {
-            specified::LengthOrPercentageOrNone::Length(value) => {
+            specified::LengthOrPercentageOrNone::Length(ref value) => {
                 LengthOrPercentageOrNone::Length(value.to_computed_value(context))
             }
             specified::LengthOrPercentageOrNone::Percentage(value) => {
                 LengthOrPercentageOrNone::Percentage(value.0)
             }
-            specified::LengthOrPercentageOrNone::Calc(calc) => {
+            specified::LengthOrPercentageOrNone::Calc(ref calc) => {
                 LengthOrPercentageOrNone::Calc(calc.to_computed_value(context))
             }
             specified::LengthOrPercentageOrNone::None => {
@@ -461,7 +461,7 @@ impl ToComputedValue for specified::LengthOrPercentageOrNone {
             }
             LengthOrPercentageOrNone::Calc(calc) => {
                 specified::LengthOrPercentageOrNone::Calc(
-                    ToComputedValue::from_computed_value(&calc)
+                    Box::new(ToComputedValue::from_computed_value(&calc))
                 )
             }
         }

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -128,7 +128,7 @@ impl ToComputedValue for specified::Length {
     fn to_computed_value(&self, context: &Context) -> Au {
         match *self {
             specified::Length::Absolute(length) => length,
-            specified::Length::Calc(calc, range) => range.clamp(calc.to_computed_value(context).length()),
+            specified::Length::Calc(ref calc, range) => range.clamp(calc.to_computed_value(context).length()),
             specified::Length::FontRelative(length) =>
                 length.to_computed_value(context, /* use inherited */ false),
             specified::Length::ViewportPercentage(length) =>

--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -80,7 +80,7 @@ impl ToCss for Gradient {
                     skipcomma = true;
                 }
             },
-            GradientKind::Radial(ref shape, position) => {
+            GradientKind::Radial(ref shape, ref position) => {
                 try!(dest.write_str("radial-gradient("));
                 try!(shape.to_css(dest));
                 try!(dest.write_str(" at "));
@@ -312,7 +312,7 @@ pub struct ColorStop {
 impl ToCss for ColorStop {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         try!(self.color.to_css(dest));
-        if let Some(position) = self.position {
+        if let Some(ref position) = self.position {
             try!(dest.write_str(" "));
             try!(position.to_css(dest));
         }
@@ -413,7 +413,7 @@ impl Parse for LengthOrPercentageOrKeyword {
 impl ToCss for LengthOrPercentageOrKeyword {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         match *self {
-            LengthOrPercentageOrKeyword::LengthOrPercentage(ref first_len, second_len) => {
+            LengthOrPercentageOrKeyword::LengthOrPercentage(ref first_len, ref second_len) => {
                 try!(first_len.to_css(dest));
                 try!(dest.write_str(" "));
                 second_len.to_css(dest)

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -11,9 +11,8 @@ use cssparser::{Parser, Token};
 use euclid::size::Size2D;
 use font_metrics::FontMetrics;
 use parser::{Parse, ParserContext};
+use std::{cmp, fmt, mem};
 use std::ascii::AsciiExt;
-use std::cmp;
-use std::fmt;
 use std::ops::Mul;
 use style_traits::ToCss;
 use style_traits::values::specified::AllowedNumericType;
@@ -209,7 +208,7 @@ impl CharacterWidth {
 /// A length.
 ///
 /// https://drafts.csswg.org/css-values/#lengths
-#[derive(Clone, PartialEq, Copy, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum Length {
     /// An absolute length: https://drafts.csswg.org/css-values/#absolute-length
@@ -237,7 +236,7 @@ pub enum Length {
     ///
     /// TODO(emilio): We have more `Calc` variants around, we should only use
     /// one.
-    Calc(CalcLengthOrPercentage, AllowedNumericType),
+    Calc(Box<CalcLengthOrPercentage>, AllowedNumericType),
 }
 
 impl HasViewportPercentage for Length {
@@ -381,6 +380,15 @@ impl Length {
     #[inline]
     pub fn from_px(px_value: CSSFloat) -> Length {
         Length::Absolute(Au((px_value * AU_PER_PX) as i32))
+    }
+
+    /// Extract inner length without a clone, replacing it with a 0 Au
+    ///
+    /// Use when you need to move out of a length array without cloning
+    #[inline]
+    pub fn take(&mut self) -> Self {
+        let new = Length::Absolute(Au(0));
+        mem::replace(self, new)
     }
 }
 
@@ -584,7 +592,7 @@ impl CalcLengthOrPercentage {
                     node_with_unit = Some(match *node {
                         CalcValueNode::Sum(ref sum) =>
                             try!(CalcLengthOrPercentage::simplify_products_in_sum(sum)),
-                        CalcValueNode::Length(l) => SimplifiedValueNode::Length(l),
+                        CalcValueNode::Length(ref l) => SimplifiedValueNode::Length(l.clone()),
                         CalcValueNode::Angle(a) => SimplifiedValueNode::Angle(a),
                         CalcValueNode::Time(t) => SimplifiedValueNode::Time(t),
                         CalcValueNode::Percentage(p) => SimplifiedValueNode::Percentage(p),
@@ -604,7 +612,7 @@ impl CalcLengthOrPercentage {
     fn parse_length(input: &mut Parser,
                     context: AllowedNumericType) -> Result<Length, ()> {
         CalcLengthOrPercentage::parse(input, CalcUnit::Length).map(|calc| {
-            Length::Calc(calc, context)
+            Length::Calc(Box::new(calc), context)
         })
     }
 
@@ -829,13 +837,13 @@ impl Parse for Percentage {
 /// A length or a percentage value.
 ///
 /// TODO(emilio): Does this make any sense vs. CalcLengthOrPercentage?
-#[derive(Clone, PartialEq, Copy, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[allow(missing_docs)]
 pub enum LengthOrPercentage {
     Length(Length),
     Percentage(Percentage),
-    Calc(CalcLengthOrPercentage),
+    Calc(Box<CalcLengthOrPercentage>),
 }
 
 impl HasViewportPercentage for LengthOrPercentage {
@@ -851,9 +859,9 @@ impl HasViewportPercentage for LengthOrPercentage {
 impl ToCss for LengthOrPercentage {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         match *self {
-            LengthOrPercentage::Length(length) => length.to_css(dest),
+            LengthOrPercentage::Length(ref length) => length.to_css(dest),
             LengthOrPercentage::Percentage(percentage) => percentage.to_css(dest),
-            LengthOrPercentage::Calc(calc) => calc.to_css(dest),
+            LengthOrPercentage::Calc(ref calc) => calc.to_css(dest),
         }
     }
 }
@@ -875,7 +883,7 @@ impl LengthOrPercentage {
                 Ok(LengthOrPercentage::Length(Length::Absolute(Au(0)))),
             Token::Function(ref name) if name.eq_ignore_ascii_case("calc") => {
                 let calc = try!(input.parse_nested_block(CalcLengthOrPercentage::parse_length_or_percentage));
-                Ok(LengthOrPercentage::Calc(calc))
+                Ok(LengthOrPercentage::Calc(Box::new(calc)))
             },
             _ => Err(())
         }
@@ -885,6 +893,15 @@ impl LengthOrPercentage {
     #[inline]
     pub fn parse_non_negative(input: &mut Parser) -> Result<LengthOrPercentage, ()> {
         LengthOrPercentage::parse_internal(input, AllowedNumericType::NonNegative)
+    }
+
+    /// Extract value from ref without a clone, replacing it with a 0 Au
+    ///
+    /// Use when you need to move out of a length array without cloning
+    #[inline]
+    pub fn take(&mut self) -> Self {
+        let new = LengthOrPercentage::Length(Length::Absolute(Au(0)));
+        mem::replace(self, new)
     }
 }
 
@@ -897,14 +914,14 @@ impl Parse for LengthOrPercentage {
 
 /// TODO(emilio): Do the Length and Percentage variants make any sense with
 /// CalcLengthOrPercentage?
-#[derive(Clone, PartialEq, Copy, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[allow(missing_docs)]
 pub enum LengthOrPercentageOrAuto {
     Length(Length),
     Percentage(Percentage),
     Auto,
-    Calc(CalcLengthOrPercentage),
+    Calc(Box<CalcLengthOrPercentage>),
 }
 
 impl HasViewportPercentage for LengthOrPercentageOrAuto {
@@ -920,10 +937,10 @@ impl HasViewportPercentage for LengthOrPercentageOrAuto {
 impl ToCss for LengthOrPercentageOrAuto {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         match *self {
-            LengthOrPercentageOrAuto::Length(length) => length.to_css(dest),
+            LengthOrPercentageOrAuto::Length(ref length) => length.to_css(dest),
             LengthOrPercentageOrAuto::Percentage(percentage) => percentage.to_css(dest),
             LengthOrPercentageOrAuto::Auto => dest.write_str("auto"),
-            LengthOrPercentageOrAuto::Calc(calc) => calc.to_css(dest),
+            LengthOrPercentageOrAuto::Calc(ref calc) => calc.to_css(dest),
         }
     }
 }
@@ -943,7 +960,7 @@ impl LengthOrPercentageOrAuto {
                 Ok(LengthOrPercentageOrAuto::Auto),
             Token::Function(ref name) if name.eq_ignore_ascii_case("calc") => {
                 let calc = try!(input.parse_nested_block(CalcLengthOrPercentage::parse_length_or_percentage));
-                Ok(LengthOrPercentageOrAuto::Calc(calc))
+                Ok(LengthOrPercentageOrAuto::Calc(Box::new(calc)))
             },
             _ => Err(())
         }
@@ -965,13 +982,13 @@ impl Parse for LengthOrPercentageOrAuto {
 
 /// TODO(emilio): Do the Length and Percentage variants make any sense with
 /// CalcLengthOrPercentage?
-#[derive(Clone, PartialEq, Copy, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[allow(missing_docs)]
 pub enum LengthOrPercentageOrNone {
     Length(Length),
     Percentage(Percentage),
-    Calc(CalcLengthOrPercentage),
+    Calc(Box<CalcLengthOrPercentage>),
     None,
 }
 
@@ -1008,7 +1025,7 @@ impl LengthOrPercentageOrNone {
                 Ok(LengthOrPercentageOrNone::Length(Length::Absolute(Au(0)))),
             Token::Function(ref name) if name.eq_ignore_ascii_case("calc") => {
                 let calc = try!(input.parse_nested_block(CalcLengthOrPercentage::parse_length_or_percentage));
-                Ok(LengthOrPercentageOrNone::Calc(calc))
+                Ok(LengthOrPercentageOrNone::Calc(Box::new(calc)))
             },
             Token::Ident(ref value) if value.eq_ignore_ascii_case("none") =>
                 Ok(LengthOrPercentageOrNone::None),
@@ -1042,7 +1059,7 @@ pub type LengthOrAuto = Either<Length, Auto>;
 /// `content` keyword.
 ///
 /// TODO(emilio): Do the Length and Percentage variants make any sense with
-#[derive(Clone, PartialEq, Copy, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum LengthOrPercentageOrAutoOrContent {
     /// A `<length>`.
@@ -1050,7 +1067,7 @@ pub enum LengthOrPercentageOrAutoOrContent {
     /// A percentage.
     Percentage(Percentage),
     /// A `calc` node.
-    Calc(CalcLengthOrPercentage),
+    Calc(Box<CalcLengthOrPercentage>),
     /// The `auto` keyword.
     Auto,
     /// The `content` keyword.
@@ -1060,7 +1077,7 @@ pub enum LengthOrPercentageOrAutoOrContent {
 impl HasViewportPercentage for LengthOrPercentageOrAutoOrContent {
     fn has_viewport_percentage(&self) -> bool {
         match *self {
-            LengthOrPercentageOrAutoOrContent::Length(length) => length.has_viewport_percentage(),
+            LengthOrPercentageOrAutoOrContent::Length(ref length) => length.has_viewport_percentage(),
             LengthOrPercentageOrAutoOrContent::Calc(ref calc) => calc.has_viewport_percentage(),
             _ => false
         }
@@ -1070,11 +1087,11 @@ impl HasViewportPercentage for LengthOrPercentageOrAutoOrContent {
 impl ToCss for LengthOrPercentageOrAutoOrContent {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         match *self {
-            LengthOrPercentageOrAutoOrContent::Length(len) => len.to_css(dest),
+            LengthOrPercentageOrAutoOrContent::Length(ref len) => len.to_css(dest),
             LengthOrPercentageOrAutoOrContent::Percentage(perc) => perc.to_css(dest),
             LengthOrPercentageOrAutoOrContent::Auto => dest.write_str("auto"),
             LengthOrPercentageOrAutoOrContent::Content => dest.write_str("content"),
-            LengthOrPercentageOrAutoOrContent::Calc(calc) => calc.to_css(dest),
+            LengthOrPercentageOrAutoOrContent::Calc(ref calc) => calc.to_css(dest),
         }
     }
 }
@@ -1095,7 +1112,7 @@ impl Parse for LengthOrPercentageOrAutoOrContent {
                 Ok(LengthOrPercentageOrAutoOrContent::Content),
             Token::Function(ref name) if name.eq_ignore_ascii_case("calc") => {
                 let calc = try!(input.parse_nested_block(CalcLengthOrPercentage::parse_length_or_percentage));
-                Ok(LengthOrPercentageOrAutoOrContent::Calc(calc))
+                Ok(LengthOrPercentageOrAutoOrContent::Calc(Box::new(calc)))
             },
             _ => Err(())
         }

--- a/components/style/viewport.rs
+++ b/components/style/viewport.rs
@@ -85,7 +85,7 @@ macro_rules! declare_viewport_descriptor_inner {
             fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
                 match *self {
                     $(
-                        ViewportDescriptor::$assigned_variant(val) => {
+                        ViewportDescriptor::$assigned_variant(ref val) => {
                             try!(dest.write_str($assigned_variant_name));
                             try!(dest.write_str(": "));
                             try!(val.to_css(dest));
@@ -121,7 +121,7 @@ trait FromMeta: Sized {
 /// See:
 /// * http://dev.w3.org/csswg/css-device-adapt/#min-max-width-desc
 /// * http://dev.w3.org/csswg/css-device-adapt/#extend-to-zoom
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[allow(missing_docs)]
 pub enum ViewportLength {
@@ -134,7 +134,7 @@ impl ToCss for ViewportLength {
         where W: fmt::Write,
     {
         match *self {
-            ViewportLength::Specified(length) => length.to_css(dest),
+            ViewportLength::Specified(ref length) => length.to_css(dest),
             ViewportLength::ExtendToZoom => write!(dest, "extend-to-zoom"),
         }
     }
@@ -244,11 +244,11 @@ impl ToCss for ViewportDescriptorDeclaration {
     }
 }
 
-fn parse_shorthand(input: &mut Parser) -> Result<[ViewportLength; 2], ()> {
+fn parse_shorthand(input: &mut Parser) -> Result<(ViewportLength, ViewportLength), ()> {
     let min = try!(ViewportLength::parse(input));
     match input.try(|input| ViewportLength::parse(input)) {
-        Err(()) => Ok([min, min]),
-        Ok(max) => Ok([min, max])
+        Err(()) => Ok((min.clone(), min)),
+        Ok(max) => Ok((min, max))
     }
 }
 
@@ -282,8 +282,8 @@ impl<'a, 'b> DeclarationParser for ViewportRuleParser<'a, 'b> {
                 let shorthand = try!(parse_shorthand(input));
                 let important = input.try(parse_important).is_ok();
 
-                Ok(vec![declaration!($min(value: shorthand[0], important: important)),
-                        declaration!($max(value: shorthand[1], important: important))])
+                Ok(vec![declaration!($min(value: shorthand.0, important: important)),
+                        declaration!($max(value: shorthand.1, important: important))])
             }}
         }
 
@@ -631,11 +631,11 @@ impl MaybeNew for ViewportConstraints {
         // collapse the list of declarations into descriptor values
         for declaration in &rule.declarations {
             match declaration.descriptor {
-                ViewportDescriptor::MinWidth(value) => min_width = Some(value),
-                ViewportDescriptor::MaxWidth(value) => max_width = Some(value),
+                ViewportDescriptor::MinWidth(ref value) => min_width = Some(value),
+                ViewportDescriptor::MaxWidth(ref value) => max_width = Some(value),
 
-                ViewportDescriptor::MinHeight(value) => min_height = Some(value),
-                ViewportDescriptor::MaxHeight(value) => max_height = Some(value),
+                ViewportDescriptor::MinHeight(ref value) => min_height = Some(value),
+                ViewportDescriptor::MaxHeight(ref value) => max_height = Some(value),
 
                 ViewportDescriptor::Zoom(value) => initial_zoom = value.to_f32(),
                 ViewportDescriptor::MinZoom(value) => min_zoom = value.to_f32(),
@@ -654,7 +654,7 @@ impl MaybeNew for ViewportConstraints {
                     (None, None) => None,
                     (a, None) => a,
                     (None, b) => b,
-                    (a, b) => Some(a.unwrap().$op(b.unwrap())),
+                    (Some(a), Some(b)) => Some(a.$op(b)),
                 }
             }
         }
@@ -709,14 +709,14 @@ impl MaybeNew for ViewportConstraints {
         macro_rules! to_pixel_length {
             ($value:ident, $dimension:ident, $extend_to:ident => $auto_extend_to:expr) => {
                 if let Some($value) = $value {
-                    match $value {
-                        ViewportLength::Specified(length) => match length {
-                            LengthOrPercentageOrAuto::Length(value) =>
+                    match *$value {
+                        ViewportLength::Specified(ref length) => match *length {
+                            LengthOrPercentageOrAuto::Length(ref value) =>
                                 Some(value.to_computed_value(&context)),
                             LengthOrPercentageOrAuto::Percentage(value) =>
                                 Some(initial_viewport.$dimension.scale_by(value.0)),
                             LengthOrPercentageOrAuto::Auto => None,
-                            LengthOrPercentageOrAuto::Calc(calc) => {
+                            LengthOrPercentageOrAuto::Calc(ref calc) => {
                                 let calc = calc.to_computed_value(&context);
                                 Some(initial_viewport.$dimension.scale_by(calc.percentage()) + calc.length())
                             }

--- a/tests/unit/style/media_queries.rs
+++ b/tests/unit/style/media_queries.rs
@@ -207,7 +207,7 @@ fn test_mq_default_expressions() {
         assert!(q.media_type == MediaQueryType::All, css.to_owned());
         assert!(q.expressions.len() == 1, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
-            ExpressionKind::Width(Range::Min(w)) => assert!(w == specified::Length::Absolute(Au::from_px(100))),
+            ExpressionKind::Width(Range::Min(ref w)) => assert!(*w == specified::Length::Absolute(Au::from_px(100))),
             _ => panic!("wrong expression type"),
         }
     });
@@ -219,7 +219,7 @@ fn test_mq_default_expressions() {
         assert!(q.media_type == MediaQueryType::All, css.to_owned());
         assert!(q.expressions.len() == 1, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
-            ExpressionKind::Width(Range::Max(w)) => assert!(w == specified::Length::Absolute(Au::from_px(43))),
+            ExpressionKind::Width(Range::Max(ref w)) => assert!(*w == specified::Length::Absolute(Au::from_px(43))),
             _ => panic!("wrong expression type"),
         }
     });
@@ -234,7 +234,7 @@ fn test_mq_expressions() {
         assert!(q.media_type == MediaQueryType::Known(MediaType::Screen), css.to_owned());
         assert!(q.expressions.len() == 1, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
-            ExpressionKind::Width(Range::Min(w)) => assert!(w == specified::Length::Absolute(Au::from_px(100))),
+            ExpressionKind::Width(Range::Min(ref w)) => assert!(*w == specified::Length::Absolute(Au::from_px(100))),
             _ => panic!("wrong expression type"),
         }
     });
@@ -246,7 +246,7 @@ fn test_mq_expressions() {
         assert!(q.media_type == MediaQueryType::Known(MediaType::Print), css.to_owned());
         assert!(q.expressions.len() == 1, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
-            ExpressionKind::Width(Range::Max(w)) => assert!(w == specified::Length::Absolute(Au::from_px(43))),
+            ExpressionKind::Width(Range::Max(ref w)) => assert!(*w == specified::Length::Absolute(Au::from_px(43))),
             _ => panic!("wrong expression type"),
         }
     });
@@ -258,7 +258,7 @@ fn test_mq_expressions() {
         assert!(q.media_type == MediaQueryType::Known(MediaType::Print), css.to_owned());
         assert!(q.expressions.len() == 1, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
-            ExpressionKind::Width(Range::Eq(w)) => assert!(w == specified::Length::Absolute(Au::from_px(43))),
+            ExpressionKind::Width(Range::Eq(ref w)) => assert!(*w == specified::Length::Absolute(Au::from_px(43))),
             _ => panic!("wrong expression type"),
         }
     });
@@ -270,7 +270,7 @@ fn test_mq_expressions() {
         assert!(q.media_type == MediaQueryType::Unknown(Atom::from("fridge")), css.to_owned());
         assert!(q.expressions.len() == 1, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
-            ExpressionKind::Width(Range::Max(w)) => assert!(w == specified::Length::Absolute(Au::from_px(52))),
+            ExpressionKind::Width(Range::Max(ref w)) => assert!(*w == specified::Length::Absolute(Au::from_px(52))),
             _ => panic!("wrong expression type"),
         }
     });
@@ -295,11 +295,11 @@ fn test_mq_multiple_expressions() {
         assert!(q.media_type == MediaQueryType::All, css.to_owned());
         assert!(q.expressions.len() == 2, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
-            ExpressionKind::Width(Range::Min(w)) => assert!(w == specified::Length::Absolute(Au::from_px(100))),
+            ExpressionKind::Width(Range::Min(ref w)) => assert!(*w == specified::Length::Absolute(Au::from_px(100))),
             _ => panic!("wrong expression type"),
         }
         match *q.expressions[1].kind_for_testing() {
-            ExpressionKind::Width(Range::Max(w)) => assert!(w == specified::Length::Absolute(Au::from_px(200))),
+            ExpressionKind::Width(Range::Max(ref w)) => assert!(*w == specified::Length::Absolute(Au::from_px(200))),
             _ => panic!("wrong expression type"),
         }
     });
@@ -311,11 +311,11 @@ fn test_mq_multiple_expressions() {
         assert!(q.media_type == MediaQueryType::Known(MediaType::Screen), css.to_owned());
         assert!(q.expressions.len() == 2, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
-            ExpressionKind::Width(Range::Min(w)) => assert!(w == specified::Length::Absolute(Au::from_px(100))),
+            ExpressionKind::Width(Range::Min(ref w)) => assert!(*w == specified::Length::Absolute(Au::from_px(100))),
             _ => panic!("wrong expression type"),
         }
         match *q.expressions[1].kind_for_testing() {
-            ExpressionKind::Width(Range::Max(w)) => assert!(w == specified::Length::Absolute(Au::from_px(200))),
+            ExpressionKind::Width(Range::Max(ref w)) => assert!(*w == specified::Length::Absolute(Au::from_px(200))),
             _ => panic!("wrong expression type"),
         }
     });


### PR DESCRIPTION
For #15061

CalcLOP is a large struct, and gets used quite often. While #15063 reduces its size a bit,
it will still be much larger than any of the other variants in the `specified::Length*` types,
so it will still bloat sizes, especially for specified values that contain many lengths.

This change boxes it in the length types, so that it just takes one word.

r? @heycam

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15065)
<!-- Reviewable:end -->
