### PR TITLE
Prevent crashing when a link tag has two or more in-flight requests (fix for issue #15101)

### DIFF
--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -37,6 +37,15 @@ use stylesheet_loader::{StylesheetLoader, StylesheetContextSource, StylesheetOwn
 
 unsafe_no_jsmanaged_fields!(Stylesheet);
 
+#[derive(JSTraceable, PartialEq, Clone, Copy, HeapSizeOf)]
+pub struct RequestGenerationId(u32);
+
+impl RequestGenerationId {
+    fn increment(self) -> RequestGenerationId {
+        RequestGenerationId(self.0 + 1)
+    }
+}
+
 #[dom_struct]
 pub struct HTMLLinkElement {
     htmlelement: HTMLElement,
@@ -52,6 +61,8 @@ pub struct HTMLLinkElement {
     pending_loads: Cell<u32>,
     /// Whether any of the loads have failed.
     any_failed_load: Cell<bool>,
+    /// A monotonically increasing counter that keeps track of which stylesheet to apply.
+    request_generation_id: Cell<RequestGenerationId>,
 }
 
 impl HTMLLinkElement {
@@ -65,6 +76,7 @@ impl HTMLLinkElement {
             cssom_stylesheet: MutNullableJS::new(None),
             pending_loads: Cell::new(0),
             any_failed_load: Cell::new(false),
+            request_generation_id: Cell::new(RequestGenerationId(0)),
         }
     }
 
@@ -78,11 +90,14 @@ impl HTMLLinkElement {
                            HTMLLinkElementBinding::Wrap)
     }
 
-    pub fn set_stylesheet(&self, s: Arc<Stylesheet>) {
-        assert!(self.stylesheet.borrow().is_none());
-        *self.stylesheet.borrow_mut() = Some(s);
+    pub fn get_request_generation_id(&self) -> RequestGenerationId {
+        self.request_generation_id.get()
     }
 
+    pub fn set_stylesheet(&self, s: Arc<Stylesheet>) {
+        assert!(self.stylesheet.borrow().is_none()); // Useful for catching timing issues.
+        *self.stylesheet.borrow_mut() = Some(s);
+    }
 
     pub fn get_stylesheet(&self) -> Option<Arc<Stylesheet>> {
         self.stylesheet.borrow().clone()
@@ -259,6 +274,8 @@ impl HTMLLinkElement {
             Some(ref value) => &***value,
             None => "",
         };
+
+        self.request_generation_id.set(self.request_generation_id.get().increment());
 
         // TODO: #8085 - Don't load external stylesheets if the node's mq
         // doesn't match.

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -8750,6 +8750,18 @@
             "url": "/_mozilla/mozilla/node_replaceChild.html"
           }
         ],
+        "mozilla/out-of-order-stylesheet-loads-and-imports.html": [
+          {
+            "path": "mozilla/out-of-order-stylesheet-loads-and-imports.html",
+            "url": "/_mozilla/mozilla/out-of-order-stylesheet-loads-and-imports.html"
+          }
+        ],
+        "mozilla/out-of-order-stylesheet-loads.html": [
+          {
+            "path": "mozilla/out-of-order-stylesheet-loads.html",
+            "url": "/_mozilla/mozilla/out-of-order-stylesheet-loads.html"
+          }
+        ],
         "mozilla/parentNode_querySelector.html": [
           {
             "path": "mozilla/parentNode_querySelector.html",

--- a/tests/wpt/mozilla/tests/mozilla/out-of-order-stylesheet-loads-and-imports.html
+++ b/tests/wpt/mozilla/tests/mozilla/out-of-order-stylesheet-loads-and-imports.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Out-of-order stylesheet loads for the same element happen correctly, even with imports (issue #15101)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(function(t) {
+  var link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "resources/imports-background-red.css?pipe=trickle(d3)";
+  document.head.appendChild(link);
+  link.href = "resources/imports-background-green.css";
+  t.step_timeout(function() {
+    assert_equals(getComputedStyle(document.body).getPropertyValue("background-color"), "rgb(0, 128, 0)");
+    t.done();
+  }, 4000);
+}, "out-of-order stylesheet loads for the same element happen correctly, even with imports");
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/out-of-order-stylesheet-loads.html
+++ b/tests/wpt/mozilla/tests/mozilla/out-of-order-stylesheet-loads.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Out-of-order stylesheet loads for the same element happen correctly (issue #15101)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(function(t) {
+  var link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "resources/background-red.css?pipe=trickle(d3)";
+  document.head.appendChild(link);
+  link.href = "resources/background-green.css";
+  t.step_timeout(function() {
+    assert_equals(getComputedStyle(document.body).getPropertyValue("background-color"), "rgb(0, 128, 0)");
+    t.done();
+  }, 4000);
+}, "out-of-order stylesheet loads for the same element happen correctly");
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/resources/background-green.css
+++ b/tests/wpt/mozilla/tests/mozilla/resources/background-green.css
@@ -1,0 +1,3 @@
+body {
+  background-color: green;
+}

--- a/tests/wpt/mozilla/tests/mozilla/resources/background-red.css
+++ b/tests/wpt/mozilla/tests/mozilla/resources/background-red.css
@@ -1,0 +1,3 @@
+body {
+  background-color: red;
+}

--- a/tests/wpt/mozilla/tests/mozilla/resources/imports-background-green.css
+++ b/tests/wpt/mozilla/tests/mozilla/resources/imports-background-green.css
@@ -1,0 +1,1 @@
+@import url("background-green.css");

--- a/tests/wpt/mozilla/tests/mozilla/resources/imports-background-red.css
+++ b/tests/wpt/mozilla/tests/mozilla/resources/imports-background-red.css
@@ -1,0 +1,1 @@
+@import url("background-red.css");


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The `HTMLLinkElement::set_stylesheet` function now checks whether there already is a stylesheet, and if there is, calls `Document::invalidate_stylesheets` after modifying `self.stylesheet`.

This PR also includes a minimal WPT that causes the panic.

This is fundamentally a timing issue, so while this fix prevents the crash, it does not fix the underlying issue. Making a &lt;link&gt; element send a second request before the first can finish and then getting the two stylesheet responses out-of-order will apply the wrong stylesheet, as demonstrated with https://gist.github.com/SwagColoredKitteh/2c24c7fac635445042eda4a30e10420e.

r? @emilio

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15101 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15145)
<!-- Reviewable:end -->
