### PR TITLE
add font-stretch to font shorthand sub-property

### DIFF
--- a/components/style/properties/shorthand/font.mako.rs
+++ b/components/style/properties/shorthand/font.mako.rs
@@ -4,21 +4,22 @@
 
 <%namespace name="helpers" file="/helpers.mako.rs" />
 
-<%helpers:shorthand name="font" sub_properties="font-style font-variant font-weight
+<%helpers:shorthand name="font" sub_properties="font-style font-variant font-weight font-stretch
                                                 font-size line-height font-family"
                     spec="https://drafts.csswg.org/css-fonts-3/#propdef-font">
-    use properties::longhands::{font_style, font_variant, font_weight, font_size,
-                                line_height, font_family};
+    use properties::longhands::{font_style, font_variant, font_weight, font_stretch};
+    use properties::longhands::{font_size, line_height, font_family};
 
     pub fn parse_value(context: &ParserContext, input: &mut Parser) -> Result<Longhands, ()> {
         let mut nb_normals = 0;
         let mut style = None;
         let mut variant = None;
         let mut weight = None;
+        let mut stretch = None;
         let size;
         loop {
             // Special-case 'normal' because it is valid in each of
-            // font-style, font-weight and font-variant.
+            // font-style, font-weight, font-variant and font-stretch.
             // Leaves the values to None, 'normal' is the initial value for each of them.
             if input.try(|input| input.expect_ident_matching("normal")).is_ok() {
                 nb_normals += 1;
@@ -42,6 +43,12 @@
                     continue
                 }
             }
+            if stretch.is_none() {
+                if let Ok(value) = input.try(|input| font_stretch::parse(context, input)) {
+                    stretch = Some(value);
+                    continue
+                }
+            }
             size = Some(try!(font_size::parse(context, input)));
             break
         }
@@ -49,7 +56,7 @@
         fn count<T>(opt: &Option<T>) -> u8 {
             if opt.is_some() { 1 } else { 0 }
         }
-        if size.is_none() || (count(&style) + count(&weight) + count(&variant) + nb_normals) > 3 {
+        if size.is_none() || (count(&style) + count(&weight) + count(&variant) + count(&stretch) + nb_normals) > 4 {
             return Err(())
         }
         let line_height = if input.try(|input| input.expect_delim('/')).is_ok() {
@@ -62,6 +69,7 @@
             font_style: style,
             font_variant: variant,
             font_weight: weight,
+            font_stretch: stretch,
             font_size: size,
             line_height: line_height,
             font_family: Some(font_family::SpecifiedValue(family))
@@ -83,6 +91,11 @@
 
             if let DeclaredValue::Value(ref weight) = *self.font_weight {
                 try!(weight.to_css(dest));
+                try!(write!(dest, " "));
+            }
+
+            if let DeclaredValue::Value(ref stretch) = *self.font_stretch {
+                try!(stretch.to_css(dest));
                 try!(write!(dest, " "));
             }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Add `font-stretch` sub-property to font shorthand

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15027 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15134)
<!-- Reviewable:end -->
