### PR TITLE
Correct serialization of column-rule shorthand

### DIFF
--- a/components/style/properties/shorthand/column.mako.rs
+++ b/components/style/properties/shorthand/column.mako.rs
@@ -101,7 +101,6 @@
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             let mut need_space = false;
-            try!(self.column_rule_width.to_css(dest));
 
             if let DeclaredValue::Value(ref width) = *self.column_rule_width {
                 try!(width.to_css(dest));


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15170)
<!-- Reviewable:end -->
