### PR TITLE
Expose interfaces only where they should be. #12415 - Partial

### DIFF
--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -8,7 +8,7 @@
  * Copyright © 2013 W3C® (MIT, ERCIM, Keio, Beihang), All Rights Reserved.
  */
 
-[Exposed=(Window, Worker)]
+[Exposed=Window]
 interface CSSStyleDeclaration {
   [SetterThrows]
            attribute DOMString cssText;

--- a/components/script/dom/webidls/Client.webidl
+++ b/components/script/dom/webidls/Client.webidl
@@ -4,7 +4,7 @@
 
 // https://w3c.github.io/ServiceWorker/#client
 
-[Pref="dom.serviceworker.enabled", Exposed=(Window,Worker)]
+[Pref="dom.serviceworker.enabled", Exposed=ServiceWorker]
 interface Client {
   readonly attribute USVString url;
   readonly attribute FrameType frameType;

--- a/components/script/dom/webidls/ElementCSSInlineStyle.webidl
+++ b/components/script/dom/webidls/ElementCSSInlineStyle.webidl
@@ -4,7 +4,7 @@
 
 //http://dev.w3.org/csswg/cssom/#elementcssinlinestyle
 
-[NoInterfaceObject, Exposed=(Window,Worker)]
+[NoInterfaceObject, Exposed=Window]
 interface ElementCSSInlineStyle {
   [SameObject/*, PutForwards=cssText*/] readonly attribute CSSStyleDeclaration style;
 };

--- a/components/script/dom/webidls/ElementContentEditable.webidl
+++ b/components/script/dom/webidls/ElementContentEditable.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // https://html.spec.whatwg.org/multipage/#elementcontenteditable
-[NoInterfaceObject, Exposed=(Window,Worker)]
+[NoInterfaceObject, Exposed=Window]
 interface ElementContentEditable {
   // attribute DOMString contentEditable;
   // readonly attribute boolean isContentEditable;

--- a/components/script/dom/webidls/EventHandler.webidl
+++ b/components/script/dom/webidls/EventHandler.webidl
@@ -25,7 +25,7 @@ callback OnBeforeUnloadEventHandlerNonNull = DOMString? (Event event);
 typedef OnBeforeUnloadEventHandlerNonNull? OnBeforeUnloadEventHandler;
 
 // https://html.spec.whatwg.org/multipage/#globaleventhandlers
-[NoInterfaceObject, Exposed=(Window,Worker)]
+[NoInterfaceObject, Exposed=Window]
 interface GlobalEventHandlers {
            attribute EventHandler onabort;
            attribute EventHandler onblur;
@@ -95,7 +95,7 @@ partial interface GlobalEventHandlers {
 };
 
 // https://html.spec.whatwg.org/multipage/#windoweventhandlers
-[NoInterfaceObject, Exposed=(Window,Worker)]
+[NoInterfaceObject, Exposed=Window]
 interface WindowEventHandlers {
            attribute EventHandler onafterprint;
            attribute EventHandler onbeforeprint;
@@ -115,7 +115,7 @@ interface WindowEventHandlers {
 };
 
 // https://html.spec.whatwg.org/multipage/#documentandelementeventhandlers
-[NoInterfaceObject, Exposed=(Window,Worker)]
+[NoInterfaceObject, Exposed=Window]
 interface DocumentAndElementEventHandlers {
           attribute EventHandler oncopy;
           attribute EventHandler oncut;

--- a/components/script/dom/webidls/Screen.webidl
+++ b/components/script/dom/webidls/Screen.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // http://dev.w3.org/csswg/cssom-view/#the-screen-interface
-[Exposed=(Window,Worker)]
+[Exposed=Window]
 interface Screen {
   //readonly attribute double availWidth;
   //readonly attribute double availHeight;

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
@@ -9,7 +9,6 @@ importScripts("interfaces.js");
 test_interfaces([
   "Blob",
   "CloseEvent",
-  "CSSStyleDeclaration",
   "DOMMatrix",
   "DOMMatrixReadOnly",
   "DOMPoint",
@@ -38,7 +37,6 @@ test_interfaces([
   "ProgressEvent",
   "Request",
   "Response",
-  "Screen",
   "Storage",
   "StorageEvent",
   "TextDecoder",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

I verified the following interfaces:
CSSStyleDeclaration.webidl
ElementCSSInlineStyle.webidl
ElementContentEditable.webidl
EventHandler.webidl
Screen.webidl
StyleSheetList.webidl
StyleSheet.webidl
Client.webidl

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #12415 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15289)
<!-- Reviewable:end -->
