### PR TITLE
Add support for more @font-face descriptors

### DIFF
--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -25,7 +25,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::u32;
 use style::font_face::{EffectiveSources, Source};
-use style::properties::longhands::font_family::computed_value::FontFamily;
+use style::properties::longhands::font_family::computed_value::{FontFamily, FamilyName};
 use webrender_traits;
 
 /// A list of font templates that make up a given font family.
@@ -269,7 +269,7 @@ impl FontCache {
                 });
             }
             Source::Local(ref font) => {
-                let font_face_name = LowercaseString::new(font.name());
+                let font_face_name = LowercaseString::new(&font.0);
                 let templates = &mut self.web_families.get_mut(&family_name).unwrap();
                 let mut found = false;
                 for_each_variation(&font_face_name, |path| {
@@ -461,8 +461,8 @@ impl FontCacheThread {
         }
     }
 
-    pub fn add_web_font(&self, family: FontFamily, sources: EffectiveSources, sender: IpcSender<()>) {
-        self.chan.send(Command::AddWebFont(LowercaseString::new(family.name()), sources, sender)).unwrap();
+    pub fn add_web_font(&self, family: FamilyName, sources: EffectiveSources, sender: IpcSender<()>) {
+        self.chan.send(Command::AddWebFont(LowercaseString::new(&family.0), sources, sender)).unwrap();
     }
 
     pub fn exit(&self) {

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -286,10 +286,10 @@ macro_rules! font_face_descriptors {
 #[cfg(feature = "gecko")]
 font_face_descriptors! {
     mandatory descriptors = [
-        /// The specified url.
+        /// The name of this font face
         "font-family" family: FamilyName = FamilyName(atom!("")),
 
-        /// The format hints specified with the `format()` function.
+        /// The alternative sources for this font face.
         "src" sources: Vec<Source> = Vec::new(),
     ]
     optional descriptors = [
@@ -307,10 +307,10 @@ font_face_descriptors! {
 #[cfg(feature = "servo")]
 font_face_descriptors! {
     mandatory descriptors = [
-        /// The specified url.
+        /// The name of this font face
         "font-family" family: FamilyName = FamilyName(atom!("")),
 
-        /// The format hints specified with the `format()` function.
+        /// The alternative sources for this font face.
         "src" sources: Vec<Source> = Vec::new(),
     ]
     optional descriptors = [

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -8,7 +8,7 @@
 
 #![deny(missing_docs)]
 
-use computed_values::font_family::FontFamily;
+use computed_values::font_family::FamilyName;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser};
 use parser::{ParserContext, log_css_error, Parse};
 use std::fmt;
@@ -23,7 +23,7 @@ pub enum Source {
     /// A `url()` source.
     Url(UrlSource),
     /// A `local()` source.
-    Local(FontFamily),
+    Local(FamilyName),
 }
 
 impl ToCss for Source {
@@ -150,7 +150,7 @@ impl Parse for Source {
     fn parse(context: &ParserContext, input: &mut Parser) -> Result<Source, ()> {
         if input.try(|input| input.expect_function_matching("local")).is_ok() {
             return input.parse_nested_block(|input| {
-                FontFamily::parse(context, input)
+                FamilyName::parse(context, input)
             }).map(Source::Local)
         }
 
@@ -177,10 +177,10 @@ impl Parse for Source {
 macro_rules! font_face_descriptors {
     (
         mandatory descriptors = [
-            $( #[$m_doc: meta] $m_name: tt $m_ident: ident : $m_ty: ty = $m_initial: expr, )*
+            $( #[$m_doc: meta] $m_name: tt $m_ident: ident: $m_ty: ty = $m_initial: expr, )*
         ]
         optional descriptors = [
-            $( #[$o_doc: meta] $o_name: tt $o_ident: ident : $o_ty: ty = $o_initial: expr, )*
+            $( #[$o_doc: meta] $o_name: tt $o_ident: ident: $o_ty: ty = $o_initial: expr, )*
         ]
     ) => {
         /// A `@font-face` rule.
@@ -285,7 +285,7 @@ macro_rules! font_face_descriptors {
 font_face_descriptors! {
     mandatory descriptors = [
         /// The specified url.
-        "font-family" family: FontFamily = FontFamily::Generic(atom!("")),
+        "font-family" family: FamilyName = FamilyName(atom!("")),
 
         /// The format hints specified with the `format()` function.
         "src" sources: Vec<Source> = Vec::new(),

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -8,7 +8,7 @@
 
 #![deny(missing_docs)]
 
-#[cfg(feature = "gecko")] use computed_values::{font_style,  font_weight};
+#[cfg(feature = "gecko")] use computed_values::{font_style,  font_weight, font_stretch};
 use computed_values::font_family::FamilyName;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser};
 use parser::{ParserContext, log_css_error, Parse};
@@ -298,6 +298,9 @@ font_face_descriptors! {
 
         /// The weight of this font face
         "font-weight" weight: font_weight::T = font_weight::T::Weight400 /* normal */,
+
+        /// The stretch of this font face
+        "font-stretch" stretch: font_stretch::T = font_stretch::T::normal,
     ]
 }
 

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -9,6 +9,7 @@
 #![deny(missing_docs)]
 
 use computed_values::font_family::FamilyName;
+#[cfg(feature = "gecko")] use computed_values::font_style;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser};
 use parser::{ParserContext, log_css_error, Parse};
 use std::fmt;
@@ -282,6 +283,22 @@ macro_rules! font_face_descriptors {
 }
 
 /// css-name rust_identifier: Type = initial_value,
+#[cfg(feature = "gecko")]
+font_face_descriptors! {
+    mandatory descriptors = [
+        /// The specified url.
+        "font-family" family: FamilyName = FamilyName(atom!("")),
+
+        /// The format hints specified with the `format()` function.
+        "src" sources: Vec<Source> = Vec::new(),
+    ]
+    optional descriptors = [
+        /// The style of this font face
+        "font-style" style: font_style::T = font_style::T::normal,
+    ]
+}
+
+#[cfg(feature = "servo")]
 font_face_descriptors! {
     mandatory descriptors = [
         /// The specified url.

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -15,7 +15,7 @@ use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser};
 use parser::{ParserContext, log_css_error, Parse};
 use std::fmt;
 use std::iter;
-use style_traits::{ToCss, CommaSeparated};
+use style_traits::{ToCss, OneOrMoreCommaSeparated};
 use values::specified::url::SpecifiedUrl;
 
 /// A source for a font-face rule.
@@ -46,7 +46,7 @@ impl ToCss for Source {
     }
 }
 
-impl CommaSeparated for Source {}
+impl OneOrMoreCommaSeparated for Source {}
 
 /// A `UrlSource` represents a font-face source that has been specified with a
 /// `url()` function.
@@ -323,7 +323,7 @@ pub mod unicode_range {
     use cssparser::{Parser, Token};
     use parser::{ParserContext, Parse};
     use std::fmt;
-    use style_traits::{ToCss, CommaSeparated};
+    use style_traits::{ToCss, OneOrMoreCommaSeparated};
 
     /// Maximum value of the end of a range
     pub const MAX: u32 = ::std::char::MAX as u32;
@@ -338,7 +338,7 @@ pub mod unicode_range {
         pub end: u32,
     }
 
-    impl CommaSeparated for Range {}
+    impl OneOrMoreCommaSeparated for Range {}
 
     impl Parse for Range {
         fn parse(_context: &ParserContext, input: &mut Parser) -> Result<Self, ()> {

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -8,8 +8,8 @@
 
 #![deny(missing_docs)]
 
+#[cfg(feature = "gecko")] use computed_values::{font_style,  font_weight};
 use computed_values::font_family::FamilyName;
-#[cfg(feature = "gecko")] use computed_values::font_style;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser};
 use parser::{ParserContext, log_css_error, Parse};
 use std::fmt;
@@ -295,6 +295,9 @@ font_face_descriptors! {
     optional descriptors = [
         /// The style of this font face
         "font-style" style: font_style::T = font_style::T::normal,
+
+        /// The weight of this font face
+        "font-weight" weight: font_weight::T = font_weight::T::Weight400 /* normal */,
     ]
 }
 

--- a/components/style/parser.rs
+++ b/components/style/parser.rs
@@ -11,7 +11,7 @@ use error_reporting::ParseErrorReporter;
 #[cfg(feature = "gecko")]
 use gecko_bindings::sugar::refptr::{GeckoArcPrincipal, GeckoArcURI};
 use servo_url::ServoUrl;
-use style_traits::CommaSeparated;
+use style_traits::OneOrMoreCommaSeparated;
 use stylesheets::{MemoryHoleReporter, Origin};
 
 /// Extra data that the style backend may need to parse stylesheets.
@@ -104,7 +104,7 @@ pub trait Parse : Sized {
     fn parse(context: &ParserContext, input: &mut Parser) -> Result<Self, ()>;
 }
 
-impl<T> Parse for Vec<T> where T: Parse + CommaSeparated {
+impl<T> Parse for Vec<T> where T: Parse + OneOrMoreCommaSeparated {
     fn parse(context: &ParserContext, input: &mut Parser) -> Result<Self, ()> {
         input.parse_comma_separated(|input| T::parse(context, input))
     }

--- a/components/style/parser.rs
+++ b/components/style/parser.rs
@@ -11,6 +11,7 @@ use error_reporting::ParseErrorReporter;
 #[cfg(feature = "gecko")]
 use gecko_bindings::sugar::refptr::{GeckoArcPrincipal, GeckoArcURI};
 use servo_url::ServoUrl;
+use style_traits::CommaSeparated;
 use stylesheets::{MemoryHoleReporter, Origin};
 
 /// Extra data that the style backend may need to parse stylesheets.
@@ -101,4 +102,10 @@ pub trait Parse : Sized {
     ///
     /// Returns an error on failure.
     fn parse(context: &ParserContext, input: &mut Parser) -> Result<Self, ()>;
+}
+
+impl<T> Parse for Vec<T> where T: Parse + CommaSeparated {
+    fn parse(context: &ParserContext, input: &mut Parser) -> Result<Self, ()> {
+        input.parse_comma_separated(|input| T::parse(context, input))
+    }
 }

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -944,7 +944,7 @@ fn static_assert() {
         for family in &v.0 {
             match *family {
                 FontFamily::FamilyName(ref name) => {
-                    unsafe { Gecko_FontFamilyList_AppendNamed(list, name.as_ptr()); }
+                    unsafe { Gecko_FontFamilyList_AppendNamed(list, name.0.as_ptr()); }
                 }
                 FontFamily::Generic(ref name) => {
                     let family_type =

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -380,6 +380,13 @@
                      -> Result<SpecifiedValue, ()> {
             SpecifiedValue::parse(input)
         }
+        impl Parse for SpecifiedValue {
+            #[inline]
+            fn parse(_context: &ParserContext, input: &mut Parser)
+                         -> Result<SpecifiedValue, ()> {
+                SpecifiedValue::parse(input)
+            }
+        }
     </%def>
     % if vector:
         <%call expr="vector_longhand(name, keyword=Keyword(name, values, **keyword_kwargs), **kwargs)">

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -273,6 +273,20 @@ ${helpers.single_keyword("font-variant-caps",
             }
         })
     }
+
+    /// Used in @font-face, where relative keywords are not allowed.
+    impl Parse for computed_value::T {
+        fn parse(context: &ParserContext, input: &mut Parser) -> Result<Self, ()> {
+            match parse(context, input)? {
+                % for weight in range(100, 901, 100):
+                    SpecifiedValue::Weight${weight} => Ok(computed_value::T::Weight${weight}),
+                % endfor
+                SpecifiedValue::Bolder |
+                SpecifiedValue::Lighter => Err(())
+            }
+        }
+    }
+
     pub mod computed_value {
         use std::fmt;
         #[derive(PartialEq, Eq, Copy, Clone, Hash, Debug)]

--- a/components/style/properties/shorthand/font.mako.rs
+++ b/components/style/properties/shorthand/font.mako.rs
@@ -7,8 +7,10 @@
 <%helpers:shorthand name="font" sub_properties="font-style font-variant font-weight font-stretch
                                                 font-size line-height font-family"
                     spec="https://drafts.csswg.org/css-fonts-3/#propdef-font">
+    use parser::Parse;
     use properties::longhands::{font_style, font_variant, font_weight, font_stretch};
     use properties::longhands::{font_size, line_height, font_family};
+    use properties::longhands::font_family::computed_value::FontFamily;
 
     pub fn parse_value(context: &ParserContext, input: &mut Parser) -> Result<Longhands, ()> {
         let mut nb_normals = 0;
@@ -64,7 +66,7 @@
         } else {
             None
         };
-        let family = try!(input.parse_comma_separated(font_family::parse_one_family));
+        let family = Vec::<FontFamily>::parse(context, input)?;
         Ok(Longhands {
             font_style: style,
             font_variant: variant,

--- a/components/style_traits/lib.rs
+++ b/components/style_traits/lib.rs
@@ -59,4 +59,4 @@ pub mod cursor;
 pub mod values;
 pub mod viewport;
 
-pub use values::{ToCss, CommaSeparated};
+pub use values::{ToCss, OneOrMoreCommaSeparated};

--- a/components/style_traits/lib.rs
+++ b/components/style_traits/lib.rs
@@ -59,4 +59,4 @@ pub mod cursor;
 pub mod values;
 pub mod viewport;
 
-pub use values::ToCss;
+pub use values::{ToCss, CommaSeparated};

--- a/components/style_traits/values.rs
+++ b/components/style_traits/values.rs
@@ -25,9 +25,9 @@ pub trait ToCss {
 }
 
 /// Marker trait to automatically implement ToCss for Vec<T>.
-pub trait CommaSeparated {}
+pub trait OneOrMoreCommaSeparated {}
 
-impl<T> ToCss for Vec<T> where T: ToCss + CommaSeparated {
+impl<T> ToCss for Vec<T> where T: ToCss + OneOrMoreCommaSeparated {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         let mut iter = self.iter();
         iter.next().unwrap().to_css(dest)?;

--- a/components/style_traits/values.rs
+++ b/components/style_traits/values.rs
@@ -24,6 +24,21 @@ pub trait ToCss {
     }
 }
 
+/// Marker trait to automatically implement ToCss for Vec<T>.
+pub trait CommaSeparated {}
+
+impl<T> ToCss for Vec<T> where T: ToCss + CommaSeparated {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        let mut iter = self.iter();
+        iter.next().unwrap().to_css(dest)?;
+        for item in iter {
+            dest.write_str(", ")?;
+            item.to_css(dest)?;
+        }
+        Ok(())
+    }
+}
+
 impl ToCss for Au {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         write!(dest, "{}px", self.to_f64_px())

--- a/tests/unit/gfx/font_cache_thread.rs
+++ b/tests/unit/gfx/font_cache_thread.rs
@@ -4,7 +4,7 @@
 
 use gfx::font_cache_thread::FontCacheThread;
 use ipc_channel::ipc;
-use style::computed_values::font_family::FontFamily;
+use style::computed_values::font_family::{FontFamily, FamilyName};
 use style::font_face::{FontFaceRule, Source};
 
 #[test]
@@ -12,8 +12,8 @@ fn test_local_web_font() {
     let (inp_chan, _) = ipc::channel().unwrap();
     let (out_chan, out_receiver) = ipc::channel().unwrap();
     let font_cache_thread = FontCacheThread::new(inp_chan, None);
-    let family_name = FontFamily::FamilyName(From::from("test family"));
-    let variant_name = FontFamily::FamilyName(From::from("test font face"));
+    let family_name = FontFamily::FamilyName(FamilyName(From::from("test family")));
+    let variant_name = FontFamily::FamilyName(FamilyName(From::from("test font face")));
     let font_face_rule = FontFaceRule {
         family: family_name.clone(),
         sources: vec![Source::Local(variant_name)],

--- a/tests/unit/gfx/font_cache_thread.rs
+++ b/tests/unit/gfx/font_cache_thread.rs
@@ -12,8 +12,8 @@ fn test_local_web_font() {
     let (inp_chan, _) = ipc::channel().unwrap();
     let (out_chan, out_receiver) = ipc::channel().unwrap();
     let font_cache_thread = FontCacheThread::new(inp_chan, None);
-    let family_name = FontFamily::FamilyName(FamilyName(From::from("test family")));
-    let variant_name = FontFamily::FamilyName(FamilyName(From::from("test font face")));
+    let family_name = FamilyName(From::from("test family"));
+    let variant_name = FamilyName(From::from("test font face"));
     let font_face_rule = FontFaceRule {
         family: family_name.clone(),
         sources: vec![Source::Local(variant_name)],


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Part of https://bugzilla.mozilla.org/show_bug.cgi?id=1290237. I’ll add conversions to `nsCSSValue` separately because that requires new C++ functions in the stylo repository.

r? @bholley 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15356)
<!-- Reviewable:end -->
