### PR TITLE
Remove unused builders

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -100,11 +100,6 @@ arm64:
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 
-windows-dev:
-  - ./mach build --dev
-  - ./mach test-unit
-  - ./mach build-geckolib
-
 windows-gnu-dev:
   - ./mach build --dev
   - ./mach test-unit
@@ -114,11 +109,6 @@ windows-msvc-dev:
   - mach.bat build --dev
   - mach.bat test-unit
   - mach.bat build-geckolib
-
-windows-nightly:
-  - ./mach build --release
-  - ./mach package --release
-  - ./etc/ci/upload_nightly.sh windows-gnu
 
 windows-gnu-nightly:
   - ./mach build --release


### PR DESCRIPTION
These have been superseded by the windows-gnu and windows-msvc versions.
Removing them allows freeing up disk space on the Windows builders.

r? @larsbergstrom 

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15284)
<!-- Reviewable:end -->
