### PR TITLE
stylo: Remove unused macro_use annotation that warns on nightly.

### DIFF
--- a/ports/geckolib/lib.rs
+++ b/ports/geckolib/lib.rs
@@ -4,7 +4,6 @@
 
 #![deny(warnings)]
 
-#[macro_use]extern crate style;
 extern crate app_units;
 extern crate atomic_refcell;
 extern crate cssparser;
@@ -15,6 +14,7 @@ extern crate libc;
 extern crate parking_lot;
 extern crate selectors;
 extern crate servo_url;
+extern crate style;
 extern crate style_traits;
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
r? anyone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15348)
<!-- Reviewable:end -->
