### PR TITLE
Windows: Instructions update, removed freetype and silent some warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,6 @@ matrix:
             - xorg-dev
             - ccache
             - libdbus-glib-1-dev
-            - libavformat-dev
-            - libavcodec-dev
-            - libavutil-dev
             - libedit-dev
 
 branches:

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ dependencies. We are upgrading to a gcc-free build on Windows as soon as possibl
 
  ```sh
 pacman -Su
-pacman -Sy git mingw-w64-x86_64-toolchain mingw-w64-x86_64-freetype \
-    mingw-w64-x86_64-icu mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates \
+pacman -Sy git mingw-w64-x86_64-toolchain mingw-w64-x86_64-icu \
+    mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates \
     mingw-w64-x86_64-expat mingw-w64-x86_64-cmake tar diffutils patch \
     patchutils make python2-setuptools
 export GCC_URL=http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Please select your operating system:
 * [Arch Linux](#on-arch-linux)
 * [openSUSE](#on-opensuse-linux)
 * [Gentoo Linux](#on-gentoo-linux)
-* [Microsoft Windows (MSVC)](#on-windows-msvc)
-* [Microsoft Windows (mingw)](#on-windows-mingw)
+* [Microsoft Windows](#on-windows-msvc--mingw)
 * [Android](#cross-compilation-for-android)
 
 #### OS X
@@ -93,36 +92,31 @@ sudo emerge net-misc/curl media-libs/freeglut \
     dev-python/virtualenv dev-python/pip dev-libs/openssl \
     x11-libs/libXmu media-libs/glu x11-base/xorg-server
 ```
-#### On Windows MSVC
+#### On Windows (MSVC & MinGW)
 
-Install Git for Windows (https://git-scm.com/download/win). DO allow it to add git.exe to the PATH (default
-settings for the installer are fine).
-
-Install Visual Studio 2015 Community Edition (https://www.visualstudio.com/). You MUST add "Visual C++" to the
-list of installed components. It is not on by default.
-
-Install Python for Windows (https://www.python.org/downloads/release/python-2711/). The windows x86-64 MSI installer is fine.
+1. Install Python for Windows (https://www.python.org/downloads/release/python-2711/). The windows x86-64 MSI installer is fine.
 You should change the installation to install the "Add python.exe to Path" feature.
 
-Install virtualenv.
+2. Install virtualenv.
 
-In a normal Windows Shell (cmd.exe or "Command Prompt" from the start menu), do:
-```
+ In a normal Windows Shell (cmd.exe or "Command Prompt" from the start menu), do:
+ ```
 pip install virtualenv
 ```
-If this does not work, you may need to reboot for the changed PATH settings (by the python installer) to take effect.
+ If this does not work, you may need to reboot for the changed PATH settings (by the python installer) to take effect.
 
-#### On Windows mingw
+3. __(MSVC only)__ Install Git for Windows (https://git-scm.com/download/win). DO allow it to add git.exe to the PATH (default
+settings for the installer are fine).
 
-Download Python for Windows [here](https://www.python.org/downloads/release/python-2711/). This is
-required for the SpiderMonkey build on Windows.
+4. __(MSVC only)__ Install Visual Studio 2015 Community Edition (https://www.visualstudio.com/). You MUST add "Visual C++" to the
+list of installed components. It is not on by default.
 
-Install MSYS2 from [here](https://msys2.github.io/). After you have done so, open an MSYS shell
+5. __(MinGW only)__ Install MSYS2 (https://msys2.github.io/). After you have done so, open an MSYS shell
 window and update the core libraries and install new packages. The extra step at the end is to
 downgrade GCC to 5.4, as the GCC6 versions in mingw currently fail to compile some of our
 dependencies. We are upgrading to a gcc-free build on Windows as soon as possible:
 
-```sh
+ ```sh
 pacman -Su
 pacman -Sy git mingw-w64-x86_64-toolchain mingw-w64-x86_64-freetype \
     mingw-w64-x86_64-icu mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates \
@@ -133,16 +127,15 @@ export GCC_EXT=5.4.0-1-any.pkg.tar.xz
 pacman -U --noconfirm $GCC_URL-$GCC_EXT $GCC_URL-ada-$GCC_EXT \
     $GCC_URL-fortran-$GCC_EXT $GCC_URL-libgfortran-$GCC_EXT $GCC_URL-libs-$GCC_EXT \
     $GCC_URL-objc-$GCC_EXT
-easy_install-2.7 pip virtualenv
 ```
 
-Add the following line to the end of `.profile` in your home directory:
+ Add the following line to the end of `.profile` in your home directory:
 
-```
-export PATH=/c/Python27:$PATH
+ ```
+export PATH=/c/Python27:/c/Python27/Scripts:$PATH
 ```
 
-Now, open a MINGW64 (not MSYS!) shell window, and you should be able to build
+ Now, open a MINGW64 (not MSYS!) shell window, and you should be able to build
 servo as usual!
 
 #### Cross-compilation for Android

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ install:
   - if %BUILD_ENV%==gnu  set MSYS=winsymlinks=lnk
   - if %BUILD_ENV%==gnu  bash -lc "echo $MSYSTEM; pacman --needed --noconfirm -Sy pacman-mirrors"
   - if %BUILD_ENV%==gnu  bash -lc "pacman --noconfirm -Sy"
-  - if %BUILD_ENV%==gnu  bash -lc "pacman -Sy --needed --noconfirm mingw-w64-x86_64-ccache mingw-w64-x86_64-toolchain mingw-w64-x86_64-freetype mingw-w64-x86_64-icu mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates mingw-w64-x86_64-expat mingw-w64-x86_64-cmake tar diffutils patch patchutils make python2-setuptools"
+  - if %BUILD_ENV%==gnu  bash -lc "pacman -Sy --needed --noconfirm mingw-w64-x86_64-ccache mingw-w64-x86_64-toolchain mingw-w64-x86_64-icu mingw-w64-x86_64-nspr mingw-w64-x86_64-ca-certificates mingw-w64-x86_64-expat mingw-w64-x86_64-cmake tar diffutils patch patchutils make python2-setuptools"
   # Downgrade msys2 build GCC to 5.4.0-1 - https://github.com/servo/servo/issues/12512
   - if %BUILD_ENV%==gnu  set GCC_URL=http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc
   - if %BUILD_ENV%==gnu  set GCC_EXT=5.4.0-1-any.pkg.tar.xz

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -28,6 +28,7 @@ use servo_config::opts::{self, Opts};
 use servo_config::prefs::{PREFS, Pref};
 use servo_url::ServoUrl;
 use std::collections::HashMap;
+#[cfg(not(windows))]
 use std::env;
 use std::ffi::OsStr;
 use std::io::Error as IOError;

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -4,7 +4,7 @@
 
 // For SIMD
 #![feature(cfg_target_feature)]
-#![cfg_attr(any(target_os = "linux", target_os = "android", target_os = "windows"), feature(heap_api))]
+#![cfg_attr(any(target_os = "linux", target_os = "android"), feature(heap_api))]
 
 #![feature(alloc)]
 #![feature(box_syntax)]

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -401,6 +401,8 @@ class CommandBase(object):
         if is_windows():
             if not os.environ.get("NATIVE_WIN32_PYTHON"):
                 env["NATIVE_WIN32_PYTHON"] = sys.executable
+            # Always build harfbuzz from source
+            env["HARFBUZZ_SYS_NO_PKG_CONFIG"] = "true"
 
         if not self.config["tools"]["system-rust"] \
                 or self.config["tools"]["rust-root"]:

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -117,19 +117,15 @@ def copy_windows_dependencies(binary_path, destination):
             "libgcc_s_seh-1.dll",
             "libexpat-1.dll",
             "zlib1.dll",
-            "libpng16-16.dll",
             "libiconv-2.dll",
-            "libglib-2.0-0.dll",
-            "libgraphite2.dll",
-            "libfreetype-6.dll",
-            "libfontconfig-1.dll",
             "libintl-8.dll",
-            "libpcre-1.dll",
             "libeay32.dll",
             "ssleay32.dll",
-            "libharfbuzz-0.dll",
         ]
-        [shutil.copy(path.join("C:\\msys64\\mingw64\\bin", d), path.join(destination, d)) for d in deps]
+        for d in deps:
+            dep_path = path.join("C:\\msys64\\mingw64\\bin", d)
+            if path.exists(dep_path):
+                shutil.copy(dep_path, path.join(destination, d))
 
 
 def change_prefs(resources_path, platform):

--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -6,7 +6,6 @@ WINDOWS_GNU = set([
     "diffutils",
     "make",
     "mingw-w64-x86_64-toolchain",
-    "mingw-w64-x86_64-freetype",
     "mingw-w64-x86_64-icu",
     "mingw-w64-x86_64-nspr",
     "mingw-w64-x86_64-ca-certificates",


### PR DESCRIPTION
i made some changes to Windows instruction, more unified.
Also removed freetype dependencies on Windows, by forcing to build harfbuzz from source, which is also dependent on freetype.

cc @larsbergstrom @metajack

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15393)
<!-- Reviewable:end -->
