### PR TITLE
Update geckolib build-time bindgen build script for recent regex changes.

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -91,7 +91,7 @@ mod bindings {
         added_paths.insert(path);
         // Find all includes and add them recursively
         for cap in INCLUDE_RE.captures_iter(&content) {
-            if let Some(path) = search_include(cap.at(1).unwrap()) {
+            if let Some(path) = search_include(cap.get(1).unwrap().as_str()) {
                 add_headers_recursively(path, added_paths);
             }
         }
@@ -212,7 +212,8 @@ mod bindings {
         }
         let mut result = builder.generate().expect("Unable to generate bindings").to_string();
         for fixup in fixups.iter() {
-            result = Regex::new(&format!(r"\b{}\b", fixup.pat)).unwrap().replace_all(&result, fixup.rep.as_str());
+            result = Regex::new(&format!(r"\b{}\b", fixup.pat)).unwrap().replace_all(&result, fixup.rep.as_str())
+                .into_owned().into();
         }
         File::create(&out_file).unwrap().write_all(&result.into_bytes()).expect("Unable to write output");
     }


### PR DESCRIPTION
`./mach build-geckolib --with-gecko ...` is broken due to regex's API changing a bit.

r? @Manishearth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15069)
<!-- Reviewable:end -->
