### PR TITLE
tidy now reports when a doc comment contains TODO, FIXME or NOTE. Add…

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -480,6 +480,9 @@ def check_rust(file_name, lines):
             line = re.sub(r'"(\\.|[^\\"])*?"', '""', line)
             line = re.sub(r"'(\\.|[^\\'])*?'", "''", line)
 
+        if re.search(r".*//[/!].*(TODO|NOTE|FIXME).*", line):
+            yield(idx + 1, "TODO, NOTE or FIXME in doc comment")
+            
         # get rid of comments
         line = re.sub('//.*?$|/\*.*?$|^\*.*?$', '//', line)
 

--- a/python/tidy/servo_tidy_tests/rust_tidy.rs
+++ b/python/tidy/servo_tidy_tests/rust_tidy.rs
@@ -22,6 +22,7 @@ extern crate style_traits;
 #[foo = "bar,baz"]
 impl test {
 
+    ///TODO something
     fn test_fun(y:f32)->f32{
         let x=5;
         x = x-1;

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -105,6 +105,7 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('mod declaration spans multiple lines', errors.next()[2])
         self.assertTrue('extern crate declaration is not in alphabetical order' in errors.next()[2])
         self.assertEqual('found an empty line following a {', errors.next()[2])
+        self.assertEqual('TODO, NOTE or FIXME in doc comment', errors.next()[2])
         self.assertEqual('missing space before ->', errors.next()[2])
         self.assertEqual('missing space after ->', errors.next()[2])
         self.assertEqual('missing space after :', errors.next()[2])


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

With the use of 2 regex I check in the check_rust function in tidy.py if the line has a documentation comment that contains TODO, FIXME or NOTE. I have also added a test for this.
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] These changes fix #15290 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15292)
<!-- Reviewable:end -->
