### PR TITLE
Ensured all font-weight keywords are preserved until computed-value time

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -230,6 +230,8 @@ ${helpers.single_keyword("font-variant-caps",
     #[derive(Debug, Clone, PartialEq, Eq, Copy)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum SpecifiedValue {
+        Normal,
+        Bold,
         Bolder,
         Lighter,
         % for weight in range(100, 901, 100):
@@ -240,6 +242,8 @@ ${helpers.single_keyword("font-variant-caps",
     impl ToCss for SpecifiedValue {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self {
+                SpecifiedValue::Normal => dest.write_str("normal"),
+                SpecifiedValue::Bold => dest.write_str("bold"),
                 SpecifiedValue::Bolder => dest.write_str("bolder"),
                 SpecifiedValue::Lighter => dest.write_str("lighter"),
                 % for weight in range(100, 901, 100):
@@ -252,8 +256,8 @@ ${helpers.single_keyword("font-variant-caps",
     pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
         input.try(|input| {
             match_ignore_ascii_case! { try!(input.expect_ident()),
-                "bold" => Ok(SpecifiedValue::Weight700),
-                "normal" => Ok(SpecifiedValue::Weight400),
+                "normal" => Ok(SpecifiedValue::Normal),
+                "bold" => Ok(SpecifiedValue::Bold),
                 "bolder" => Ok(SpecifiedValue::Bolder),
                 "lighter" => Ok(SpecifiedValue::Lighter),
                 _ => Err(())
@@ -281,6 +285,8 @@ ${helpers.single_keyword("font-variant-caps",
                 % for weight in range(100, 901, 100):
                     SpecifiedValue::Weight${weight} => Ok(computed_value::T::Weight${weight}),
                 % endfor
+                SpecifiedValue::Normal => Ok(computed_value::T::Weight400),
+                SpecifiedValue::Bold => Ok(computed_value::T::Weight700),
                 SpecifiedValue::Bolder |
                 SpecifiedValue::Lighter => Err(())
             }
@@ -331,6 +337,8 @@ ${helpers.single_keyword("font-variant-caps",
                 % for weight in range(100, 901, 100):
                     SpecifiedValue::Weight${weight} => computed_value::T::Weight${weight},
                 % endfor
+                SpecifiedValue::Normal => computed_value::T::Weight400,
+                SpecifiedValue::Bold => computed_value::T::Weight700,
                 SpecifiedValue::Bolder => match context.inherited_style().get_font().clone_font_weight() {
                     computed_value::T::Weight100 => computed_value::T::Weight400,
                     computed_value::T::Weight200 => computed_value::T::Weight400,

--- a/tests/unit/style/parsing/font.rs
+++ b/tests/unit/style/parsing/font.rs
@@ -6,7 +6,7 @@ use cssparser::Parser;
 use media_queries::CSSErrorReporterTest;
 use servo_url::ServoUrl;
 use style::parser::ParserContext;
-use style::properties::longhands::font_feature_settings;
+use style::properties::longhands::{font_feature_settings, font_weight};
 use style::properties::longhands::font_feature_settings::computed_value;
 use style::properties::longhands::font_feature_settings::computed_value::FeatureTagValue;
 use style::stylesheets::Origin;
@@ -96,6 +96,21 @@ fn font_language_override_should_parse_properly() {
 
     let danish = parse_longhand!(font_language_override, "\"DAN\"");
     assert_eq!(danish, SpecifiedValue::Override("DAN".to_string()));
+}
+
+#[test]
+fn font_weight_keyword_should_preserve_keyword() {
+    use style::properties::longhands::font_weight::SpecifiedValue;
+
+    let url = ServoUrl::parse("http://localhost").unwrap();
+    let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+    let mut parser = Parser::new("normal");
+    let result = font_weight::parse(&context, &mut parser);
+    assert_eq!(result.unwrap(), SpecifiedValue::Normal);
+
+    let mut parser = Parser::new("bold");
+    let result = font_weight::parse(&context, &mut parser);
+    assert_eq!(result.unwrap(), SpecifiedValue::Bold);
 }
 
 #[test]

--- a/tests/wpt/metadata-css/cssom-1_dev/html/index-002.htm.ini
+++ b/tests/wpt/metadata-css/cssom-1_dev/html/index-002.htm.ini
@@ -33,6 +33,3 @@
   [list is expected to be list-style: circle inside;]
     expected: FAIL
 
-  [font-family is expected to be font-family: sans-serif; line-height: 2em; font-size: 3em; font-style: italic; font-weight: bold;]
-    expected: FAIL
-


### PR DESCRIPTION
Fixed the serialization of `font-weight` keywords (i.e. `bold`, `normal`, etc.) to ensure that Servo preserves the keyword until computed-value time (just as other major browsers do). 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15337 

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15360)
<!-- Reviewable:end -->
