### PR TITLE
Use 'alloc' gate only for platforms which use freetype in gfx

### DIFF
--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -6,7 +6,7 @@
 #![feature(cfg_target_feature)]
 #![cfg_attr(any(target_os = "linux", target_os = "android"), feature(heap_api))]
 
-#![feature(alloc)]
+#![cfg_attr(any(target_os = "linux", target_os = "android"), feature(alloc))]
 #![feature(box_syntax)]
 #![feature(plugin)]
 #![feature(range_contains)]
@@ -15,6 +15,9 @@
 #![plugin(plugins)]
 
 #![deny(unsafe_code)]
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+extern crate alloc;
 
 extern crate app_units;
 #[macro_use]

--- a/components/gfx/platform/freetype/font_context.rs
+++ b/components/gfx/platform/freetype/font_context.rs
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate alloc;
-
+use alloc::heap;
 use freetype::freetype::FT_Add_Default_Modules;
 use freetype::freetype::FT_Done_Library;
 use freetype::freetype::FT_Library;
@@ -11,7 +10,6 @@ use freetype::freetype::FT_Memory;
 use freetype::freetype::FT_MemoryRec_;
 use freetype::freetype::FT_New_Library;
 use heapsize::{HeapSizeOf, heap_size_of};
-use self::alloc::heap;
 use std::os::raw::{c_long, c_void};
 use std::ptr;
 use std::rc::Rc;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15406)
<!-- Reviewable:end -->
