### PR TITLE
Allow running servo in software rendering mode from ./mach run

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -25,7 +25,7 @@ from mach.decorators import (
 from servo.command_base import (
     CommandBase,
     call, check_call,
-    is_windows, is_macosx, set_osmesa_env,
+    is_linux, is_windows, is_macosx, set_osmesa_env,
     get_browserhtml_path,
 )
 
@@ -59,11 +59,13 @@ class PostBuildCommands(CommandBase):
                      help='Launch with Browser.html')
     @CommandArgument('--headless', '-z', action='store_true',
                      help='Launch in headless mode')
+    @CommandArgument('--software', '-s', action='store_true',
+                     help='Launch with software rendering')
     @CommandArgument(
         'params', nargs='...',
         help="Command-line arguments to be passed through to Servo")
     def run(self, params, release=False, dev=False, android=None, debug=False, debugger=None, browserhtml=False,
-            headless=False):
+            headless=False, software=False):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 
@@ -114,6 +116,13 @@ class PostBuildCommands(CommandBase):
         if headless:
             set_osmesa_env(args[0], env)
             args.append('-z')
+
+        if software:
+            if not is_linux():
+                print("Software rendering is only supported on Linux at the moment.")
+                return
+
+            env['LIBGL_ALWAYS_SOFTWARE'] = "1"
 
         # Borrowed and modified from:
         # http://hg.mozilla.org/mozilla-central/file/c9cfa9b91dea/python/mozbuild/mozbuild/mach_commands.py#l883


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This adds a flag to ./mach run to use software rendering on Linux (through the LIBGL_ALWAYS_SOFTWARE env var).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14982.

<!-- Either: -->
- [X] These changes do not require tests because like said in the issue "There's no way to add automated tests for this".
<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15138)
<!-- Reviewable:end -->
