### PR TITLE
Issue #15017: Properly handle and report network errors on page loads.

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -431,6 +431,7 @@ impl FetchResponseListener for ParserContext {
 
     fn process_response(&mut self, meta_result: Result<FetchMetadata, NetworkError>) {
         let mut ssl_error = None;
+        let mut network_error = None;
         let metadata = match meta_result {
             Ok(meta) => {
                 Some(match meta {
@@ -441,6 +442,13 @@ impl FetchResponseListener for ParserContext {
             Err(NetworkError::SslValidation(url, reason)) => {
                 ssl_error = Some(reason);
                 let mut meta = Metadata::default(url);
+                let mime: Option<Mime> = "text/html".parse().ok();
+                meta.set_content_type(mime.as_ref());
+                Some(meta)
+            },
+            Err(NetworkError::Internal(reason)) => {
+                network_error = Some(reason);
+                let mut meta = Metadata::default(self.url.clone());
                 let mime: Option<Mime> = "text/html".parse().ok();
                 meta.set_content_type(mime.as_ref());
                 Some(meta)
@@ -481,6 +489,14 @@ impl FetchResponseListener for ParserContext {
                 if let Some(reason) = ssl_error {
                     self.is_synthesized_document = true;
                     let page_bytes = read_resource_file("badcert.html").unwrap();
+                    let page = String::from_utf8(page_bytes).unwrap();
+                    let page = page.replace("${reason}", &reason);
+                    parser.push_input_chunk(page);
+                    parser.parse_sync();
+                }
+                if let Some(reason) = network_error {
+                    self.is_synthesized_document = true;
+                    let page_bytes = read_resource_file("neterror.html").unwrap();
                     let page = String::from_utf8(page_bytes).unwrap();
                     let page = page.replace("${reason}", &reason);
                     parser.push_input_chunk(page);
@@ -527,16 +543,7 @@ impl FetchResponseListener for ParserContext {
             None => return,
         };
 
-        if let Err(NetworkError::Internal(ref reason)) = status {
-            // Show an error page for network errors,
-            // certificate errors are handled earlier.
-            self.is_synthesized_document = true;
-            let page_bytes = read_resource_file("neterror.html").unwrap();
-            let page = String::from_utf8(page_bytes).unwrap();
-            let page = page.replace("${reason}", reason);
-            parser.push_input_chunk(page);
-            parser.parse_sync();
-        } else if let Err(err) = status {
+        if let Err(err) = status {
             // TODO(Savago): we should send a notification to callers #5463.
             debug!("Failed to load page URL {}, error: {:?}", self.url, err);
         }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -8768,6 +8768,12 @@
             "url": "/_mozilla/mozilla/nested_asap_script.html"
           }
         ],
+        "mozilla/network_error_page_load.html": [
+          {
+            "path": "mozilla/network_error_page_load.html",
+            "url": "/_mozilla/mozilla/network_error_page_load.html"
+          }
+        ],
         "mozilla/node_compareDocumentPosition.html": [
           {
             "path": "mozilla/node_compareDocumentPosition.html",

--- a/tests/wpt/mozilla/tests/mozilla/network_error_page_load.html
+++ b/tests/wpt/mozilla/tests/mozilla/network_error_page_load.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test for issue #15017</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<html>
+    <iframe src="http://aowiejfoiawjef" id="foo"></iframe>
+</html>
+<script>
+    var t = async_test("Load resource with network error")
+    var iframe = document.getElementById('foo')
+    iframe.onload = t.step_func(function(e) { t.done() })
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This patch fixes how network errors are handled during page loads: they would not be reported and cause crashes before, and do not anymore.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15017 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15285)
<!-- Reviewable:end -->
