### PR TITLE
Update WR (pixel snapping improvements).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,6 +1300,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "json"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "jstraceable_derive"
 version = "0.0.1"
 dependencies = [
@@ -2971,6 +2976,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_profiler"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "json 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3175,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.15.0"
-source = "git+https://github.com/servo/webrender#512b4a1433a7827ef7cfd121d2f99fdd91ecf80e"
+source = "git+https://github.com/servo/webrender#fee480599bef729c912a940f6e039c7fafb9a375"
 dependencies = [
  "app_units 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3194,6 +3209,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_profiler 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_traits 0.14.0 (git+https://github.com/servo/webrender)",
@@ -3202,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "webrender_traits"
 version = "0.14.0"
-source = "git+https://github.com/servo/webrender#512b4a1433a7827ef7cfd121d2f99fdd91ecf80e"
+source = "git+https://github.com/servo/webrender#fee480599bef729c912a940f6e039c7fafb9a375"
 dependencies = [
  "app_units 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3440,6 +3456,7 @@ dependencies = [
 "checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
 "checksum jpeg-decoder 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "5c4ff3d14e7ef3522471ab712832c3dd50001f7fb7aa4cdc48af811d63b531e9"
 "checksum js 0.1.4 (git+https://github.com/servo/rust-mozjs)" = "<none>"
+"checksum json 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7eb285e773498f9473a6e2255feffe95db9c55579c7931a6db83c9e02a4673"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum khronos_api 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09c9d3760673c427d46f91a0350f0a84a52e6bc5a84adf26dc610b6c52436630"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
@@ -3555,6 +3572,7 @@ dependencies = [
 "checksum term_size 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "71662702fe5cd2cf95edd4ad655eea42f24a87a0e44059cbaa4e55260b7bc331"
 "checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
 "checksum thread_local 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7793b722f0f77ce716e7f1acf416359ca32ff24d04ffbac4269f44a4a83be05d"
+"checksum thread_profiler 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c82b4f86ccf6ee107b1b6c9249aff6c9883ad1dd43a8fe29ffa8c4ed21add95"
 "checksum threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59f6d3eff89920113dac9db44dde461d71d01e88a5b57b258a0466c32b5d7fe1"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum tinyfiledialogs 2.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d401358cd71aca93d5f4fccd3db5b87d970ae70fe457911929d99f4a87f7531"

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -734,7 +734,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
 
         let pipeline_id = frame_tree.pipeline.id.to_webrender();
         self.webrender_api.set_root_pipeline(pipeline_id);
-        self.webrender_api.generate_frame();
+        self.webrender_api.generate_frame(None);
 
         self.create_pipeline_details_for_frame_tree(&frame_tree);
 

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -184,7 +184,7 @@ impl ToFilterOps for filter::T {
                 Filter::Grayscale(amount) => result.push(webrender_traits::FilterOp::Grayscale(amount)),
                 Filter::HueRotate(angle) => result.push(webrender_traits::FilterOp::HueRotate(angle.0)),
                 Filter::Invert(amount) => result.push(webrender_traits::FilterOp::Invert(amount)),
-                Filter::Opacity(amount) => result.push(webrender_traits::FilterOp::Opacity(amount)),
+                Filter::Opacity(amount) => result.push(webrender_traits::FilterOp::Opacity(amount.into())),
                 Filter::Saturate(amount) => result.push(webrender_traits::FilterOp::Saturate(amount)),
                 Filter::Sepia(amount) => result.push(webrender_traits::FilterOp::Sepia(amount)),
             }
@@ -347,8 +347,8 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                               stacking_context.bounds.to_rectf(),
                                               clip,
                                               stacking_context.z_index,
-                                              &LayoutTransform::from_untyped(&stacking_context.transform),
-                                              &LayoutTransform::from_untyped(&stacking_context.perspective),
+                                              LayoutTransform::from_untyped(&stacking_context.transform).into(),
+                                              LayoutTransform::from_untyped(&stacking_context.perspective),
                                               stacking_context.blend_mode.to_blend_mode(),
                                               stacking_context.filters.to_filter_ops());
             }

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -989,7 +989,7 @@ impl LayoutThread {
                 viewport_size,
                 builder,
                 true);
-            self.webrender_api.generate_frame();
+            self.webrender_api.generate_frame(None);
         });
     }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -184,6 +184,7 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
                 clear_framebuffer: true,
                 clear_color: webrender_traits::ColorF::new(1.0, 1.0, 1.0, 1.0),
                 render_target_debug: false,
+                workers: None,
             }).expect("Unable to initialize webrender!")
         };
 

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-repeat-repeat-y.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-repeat-repeat-y.htm.ini
@@ -1,3 +1,0 @@
-[background-repeat-repeat-y.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-025.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-025.htm.ini
@@ -1,3 +1,3 @@
-[transform-input-019.htm]
+[background-size-025.htm]
   type: reftest
   expected: FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-028.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-028.htm.ini
@@ -1,4 +1,4 @@
-[transform-input-017.htm]
+[background-size-028.htm]
   type: reftest
   expected:
     if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-028.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-028.htm.ini
@@ -1,4 +1,0 @@
-[background-size-028.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-030.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-030.htm.ini
@@ -1,4 +1,4 @@
-[table-anonymous-objects-204.htm]
+[background-size-030.htm]
   type: reftest
   expected:
     if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-030.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-030.htm.ini
@@ -1,4 +1,0 @@
-[background-size-030.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-contain.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-contain.htm.ini
@@ -1,3 +1,3 @@
-[background-size-025.htm]
+[background-size-contain.htm]
   type: reftest
   expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transforms-3d-on-anonymous-block-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transforms-3d-on-anonymous-block-001.htm.ini
@@ -1,4 +1,0 @@
-[css-transforms-3d-on-anonymous-block-001.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-018.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-input-018.htm.ini
@@ -1,4 +1,0 @@
-[transform-input-018.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-008.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-008.htm.ini
@@ -1,4 +1,0 @@
-[abspos-008.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-repeat-repeat-x.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-repeat-repeat-x.htm.ini
@@ -1,3 +1,0 @@
-[background-repeat-repeat-x.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-repeat-repeat-y.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-repeat-repeat-y.htm.ini
@@ -1,3 +1,0 @@
-[background-repeat-repeat-y.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/background-size-contain.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/background-size-contain.htm.ini
@@ -1,3 +1,3 @@
-[background-repeat-repeat-x.htm]
+[background-size-contain.htm]
   type: reftest
   expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/c5525-fltmrgn-000.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/c5525-fltmrgn-000.htm.ini
@@ -1,3 +1,3 @@
-[background-size-contain.htm]
+[c5525-fltmrgn-000.htm]
   type: reftest
   expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-009.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-009.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-009.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-010.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-010.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-010.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-011.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-011.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-011.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-012.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-012.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-012.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-017.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-017.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-017.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-018.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-018.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-018.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-019.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-019.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-019.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-020.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-020.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-020.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-115.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-115.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-115.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-116.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-116.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-116.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-121.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-121.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-121.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-122.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-122.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-122.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-173.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-173.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-173.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-174.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-174.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-174.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-175.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-175.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-175.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-176.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-176.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-176.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-197.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-197.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-197.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-198.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-198.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-198.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-199.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-199.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-199.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-200.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-200.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-200.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-201.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-201.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-201.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-202.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-202.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-202.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-203.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/table-anonymous-objects-203.htm.ini
@@ -1,4 +1,0 @@
-[table-anonymous-objects-203.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/mozilla/meta/css/inline_block_overflow_hidden_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/inline_block_overflow_hidden_a.html.ini
@@ -1,4 +1,4 @@
-[border_radius_elliptical_a.html]
+[inline_block_overflow_hidden_a.html]
   type: reftest
   expected:
     if os == "mac": FAIL

--- a/tests/wpt/mozilla/meta/css/input_selection_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/input_selection_a.html.ini
@@ -1,0 +1,4 @@
+[input_selection_a.html]
+  type: reftest
+  expected:
+    if os == "mac": FAIL


### PR DESCRIPTION
This includes a WR update that improves pixel snapping. Specifically,
the non-transform shader now snaps to device pixels in world space,
rather than local space.

This makes 31 new tests pass, and adds 4 new failures.

Of the new failures:
 - The three background size tests appear to be an OSMesa accuracy
   issue. Near the bottom of the image, a small number of pixels
   are different from the reference by a value of 1.0 / 255.0. I've
   confirmed on 3 real GPUs and also on llvmpipe that the tests
   match on those devices. This would be a good case for fuzzy test
   support in WPT.
 - The other failing test appears to have unreasonable accuracy
   requirements as it also fails on Gecko and Chromium in the same
   way that the test now fails on WR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15467)
<!-- Reviewable:end -->
