### PR TITLE
Bug 1332969: stylo: Synchronously do a style update when the device changes

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -685,7 +685,7 @@ pub extern "C" fn Servo_StyleSet_Init(pres_context: RawGeckoPresContextOwned)
 #[no_mangle]
 pub extern "C" fn Servo_StyleSet_RebuildData(raw_data: RawServoStyleSetBorrowed) {
     let mut data = PerDocumentStyleData::from_ffi(raw_data).borrow_mut();
-    data.device_changed = true;
+    data.reset_device();
 }
 
 #[no_mangle]


### PR DESCRIPTION
Ideally this would be lazy, but eventually we're going to need to restyle in
RebuildAllStyleData anyway, which would require us to have the style up to date,
so no need to complicate our lives.

r? @heycam or @upsuper or @bholley

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15157)
<!-- Reviewable:end -->
