### PR TITLE
crop_area_bytes_length multiplies width and height (fixes #15386)

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -745,7 +745,7 @@ fn crop_image(image_data: Vec<u8>,
     // (consecutive elements in a pixel row of the image are contiguous in memory)
     let stride = image_size.width * 4;
     let image_bytes_length = image_size.height * image_size.width * 4;
-    let crop_area_bytes_length = crop_rect.size.height * crop_rect.size.height * 4;
+    let crop_area_bytes_length = crop_rect.size.height * crop_rect.size.width * 4;
     // If the image size is less or equal than the crop area we do nothing
     if image_bytes_length <= crop_area_bytes_length {
         return image_data;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`crop_image()` in component/canvas/canvas_paint_thread.rs calculated the crop_area_bytes_length variable by multiplying `height*height*4`

It should multiply `height*width*4`, like so

```diff
-    let crop_area_bytes_length = crop_rect.size.height * crop_rect.size.height * 4;
+    let crop_area_bytes_length = crop_rect.size.height * crop_rect.size.width * 4;
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15386

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

^--- Not entirely sure here ;)

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15423)
<!-- Reviewable:end -->
