### PR TITLE
Implement XHR progress event changes

### DIFF
--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -42,7 +42,7 @@ use encoding::types::{DecoderTrap, EncoderTrap, Encoding, EncodingRef};
 use euclid::length::Length;
 use html5ever::serialize;
 use html5ever::serialize::SerializeOpts;
-use hyper::header::{ContentLength, ContentType};
+use hyper::header::{ContentLength, ContentType, ContentEncoding};
 use hyper::header::Headers;
 use hyper::method::Method;
 use hyper::mime::{self, Attr as MimeAttr, Mime, Value as MimeValue};
@@ -979,14 +979,12 @@ impl XMLHttpRequest {
                 // Part of step 11, send() (processing response end of file)
                 // XXXManishearth handle errors, if any (substep 2)
 
-                // Subsubsteps 5-7
+                // Subsubsteps 6-8
                 self.send_flag.set(false);
 
                 self.change_ready_state(XMLHttpRequestState::Done);
                 return_if_fetch_was_terminated!();
-                // Subsubsteps 10-12
-                self.dispatch_response_progress_event(atom!("progress"));
-                return_if_fetch_was_terminated!();
+                // Subsubsteps 11-12
                 self.dispatch_response_progress_event(atom!("load"));
                 return_if_fetch_was_terminated!();
                 self.dispatch_response_progress_event(atom!("loadend"));
@@ -1009,15 +1007,11 @@ impl XMLHttpRequest {
                 let upload_complete = &self.upload_complete;
                 if !upload_complete.get() {
                     upload_complete.set(true);
-                    self.dispatch_upload_progress_event(atom!("progress"), None);
-                    return_if_fetch_was_terminated!();
                     self.dispatch_upload_progress_event(Atom::from(errormsg), None);
                     return_if_fetch_was_terminated!();
                     self.dispatch_upload_progress_event(atom!("loadend"), None);
                     return_if_fetch_was_terminated!();
                 }
-                self.dispatch_response_progress_event(atom!("progress"));
-                return_if_fetch_was_terminated!();
                 self.dispatch_response_progress_event(Atom::from(errormsg));
                 return_if_fetch_was_terminated!();
                 self.dispatch_response_progress_event(atom!("loadend"));
@@ -1032,12 +1026,17 @@ impl XMLHttpRequest {
     }
 
     fn dispatch_progress_event(&self, upload: bool, type_: Atom, loaded: u64, total: Option<u64>) {
+        let (total_length, length_computable) = if self.response_headers.borrow().has::<ContentEncoding>() {
+            (0, false)
+        } else {
+            (total.unwrap_or(0), total.is_some())
+        };
         let progressevent = ProgressEvent::new(&self.global(),
                                                type_,
                                                EventBubbles::DoesNotBubble,
                                                EventCancelable::NotCancelable,
-                                               total.is_some(), loaded,
-                                               total.unwrap_or(0));
+                                               length_computable, loaded,
+                                               total_length);
         let target = if upload {
             self.upload.upcast()
         } else {

--- a/tests/wpt/metadata/XMLHttpRequest/progress-events-response-data-gzip.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/progress-events-response-data-gzip.htm.ini
@@ -1,5 +1,0 @@
-[progress-events-response-data-gzip.htm]
-  type: testharness
-  [XMLHttpRequest: progress events and GZIP encoding]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/security-consideration.sub.html.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/security-consideration.sub.html.ini
@@ -1,5 +1,0 @@
-[security-consideration.sub.html]
-  type: testharness
-  [ProgressEvent: security consideration]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/send-response-event-order.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-response-event-order.htm.ini
@@ -1,5 +1,0 @@
-[send-response-event-order.htm]
-  type: testharness
-  [XMLHttpRequest: The send() method: event order when synchronous flag is unset]
-    expected: FAIL
-

--- a/tests/wpt/metadata/XMLHttpRequest/send-sync-response-event-order.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/send-sync-response-event-order.htm.ini
@@ -1,5 +1,0 @@
-[send-sync-response-event-order.htm]
-  type: testharness
-  [XMLHttpRequest: The send() method: event order when synchronous flag is set]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR implements change in the specs in XHR.

Unfortunatelly, @jdm the test are not passing. It looks like the fetch module send more bytes that we should according the ```Content-Length```. This [lines](https://github.com/servo/servo/blob/master/tests/wpt/web-platform-tests/XMLHttpRequest/progress-events-response-data-gzip.htm#L70) make the test fail.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13276  (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15455)
<!-- Reviewable:end -->
