### PR TITLE
Retrieve the opacity and the transform list from RawServoAnimationValue

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -505,6 +505,7 @@ mod bindings {
             "RawServoDeclarationBlock",
             "RawGeckoPresContext",
             "RawGeckoPresContextOwned",
+            "RefPtr",
             "ThreadSafeURIHolder",
             "ThreadSafePrincipalHolder",
             "CSSPseudoClassType",

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1302,6 +1302,11 @@ extern "C" {
      -> RawServoDeclarationBlockStrong;
 }
 extern "C" {
+    pub fn Servo_AnimationValues_GetOpacity(value:
+                                                RawServoAnimationValueBorrowed)
+     -> f32;
+}
+extern "C" {
     pub fn Servo_ParseStyleAttribute(data: *const nsACString_internal)
      -> RawServoDeclarationBlockStrong;
 }

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -156,6 +156,7 @@ use gecko_bindings::structs::Loader;
 use gecko_bindings::structs::ServoStyleSheet;
 use gecko_bindings::structs::EffectCompositor_CascadeLevel;
 use gecko_bindings::structs::RawServoAnimationValueBorrowedListBorrowed;
+use gecko_bindings::structs::RefPtr;
 pub type nsTArrayBorrowed_uintptr_t<'a> = &'a mut ::gecko_bindings::structs::nsTArray<usize>;
 pub type ServoComputedValuesStrong = ::gecko_bindings::sugar::ownership::Strong<ServoComputedValues>;
 pub type ServoComputedValuesBorrowed<'a> = &'a ServoComputedValues;
@@ -1305,6 +1306,10 @@ extern "C" {
     pub fn Servo_AnimationValues_GetOpacity(value:
                                                 RawServoAnimationValueBorrowed)
      -> f32;
+}
+extern "C" {
+    pub fn Servo_AnimationValues_GetTransform(value: RawServoAnimationValueBorrowed,
+                                              list: &mut RefPtr<nsCSSValueSharedList>);
 }
 extern "C" {
     pub fn Servo_ParseStyleAttribute(data: *const nsACString_internal)

--- a/components/style/gecko_bindings/structs_debug.rs
+++ b/components/style/gecko_bindings/structs_debug.rs
@@ -5152,10 +5152,15 @@ pub mod root {
         pub struct ContainerLayerParameters([u8; 0]);
         #[repr(C)]
         #[derive(Debug)]
+        pub struct AnimationValue {
+            pub mGecko: root::mozilla::StyleAnimationValue,
+            pub mServo: root::RefPtr<root::RawServoAnimationValue>,
+        }
+        #[repr(C)]
+        #[derive(Debug)]
         pub struct PropertyStyleAnimationValuePair {
             pub mProperty: root::nsCSSPropertyID,
-            pub mValue: root::mozilla::StyleAnimationValue,
-            pub mServoValue: root::RefPtr<root::RawServoAnimationValue>,
+            pub mValue: root::mozilla::AnimationValue,
         }
         #[test]
         fn bindgen_test_layout_PropertyStyleAnimationValuePair() {

--- a/components/style/gecko_bindings/structs_release.rs
+++ b/components/style/gecko_bindings/structs_release.rs
@@ -5068,10 +5068,15 @@ pub mod root {
         pub struct ContainerLayerParameters([u8; 0]);
         #[repr(C)]
         #[derive(Debug)]
+        pub struct AnimationValue {
+            pub mGecko: root::mozilla::StyleAnimationValue,
+            pub mServo: root::RefPtr<root::RawServoAnimationValue>,
+        }
+        #[repr(C)]
+        #[derive(Debug)]
         pub struct PropertyStyleAnimationValuePair {
             pub mProperty: root::nsCSSPropertyID,
-            pub mValue: root::mozilla::StyleAnimationValue,
-            pub mServoValue: root::RefPtr<root::RawServoAnimationValue>,
+            pub mValue: root::mozilla::AnimationValue,
         }
         #[test]
         fn bindgen_test_layout_PropertyStyleAnimationValuePair() {

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -253,7 +253,7 @@ pub extern "C" fn Servo_AnimationValues_Populate(anim: RawGeckoAnimationValueLis
         // and thus can't directly use `geckoiter`
         let local_geckoiter = &mut geckoiter;
         for (gecko, servo) in local_geckoiter.zip(&mut iter) {
-            gecko.mServoValue.set_arc_leaky(Arc::new(servo));
+            gecko.mValue.mServo.set_arc_leaky(Arc::new(servo));
         }
     }
 

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -205,6 +205,18 @@ pub extern "C" fn Servo_AnimationValues_Uncompute(value: RawServoAnimationValueB
     })).into_strong()
 }
 
+#[no_mangle]
+pub extern "C" fn Servo_AnimationValues_GetOpacity(value: RawServoAnimationValueBorrowed)
+     -> f32
+{
+    let value = AnimationValue::as_arc(&value);
+    if let AnimationValue::Opacity(opacity) = **value {
+        opacity
+    } else {
+        panic!("The AnimationValue should be Opacity");
+    }
+}
+
 /// Takes a ServoAnimationValues and populates it with the animation values corresponding
 /// to a given property declaration block
 #[no_mangle]

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -53,11 +53,13 @@ use style::gecko_bindings::structs::Loader;
 use style::gecko_bindings::structs::RawGeckoPresContextOwned;
 use style::gecko_bindings::structs::RawServoAnimationValueBorrowedListBorrowed;
 use style::gecko_bindings::structs::ServoStyleSheet;
+use style::gecko_bindings::structs::nsCSSValueSharedList;
 use style::gecko_bindings::structs::nsTimingFunction;
 use style::gecko_bindings::structs::nsresult;
 use style::gecko_bindings::sugar::ownership::{FFIArcHelpers, HasArcFFI, HasBoxFFI};
 use style::gecko_bindings::sugar::ownership::{HasSimpleFFI, Strong};
 use style::gecko_bindings::sugar::refptr::{GeckoArcPrincipal, GeckoArcURI};
+use style::gecko_properties::style_structs;
 use style::keyframes::KeyframesStepValue;
 use style::parallel;
 use style::parser::{ParserContext, ParserContextExtraData};
@@ -214,6 +216,18 @@ pub extern "C" fn Servo_AnimationValues_GetOpacity(value: RawServoAnimationValue
         opacity
     } else {
         panic!("The AnimationValue should be Opacity");
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_AnimationValues_GetTransform(value: RawServoAnimationValueBorrowed,
+                                                     list: &mut structs::RefPtr<nsCSSValueSharedList>)
+{
+    let value = AnimationValue::as_arc(&value);
+    if let AnimationValue::Transform(ref servo_list) = **value {
+        style_structs::Box::convert_transform(servo_list.0.clone().unwrap(), list);
+    } else {
+        panic!("The AnimationValue should be transform");
     }
 }
 


### PR DESCRIPTION
These are the servo-side changes for [bug 1335942](https://bugzilla.mozilla.org/show_bug.cgi?id=1335942). @Manishearth had already reviewed them there. Please merge these patches until the gecko-side changes for [bug 1335942](https://bugzilla.mozilla.org/show_bug.cgi?id=1335942) is landed.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [bug 1335942](https://bugzilla.mozilla.org/show_bug.cgi?id=1335942).
- [X] These changes do not require tests because there are existing tests for this in mozilla-central

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15442)
<!-- Reviewable:end -->
