### PR TITLE
WPT tests now show debug ouput for passing tests as well

### DIFF
--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -31,7 +31,11 @@ def run_tests(paths=None, **kwargs):
 
     mozlog.commandline.log_formatters["servo"] = \
         (grouping_formatter.GroupingFormatter, "A grouping output formatter")
-    wptrunner.setup_logging(kwargs, {"servo": sys.stdout})
+
+    if len(kwargs["test_list"]) == 1:
+        wptrunner.setup_logging(kwargs, {"mach": sys.stdout})
+    else:
+        wptrunner.setup_logging(kwargs, {"servo": sys.stdout})
 
     success = wptrunner.run_tests(**kwargs)
     return 0 if success else 1


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix (partially) #12808 
<!-- Either: -->

@jdm I thought it would be better to make a PR for my local changes anyway, since you wanted it :)
<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15124)
<!-- Reviewable:end -->
