### PR TITLE
Enable more CSS tests under web-platform-tests.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -7,7 +7,11 @@ skip: true
   skip: false
 [cors]
   skip: false
+[cssom]
+  skip: false
 [cssom-view]
+  skip: false
+[css-values]
   skip: false
 [dom]
   skip: false

--- a/tests/wpt/metadata/cssom/serialize-values.html.ini
+++ b/tests/wpt/metadata/cssom/serialize-values.html.ini
@@ -1,0 +1,149 @@
+[serialize-values.html]
+  type: testharness
+  [border-spacing: 0px]
+    expected: FAIL
+
+  [border-spacing: 1px]
+    expected: FAIL
+
+  [border-spacing: .1em]
+    expected: FAIL
+
+  [content: url("http://localhost/")]
+    expected: FAIL
+
+  [content: url(http://localhost/)]
+    expected: FAIL
+
+  [content: counter(par-num, upper-roman)]
+    expected: FAIL
+
+  [content: attr(foo-bar)]
+    expected: FAIL
+
+  [content: attr(foo_bar)]
+    expected: FAIL
+
+  [font-family: Arial]
+    expected: FAIL
+
+  [font-size: xx-small]
+    expected: FAIL
+
+  [font-size: x-small]
+    expected: FAIL
+
+  [font-size: small]
+    expected: FAIL
+
+  [font-size: medium]
+    expected: FAIL
+
+  [font-size: large]
+    expected: FAIL
+
+  [font-size: x-large]
+    expected: FAIL
+
+  [font-size: xx-large]
+    expected: FAIL
+
+  [font-size: larger]
+    expected: FAIL
+
+  [font-size: smaller]
+    expected: FAIL
+
+  [list-style-type: decimal-leading-zero]
+    expected: FAIL
+
+  [list-style-type: lower-roman]
+    expected: FAIL
+
+  [list-style-type: upper-roman]
+    expected: FAIL
+
+  [list-style-type: lower-latin]
+    expected: FAIL
+
+  [list-style-type: upper-latin]
+    expected: FAIL
+
+  [list-style-type: armenian]
+    expected: FAIL
+
+  [list-style-type: georgian]
+    expected: FAIL
+
+  [orphans: 101]
+    expected: FAIL
+
+  [orphans: inherit]
+    expected: FAIL
+
+  [outline-color: invert]
+    expected: FAIL
+
+  [outline-width: thin]
+    expected: FAIL
+
+  [outline-width: medium]
+    expected: FAIL
+
+  [outline-width: thick]
+    expected: FAIL
+
+  [page-break-after: auto]
+    expected: FAIL
+
+  [page-break-after: always]
+    expected: FAIL
+
+  [page-break-after: avoid]
+    expected: FAIL
+
+  [page-break-after: left]
+    expected: FAIL
+
+  [page-break-after: right]
+    expected: FAIL
+
+  [page-break-after: inherit]
+    expected: FAIL
+
+  [page-break-before: auto]
+    expected: FAIL
+
+  [page-break-before: always]
+    expected: FAIL
+
+  [page-break-before: avoid]
+    expected: FAIL
+
+  [page-break-before: left]
+    expected: FAIL
+
+  [page-break-before: right]
+    expected: FAIL
+
+  [page-break-before: inherit]
+    expected: FAIL
+
+  [page-break-inside: avoid]
+    expected: FAIL
+
+  [page-break-inside: auto]
+    expected: FAIL
+
+  [page-break-inside: inherit]
+    expected: FAIL
+
+  [visibility: collapse]
+    expected: FAIL
+
+  [widows: 101]
+    expected: FAIL
+
+  [widows: inherit]
+    expected: FAIL
+


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they are tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15499)
<!-- Reviewable:end -->
