### PR TITLE
Permissions API and WebBluetooth integration

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -65,3 +65,4 @@ characteristicvaluechanged
 fullscreenchange
 fullscreenerror
 gattserverdisconnected
+onchange

--- a/components/bluetooth_traits/lib.rs
+++ b/components/bluetooth_traits/lib.rs
@@ -12,7 +12,7 @@ pub mod blocklist;
 pub mod scanfilter;
 
 use ipc_channel::ipc::IpcSender;
-use scanfilter::RequestDeviceoptions;
+use scanfilter::{BluetoothScanfilterSequence, RequestDeviceoptions};
 
 #[derive(Deserialize, Serialize)]
 pub enum BluetoothError {
@@ -92,6 +92,7 @@ pub enum BluetoothRequest {
     SetRepresentedToNull(Vec<String>, Vec<String>, Vec<String>),
     IsRepresentedDeviceNull(String, IpcSender<bool>),
     GetAvailability(IpcSender<BluetoothResponseResult>),
+    MatchesFilter(String, BluetoothScanfilterSequence, IpcSender<BluetoothResult<bool>>),
     Test(String, IpcSender<BluetoothResult<()>>),
     Exit,
 }

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1845,6 +1845,8 @@ class CGImports(CGWrapper):
                 return type.flatMemberTypes
             if type.isDictionary():
                 return [type] + getTypesFromDictionary(type)
+            if type.isSequence():
+                return componentTypes(type.inner)
             return [type]
 
         def isImportable(type):

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -11,8 +11,14 @@ use core::clone::Clone;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::BluetoothBinding::{self, BluetoothDataFilterInit, BluetoothLEScanFilterInit};
 use dom::bindings::codegen::Bindings::BluetoothBinding::{BluetoothMethods, RequestDeviceOptions};
+use dom::bindings::codegen::Bindings::BluetoothPermissionResultBinding::AllowedBluetoothDevice;
+use dom::bindings::codegen::Bindings::BluetoothPermissionResultBinding::BluetoothPermissionData;
+use dom::bindings::codegen::Bindings::BluetoothPermissionResultBinding::BluetoothPermissionDescriptor;
+use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerBinding::
+    BluetoothRemoteGATTServerMethods;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
-use dom::bindings::codegen::UnionTypes::StringOrUnsignedLong;
+use dom::bindings::codegen::Bindings::PermissionStatusBinding::PermissionState;
+use dom::bindings::codegen::UnionTypes::{StringOrStringSequence, StringOrUnsignedLong};
 use dom::bindings::error::Error::{self, Network, Security, Type};
 use dom::bindings::error::Fallible;
 use dom::bindings::js::{JS, Root};
@@ -20,14 +26,19 @@ use dom::bindings::refcounted::{Trusted, TrustedPromise};
 use dom::bindings::reflector::{DomObject, reflect_dom_object};
 use dom::bindings::str::DOMString;
 use dom::bluetoothdevice::BluetoothDevice;
+use dom::bluetoothpermissionresult::BluetoothPermissionResult;
 use dom::bluetoothuuid::{BluetoothServiceUUID, BluetoothUUID, UUID};
 use dom::eventtarget::EventTarget;
 use dom::globalscope::GlobalScope;
+use dom::permissions::{get_descriptor_permission_state, PermissionAlgorithm};
 use dom::promise::Promise;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
-use js::jsapi::{JSAutoCompartment, JSContext};
+use js::conversions::ConversionResult;
+use js::jsapi::{JSAutoCompartment, JSContext, JSObject};
+use js::jsval::{ObjectValue, UndefinedValue};
 use script_thread::Runnable;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -46,6 +57,48 @@ const SERVICE_DATA_ERROR: &'static str = "'serviceData', if present, must be non
 const SERVICE_ERROR: &'static str = "'services', if present, must contain at least one service.";
 const OPTIONS_ERROR: &'static str = "Fields of 'options' conflict with each other.
  Either 'acceptAllDevices' member must be true, or 'filters' member must be set to a value.";
+const BT_DESC_CONVERSION_ERROR: &'static str = "Can't convert to an IDL value of type BluetoothPermissionDescriptor";
+
+
+thread_local!(pub static EXTRA_PERMISSION_DATA: RefCell<BluetoothPermissionData> =
+              RefCell::new(BluetoothPermissionData { allowedDevices: Vec::new() }));
+
+pub fn add_new_allowed_device(allowed_device: AllowedBluetoothDevice) {
+    EXTRA_PERMISSION_DATA.with(|epdata| {
+        epdata.borrow_mut().allowedDevices.push(allowed_device);
+    });
+}
+
+fn get_allowed_devices() -> Vec<AllowedBluetoothDevice> {
+    EXTRA_PERMISSION_DATA.with(|epdata| {
+        epdata.borrow().allowedDevices.clone()
+    })
+}
+
+pub fn allowed_devices_contains_id(id: DOMString) -> bool {
+    EXTRA_PERMISSION_DATA.with(|epdata| {
+        epdata.borrow_mut().allowedDevices.iter().any(|d| d.deviceId == id)
+    })
+}
+
+impl Clone for StringOrStringSequence {
+    fn clone(&self) -> StringOrStringSequence {
+        match self {
+            &StringOrStringSequence::String(ref s) => StringOrStringSequence::String(s.clone()),
+            &StringOrStringSequence::StringSequence(ref v) => StringOrStringSequence::StringSequence(v.clone()),
+        }
+    }
+}
+
+impl Clone for AllowedBluetoothDevice {
+    fn clone(&self) -> AllowedBluetoothDevice {
+        AllowedBluetoothDevice {
+            deviceId: self.deviceId.clone(),
+            mayUseGATT: self.mayUseGATT,
+            allowedServices: self.allowedServices.clone(),
+        }
+    }
+}
 
 struct BluetoothContext<T: AsyncBluetoothListener + DomObject> {
     promise: Option<TrustedPromise>,
@@ -107,7 +160,8 @@ impl Bluetooth {
     fn request_bluetooth_devices(&self,
                                  p: &Rc<Promise>,
                                  filters: &Option<Vec<BluetoothLEScanFilterInit>>,
-                                 optional_services: &Option<Vec<BluetoothServiceUUID>>) {
+                                 optional_services: &Option<Vec<BluetoothServiceUUID>>,
+                                 sender: IpcSender<BluetoothResponseResult>) {
         // TODO: Step 1: Triggered by user activation.
 
         // Step 2.2: There are no requiredServiceUUIDS, we scan for all devices.
@@ -161,11 +215,15 @@ impl Bluetooth {
         let option = RequestDeviceoptions::new(BluetoothScanfilterSequence::new(uuid_filters),
                                                ServiceUUIDSequence::new(optional_services_uuids));
 
-        // TODO: Step 3 - 5: Implement the permission API.
+        // Step 3 - 5
+        // FIXME The following call will create a popup, which will mess up the testing...
+        // Maybe create a call to the lower level to check if we are testing or not
+        // if let PermissionState::Denied = get_descriptor_permission_state(PermissionName::Bluetooth, None) {
+        //     return p.reject_error(p.global().get_cx(), Error::NotFound);
+        // }
 
         // Note: Steps 6 - 8 are implemented in
         // components/net/bluetooth_thread.rs in request_device function.
-        let sender = response_async(p, self);
         self.get_bluetooth_thread().send(BluetoothRequest::RequestDevice(option, sender)).unwrap();
     }
 }
@@ -438,7 +496,8 @@ impl BluetoothMethods for Bluetooth {
         }
 
         // Step 2.
-        self.request_bluetooth_devices(&p, &option.filters, &option.optionalServices);
+        let sender = response_async(&p, self);
+        self.request_bluetooth_devices(&p, &option.filters, &option.optionalServices, sender);
         //Note: Step 3 - 4. in response function, Step 5. in handle_response function.
         return p;
     }
@@ -463,7 +522,7 @@ impl AsyncBluetoothListener for Bluetooth {
     fn handle_response(&self, response: BluetoothResponse, promise_cx: *mut JSContext, promise: &Rc<Promise>) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices
-            // Step 13 - 14.
+            // Step 11, 13 - 14.
             BluetoothResponse::RequestDevice(device) => {
                 let mut device_instance_map = self.device_instance_map.borrow_mut();
                 if let Some(existing_device) = device_instance_map.get(&device.id.clone()) {
@@ -473,7 +532,16 @@ impl AsyncBluetoothListener for Bluetooth {
                                                      DOMString::from(device.id.clone()),
                                                      device.name.map(DOMString::from),
                                                      &self);
-                device_instance_map.insert(device.id, JS::from_ref(&bt_device));
+                device_instance_map.insert(device.id.clone(), JS::from_ref(&bt_device));
+                add_new_allowed_device(
+                    AllowedBluetoothDevice {
+                        // TODO fix this
+                        // allowedServices only relevant if the device store it as an inter slot as well
+                        allowedServices: StringOrStringSequence::String(DOMString::from("all".to_owned())),
+                        deviceId: DOMString::from(device.id),
+                        mayUseGATT: true,
+                    }
+                );
                 // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice
                 // Step 5.
                 promise.resolve_native(promise_cx, &bt_device);
@@ -484,6 +552,151 @@ impl AsyncBluetoothListener for Bluetooth {
                 promise.resolve_native(promise_cx, &is_available);
             }
             _ => promise.reject_error(promise_cx, Error::Type("Something went wrong...".to_owned())),
+        }
+    }
+}
+
+impl PermissionAlgorithm for Bluetooth {
+    type Descriptor = BluetoothPermissionDescriptor;
+    type Status = BluetoothPermissionResult;
+
+    #[allow(unsafe_code)]
+    fn create_descriptor(cx: *mut JSContext,
+                         permission_descriptor_obj: *mut JSObject)
+                         -> Result<BluetoothPermissionDescriptor, Error> {
+        rooted!(in(cx) let mut property = UndefinedValue());
+        property.handle_mut().set(ObjectValue(permission_descriptor_obj));
+        unsafe {
+            match BluetoothPermissionDescriptor::new(cx, property.handle()) {
+                Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
+                Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
+                Err(_) => Err(Error::Type(String::from(BT_DESC_CONVERSION_ERROR))),
+            }
+        }
+    }
+
+    #[allow(unrooted_must_root)]
+    // https://webbluetoothcg.github.io/web-bluetooth/#query-the-bluetooth-permission
+    fn permission_query(cx: *mut JSContext, promise: &Rc<Promise>,
+                        descriptor: &BluetoothPermissionDescriptor,
+                        status: &BluetoothPermissionResult) {
+        // Step 1.
+        // TODO: `environment settings object` is not implemented in Servo yet.
+
+        // Step 2.
+        status.set_state(get_descriptor_permission_state(status.get_query(), None));
+
+        // Step 3.
+        if let PermissionState::Denied = status.get_state() {
+            status.set_devices(Vec::new());
+            return promise.resolve_native(cx, status);
+        }
+
+        // Step 4.
+        let mut matching_devices: Vec<JS<BluetoothDevice>> = Vec::new();
+
+        // TODO: Step 5: Create a map between the current setting object and BluetoothPermissionData
+        // extra permission data, which replaces the exisitng EXTRA_PERMISSION_DATA global variable.
+        // For this also use the extra permission data constraints from the specification:
+        // https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothpermissiondata
+
+        // Step 5.
+        let allowed_devices = get_allowed_devices();
+
+        let bluetooth = status.get_bluetooth();
+        let device_map = bluetooth.get_device_map().borrow();
+
+        // Step 6.
+        for allowed_device in allowed_devices {
+            // Step 6.1.
+            if let Some(ref id) = descriptor.deviceId {
+                if &allowed_device.deviceId != id {
+                    continue;
+                }
+            }
+            let device_id = String::from(allowed_device.deviceId.as_ref());
+            if let Some(ref filters) = descriptor.filters {
+                let mut scan_filters: Vec<BluetoothScanfilter> = Vec::new();
+
+                // NOTE(zakorgy): This canonicalizing step is missing from the specification.
+                // But there is an issue for this: https://github.com/WebBluetoothCG/web-bluetooth/issues/347
+                for filter in filters {
+                    match canonicalize_filter(&filter) {
+                        Ok(f) => scan_filters.push(f),
+                        Err(error) => return promise.reject_error(cx, error),
+                    }
+                }
+
+                // Step 6.2.
+                // Instead of creating an internal slot we send an ipc message to the Bluetooth thread
+                // to check if one of the filters matches.
+                let (sender, receiver) = ipc::channel().unwrap();
+                status.get_bluetooth_thread()
+                      .send(BluetoothRequest::MatchesFilter(device_id.clone(),
+                                                            BluetoothScanfilterSequence::new(scan_filters),
+                                                            sender)).unwrap();
+
+                match receiver.recv().unwrap() {
+                    Ok(true) => (),
+                    Ok(false) => continue,
+                    Err(error) => return promise.reject_error(cx, Error::from(error)),
+                };
+            }
+
+            // Step 6.4.
+            // TODO: Implement this correctly, not just using device ids here.
+            // https://webbluetoothcg.github.io/web-bluetooth/#get-the-bluetoothdevice-representing
+            if let Some(ref device) = device_map.get(&device_id) {
+                matching_devices.push(JS::from_ref(&*device));
+            }
+        }
+
+        // Step 7.
+        status.set_devices(matching_devices);
+
+        // https://w3c.github.io/permissions/#dom-permissions-query
+        // Step 7.
+        promise.resolve_native(cx, status);
+    }
+
+    // NOTE(zakorgy): There is no link for this algorithm until this PR for the spec is pending:
+    // https://github.com/WebBluetoothCG/web-bluetooth/pull/349
+    fn permission_request(cx: *mut JSContext, promise: &Rc<Promise>,
+                          descriptor: &BluetoothPermissionDescriptor,
+                          status: &BluetoothPermissionResult) {
+        // Step 1.
+        if descriptor.filters.is_some() == descriptor.acceptAllDevices {
+            return promise.reject_error(cx, Error::Type(OPTIONS_ERROR.to_owned()));
+        }
+
+        // Step 2.
+        let sender = response_async(promise, status);
+        let bluetooth = status.get_bluetooth();
+        bluetooth.request_bluetooth_devices(promise, &descriptor.filters, &descriptor.optionalServices, sender);
+
+        // NOTE: Step 3. is in BluetoothPermissionResult's `handle_response` function.
+    }
+
+    #[allow(unrooted_must_root)]
+    // https://webbluetoothcg.github.io/web-bluetooth/#revoke-bluetooth-access
+    fn permission_revoke(_descriptor: &BluetoothPermissionDescriptor, status: &BluetoothPermissionResult) {
+        // Step 1.
+        let allowed_devices = get_allowed_devices();
+        // Step 2.
+        let bluetooth = status.get_bluetooth();
+        let device_map = bluetooth.get_device_map().borrow();
+        for (id, device) in device_map.iter() {
+            let id = DOMString::from(id.clone());
+            // Step 2.1.
+            if allowed_devices.iter().any(|d| d.deviceId == id) &&
+               !device.is_represented_device_null() {
+                // Note: We don't need to update the allowed_services,
+                // because we store it in the lower level
+                // where it is already up-to-date
+                continue;
+            }
+            // Step 2.2 - 2.4
+            let _ = device.get_gatt().Disconnect();
         }
     }
 }

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -215,12 +215,12 @@ impl Bluetooth {
         let option = RequestDeviceoptions::new(BluetoothScanfilterSequence::new(uuid_filters),
                                                ServiceUUIDSequence::new(optional_services_uuids));
 
-        // Step 3 - 5
+        // Step 4 - 5.
         if let PermissionState::Denied = get_descriptor_permission_state(PermissionName::Bluetooth, None) {
             return p.reject_error(p.global().get_cx(), Error::NotFound);
         }
 
-        // Note: Steps 6 - 8 are implemented in
+        // Note: Step 3, 6 - 8 are implemented in
         // components/net/bluetooth_thread.rs in request_device function.
         self.get_bluetooth_thread().send(BluetoothRequest::RequestDevice(option, sender)).unwrap();
     }

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -17,7 +17,7 @@ use dom::bindings::codegen::Bindings::BluetoothPermissionResultBinding::Bluetoot
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerBinding::
     BluetoothRemoteGATTServerMethods;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
-use dom::bindings::codegen::Bindings::PermissionStatusBinding::PermissionState;
+use dom::bindings::codegen::Bindings::PermissionStatusBinding::{PermissionName, PermissionState};
 use dom::bindings::codegen::UnionTypes::{StringOrStringSequence, StringOrUnsignedLong};
 use dom::bindings::error::Error::{self, Network, Security, Type};
 use dom::bindings::error::Fallible;
@@ -216,11 +216,9 @@ impl Bluetooth {
                                                ServiceUUIDSequence::new(optional_services_uuids));
 
         // Step 3 - 5
-        // FIXME The following call will create a popup, which will mess up the testing...
-        // Maybe create a call to the lower level to check if we are testing or not
-        // if let PermissionState::Denied = get_descriptor_permission_state(PermissionName::Bluetooth, None) {
-        //     return p.reject_error(p.global().get_cx(), Error::NotFound);
-        // }
+        if let PermissionState::Denied = get_descriptor_permission_state(PermissionName::Bluetooth, None) {
+            return p.reject_error(p.global().get_cx(), Error::NotFound);
+        }
 
         // Note: Steps 6 - 8 are implemented in
         // components/net/bluetooth_thread.rs in request_device function.

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -573,7 +573,6 @@ impl PermissionAlgorithm for Bluetooth {
         }
     }
 
-    #[allow(unrooted_must_root)]
     // https://webbluetoothcg.github.io/web-bluetooth/#query-the-bluetooth-permission
     fn permission_query(cx: *mut JSContext, promise: &Rc<Promise>,
                         descriptor: &BluetoothPermissionDescriptor,
@@ -590,7 +589,7 @@ impl PermissionAlgorithm for Bluetooth {
         }
 
         // Step 4.
-        let mut matching_devices: Vec<JS<BluetoothDevice>> = Vec::new();
+        rooted_vec!(let mut matching_devices);
 
         // TODO: Step 5: Create a map between the current setting object and BluetoothPermissionData
         // extra permission data, which replaces the exisitng EXTRA_PERMISSION_DATA global variable.
@@ -644,13 +643,13 @@ impl PermissionAlgorithm for Bluetooth {
             // Step 6.3.
             // TODO: Implement this correctly, not just using device ids here.
             // https://webbluetoothcg.github.io/web-bluetooth/#get-the-bluetoothdevice-representing
-            if let Some(ref device) = device_map.get(&device_id) {
-                matching_devices.push(JS::from_ref(&*device));
+            if let Some(device) = device_map.get(&device_id) {
+                matching_devices.push(JS::from_ref(&**device));
             }
         }
 
         // Step 7.
-        status.set_devices(matching_devices);
+        status.set_devices(matching_devices.drain(..).collect());
 
         // https://w3c.github.io/permissions/#dom-permissions-query
         // Step 7.

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -580,8 +580,7 @@ impl PermissionAlgorithm for Bluetooth {
     fn permission_query(cx: *mut JSContext, promise: &Rc<Promise>,
                         descriptor: &BluetoothPermissionDescriptor,
                         status: &BluetoothPermissionResult) {
-        // Step 1.
-        // TODO: `environment settings object` is not implemented in Servo yet.
+        // Step 1: We are not using the `global` variable.
 
         // Step 2.
         status.set_state(get_descriptor_permission_state(status.get_query(), None));
@@ -615,11 +614,12 @@ impl PermissionAlgorithm for Bluetooth {
                 }
             }
             let device_id = String::from(allowed_device.deviceId.as_ref());
+
+            // Step 6.2.
             if let Some(ref filters) = descriptor.filters {
                 let mut scan_filters: Vec<BluetoothScanfilter> = Vec::new();
 
-                // NOTE(zakorgy): This canonicalizing step is missing from the specification.
-                // But there is an issue for this: https://github.com/WebBluetoothCG/web-bluetooth/issues/347
+                // Step 6.2.1.
                 for filter in filters {
                     match canonicalize_filter(&filter) {
                         Ok(f) => scan_filters.push(f),
@@ -627,7 +627,7 @@ impl PermissionAlgorithm for Bluetooth {
                     }
                 }
 
-                // Step 6.2.
+                // Step 6.2.2.
                 // Instead of creating an internal slot we send an ipc message to the Bluetooth thread
                 // to check if one of the filters matches.
                 let (sender, receiver) = ipc::channel().unwrap();
@@ -643,7 +643,7 @@ impl PermissionAlgorithm for Bluetooth {
                 };
             }
 
-            // Step 6.4.
+            // Step 6.3.
             // TODO: Implement this correctly, not just using device ids here.
             // https://webbluetoothcg.github.io/web-bluetooth/#get-the-bluetoothdevice-representing
             if let Some(ref device) = device_map.get(&device_id) {
@@ -659,8 +659,7 @@ impl PermissionAlgorithm for Bluetooth {
         promise.resolve_native(cx, status);
     }
 
-    // NOTE(zakorgy): There is no link for this algorithm until this PR for the spec is pending:
-    // https://github.com/WebBluetoothCG/web-bluetooth/pull/349
+    // https://webbluetoothcg.github.io/web-bluetooth/#request-the-bluetooth-permission
     fn permission_request(cx: *mut JSContext, promise: &Rc<Promise>,
                           descriptor: &BluetoothPermissionDescriptor,
                           status: &BluetoothPermissionResult) {

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -15,7 +15,7 @@ use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{JS, MutNullableJS, Root};
 use dom::bindings::reflector::{DomObject, reflect_dom_object};
 use dom::bindings::str::DOMString;
-use dom::bluetooth::{allowed_devices_contains_id, AsyncBluetoothListener, Bluetooth, response_async};
+use dom::bluetooth::{AsyncBluetoothListener, Bluetooth, response_async};
 use dom::bluetoothcharacteristicproperties::BluetoothCharacteristicProperties;
 use dom::bluetoothremotegattcharacteristic::BluetoothRemoteGATTCharacteristic;
 use dom::bluetoothremotegattdescriptor::BluetoothRemoteGATTDescriptor;
@@ -228,7 +228,8 @@ impl BluetoothDeviceMethods for BluetoothDevice {
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-gatt
     fn GetGatt(&self) -> Option<Root<BluetoothRemoteGATTServer>> {
         // Step 1.
-        if allowed_devices_contains_id(self.id.clone()) && !self.is_represented_device_null() {
+        if self.global().as_window().bluetooth_extra_permission_data()
+               .allowed_devices_contains_id(self.id.clone()) && !self.is_represented_device_null() {
             return Some(self.get_gatt())
         }
         // Step 2.

--- a/components/script/dom/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetoothpermissionresult.rs
@@ -5,17 +5,15 @@
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse};
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::BluetoothPermissionResultBinding::{self, BluetoothPermissionResultMethods};
-use dom::bindings::codegen::Bindings::BluetoothPermissionResultBinding::AllowedBluetoothDevice;
 use dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorBinding::NavigatorMethods;
 use dom::bindings::codegen::Bindings::PermissionStatusBinding::{PermissionName, PermissionState};
 use dom::bindings::codegen::Bindings::PermissionStatusBinding::PermissionStatusBinding::PermissionStatusMethods;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowBinding::WindowMethods;
-use dom::bindings::codegen::UnionTypes::StringOrStringSequence;
 use dom::bindings::error::Error;
 use dom::bindings::js::{JS, Root};
 use dom::bindings::reflector::{DomObject, reflect_dom_object};
 use dom::bindings::str::DOMString;
-use dom::bluetooth::{AsyncBluetoothListener, Bluetooth};
+use dom::bluetooth::{AsyncBluetoothListener, Bluetooth, AllowedBluetoothDevice};
 use dom::bluetoothdevice::BluetoothDevice;
 use dom::globalscope::GlobalScope;
 use dom::permissionstatus::PermissionStatus;
@@ -108,9 +106,6 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
                 device_instance_map.insert(device.id.clone(), JS::from_ref(&bt_device));
                 self.global().as_window().bluetooth_extra_permission_data().add_new_allowed_device(
                     AllowedBluetoothDevice {
-                        // TODO fix this
-                        // allowedServices only relevant if the device store it as an internal slot as well
-                        allowedServices: StringOrStringSequence::String(DOMString::from("all".to_owned())),
                         deviceId: DOMString::from(device.id),
                         mayUseGATT: true,
                     }

--- a/components/script/dom/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetoothpermissionresult.rs
@@ -87,8 +87,9 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
     fn handle_response(&self, response: BluetoothResponse, promise_cx: *mut JSContext, promise: &Rc<Promise>) {
         match response {
             // https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices
-            // Step 11, 13 - 14.
+            // Step 3, 11, 13 - 14.
             BluetoothResponse::RequestDevice(device) => {
+                self.set_state(PermissionState::Granted);
                 let bluetooth = self.get_bluetooth();
                 let mut device_instance_map = bluetooth.get_device_map().borrow_mut();
                 if let Some(ref existing_device) = device_instance_map.get(&device.id) {

--- a/components/script/dom/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetoothpermissionresult.rs
@@ -15,7 +15,7 @@ use dom::bindings::error::Error;
 use dom::bindings::js::{JS, Root};
 use dom::bindings::reflector::{DomObject, reflect_dom_object};
 use dom::bindings::str::DOMString;
-use dom::bluetooth::{add_new_allowed_device, AsyncBluetoothListener, Bluetooth};
+use dom::bluetooth::{AsyncBluetoothListener, Bluetooth};
 use dom::bluetoothdevice::BluetoothDevice;
 use dom::globalscope::GlobalScope;
 use dom::permissionstatus::PermissionStatus;
@@ -106,7 +106,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
                                                      device.name.map(DOMString::from),
                                                      &bluetooth);
                 device_instance_map.insert(device.id.clone(), JS::from_ref(&bt_device));
-                add_new_allowed_device(
+                self.global().as_window().bluetooth_extra_permission_data().add_new_allowed_device(
                     AllowedBluetoothDevice {
                         // TODO fix this
                         // allowedServices only relevant if the device store it as an internal slot as well

--- a/components/script/dom/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetoothpermissionresult.rs
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use bluetooth_traits::{BluetoothRequest, BluetoothResponse};
+use dom::bindings::cell::DOMRefCell;
+use dom::bindings::codegen::Bindings::BluetoothPermissionResultBinding::{self, BluetoothPermissionResultMethods};
+use dom::bindings::codegen::Bindings::BluetoothPermissionResultBinding::AllowedBluetoothDevice;
+use dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorBinding::NavigatorMethods;
+use dom::bindings::codegen::Bindings::PermissionStatusBinding::{PermissionName, PermissionState};
+use dom::bindings::codegen::Bindings::PermissionStatusBinding::PermissionStatusBinding::PermissionStatusMethods;
+use dom::bindings::codegen::Bindings::WindowBinding::WindowBinding::WindowMethods;
+use dom::bindings::codegen::UnionTypes::StringOrStringSequence;
+use dom::bindings::error::Error;
+use dom::bindings::js::{JS, Root};
+use dom::bindings::reflector::{DomObject, reflect_dom_object};
+use dom::bindings::str::DOMString;
+use dom::bluetooth::{add_new_allowed_device, AsyncBluetoothListener, Bluetooth};
+use dom::bluetoothdevice::BluetoothDevice;
+use dom::globalscope::GlobalScope;
+use dom::permissionstatus::PermissionStatus;
+use dom::promise::Promise;
+use ipc_channel::ipc::IpcSender;
+use js::jsapi::JSContext;
+use std::rc::Rc;
+
+// https://webbluetoothcg.github.io/web-bluetooth/#bluetoothpermissionresult
+#[dom_struct]
+pub struct BluetoothPermissionResult {
+    status: PermissionStatus,
+    devices: DOMRefCell<Vec<JS<BluetoothDevice>>>,
+}
+
+impl BluetoothPermissionResult {
+    #[allow(unrooted_must_root)]
+    pub fn new_inherited(status: &PermissionStatus) -> BluetoothPermissionResult {
+        let result = BluetoothPermissionResult {
+            status: PermissionStatus::new_inherited(status.get_query()),
+            devices: DOMRefCell::new(Vec::new()),
+        };
+        result.status.set_state(status.State());
+        result
+    }
+
+    pub fn new(global: &GlobalScope, status: &PermissionStatus) -> Root<BluetoothPermissionResult> {
+        reflect_dom_object(box BluetoothPermissionResult::new_inherited(status),
+                           global,
+                           BluetoothPermissionResultBinding::Wrap)
+    }
+
+    pub fn get_bluetooth(&self) -> Root<Bluetooth> {
+        self.global().as_window().Navigator().Bluetooth()
+    }
+
+    pub fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+        self.global().as_window().bluetooth_thread()
+    }
+
+    pub fn get_query(&self) -> PermissionName {
+        self.status.get_query()
+    }
+
+    pub fn set_state(&self, state: PermissionState) {
+        self.status.set_state(state)
+    }
+
+    pub fn get_state(&self) -> PermissionState {
+        self.status.State()
+    }
+
+    #[allow(unrooted_must_root)]
+    pub fn set_devices(&self, devices: Vec<JS<BluetoothDevice>>) {
+        *self.devices.borrow_mut() = devices;
+    }
+}
+
+impl BluetoothPermissionResultMethods for BluetoothPermissionResult {
+    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothpermissionresult-devices
+    fn Devices(&self) -> Vec<Root<BluetoothDevice>> {
+        let device_vec: Vec<Root<BluetoothDevice>> =
+            self.devices.borrow().iter().map(|d| Root::from_ref(&**d)).collect();
+        device_vec
+    }
+}
+
+impl AsyncBluetoothListener for BluetoothPermissionResult {
+    fn handle_response(&self, response: BluetoothResponse, promise_cx: *mut JSContext, promise: &Rc<Promise>) {
+        match response {
+            // https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices
+            // Step 11, 13 - 14.
+            BluetoothResponse::RequestDevice(device) => {
+                let bluetooth = &self.get_bluetooth();
+                let mut device_instance_map = bluetooth.get_device_map().borrow_mut();
+                if let Some(ref existing_device) = device_instance_map.get(&device.id) {
+                    // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothpermissionresult
+                    // Step 3.
+                    self.set_devices(vec!(JS::from_ref(&*existing_device)));
+
+                    // https://w3c.github.io/permissions/#dom-permissions-request
+                    // Step 8.
+                    return promise.resolve_native(promise_cx, self);
+                }
+                let bt_device = BluetoothDevice::new(&self.global(),
+                                                     DOMString::from(device.id.clone()),
+                                                     device.name.map(DOMString::from),
+                                                     bluetooth);
+                device_instance_map.insert(device.id.clone(), JS::from_ref(&bt_device));
+                add_new_allowed_device(
+                    AllowedBluetoothDevice {
+                        // TODO fix this
+                        // allowedServices only relevant if the device store it as an internal slot as well
+                        allowedServices: StringOrStringSequence::String(DOMString::from("all".to_owned())),
+                        deviceId: DOMString::from(device.id),
+                        mayUseGATT: true,
+                    }
+                );
+                // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothpermissionresult
+                // Step 3.
+                self.set_devices(vec!(JS::from_ref(&bt_device)));
+
+                // https://w3c.github.io/permissions/#dom-permissions-request
+                // Step 8.
+                promise.resolve_native(promise_cx, self);
+            },
+            _ => promise.reject_error(promise_cx, Error::Type("Something went wrong...".to_owned())),
+        }
+    }
+}

--- a/components/script/dom/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetoothpermissionresult.rs
@@ -33,7 +33,7 @@ pub struct BluetoothPermissionResult {
 
 impl BluetoothPermissionResult {
     #[allow(unrooted_must_root)]
-    pub fn new_inherited(status: &PermissionStatus) -> BluetoothPermissionResult {
+    fn new_inherited(status: &PermissionStatus) -> BluetoothPermissionResult {
         let result = BluetoothPermissionResult {
             status: PermissionStatus::new_inherited(status.get_query()),
             devices: DOMRefCell::new(Vec::new()),
@@ -89,10 +89,10 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
             // https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices
             // Step 11, 13 - 14.
             BluetoothResponse::RequestDevice(device) => {
-                let bluetooth = &self.get_bluetooth();
+                let bluetooth = self.get_bluetooth();
                 let mut device_instance_map = bluetooth.get_device_map().borrow_mut();
                 if let Some(ref existing_device) = device_instance_map.get(&device.id) {
-                    // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothpermissionresult
+                    // https://webbluetoothcg.github.io/web-bluetooth/#request-the-bluetooth-permission
                     // Step 3.
                     self.set_devices(vec!(JS::from_ref(&*existing_device)));
 
@@ -103,7 +103,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
                 let bt_device = BluetoothDevice::new(&self.global(),
                                                      DOMString::from(device.id.clone()),
                                                      device.name.map(DOMString::from),
-                                                     bluetooth);
+                                                     &bluetooth);
                 device_instance_map.insert(device.id.clone(), JS::from_ref(&bt_device));
                 add_new_allowed_device(
                     AllowedBluetoothDevice {
@@ -114,7 +114,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
                         mayUseGATT: true,
                     }
                 );
-                // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothpermissionresult
+                // https://webbluetoothcg.github.io/web-bluetooth/#request-the-bluetooth-permission
                 // Step 3.
                 self.set_devices(vec!(JS::from_ref(&bt_device)));
 

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -7,7 +7,6 @@ use bluetooth_traits::blocklist::{Blocklist, uuid_is_blocklisted};
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::BluetoothCharacteristicPropertiesBinding::
     BluetoothCharacteristicPropertiesMethods;
-use dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding::
     BluetoothRemoteGATTCharacteristicMethods;
@@ -104,7 +103,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-getdescriptor
     fn GetDescriptor(&self, descriptor: BluetoothDescriptorUUID) -> Rc<Promise> {
         get_gatt_children(self, true, BluetoothUUID::descriptor, Some(descriptor), self.get_instance_id(),
-                          self.Service().Device().Gatt().Connected(), GATTType::Descriptor)
+                          self.Service().Device().get_gatt().Connected(), GATTType::Descriptor)
     }
 
     #[allow(unrooted_must_root)]
@@ -113,7 +112,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
                       descriptor: Option<BluetoothDescriptorUUID>)
                       -> Rc<Promise> {
         get_gatt_children(self, false, BluetoothUUID::descriptor, descriptor, self.get_instance_id(),
-                          self.Service().Device().Gatt().Connected(), GATTType::Descriptor)
+                          self.Service().Device().get_gatt().Connected(), GATTType::Descriptor)
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-value
@@ -134,7 +133,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         }
 
         // Step 2.
-        if !self.Service().Device().Gatt().Connected() {
+        if !self.Service().Device().get_gatt().Connected() {
             p.reject_error(p_cx, Network);
             return p;
         }
@@ -174,7 +173,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         }
 
         // Step 4.
-        if !self.Service().Device().Gatt().Connected() {
+        if !self.Service().Device().get_gatt().Connected() {
             p.reject_error(p_cx, Network);
             return p;
         }
@@ -210,7 +209,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         }
 
         // Step 2.
-        if !self.Service().Device().Gatt().Connected() {
+        if !self.Service().Device().get_gatt().Connected() {
             p.reject_error(p_cx, Network);
             return p;
         }

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -5,7 +5,6 @@
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse};
 use bluetooth_traits::blocklist::{Blocklist, uuid_is_blocklisted};
 use dom::bindings::cell::DOMRefCell;
-use dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding::
     BluetoothRemoteGATTCharacteristicMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTDescriptorBinding;
@@ -98,7 +97,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         }
 
         // Step 2.
-        if !self.Characteristic().Service().Device().Gatt().Connected() {
+        if !self.Characteristic().Service().Device().get_gatt().Connected() {
             p.reject_error(p_cx, Network);
             return p;
         }
@@ -131,7 +130,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         }
 
         // Step 4.
-        if !self.Characteristic().Service().Device().Gatt().Connected() {
+        if !self.Characteristic().Service().Device().get_gatt().Connected() {
             p.reject_error(p_cx, Network);
             return p;
         }

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -103,8 +103,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
     #[allow(unrooted_must_root)]
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-getprimaryservice
     fn GetPrimaryService(&self, service: BluetoothServiceUUID) -> Rc<Promise> {
-        // Step 1. is in get_gatt_children
-        // Step 2.
+        // Step 1 - 2.
         get_gatt_children(self, true, BluetoothUUID::service, Some(service), String::from(self.Device().Id()),
                           self.Device().get_gatt().Connected(), GATTType::PrimaryService)
     }
@@ -112,8 +111,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
     #[allow(unrooted_must_root)]
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-getprimaryservices
     fn GetPrimaryServices(&self, service: Option<BluetoothServiceUUID>) -> Rc<Promise> {
-        // Step 1. is in get_gatt_children
-        // Step 2.
+        // Step 1 - 2.
         get_gatt_children(self, false, BluetoothUUID::service, service, String::from(self.Device().Id()),
                           self.Connected(), GATTType::PrimaryService)
 

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -103,16 +103,16 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
     #[allow(unrooted_must_root)]
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-getprimaryservice
     fn GetPrimaryService(&self, service: BluetoothServiceUUID) -> Rc<Promise> {
-        // TODO: Step 1: Implement the Permission API and the allowedServices BluetoothDevice internal slot.
+        // Step 1. is in get_gatt_children
         // Step 2.
         get_gatt_children(self, true, BluetoothUUID::service, Some(service), String::from(self.Device().Id()),
-                          self.Device().Gatt().Connected(), GATTType::PrimaryService)
+                          self.Device().get_gatt().Connected(), GATTType::PrimaryService)
     }
 
     #[allow(unrooted_must_root)]
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-getprimaryservices
     fn GetPrimaryServices(&self, service: Option<BluetoothServiceUUID>) -> Rc<Promise> {
-        // TODO: Step 1: Implement the Permission API and the allowedServices BluetoothDevice internal slot.
+        // Step 1. is in get_gatt_children
         // Step 2.
         get_gatt_children(self, false, BluetoothUUID::service, service, String::from(self.Device().Id()),
                           self.Connected(), GATTType::PrimaryService)

--- a/components/script/dom/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetoothremotegattservice.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use bluetooth_traits::{BluetoothResponse, GATTType};
-use dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding::BluetoothRemoteGATTServiceMethods;
@@ -87,7 +86,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                          characteristic: BluetoothCharacteristicUUID)
                          -> Rc<Promise> {
         get_gatt_children(self, true, BluetoothUUID::characteristic, Some(characteristic), self.get_instance_id(),
-                          self.Device().Gatt().Connected(), GATTType::Characteristic)
+                          self.Device().get_gatt().Connected(), GATTType::Characteristic)
     }
 
     #[allow(unrooted_must_root)]
@@ -96,7 +95,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                           characteristic: Option<BluetoothCharacteristicUUID>)
                           -> Rc<Promise> {
         get_gatt_children(self, false, BluetoothUUID::characteristic, characteristic, self.get_instance_id(),
-                          self.Device().Gatt().Connected(), GATTType::Characteristic)
+                          self.Device().get_gatt().Connected(), GATTType::Characteristic)
     }
 
     #[allow(unrooted_must_root)]
@@ -105,7 +104,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                           service: BluetoothServiceUUID)
                           -> Rc<Promise> {
         get_gatt_children(self, false, BluetoothUUID::service, Some(service), self.get_instance_id(),
-                          self.Device().Gatt().Connected(), GATTType::IncludedService)
+                          self.Device().get_gatt().Connected(), GATTType::IncludedService)
     }
 
 
@@ -115,7 +114,7 @@ impl BluetoothRemoteGATTServiceMethods for BluetoothRemoteGATTService {
                           service: Option<BluetoothServiceUUID>)
                           -> Rc<Promise> {
         get_gatt_children(self, false, BluetoothUUID::service, service, self.get_instance_id(),
-                          self.Device().Gatt().Connected(), GATTType::IncludedService)
+                          self.Device().get_gatt().Connected(), GATTType::IncludedService)
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-serviceeventhandlers-onserviceadded
@@ -151,12 +150,12 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
             // Step 7.
             BluetoothResponse::GetIncludedServices(services_vec, single) => {
                 if single {
-                    promise.resolve_native(promise_cx, &device.get_or_create_service(&services_vec[0], &device.Gatt()));
-                    return;
+                    return promise.resolve_native(promise_cx,
+                                                  &device.get_or_create_service(&services_vec[0], &device.get_gatt()));
                 }
                 let mut services = vec!();
                 for service in services_vec {
-                    let bt_service = device.get_or_create_service(&service, &device.Gatt());
+                    let bt_service = device.get_or_create_service(&service, &device.get_gatt());
                     services.push(bt_service);
                 }
                 promise.resolve_native(promise_cx, &services);

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -223,6 +223,7 @@ pub mod bluetooth;
 pub mod bluetoothadvertisingevent;
 pub mod bluetoothcharacteristicproperties;
 pub mod bluetoothdevice;
+pub mod bluetoothpermissionresult;
 pub mod bluetoothremotegattcharacteristic;
 pub mod bluetoothremotegattdescriptor;
 pub mod bluetoothremotegattserver;

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -384,6 +384,8 @@ pub mod nodelist;
 pub mod pagetransitionevent;
 pub mod performance;
 pub mod performancetiming;
+pub mod permissions;
+pub mod permissionstatus;
 pub mod plugin;
 pub mod pluginarray;
 pub mod popstateevent;

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -10,6 +10,7 @@ use dom::bindings::str::DOMString;
 use dom::bluetooth::Bluetooth;
 use dom::mimetypearray::MimeTypeArray;
 use dom::navigatorinfo;
+use dom::permissions::Permissions;
 use dom::pluginarray::PluginArray;
 use dom::serviceworkercontainer::ServiceWorkerContainer;
 use dom::vr::VR;
@@ -23,7 +24,8 @@ pub struct Navigator {
     plugins: MutNullableJS<PluginArray>,
     mime_types: MutNullableJS<MimeTypeArray>,
     service_worker: MutNullableJS<ServiceWorkerContainer>,
-    vr: MutNullableJS<VR>
+    vr: MutNullableJS<VR>,
+    permissions: MutNullableJS<Permissions>,
 }
 
 impl Navigator {
@@ -35,6 +37,7 @@ impl Navigator {
             mime_types: Default::default(),
             service_worker: Default::default(),
             vr: Default::default(),
+            permissions: Default::default(),
         }
     }
 
@@ -122,6 +125,11 @@ impl NavigatorMethods for Navigator {
     // https://w3c.github.io/webvr/#interface-navigator
     fn Vr(&self) -> Root<VR> {
         self.vr.or_init(|| VR::new(&self.global()))
+    }
+
+    // https://w3c.github.io/permissions/#navigator-and-workernavigator-extension
+    fn Permissions(&self) -> Root<Permissions> {
+        self.permissions.or_init(|| Permissions::new(&self.global()))
     }
 }
 

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -247,9 +247,9 @@ fn prompt_user(permission_name: PermissionName) -> PermissionState {
                                               &format!("{} {:?} ?", QUERY_DIALOG_MESSAGE, permission_name),
                                               MessageBoxIcon::Question,
                                               YesNo::No) {
-        YesNo::Yes => return PermissionState::Granted,
-        YesNo::No => return PermissionState::Denied,
-    };
+        YesNo::Yes => PermissionState::Granted,
+        YesNo::No => PermissionState::Denied,
+    }
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -7,6 +7,8 @@ use dom::bindings::codegen::Bindings::PermissionsBinding::{self, PermissionsMeth
 use dom::bindings::error::Error;
 use dom::bindings::js::Root;
 use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
+use dom::bluetooth::Bluetooth;
+use dom::bluetoothpermissionresult::BluetoothPermissionResult;
 use dom::globalscope::GlobalScope;
 use dom::permissionstatus::PermissionStatus;
 use dom::promise::Promise;
@@ -79,6 +81,20 @@ impl PermissionsMethods for Permissions {
 
         // Step 2.
         match root_desc.name {
+            PermissionName::Bluetooth => {
+                let bluetooth_desc = match Bluetooth::create_descriptor(cx, permissionDesc) {
+                    Ok(descriptor) => descriptor,
+                    Err(error) => {
+                        p.reject_error(cx, error);
+                        return p;
+                    },
+                };
+                // Step 5.
+                let result = BluetoothPermissionResult::new(&self.global(), &status);
+                // Step 6.
+                Bluetooth::permission_query(cx, &p, &bluetooth_desc, &result);
+                // Step 7. in permission_query
+            },
             _ => {
                 // Step 6.
                 Permissions::permission_query(cx, &p, &root_desc, &status);
@@ -113,6 +129,20 @@ impl PermissionsMethods for Permissions {
 
         // Step 2.
         match root_desc.name {
+            PermissionName::Bluetooth => {
+                let bluetooth_desc = match Bluetooth::create_descriptor(cx, permissionDesc) {
+                    Ok(descriptor) => descriptor,
+                    Err(error) => {
+                        p.reject_error(cx, error);
+                        return p;
+                    },
+                };
+                // Step 5.
+                let result = BluetoothPermissionResult::new(&self.global(), &status);
+                // Step 6.
+                Bluetooth::permission_request(cx, &p, &bluetooth_desc, &result);
+                // Step 7 - 8. in permission_request
+            },
             _ => {
                 // Step 6.
                 Permissions::permission_request(cx, &p, &root_desc, &status);
@@ -145,6 +175,19 @@ impl PermissionsMethods for Permissions {
 
         // Step 2.
         match root_desc.name {
+            PermissionName::Bluetooth => {
+                let bluetooth_desc = match Bluetooth::create_descriptor(cx, permissionDesc) {
+                    Ok(descriptor) => descriptor,
+                    Err(error) => {
+                        let p = Promise::new(&self.global());
+                        p.reject_error(cx, error);
+                        return p;
+                    },
+                };
+                let result = BluetoothPermissionResult::new(&self.global(), &status);
+                // Step 3 - 4. in permission_revoke
+                Bluetooth::permission_revoke(&bluetooth_desc, &result);
+            },
             _ => {
                 Permissions::permission_revoke(&root_desc, &status);
             },

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -15,6 +15,7 @@ use dom::promise::Promise;
 use js::conversions::ConversionResult;
 use js::jsapi::{JSContext, JSObject};
 use js::jsval::{ObjectValue, UndefinedValue};
+use servo_config::prefs::PREFS;
 use std::rc::Rc;
 #[cfg(target_os = "linux")]
 use tinyfiledialogs::{self, MessageBoxIcon, YesNo};
@@ -231,7 +232,11 @@ pub fn get_descriptor_permission_state(permission_name: PermissionName ,
     // if the feature is not allowed in non-secure contexcts,
     // and let the user decide to grant the permission or not.
     if !allowed_in_nonsecure_contexts(&permission_name) {
-        return prompt_user(permission_name);
+        if PREFS.get("dom.permissions.testing.allowed_in_nonsecure_contexts").as_boolean().unwrap_or(false) {
+            return PermissionState::Granted;
+        } else {
+            return prompt_user(permission_name);
+        }
     }
 
     // TODO: Step 3: Store the invocation results

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -1,0 +1,262 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::codegen::Bindings::PermissionStatusBinding::{PermissionDescriptor, PermissionName, PermissionState};
+use dom::bindings::codegen::Bindings::PermissionsBinding::{self, PermissionsMethods};
+use dom::bindings::error::Error;
+use dom::bindings::js::Root;
+use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
+use dom::globalscope::GlobalScope;
+use dom::permissionstatus::PermissionStatus;
+use dom::promise::Promise;
+use js::conversions::ConversionResult;
+use js::jsapi::{JSContext, JSObject};
+use js::jsval::{ObjectValue, UndefinedValue};
+use std::rc::Rc;
+#[cfg(target_os = "linux")]
+use tinyfiledialogs::{self, MessageBoxIcon, YesNo};
+
+#[cfg(target_os = "linux")]
+const DIALOG_TITLE: &'static str = "Permission request dialog";
+#[cfg(target_os = "linux")]
+const QUERY_DIALOG_MESSAGE: &'static str = "Can't guarantee, that the current context is secure.
+\t\tStill grant permission for";
+const ROOT_DESC_CONVERSION_ERROR: &'static str = "Can't convert to an IDL value of type PermissionDescriptor";
+
+pub trait PermissionAlgorithm {
+    type Descriptor;
+    type Status;
+    fn create_descriptor(cx: *mut JSContext,
+                         permission_descriptor_obj: *mut JSObject)
+                         -> Result<Self::Descriptor, Error>;
+    fn permission_query(cx: *mut JSContext, promise: &Rc<Promise>,
+                        descriptor: &Self::Descriptor, status: &Self::Status);
+    fn permission_request(cx: *mut JSContext, promise: &Rc<Promise>,
+                          descriptor: &Self::Descriptor, status: &Self::Status);
+    fn permission_revoke(descriptor: &Self::Descriptor, status: &Self::Status);
+}
+
+// https://w3c.github.io/permissions/#permissions
+#[dom_struct]
+pub struct Permissions {
+    reflector_: Reflector,
+}
+
+impl Permissions {
+    pub fn new_inherited() -> Permissions {
+        Permissions {
+            reflector_: Reflector::new(),
+        }
+    }
+
+    pub fn new(global: &GlobalScope) -> Root<Permissions> {
+        reflect_dom_object(box Permissions::new_inherited(),
+                           global,
+                           PermissionsBinding::Wrap)
+    }
+}
+
+impl PermissionsMethods for Permissions {
+    #[allow(unrooted_must_root)]
+    #[allow(unsafe_code)]
+    // https://w3c.github.io/permissions/#dom-permissions-query
+    unsafe fn Query(&self, cx: *mut JSContext, permissionDesc: *mut JSObject) -> Rc<Promise> {
+        // Step 3.
+        let p = Promise::new(&self.global());
+
+        // Step 1.
+        let root_desc = match Permissions::create_descriptor(cx, permissionDesc) {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                p.reject_error(cx, error);
+                return p;
+            },
+        };
+
+        // Step 5.
+        let status = PermissionStatus::new(&self.global(), &root_desc);
+
+        // Step 2.
+        match root_desc.name {
+            _ => {
+                // Step 6.
+                Permissions::permission_query(cx, &p, &root_desc, &status);
+
+                // Step 7.
+                p.resolve_native(cx, &status);
+            },
+        };
+
+        // Step 4.
+        return p;
+    }
+
+    #[allow(unrooted_must_root)]
+    #[allow(unsafe_code)]
+    // https://w3c.github.io/permissions/#dom-permissions-request
+    unsafe fn Request(&self, cx: *mut JSContext, permissionDesc: *mut JSObject) -> Rc<Promise> {
+        // Step 3.
+        let p = Promise::new(&self.global());
+
+        // Step 1.
+        let root_desc = match Permissions::create_descriptor(cx, permissionDesc) {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                p.reject_error(cx, error);
+                return p;
+            },
+        };
+
+        // Step 5.
+        let status = PermissionStatus::new(&self.global(), &root_desc);
+
+        // Step 2.
+        match root_desc.name {
+            _ => {
+                // Step 6.
+                Permissions::permission_request(cx, &p, &root_desc, &status);
+
+                // Step 7. The default algorithm always resolve
+
+                // Step 8.
+                p.resolve_native(cx, &status);
+            },
+        };
+        // Step 4.
+        return p;
+    }
+
+    #[allow(unrooted_must_root)]
+    #[allow(unsafe_code)]
+    // https://w3c.github.io/permissions/#dom-permissions-revoke
+    unsafe fn Revoke(&self, cx: *mut JSContext, permissionDesc: *mut JSObject) -> Rc<Promise> {
+        // Step 1.
+        let root_desc = match Permissions::create_descriptor(cx, permissionDesc) {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                let p = Promise::new(&self.global());
+                p.reject_error(cx, error);
+                return p;
+            },
+        };
+
+        let status = PermissionStatus::new(&self.global(), &root_desc);
+
+        // Step 2.
+        match root_desc.name {
+            _ => {
+                Permissions::permission_revoke(&root_desc, &status);
+            },
+        };
+
+        // Step 5.
+        return self.Query(cx, permissionDesc);
+    }
+}
+
+impl PermissionAlgorithm for Permissions {
+    type Descriptor = PermissionDescriptor;
+    type Status = PermissionStatus;
+
+    #[allow(unsafe_code)]
+    fn create_descriptor(cx: *mut JSContext,
+                         permission_descriptor_obj: *mut JSObject)
+                         -> Result<PermissionDescriptor, Error> {
+        rooted!(in(cx) let mut property = UndefinedValue());
+        property.handle_mut().set(ObjectValue(permission_descriptor_obj));
+        unsafe {
+            match PermissionDescriptor::new(cx, property.handle()) {
+                Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
+                Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
+                Err(_) => Err(Error::Type(String::from(ROOT_DESC_CONVERSION_ERROR))),
+            }
+        }
+    }
+
+    // https://w3c.github.io/permissions/#boolean-permission-query-algorithm
+    fn permission_query(_cx: *mut JSContext,
+                        _promise: &Rc<Promise>,
+                        _descriptor: &PermissionDescriptor,
+                        status: &PermissionStatus) {
+        // Step 1.
+        status.set_state(get_descriptor_permission_state(status.get_query(), None));
+    }
+
+    // https://w3c.github.io/permissions/#boolean-permission-request-algorithm
+    fn permission_request(cx: *mut JSContext,
+                          promise: &Rc<Promise>,
+                          descriptor: &PermissionDescriptor,
+                          status: &PermissionStatus) {
+        // Step 1.
+        Permissions::permission_query(cx, promise, descriptor, status);
+
+        // TODO: Step 2 - 4: `environment settings object` is not implemented in Servo yet.
+        // For this reason in the `get_descriptor_permission_state` function we can't decide
+        // if we have a secure context or not, or store the previous invocation results.
+        // Without these the remaining steps can't be implemented properly.
+    }
+
+    fn permission_revoke(_descriptor: &PermissionDescriptor, _status: &PermissionStatus) {}
+}
+
+// https://w3c.github.io/permissions/#permission-state
+pub fn get_descriptor_permission_state(permission_name: PermissionName ,
+                                       _env_settings_obj: Option<*mut JSObject>)
+                                       -> PermissionState {
+    // TODO: Step 1: If settings wasn’t passed, set it to the current settings object.
+    // TODO: `environment settings object` is not implemented in Servo yet.
+
+    // Step 2.
+    // TODO: The `is the environment settings object a non-secure context` check is missing.
+    // The current solution is a workaround with a message box to warn about this,
+    // if the feature is not allowed in non-secure contexcts,
+    // and let the user decide to grant the permission or not.
+    if !allowed_in_nonsecure_contexts(&permission_name) {
+        if cfg!(target_os = "linux") {
+            match tinyfiledialogs::message_box_yes_no(DIALOG_TITLE,
+                                                      &format!("{} {:?} ?", QUERY_DIALOG_MESSAGE, permission_name),
+                                                      MessageBoxIcon::Question,
+                                                      YesNo::No) {
+                YesNo::Yes => return PermissionState::Granted,
+                YesNo::No => return PermissionState::Denied,
+            };
+        } else {
+            return PermissionState::Denied;
+        }
+    }
+
+    // TODO: Step 3: Store the invocation results
+    // TODO: `environment settings object` is not implemented in Servo yet.
+
+    // Step 4.
+    PermissionState::Granted
+}
+
+// https://w3c.github.io/permissions/#allowed-in-non-secure-contexts
+fn allowed_in_nonsecure_contexts(permission_name: &PermissionName) -> bool {
+    match *permission_name {
+        // https://w3c.github.io/permissions/#dom-permissionname-geolocation
+        PermissionName::Geolocation => true,
+        // https://w3c.github.io/permissions/#dom-permissionname-notifications
+        PermissionName::Notifications => true,
+        // https://w3c.github.io/permissions/#dom-permissionname-push
+        PermissionName::Push => false,
+        // https://w3c.github.io/permissions/#dom-permissionname-midi
+        PermissionName::Midi => true,
+        // https://w3c.github.io/permissions/#dom-permissionname-camera
+        PermissionName::Camera => false,
+        // https://w3c.github.io/permissions/#dom-permissionname-microphone
+        PermissionName::Microphone => false,
+        // https://w3c.github.io/permissions/#dom-permissionname-speaker
+        PermissionName::Speaker => false,
+        // https://w3c.github.io/permissions/#dom-permissionname-device-info
+        PermissionName::Device_info => false,
+        // https://w3c.github.io/permissions/#dom-permissionname-background-sync
+        PermissionName::Background_sync => false,
+        // https://webbluetoothcg.github.io/web-bluetooth/#dom-permissionname-bluetooth
+        PermissionName::Bluetooth => false,
+        // https://storage.spec.whatwg.org/#dom-permissionname-persistent-storage
+        PermissionName::Persistent_storage => false,
+    }
+}

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -256,17 +256,7 @@ pub fn get_descriptor_permission_state(permission_name: PermissionName ,
     // if the feature is not allowed in non-secure contexcts,
     // and let the user decide to grant the permission or not.
     if !allowed_in_nonsecure_contexts(&permission_name) {
-        if cfg!(target_os = "linux") {
-            match tinyfiledialogs::message_box_yes_no(DIALOG_TITLE,
-                                                      &format!("{} {:?} ?", QUERY_DIALOG_MESSAGE, permission_name),
-                                                      MessageBoxIcon::Question,
-                                                      YesNo::No) {
-                YesNo::Yes => return PermissionState::Granted,
-                YesNo::No => return PermissionState::Denied,
-            };
-        } else {
-            return PermissionState::Denied;
-        }
+        return prompt_user(permission_name);
     }
 
     // TODO: Step 3: Store the invocation results
@@ -274,6 +264,23 @@ pub fn get_descriptor_permission_state(permission_name: PermissionName ,
 
     // Step 4.
     PermissionState::Granted
+}
+
+#[cfg(target_os = "linux")]
+fn prompt_user(permission_name: PermissionName) -> PermissionState {
+    match tinyfiledialogs::message_box_yes_no(DIALOG_TITLE,
+                                              &format!("{} {:?} ?", QUERY_DIALOG_MESSAGE, permission_name),
+                                              MessageBoxIcon::Question,
+                                              YesNo::No) {
+        YesNo::Yes => return PermissionState::Granted,
+        YesNo::No => return PermissionState::Denied,
+    };
+}
+
+#[cfg(not(target_os = "linux"))]
+fn prompt_user(_permission_name: PermissionName) -> PermissionState {
+    // TODO popup only supported on linux
+    PermissionState::Denied
 }
 
 // https://w3c.github.io/permissions/#allowed-in-non-secure-contexts

--- a/components/script/dom/permissionstatus.rs
+++ b/components/script/dom/permissionstatus.rs
@@ -4,12 +4,14 @@
 
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::PermissionStatusBinding::{self, PermissionDescriptor, PermissionName};
-use dom::bindings::codegen::Bindings::PermissionStatusBinding::{PermissionState, PermissionStatusMethods};
+use dom::bindings::codegen::Bindings::PermissionStatusBinding::{PermissionNameValues, PermissionState};
+use dom::bindings::codegen::Bindings::PermissionStatusBinding::PermissionStatusMethods;
 use dom::bindings::js::Root;
 use dom::bindings::reflector::reflect_dom_object;
 use dom::eventtarget::EventTarget;
 use dom::globalscope::GlobalScope;
 use std::cell::Cell;
+use std::fmt::{self, Display, Formatter};
 
 // https://w3c.github.io/permissions/#permissionstatus
 #[dom_struct]
@@ -51,4 +53,10 @@ impl PermissionStatusMethods for PermissionStatus {
 
     // https://w3c.github.io/permissions/#dom-permissionstatus-onchange
     event_handler!(onchange, GetOnchange, SetOnchange);
+}
+
+impl Display for PermissionName {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", PermissionNameValues::strings[*self as usize].to_string())
+    }
 }

--- a/components/script/dom/permissionstatus.rs
+++ b/components/script/dom/permissionstatus.rs
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use core::clone::Clone;
+use dom::bindings::cell::DOMRefCell;
+use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
+use dom::bindings::codegen::Bindings::PermissionStatusBinding::{self, PermissionDescriptor, PermissionName};
+use dom::bindings::codegen::Bindings::PermissionStatusBinding::{PermissionState, PermissionStatusMethods};
+use dom::bindings::js::Root;
+use dom::bindings::reflector::reflect_dom_object;
+use dom::eventtarget::EventTarget;
+use dom::globalscope::GlobalScope;
+
+// https://w3c.github.io/permissions/#permissionstatus
+#[dom_struct]
+pub struct PermissionStatus {
+    eventtarget: EventTarget,
+    state: DOMRefCell<PermissionState>,
+    query: DOMRefCell<PermissionName>,
+}
+
+impl PermissionStatus {
+    pub fn new_inherited(query: PermissionName) -> PermissionStatus {
+        PermissionStatus {
+            eventtarget: EventTarget::new_inherited(),
+            state: DOMRefCell::new(PermissionState::Denied),
+            query: DOMRefCell::new(query),
+        }
+    }
+
+    pub fn new(global: &GlobalScope, query: &PermissionDescriptor) -> Root<PermissionStatus> {
+        reflect_dom_object(box PermissionStatus::new_inherited(query.name),
+                           global,
+                           PermissionStatusBinding::Wrap)
+    }
+
+    pub fn set_state(&self, state: PermissionState) {
+        *self.state.borrow_mut() = state;
+    }
+
+    pub fn get_query(&self) -> PermissionName {
+        self.query.borrow().clone()
+    }
+}
+
+impl PermissionStatusMethods for PermissionStatus {
+    // https://w3c.github.io/permissions/#dom-permissionstatus-state
+    fn State(&self) -> PermissionState {
+        self.state.borrow().clone()
+    }
+
+    // https://w3c.github.io/permissions/#dom-permissionstatus-onchange
+    event_handler!(onchange, GetOnchange, SetOnchange);
+}

--- a/components/script/dom/permissionstatus.rs
+++ b/components/script/dom/permissionstatus.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use core::clone::Clone;
-use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::PermissionStatusBinding::{self, PermissionDescriptor, PermissionName};
 use dom::bindings::codegen::Bindings::PermissionStatusBinding::{PermissionState, PermissionStatusMethods};
@@ -11,21 +9,22 @@ use dom::bindings::js::Root;
 use dom::bindings::reflector::reflect_dom_object;
 use dom::eventtarget::EventTarget;
 use dom::globalscope::GlobalScope;
+use std::cell::Cell;
 
 // https://w3c.github.io/permissions/#permissionstatus
 #[dom_struct]
 pub struct PermissionStatus {
     eventtarget: EventTarget,
-    state: DOMRefCell<PermissionState>,
-    query: DOMRefCell<PermissionName>,
+    state: Cell<PermissionState>,
+    query: Cell<PermissionName>,
 }
 
 impl PermissionStatus {
     pub fn new_inherited(query: PermissionName) -> PermissionStatus {
         PermissionStatus {
             eventtarget: EventTarget::new_inherited(),
-            state: DOMRefCell::new(PermissionState::Denied),
-            query: DOMRefCell::new(query),
+            state: Cell::new(PermissionState::Denied),
+            query: Cell::new(query),
         }
     }
 
@@ -36,18 +35,18 @@ impl PermissionStatus {
     }
 
     pub fn set_state(&self, state: PermissionState) {
-        *self.state.borrow_mut() = state;
+        self.state.set(state);
     }
 
     pub fn get_query(&self) -> PermissionName {
-        self.query.borrow().clone()
+        self.query.get()
     }
 }
 
 impl PermissionStatusMethods for PermissionStatus {
     // https://w3c.github.io/permissions/#dom-permissionstatus-state
     fn State(&self) -> PermissionState {
-        self.state.borrow().clone()
+        self.state.get()
     }
 
     // https://w3c.github.io/permissions/#dom-permissionstatus-onchange

--- a/components/script/dom/webidls/BluetoothDevice.webidl
+++ b/components/script/dom/webidls/BluetoothDevice.webidl
@@ -8,7 +8,7 @@
 interface BluetoothDevice : EventTarget {
   readonly attribute DOMString id;
   readonly attribute DOMString? name;
-  readonly attribute BluetoothRemoteGATTServer gatt;
+  readonly attribute BluetoothRemoteGATTServer? gatt;
 
   Promise<void> watchAdvertisements();
   void unwatchAdvertisements();

--- a/components/script/dom/webidls/BluetoothPermissionResult.webidl
+++ b/components/script/dom/webidls/BluetoothPermissionResult.webidl
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// https://webbluetoothcg.github.io/web-bluetooth/#bluetoothpermissionresult
+
+dictionary BluetoothPermissionDescriptor : PermissionDescriptor {
+  DOMString deviceId;
+  // These match RequestDeviceOptions.
+  sequence<BluetoothLEScanFilterInit> filters;
+  sequence<BluetoothServiceUUID> optionalServices/* = []*/;
+  boolean acceptAllDevices = false;
+};
+
+dictionary AllowedBluetoothDevice {
+  required DOMString deviceId;
+  required boolean mayUseGATT;
+  // An allowedServices of "all" means all services are allowed.
+  required (DOMString or sequence<UUID>) allowedServices;
+};
+
+dictionary BluetoothPermissionData {
+  required sequence<AllowedBluetoothDevice> allowedDevices/* = []*/;
+};
+
+// [Pref="dom.bluetooth.enabled"]
+interface BluetoothPermissionResult : PermissionStatus {
+  // attribute FrozenArray<BluetoothDevice> devices;
+  // Workaround until FrozenArray get implemented.
+  sequence<BluetoothDevice> devices();
+};

--- a/components/script/dom/webidls/BluetoothPermissionResult.webidl
+++ b/components/script/dom/webidls/BluetoothPermissionResult.webidl
@@ -23,7 +23,7 @@ dictionary BluetoothPermissionData {
   required sequence<AllowedBluetoothDevice> allowedDevices/* = []*/;
 };
 
-// [Pref="dom.bluetooth.enabled"]
+[Pref="dom.bluetooth.enabled"]
 interface BluetoothPermissionResult : PermissionStatus {
   // attribute FrozenArray<BluetoothDevice> devices;
   // Workaround until FrozenArray get implemented.

--- a/components/script/dom/webidls/BluetoothPermissionResult.webidl
+++ b/components/script/dom/webidls/BluetoothPermissionResult.webidl
@@ -12,17 +12,6 @@ dictionary BluetoothPermissionDescriptor : PermissionDescriptor {
   boolean acceptAllDevices = false;
 };
 
-dictionary AllowedBluetoothDevice {
-  required DOMString deviceId;
-  required boolean mayUseGATT;
-  // An allowedServices of "all" means all services are allowed.
-  required (DOMString or sequence<UUID>) allowedServices;
-};
-
-dictionary BluetoothPermissionData {
-  required sequence<AllowedBluetoothDevice> allowedDevices/* = []*/;
-};
-
 [Pref="dom.bluetooth.enabled"]
 interface BluetoothPermissionResult : PermissionStatus {
   // attribute FrozenArray<BluetoothDevice> devices;

--- a/components/script/dom/webidls/Navigator.webidl
+++ b/components/script/dom/webidls/Navigator.webidl
@@ -62,3 +62,9 @@ interface NavigatorCookies {
 partial interface Navigator {
   [SameObject, Pref="dom.webvr.enabled"] readonly attribute VR vr;
 };
+
+// https://w3c.github.io/permissions/#navigator-and-workernavigator-extension
+[Exposed=(Window)]
+partial interface Navigator {
+  readonly attribute Permissions permissions;
+};

--- a/components/script/dom/webidls/Navigator.webidl
+++ b/components/script/dom/webidls/Navigator.webidl
@@ -66,5 +66,5 @@ partial interface Navigator {
 // https://w3c.github.io/permissions/#navigator-and-workernavigator-extension
 [Exposed=(Window)]
 partial interface Navigator {
-  readonly attribute Permissions permissions;
+  [Pref="dom.permissions.enabled"] readonly attribute Permissions permissions;
 };

--- a/components/script/dom/webidls/PermissionStatus.webidl
+++ b/components/script/dom/webidls/PermissionStatus.webidl
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ // https://w3c.github.io/permissions/#permissionstatus
+
+dictionary PermissionDescriptor {
+  required PermissionName name;
+};
+
+enum PermissionState {
+  "granted",
+  "denied",
+  "prompt",
+};
+
+enum PermissionName {
+  "geolocation",
+  "notifications",
+  "push",
+  "midi",
+  "camera",
+  "microphone",
+  "speaker",
+  "device-info",
+  "background-sync",
+  "bluetooth",
+  "persistent-storage",
+};
+
+[Exposed=(Window,Worker)]
+interface PermissionStatus : EventTarget {
+  readonly attribute PermissionState state;
+  attribute EventHandler onchange;
+};
+
+dictionary PushPermissionDescriptor : PermissionDescriptor {
+  boolean userVisibleOnly = false;
+};
+
+dictionary MidiPermissionDescriptor : PermissionDescriptor {
+  boolean sysex = false;
+};
+
+dictionary DevicePermissionDescriptor : PermissionDescriptor {
+  DOMString deviceId;
+};

--- a/components/script/dom/webidls/PermissionStatus.webidl
+++ b/components/script/dom/webidls/PermissionStatus.webidl
@@ -28,7 +28,7 @@ enum PermissionName {
   "persistent-storage",
 };
 
-[Exposed=(Window,Worker)]
+[Pref="dom.permissions.enabled", Exposed=(Window,Worker)]
 interface PermissionStatus : EventTarget {
   readonly attribute PermissionState state;
   attribute EventHandler onchange;

--- a/components/script/dom/webidls/Permissions.webidl
+++ b/components/script/dom/webidls/Permissions.webidl
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/permissions/#permissions-interface
+
+[Exposed=(Window,Worker)]
+interface Permissions {
+  Promise<PermissionStatus> query(object permissionDesc);
+
+  Promise<PermissionStatus> request(object permissionDesc);
+
+  Promise<PermissionStatus> revoke(object permissionDesc);
+};

--- a/components/script/dom/webidls/Permissions.webidl
+++ b/components/script/dom/webidls/Permissions.webidl
@@ -4,7 +4,7 @@
 
 // https://w3c.github.io/permissions/#permissions-interface
 
-[Exposed=(Window,Worker)]
+[Pref="dom.permissions.enabled", Exposed=(Window,Worker)]
 interface Permissions {
   Promise<PermissionStatus> query(object permissionDesc);
 

--- a/components/script/dom/webidls/WorkerNavigator.webidl
+++ b/components/script/dom/webidls/WorkerNavigator.webidl
@@ -8,3 +8,10 @@ interface WorkerNavigator {};
 WorkerNavigator implements NavigatorID;
 WorkerNavigator implements NavigatorLanguage;
 //WorkerNavigator implements NavigatorOnLine;
+
+// https://w3c.github.io/permissions/#navigator-and-workernavigator-extension
+
+[Exposed=(Worker)]
+partial interface WorkerNavigator {
+  readonly attribute Permissions permissions;
+};

--- a/components/script/dom/webidls/WorkerNavigator.webidl
+++ b/components/script/dom/webidls/WorkerNavigator.webidl
@@ -13,5 +13,5 @@ WorkerNavigator implements NavigatorLanguage;
 
 [Exposed=(Worker)]
 partial interface WorkerNavigator {
-  readonly attribute Permissions permissions;
+  [Pref="dom.permissions.enabled"] readonly attribute Permissions permissions;
 };

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -13,6 +13,7 @@ use dom::bindings::codegen::Bindings::EventHandlerBinding::OnBeforeUnloadEventHa
 use dom::bindings::codegen::Bindings::EventHandlerBinding::OnErrorEventHandlerNonNull;
 use dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
+use dom::bindings::codegen::Bindings::PermissionStatusBinding::PermissionState;
 use dom::bindings::codegen::Bindings::RequestBinding::RequestInit;
 use dom::bindings::codegen::Bindings::WindowBinding::{self, FrameRequestCallback, WindowMethods};
 use dom::bindings::codegen::Bindings::WindowBinding::{ScrollBehavior, ScrollToOptions};
@@ -249,7 +250,10 @@ pub struct Window {
 
     /// A handle for communicating messages to the webvr thread, if available.
     #[ignore_heap_size_of = "channels are hard"]
-    webvr_thread: Option<IpcSender<WebVRMsg>>
+    webvr_thread: Option<IpcSender<WebVRMsg>>,
+
+    /// A map for storing the previous permission state read results.
+    permission_state_invocation_results: DOMRefCell<HashMap<String, PermissionState>>
 }
 
 impl Window {
@@ -337,6 +341,10 @@ impl Window {
 
     pub fn webvr_thread(&self) -> Option<IpcSender<WebVRMsg>> {
         self.webvr_thread.clone()
+    }
+
+    pub fn permission_state_invocation_results(&self) -> &DOMRefCell<HashMap<String, PermissionState>> {
+        &self.permission_state_invocation_results
     }
 }
 
@@ -1704,7 +1712,8 @@ impl Window {
             scroll_offsets: DOMRefCell::new(HashMap::new()),
             media_query_lists: WeakMediaQueryListVec::new(),
             test_runner: Default::default(),
-            webvr_thread: webvr_thread
+            webvr_thread: webvr_thread,
+            permission_state_invocation_results: DOMRefCell::new(HashMap::new()),
         };
 
         unsafe {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -26,6 +26,7 @@ use dom::bindings::reflector::DomObject;
 use dom::bindings::str::DOMString;
 use dom::bindings::structuredclone::StructuredCloneData;
 use dom::bindings::utils::{GlobalStaticData, WindowProxyHandler};
+use dom::bluetooth::BluetoothExtraPermissionData;
 use dom::browsingcontext::BrowsingContext;
 use dom::crypto::Crypto;
 use dom::cssstyledeclaration::{CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner};
@@ -209,6 +210,8 @@ pub struct Window {
     #[ignore_heap_size_of = "channels are hard"]
     bluetooth_thread: IpcSender<BluetoothRequest>,
 
+    bluetooth_extra_permission_data: BluetoothExtraPermissionData,
+
     /// An enlarged rectangle around the page contents visible in the viewport, used
     /// to prevent creating display list items for content that is far away from the viewport.
     page_clip_rect: Cell<Rect<Au>>,
@@ -311,6 +314,10 @@ impl Window {
 
     pub fn bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
         self.bluetooth_thread.clone()
+    }
+
+    pub fn bluetooth_extra_permission_data(&self) -> &BluetoothExtraPermissionData {
+         &self.bluetooth_extra_permission_data
     }
 
     pub fn css_error_reporter(&self) -> Box<ParseErrorReporter + Send> {
@@ -1678,6 +1685,7 @@ impl Window {
             dom_static: GlobalStaticData::new(),
             js_runtime: DOMRefCell::new(Some(runtime.clone())),
             bluetooth_thread: bluetooth_thread,
+            bluetooth_extra_permission_data: BluetoothExtraPermissionData::new(),
             page_clip_rect: Cell::new(max_rect()),
             resize_event: Cell::new(None),
             layout_chan: layout_chan,

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -4,22 +4,25 @@
 
 use dom::bindings::codegen::Bindings::WorkerNavigatorBinding;
 use dom::bindings::codegen::Bindings::WorkerNavigatorBinding::WorkerNavigatorMethods;
-use dom::bindings::js::Root;
-use dom::bindings::reflector::{Reflector, reflect_dom_object};
+use dom::bindings::js::{MutNullableJS, Root};
+use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use dom::bindings::str::DOMString;
 use dom::navigatorinfo;
+use dom::permissions::Permissions;
 use dom::workerglobalscope::WorkerGlobalScope;
 
 // https://html.spec.whatwg.org/multipage/#workernavigator
 #[dom_struct]
 pub struct WorkerNavigator {
     reflector_: Reflector,
+    permissions: MutNullableJS<Permissions>,
 }
 
 impl WorkerNavigator {
     fn new_inherited() -> WorkerNavigator {
         WorkerNavigator {
             reflector_: Reflector::new(),
+            permissions: Default::default(),
         }
     }
 
@@ -69,5 +72,10 @@ impl WorkerNavigatorMethods for WorkerNavigator {
     // https://html.spec.whatwg.org/multipage/#navigatorlanguage
     fn Language(&self) -> DOMString {
         navigatorinfo::Language()
+    }
+
+    // https://w3c.github.io/permissions/#navigator-and-workernavigator-extension
+    fn Permissions(&self) -> Root<Permissions> {
+        self.permissions.or_init(|| Permissions::new(&self.global()))
     }
 }

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -5,6 +5,7 @@
   "dom.mouseevent.which.enabled": false,
   "dom.mozbrowser.enabled": false,
   "dom.permissions.enabled": false,
+  "dom.permissions.testing.allowed_in_nonsecure_contexts": false,
   "dom.serviceworker.timeout_seconds": 60,
   "dom.testable_crash.enabled": false,
   "dom.testbinding.enabled": false,

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -4,6 +4,7 @@
   "dom.forcetouch.enabled": false,
   "dom.mouseevent.which.enabled": false,
   "dom.mozbrowser.enabled": false,
+  "dom.permissions.enabled": false,
   "dom.serviceworker.timeout_seconds": 60,
   "dom.testable_crash.enabled": false,
   "dom.testbinding.enabled": false,

--- a/tests/html/bluetooth-permission.html
+++ b/tests/html/bluetooth-permission.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<title>Bluetooth Permission Test</title>
+<body>
+    <button type="button" onclick="onRequestButtonClick()">request</button>
+    <button type="button" onclick="onQueryButtonClick()">query</button>
+    <pre id="log"></pre>
+    <script>
+    window.testRunner.setBluetoothMockDataSet('HeartRateAdapter');
+
+    function onRequestButtonClick() {
+        clear();
+        window.navigator.permissions.request({
+            name: 'bluetooth',
+            filters: [{
+                services: ['heart_rate'],
+            }],
+        })
+        .then(r => {
+            log("Result is instance of PermissionStatus: " + (r instanceof PermissionStatus));
+            log("Result is instance of BluetoothPermissionResult subclass: " + (r instanceof BluetoothPermissionResult));
+            log("State of result: " + r.state);
+            let device = r.devices()[0];
+            if (device) {
+                log("Result contains device: " + device.name);
+                sessionStorage.lastDevice = device.id;
+                log("Device id stored: " + device.id);
+            } else {
+                log("No device found!");
+            }
+        })
+        .catch(err => log(err));
+    }
+
+    function onQueryButtonClick() {
+        clear();
+        if (!sessionStorage.lastDevice)
+            return log("No stored device id!");
+        window.navigator.permissions.query({
+            name: "bluetooth",
+            deviceId: sessionStorage.lastDevice,
+        })
+        .then(r => {
+            log("Result is instance of PermissionStatus: " + (r instanceof PermissionStatus));
+            log("Result is instance of BluetoothPermissionResult subclass: " + (r instanceof BluetoothPermissionResult));
+            log("State of result: " + r.state);
+            log("Stored Device id: " + sessionStorage.lastDevice);
+            let device = r.devices()[0];
+            if (device) {
+                log("Result contains device: " + device.name);
+                log("Device id: " + device.id);
+            } else {
+                log("No device found!");
+            }
+        })
+        .catch(err => log(err));
+    }
+
+    function log(line) {
+        document.getElementById("log").textContent += line + '\n';
+    }
+
+    function clear() {
+        document.getElementById("log").textContent = "";
+    }
+    </script>
+</body>
+</html>

--- a/tests/html/bluetooth-permission.html
+++ b/tests/html/bluetooth-permission.html
@@ -6,7 +6,8 @@
     <button type="button" onclick="onQueryButtonClick()">query</button>
     <pre id="log"></pre>
     <script>
-    window.testRunner.setBluetoothMockDataSet('HeartRateAdapter');
+    if (window.testRunner)
+        window.testRunner.setBluetoothMockDataSet('HeartRateAdapter');
 
     function onRequestButtonClick() {
         clear();

--- a/tests/html/permission-test.html
+++ b/tests/html/permission-test.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<title>Permission Test</title>
+<body>
+    <button type="button" onclick="onQueryButtonClick()">query</button>
+    <button type="button" onclick="onRequestButtonClick()">request</button>
+    <button type="button" onclick="onRevokeButtonClick()">revoke</button>
+    <input type="text" id="permissionName" value="geolocation"></input>
+    <pre id="log"></pre>
+    <script>
+    function onQueryButtonClick() {
+        let permissionName = document.getElementById('permissionName').value;
+        let permissionDescriptor = {name: permissionName};
+        window.navigator.permissions.query(permissionDescriptor)
+        .then(status => log("permission status of " + permissionName + " is: " + status.state))
+        .catch(err => log(err));
+    }
+    function onRequestButtonClick() {
+        let permissionName = document.getElementById('permissionName').value;
+        let permissionDescriptor = {name: permissionName};
+        window.navigator.permissions.request(permissionDescriptor)
+        .then(status => log("permission status of " + permissionName + " is: " + status.state))
+        .catch(err => log(err));
+    }
+    function onRevokeButtonClick() {
+        let permissionName = document.getElementById('permissionName').value;
+        let permissionDescriptor = {name: permissionName};
+        window.navigator.permissions.revoke(permissionDescriptor)
+        .then(status => log("permission status of " + permissionName + " is: " + status.state))
+        .catch(err => log(err));
+    }
+    function log(line) {
+        document.getElementById("log").textContent += line + '\n';
+    }
+    </script>
+</body>
+</html>

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -24367,7 +24367,7 @@
    "testharness"
   ],
   "mozilla/bluetooth/connect/device-goes-out-of-range.html": [
-   "9e5dc423f92c3f73273d221e7fb7b8d905716db3",
+   "3ade30929f621b7c8c93b87e5392309729d68e42",
    "testharness"
   ],
   "mozilla/bluetooth/connect/get-same-gatt-server.html": [

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/__dir__.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/__dir__.ini
@@ -1,1 +1,1 @@
-prefs: [dom.bluetooth.enabled:true, dom.bluetooth.testing.enabled:true]
+prefs: [dom.bluetooth.enabled:true, dom.bluetooth.testing.enabled:true, dom.permissions.testing.allowed_in_nonsecure_contexts:true]

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/interfaces.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/interfaces.html.ini
@@ -51,16 +51,7 @@
   [BluetoothPermissionResult interface: existence and properties of interface object]
     expected: FAIL
 
-  [BluetoothPermissionResult interface object length]
-    expected: FAIL
-
-  [BluetoothPermissionResult interface object name]
-    expected: FAIL
-
   [BluetoothPermissionResult interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [BluetoothPermissionResult interface: existence and properties of interface prototype object's "constructor" property]
     expected: FAIL
 
   [BluetoothPermissionResult interface: attribute devices]

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/connect/device-goes-out-of-range.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/connect/device-goes-out-of-range.html
@@ -10,8 +10,9 @@ promise_test(t => {
         filters: [{services: [heart_rate.name]}]
     })
     .then(device => {
+        var gatt_server = device.gatt;
         window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
-        return promise_rejects(t, 'NetworkError', device.gatt.connect());
+        return promise_rejects(t, 'NetworkError', gatt_server.connect());
     });
 }, 'Device goes out of range. Reject with NetworkError.');
 </script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This implements the [Permissions API](https://w3c.github.io/permissions/) spec.
Also includes the WebBluetooth related implementation for this.

There are some know issues:
- [ ] If the descriptor name is invalid [this](https://gist.github.com/dati91/7a6a0a563d90f49ba5a351e48c5b626b#file-permissionstatusbindings-rs-L323) will throw an error, rather that return it and we could handle it.
- [x] The [environment settings object](https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object) is not implemented in servo and the spec rely on it.
- [x] There is a popup in the implementation which prevent us to add wpt test, we should figure out a way to make it work
- [ ] The allowedDevice's allowed_services attribute is not used in our implementation, because we store these in the lower level, not in the dom side.
- [ ] We think the bluetooth revoke function will need some more work, but the problem is the spec needs clarifications on that part.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because 

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15314)
<!-- Reviewable:end -->
