### PR TITLE
use `::parse_non_negative instead` of `::parse` for background_size property parsing

### DIFF
--- a/components/style/properties/longhand/background.mako.rs
+++ b/components/style/properties/longhand/background.mako.rs
@@ -373,7 +373,7 @@ ${helpers.single_keyword("background-origin",
         })
     }
 
-    pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue,()> {
+    pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue,()> {
         let width;
         if let Ok(value) = input.try(|input| {
             match input.next() {
@@ -389,7 +389,7 @@ ${helpers.single_keyword("background-origin",
         }) {
             return Ok(value)
         } else {
-            width = try!(specified::LengthOrPercentageOrAuto::parse(context, input))
+            width = try!(specified::LengthOrPercentageOrAuto::parse_non_negative(input))
         }
 
         let height;
@@ -401,7 +401,7 @@ ${helpers.single_keyword("background-origin",
         }) {
             height = value
         } else {
-            height = try!(specified::LengthOrPercentageOrAuto::parse(context, input));
+            height = try!(specified::LengthOrPercentageOrAuto::parse_non_negative(input));
         }
 
         Ok(SpecifiedValue::Explicit(ExplicitSize {

--- a/tests/unit/style/properties/background.rs
+++ b/tests/unit/style/properties/background.rs
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use cssparser::Parser;
+use media_queries::CSSErrorReporterTest;
+use style::parser::ParserContext;
+use style::properties::longhands::background_size;
+use style::stylesheets::Origin;
+
+#[test]
+fn background_size_should_reject_negative_values() {
+    let url = ::servo_url::ServoUrl::parse("http://localhost").unwrap();
+    let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+
+    let parse_result = background_size::parse(&context, &mut Parser::new("-40% -40%"));
+
+    assert_eq!(parse_result.is_err(), true);
+}

--- a/tests/unit/style/properties/mod.rs
+++ b/tests/unit/style/properties/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+mod background;
 mod scaffolding;
 mod serialization;
 mod viewport;


### PR DESCRIPTION
Use  `::parse_non_negative` instead of `::parse` for background_size property parsing

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #15450 

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15454)
<!-- Reviewable:end -->
