### PR TITLE
Fix the panic when transform is non-invertible

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -182,7 +182,14 @@ impl DisplayList {
             *client_point
         } else {
             let point = *translated_point - stacking_context.bounds.origin;
-            let inv_transform = stacking_context.transform.inverse().unwrap();
+            let inv_transform = match stacking_context.transform.inverse() {
+                Some(transform) => transform,
+                None => {
+                    // If a transform function causes the current transformation matrix of an object
+                    // to be non-invertible, the object and its content do not get displayed.
+                    return;
+                }
+            };
             let frac_point = inv_transform.transform_point(&Point2D::new(point.x.to_f32_px(),
                                                                          point.y.to_f32_px()));
             Point2D::new(Au::from_f32_px(frac_point.x), Au::from_f32_px(frac_point.y))

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13321,6 +13321,12 @@
      {}
     ]
    ],
+   "mozilla/non-invertible-transform.html": [
+    [
+     "/_mozilla/mozilla/non-invertible-transform.html",
+     {}
+    ]
+   ],
    "mozilla/out-of-order-stylesheet-loads-and-imports.html": [
     [
      "/_mozilla/mozilla/out-of-order-stylesheet-loads-and-imports.html",
@@ -25884,6 +25890,10 @@
   ],
   "mozilla/node_replaceChild.html": [
    "fe965e58fdcb78d08384a9fde74c982e34768745",
+   "testharness"
+  ],
+  "mozilla/non-invertible-transform.html": [
+   "6fa68fe08c9dd5d594e838da51617951193fee19",
    "testharness"
   ],
   "mozilla/out-of-order-stylesheet-loads-and-imports.html": [

--- a/tests/wpt/mozilla/tests/mozilla/non-invertible-transform.html
+++ b/tests/wpt/mozilla/tests/mozilla/non-invertible-transform.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Shouldn't panic when transform is non-invertible</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style>
+        #test {
+            width: 100px;
+            height: 100px;
+            transform: scale(0);
+        }
+    </style>
+</head>
+<body>
+<div id="test"></div>
+<script>
+    async_test(function(t) {
+        setTimeout(t.step_func_done(function() {
+            var elements = document.elementsFromPoint(10, 10);
+        }), 500);
+    }, "Shouldn't panic when transform is non-invertible");
+</script>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixes the panic when transform is non-invertible.
Counterpart of https://github.com/servo/webrender/pull/823
r? @glennw 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13266 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15334)
<!-- Reviewable:end -->
