### PR TITLE
Make text-orientation:sideways-right an alias for sideways in Gecko

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1659,11 +1659,9 @@ impl FragmentDisplayListBuilding for Fragment {
 
         // Determine the orientation and cursor to use.
         let (orientation, cursor) = if self.style.writing_mode.is_vertical() {
-            if self.style.writing_mode.is_sideways_left() {
-                (TextOrientation::SidewaysLeft, Cursor::VerticalText)
-            } else {
-                (TextOrientation::SidewaysRight, Cursor::VerticalText)
-            }
+            // TODO: Distinguish between 'sideways-lr' and 'sideways-rl' writing modes in CSS
+            // Writing Modes Level 4.
+            (TextOrientation::SidewaysRight, Cursor::VerticalText)
         } else {
             (TextOrientation::Upright, Cursor::Text)
         };

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -23,7 +23,7 @@ use std::borrow::ToOwned;
 use std::collections::LinkedList;
 use std::mem;
 use std::sync::Arc;
-use style::computed_values::{line_height, text_orientation, text_rendering, text_transform};
+use style::computed_values::{line_height, text_rendering, text_transform};
 use style::computed_values::{word_break, white_space};
 use style::logical_geometry::{LogicalSize, WritingMode};
 use style::properties::ServoComputedValues;
@@ -418,25 +418,12 @@ impl TextRunScanner {
 #[inline]
 fn bounding_box_for_run_metrics(metrics: &RunMetrics, writing_mode: WritingMode)
                                 -> LogicalSize<Au> {
-    // This does nothing, but it will fail to build
-    // when more values are added to the `text-orientation` CSS property.
-    // This will be a reminder to update the code below.
-    let dummy: Option<text_orientation::T> = None;
-    match dummy {
-        Some(text_orientation::T::sideways_right) |
-        Some(text_orientation::T::sideways_left) |
-        Some(text_orientation::T::sideways) |
-        None => {}
-    }
-
-    // In vertical sideways or horizontal upright text,
-    // the "width" of text metrics is always inline
-    // This will need to be updated when other text orientations are supported.
+    // TODO: When the text-orientation property is supported, the block and inline directions may
+    // be swapped for horizontal glyphs in vertical lines.
     LogicalSize::new(
         writing_mode,
         metrics.bounding_box.size.width,
         metrics.bounding_box.size.height)
-
 }
 
 /// Returns the metrics of the font represented by the given `style_structs::Font`, respectively.

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -249,8 +249,8 @@ partial interface CSSStyleDeclaration {
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString text-indent;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString textJustify;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString text-justify;
-  [SetterThrows, TreatNullAs=EmptyString] attribute DOMString textOrientation;
-  [SetterThrows, TreatNullAs=EmptyString] attribute DOMString text-orientation;
+  //[SetterThrows, TreatNullAs=EmptyString] attribute DOMString textOrientation;
+  //[SetterThrows, TreatNullAs=EmptyString] attribute DOMString text-orientation;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString textRendering;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString text-rendering;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString textTransform;

--- a/components/style/logical_geometry.rs
+++ b/components/style/logical_geometry.rs
@@ -29,7 +29,8 @@ bitflags!(
         const FLAG_RTL = 1 << 0,
         const FLAG_VERTICAL = 1 << 1,
         const FLAG_VERTICAL_LR = 1 << 2,
-        const FLAG_SIDEWAYS_LEFT = 1 << 3
+        const FLAG_SIDEWAYS = 1 << 3,
+        const FLAG_UPRIGHT = 1 << 4,
     }
 );
 
@@ -48,7 +49,8 @@ impl WritingMode {
     /// Assuming .is_vertical(), does the inline direction go top to bottom?
     #[inline]
     pub fn is_inline_tb(&self) -> bool {
-        !(self.intersects(FLAG_SIDEWAYS_LEFT) ^ self.intersects(FLAG_RTL))
+        // https://drafts.csswg.org/css-writing-modes-3/#logical-to-physical
+        !self.intersects(FLAG_RTL)
     }
 
     #[inline]
@@ -57,8 +59,13 @@ impl WritingMode {
     }
 
     #[inline]
-    pub fn is_sideways_left(&self) -> bool {
-        self.intersects(FLAG_SIDEWAYS_LEFT)
+    pub fn is_sideways(&self) -> bool {
+        self.intersects(FLAG_SIDEWAYS)
+    }
+
+    #[inline]
+    pub fn is_upright(&self) -> bool {
+        self.intersects(FLAG_UPRIGHT)
     }
 
     #[inline]
@@ -135,8 +142,8 @@ impl fmt::Display for WritingMode {
             } else {
                 try!(write!(formatter, " RL"));
             }
-            if self.intersects(FLAG_SIDEWAYS_LEFT) {
-                try!(write!(formatter, " SidewaysL"));
+            if self.intersects(FLAG_SIDEWAYS) {
+                try!(write!(formatter, " Sideways"));
             }
         } else {
             try!(write!(formatter, "H"));

--- a/components/style/properties/longhand/inherited_box.mako.rs
+++ b/components/style/properties/longhand/inherited_box.mako.rs
@@ -26,17 +26,42 @@ ${helpers.single_keyword("writing-mode",
 ${helpers.single_keyword("direction", "ltr rtl", need_clone=True, animatable=False,
                          spec="https://drafts.csswg.org/css-writing-modes/#propdef-direction")}
 
-// FIXME(SimonSapin): Add 'mixed' and 'upright' (needs vertical text support)
-// FIXME(SimonSapin): initial (first) value should be 'mixed', when that's implemented
-// FIXME(bholley): sideways-right is needed as an alias to sideways in gecko.
-${helpers.single_keyword("text-orientation",
-                         "sideways",
-                         experimental=True,
-                         need_clone=True,
-                         extra_gecko_values="mixed upright",
-                         extra_servo_values="sideways-right sideways-left",
-                         animatable=False,
-                         spec="https://drafts.csswg.org/css-writing-modes/#propdef-text-orientation")}
+<%helpers:single_keyword_computed
+    name="text-orientation"
+    values="mixed upright sideways"
+    extra_specified="sideways-right"
+    products="gecko"
+    need_clone="True"
+    animatable="False"
+    spec="https://drafts.csswg.org/css-writing-modes/#propdef-text-orientation"
+>
+    use values::NoViewportPercentage;
+    impl NoViewportPercentage for SpecifiedValue {}
+
+    impl ToComputedValue for SpecifiedValue {
+        type ComputedValue = computed_value::T;
+
+        #[inline]
+        fn to_computed_value(&self, _: &Context) -> computed_value::T {
+            match *self {
+                % for value in "mixed upright sideways".split():
+                    SpecifiedValue::${value} => computed_value::T::${value},
+                % endfor
+                // https://drafts.csswg.org/css-writing-modes-3/#valdef-text-orientation-sideways-right
+                SpecifiedValue::sideways_right => computed_value::T::sideways,
+            }
+        }
+
+        #[inline]
+        fn from_computed_value(computed: &computed_value::T) -> SpecifiedValue {
+            match *computed {
+                % for value in "mixed upright sideways".split():
+                    computed_value::T::${value} => SpecifiedValue::${value},
+                % endfor
+            }
+        }
+    }
+</%helpers:single_keyword_computed>
 
 // CSS Color Module Level 4
 // https://drafts.csswg.org/css-color/

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1664,24 +1664,17 @@ pub fn get_writing_mode(inheritedbox_style: &style_structs::InheritedBox) -> Wri
             flags.insert(logical_geometry::FLAG_VERTICAL_LR);
         },
     }
+    % if product == "gecko":
     match inheritedbox_style.clone_text_orientation() {
-    % if product == "servo":
-        computed_values::text_orientation::T::sideways_right => {},
-        computed_values::text_orientation::T::sideways_left => {
-            flags.insert(logical_geometry::FLAG_VERTICAL_LR);
-        },
-    % elif product == "gecko":
-        // FIXME(bholley): Need to make sure these are correct when we add
-        // full writing-mode support.
         computed_values::text_orientation::T::mixed => {},
-        computed_values::text_orientation::T::upright => {},
-    % endif
+        computed_values::text_orientation::T::upright => {
+            flags.insert(logical_geometry::FLAG_UPRIGHT);
+        },
         computed_values::text_orientation::T::sideways => {
-            if flags.intersects(logical_geometry::FLAG_VERTICAL_LR) {
-                flags.insert(logical_geometry::FLAG_SIDEWAYS_LEFT);
-            }
+            flags.insert(logical_geometry::FLAG_SIDEWAYS);
         },
     }
+    % endif
     flags
 }
 
@@ -1915,8 +1908,10 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
                 PropertyDeclaration::Float(_) |
                 PropertyDeclaration::TextDecoration${'' if product == 'servo' else 'Line'}(_) |
                 PropertyDeclaration::WritingMode(_) |
-                PropertyDeclaration::Direction(_) |
-                PropertyDeclaration::TextOrientation(_)
+                PropertyDeclaration::Direction(_)
+                % if product == 'gecko':
+                    | PropertyDeclaration::TextOrientation(_)
+                % endif
             );
             if
                 % if category_to_cascade_now == "early":

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -185,7 +185,6 @@ fn compute_damage(old: &ServoComputedValues, new: &ServoComputedValues) -> Servo
         get_font.font_family, get_font.font_style, get_font.font_variant, get_font.font_weight,
         get_font.font_size, get_font.font_stretch,
         get_inheritedbox.direction, get_inheritedbox.writing_mode,
-        get_inheritedbox.text_orientation,
         get_text.text_decoration, get_text.unicode_bidi,
         get_inheritedtable.empty_cells, get_inheritedtable.caption_side,
         get_column.column_width, get_column.column_count

--- a/tests/unit/style/lib.rs
+++ b/tests/unit/style/lib.rs
@@ -15,7 +15,7 @@ extern crate parking_lot;
 extern crate rayon;
 extern crate rustc_serialize;
 extern crate selectors;
-#[macro_use] extern crate servo_atoms;
+extern crate servo_atoms;
 extern crate servo_config;
 extern crate servo_url;
 extern crate style;

--- a/tests/unit/style/logical_geometry.rs
+++ b/tests/unit/style/logical_geometry.rs
@@ -3,22 +3,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use euclid::{Size2D, Point2D, SideOffsets2D, Rect};
-use style::logical_geometry::{FLAG_RTL, FLAG_VERTICAL, FLAG_VERTICAL_LR, FLAG_SIDEWAYS_LEFT};
+use style::logical_geometry::{FLAG_RTL, FLAG_VERTICAL, FLAG_VERTICAL_LR};
+use style::logical_geometry::{FLAG_SIDEWAYS, FLAG_UPRIGHT};
 use style::logical_geometry::{WritingMode, LogicalSize, LogicalPoint, LogicalMargin, LogicalRect};
 
 #[cfg(test)]
-fn modes() -> [WritingMode; 10] {
+fn modes() -> [WritingMode; 13] {
     [
         WritingMode::empty(),
         FLAG_VERTICAL,
         FLAG_VERTICAL | FLAG_VERTICAL_LR,
-        FLAG_VERTICAL | FLAG_VERTICAL_LR | FLAG_SIDEWAYS_LEFT,
-        FLAG_VERTICAL | FLAG_SIDEWAYS_LEFT,
+        FLAG_VERTICAL | FLAG_VERTICAL_LR | FLAG_SIDEWAYS,
+        FLAG_VERTICAL | FLAG_SIDEWAYS,
+        FLAG_VERTICAL | FLAG_UPRIGHT,
         FLAG_RTL,
         FLAG_VERTICAL | FLAG_RTL,
         FLAG_VERTICAL | FLAG_VERTICAL_LR | FLAG_RTL,
-        FLAG_VERTICAL | FLAG_VERTICAL_LR | FLAG_SIDEWAYS_LEFT | FLAG_RTL,
-        FLAG_VERTICAL | FLAG_SIDEWAYS_LEFT | FLAG_RTL,
+        FLAG_VERTICAL | FLAG_VERTICAL_LR | FLAG_SIDEWAYS | FLAG_RTL,
+        FLAG_VERTICAL | FLAG_VERTICAL_LR | FLAG_UPRIGHT | FLAG_RTL,
+        FLAG_VERTICAL | FLAG_SIDEWAYS | FLAG_RTL,
+        FLAG_VERTICAL | FLAG_UPRIGHT | FLAG_RTL,
     ]
 }
 


### PR DESCRIPTION
Fixes #15214. r? @upsuper

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15268)
<!-- Reviewable:end -->
