### PR TITLE
Added compiletest to verify TrustedPromise does not implement Clone

### DIFF
--- a/components/script/test.rs
+++ b/components/script/test.rs
@@ -9,6 +9,7 @@ pub use dom::headers::normalize_value;
 pub use dom::bindings::cell::DOMRefCell;
 pub use dom::bindings::js::JS;
 pub use dom::node::Node;
+pub use dom::bindings::refcounted::TrustedPromise;
 
 pub mod area {
     pub use dom::htmlareaelement::{Area, Shape};

--- a/tests/compiletest/plugin/compile-fail/trustedpromise_mustnot_deriveclone.rs
+++ b/tests/compiletest/plugin/compile-fail/trustedpromise_mustnot_deriveclone.rs
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![feature(plugin)]
+#![plugin(plugins)]
+
+extern crate script;
+
+use script::test::TrustedPromise;
+
+fn cloneable<T: Clone>() {
+}
+
+fn main() {
+    cloneable::<TrustedPromise>();
+    //~^ ERROR the trait bound `script::test::TrustedPromise: std::clone::Clone` is not satisfied
+}


### PR DESCRIPTION
As per issue: https://github.com/servo/servo/issues/14500

I have added a test to ensure that TrustedPromise does not implement Clone. 

This is my first PR to the project, so feedback in terms of both code and the actual PR would be very welcome.

Thanks,
Verlet64

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14500
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15146)
<!-- Reviewable:end -->
