### PR TITLE
Allow negative values for letter-spacing and word-spacing.  Inline Le…

### DIFF
--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -335,11 +335,11 @@ ${helpers.single_keyword("text-align-last",
         }
     }
 
-    pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
+    pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
         if input.try(|input| input.expect_ident_matching("normal")).is_ok() {
             Ok(SpecifiedValue::Normal)
         } else {
-            specified::Length::parse_non_negative(input).map(SpecifiedValue::Specified)
+            specified::Length::parse(context, input).map(SpecifiedValue::Specified)
         }
     }
 </%helpers:longhand>
@@ -416,11 +416,11 @@ ${helpers.single_keyword("text-align-last",
         }
     }
 
-    pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
+    pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
         if input.try(|input| input.expect_ident_matching("normal")).is_ok() {
             Ok(SpecifiedValue::Normal)
         } else {
-            specified::LengthOrPercentage::parse_non_negative(input)
+            specified::LengthOrPercentage::parse(context, input)
                                           .map(SpecifiedValue::Specified)
         }
     }

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -463,6 +463,7 @@ impl Length {
     }
 
     /// Parse a non-negative length
+    #[inline]
     pub fn parse_non_negative(input: &mut Parser) -> Result<Length, ()> {
         Length::parse_internal(input, AllowedNumericType::NonNegative)
     }

--- a/tests/unit/style/parsing/inherited_text.rs
+++ b/tests/unit/style/parsing/inherited_text.rs
@@ -8,6 +8,29 @@ use style::parser::ParserContext;
 use style::stylesheets::Origin;
 
 #[test]
+fn negative_letter_spacing_should_parse_properly() {
+    use style::properties::longhands::letter_spacing;
+    use style::properties::longhands::letter_spacing::SpecifiedValue;
+    use style::values::specified::length::{Length, NoCalcLength, FontRelativeLength};
+
+    let negative_value = parse_longhand!(letter_spacing, "-0.5em");
+    let expected = SpecifiedValue::Specified(Length::NoCalc(NoCalcLength::FontRelative(FontRelativeLength::Em(-0.5))));
+    assert_eq!(negative_value, expected);
+}
+
+#[test]
+fn negative_word_spacing_should_parse_properly() {
+    use style::properties::longhands::word_spacing;
+    use style::properties::longhands::word_spacing::SpecifiedValue;
+    use style::values::specified::length::{NoCalcLength, LengthOrPercentage, FontRelativeLength};
+
+    let negative_value = parse_longhand!(word_spacing, "-0.5em");
+    let expected = SpecifiedValue::Specified(LengthOrPercentage::Length(NoCalcLength::FontRelative(
+                                             FontRelativeLength::Em(-0.5))));
+    assert_eq!(negative_value, expected);
+}
+
+#[test]
 fn text_emphasis_style_longhand_should_parse_properly() {
     use style::properties::longhands::text_emphasis_style;
     use style::properties::longhands::text_emphasis_style::{ShapeKeyword, SpecifiedValue, KeywordValue};
@@ -78,7 +101,6 @@ fn test_text_emphasis_position() {
     let left_under = parse_longhand!(text_emphasis_position, "left under");
     assert_eq!(left_under, SpecifiedValue(HorizontalWritingModeValue::Under, VerticalWritingModeValue::Left));
 }
-
 
 #[test]
 fn webkit_text_stroke_shorthand_should_parse_properly() {

--- a/tests/wpt/metadata-css/css-text-3_dev/html/text-word-spacing-001.htm.ini
+++ b/tests/wpt/metadata-css/css-text-3_dev/html/text-word-spacing-001.htm.ini
@@ -1,3 +1,0 @@
-[text-word-spacing-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/c542-letter-sp-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/c542-letter-sp-001.htm.ini
@@ -1,3 +1,0 @@
-[c542-letter-sp-001.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Allow negative values when parsing `letter-spacing` and `word-spacing`.  Inline `parse_non_negative` in `Length`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15204 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15237)
<!-- Reviewable:end -->
