### PR TITLE
make -webkit-text-stroke color and width shorthand no longer sensitive to ordering

### DIFF
--- a/components/style/properties/shorthand/inherited_text.mako.rs
+++ b/components/style/properties/shorthand/inherited_text.mako.rs
@@ -76,25 +76,34 @@
         use values::specified::{BorderWidth, Length};
         use app_units::Au;
 
-        let (mut color, mut width, mut any) = (None, None, false);
-        % for value in "color width".split():
-            if ${value}.is_none() {
-                if let Ok(value) = input.try(|input| _webkit_text_stroke_${value}::parse(context, input)) {
-                    ${value} = Some(value);
-                    any = true;
+        let mut color = None;
+        let mut width = None;
+        loop {
+            if color.is_none() {
+                if let Ok(value) = input.try(|input| _webkit_text_stroke_color::parse(context, input)) {
+                    color = Some(value);
+                    continue
                 }
             }
-        % endfor
 
-        if !any {
-            return Err(());
+            if width.is_none() {
+                if let Ok(value) = input.try(|input| _webkit_text_stroke_width::parse(context, input)) {
+                    width = Some(value);
+                    continue
+                }
+            }
+            break
         }
 
-        Ok(Longhands {
-            _webkit_text_stroke_color: color.or(Some(CSSColor { parsed: CSSParserColor::CurrentColor,
-                                                                authored: None })),
-            _webkit_text_stroke_width: width.or(Some(BorderWidth::from_length(Length::Absolute(Au::from_px(0))))),
-        })
+        if color.is_some() || width.is_some() {
+            Ok(Longhands {
+                _webkit_text_stroke_color: color.or(Some(CSSColor { parsed: CSSParserColor::CurrentColor,
+                    authored: None })),
+                _webkit_text_stroke_width: width.or(Some(BorderWidth::from_length(Length::Absolute(Au::from_px(0))))),
+            })
+        } else {
+            Err(())
+        }
     }
 
     impl<'a> LonghandsToSerialize<'a>  {

--- a/tests/unit/style/parsing/inherited_text.rs
+++ b/tests/unit/style/parsing/inherited_text.rs
@@ -78,3 +78,26 @@ fn test_text_emphasis_position() {
     let left_under = parse_longhand!(text_emphasis_position, "left under");
     assert_eq!(left_under, SpecifiedValue(HorizontalWritingModeValue::Under, VerticalWritingModeValue::Left));
 }
+
+
+#[test]
+fn webkit_text_stroke_shorthand_should_parse_properly() {
+    use style::properties::longhands::_webkit_text_stroke_color;
+    use style::properties::longhands::_webkit_text_stroke_width;
+    use style::properties::shorthands::_webkit_text_stroke;
+    use media_queries::CSSErrorReporterTest;
+    use servo_url::ServoUrl;
+    let url = ServoUrl::parse("http://localhost").unwrap();
+    let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+
+    let mut parser = Parser::new("thin red");
+    let result = _webkit_text_stroke::parse_value(&context, &mut parser).unwrap();
+    assert_eq!(result._webkit_text_stroke_color.unwrap(), parse_longhand!(_webkit_text_stroke_color, "red"));
+    assert_eq!(result._webkit_text_stroke_width.unwrap(), parse_longhand!(_webkit_text_stroke_width, "thin"));
+
+    // ensure its no longer sensitive to order
+    let mut parser = Parser::new("red thin");
+    let result = _webkit_text_stroke::parse_value(&context, &mut parser).unwrap();
+    assert_eq!(result._webkit_text_stroke_color.unwrap(), parse_longhand!(_webkit_text_stroke_color, "red"));
+    assert_eq!(result._webkit_text_stroke_width.unwrap(), parse_longhand!(_webkit_text_stroke_width, "thin"));
+}

--- a/tests/unit/style/parsing/inherited_text.rs
+++ b/tests/unit/style/parsing/inherited_text.rs
@@ -82,11 +82,12 @@ fn test_text_emphasis_position() {
 
 #[test]
 fn webkit_text_stroke_shorthand_should_parse_properly() {
+    use media_queries::CSSErrorReporterTest;
+    use servo_url::ServoUrl;
     use style::properties::longhands::_webkit_text_stroke_color;
     use style::properties::longhands::_webkit_text_stroke_width;
     use style::properties::shorthands::_webkit_text_stroke;
-    use media_queries::CSSErrorReporterTest;
-    use servo_url::ServoUrl;
+
     let url = ServoUrl::parse("http://localhost").unwrap();
     let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
this makes `-webkit-text-stroke` shorthand work with line-width and color in either order. 

I added a shorthand parser test to the existing inherited_text test, which wasn't very similar to any of the other tests in there, hope sticking shorthand below the longhand stuff is ok.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15165 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15174)
<!-- Reviewable:end -->
