### PR TITLE
Bug 1334579: Ensure constructors for nsStyleContentData run.

### DIFF
--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -644,7 +644,8 @@ extern "C" {
     pub fn Gecko_DropElementSnapshot(snapshot: ServoElementSnapshotOwned);
 }
 extern "C" {
-    pub fn Gecko_ClearStyleContents(content: *mut nsStyleContent);
+    pub fn Gecko_ClearAndResizeStyleContents(content: *mut nsStyleContent,
+                                             how_many: u32);
 }
 extern "C" {
     pub fn Gecko_CopyStyleContentsFrom(content: *mut nsStyleContent,


### PR DESCRIPTION
Reviewed upstream by @bholley

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15280)
<!-- Reviewable:end -->
