### PR TITLE
Refactor to send iframe resize messages directly from layout thread to constellation

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -343,15 +343,13 @@ fn initialize_png(width: usize, height: usize) -> RenderTargetInfo {
 
 struct RenderNotifier {
     compositor_proxy: Box<CompositorProxy>,
-    constellation_chan: Sender<ConstellationMsg>,
 }
 
 impl RenderNotifier {
     fn new(compositor_proxy: Box<CompositorProxy>,
-           constellation_chan: Sender<ConstellationMsg>) -> RenderNotifier {
+           _: Sender<ConstellationMsg>) -> RenderNotifier {
         RenderNotifier {
             compositor_proxy: compositor_proxy,
-            constellation_chan: constellation_chan,
         }
     }
 }
@@ -366,16 +364,8 @@ impl webrender_traits::RenderNotifier for RenderNotifier {
     }
 
     fn pipeline_size_changed(&mut self,
-                             pipeline_id: webrender_traits::PipelineId,
-                             size: Option<webrender_traits::LayoutSize>) {
-        let pipeline_id = pipeline_id.from_webrender();
-
-        if let Some(size) = size {
-            let msg = ConstellationMsg::FrameSize(pipeline_id, size.to_untyped());
-            if let Err(e) = self.constellation_chan.send(msg) {
-                warn!("Compositor resize to constellation failed ({}).", e);
-            }
-        }
+                             _: webrender_traits::PipelineId,
+                             _: Option<webrender_traits::LayoutSize>) {
     }
 }
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -817,12 +817,6 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                 debug!("constellation exiting");
                 self.handle_exit();
             }
-            // The compositor discovered the size of a subframe. This needs to be reflected by all
-            // frame trees in the navigation context containing the subframe.
-            FromCompositorMsg::FrameSize(pipeline_id, size) => {
-                debug!("constellation got frame size message");
-                self.handle_frame_size_msg(pipeline_id, &TypedSize2D::from_untyped(&size));
-            }
             FromCompositorMsg::GetFrame(pipeline_id, resp_chan) => {
                 debug!("constellation got get root pipeline message");
                 self.handle_get_frame(pipeline_id, resp_chan);
@@ -1089,6 +1083,12 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             FromLayoutMsg::ChangeRunningAnimationsState(pipeline_id, animation_state) => {
                 self.handle_change_running_animations_state(pipeline_id, animation_state)
             }
+            // Layout sends new sizes for all subframes. This needs to be reflected by all
+            // frame trees in the navigation context containing the subframe.
+            FromLayoutMsg::FrameSizes(iframe_sizes) => {
+                debug!("constellation got frame size message");
+                self.handle_frame_size_msg(iframe_sizes);
+            }
             FromLayoutMsg::SetCursor(cursor) => {
                 self.handle_set_cursor_msg(cursor)
             }
@@ -1327,30 +1327,27 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
     }
 
     fn handle_frame_size_msg(&mut self,
-                             pipeline_id: PipelineId,
-                             size: &TypedSize2D<f32, PagePx>) {
-        let msg = ConstellationControlMsg::Resize(pipeline_id, WindowSizeData {
-            visible_viewport: *size,
-            initial_viewport: *size * ScaleFactor::new(1.0),
-            device_pixel_ratio: self.window_size.device_pixel_ratio,
-        }, WindowSizeType::Initial);
-
-        // Store the new rect inside the pipeline
-        let result = {
-            // Find the pipeline that corresponds to this rectangle. It's possible that this
-            // pipeline may have already exited before we process this message, so just
-            // early exit if that occurs.
-            match self.pipelines.get_mut(&pipeline_id) {
+                             iframe_sizes: Vec<(PipelineId, TypedSize2D<f32, PagePx>)>) {
+        for (pipeline_id, size) in iframe_sizes {
+            let result = match self.pipelines.get_mut(&pipeline_id) {
                 Some(pipeline) => {
-                    pipeline.size = Some(*size);
-                    pipeline.event_loop.send(msg)
+                    if pipeline.size != Some(size) {
+                        pipeline.size = Some(size);
+                        let msg = ConstellationControlMsg::Resize(pipeline_id, WindowSizeData {
+                            visible_viewport: size,
+                            initial_viewport: size * ScaleFactor::new(1.0),
+                            device_pixel_ratio: self.window_size.device_pixel_ratio,
+                        }, WindowSizeType::Initial);
+                        Some(pipeline.event_loop.send(msg))
+                    } else {
+                        None
+                    }
                 }
-                None => return,
+                None => None
+            };
+            if let Some(Err(e)) = result {
+                self.handle_send_error(pipeline_id, e);
             }
-        };
-
-        if let Err(e) = result {
-            self.handle_send_error(pipeline_id, e);
         }
     }
 

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -934,6 +934,17 @@ impl LayoutThread {
                         let origin = Rect::new(Point2D::new(Au(0), Au(0)), root_size);
                         build_state.root_stacking_context.bounds = origin;
                         build_state.root_stacking_context.overflow = origin;
+
+                        if !build_state.iframe_sizes.is_empty() {
+                            // build_state.iframe_sizes is only used here, so its okay to replace
+                            // it with an empty vector
+                            let iframe_sizes = std::mem::replace(&mut build_state.iframe_sizes, vec![]);
+                            let msg = ConstellationMsg::FrameSizes(iframe_sizes);
+                            if let Err(e) = self.constellation_chan.send(msg) {
+                                warn!("Layout resize to constellation failed ({}).", e);
+                            }
+                        }
+
                         rw_data.display_list = Some(Arc::new(build_state.to_display_list()));
                     }
                     (ReflowGoal::ForScriptQuery, false) => {}

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -691,8 +691,6 @@ pub enum WebDriverCommandMsg {
 pub enum ConstellationMsg {
     /// Exit the constellation.
     Exit,
-    /// Inform the constellation of the size of the viewport.
-    FrameSize(PipelineId, Size2D<f32>),
     /// Request that the constellation send the FrameId corresponding to the document
     /// with the provided pipeline id
     GetFrame(PipelineId, IpcSender<Option<FrameId>>),

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -15,7 +15,7 @@ use WorkerScriptLoadOrigin;
 use canvas_traits::CanvasMsg;
 use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
 use euclid::point::Point2D;
-use euclid::size::Size2D;
+use euclid::size::{Size2D, TypedSize2D};
 use gfx_traits::ScrollRootId;
 use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::{FrameId, PipelineId, TraversalDirection};
@@ -24,6 +24,7 @@ use net_traits::CoreResourceMsg;
 use net_traits::storage_thread::StorageType;
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use servo_url::ServoUrl;
+use style_traits::PagePx;
 use style_traits::cursor::Cursor;
 use style_traits::viewport::ViewportConstraints;
 
@@ -32,6 +33,8 @@ use style_traits::viewport::ViewportConstraints;
 pub enum LayoutMsg {
     /// Indicates whether this pipeline is currently running animations.
     ChangeRunningAnimationsState(PipelineId, AnimationState),
+    /// Inform the constellation of the size of the pipeline's viewport.
+    FrameSizes(Vec<(PipelineId, TypedSize2D<f32, PagePx>)>),
     /// Requests that the constellation inform the compositor of the a cursor change.
     SetCursor(Cursor),
     /// Notifies the constellation that the viewport has been constrained in some manner


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14682.
<!-- Either: -->

r? @jdm 
passing tests: 
tests/wpt/mozilla/tests/css/matchMedia.html, tests/wpt/mozilla/tests/mozilla/window_resize_not_triggered_on_load.html, tests/wpt/mozilla/tests/mozilla/iframe/resize_after_load.html, tests/wpt/mozilla/tests/css/meta_viewport_resize.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15129)
<!-- Reviewable:end -->
