### PR TITLE
Disable test-unit on TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ matrix:
       script:
          - ./mach build -d --verbose
          - ./mach test-compiletest
-         - ./mach test-unit
+         # disabled due to #15076
+         #- ./mach test-unit
          # disabled due to #14723
          #- ./mach build-geckolib
          #- ./mach test-stylo


### PR DESCRIPTION
Due to #15076, I want to make sure that the TravisCI status is meaningful as much as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15078)
<!-- Reviewable:end -->
