### PR TITLE
Remove 'buildtimetrend' Travis webhook.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,3 @@ matrix:
 branches:
   only:
     - master
-
-notifications:
-  webhooks:
-    - https://buildtimetrend.herokuapp.com/travis


### PR DESCRIPTION
The service is discontinued.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15304)
<!-- Reviewable:end -->
