### PR TITLE
Make additional properties be reset by the 'font' shorthand.

### DIFF
--- a/components/style/properties/shorthand/font.mako.rs
+++ b/components/style/properties/shorthand/font.mako.rs
@@ -5,7 +5,12 @@
 <%namespace name="helpers" file="/helpers.mako.rs" />
 
 <%helpers:shorthand name="font" sub_properties="font-style font-variant font-weight font-stretch
-                                                font-size line-height font-family"
+                                                font-size line-height font-family
+                                                ${'font-size-adjust' if product == 'gecko' else ''}
+                                                ${'font-kerning' if product == 'gecko' else ''}
+                                                ${'font-variant-caps' if product == 'gecko' else ''}
+                                                ${'font-variant-position' if product == 'gecko' else ''}
+                                                ${'font-language-override' if product == 'none' else ''}"
                     spec="https://drafts.csswg.org/css-fonts-3/#propdef-font">
     use properties::longhands::{font_style, font_variant, font_weight, font_stretch};
     use properties::longhands::{font_size, line_height, font_family};
@@ -72,7 +77,16 @@
             font_stretch: stretch,
             font_size: size,
             line_height: line_height,
-            font_family: Some(font_family::SpecifiedValue(family))
+            font_family: Some(font_family::SpecifiedValue(family)),
+    % if product == "gecko":
+            font_size_adjust: None,
+            font_kerning: None,
+            font_variant_caps: None,
+            font_variant_position: None,
+    % endif
+    % if product == "none":
+            font_language_override: None,
+    % endif
         })
     }
 


### PR DESCRIPTION
A number of properties are supposed to be reset to initial values by the
'font' shorthand.  This does so for all such properties that Servo
currently supports (conditional on when they're supported).

Fixes #15033.


It's not clear to me that the use of <code>None</code> is correct for resetting to initial values, but it seems to match what at least some other shorthands do (I think I was looking at the code for border), and it appears to fix the tests as expected.  I haven't probed into it more than that.

/cc @Manishearth 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors (I haven't quite gotten the servo build to work, but stylo build works)
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15033 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes
- [ ] These changes do not require tests because _____

This has test coverage when running stylo.  In particular, it fixes a bunch of sets of mochitest failures in layout/style/test/test_value_storage.html, with the set for each value of the 'font' shorthand listed in property_database.js looking like:
```
 TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' 
 TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-style') 
 TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-variant') 
 TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-weight') 
 TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-size') 
 TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'line-height') 
 TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-family') 
 TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-stretch') 
-TEST-UNEXPECTED-FAIL | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-size-adjust') - didn't expect "", but got it
+TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-size-adjust') 
 TEST-UNEXPECTED-FAIL | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-feature-settings') - didn't expect "", but got it
 TEST-UNEXPECTED-FAIL | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-language-override') - didn't expect "", but got it
-TEST-UNEXPECTED-FAIL | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-kerning') - didn't expect "", but got it
+TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-kerning') 
 TEST-UNEXPECTED-FAIL | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-synthesis') - didn't expect "", but got it
 TEST-UNEXPECTED-FAIL | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-variant-alternates') - didn't expect "", but got it
-TEST-UNEXPECTED-FAIL | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-variant-caps') - didn't expect "", but got it
+TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-variant-caps') 
 TEST-UNEXPECTED-FAIL | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-variant-east-asian') - didn't expect "", but got it
 TEST-UNEXPECTED-FAIL | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-variant-ligatures') - didn't expect "", but got it
 TEST-UNEXPECTED-FAIL | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-variant-numeric') - didn't expect "", but got it
-TEST-UNEXPECTED-FAIL | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-variant-position') - didn't expect "", but got it
+TEST-PASS | layout/style/test/test_value_storage.html | setting 'medium serif' on 'font' (for 'font-variant-position') 
```

I'm not sure if separate Servo test coverage is needed.
<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15305)
<!-- Reviewable:end -->
