### PR TITLE
Implement GetAvailability for Bluetooth

### DIFF
--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -246,13 +246,16 @@ impl BluetoothManager {
                 },
                 BluetoothRequest::Test(data_set_name, sender) => {
                     let _ = sender.send(self.test(data_set_name));
-                }
+                },
                 BluetoothRequest::SetRepresentedToNull(service_ids, characteristic_ids, descriptor_ids) => {
                     self.remove_ids_from_caches(service_ids, characteristic_ids, descriptor_ids)
-                }
+                },
                 BluetoothRequest::IsRepresentedDeviceNull(id, sender) => {
                     let _ = sender.send(!self.device_is_cached(&id));
-                }
+                },
+                BluetoothRequest::GetAvailability(sender) => {
+                    let _ = sender.send(self.get_availability());
+                },
                 BluetoothRequest::Exit => {
                     break
                 },
@@ -923,5 +926,10 @@ impl BluetoothManager {
         // Step 2.
         // TODO: Implement this when supported in lower level
         return Err(BluetoothError::NotSupported);
+    }
+
+    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-getavailability
+    fn get_availability(&mut self) -> BluetoothResponseResult {
+        Ok(BluetoothResponse::GetAvailability(self.get_adapter().is_ok()))
     }
 }

--- a/components/bluetooth_traits/lib.rs
+++ b/components/bluetooth_traits/lib.rs
@@ -91,6 +91,7 @@ pub enum BluetoothRequest {
     WatchAdvertisements(String, IpcSender<BluetoothResponseResult>),
     SetRepresentedToNull(Vec<String>, Vec<String>, Vec<String>),
     IsRepresentedDeviceNull(String, IpcSender<bool>),
+    GetAvailability(IpcSender<BluetoothResponseResult>),
     Test(String, IpcSender<BluetoothResult<()>>),
     Exit,
 }
@@ -107,4 +108,5 @@ pub enum BluetoothResponse {
     WriteValue(Vec<u8>),
     EnableNotification(()),
     WatchAdvertisements(()),
+    GetAvailability(bool),
 }

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -443,6 +443,18 @@ impl BluetoothMethods for Bluetooth {
         return p;
     }
 
+    #[allow(unrooted_must_root)]
+    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-getavailability
+    fn GetAvailability(&self) -> Rc<Promise> {
+        let p = Promise::new(&self.global());
+        // Step 1. We did not override the method
+        // Step 2 - 3. in handle_response
+        let sender = response_async(&p, self);
+        self.get_bluetooth_thread().send(
+            BluetoothRequest::GetAvailability(sender)).unwrap();
+        p
+    }
+
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-onavailabilitychanged
     event_handler!(availabilitychanged, GetOnavailabilitychanged, SetOnavailabilitychanged);
 }
@@ -466,6 +478,11 @@ impl AsyncBluetoothListener for Bluetooth {
                 // Step 5.
                 promise.resolve_native(promise_cx, &bt_device);
             },
+            // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-getavailability
+            // Step 2 - 3.
+            BluetoothResponse::GetAvailability(is_available) => {
+                promise.resolve_native(promise_cx, &is_available);
+            }
             _ => promise.reject_error(promise_cx, Error::Type("Something went wrong...".to_owned())),
         }
     }

--- a/components/script/dom/webidls/Bluetooth.webidl
+++ b/components/script/dom/webidls/Bluetooth.webidl
@@ -29,8 +29,8 @@ dictionary RequestDeviceOptions {
 
 [Pref="dom.bluetooth.enabled"]
 interface Bluetooth : EventTarget {
-  // [SecureContext]
-  // Promise<boolean> getAvailability();
+  [SecureContext]
+  Promise<boolean> getAvailability();
   [SecureContext]
   attribute EventHandler onavailabilitychanged;
   // [SecureContext, SameObject]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11443,6 +11443,24 @@
      {}
     ]
    ],
+   "mozilla/bluetooth/getAvailability/adapter-not-present.html": [
+    [
+     "/_mozilla/mozilla/bluetooth/getAvailability/adapter-not-present.html",
+     {}
+    ]
+   ],
+   "mozilla/bluetooth/getAvailability/adapter-off.html": [
+    [
+     "/_mozilla/mozilla/bluetooth/getAvailability/adapter-off.html",
+     {}
+    ]
+   ],
+   "mozilla/bluetooth/getAvailability/adapter-on.html": [
+    [
+     "/_mozilla/mozilla/bluetooth/getAvailability/adapter-on.html",
+     {}
+    ]
+   ],
    "mozilla/bluetooth/getCharacteristic/blocklisted-characteristic.html": [
     [
      "/_mozilla/mozilla/bluetooth/getCharacteristic/blocklisted-characteristic.html",
@@ -24370,6 +24388,18 @@
   ],
   "mozilla/bluetooth/disconnect/event-is-fired.html": [
    "6bba458074ce7d8067b6420d4326cbb133e35304",
+   "testharness"
+  ],
+  "mozilla/bluetooth/getAvailability/adapter-not-present.html": [
+   "e4d5e516bee397ecefee1ef679f48f11b5dabe78",
+   "testharness"
+  ],
+  "mozilla/bluetooth/getAvailability/adapter-off.html": [
+   "0e3d7824d57ba676ae52c775fa21d8e6ec6d7073",
+   "testharness"
+  ],
+  "mozilla/bluetooth/getAvailability/adapter-on.html": [
+   "7e37c1b939712f5920b607e27a82f34573ca40fd",
    "testharness"
   ],
   "mozilla/bluetooth/getCharacteristic/blocklisted-characteristic.html": [

--- a/tests/wpt/mozilla/meta/mozilla/bluetooth/interfaces.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/bluetooth/interfaces.html.ini
@@ -30,9 +30,6 @@
   [Bluetooth interface: attribute onserviceremoved]
     expected: FAIL
 
-  [Bluetooth interface: window.navigator.bluetooth must inherit property "getAvailability" with the proper type (0)]
-    expected: FAIL
-
   [Bluetooth interface: window.navigator.bluetooth must inherit property "referringDevice" with the proper type (2)]
     expected: FAIL
 
@@ -431,4 +428,3 @@
 
   [BluetoothRemoteGATTDescriptor interface: calling writeValue(BufferSource) on bluetooth_descriptor with too few arguments must throw TypeError]
     expected: FAIL
-

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getAvailability/adapter-not-present.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getAvailability/adapter-not-present.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(() => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.not_present);
+    return window.navigator.bluetooth.getAvailability()
+    .then(isAvailable => assert_equals(isAvailable, false));
+}, 'GetAvailability is false if the adapter is not present.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getAvailability/adapter-off.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getAvailability/adapter-off.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(() => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.not_powered);
+    return window.navigator.bluetooth.getAvailability()
+    .then(isAvailable => assert_equals(isAvailable, false));
+}, 'GetAvailability is false if the adapter is off.');
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/bluetooth/getAvailability/adapter-on.html
+++ b/tests/wpt/mozilla/tests/mozilla/bluetooth/getAvailability/adapter-on.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/_mozilla/mozilla/bluetooth/bluetooth-helpers.js"></script>
+<script>
+'use strict';
+promise_test(() => {
+    window.testRunner.setBluetoothMockDataSet(adapter_type.empty);
+    return window.navigator.bluetooth.getAvailability()
+    .then(isAvailable => assert_equals(isAvailable, true));
+}, 'GetAvailability is true if the adapter is present.');
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This implements the [getAvailability](https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-getavailability) function from the spec.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15368)
<!-- Reviewable:end -->
