### PR TITLE
Ensure that position_fixed reftest matches ahem font requirements.

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -22977,11 +22977,11 @@
    "support"
   ],
   "css/position_fixed_a.html": [
-   "e0cec72521c5ad893c260f7d0f3542d1464161e9",
+   "afbcc31b0460931d7ed8a2fdc1399d2f84fe33d5",
    "reftest"
   ],
   "css/position_fixed_b.html": [
-   "4a4589634026999bbb40d0cb92c114e7af4ad61a",
+   "251a490233a7836accc5883093a765f88e6006b5",
    "support"
   ],
   "css/position_fixed_background_color_a.html": [

--- a/tests/wpt/mozilla/tests/css/position_fixed_a.html
+++ b/tests/wpt/mozilla/tests/css/position_fixed_a.html
@@ -13,6 +13,7 @@
          because test reference depends on dynamic sizing, and different
          fonts change the required margins. */
       font-family: 'Ahem';
+      font-size: 20px;
     }
     .fixed_block {
       background: green;

--- a/tests/wpt/mozilla/tests/css/position_fixed_b.html
+++ b/tests/wpt/mozilla/tests/css/position_fixed_b.html
@@ -9,6 +9,7 @@
       background: blue;
 
       font-family: 'Ahem';
+      font-size: 20px;
     }
     div {
       position: absolute;


### PR DESCRIPTION
The ahem font should always be a multiple of 5px and a minimum size
of 20px for reliable results [1]. In particular, on some macs, using
the default size of 16 results in a reported metric of 16 x 17 from
the OS. This is currently working, but breaks when WR is updated to
do pixel snapping in world space.

[1] http://testthewebforward.org/docs/test-style-guidelines.html#special-fonts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15485)
<!-- Reviewable:end -->
