### PR TITLE
Initialize block_container_inline_size for non-block root flows

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1701,6 +1701,19 @@ impl BlockFlow {
 
         self.base.floats = Floats::new(self.base.writing_mode);
 
+        self.initialize_container_size_for_root(shared_context);
+
+        // Our inline-size was set to the inline-size of the containing block by the flow's parent.
+        // Now compute the real value.
+        self.propagate_and_compute_used_inline_size(shared_context);
+
+        self.guess_inline_size_for_block_formatting_context_if_necessary()
+    }
+
+    /// If this is the root flow, initialize values that would normally be set by the parent.
+    ///
+    /// Should be called during `assign_inline_sizes` for flows that may be the root.
+    pub fn initialize_container_size_for_root(&mut self, shared_context: &SharedStyleContext) {
         if self.is_root() {
             debug!("Setting root position");
             self.base.position.start = LogicalPoint::zero(self.base.writing_mode);
@@ -1708,12 +1721,6 @@ impl BlockFlow {
                 self.base.writing_mode, shared_context.viewport_size).inline;
             self.base.block_container_writing_mode = self.base.writing_mode;
         }
-
-        // Our inline-size was set to the inline-size of the containing block by the flow's parent.
-        // Now compute the real value.
-        self.propagate_and_compute_used_inline_size(shared_context);
-
-        self.guess_inline_size_for_block_formatting_context_if_necessary()
     }
 
     fn guess_inline_size_for_block_formatting_context_if_necessary(&mut self) {

--- a/components/layout/flex.rs
+++ b/components/layout/flex.rs
@@ -868,6 +868,8 @@ impl Flow for FlexFlow {
             return
         }
 
+        self.block_flow.initialize_container_size_for_root(shared_context);
+
         // Our inline-size was set to the inline-size of the containing block by the flow's parent.
         // Now compute the real value.
         let containing_block_inline_size = self.block_flow.base.block_container_inline_size;

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -341,6 +341,8 @@ impl Flow for TableWrapperFlow {
                    "table_wrapper"
                });
 
+        self.block_flow.initialize_container_size_for_root(shared_context);
+
         let mut intermediate_column_inline_sizes = self.column_intrinsic_inline_sizes
                                                        .iter()
                                                        .map(|column_intrinsic_inline_size| {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1580,6 +1580,18 @@
             "url": "/_mozilla/css/flex_nochild.html"
           }
         ],
+        "css/flex_root_percent_size.html": [
+          {
+            "path": "css/flex_root_percent_size.html",
+            "references": [
+              [
+                "/_mozilla/css/flex_root_percent_size_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/flex_root_percent_size.html"
+          }
+        ],
         "css/flex_row_direction.html": [
           {
             "path": "css/flex_row_direction.html",
@@ -5302,6 +5314,18 @@
               ]
             ],
             "url": "/_mozilla/css/table_preferred_width_a.html"
+          }
+        ],
+        "css/table_root_percent_width.html": [
+          {
+            "path": "css/table_root_percent_width.html",
+            "references": [
+              [
+                "/_mozilla/css/table_root_percent_width_ref.html",
+                "=="
+              ]
+            ],
+            "url": "/_mozilla/css/table_root_percent_width.html"
           }
         ],
         "css/table_row_direction_a.html": [
@@ -17012,6 +17036,18 @@
           "url": "/_mozilla/css/flex_nochild.html"
         }
       ],
+      "css/flex_root_percent_size.html": [
+        {
+          "path": "css/flex_root_percent_size.html",
+          "references": [
+            [
+              "/_mozilla/css/flex_root_percent_size_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/flex_root_percent_size.html"
+        }
+      ],
       "css/flex_row_direction.html": [
         {
           "path": "css/flex_row_direction.html",
@@ -20734,6 +20770,18 @@
             ]
           ],
           "url": "/_mozilla/css/table_preferred_width_a.html"
+        }
+      ],
+      "css/table_root_percent_width.html": [
+        {
+          "path": "css/table_root_percent_width.html",
+          "references": [
+            [
+              "/_mozilla/css/table_root_percent_width_ref.html",
+              "=="
+            ]
+          ],
+          "url": "/_mozilla/css/table_root_percent_width.html"
         }
       ],
       "css/table_row_direction_a.html": [

--- a/tests/wpt/mozilla/tests/css/flex_root_percent_size.html
+++ b/tests/wpt/mozilla/tests/css/flex_root_percent_size.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="match" href="flex_root_percent_size_ref.html">
+    <style>
+      html {
+        display: flex;
+        box-sizing: border-box;
+        height: 100%;
+        width: 100%;
+        border: 4px solid red;
+      }
+    </style>
+  </head>
+<body>
+</body>
+</html>
+<title></title>

--- a/tests/wpt/mozilla/tests/css/flex_root_percent_size_ref.html
+++ b/tests/wpt/mozilla/tests/css/flex_root_percent_size_ref.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>
+      html {
+        box-sizing: border-box;
+        height: 100%;
+        width: 100%;
+        border: 4px solid red;
+      }
+    </style>
+  </head>
+<body>
+</body>
+</html>
+<title></title>

--- a/tests/wpt/mozilla/tests/css/table_root_percent_width.html
+++ b/tests/wpt/mozilla/tests/css/table_root_percent_width.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="match" href="table_root_percent_width_ref.html">
+    <style>
+      html {
+        display: table;
+        box-sizing: border-box;
+        height: 100%;
+        width: 100%;
+        border: 4px solid red;
+      }
+    </style>
+  </head>
+<body>
+</body>
+</html>
+<title></title>

--- a/tests/wpt/mozilla/tests/css/table_root_percent_width_ref.html
+++ b/tests/wpt/mozilla/tests/css/table_root_percent_width_ref.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>
+      html {
+        box-sizing: border-box;
+        height: 100%;
+        width: 100%;
+        border: 4px solid red;
+      }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>
+<title></title>


### PR DESCRIPTION
Fixes #14948. Fixes #14945.  Needs a try run.  r? @notriddle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15271)
<!-- Reviewable:end -->
