### PR TITLE
Remove out-of-date handling for align-self in Gecko builds.

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2017,7 +2017,11 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
         }
     }
 
-    % if "align-items" in data.longhands_by_name:
+    // This implements an out-of-date spec. The new spec moves the handling of
+    // this to layout, which Gecko implements but Servo doesn't.
+    //
+    // See https://github.com/servo/servo/issues/15229
+    % if product == "servo" and "align-items" in data.longhands_by_name:
     {
         use computed_values::align_self::T as align_self;
         use computed_values::align_items::T as align_items;
@@ -2029,9 +2033,6 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
                     align_items::flex_start => align_self::flex_start,
                     align_items::flex_end => align_self::flex_end,
                     align_items::center => align_self::center,
-                    % if product == "gecko":
-                        align_items::normal => align_self::normal,
-                    % endif
                 };
             style.mutate_position().set_align_self(self_align);
         }


### PR DESCRIPTION
See #15229.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15231)
<!-- Reviewable:end -->
