### PR TITLE
Fix #14497: WeakMediaQueryListVec assumes its contents are still alive

### DIFF
--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -138,7 +138,7 @@ impl WeakMediaQueryListVec {
     /// Evaluate media query lists and report changes
     /// https://drafts.csswg.org/cssom-view/#evaluate-media-queries-and-report-changes
     pub fn evaluate_and_report_changes(&self) {
-        for mql in self.cell.borrow().iter() {
+        self.cell.borrow_mut().update(|mql| {
             let mql = mql.root().unwrap();
             if let MediaQueryListMatchState::Changed(_) = mql.evaluate_changes() {
                 let event = MediaQueryListEvent::new(&mql.global(),
@@ -148,7 +148,7 @@ impl WeakMediaQueryListVec {
                                                      mql.Matches());
                 event.upcast::<Event>().fire(mql.upcast::<EventTarget>());
             }
-        }
+        });
     }
 }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -8576,6 +8576,12 @@
             "url": "/_mozilla/mozilla/localeCompare.html"
           }
         ],
+        "mozilla/media_query_list_gc.html": [
+          {
+            "path": "mozilla/media_query_list_gc.html",
+            "url": "/_mozilla/mozilla/media_query_list_gc.html"
+          }
+        ],
         "mozilla/mime_sniffing_font_context.html": [
           {
             "path": "mozilla/mime_sniffing_font_context.html",

--- a/tests/wpt/mozilla/tests/mozilla/media_query_list_gc.html
+++ b/tests/wpt/mozilla/tests/mozilla/media_query_list_gc.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Should not crash on the resize</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  var mql = matchMedia("(min-width: 1000px)");
+  mql = null;
+  gc();
+  window.resizeBy(1,1);
+})
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
First time contributor here. Noticed this issue is easily solved, so I did it. I am very unsure about how things work here: Is a test needed? What should it look like? Should the "unwrap" be avoided (making bigger changes to the code)?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14497  (github issue number if applicable).

- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15083)
<!-- Reviewable:end -->
