### PR TITLE
Ensure FrameState consistency

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2033,9 +2033,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
 
                 debug_assert_eq!(entry.instant, curr_entry.instant);
 
-                frame.pipeline_id = pipeline_id;
-                frame.instant = entry.instant;
-                frame.url = entry.url.clone();
+                frame.update_current(pipeline_id, &entry);
 
                 old_pipeline_id
             },
@@ -2130,7 +2128,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         let (evicted_id, new_frame, clear_future, location_changed) = if let Some(mut entry) = frame_change.replace {
             debug!("Replacing pipeline in existing frame.");
             let evicted_id = entry.pipeline_id;
-            entry.pipeline_id = Some(frame_change.new_pipeline_id);
+            entry.replace_pipeline(frame_change.new_pipeline_id, frame_change.url.clone());
             self.traverse_to_entry(entry);
             (evicted_id, false, false, false)
         } else if let Some(frame) = self.frames.get_mut(&frame_change.frame_id) {

--- a/components/constellation/frame.rs
+++ b/components/constellation/frame.rs
@@ -76,6 +76,13 @@ impl Frame {
     pub fn remove_forward_entries(&mut self) -> Vec<FrameState> {
         replace(&mut self.next, vec!())
     }
+
+    /// Update the current entry of the Frame from an entry that has been traversed to.
+    pub fn update_current(&mut self, pipeline_id: PipelineId, entry: &FrameState) {
+        self.pipeline_id = pipeline_id;
+        self.instant = entry.instant;
+        self.url = entry.url.clone();
+    }
 }
 
 /// An entry in a frame's session history.
@@ -97,6 +104,15 @@ pub struct FrameState {
 
     /// The frame that this session history entry is part of
     pub frame_id: FrameId,
+}
+
+impl FrameState {
+    /// Updates the entry's pipeline and url. This is used when navigating with replacement
+    /// enabled.
+    pub fn replace_pipeline(&mut self, pipeline_id: PipelineId, url: ServoUrl) {
+        self.pipeline_id = Some(pipeline_id);
+        self.url = url;
+    }
 }
 
 /// Represents a pending change in the frame tree, that will be applied


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
As we begin to add more state to `FrameState`, we need to make sure that when we do replacements and when we finish traversals that the state is properly updated. This also fixes an issue where we were not updating the `url` of the `FrameState` when navigating with replacement enabled (I wonder if it would be possible to write a test to detect this. The url only matters when reloading a document after it was discarded by the max session history).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15091)
<!-- Reviewable:end -->
