### PR TITLE
Fixed mach/servo logger choice for single files

### DIFF
--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -32,7 +32,13 @@ def run_tests(paths=None, **kwargs):
     mozlog.commandline.log_formatters["servo"] = \
         (grouping_formatter.GroupingFormatter, "A grouping output formatter")
 
+    use_mach_logging = False
     if len(kwargs["test_list"]) == 1:
+        file_ext = os.path.splitext(kwargs["test_list"][0])[1].lower()
+        if file_ext in [".htm", ".html", ".js", ".xhtml"]:
+            use_mach_logging = True
+
+    if use_mach_logging:
         wptrunner.setup_logging(kwargs, {"mach": sys.stdout})
     else:
         wptrunner.setup_logging(kwargs, {"servo": sys.stdout})


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed mach/servo logger choice for single files as per @jdm’s [suggestion](https://github.com/servo/servo/issues/15193#issuecomment-275586263).

It’s also possible to do this by checking if the `test_list` path is a directory. This might be trying to make an implementation that is “too smart” though, so I stuck with checking the file extension against `[.html, .htm, .js, .xhtml]` as per the suggestion.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15193 (github issue number if applicable).

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15282)
<!-- Reviewable:end -->
