### PR TITLE
Properly cancel event when beforeunload handler returns null

### DIFF
--- a/components/script/dom/beforeunloadevent.rs
+++ b/components/script/dom/beforeunloadevent.rs
@@ -15,6 +15,7 @@ use dom::bindings::str::DOMString;
 use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::window::Window;
 use servo_atoms::Atom;
+use std::cell::Ref;
 
 // https://html.spec.whatwg.org/multipage/#beforeunloadevent
 #[dom_struct]
@@ -48,6 +49,10 @@ impl BeforeUnloadEvent {
                              bool::from(cancelable));
         }
         ev
+    }
+
+    pub fn return_value(&self) -> Ref<DOMString> {
+        self.return_value.borrow()
     }
 }
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -178,20 +178,12 @@ impl CompiledEventListener {
                     }
 
                     CommonEventHandler::BeforeUnloadEventHandler(ref handler) => {
-                        if let Some(event) = event.downcast::<BeforeUnloadEvent>() {
-                            let rv = event.ReturnValue();
-
-                            if let Ok(value) = handler.Call_(object,
-                                                             event.upcast::<Event>(),
-                                                             exception_handle) {
-                                match value {
-                                    Some(value) => {
-                                        if rv.is_empty() {
-                                            event.SetReturnValue(value);
-                                        }
-                                    }
-                                    None => {
-                                        event.upcast::<Event>().PreventDefault();
+                        if let Ok(value) = handler.Call_(object, event, exception_handle) {
+                            if let Some(before_unload_event) = event.downcast::<BeforeUnloadEvent>() {
+                                if let Some(return_value) = value {
+                                    event.PreventDefault();
+                                    if before_unload_event.return_value().is_empty() {
+                                        before_unload_event.SetReturnValue(return_value);
                                     }
                                 }
                             }

--- a/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-processing-algorithm.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-processing-algorithm.html.ini
@@ -1,6 +1,0 @@
-[event-handler-processing-algorithm.html]
-  type: testharness
-  [beforeunload listener returning null cancels event]
-    bug: https://github.com/servo/servo/issues/10787
-    expected: FAIL
-


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15142)
<!-- Reviewable:end -->
