### PR TITLE
Only expose Storage/StorageEvent in Window

### DIFF
--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -11,8 +11,8 @@ use dom::bindings::refcounted::Trusted;
 use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use dom::bindings::str::DOMString;
 use dom::event::{Event, EventBubbles, EventCancelable};
-use dom::globalscope::GlobalScope;
 use dom::storageevent::StorageEvent;
+use dom::window::Window;
 use ipc_channel::ipc::{self, IpcSender};
 use net_traits::IpcSend;
 use net_traits::storage_thread::{StorageThreadMsg, StorageType};
@@ -35,7 +35,7 @@ impl Storage {
         }
     }
 
-    pub fn new(global: &GlobalScope, storage_type: StorageType) -> Root<Storage> {
+    pub fn new(global: &Window, storage_type: StorageType) -> Root<Storage> {
         reflect_dom_object(box Storage::new_inherited(storage_type), global, StorageBinding::Wrap)
     }
 
@@ -196,7 +196,7 @@ impl Runnable for StorageEventRunnable {
         let window = global.as_window();
 
         let storage_event = StorageEvent::new(
-            &global,
+            &window,
             atom!("storage"),
             EventBubbles::DoesNotBubble, EventCancelable::NotCancelable,
             this.key.map(DOMString::from), this.old_value.map(DOMString::from), this.new_value.map(DOMString::from),

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -11,7 +11,6 @@ use dom::bindings::js::{MutNullableJS, Root, RootedReference};
 use dom::bindings::reflector::reflect_dom_object;
 use dom::bindings::str::DOMString;
 use dom::event::{Event, EventBubbles, EventCancelable};
-use dom::globalscope::GlobalScope;
 use dom::storage::Storage;
 use dom::window::Window;
 use servo_atoms::Atom;
@@ -50,7 +49,7 @@ impl StorageEvent {
                            StorageEventBinding::Wrap)
     }
 
-    pub fn new(global: &GlobalScope,
+    pub fn new(global: &Window,
                type_: Atom,
                bubbles: EventBubbles,
                cancelable: EventCancelable,
@@ -70,7 +69,7 @@ impl StorageEvent {
         ev
     }
 
-    pub fn Constructor(global: &GlobalScope,
+    pub fn Constructor(global: &Window,
                        type_: DOMString,
                        init: &StorageEventBinding::StorageEventInit) -> Fallible<Root<StorageEvent>> {
         let key = init.key.clone();

--- a/components/script/dom/webidls/Storage.webidl
+++ b/components/script/dom/webidls/Storage.webidl
@@ -7,7 +7,7 @@
  *
  */
 
-[Exposed=(Window,Worker)]
+[Exposed=Window]
 interface Storage {
 
   readonly attribute unsigned long length;

--- a/components/script/dom/webidls/StorageEvent.webidl
+++ b/components/script/dom/webidls/StorageEvent.webidl
@@ -9,7 +9,7 @@
  * Event sent to a window when a storage area changes.
  */
 
-[Constructor(DOMString type, optional StorageEventInit eventInitDict), Exposed=(Window,Worker)]
+[Constructor(DOMString type, optional StorageEventInit eventInitDict), Exposed=Window]
 interface StorageEvent : Event {
   readonly attribute DOMString? key;
   readonly attribute DOMString? oldValue;

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -469,12 +469,12 @@ impl WindowMethods for Window {
 
     // https://html.spec.whatwg.org/multipage/#dom-sessionstorage
     fn SessionStorage(&self) -> Root<Storage> {
-        self.session_storage.or_init(|| Storage::new(self.upcast(), StorageType::Session))
+        self.session_storage.or_init(|| Storage::new(self, StorageType::Session))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-localstorage
     fn LocalStorage(&self) -> Root<Storage> {
-        self.local_storage.or_init(|| Storage::new(self.upcast(), StorageType::Local))
+        self.local_storage.or_init(|| Storage::new(self, StorageType::Local))
     }
 
     // https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#dfn-GlobalCrypto

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -25645,7 +25645,7 @@
    "support"
   ],
   "mozilla/interfaces.worker.js": [
-   "3fbec39bafa473f0eeb7af3461f38151856bf362",
+   "9b3a3c96ec539bb323a0def92c747996deaa7331",
    "testharness"
   ],
   "mozilla/iterable.html": [

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
@@ -37,8 +37,6 @@ test_interfaces([
   "ProgressEvent",
   "Request",
   "Response",
-  "Storage",
-  "StorageEvent",
   "TextDecoder",
   "TextEncoder",
   "URL",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This patch removes Worker scope from Storage and StorageEvent WebIDL definition. This way it is possible to construct the objects passing Window instead of GlobalScope. It also removes some tests as they would run out of the scope.

It removes Worker from the WebIDL files defining the Storage and StorageEvent interfaces, as they should not be exposed in that scope.

In Rust source code, this patch replaces "GlobalScope" with "Window" on the contructors. It also modifies constructor calling code in order to pass Window instead of the previously used GlobalScope.

There has been removed these interfaces from the Worker tests.

(This time I did a real build and real tests. Sorry about previous pull requests, I am used to the Mozilla flow, which doesn't uses GitHub)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15436 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15475)
<!-- Reviewable:end -->
