### PR TITLE
Shorthand with variable reference should not have extra whitespace after colon for serialization

### DIFF
--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -475,9 +475,6 @@ pub fn append_serialization<'a, W, I, N>(dest: &mut W,
 
     // for normal parsed values, add a space between key: and value
     match &appendable_value {
-        &AppendableValue::Css(_) => {
-            try!(write!(dest, " "))
-        },
         &AppendableValue::Declaration(decl) => {
             if !decl.value_is_unparsed() {
                 // for normal parsed values, add a space between key: and value
@@ -486,7 +483,8 @@ pub fn append_serialization<'a, W, I, N>(dest: &mut W,
         },
         // Currently append_serialization is only called with a Css or
         // a Declaration AppendableValue.
-        &AppendableValue::DeclarationsForShorthand(..) => unreachable!()
+        &AppendableValue::DeclarationsForShorthand(..) => unreachable!(),
+        &AppendableValue::Css(_) => {}
     }
 
     try!(append_declaration_value(dest, appendable_value));

--- a/tests/wpt/web-platform-tests/cssom/serialize-variable-reference.html
+++ b/tests/wpt/web-platform-tests/cssom/serialize-variable-reference.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM - Serialization with variable preserves original serialization.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="longhand-whitespace" style="font-size: var(--a);"></div>
+<div id="shorthand-whitespace" style="font: var(--a);"></div>
+<div id="longhand" style="font-size:var(--a);"></div>
+<div id="shorthand" style="font:var(--a);"></div>
+<script>
+    test(function() {
+        var elem = document.getElementById('longhand-whitespace');
+
+        assert_equals(elem.style.cssText, 'font-size: var(--a);');
+    }, 'Longhand with variable preserves original serialization: with withespace')
+
+    test(function() {
+        var elem = document.getElementById('shorthand-whitespace');
+
+        assert_equals(elem.style.cssText, 'font: var(--a);');
+    }, 'Shorthand with variable preserves original serialization: with withespace')
+
+    test(function() {
+        var elem = document.getElementById('longhand');
+
+        assert_equals(elem.style.cssText, 'font-size:var(--a);');
+    }, 'Longhand with variable preserves original serialization: without withespace')
+
+    test(function() {
+        var elem = document.getElementById('shorthand');
+
+        assert_equals(elem.style.cssText, 'font:var(--a);');
+    }, 'Shorthand with variable preserves original serialization: without withespace')
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixes #15295. Tell me if anything is wrong with the tests, I'm not sure I created them correctly.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes fix #15295.

- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15422)
<!-- Reviewable:end -->
