### PR TITLE
add parsing/serialisation of 'grid-auto-flow', fixing issue #15313

### DIFF
--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -363,3 +363,79 @@ ${helpers.predefined_type("object-position",
                               products="gecko",
                               boxed=True)}
 % endfor
+
+<%helpers:longhand name="grid-auto-flow"
+        spec="https://drafts.csswg.org/css-grid/#propdef-grid-auto-flow"
+        products="none"
+        animatable="False">
+    use std::fmt;
+    use style_traits::ToCss;
+    use values::HasViewportPercentage;
+    use values::computed::ComputedValueAsSpecified;
+
+    pub type SpecifiedValue = computed_value::T;
+
+    pub mod computed_value {
+        #[derive(PartialEq, Clone, Eq, Copy, Debug)]
+        #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+        pub enum AutoFlow {
+            Row,
+            Column,
+        }
+
+        #[derive(PartialEq, Clone, Eq, Copy, Debug)]
+        #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+        pub struct T {
+            pub autoflow: AutoFlow,
+            pub dense: bool,
+        }
+    }
+
+    no_viewport_percentage!(SpecifiedValue);
+    impl ComputedValueAsSpecified for SpecifiedValue {}
+
+    impl ToCss for computed_value::T {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            dest.write_str(match self.autoflow {
+                computed_value::AutoFlow::Column => "column",
+                computed_value::AutoFlow::Row => "row"
+            })?;
+
+            if self.dense { dest.write_str(" dense")?; }
+            Ok(())
+        }
+    }
+
+    #[inline]
+    pub fn get_initial_value() -> computed_value::T {
+        computed_value::T {
+            autoflow: computed_value::AutoFlow::Row,
+            dense: false
+        }
+    }
+
+    /// [ row | column ] || dense
+    pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
+        let mut autoflow = false;
+        let mut value = get_initial_value();
+        loop {
+            match_ignore_ascii_case! { &try!(input.expect_ident()),
+                "row" => if autoflow { return Err(()) }
+                         else {
+                             autoflow = true;
+                             value.autoflow = computed_value::AutoFlow::Row;
+                         },
+                "column" => if autoflow { return Err(()) }
+                            else {
+                                autoflow = true;
+                                value.autoflow = computed_value::AutoFlow::Column;
+                            },
+                "dense" => if value.dense { return Err(()) }
+                           else { value.dense = true },
+                _ => return Err(())
+            }
+        }
+
+        if autoflow || value.dense { Ok(value) } else { Err(()) }
+    }
+</%helpers:longhand>

--- a/tests/unit/style/parsing/position.rs
+++ b/tests/unit/style/parsing/position.rs
@@ -137,3 +137,28 @@ fn test_vertical_position() {
     assert!(parse(VerticalPosition::parse, "left right").is_err());
     assert!(parse(VerticalPosition::parse, "20px 30px").is_err());
 }
+
+#[test]
+fn test_grid_auto_flow() {
+    use style::properties::longhands::grid_auto_flow;
+
+    assert_roundtrip_with_context!(grid_auto_flow::parse, "row dense", "row dense");
+    assert_roundtrip_with_context!(grid_auto_flow::parse, "dense row", "row dense");
+    assert_roundtrip_with_context!(grid_auto_flow::parse, "column dense", "column dense");
+    assert_roundtrip_with_context!(grid_auto_flow::parse, "dense column", "column dense");
+    assert_roundtrip_with_context!(grid_auto_flow::parse, "dense", "row dense");
+    assert_roundtrip_with_context!(grid_auto_flow::parse, "row", "row");
+    assert_roundtrip_with_context!(grid_auto_flow::parse, "column", "column");
+
+    // Neither row, column or dense can be repeated
+    assert!(parse(grid_auto_flow::parse, "dense dense").is_err());
+    assert!(parse(grid_auto_flow::parse, "row row").is_err());
+    assert!(parse(grid_auto_flow::parse, "column column").is_err());
+    assert!(parse(grid_auto_flow::parse, "row dense dense").is_err());
+    assert!(parse(grid_auto_flow::parse, "column dense dense").is_err());
+
+    // Only row, column, dense idents are allowed
+    assert!(parse(grid_auto_flow::parse, "dense 1").is_err());
+    assert!(parse(grid_auto_flow::parse, "column 'dense'").is_err());
+    assert!(parse(grid_auto_flow::parse, "column 2px dense").is_err());
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This pull request adds the parsing and serialisation code for 'grid-auto-flow', as part of issue #15313.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15313

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because _only the parsing/serialisation code is added by this PR_

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15364)
<!-- Reviewable:end -->
