### PR TITLE
Implement microtask checkpoints

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -230,17 +230,23 @@ impl DedicatedWorkerGlobalScope {
             }
 
             {
-                let _ar = AutoWorkerReset::new(&global, worker);
+                let _ar = AutoWorkerReset::new(&global, worker.clone());
                 scope.execute_script(DOMString::from(source));
             }
 
             let reporter_name = format!("dedicated-worker-reporter-{}", random::<u64>());
             scope.upcast::<GlobalScope>().mem_profiler_chan().run_with_memory_reporting(|| {
+                // https://html.spec.whatwg.org/multipage/#event-loop-processing-model
+                // Step 1
                 while let Ok(event) = global.receive_event() {
                     if scope.is_closing() {
                         break;
                     }
+                    // Step 3
                     global.handle_event(event);
+                    // Step 6
+                    let _ar = AutoWorkerReset::new(&global, worker.clone());
+                    global.upcast::<WorkerGlobalScope>().perform_a_microtask_checkpoint();
                 }
             }, reporter_name, parent_sender, CommonScriptMsg::CollectReports);
         }).expect("Thread spawning failed");

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -29,10 +29,11 @@ use js::jsapi::{JS_GetObjectRuntime, MutableHandleValue};
 use js::panic::maybe_resume_unwind;
 use js::rust::{CompileOptionsWrapper, Runtime, get_object_class};
 use libc;
+use microtask::Microtask;
 use msg::constellation_msg::PipelineId;
 use net_traits::{CoreResourceThread, ResourceThreads, IpcSend};
 use profile_traits::{mem, time};
-use script_runtime::{CommonScriptMsg, EnqueuedPromiseCallback, ScriptChan, ScriptPort};
+use script_runtime::{CommonScriptMsg, ScriptChan, ScriptPort};
 use script_thread::{MainThreadScriptChan, RunnableWrapper, ScriptThread};
 use script_traits::{MsDuration, ScriptMsg as ConstellationMsg, TimerEvent};
 use script_traits::{TimerEventId, TimerEventRequest, TimerSource};
@@ -448,25 +449,13 @@ impl GlobalScope {
         unreachable!();
     }
 
-    /// Start the process of executing the pending promise callbacks. They will be invoked
-    /// in FIFO order, synchronously, at some point in the future.
-    pub fn flush_promise_jobs(&self) {
+    /// Enqueue a microtask for subsequent execution.
+    pub fn enqueue_microtask(&self, job: Microtask) {
         if self.is::<Window>() {
-            return ScriptThread::flush_promise_jobs(self);
+            return ScriptThread::enqueue_microtask(job);
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
-            return worker.flush_promise_jobs();
-        }
-        unreachable!();
-    }
-
-    /// Enqueue a promise callback for subsequent execution.
-    pub fn enqueue_promise_job(&self, job: EnqueuedPromiseCallback) {
-        if self.is::<Window>() {
-            return ScriptThread::enqueue_promise_job(job, self);
-        }
-        if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
-            return worker.enqueue_promise_job(job);
+            return worker.enqueue_microtask(job);
         }
         unreachable!();
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -449,6 +449,17 @@ impl GlobalScope {
         unreachable!();
     }
 
+    /// Perform a microtask checkpoint.
+    pub fn perform_a_microtask_checkpoint(&self) {
+        if self.is::<Window>() {
+            return ScriptThread::invoke_perform_a_microtask_checkpoint();
+        }
+        if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
+            return worker.perform_a_microtask_checkpoint();
+        }
+        unreachable!();
+    }
+
     /// Enqueue a microtask for subsequent execution.
     pub fn enqueue_microtask(&self, job: Microtask) {
         if self.is::<Window>() {

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -210,10 +210,15 @@ impl ServiceWorkerGlobalScope {
             global.dispatch_activate();
             let reporter_name = format!("service-worker-reporter-{}", random::<u64>());
             scope.upcast::<GlobalScope>().mem_profiler_chan().run_with_memory_reporting(|| {
+                // https://html.spec.whatwg.org/multipage/#event-loop-processing-model
+                // Step 1
                 while let Ok(event) = global.receive_event() {
+                    // Step 3
                     if !global.handle_event(event) {
                         break;
                     }
+                    // Step 6
+                    global.upcast::<WorkerGlobalScope>().perform_a_microtask_checkpoint();
                 }
             }, reporter_name, scope.script_chan(), CommonScriptMsg::CollectReports);
         }).expect("Thread spawning failed");

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -108,6 +108,7 @@ mod dom;
 pub mod fetch;
 pub mod layout_wrapper;
 mod mem;
+mod microtask;
 mod network_listener;
 pub mod origin;
 pub mod script_runtime;

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Implementation of [microtasks](https://html.spec.whatwg.org/multipage/#microtask) and
+//! microtask queues. It is up to implementations of event loops to store a queue and
+//! perform checkpoints at appropriate times, as well as enqueue microtasks as required.
+
+use dom::bindings::callback::ExceptionHandling;
+use dom::bindings::cell::DOMRefCell;
+use dom::bindings::codegen::Bindings::PromiseBinding::PromiseJobCallback;
+use dom::bindings::js::Root;
+use dom::globalscope::GlobalScope;
+use msg::constellation_msg::PipelineId;
+use std::cell::Cell;
+use std::mem;
+use std::rc::Rc;
+
+/// A collection of microtasks in FIFO order.
+#[derive(JSTraceable, HeapSizeOf, Default)]
+pub struct MicrotaskQueue {
+    /// The list of enqueued microtasks that will be invoked at the next microtask checkpoint.
+    microtask_queue: DOMRefCell<Vec<Microtask>>,
+    /// https://html.spec.whatwg.org/multipage/#performing-a-microtask-checkpoint
+    performing_a_microtask_checkpoint: Cell<bool>,
+}
+
+#[derive(JSTraceable, HeapSizeOf)]
+pub enum Microtask {
+    Promise(EnqueuedPromiseCallback),
+}
+
+/// A promise callback scheduled to run during the next microtask checkpoint (#4283).
+#[derive(JSTraceable, HeapSizeOf)]
+pub struct EnqueuedPromiseCallback {
+    #[ignore_heap_size_of = "Rc has unclear ownership"]
+    pub callback: Rc<PromiseJobCallback>,
+    pub pipeline: PipelineId,
+}
+
+impl MicrotaskQueue {
+    /// Add a new microtask to this queue. It will be invoked as part of the next
+    /// microtask checkpoint.
+    pub fn enqueue(&self, job: Microtask) {
+        self.microtask_queue.borrow_mut().push(job);
+    }
+
+    /// https://html.spec.whatwg.org/multipage/#perform-a-microtask-checkpoint
+    /// Perform a microtask checkpoint, executing all queued microtasks until the queue is empty.
+    pub fn checkpoint<F>(&self, target_provider: F)
+        where F: Fn(PipelineId) -> Option<Root<GlobalScope>>
+    {
+        if self.performing_a_microtask_checkpoint.get() {
+            return;
+        }
+
+        // Step 1
+        self.performing_a_microtask_checkpoint.set(true);
+
+        // Steps 2-7
+        while !self.microtask_queue.borrow().is_empty() {
+            rooted_vec!(let mut pending_queue);
+            mem::swap(
+                &mut *pending_queue,
+                &mut *self.microtask_queue.borrow_mut());
+
+            for job in pending_queue.iter() {
+                match *job {
+                    Microtask::Promise(ref job) => {
+                        if let Some(target) = target_provider(job.pipeline) {
+                            let _ = job.callback.Call_(&*target, ExceptionHandling::Report);
+                        }
+                    }
+                }
+            }
+        }
+
+        //TODO: Step 8 - notify about rejected promises
+
+        // Step 9
+        self.performing_a_microtask_checkpoint.set(false);
+    }
+}

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -35,7 +35,6 @@ use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{JS, MutNullableJS, Root, RootCollection};
 use dom::bindings::js::{RootCollectionPtr, RootedReference};
 use dom::bindings::num::Finite;
-use dom::bindings::refcounted::Trusted;
 use dom::bindings::reflector::DomObject;
 use dom::bindings::str::DOMString;
 use dom::bindings::trace::JSTraceable;
@@ -94,7 +93,7 @@ use script_traits::CompositorEvent::{KeyEvent, MouseButtonEvent, MouseMoveEvent,
 use script_traits::CompositorEvent::{TouchEvent, TouchpadPressureEvent};
 use script_traits::WebVREventMsg;
 use script_traits::webdriver_msg::WebDriverScriptCommand;
-use serviceworkerjob::{Job, JobQueue, AsyncJobHandler, FinishJobHandler, InvokeType, SettleType};
+use serviceworkerjob::{Job, JobQueue, AsyncJobHandler};
 use servo_config::opts;
 use servo_url::ServoUrl;
 use std::cell::Cell;
@@ -112,7 +111,6 @@ use std::thread;
 use style::context::ReflowGoal;
 use style::dom::{TNode, UnsafeNode};
 use style::thread_state;
-use task_source::TaskSource;
 use task_source::dom_manipulation::{DOMManipulationTask, DOMManipulationTaskSource};
 use task_source::file_reading::FileReadingTaskSource;
 use task_source::history_traversal::HistoryTraversalTaskSource;
@@ -1469,49 +1467,11 @@ impl ScriptThread {
     }
 
     pub fn dispatch_job_queue(&self, job_handler: Box<AsyncJobHandler>) {
-        let scope_url = job_handler.scope_url.clone();
-        let queue_ref = self.job_queue_map.0.borrow();
-        let front_job = {
-            let job_vec = queue_ref.get(&scope_url);
-            job_vec.unwrap().first().unwrap()
-        };
-        match job_handler.invoke_type {
-            InvokeType::Run => (&*self.job_queue_map).run_job(job_handler, self),
-            InvokeType::Register => self.job_queue_map.run_register(front_job, job_handler, self),
-            InvokeType::Update => self.job_queue_map.update(front_job, &*front_job.client.global(), self),
-            InvokeType::Settle(settle_type) => {
-                let promise = &front_job.promise;
-                let global = &*front_job.client.global();
-                let trusted_global = Trusted::new(global);
-                let _ac = JSAutoCompartment::new(global.get_cx(), promise.reflector().get_jsobject().get());
-                match settle_type {
-                    SettleType::Resolve(reg) => promise.resolve_native(global.get_cx(), &*reg.root()),
-                    SettleType::Reject(err) => promise.reject_error(global.get_cx(), err)
-                }
-                let finish_job_handler = box FinishJobHandler::new(scope_url, trusted_global);
-                self.queue_finish_job(finish_job_handler, global);
-            }
-        }
+        self.job_queue_map.run_job(job_handler, self);
     }
 
-    pub fn queue_serviceworker_job(&self, async_job_handler: Box<AsyncJobHandler>, global: &GlobalScope) {
-        let _ = self.dom_manipulation_task_source.queue(async_job_handler, &*global);
-    }
-
-    pub fn queue_finish_job(&self, finish_job_handler: Box<FinishJobHandler>, global: &GlobalScope) {
-        let _ = self.dom_manipulation_task_source.queue(finish_job_handler, global);
-    }
-
-    pub fn invoke_finish_job(&self, finish_job_handler: Box<FinishJobHandler>) {
-        let job_queue = &*self.job_queue_map;
-        let global = &*finish_job_handler.global.root();
-        let scope_url = (*finish_job_handler).scope_url;
-        job_queue.finish_job(scope_url, global, self);
-    }
-
-    pub fn invoke_job_update(&self, job: &Job, global: &GlobalScope) {
-        let job_queue = &*self.job_queue_map;
-        job_queue.update(job, global, self);
+    pub fn dom_manipulation_task_source(&self) -> &DOMManipulationTaskSource {
+        &self.dom_manipulation_task_source
     }
 
     /// Handles a request for the window title.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -567,6 +567,13 @@ impl ScriptThreadFactory for ScriptThread {
 }
 
 impl ScriptThread {
+    pub fn invoke_perform_a_microtask_checkpoint() {
+        SCRIPT_THREAD_ROOT.with(|root| {
+            let script_thread = unsafe { &*root.get().unwrap() };
+            script_thread.perform_a_microtask_checkpoint()
+        })
+    }
+
     pub fn page_headers_available(id: &PipelineId, metadata: Option<Metadata>)
                                   -> Option<Root<ServoParser>> {
         SCRIPT_THREAD_ROOT.with(|root| {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -70,6 +70,7 @@ use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use layout_wrapper::ServoLayoutNode;
 use mem::heap_size_of_self_and_children;
+use microtask::{MicrotaskQueue, Microtask};
 use msg::constellation_msg::{FrameId, FrameType, PipelineId, PipelineNamespace};
 use net_traits::{CoreResourceMsg, FetchMetadata, FetchResponseListener};
 use net_traits::{IpcSend, Metadata, ReferrerPolicy, ResourceThreads};
@@ -81,8 +82,8 @@ use origin::Origin;
 use profile_traits::mem::{self, OpaqueSender, Report, ReportKind, ReportsChan};
 use profile_traits::time::{self, ProfilerCategory, profile};
 use script_layout_interface::message::{self, NewLayoutThreadInfo, ReflowQueryType};
-use script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory, EnqueuedPromiseCallback};
-use script_runtime::{ScriptPort, StackRootTLS, get_reports, new_rt_and_cx, PromiseJobQueue};
+use script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory};
+use script_runtime::{ScriptPort, StackRootTLS, get_reports, new_rt_and_cx};
 use script_traits::{CompositorEvent, ConstellationControlMsg};
 use script_traits::{DocumentActivity, DiscardBrowsingContext, EventResult};
 use script_traits::{InitialScriptState, LayoutMsg, LoadData, MouseButton, MouseEventType, MozBrowserEvent};
@@ -98,6 +99,7 @@ use servo_config::opts;
 use servo_url::ServoUrl;
 use std::cell::Cell;
 use std::collections::{hash_map, HashMap, HashSet};
+use std::default::Default;
 use std::ops::Deref;
 use std::option::Option;
 use std::ptr;
@@ -477,7 +479,7 @@ pub struct ScriptThread {
 
     content_process_shutdown_chan: IpcSender<()>,
 
-    promise_job_queue: PromiseJobQueue,
+    microtask_queue: MicrotaskQueue,
 
     /// A handle to the webvr thread, if available
     webvr_thread: Option<IpcSender<WebVRMsg>>,
@@ -694,7 +696,7 @@ impl ScriptThread {
 
             content_process_shutdown_chan: state.content_process_shutdown_chan,
 
-            promise_job_queue: PromiseJobQueue::new(),
+            microtask_queue: MicrotaskQueue::default(),
 
             layout_to_constellation_chan: state.layout_to_constellation_chan,
 
@@ -776,6 +778,7 @@ impl ScriptThread {
         let mut mouse_move_event_index = None;
         let mut animation_ticks = HashSet::new();
         loop {
+            // https://html.spec.whatwg.org/multipage/#event-loop-processing-model step 7
             match event {
                 // This has to be handled before the ResizeMsg below,
                 // otherwise the page may not have been added to the
@@ -788,6 +791,7 @@ impl ScriptThread {
                     })
                 }
                 FromConstellation(ConstellationControlMsg::Resize(id, size, size_type)) => {
+                    // step 7.7
                     self.profile_event(ScriptThreadEventCategory::Resize, || {
                         self.handle_resize(id, size, size_type);
                     })
@@ -804,6 +808,7 @@ impl ScriptThread {
                 }
                 FromConstellation(ConstellationControlMsg::TickAllAnimations(
                         pipeline_id)) => {
+                    // step 7.8
                     if !animation_ticks.contains(&pipeline_id) {
                         animation_ticks.insert(pipeline_id);
                         sequential.push(event);
@@ -868,10 +873,15 @@ impl ScriptThread {
                 None
             });
 
+            // https://html.spec.whatwg.org/multipage/#event-loop-processing-model step 6
+            self.perform_a_microtask_checkpoint();
+
             if let Some(retval) = result {
                 return retval
             }
         }
+
+        // https://html.spec.whatwg.org/multipage/#event-loop-processing-model step 7.12
 
         // Issue batched reflows on any pages that require it (e.g. if images loaded)
         // TODO(gw): In the future we could probably batch other types of reflows
@@ -2108,30 +2118,15 @@ impl ScriptThread {
         }
     }
 
-    pub fn enqueue_promise_job(job: EnqueuedPromiseCallback, global: &GlobalScope) {
+    pub fn enqueue_microtask(job: Microtask) {
         SCRIPT_THREAD_ROOT.with(|root| {
             let script_thread = unsafe { &*root.get().unwrap() };
-            script_thread.promise_job_queue.enqueue(job, global);
+            script_thread.microtask_queue.enqueue(job);
         });
     }
 
-    pub fn flush_promise_jobs(global: &GlobalScope) {
-        SCRIPT_THREAD_ROOT.with(|root| {
-            let script_thread = unsafe { &*root.get().unwrap() };
-            let _ = script_thread.dom_manipulation_task_source.queue(
-                box FlushPromiseJobs, global);
-        })
-    }
-
-    fn do_flush_promise_jobs(&self) {
-        self.promise_job_queue.flush_promise_jobs(|id| self.documents.borrow().find_global(id))
-    }
-}
-
-struct FlushPromiseJobs;
-impl Runnable for FlushPromiseJobs {
-    fn main_thread_handler(self: Box<FlushPromiseJobs>, script_thread: &ScriptThread) {
-        script_thread.do_flush_promise_jobs();
+    fn perform_a_microtask_checkpoint(&self) {
+        self.microtask_queue.checkpoint(|id| self.documents.borrow().find_global(id))
     }
 }
 

--- a/tests/wpt/metadata/html/webappapis/scripting/event-loops/microtask_after_raf.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/event-loops/microtask_after_raf.html.ini
@@ -1,6 +1,0 @@
-[microtask_after_raf.html]
-  type: testharness
-  disabled: https://github.com/servo/servo/issues/13501
-  [Microtask execute immediately after script]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/scripting/event-loops/microtask_after_script.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/event-loops/microtask_after_script.html.ini
@@ -1,5 +1,0 @@
-[microtask_after_script.html]
-  type: testharness
-  [Microtask immediately after script]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/scripting/event-loops/task_microtask_ordering.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/event-loops/task_microtask_ordering.html.ini
@@ -1,8 +1,5 @@
 [task_microtask_ordering.html]
   type: testharness
-  [Basic task and microtask ordering]
-    expected: FAIL
-
   [Level 1 bossfight (synthetic click)]
     expected: FAIL
-
+    bug: https://github.com/servo/servo/issues/1980


### PR DESCRIPTION
This generalizes the work previously done for Promise job callbacks. There is now a microtask queue that correctly processes all queued microtasks after each turn of the event loop, as well as after a scripted callback finishes executing, and after a classic script executes.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #4283
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15189)
<!-- Reviewable:end -->
