### PR TITLE
Avoid codesize impact of pushing in PropertyDeclaration::parse, take 2

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1076,29 +1076,40 @@ impl PropertyDeclaration {
                     ${property_pref_check(shorthand)}
 
                     match input.try(|i| CSSWideKeyword::parse(context, i)) {
-                        Ok(CSSWideKeyword::InheritKeyword) => {
-                            % for sub_property in shorthand.sub_properties:
-                                result_list.push((
-                                    PropertyDeclaration::${sub_property.camel_case}(
-                                        DeclaredValue::Inherit), Importance::Normal));
-                            % endfor
-                            PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
-                        },
-                        Ok(CSSWideKeyword::InitialKeyword) => {
-                            % for sub_property in shorthand.sub_properties:
-                                result_list.push((
-                                    PropertyDeclaration::${sub_property.camel_case}(
-                                        DeclaredValue::Initial), Importance::Normal));
-                            % endfor
-                            PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
-                        },
-                        Ok(CSSWideKeyword::UnsetKeyword) => {
-                            % for sub_property in shorthand.sub_properties:
-                                result_list.push((PropertyDeclaration::${sub_property.camel_case}(
-                                        DeclaredValue::Unset), Importance::Normal));
-                            % endfor
-                            PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
-                        },
+                        Ok(keyword) => {
+                            match keyword {
+                                CSSWideKeyword::InheritKeyword => {
+                                    result_list.extend_from_slice(&[
+                                        % for sub_property in shorthand.sub_properties:
+                                            (PropertyDeclaration::${sub_property.camel_case}(
+                                                DeclaredValue::Inherit),
+                                             Importance::Normal),
+                                        % endfor
+                                    ]);
+                                    PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
+                                },
+                                CSSWideKeyword::InitialKeyword => {
+                                    result_list.extend_from_slice(&[
+                                        % for sub_property in shorthand.sub_properties:
+                                            (PropertyDeclaration::${sub_property.camel_case}(
+                                                DeclaredValue::Initial),
+                                             Importance::Normal),
+                                        % endfor
+                                    ]);
+                                    PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
+                                },
+                                CSSWideKeyword::UnsetKeyword => {
+                                    result_list.extend_from_slice(&[
+                                        % for sub_property in shorthand.sub_properties:
+                                            (PropertyDeclaration::${sub_property.camel_case}(
+                                                DeclaredValue::Unset),
+                                             Importance::Normal),
+                                        % endfor
+                                    ]);
+                                    PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
+                                },
+                            }
+                        }
                         Err(()) => match shorthands::${shorthand.ident}::parse(context, input, result_list) {
                             Ok(()) => PropertyDeclarationParseResult::ValidOrIgnoredDeclaration,
                             Err(()) => PropertyDeclarationParseResult::InvalidValue,


### PR DESCRIPTION
Trying #14950 with a different approach.


@mbrubeck could you check what the impact of the second commit here is?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15279)
<!-- Reviewable:end -->
