### PR TITLE
Add .hgignore file

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,0 +1,30 @@
+^\.servo
+^\.cargo
+^\.servobuild
+^target/
+^ports/android/bin
+^ports/android/libs
+^ports/android/local.properties
+^ports/android/obj
+^python/_virtualenv
+^python/tidy/servo_tidy\.egg-info
+~$
+\.pkl$
+\.pyc$
+\.swp$
+\.swo$
+\.csv$
+
+\.DS_Store$
+Servo\.app/
+\.config\.mk\.last$
+/glfw
+
+# Editors
+
+# IntelliJ
+\.idea
+\.iws$
+
+# VSCode
+\.vscode


### PR DESCRIPTION
The Firefox repository now contains a vendored copy of the Servo
repository. The Firefox repository is canonically stored in
Mercurial. If someone attempts to do Servo things in a checkout of
the Firefox repository, they get a bunch of untracked files because
there is no .hgignore file.

This commit ports the .gitignore file to Mercurial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15376)
<!-- Reviewable:end -->
