### PR TITLE
layout: Remove cached thread local context from LayoutContext, and use LayoutContext for assign_inline_sizes()

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -4,7 +4,7 @@
 
 //! CSS transitions and animations.
 
-use context::SharedLayoutContext;
+use context::LayoutContext;
 use flow::{self, Flow};
 use gfx::display_list::OpaqueNode;
 use ipc_channel::ipc::IpcSender;
@@ -132,7 +132,7 @@ pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
 // NB: This is specific for SelectorImpl, since the layout context and the
 // flows are SelectorImpl specific too. If that goes away at some point,
 // this should be made generic.
-pub fn recalc_style_for_animations(context: &SharedLayoutContext,
+pub fn recalc_style_for_animations(context: &LayoutContext,
                                    flow: &mut Flow,
                                    animations: &HashMap<OpaqueNode,
                                                         Vec<Animation>>) {

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -333,7 +333,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
 
     #[inline]
     fn style_context(&self) -> &SharedStyleContext {
-        self.layout_context.style_context()
+        self.layout_context.shared_context()
     }
 
     #[inline]

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -15,7 +15,7 @@
 
 use app_units::Au;
 use block::BlockFlow;
-use context::LayoutContext;
+use context::{LayoutContext, with_thread_local_font_context};
 use data::{HAS_NEWLY_CONSTRUCTED_FLOW, PersistentLayoutData};
 use flex::FlexFlow;
 use floats::FloatKind;
@@ -315,7 +315,7 @@ impl InlineFragmentsAccumulator {
 /// An object that knows how to create flows.
 pub struct FlowConstructor<'a, N: ThreadSafeLayoutNode> {
     /// The layout context.
-    pub layout_context: &'a LayoutContext<'a>,
+    pub layout_context: &'a LayoutContext,
     /// Satisfy the compiler about the unused parameters, which we use to improve the ergonomics of
     /// the ensuing impl {} by removing the need to parameterize all the methods individually.
     phantom2: PhantomData<N>,
@@ -324,7 +324,7 @@ pub struct FlowConstructor<'a, N: ThreadSafeLayoutNode> {
 impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
   FlowConstructor<'a, ConcreteThreadSafeLayoutNode> {
     /// Creates a new flow constructor.
-    pub fn new(layout_context: &'a LayoutContext<'a>) -> Self {
+    pub fn new(layout_context: &'a LayoutContext) -> Self {
         FlowConstructor {
             layout_context: layout_context,
             phantom2: PhantomData,
@@ -351,12 +351,12 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
             }
             Some(LayoutNodeType::Element(LayoutElementType::HTMLImageElement)) => {
                 let image_info = box ImageFragmentInfo::new(node.image_url(),
-                                                            &self.layout_context.shared);
+                                                            &self.layout_context);
                 SpecificFragmentInfo::Image(image_info)
             }
             Some(LayoutNodeType::Element(LayoutElementType::HTMLObjectElement)) => {
                 let image_info = box ImageFragmentInfo::new(node.object_data(),
-                                                            &self.layout_context.shared);
+                                                            &self.layout_context);
                 SpecificFragmentInfo::Image(image_info)
             }
             Some(LayoutNodeType::Element(LayoutElementType::HTMLTableElement)) => {
@@ -434,8 +434,10 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
         // for runs might collapse so much whitespace away that only hypothetical fragments
         // remain. In that case the inline flow will compute its ascent and descent to be zero.
         let scanned_fragments =
-            TextRunScanner::new().scan_for_runs(&mut self.layout_context.font_context(),
-                                                fragments.fragments);
+            with_thread_local_font_context(self.layout_context, |font_context| {
+                TextRunScanner::new().scan_for_runs(font_context,
+                                                    mem::replace(&mut fragments.fragments, LinkedList::new()))
+            });
         let mut inline_flow_ref =
             FlowRef::new(Arc::new(InlineFlow::from_fragments(scanned_fragments,
                                                 node.style(self.style_context()).writing_mode)));
@@ -464,8 +466,9 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
             // FIXME(#6503): Use Arc::get_mut().unwrap() here.
             let inline_flow = FlowRef::deref_mut(&mut inline_flow_ref).as_mut_inline();
             inline_flow.minimum_line_metrics =
-                inline_flow.minimum_line_metrics(&mut self.layout_context.font_context(),
-                                                 &node.style(self.style_context()))
+                with_thread_local_font_context(self.layout_context, |font_context| {
+                    inline_flow.minimum_line_metrics(font_context, &node.style(self.style_context()))
+                });
         }
 
         inline_flow_ref.finish();
@@ -1216,7 +1219,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
         let marker_fragments = match node.style(self.style_context()).get_list().list_style_image {
             Either::First(ref url_value) => {
                 let image_info = box ImageFragmentInfo::new(url_value.url().map(|u| u.clone()),
-                                                            &self.layout_context.shared);
+                                                            &self.layout_context);
                 vec![Fragment::new(node, SpecificFragmentInfo::Image(image_info), self.layout_context)]
             }
             Either::Second(_none) => {
@@ -1232,9 +1235,11 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                             SpecificFragmentInfo::UnscannedText(
                                 box UnscannedTextFragmentInfo::new(text, None)),
                             self.layout_context));
-                        let marker_fragments = TextRunScanner::new().scan_for_runs(
-                            &mut self.layout_context.font_context(),
-                            unscanned_marker_fragments);
+                        let marker_fragments =
+                            with_thread_local_font_context(self.layout_context, |mut font_context| {
+                                TextRunScanner::new().scan_for_runs(&mut font_context,
+                                                                    unscanned_marker_fragments)
+                            });
                         marker_fragments.fragments
                     }
                     ListStyleTypeContent::GeneratedContent(info) => {

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -20,7 +20,6 @@ use std::borrow::{Borrow, BorrowMut};
 use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
-use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use style::context::{SharedStyleContext, ThreadLocalStyleContext};
 use style::dom::TElement;
@@ -31,9 +30,9 @@ pub struct ScopedThreadLocalLayoutContext<E: TElement> {
 }
 
 impl<E: TElement> ScopedThreadLocalLayoutContext<E> {
-    pub fn new(shared: &SharedLayoutContext) -> Self {
+    pub fn new(context: &LayoutContext) -> Self {
         ScopedThreadLocalLayoutContext {
-            style_context: ThreadLocalStyleContext::new(&shared.style_context),
+            style_context: ThreadLocalStyleContext::new(&context.style_context),
         }
     }
 }
@@ -50,53 +49,33 @@ impl<E: TElement> BorrowMut<ThreadLocalStyleContext<E>> for ScopedThreadLocalLay
     }
 }
 
-/// TLS data that persists across traversals.
-pub struct PersistentThreadLocalLayoutContext {
-    // FontContext uses Rc all over the place and so isn't Send, which means we
-    // can't use ScopedTLS for it. There's also no reason to scope it to the
-    // traversal, and performance is probably better if we don't.
-    pub font_context: RefCell<FontContext>,
-}
+thread_local!(static FONT_CONTEXT_KEY: RefCell<Option<FontContext>> = RefCell::new(None));
 
-impl PersistentThreadLocalLayoutContext {
-    pub fn new(shared: &SharedLayoutContext) -> Rc<Self> {
-        let font_cache_thread = shared.font_cache_thread.lock().unwrap().clone();
-        Rc::new(PersistentThreadLocalLayoutContext {
-            font_context: RefCell::new(FontContext::new(font_cache_thread)),
-        })
-    }
-}
-
-impl HeapSizeOf for PersistentThreadLocalLayoutContext {
-    fn heap_size_of_children(&self) -> usize {
-        self.font_context.heap_size_of_children()
-    }
-}
-
-thread_local!(static LOCAL_CONTEXT_KEY: RefCell<Option<Rc<PersistentThreadLocalLayoutContext>>> = RefCell::new(None));
-
-fn create_or_get_persistent_context(shared: &SharedLayoutContext)
-                                    -> Rc<PersistentThreadLocalLayoutContext> {
-    LOCAL_CONTEXT_KEY.with(|r| {
-        let mut r = r.borrow_mut();
-        if let Some(context) = r.clone() {
-            context
-        } else {
-            let context = PersistentThreadLocalLayoutContext::new(shared);
-            *r = Some(context.clone());
-            context
+pub fn with_thread_local_font_context<F, R>(layout_context: &LayoutContext, f: F) -> R
+    where F: FnOnce(&mut FontContext) -> R
+{
+    FONT_CONTEXT_KEY.with(|k| {
+        let mut font_context = k.borrow_mut();
+        if font_context.is_none() {
+            let font_cache_thread = layout_context.font_cache_thread.lock().unwrap().clone();
+            *font_context = Some(FontContext::new(font_cache_thread));
         }
+        f(&mut RefMut::map(font_context, |x| x.as_mut().unwrap()))
     })
 }
 
 pub fn heap_size_of_persistent_local_context() -> usize {
-    LOCAL_CONTEXT_KEY.with(|r| {
-        r.borrow().clone().map_or(0, |context| context.heap_size_of_children())
+    FONT_CONTEXT_KEY.with(|r| {
+        if let Some(ref context) = *r.borrow() {
+            context.heap_size_of_children()
+        } else {
+            0
+        }
     })
 }
 
 /// Layout information shared among all workers. This must be thread-safe.
-pub struct SharedLayoutContext {
+pub struct LayoutContext {
     /// Bits shared by the layout and style system.
     pub style_context: SharedStyleContext,
 
@@ -115,34 +94,12 @@ pub struct SharedLayoutContext {
                                                   BuildHasherDefault<FnvHasher>>>>,
 }
 
-pub struct LayoutContext<'a> {
-    pub shared: &'a SharedLayoutContext,
-    pub persistent: Rc<PersistentThreadLocalLayoutContext>,
-}
-
-impl<'a> LayoutContext<'a> {
-    pub fn new(shared: &'a SharedLayoutContext) -> Self
-    {
-        LayoutContext {
-            shared: shared,
-            persistent: create_or_get_persistent_context(shared),
-        }
-    }
-}
-
-impl<'a> LayoutContext<'a> {
+impl LayoutContext {
     #[inline(always)]
     pub fn shared_context(&self) -> &SharedStyleContext {
-        &self.shared.style_context
+        &self.style_context
     }
 
-    #[inline(always)]
-    pub fn font_context(&self) -> RefMut<FontContext> {
-        self.persistent.font_context.borrow_mut()
-    }
-}
-
-impl SharedLayoutContext {
     fn get_or_request_image_synchronously(&self, url: ServoUrl, use_placeholder: UsePlaceholder)
                                           -> Option<Arc<Image>> {
         debug_assert!(opts::get().output_file.is_some() || opts::get().exit_after_load);

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -131,16 +131,8 @@ impl<'a> LayoutContext<'a> {
 }
 
 impl<'a> LayoutContext<'a> {
-    // FIXME(bholley): The following two methods are identical and should be merged.
-    // shared_context() is the appropriate name, but it involves renaming a lot of
-    // calls.
     #[inline(always)]
     pub fn shared_context(&self) -> &SharedStyleContext {
-        &self.shared.style_context
-    }
-
-    #[inline(always)]
-    pub fn style_context(&self) -> &SharedStyleContext {
         &self.shared.style_context
     }
 

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -13,7 +13,7 @@
 use app_units::{AU_PER_PX, Au};
 use block::{BlockFlow, BlockStackingContextType};
 use canvas_traits::{CanvasData, CanvasMsg, FromLayoutMsg};
-use context::SharedLayoutContext;
+use context::LayoutContext;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D, TypedSize2D};
 use flex::FlexFlow;
 use flow::{BaseFlow, Flow, IS_ABSOLUTELY_POSITIONED};
@@ -93,7 +93,7 @@ fn get_cyclic<T>(arr: &[T], index: usize) -> &T {
 }
 
 pub struct DisplayListBuildState<'a> {
-    pub shared_layout_context: &'a SharedLayoutContext,
+    pub layout_context: &'a LayoutContext,
     pub root_stacking_context: StackingContext,
     pub items: HashMap<StackingContextId, Vec<DisplayItem>>,
     pub stacking_context_children: HashMap<StackingContextId, Vec<StackingContext>>,
@@ -114,9 +114,9 @@ pub struct DisplayListBuildState<'a> {
 }
 
 impl<'a> DisplayListBuildState<'a> {
-    pub fn new(shared_layout_context: &'a SharedLayoutContext) -> DisplayListBuildState<'a> {
+    pub fn new(layout_context: &'a LayoutContext) -> DisplayListBuildState<'a> {
         DisplayListBuildState {
-            shared_layout_context: shared_layout_context,
+            layout_context: layout_context,
             root_stacking_context: StackingContext::root(),
             items: HashMap::new(),
             stacking_context_children: HashMap::new(),
@@ -682,7 +682,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                image_url: &ServoUrl,
                                                index: usize) {
         let background = style.get_background();
-        let webrender_image = state.shared_layout_context
+        let webrender_image = state.layout_context
                                    .get_webrender_image_for_url(image_url.clone(),
                                                                 UsePlaceholder::No);
 

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -27,7 +27,7 @@
 
 use app_units::Au;
 use block::{BlockFlow, FormattingContextType};
-use context::{LayoutContext, SharedLayoutContext};
+use context::LayoutContext;
 use display_list_builder::DisplayListBuildState;
 use euclid::{Point2D, Size2D};
 use flex::FlexFlow;
@@ -193,12 +193,12 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
     }
 
     /// Pass 2 of reflow: computes inline-size.
-    fn assign_inline_sizes(&mut self, _shared_context: &SharedStyleContext) {
+    fn assign_inline_sizes(&mut self, _ctx: &LayoutContext) {
         panic!("assign_inline_sizes not yet implemented")
     }
 
     /// Pass 3a of reflow: computes block-size.
-    fn assign_block_size<'a>(&mut self, _ctx: &'a LayoutContext<'a>) {
+    fn assign_block_size(&mut self, _ctx: &LayoutContext) {
         panic!("assign_block_size not yet implemented")
     }
 
@@ -234,11 +234,11 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
     /// `parent_thread_id` is the thread ID of the parent. This is used for the layout tinting
     /// debug mode; if the block size of this flow was determined by its parent, we should treat
     /// it as laid out by its parent.
-    fn assign_block_size_for_inorder_child_if_necessary<'a>(&mut self,
-                                                            layout_context: &'a LayoutContext<'a>,
-                                                            parent_thread_id: u8,
-                                                            _content_box: LogicalRect<Au>)
-                                                            -> bool {
+    fn assign_block_size_for_inorder_child_if_necessary(&mut self,
+                                                        layout_context: &LayoutContext,
+                                                        parent_thread_id: u8,
+                                                        _content_box: LogicalRect<Au>)
+                                                        -> bool {
         let might_have_floats_in_or_out = base(self).might_have_floats_in() ||
             base(self).might_have_floats_out();
         if might_have_floats_in_or_out {
@@ -349,7 +349,7 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
     }
 
     /// Phase 4 of reflow: computes absolute positions.
-    fn compute_absolute_position(&mut self, _: &SharedLayoutContext) {
+    fn compute_absolute_position(&mut self, _: &LayoutContext) {
         // The default implementation is a no-op.
         mut_base(self).restyle_damage.remove(REPOSITION)
     }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -8,7 +8,7 @@
 
 use app_units::Au;
 use canvas_traits::CanvasMsg;
-use context::{LayoutContext, SharedLayoutContext};
+use context::{LayoutContext, with_thread_local_font_context};
 use euclid::{Matrix4D, Point2D, Radians, Rect, Size2D};
 use floats::ClearType;
 use flow::{self, ImmutableFlowUtils};
@@ -368,10 +368,10 @@ impl ImageFragmentInfo {
     /// FIXME(pcwalton): The fact that image fragments store the cache in the fragment makes little
     /// sense to me.
     pub fn new(url: Option<ServoUrl>,
-               shared_layout_context: &SharedLayoutContext)
+               layout_context: &LayoutContext)
                -> ImageFragmentInfo {
         let image_or_metadata = url.and_then(|url| {
-            shared_layout_context.get_or_request_image_or_meta(url, UsePlaceholder::Yes)
+            layout_context.get_or_request_image_or_meta(url, UsePlaceholder::Yes)
         });
 
         let (image, metadata) = match image_or_metadata {
@@ -786,8 +786,9 @@ impl Fragment {
             SpecificFragmentInfo::UnscannedText(
                 box UnscannedTextFragmentInfo::new(text_overflow_string, None)));
         unscanned_ellipsis_fragments.push_back(ellipsis_fragment);
-        let ellipsis_fragments = TextRunScanner::new().scan_for_runs(&mut layout_context.font_context(),
-                                                                     unscanned_ellipsis_fragments);
+        let ellipsis_fragments = with_thread_local_font_context(layout_context, |font_context| {
+            TextRunScanner::new().scan_for_runs(font_context, unscanned_ellipsis_fragments)
+        });
         debug_assert!(ellipsis_fragments.len() == 1);
         ellipsis_fragment = ellipsis_fragments.fragments.into_iter().next().unwrap();
         ellipsis_fragment.flags |= IS_ELLIPSIS;
@@ -2111,8 +2112,9 @@ impl Fragment {
                     return InlineMetrics::new(Au(0), Au(0), Au(0));
                 }
                 // See CSS 2.1 § 10.8.1.
-                let font_metrics = text::font_metrics_for_style(&mut layout_context.font_context(),
-                                                                self.style.clone_font());
+                let font_metrics = with_thread_local_font_context(layout_context, |font_context| {
+                    text::font_metrics_for_style(font_context, self.style.clone_font())
+                });
                 let line_height = text::line_height_from_style(&*self.style, &font_metrics);
                 InlineMetrics::from_font_metrics(&info.run.font_metrics, line_height)
             }
@@ -2194,9 +2196,9 @@ impl Fragment {
             match style.get_box().vertical_align {
                 vertical_align::T::baseline => {}
                 vertical_align::T::middle => {
-                    let font_metrics =
-                        text::font_metrics_for_style(&mut layout_context.font_context(),
-                                                     style.clone_font());
+                    let font_metrics = with_thread_local_font_context(layout_context, |font_context| {
+                        text::font_metrics_for_style(font_context, self.style.clone_font())
+                    });
                     offset += (content_inline_metrics.ascent -
                                content_inline_metrics.space_below_baseline -
                                font_metrics.x_height).scale_by(0.5)

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -642,8 +642,8 @@ pub struct TruncatedFragmentInfo {
 impl Fragment {
     /// Constructs a new `Fragment` instance.
     pub fn new<N: ThreadSafeLayoutNode>(node: &N, specific: SpecificFragmentInfo, ctx: &LayoutContext) -> Fragment {
-        let style_context = ctx.style_context();
-        let style = node.style(style_context);
+        let shared_context = ctx.shared_context();
+        let style = node.style(shared_context);
         let writing_mode = style.writing_mode;
 
         let mut restyle_damage = node.restyle_damage();

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -6,7 +6,7 @@
 
 use app_units::Au;
 use block::AbsoluteAssignBSizesTraversal;
-use context::{LayoutContext, SharedLayoutContext};
+use context::LayoutContext;
 use display_list_builder::{DisplayListBuildState, InlineFlowDisplayListBuilding};
 use euclid::{Point2D, Size2D};
 use floats::{FloatKind, Floats, PlacementInfo};
@@ -32,7 +32,6 @@ use std::sync::Arc;
 use style::arc_ptr_eq;
 use style::computed_values::{display, overflow_x, position, text_align, text_justify};
 use style::computed_values::{vertical_align, white_space};
-use style::context::SharedStyleContext;
 use style::logical_geometry::{LogicalRect, LogicalSize, WritingMode};
 use style::properties::{longhands, ServoComputedValues};
 use style::servo::restyle_damage::{BUBBLE_ISIZES, REFLOW, REFLOW_OUT_OF_FLOW, REPOSITION, RESOLVE_GENERATED_CONTENT};
@@ -1347,7 +1346,7 @@ impl Flow for InlineFlow {
 
     /// Recursively (top-down) determines the actual inline-size of child contexts and fragments.
     /// When called on this context, the context has had its inline-size set by the parent context.
-    fn assign_inline_sizes(&mut self, _: &SharedStyleContext) {
+    fn assign_inline_sizes(&mut self, _: &LayoutContext) {
         let _scope = layout_debug_scope!("inline::assign_inline_sizes {:x}", self.base.debug_id());
 
         // Initialize content fragment inline-sizes if they haven't been initialized already.
@@ -1506,7 +1505,7 @@ impl Flow for InlineFlow {
         }
     }
 
-    fn compute_absolute_position(&mut self, _: &SharedLayoutContext) {
+    fn compute_absolute_position(&mut self, _: &LayoutContext) {
         // First, gather up the positions of all the containing blocks (if any).
         //
         // FIXME(pcwalton): This will get the absolute containing blocks inside `...` wrong in the

--- a/components/layout/multicol.rs
+++ b/components/layout/multicol.rs
@@ -8,7 +8,7 @@
 
 use app_units::Au;
 use block::BlockFlow;
-use context::{LayoutContext, SharedLayoutContext};
+use context::LayoutContext;
 use display_list_builder::DisplayListBuildState;
 use euclid::Point2D;
 use euclid::Size2D;
@@ -19,7 +19,6 @@ use gfx_traits::print_tree::PrintTree;
 use std::cmp::{min, max};
 use std::fmt;
 use std::sync::Arc;
-use style::context::SharedStyleContext;
 use style::logical_geometry::LogicalSize;
 use style::properties::ServoComputedValues;
 use style::values::Either;
@@ -76,8 +75,9 @@ impl Flow for MulticolFlow {
         self.block_flow.bubble_inline_sizes();
     }
 
-    fn assign_inline_sizes(&mut self, shared_context: &SharedStyleContext) {
+    fn assign_inline_sizes(&mut self, layout_context: &LayoutContext) {
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "multicol");
+        let shared_context = layout_context.shared_context();
         self.block_flow.compute_inline_sizes(shared_context);
 
         // Move in from the inline-start border edge.
@@ -89,7 +89,7 @@ impl Flow for MulticolFlow {
             self.block_flow.fragment.margin.inline_end +
             self.block_flow.fragment.border_padding.inline_end;
 
-        self.block_flow.assign_inline_sizes(shared_context);
+        self.block_flow.assign_inline_sizes(layout_context);
         let padding_and_borders = self.block_flow.fragment.border_padding.inline_start_end();
         let content_inline_size =
             self.block_flow.fragment.border_box.size.inline - padding_and_borders;
@@ -124,7 +124,7 @@ impl Flow for MulticolFlow {
             |_, _, _, _, _, _| {});
     }
 
-    fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {
+    fn assign_block_size(&mut self, ctx: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for multicol");
 
         let fragmentation_context = Some(FragmentationContext {
@@ -163,7 +163,7 @@ impl Flow for MulticolFlow {
         }
     }
 
-    fn compute_absolute_position(&mut self, layout_context: &SharedLayoutContext) {
+    fn compute_absolute_position(&mut self, layout_context: &LayoutContext) {
         self.block_flow.compute_absolute_position(layout_context);
         let pitch = LogicalSize::new(self.block_flow.base.writing_mode, self.column_pitch, Au(0));
         let pitch = pitch.to_physical(self.block_flow.base.writing_mode);
@@ -235,12 +235,12 @@ impl Flow for MulticolColumnFlow {
         self.block_flow.bubble_inline_sizes();
     }
 
-    fn assign_inline_sizes(&mut self, shared_context: &SharedStyleContext) {
+    fn assign_inline_sizes(&mut self, layout_context: &LayoutContext) {
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "multicol column");
-        self.block_flow.assign_inline_sizes(shared_context);
+        self.block_flow.assign_inline_sizes(layout_context);
     }
 
-    fn assign_block_size<'a>(&mut self, ctx: &'a LayoutContext<'a>) {
+    fn assign_block_size(&mut self, ctx: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for multicol column");
         self.block_flow.assign_block_size(ctx);
     }
@@ -251,7 +251,7 @@ impl Flow for MulticolColumnFlow {
         Flow::fragment(&mut self.block_flow, layout_context, fragmentation_context)
     }
 
-    fn compute_absolute_position(&mut self, layout_context: &SharedLayoutContext) {
+    fn compute_absolute_position(&mut self, layout_context: &LayoutContext) {
         self.block_flow.compute_absolute_position(layout_context)
     }
 

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -8,7 +8,7 @@
 
 #![allow(unsafe_code)]
 
-use context::{LayoutContext, SharedLayoutContext};
+use context::LayoutContext;
 use flow::{self, Flow, MutableFlowUtils, PostorderFlowTraversal, PreorderFlowTraversal};
 use flow_ref::FlowRef;
 use profile_traits::time::{self, TimerMetadata, profile};
@@ -49,11 +49,6 @@ pub fn borrowed_flow_to_unsafe_flow(flow: &Flow) -> UnsafeFlow {
     }
 }
 
-pub type ChunkedFlowTraversalFunction<'scope> =
-    extern "Rust" fn(Box<[UnsafeFlow]>, &rayon::Scope<'scope>, &'scope SharedLayoutContext);
-
-pub type FlowTraversalFunction = extern "Rust" fn(UnsafeFlow, &LayoutContext);
-
 /// Information that we need stored in each flow.
 pub struct FlowParallelInfo {
     /// The number of children that still need work done.
@@ -71,183 +66,128 @@ impl FlowParallelInfo {
     }
 }
 
-/// A parallel bottom-up flow traversal.
-trait ParallelPostorderFlowTraversal : PostorderFlowTraversal {
-    /// Process current flow and potentially traverse its ancestors.
-    ///
-    /// If we are the last child that finished processing, recursively process
-    /// our parent. Else, stop. Also, stop at the root.
-    ///
-    /// Thus, if we start with all the leaves of a tree, we end up traversing
-    /// the whole tree bottom-up because each parent will be processed exactly
-    /// once (by the last child that finishes processing).
-    ///
-    /// The only communication between siblings is that they both
-    /// fetch-and-subtract the parent's children count.
-    fn run_parallel(&self, mut unsafe_flow: UnsafeFlow) {
-        loop {
+/// Process current flow and potentially traverse its ancestors.
+///
+/// If we are the last child that finished processing, recursively process
+/// our parent. Else, stop. Also, stop at the root.
+///
+/// Thus, if we start with all the leaves of a tree, we end up traversing
+/// the whole tree bottom-up because each parent will be processed exactly
+/// once (by the last child that finishes processing).
+///
+/// The only communication between siblings is that they both
+/// fetch-and-subtract the parent's children count.
+fn buttom_up_flow(mut unsafe_flow: UnsafeFlow,
+                  assign_bsize_traversal: &AssignBSizes) {
+    loop {
+        // Get a real flow.
+        let flow: &mut Flow = unsafe {
+            mem::transmute(unsafe_flow)
+        };
+
+        // Perform the appropriate traversal.
+        if assign_bsize_traversal.should_process(flow) {
+            assign_bsize_traversal.process(flow);
+        }
+
+
+        let base = flow::mut_base(flow);
+
+        // Reset the count of children for the next layout traversal.
+        base.parallel.children_count.store(base.children.len() as isize,
+                                           Ordering::Relaxed);
+
+        // Possibly enqueue the parent.
+        let unsafe_parent = base.parallel.parent;
+        if unsafe_parent == null_unsafe_flow() {
+            // We're done!
+            break
+        }
+
+        // No, we're not at the root yet. Then are we the last child
+        // of our parent to finish processing? If so, we can continue
+        // on with our parent; otherwise, we've gotta wait.
+        let parent: &mut Flow = unsafe {
+            mem::transmute(unsafe_parent)
+        };
+        let parent_base = flow::mut_base(parent);
+        if parent_base.parallel.children_count.fetch_sub(1, Ordering::Relaxed) == 1 {
+            // We were the last child of our parent. Reflow our parent.
+            unsafe_flow = unsafe_parent
+        } else {
+            // Stop.
+            break
+        }
+    }
+}
+
+fn top_down_flow<'scope>(unsafe_flows: &[UnsafeFlow],
+                         scope: &rayon::Scope<'scope>,
+                         assign_isize_traversal: &'scope AssignISizes,
+                         assign_bsize_traversal: &'scope AssignBSizes)
+{
+    let mut discovered_child_flows = vec![];
+
+    for unsafe_flow in unsafe_flows {
+        let mut had_children = false;
+        unsafe {
             // Get a real flow.
-            let flow: &mut Flow = unsafe {
-                mem::transmute(unsafe_flow)
-            };
+            let flow: &mut Flow = mem::transmute(*unsafe_flow);
 
-            // Perform the appropriate traversal.
-            if self.should_process(flow) {
-                self.process(flow);
+            // FIXME(emilio): With the switch to rayon we can no longer
+            // access a thread id from here easily. Either instrument
+            // rayon (the unstable feature) to get a worker thread
+            // identifier, or remove all the layout tinting mode.
+            //
+            // flow::mut_base(flow).thread_id = proxy.worker_index();
+
+            if assign_isize_traversal.should_process(flow) {
+                // Perform the appropriate traversal.
+                assign_isize_traversal.process(flow);
             }
 
-
-            let base = flow::mut_base(flow);
-
-            // Reset the count of children for the next layout traversal.
-            base.parallel.children_count.store(base.children.len() as isize,
-                                               Ordering::Relaxed);
-
-            // Possibly enqueue the parent.
-            let unsafe_parent = base.parallel.parent;
-            if unsafe_parent == null_unsafe_flow() {
-                // We're done!
-                break
-            }
-
-            // No, we're not at the root yet. Then are we the last child
-            // of our parent to finish processing? If so, we can continue
-            // on with our parent; otherwise, we've gotta wait.
-            let parent: &mut Flow = unsafe {
-                mem::transmute(unsafe_parent)
-            };
-            let parent_base = flow::mut_base(parent);
-            if parent_base.parallel.children_count.fetch_sub(1, Ordering::Relaxed) == 1 {
-                // We were the last child of our parent. Reflow our parent.
-                unsafe_flow = unsafe_parent
-            } else {
-                // Stop.
-                break
-            }
-        }
-    }
-}
-
-/// A parallel top-down flow traversal.
-trait ParallelPreorderFlowTraversal : PreorderFlowTraversal {
-    fn run_parallel<'scope>(&self,
-                            unsafe_flows: &[UnsafeFlow],
-                            scope: &rayon::Scope<'scope>,
-                            shared: &'scope SharedLayoutContext);
-
-    fn should_record_thread_ids(&self) -> bool;
-
-    #[inline(always)]
-    fn run_parallel_helper<'scope>(&self,
-                                   unsafe_flows: &[UnsafeFlow],
-                                   scope: &rayon::Scope<'scope>,
-                                   shared: &'scope SharedLayoutContext,
-                                   top_down_func: ChunkedFlowTraversalFunction<'scope>,
-                                   bottom_up_func: FlowTraversalFunction)
-    {
-        let mut discovered_child_flows = vec![];
-        let context = LayoutContext::new(&shared);
-
-        for unsafe_flow in unsafe_flows {
-            let mut had_children = false;
-            unsafe {
-                // Get a real flow.
-                let flow: &mut Flow = mem::transmute(*unsafe_flow);
-
-                if self.should_record_thread_ids() {
-                    // FIXME(emilio): With the switch to rayon we can no longer
-                    // access a thread id from here easily. Either instrument
-                    // rayon (the unstable feature) to get a worker thread
-                    // identifier, or remove all the layout tinting mode.
-                    //
-                    // flow::mut_base(flow).thread_id = proxy.worker_index();
-                }
-
-                if self.should_process(flow) {
-                    // Perform the appropriate traversal.
-                    self.process(flow);
-                }
-
-                // Possibly enqueue the children.
-                for kid in flow::child_iter_mut(flow) {
-                    had_children = true;
-                    discovered_child_flows.push(borrowed_flow_to_unsafe_flow(kid));
-                }
-            }
-
-            // If there were no more children, start assigning block-sizes.
-            if !had_children {
-                bottom_up_func(*unsafe_flow, &context)
+            // Possibly enqueue the children.
+            for kid in flow::child_iter_mut(flow) {
+                had_children = true;
+                discovered_child_flows.push(borrowed_flow_to_unsafe_flow(kid));
             }
         }
 
-        for chunk in discovered_child_flows.chunks(CHUNK_SIZE) {
-            let nodes = chunk.iter().cloned().collect::<Vec<_>>().into_boxed_slice();
-
-            scope.spawn(move |scope| {
-                top_down_func(nodes, scope, shared);
-            });
+        // If there were no more children, start assigning block-sizes.
+        if !had_children {
+            buttom_up_flow(*unsafe_flow, &assign_bsize_traversal)
         }
     }
-}
 
-impl<'a> ParallelPreorderFlowTraversal for AssignISizes<'a> {
-    fn run_parallel<'scope>(&self,
-                                  unsafe_flows: &[UnsafeFlow],
-                                  scope: &rayon::Scope<'scope>,
-                                  shared: &'scope SharedLayoutContext)
-    {
-        self.run_parallel_helper(unsafe_flows,
-                                 scope,
-                                 shared,
-                                 assign_inline_sizes,
-                                 assign_block_sizes_and_store_overflow)
+    for chunk in discovered_child_flows.chunks(CHUNK_SIZE) {
+        let nodes = chunk.iter().cloned().collect::<Vec<_>>().into_boxed_slice();
+
+        scope.spawn(move |scope| {
+            top_down_flow(&nodes, scope, &assign_isize_traversal, &assign_bsize_traversal);
+        });
     }
-
-    fn should_record_thread_ids(&self) -> bool {
-        true
-    }
-}
-
-impl<'a> ParallelPostorderFlowTraversal for AssignBSizes<'a> {}
-
-fn assign_inline_sizes<'scope>(unsafe_flows: Box<[UnsafeFlow]>,
-                               scope: &rayon::Scope<'scope>,
-                               shared: &'scope SharedLayoutContext) {
-    let assign_inline_sizes_traversal = AssignISizes {
-        shared_context: &shared.style_context,
-    };
-    assign_inline_sizes_traversal.run_parallel(&unsafe_flows, scope, shared)
-}
-
-fn assign_block_sizes_and_store_overflow(
-        unsafe_flow: UnsafeFlow,
-        context: &LayoutContext) {
-    let assign_block_sizes_traversal = AssignBSizes {
-        layout_context: context,
-    };
-    assign_block_sizes_traversal.run_parallel(unsafe_flow)
 }
 
 pub fn traverse_flow_tree_preorder(
         root: &mut Flow,
         profiler_metadata: Option<TimerMetadata>,
         time_profiler_chan: time::ProfilerChan,
-        shared: &SharedLayoutContext,
+        context: &LayoutContext,
         queue: &rayon::ThreadPool) {
     if opts::get().bubble_inline_sizes_separately {
-        let context = LayoutContext::new(shared);
         let bubble_inline_sizes = BubbleISizes { layout_context: &context };
         root.traverse_postorder(&bubble_inline_sizes);
     }
 
+    let assign_isize_traversal = &AssignISizes { layout_context: &context };
+    let assign_bsize_traversal = &AssignBSizes { layout_context: &context };
     let nodes = vec![borrowed_flow_to_unsafe_flow(root)].into_boxed_slice();
 
     queue.install(move || {
         rayon::scope(move |scope| {
             profile(time::ProfilerCategory::LayoutParallelWarmup,
                     profiler_metadata, time_profiler_chan, move || {
-                assign_inline_sizes(nodes, scope, &shared);
+                        top_down_flow(&nodes, scope, assign_isize_traversal, assign_bsize_traversal);
             });
         });
     });

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -6,7 +6,7 @@
 
 use app_units::Au;
 use construct::ConstructionResult;
-use context::SharedLayoutContext;
+use context::LayoutContext;
 use euclid::point::Point2D;
 use euclid::rect::Rect;
 use euclid::size::Size2D;
@@ -696,7 +696,7 @@ pub fn process_node_scroll_area_request< N: LayoutNode>(requested_node: N, layou
 
 /// Return the resolved value of property for a given (pseudo)element.
 /// https://drafts.csswg.org/cssom/#resolved-value
-pub fn process_resolved_style_request<'a, N>(shared: &SharedLayoutContext,
+pub fn process_resolved_style_request<'a, N>(context: &LayoutContext,
                                              node: N,
                                              pseudo: &Option<PseudoElement>,
                                              property: &PropertyId,
@@ -715,9 +715,9 @@ pub fn process_resolved_style_request<'a, N>(shared: &SharedLayoutContext,
     // However, the element may be in a display:none subtree. The style system
     // has a mechanism to give us that within a defined scope (after which point
     // it's cleared to maintained style system invariants).
-    let mut tlc = ThreadLocalStyleContext::new(&shared.style_context);
+    let mut tlc = ThreadLocalStyleContext::new(&context.style_context);
     let context = StyleContext {
-        shared: &shared.style_context,
+        shared: &context.style_context,
         thread_local: &mut tlc,
     };
     let mut result = None;

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -9,7 +9,7 @@
 use app_units::Au;
 use block::{BlockFlow, CandidateBSizeIterator, ISizeAndMarginsComputer};
 use block::{ISizeConstraintInput, ISizeConstraintSolution};
-use context::{LayoutContext, SharedLayoutContext};
+use context::LayoutContext;
 use display_list_builder::{BlockFlowDisplayListBuilding, BorderPaintingMode, DisplayListBuildState};
 use euclid::Point2D;
 use flow;
@@ -345,11 +345,12 @@ impl Flow for TableFlow {
 
     /// Recursively (top-down) determines the actual inline-size of child contexts and fragments.
     /// When called on this context, the context has had its inline-size set by the parent context.
-    fn assign_inline_sizes(&mut self, shared_context: &SharedStyleContext) {
+    fn assign_inline_sizes(&mut self, layout_context: &LayoutContext) {
         let _scope = layout_debug_scope!("table::assign_inline_sizes {:x}",
                                             self.block_flow.base.debug_id());
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "table");
 
+        let shared_context = layout_context.shared_context();
         // The position was set to the containing block by the flow's parent.
         let containing_block_inline_size = self.block_flow.base.block_container_inline_size;
 
@@ -464,13 +465,13 @@ impl Flow for TableFlow {
         });
     }
 
-    fn assign_block_size<'a>(&mut self, _: &'a LayoutContext<'a>) {
+    fn assign_block_size(&mut self, _: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for table");
         let vertical_spacing = self.spacing().vertical;
         self.block_flow.assign_block_size_for_table_like_flow(vertical_spacing)
     }
 
-    fn compute_absolute_position(&mut self, layout_context: &SharedLayoutContext) {
+    fn compute_absolute_position(&mut self, layout_context: &LayoutContext) {
         self.block_flow.compute_absolute_position(layout_context)
     }
 

--- a/components/layout/table_caption.rs
+++ b/components/layout/table_caption.rs
@@ -8,7 +8,7 @@
 
 use app_units::Au;
 use block::BlockFlow;
-use context::{LayoutContext, SharedLayoutContext};
+use context::LayoutContext;
 use display_list_builder::DisplayListBuildState;
 use euclid::Point2D;
 use flow::{Flow, FlowClass, OpaqueFlow};
@@ -16,7 +16,6 @@ use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
 use gfx_traits::print_tree::PrintTree;
 use std::fmt;
 use std::sync::Arc;
-use style::context::SharedStyleContext;
 use style::logical_geometry::LogicalSize;
 use style::properties::ServoComputedValues;
 
@@ -54,17 +53,17 @@ impl Flow for TableCaptionFlow {
         self.block_flow.bubble_inline_sizes();
     }
 
-    fn assign_inline_sizes(&mut self, shared_context: &SharedStyleContext) {
+    fn assign_inline_sizes(&mut self, layout_context: &LayoutContext) {
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "table_caption");
-        self.block_flow.assign_inline_sizes(shared_context);
+        self.block_flow.assign_inline_sizes(layout_context);
     }
 
-    fn assign_block_size<'a>(&mut self, layout_context: &'a LayoutContext<'a>) {
+    fn assign_block_size(&mut self, layout_context: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for table_caption");
         self.block_flow.assign_block_size(layout_context);
     }
 
-    fn compute_absolute_position(&mut self, layout_context: &SharedLayoutContext) {
+    fn compute_absolute_position(&mut self, layout_context: &LayoutContext) {
         self.block_flow.compute_absolute_position(layout_context)
     }
 

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -8,7 +8,7 @@
 
 use app_units::Au;
 use block::{BlockFlow, ISizeAndMarginsComputer, MarginsMayCollapseFlag};
-use context::{LayoutContext, SharedLayoutContext};
+use context::LayoutContext;
 use cssparser::Color;
 use display_list_builder::{BlockFlowDisplayListBuilding, BorderPaintingMode, DisplayListBuildState};
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
@@ -21,7 +21,6 @@ use script_layout_interface::wrapper_traits::ThreadSafeLayoutNode;
 use std::fmt;
 use std::sync::Arc;
 use style::computed_values::{border_collapse, border_top_style, vertical_align};
-use style::context::SharedStyleContext;
 use style::logical_geometry::{LogicalMargin, LogicalRect, LogicalSize, WritingMode};
 use style::properties::ServoComputedValues;
 use table::InternalTable;
@@ -82,7 +81,7 @@ impl TableCellFlow {
     /// inline(always) because this is only ever called by in-order or non-in-order top-level
     /// methods.
     #[inline(always)]
-    fn assign_block_size_table_cell_base<'a>(&mut self, layout_context: &'a LayoutContext<'a>) {
+    fn assign_block_size_table_cell_base(&mut self, layout_context: &LayoutContext) {
         let remaining = self.block_flow.assign_block_size_block_base(
             layout_context,
             None,
@@ -193,11 +192,12 @@ impl Flow for TableCellFlow {
     /// Recursively (top-down) determines the actual inline-size of child contexts and fragments.
     /// When called on this context, the context has had its inline-size set by the parent table
     /// row.
-    fn assign_inline_sizes(&mut self, shared_context: &SharedStyleContext) {
+    fn assign_inline_sizes(&mut self, layout_context: &LayoutContext) {
         let _scope = layout_debug_scope!("table_cell::assign_inline_sizes {:x}",
                                             self.block_flow.base.debug_id());
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "table_cell");
 
+        let shared_context = layout_context.shared_context();
         // The position was set to the column inline-size by the parent flow, table row flow.
         let containing_block_inline_size = self.block_flow.base.block_container_inline_size;
 
@@ -226,12 +226,12 @@ impl Flow for TableCellFlow {
                                                                    |_, _, _, _, _, _| {});
     }
 
-    fn assign_block_size<'a>(&mut self, layout_context: &'a LayoutContext<'a>) {
+    fn assign_block_size(&mut self, layout_context: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for table_cell");
         self.assign_block_size_table_cell_base(layout_context);
     }
 
-    fn compute_absolute_position(&mut self, layout_context: &SharedLayoutContext) {
+    fn compute_absolute_position(&mut self, layout_context: &LayoutContext) {
         self.block_flow.compute_absolute_position(layout_context)
     }
 

--- a/components/layout/table_colgroup.rs
+++ b/components/layout/table_colgroup.rs
@@ -16,7 +16,6 @@ use layout_debug;
 use std::cmp::max;
 use std::fmt;
 use std::sync::Arc;
-use style::context::SharedStyleContext;
 use style::logical_geometry::LogicalSize;
 use style::properties::ServoComputedValues;
 use style::values::computed::LengthOrPercentageOrAuto;
@@ -80,7 +79,7 @@ impl Flow for TableColGroupFlow {
 
     /// Table column inline-sizes are assigned in the table flow and propagated to table row flows
     /// and/or rowgroup flows. Therefore, table colgroup flows do not need to assign inline-sizes.
-    fn assign_inline_sizes(&mut self, _: &SharedStyleContext) {
+    fn assign_inline_sizes(&mut self, _: &LayoutContext) {
     }
 
     /// Table columns do not have block-size.

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -8,7 +8,7 @@
 
 use app_units::Au;
 use block::{BlockFlow, ISizeAndMarginsComputer};
-use context::{LayoutContext, SharedLayoutContext};
+use context::LayoutContext;
 use cssparser::{Color, RGBA};
 use display_list_builder::{BlockFlowDisplayListBuilding, BorderPaintingMode, DisplayListBuildState};
 use euclid::Point2D;
@@ -24,7 +24,6 @@ use std::fmt;
 use std::iter::{Enumerate, IntoIterator, Peekable};
 use std::sync::Arc;
 use style::computed_values::{border_collapse, border_spacing, border_top_style};
-use style::context::SharedStyleContext;
 use style::logical_geometry::{LogicalSize, PhysicalSide, WritingMode};
 use style::properties::ServoComputedValues;
 use style::servo::restyle_damage::{REFLOW, REFLOW_OUT_OF_FLOW};
@@ -338,11 +337,12 @@ impl Flow for TableRowFlow {
                                                                                 pref_inline_size);
     }
 
-    fn assign_inline_sizes(&mut self, shared_context: &SharedStyleContext) {
+    fn assign_inline_sizes(&mut self, layout_context: &LayoutContext) {
         let _scope = layout_debug_scope!("table_row::assign_inline_sizes {:x}",
                                          self.block_flow.base.debug_id());
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "table_row");
 
+        let shared_context = layout_context.shared_context();
         // The position was set to the containing block by the flow's parent.
         let containing_block_inline_size = self.block_flow.base.block_container_inline_size;
         // FIXME: In case of border-collapse: collapse, inline_start_content_edge should be
@@ -454,7 +454,7 @@ impl Flow for TableRowFlow {
         self.assign_block_size_table_row_base(layout_context);
     }
 
-    fn compute_absolute_position(&mut self, layout_context: &SharedLayoutContext) {
+    fn compute_absolute_position(&mut self, layout_context: &LayoutContext) {
         self.block_flow.compute_absolute_position(layout_context)
     }
 

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -8,7 +8,7 @@
 
 use app_units::Au;
 use block::{BlockFlow, ISizeAndMarginsComputer};
-use context::{LayoutContext, SharedLayoutContext};
+use context::LayoutContext;
 use display_list_builder::DisplayListBuildState;
 use euclid::Point2D;
 use flow::{Flow, FlowClass, OpaqueFlow};
@@ -20,7 +20,6 @@ use std::fmt;
 use std::iter::{IntoIterator, Iterator, Peekable};
 use std::sync::Arc;
 use style::computed_values::{border_collapse, border_spacing};
-use style::context::SharedStyleContext;
 use style::logical_geometry::LogicalSize;
 use style::properties::ServoComputedValues;
 use table::{ColumnIntrinsicInlineSize, InternalTable, TableLikeFlow};
@@ -119,11 +118,12 @@ impl Flow for TableRowGroupFlow {
 
     /// Recursively (top-down) determines the actual inline-size of child contexts and fragments.
     /// When called on this context, the context has had its inline-size set by the parent context.
-    fn assign_inline_sizes(&mut self, shared_context: &SharedStyleContext) {
+    fn assign_inline_sizes(&mut self, layout_context: &LayoutContext) {
         let _scope = layout_debug_scope!("table_rowgroup::assign_inline_sizes {:x}",
                                             self.block_flow.base.debug_id());
         debug!("assign_inline_sizes({}): assigning inline_size for flow", "table_rowgroup");
 
+        let shared_context = layout_context.shared_context();
         // The position was set to the containing block by the flow's parent.
         let containing_block_inline_size = self.block_flow.base.block_container_inline_size;
         let (inline_start_content_edge, inline_end_content_edge) = (Au(0), Au(0));
@@ -160,12 +160,12 @@ impl Flow for TableRowGroupFlow {
         });
     }
 
-    fn assign_block_size<'a>(&mut self, _: &'a LayoutContext<'a>) {
+    fn assign_block_size(&mut self, _: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for table_rowgroup");
         self.block_flow.assign_block_size_for_table_like_flow(self.spacing.vertical)
     }
 
-    fn compute_absolute_position(&mut self, layout_context: &SharedLayoutContext) {
+    fn compute_absolute_position(&mut self, layout_context: &LayoutContext) {
         self.block_flow.compute_absolute_position(layout_context)
     }
 

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -16,7 +16,7 @@
 use app_units::Au;
 use block::{AbsoluteNonReplaced, BlockFlow, FloatNonReplaced, ISizeAndMarginsComputer, ISizeConstraintInput};
 use block::{ISizeConstraintSolution, MarginsMayCollapseFlag};
-use context::{LayoutContext, SharedLayoutContext};
+use context::LayoutContext;
 use display_list_builder::DisplayListBuildState;
 use euclid::Point2D;
 use floats::FloatKind;
@@ -333,7 +333,7 @@ impl Flow for TableWrapperFlow {
         self.block_flow.bubble_inline_sizes();
     }
 
-    fn assign_inline_sizes(&mut self, shared_context: &SharedStyleContext) {
+    fn assign_inline_sizes(&mut self, layout_context: &LayoutContext) {
         debug!("assign_inline_sizes({}): assigning inline_size for flow",
                if self.block_flow.base.flags.is_float() {
                    "floated table_wrapper"
@@ -341,6 +341,7 @@ impl Flow for TableWrapperFlow {
                    "table_wrapper"
                });
 
+        let shared_context = layout_context.shared_context();
         self.block_flow.initialize_container_size_for_root(shared_context);
 
         let mut intermediate_column_inline_sizes = self.column_intrinsic_inline_sizes
@@ -419,7 +420,7 @@ impl Flow for TableWrapperFlow {
 
     }
 
-    fn assign_block_size<'a>(&mut self, layout_context: &'a LayoutContext<'a>) {
+    fn assign_block_size(&mut self, layout_context: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for table_wrapper");
         let remaining = self.block_flow.assign_block_size_block_base(
             layout_context,
@@ -428,7 +429,7 @@ impl Flow for TableWrapperFlow {
         debug_assert!(remaining.is_none());
     }
 
-    fn compute_absolute_position(&mut self, layout_context: &SharedLayoutContext) {
+    fn compute_absolute_position(&mut self, layout_context: &LayoutContext) {
         self.block_flow.compute_absolute_position(layout_context)
     }
 
@@ -436,11 +437,11 @@ impl Flow for TableWrapperFlow {
         self.block_flow.place_float_if_applicable()
     }
 
-    fn assign_block_size_for_inorder_child_if_necessary<'a>(&mut self,
-                                                            layout_context: &'a LayoutContext<'a>,
-                                                            parent_thread_id: u8,
-                                                            content_box: LogicalRect<Au>)
-                                                            -> bool {
+    fn assign_block_size_for_inorder_child_if_necessary(&mut self,
+                                                        layout_context: &LayoutContext,
+                                                        parent_thread_id: u8,
+                                                        content_box: LogicalRect<Au>)
+                                                        -> bool {
         self.block_flow.assign_block_size_for_inorder_child_if_necessary(layout_context,
                                                                          parent_thread_id,
                                                                          content_box)

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -59,7 +59,7 @@ use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use layout::animation;
 use layout::construct::ConstructionResult;
-use layout::context::{LayoutContext, SharedLayoutContext};
+use layout::context::LayoutContext;
 use layout::context::heap_size_of_persistent_local_context;
 use layout::display_list_builder::ToGfxColor;
 use layout::flow::{self, Flow, ImmutableFlowUtils, MutableFlowUtils, MutableOwnedFlowUtils};
@@ -506,15 +506,15 @@ impl LayoutThread {
     }
 
     // Create a layout context for use in building display lists, hit testing, &c.
-    fn build_shared_layout_context(&self,
-                                   rw_data: &LayoutThreadData,
-                                   screen_size_changed: bool,
-                                   goal: ReflowGoal)
-                                   -> SharedLayoutContext {
+    fn build_layout_context(&self,
+                            rw_data: &LayoutThreadData,
+                            screen_size_changed: bool,
+                            goal: ReflowGoal)
+                            -> LayoutContext {
         let thread_local_style_context_creation_data =
             ThreadLocalStyleContextCreationInfo::new(self.new_animations_sender.clone());
 
-        SharedLayoutContext {
+        LayoutContext {
             style_context: SharedStyleContext {
                 viewport_size: self.viewport_size.clone(),
                 screen_size_changed: screen_size_changed,
@@ -623,9 +623,9 @@ impl LayoutThread {
             goal: ReflowGoal::ForDisplay,
             page_clip_rect: max_rect(),
         };
-        let mut layout_context = self.build_shared_layout_context(&*rw_data,
-                                                                  false,
-                                                                  reflow_info.goal);
+        let mut layout_context = self.build_layout_context(&*rw_data,
+                                                           false,
+                                                           reflow_info.goal);
 
         self.perform_post_style_recalc_layout_passes(&reflow_info,
                                                      None,
@@ -855,9 +855,9 @@ impl LayoutThread {
     /// benchmarked against those two. It is marked `#[inline(never)]` to aid profiling.
     #[inline(never)]
     fn solve_constraints(layout_root: &mut Flow,
-                         shared_layout_context: &SharedLayoutContext) {
+                         layout_context: &LayoutContext) {
         let _scope = layout_debug_scope!("solve_constraints");
-        sequential::traverse_flow_tree_preorder(layout_root, shared_layout_context);
+        sequential::traverse_flow_tree_preorder(layout_root, layout_context);
     }
 
     /// Performs layout constraint solving in parallel.
@@ -869,7 +869,7 @@ impl LayoutThread {
                                   layout_root: &mut Flow,
                                   profiler_metadata: Option<TimerMetadata>,
                                   time_profiler_chan: time::ProfilerChan,
-                                  shared_layout_context: &SharedLayoutContext) {
+                                  layout_context: &LayoutContext) {
         let _scope = layout_debug_scope!("solve_constraints_parallel");
 
         // NOTE: this currently computes borders, so any pruning should separate that
@@ -877,7 +877,7 @@ impl LayoutThread {
         parallel::traverse_flow_tree_preorder(layout_root,
                                               profiler_metadata,
                                               time_profiler_chan,
-                                              shared_layout_context,
+                                              layout_context,
                                               traversal);
     }
 
@@ -888,7 +888,7 @@ impl LayoutThread {
                                               query_type: Option<&ReflowQueryType>,
                                               document: Option<&ServoLayoutDocument>,
                                               layout_root: &mut Flow,
-                                              shared_layout_context: &mut SharedLayoutContext,
+                                              layout_context: &mut LayoutContext,
                                               rw_data: &mut LayoutThreadData) {
         let writing_mode = flow::base(layout_root).writing_mode;
         let (metadata, sender) = (self.profiler_metadata(), self.time_profiler_chan.clone());
@@ -905,7 +905,7 @@ impl LayoutThread {
 
             if flow::base(layout_root).restyle_damage.contains(REPOSITION) {
                 layout_root.traverse_preorder(&ComputeAbsolutePositions {
-                    layout_context: shared_layout_context
+                    layout_context: layout_context
                 });
             }
 
@@ -917,7 +917,7 @@ impl LayoutThread {
                     (ReflowGoal::ForDisplay, _) | (ReflowGoal::ForScriptQuery, true) => {
                         let mut build_state =
                             sequential::build_display_list_for_subtree(layout_root,
-                                                                       shared_layout_context);
+                                                                       layout_context);
 
                         debug!("Done building display list.");
 
@@ -1166,9 +1166,9 @@ impl LayoutThread {
         }
 
         // Create a layout context for use throughout the following passes.
-        let mut shared_layout_context = self.build_shared_layout_context(&*rw_data,
-                                                                         viewport_size_changed,
-                                                                         data.reflow_info.goal);
+        let mut layout_context = self.build_layout_context(&*rw_data,
+                                                           viewport_size_changed,
+                                                           data.reflow_info.goal);
 
         // NB: Type inference falls apart here for some reason, so we need to be very verbose. :-(
         let traversal_driver = if self.parallel_flag && self.parallel_traversal.is_some() {
@@ -1177,7 +1177,7 @@ impl LayoutThread {
             TraversalDriver::Sequential
         };
 
-        let traversal = RecalcStyleAndConstructFlows::new(shared_layout_context, traversal_driver);
+        let traversal = RecalcStyleAndConstructFlows::new(layout_context, traversal_driver);
         let dom_depth = Some(0); // This is always the root node.
         let token = {
             let stylist = &<RecalcStyleAndConstructFlows as
@@ -1220,35 +1220,35 @@ impl LayoutThread {
             self.root_flow = self.try_get_layout_root(element.as_node());
         }
 
-        shared_layout_context = traversal.destroy();
+        layout_context = traversal.destroy();
 
         if opts::get().dump_style_tree {
             println!("{:?}", ShowSubtreeDataAndPrimaryValues(element.as_node()));
         }
 
         if opts::get().dump_rule_tree {
-            shared_layout_context.style_context.stylist.rule_tree.dump_stdout();
+            layout_context.style_context.stylist.rule_tree.dump_stdout();
         }
 
         // GC the rule tree if some heuristics are met.
-        unsafe { shared_layout_context.style_context.stylist.rule_tree.maybe_gc(); }
+        unsafe { layout_context.style_context.stylist.rule_tree.maybe_gc(); }
 
         // Perform post-style recalculation layout passes.
         self.perform_post_style_recalc_layout_passes(&data.reflow_info,
                                                      Some(&data.query_type),
                                                      Some(&document),
                                                      &mut rw_data,
-                                                     &mut shared_layout_context);
+                                                     &mut layout_context);
 
         self.respond_to_query_if_necessary(&data.query_type,
                                            &mut *rw_data,
-                                           &mut shared_layout_context);
+                                           &mut layout_context);
     }
 
     fn respond_to_query_if_necessary(&mut self,
                                      query_type: &ReflowQueryType,
                                      rw_data: &mut LayoutThreadData,
-                                     shared: &mut SharedLayoutContext) {
+                                     context: &mut LayoutContext) {
         let mut root_flow = match self.root_flow.clone() {
             Some(root_flow) => root_flow,
             None => return,
@@ -1310,7 +1310,7 @@ impl LayoutThread {
             ReflowQueryType::ResolvedStyleQuery(node, ref pseudo, ref property) => {
                 let node = unsafe { ServoLayoutNode::new(&node) };
                 rw_data.resolved_style_response =
-                    process_resolved_style_request(shared,
+                    process_resolved_style_request(context,
                                                    node,
                                                    pseudo,
                                                    property,
@@ -1367,9 +1367,9 @@ impl LayoutThread {
             page_clip_rect: max_rect(),
         };
 
-        let mut layout_context = self.build_shared_layout_context(&*rw_data,
-                                                                  false,
-                                                                  reflow_info.goal);
+        let mut layout_context = self.build_layout_context(&*rw_data,
+                                                           false,
+                                                           reflow_info.goal);
 
         if let Some(mut root_flow) = self.root_flow.clone() {
             // Perform an abbreviated style recalc that operates without access to the DOM.
@@ -1400,9 +1400,9 @@ impl LayoutThread {
             page_clip_rect: max_rect(),
         };
 
-        let mut layout_context = self.build_shared_layout_context(&*rw_data,
-                                                                  false,
-                                                                  reflow_info.goal);
+        let mut layout_context = self.build_layout_context(&*rw_data,
+                                                           false,
+                                                           reflow_info.goal);
 
         // No need to do a style recalc here.
         if self.root_flow.is_none() {
@@ -1420,7 +1420,7 @@ impl LayoutThread {
                                                query_type: Option<&ReflowQueryType>,
                                                document: Option<&ServoLayoutDocument>,
                                                rw_data: &mut LayoutThreadData,
-                                               shared: &mut SharedLayoutContext) {
+                                               context: &mut LayoutContext) {
         if let Some(mut root_flow) = self.root_flow.clone() {
             // Kick off animations if any were triggered, expire completed ones.
             animation::update_animation_state(&self.constellation_chan,
@@ -1452,7 +1452,7 @@ impl LayoutThread {
             profile(time::ProfilerCategory::LayoutGeneratedContent,
                     self.profiler_metadata(),
                     self.time_profiler_chan.clone(),
-                    || sequential::resolve_generated_content(FlowRef::deref_mut(&mut root_flow), &shared));
+                    || sequential::resolve_generated_content(FlowRef::deref_mut(&mut root_flow), &context));
 
             // Guess float placement.
             profile(time::ProfilerCategory::LayoutFloatPlacementSpeculation,
@@ -1475,10 +1475,10 @@ impl LayoutThread {
                                                                  FlowRef::deref_mut(&mut root_flow),
                                                                  profiler_metadata,
                                                                  self.time_profiler_chan.clone(),
-                                                                 &*shared);
+                                                                 &*context);
                     } else {
                         //Sequential mode
-                        LayoutThread::solve_constraints(FlowRef::deref_mut(&mut root_flow), &shared)
+                        LayoutThread::solve_constraints(FlowRef::deref_mut(&mut root_flow), &context)
                     }
                 });
             }
@@ -1487,8 +1487,7 @@ impl LayoutThread {
                     self.profiler_metadata(),
                     self.time_profiler_chan.clone(),
                     || {
-                let context = LayoutContext::new(&shared);
-                sequential::store_overflow(&context,
+                sequential::store_overflow(context,
                                            FlowRef::deref_mut(&mut root_flow) as &mut Flow);
             });
 
@@ -1496,7 +1495,7 @@ impl LayoutThread {
                                                  query_type,
                                                  document,
                                                  rw_data,
-                                                 shared);
+                                                 context);
         }
     }
 
@@ -1505,7 +1504,7 @@ impl LayoutThread {
                                        query_type: Option<&ReflowQueryType>,
                                        document: Option<&ServoLayoutDocument>,
                                        rw_data: &mut LayoutThreadData,
-                                       layout_context: &mut SharedLayoutContext) {
+                                       layout_context: &mut LayoutContext) {
         // Build the display list if necessary, and send it to the painter.
         if let Some(mut root_flow) = self.root_flow.clone() {
             self.compute_abs_pos_and_build_display_list(data,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

According to https://github.com/servo/servo/pull/3069 the cached thread local context is introduced for green threads. Now green threads has gone, and the existence of cache force us to create a `LayoutContext`, an `AssignISizes` and an `AssignBSizes` for each flow during parallel layout, so the pull request tries to remove it. And it also switch `assign_inline_sizes()` to accept a `LayoutContext` parameter, as according to my current design we need to do full layout to some flex items for column flexbox during assign isize traversal.

Part of #14123.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because refactoring

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15417)
<!-- Reviewable:end -->
