### PR TITLE
Add a testcase for escaping script element contents

### DIFF
--- a/tests/wpt/web-platform-tests/html/syntax/serializing-html-fragments/serializing.html
+++ b/tests/wpt/web-platform-tests/html/syntax/serializing-html-fragments/serializing.html
@@ -25,6 +25,7 @@
 <span>&quot;</span>
 <span><style><&></style></span>
 <span><script type="test"><&></script></span>
+<script type="test"><&></script>
 <span><xmp><&></xmp></span>
 <span><iframe><&></iframe></span>
 <span><noembed><&></noembed></span>
@@ -58,6 +59,7 @@ var expected = [
 ["\"", "<span>\"</span>"],
 ["<style><&></style>", "<span><style><&></style></span>"],
 ["<script type=\"test\"><&><\/script>", "<span><script type=\"test\"><&><\/script></span>"],
+["<script type=\"test\"><&><\/script>", "<script type=\"test\"><&><\/script>"],
 ["<xmp><&></xmp>", "<span><xmp><&></xmp></span>"],
 ["<iframe><&></iframe>", "<span><iframe><&></iframe></span>"],
 ["<noembed><&></noembed>", "<span><noembed><&></noembed></span>"],

--- a/tests/wpt/web-platform-tests/html/syntax/serializing-html-fragments/serializing.html
+++ b/tests/wpt/web-platform-tests/html/syntax/serializing-html-fragments/serializing.html
@@ -25,7 +25,7 @@
 <span>&quot;</span>
 <span><style><&></style></span>
 <span><script type="test"><&></script></span>
-<script type="test"><&></script>
+<script><&></script>
 <span><xmp><&></xmp></span>
 <span><iframe><&></iframe></span>
 <span><noembed><&></noembed></span>
@@ -59,7 +59,7 @@ var expected = [
 ["\"", "<span>\"</span>"],
 ["<style><&></style>", "<span><style><&></style></span>"],
 ["<script type=\"test\"><&><\/script>", "<span><script type=\"test\"><&><\/script></span>"],
-["<script type=\"test\"><&><\/script>", "<script type=\"test\"><&><\/script>"],
+["<script><&><\/script>", "<&>"],
 ["<xmp><&></xmp>", "<span><xmp><&></xmp></span>"],
 ["<iframe><&></iframe>", "<span><iframe><&></iframe></span>"],
 ["<noembed><&></noembed>", "<span><noembed><&></noembed></span>"],

--- a/tests/wpt/web-platform-tests/html/syntax/serializing-html-fragments/serializing.html
+++ b/tests/wpt/web-platform-tests/html/syntax/serializing-html-fragments/serializing.html
@@ -59,7 +59,7 @@ var expected = [
 ["\"", "<span>\"</span>"],
 ["<style><&></style>", "<span><style><&></style></span>"],
 ["<script type=\"test\"><&><\/script>", "<span><script type=\"test\"><&><\/script></span>"],
-["<script><&><\/script>", "<&>"],
+["<&>", "<script><&><\/script>"],
 ["<xmp><&></xmp>", "<span><xmp><&></xmp></span>"],
 ["<iframe><&></iframe>", "<span><iframe><&></iframe></span>"],
 ["<noembed><&></noembed>", "<span><noembed><&></noembed></span>"],


### PR DESCRIPTION
…innerHTML on a script tag escapes tag characters". I'm honestly unsure if it does this correctly, but learning by doing and all that....

<!-- Please describe your changes on the following line: -->
Added new item to the test elements: <script type="test"><&></script>
and a corresponding item to the "expected" list: ["<script type=\"test\"><&><\/script>", "<script type=\"test\"><&><\/script>"]

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes test #14975 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it is a test

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15148)
<!-- Reviewable:end -->
