### PR TITLE
Added CSS transform serializations

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -965,6 +965,7 @@ ${helpers.single_keyword("animation-fill-mode",
     use std::fmt;
     use style_traits::ToCss;
     use values::HasViewportPercentage;
+    use values::specified::Length;
     use values::specified::LengthOrPercentage;
 
     impl HasViewportPercentage for SpecifiedValue {
@@ -1098,6 +1099,8 @@ ${helpers.predefined_type("scroll-snap-coordinate",
         use values::CSSFloat;
         use values::computed;
 
+        // https://drafts.csswg.org/css-transforms/#mathematical-description
+        // Note that the matrix elements are addressed in column-major order.
         #[derive(Clone, Copy, Debug, PartialEq)]
         #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
         pub struct ComputedMatrix {
@@ -1108,12 +1111,12 @@ ${helpers.predefined_type("scroll-snap-coordinate",
         }
 
         impl ComputedMatrix {
-            pub fn identity() -> ComputedMatrix {
+            pub fn identity() -> Self {
                 ComputedMatrix {
                     m11: 1.0, m12: 0.0, m13: 0.0, m14: 0.0,
                     m21: 0.0, m22: 1.0, m23: 0.0, m24: 0.0,
                     m31: 0.0, m32: 0.0, m33: 1.0, m34: 0.0,
-                    m41: 0.0, m42: 0.0, m43: 0.0, m44: 1.0
+                    m41: 0.0, m42: 0.0, m43: 0.0, m44: 1.0,
                 }
             }
         }
@@ -1122,12 +1125,10 @@ ${helpers.predefined_type("scroll-snap-coordinate",
         #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
         pub enum ComputedOperation {
             Matrix(ComputedMatrix),
-            Skew(computed::Angle, computed::Angle),
-            Translate(computed::LengthOrPercentage,
-                      computed::LengthOrPercentage,
-                      computed::Length),
+            Translate(computed::LengthOrPercentage, computed::LengthOrPercentage, computed::Length),
             Scale(CSSFloat, CSSFloat, CSSFloat),
             Rotate(CSSFloat, CSSFloat, CSSFloat, computed::Angle),
+            Skew(computed::Angle, computed::Angle),
             Perspective(computed::Length),
         }
 
@@ -1136,62 +1137,429 @@ ${helpers.predefined_type("scroll-snap-coordinate",
         pub struct T(pub Option<Vec<ComputedOperation>>);
     }
 
-    pub use self::computed_value::ComputedMatrix as SpecifiedMatrix;
-
-    fn parse_two_lengths_or_percentages(context: &ParserContext, input: &mut Parser)
-                                        -> Result<(specified::LengthOrPercentage,
-                                                   specified::LengthOrPercentage),()> {
-        let first = try!(specified::LengthOrPercentage::parse(context, input));
-        let second = input.try(|input| {
-            try!(input.expect_comma());
-            specified::LengthOrPercentage::parse(context, input)
-        }).unwrap_or(specified::LengthOrPercentage::zero());
-        Ok((first, second))
+    // https://drafts.csswg.org/css-transforms/#mathematical-description
+    // Note that the matrix elements are addressed in column-major order.
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+    pub enum SpecifiedMatrix {
+        Matrix(CSSFloat, CSSFloat, CSSFloat, CSSFloat, CSSFloat, CSSFloat),
+        Matrix3D(self::computed_value::ComputedMatrix),
     }
 
-    fn parse_two_floats(input: &mut Parser) -> Result<(CSSFloat,CSSFloat),()> {
-        let first = try!(specified::parse_number(input));
-        let second = input.try(|input| {
-            try!(input.expect_comma());
-            specified::parse_number(input)
-        }).unwrap_or(first);
-        Ok((first, second))
+    impl ToCss for SpecifiedMatrix {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            match *self {
+                SpecifiedMatrix::Matrix(a, b, c, d, e, f) => {
+                    try!(dest.write_str("matrix("));
+                        try!(dest.write_str(a.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(b.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(c.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(d.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(e.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(f.to_string().as_str()));
+                    dest.write_str(")")
+                }
+                SpecifiedMatrix::Matrix3D(ref matrix) => {
+                    let self::computed_value::ComputedMatrix {
+                        m11, m12, m13, m14,
+                        m21, m22, m23, m24,
+                        m31, m32, m33, m34,
+                        m41, m42, m43, m44
+                    } = *matrix;
+
+                    try!(dest.write_str("matrix3d("));
+                        try!(dest.write_str(m11.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m12.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m13.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m14.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m21.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m22.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m23.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m24.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m31.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m32.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m33.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m34.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m41.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m42.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m43.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(m44.to_string().as_str()));
+                    dest.write_str(")")
+                }
+            }
+        }
     }
 
-    fn parse_two_angles(context: &ParserContext, input: &mut Parser)
-                       -> Result<(specified::Angle, specified::Angle),()> {
-        let first = try!(specified::Angle::parse(context, input));
-        let second = input.try(|input| {
-            try!(input.expect_comma());
-            specified::Angle::parse(context, input)
-        }).unwrap_or(specified::Angle(0.0));
-        Ok((first, second))
+    impl ToComputedValue for SpecifiedMatrix {
+        type ComputedValue = computed_value::ComputedMatrix;
+
+        #[inline]
+        // Assumes computed::Angle implicitly uses radians
+        fn to_computed_value(&self, _: &Context) -> Self::ComputedValue {
+            match *self {
+                SpecifiedMatrix::Matrix(a, b, c, d, e, f) =>
+                    self::computed_value::ComputedMatrix {
+                        m11: a,   m12: b,   m13: 0.0, m14: 0.0,
+                        m21: c,   m22: d,   m23: 0.0, m24: 0.0,
+                        m31: 0.0, m32: 0.0, m33: 1.0, m34: 0.0,
+                        m41: e,   m42: f,   m43: 0.0, m44: 1.0
+                    },
+                SpecifiedMatrix::Matrix3D(matrix) => matrix
+            }
+        }
+
+        #[inline]
+        /// [The canonical unit for an angle is `deg`.](https://drafts.csswg.org/css-values-3/#angles)
+        fn from_computed_value(computed: &Self::ComputedValue) -> Self {
+            SpecifiedMatrix::Matrix3D(*computed)
+        }
     }
 
     #[derive(Copy, Clone, Debug, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    enum TranslateKind {
-        Translate,
-        TranslateX,
-        TranslateY,
-        TranslateZ,
-        Translate3D,
+    pub enum AngleUnits {
+        Degree,
+        Gradian,
+        Radian,
+        Turn,
+    }
+
+    impl fmt::Display for AngleUnits {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            let s = match *self {
+                AngleUnits::Degree  => "deg",
+                AngleUnits::Gradian => "grad",
+                AngleUnits::Radian  => "rad",
+                AngleUnits::Turn    => "turn",
+            };
+            f.write_str(s)
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+    pub struct SpecifiedAngle {
+        value: CSSFloat,
+        unit: AngleUnits,
+    }
+
+    impl SpecifiedAngle {
+        pub fn degrees(value: CSSFloat)  -> Self { SpecifiedAngle { value: value, unit: AngleUnits::Degree } }
+        pub fn gradians(value: CSSFloat) -> Self { SpecifiedAngle { value: value, unit: AngleUnits::Gradian } }
+        pub fn turns(value: CSSFloat)    -> Self { SpecifiedAngle { value: value, unit: AngleUnits::Turn } }
+        pub fn radians(value: CSSFloat)  -> Self { SpecifiedAngle { value: value, unit: AngleUnits::Radian } }
+
+        #[allow(missing_docs)]
+        fn parse_dimension(value: CSSFloat, unit: &str) -> Result<SpecifiedAngle, ()> {
+            match_ignore_ascii_case! { unit,
+                "deg"  => Ok(SpecifiedAngle::degrees(value)),
+                "grad" => Ok(SpecifiedAngle::gradians(value)),
+                "turn" => Ok(SpecifiedAngle::turns(value)),
+                "rad"  => Ok(SpecifiedAngle::radians(value)),
+                _ => Err(())
+            }
+        }
+
+        pub fn zero() -> Self {
+            SpecifiedAngle::degrees(0.0)
+        }
+    }
+
+    impl ToCss for SpecifiedAngle {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            write!(dest, "{}{}", self.value, self.unit)
+        }
+    }
+
+    impl Parse for SpecifiedAngle {
+        /// Parses an angle according to CSS-VALUES § 6.1.
+        fn parse(_context: &ParserContext, input: &mut Parser) -> Result<Self, ()> {
+            use cssparser::Token;
+            use std::ascii::AsciiExt;
+            use values::specified::CalcLengthOrPercentage;
+
+            match try!(input.next()) {
+                Token::Dimension(ref value, ref unit) => SpecifiedAngle::parse_dimension(value.value, unit),
+                Token::Number(ref value) if value.value == 0. => Ok(SpecifiedAngle::zero()),
+                Token::Function(ref name) if name.eq_ignore_ascii_case("calc") => {
+                    input
+                        .parse_nested_block(CalcLengthOrPercentage::parse_angle)
+                        .map(|angle| SpecifiedAngle::from_computed_value(&angle))
+                },
+                _ => Err(())
+            }
+        }
+    }
+
+    impl ToComputedValue for SpecifiedAngle {
+        type ComputedValue = computed::Angle;
+
+        #[inline]
+        /// Assumes `computed::Angle` implicitly uses radians
+        fn to_computed_value(&self, _: &Context) -> Self::ComputedValue {
+            use std::f32::consts::PI;
+            const RAD_PER_GRAD: CSSFloat = PI / 200.0;
+            const RAD_PER_TURN: CSSFloat = PI * 2.0;
+
+            match self.unit {
+                AngleUnits::Degree  => computed::Angle(self.value.to_radians()),
+                AngleUnits::Gradian => computed::Angle(self.value * RAD_PER_GRAD),
+                AngleUnits::Turn    => computed::Angle(self.value * RAD_PER_TURN),
+                AngleUnits::Radian  => computed::Angle(self.value),
+            }
+        }
+
+        #[inline]
+        /// [The canonical unit for an angle is `deg`.](https://drafts.csswg.org/css-values-3/#angles)
+        fn from_computed_value(computed: &Self::ComputedValue) -> Self {
+            SpecifiedAngle::degrees(computed.radians().to_degrees())
+        }
     }
 
     #[derive(Clone, Debug, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    enum SpecifiedOperation {
+    pub enum SpecifiedSkew {
+        Skew(SpecifiedAngle),
+        SkewX(SpecifiedAngle),
+        SkewY(SpecifiedAngle),
+        SkewXY(SpecifiedAngle, SpecifiedAngle),
+    }
+
+    impl ToCss for SpecifiedSkew {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            match *self {
+                SpecifiedSkew::Skew(ref ax) => {
+                    try!(dest.write_str("skew("));
+                        try!(ax.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedSkew::SkewX(ref ax) => {
+                    try!(dest.write_str("skewX("));
+                        try!(ax.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedSkew::SkewY(ref ay) => {
+                    try!(dest.write_str("skewY("));
+                        try!(ay.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedSkew::SkewXY(ref ax, ref ay) => {
+                    try!(dest.write_str("skew("));
+                        try!(ax.to_css(dest));
+                        try!(dest.write_str(", "));
+                        try!(ay.to_css(dest));
+                    dest.write_str(")")
+                }
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+    pub enum SpecifiedTranslate {
+        Translate(specified::LengthOrPercentage),
+        TranslateX(specified::LengthOrPercentage),
+        TranslateY(specified::LengthOrPercentage),
+        TranslateZ(specified::Length),
+        TranslateXY(specified::LengthOrPercentage, specified::LengthOrPercentage),
+        Translate3D(specified::LengthOrPercentage, specified::LengthOrPercentage, specified::Length),
+    }
+
+    impl ToCss for SpecifiedTranslate {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            match *self {
+                SpecifiedTranslate::Translate(ref tx) => {
+                    try!(dest.write_str("translate("));
+                        try!(tx.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedTranslate::TranslateX(ref tx) => {
+                    try!(dest.write_str("translateX("));
+                        try!(tx.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedTranslate::TranslateY(ref ty) => {
+                    try!(dest.write_str("translateY("));
+                        try!(ty.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedTranslate::TranslateZ(ref tz) => {
+                    try!(dest.write_str("translateZ("));
+                        try!(tz.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedTranslate::TranslateXY(ref tx, ref ty) => {
+                    try!(dest.write_str("translate("));
+                        try!(tx.to_css(dest));
+                        try!(dest.write_str(", "));
+                        try!(ty.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedTranslate::Translate3D(ref tx, ref ty, ref tz) => {
+                    try!(dest.write_str("translate3d("));
+                        try!(tx.to_css(dest));
+                        try!(dest.write_str(", "));
+                        try!(ty.to_css(dest));
+                        try!(dest.write_str(", "));
+                        try!(tz.to_css(dest));
+                    dest.write_str(")")
+                }
+            }
+        }
+    }
+
+    impl HasViewportPercentage for SpecifiedTranslate {
+        fn has_viewport_percentage(&self) -> bool {
+            match *self {
+                SpecifiedTranslate::Translate(ref t)
+                | SpecifiedTranslate::TranslateX(ref t)
+                | SpecifiedTranslate::TranslateY(ref t) =>
+                    t.has_viewport_percentage(),
+                SpecifiedTranslate::TranslateZ(ref tz) =>
+                    tz.has_viewport_percentage(),
+                SpecifiedTranslate::TranslateXY(ref tx, ref ty) =>
+                    tx.has_viewport_percentage() || ty.has_viewport_percentage(),
+                SpecifiedTranslate::Translate3D(ref tx, ref ty, ref tz) =>
+                    tx.has_viewport_percentage() || ty.has_viewport_percentage() || tz.has_viewport_percentage(),
+            }
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+    pub enum SpecifiedScale {
+        Scale(CSSFloat),
+        ScaleX(CSSFloat),
+        ScaleY(CSSFloat),
+        ScaleZ(CSSFloat),
+        ScaleXY(CSSFloat, CSSFloat),
+        Scale3D(CSSFloat, CSSFloat, CSSFloat),
+    }
+
+    impl ToCss for SpecifiedScale {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            match *self {
+                SpecifiedScale::Scale(s) => {
+                    try!(dest.write_str("scale("));
+                        try!(dest.write_str(s.to_string().as_str()));
+                    dest.write_str(")")
+                }
+                SpecifiedScale::ScaleX(sx)  => {
+                    try!(dest.write_str("scaleX("));
+                        try!(dest.write_str(sx.to_string().as_str()));
+                    dest.write_str(")")
+                }
+                SpecifiedScale::ScaleY(sy) => {
+                    try!(dest.write_str("scaleY("));
+                        try!(dest.write_str(sy.to_string().as_str()));
+                    dest.write_str(")")
+                }
+                SpecifiedScale::ScaleZ(sz)  => {
+                    try!(dest.write_str("scaleZ("));
+                        try!(dest.write_str(sz.to_string().as_str()));
+                    dest.write_str(")")
+                }
+                SpecifiedScale::ScaleXY(sx, sy) => {
+                    try!(dest.write_str("scale("));
+                        try!(dest.write_str(sx.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(sy.to_string().as_str()));
+                    dest.write_str(")")
+                }
+                SpecifiedScale::Scale3D(sx, sy, sz) => {
+                    try!(dest.write_str("scale3d("));
+                        try!(dest.write_str(sx.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(sy.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(sz.to_string().as_str()));
+                    dest.write_str(")")
+                }
+            }
+        }
+    }
+
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+    pub enum SpecifiedRotate {
+        Rotate(SpecifiedAngle),
+        //RotateAndTranslate(SpecifiedAngle, specified::Length, specified::Length),
+        RotateX(SpecifiedAngle),
+        RotateY(SpecifiedAngle),
+        RotateZ(SpecifiedAngle),
+        Rotate3D(CSSFloat, CSSFloat, CSSFloat, SpecifiedAngle),
+    }
+
+    impl ToCss for SpecifiedRotate {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            match *self {
+                SpecifiedRotate::Rotate(ref theta) => {
+                    try!(dest.write_str("rotate("));
+                        try!(theta.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedRotate::RotateX(ref theta)  => {
+                    try!(dest.write_str("rotateX("));
+                        try!(theta.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedRotate::RotateY(ref theta) => {
+                    try!(dest.write_str("rotateY("));
+                        try!(theta.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedRotate::RotateZ(ref theta)  => {
+                    try!(dest.write_str("rotateZ("));
+                        try!(theta.to_css(dest));
+                    dest.write_str(")")
+                }
+                SpecifiedRotate::Rotate3D(ax, ay, az, ref theta) => {
+                    try!(dest.write_str("rotate3d("));
+                        try!(dest.write_str(ax.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(ay.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(dest.write_str(az.to_string().as_str()));
+                        try!(dest.write_str(", "));
+                        try!(theta.to_css(dest));
+                    dest.write_str(")")
+                }
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+    pub enum SpecifiedOperation {
         Matrix(SpecifiedMatrix),
-        Skew(specified::Angle, specified::Angle),
-        Translate(TranslateKind,
-                  specified::LengthOrPercentage,
-                  specified::LengthOrPercentage,
-                  specified::Length),
-        Scale(CSSFloat, CSSFloat, CSSFloat),
-        Rotate(CSSFloat, CSSFloat, CSSFloat, specified::Angle),
+        Translate(SpecifiedTranslate),
+        Scale(SpecifiedScale),
+        Rotate(SpecifiedRotate),
+        Skew(SpecifiedSkew),
         Perspective(specified::Length),
     }
 
+    /// https://drafts.csswg.org/css-transforms/#serialization-of-the-computed-value
     impl ToCss for computed_value::T {
         fn to_css<W>(&self, _: &mut W) -> fmt::Result where W: fmt::Write {
             // TODO(pcwalton)
@@ -1202,69 +1570,27 @@ ${helpers.predefined_type("scroll-snap-coordinate",
     impl HasViewportPercentage for SpecifiedOperation {
         fn has_viewport_percentage(&self) -> bool {
             match *self {
-                SpecifiedOperation::Translate(_, ref l1, ref l2, ref l3) => {
-                    l1.has_viewport_percentage() ||
-                    l2.has_viewport_percentage() ||
-                    l3.has_viewport_percentage()
-                },
+                SpecifiedOperation::Translate(ref translate) => translate.has_viewport_percentage(),
                 SpecifiedOperation::Perspective(ref length) => length.has_viewport_percentage(),
                 _ => false
             }
         }
     }
 
+    /// https://drafts.csswg.org/css-transforms/#serialization-of-transform-functions
     impl ToCss for SpecifiedOperation {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self {
-                // todo(gw): implement serialization for transform
-                // types other than translate.
-                SpecifiedOperation::Matrix(..) => {
-                    Ok(())
-                }
-                SpecifiedOperation::Skew(..) => {
-                    Ok(())
-                }
-                SpecifiedOperation::Translate(kind, ref tx, ref ty, ref tz) => {
-                    match kind {
-                        TranslateKind::Translate => {
-                            try!(dest.write_str("translate("));
-                            try!(tx.to_css(dest));
-                            try!(dest.write_str(", "));
-                            try!(ty.to_css(dest));
-                            dest.write_str(")")
-                        }
-                        TranslateKind::TranslateX => {
-                            try!(dest.write_str("translateX("));
-                            try!(tx.to_css(dest));
-                            dest.write_str(")")
-                        }
-                        TranslateKind::TranslateY => {
-                            try!(dest.write_str("translateY("));
-                            try!(ty.to_css(dest));
-                            dest.write_str(")")
-                        }
-                        TranslateKind::TranslateZ => {
-                            try!(dest.write_str("translateZ("));
-                            try!(tz.to_css(dest));
-                            dest.write_str(")")
-                        }
-                        TranslateKind::Translate3D => {
-                            try!(dest.write_str("translate3d("));
-                            try!(tx.to_css(dest));
-                            try!(dest.write_str(", "));
-                            try!(ty.to_css(dest));
-                            try!(dest.write_str(", "));
-                            try!(tz.to_css(dest));
-                            dest.write_str(")")
-                        }
-                    }
-                }
-                SpecifiedOperation::Scale(..) => {
-                    Ok(())
-                }
-                SpecifiedOperation::Rotate(..) => {
-                    Ok(())
-                }
+                SpecifiedOperation::Matrix(ref matrix) =>
+                    matrix.to_css(dest),
+                SpecifiedOperation::Skew(ref skew) =>
+                    skew.to_css(dest),
+                SpecifiedOperation::Translate(ref translate) =>
+                    translate.to_css(dest),
+                SpecifiedOperation::Scale(ref scale) =>
+                    scale.to_css(dest),
+                SpecifiedOperation::Rotate(ref rotate) =>
+                    rotate.to_css(dest),
                 SpecifiedOperation::Perspective(_) => {
                     Ok(())
                 }
@@ -1281,7 +1607,7 @@ ${helpers.predefined_type("scroll-snap-coordinate",
 
     #[derive(Clone, Debug, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    pub struct SpecifiedValue(Vec<SpecifiedOperation>);
+    pub struct SpecifiedValue(pub Vec<SpecifiedOperation>);
 
     impl ToCss for SpecifiedValue {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
@@ -1329,12 +1655,8 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                             return Err(())
                         }
                         result.push(SpecifiedOperation::Matrix(
-                                SpecifiedMatrix {
-                                    m11: values[0], m12: values[1], m13: 0.0, m14: 0.0,
-                                    m21: values[2], m22: values[3], m23: 0.0, m24: 0.0,
-                                    m31:       0.0, m32:       0.0, m33: 1.0, m34: 0.0,
-                                    m41: values[4], m42: values[5], m43: 0.0, m44: 1.0
-                                }));
+                            SpecifiedMatrix::Matrix(values[0], values[1], values[2], values[3], values[4], values[5])
+                        ));
                         Ok(())
                     }))
                 },
@@ -1347,22 +1669,26 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                             return Err(())
                         }
                         result.push(SpecifiedOperation::Matrix(
-                                SpecifiedMatrix {
-                                    m11: values[ 0], m12: values[ 1], m13: values[ 2], m14: values[ 3],
-                                    m21: values[ 4], m22: values[ 5], m23: values[ 6], m24: values[ 7],
-                                    m31: values[ 8], m32: values[ 9], m33: values[10], m34: values[11],
-                                    m41: values[12], m42: values[13], m43: values[14], m44: values[15]
-                                }));
+                            SpecifiedMatrix::Matrix3D(self::computed_value::ComputedMatrix {
+                                m11: values[ 0], m12: values[ 1], m13: values[ 2], m14: values[ 3],
+                                m21: values[ 4], m22: values[ 5], m23: values[ 6], m24: values[ 7],
+                                m31: values[ 8], m32: values[ 9], m33: values[10], m34: values[11],
+                                m41: values[12], m42: values[13], m43: values[14], m44: values[15]
+                            })));
                         Ok(())
                     }))
                 },
                 "translate" => {
                     try!(input.parse_nested_block(|input| {
-                        let (tx, ty) = try!(parse_two_lengths_or_percentages(context, input));
-                        result.push(SpecifiedOperation::Translate(TranslateKind::Translate,
-                                                                  tx,
-                                                                  ty,
-                                                                  specified::Length::zero()));
+                        let tx = try!(specified::LengthOrPercentage::parse(context, input));
+                        if input.try(|input| input.expect_comma()).is_ok() {
+                            let ty = try!(specified::LengthOrPercentage::parse(context, input));
+                            result.push(SpecifiedOperation::Translate(
+                                SpecifiedTranslate::TranslateXY(tx, ty)));
+                        } else {
+                            result.push(SpecifiedOperation::Translate(
+                                SpecifiedTranslate::Translate(tx)));
+                        }
                         Ok(())
                     }))
                 },
@@ -1370,10 +1696,7 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                     try!(input.parse_nested_block(|input| {
                         let tx = try!(specified::LengthOrPercentage::parse(context, input));
                         result.push(SpecifiedOperation::Translate(
-                            TranslateKind::TranslateX,
-                            tx,
-                            specified::LengthOrPercentage::zero(),
-                            specified::Length::zero()));
+                            SpecifiedTranslate::TranslateX(tx)));
                         Ok(())
                     }))
                 },
@@ -1381,10 +1704,7 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                     try!(input.parse_nested_block(|input| {
                         let ty = try!(specified::LengthOrPercentage::parse(context, input));
                         result.push(SpecifiedOperation::Translate(
-                            TranslateKind::TranslateY,
-                            specified::LengthOrPercentage::zero(),
-                            ty,
-                            specified::Length::zero()));
+                            SpecifiedTranslate::TranslateY(ty)));
                         Ok(())
                     }))
                 },
@@ -1392,10 +1712,7 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                     try!(input.parse_nested_block(|input| {
                         let tz = try!(specified::Length::parse(context, input));
                         result.push(SpecifiedOperation::Translate(
-                            TranslateKind::TranslateZ,
-                            specified::LengthOrPercentage::zero(),
-                            specified::LengthOrPercentage::zero(),
-                            tz));
+                            SpecifiedTranslate::TranslateZ(tz)));
                         Ok(())
                     }))
                 },
@@ -1407,39 +1724,41 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                         try!(input.expect_comma());
                         let tz = try!(specified::Length::parse(context, input));
                         result.push(SpecifiedOperation::Translate(
-                            TranslateKind::Translate3D,
-                            tx,
-                            ty,
-                            tz));
+                            SpecifiedTranslate::Translate3D(tx, ty, tz)));
                         Ok(())
                     }))
 
                 },
                 "scale" => {
                     try!(input.parse_nested_block(|input| {
-                        let (sx, sy) = try!(parse_two_floats(input));
-                        result.push(SpecifiedOperation::Scale(sx, sy, 1.0));
+                        let sx = try!(specified::parse_number(input));
+                        if input.try(|input| input.expect_comma()).is_ok() {
+                            let sy = try!(specified::parse_number(input));
+                            result.push(SpecifiedOperation::Scale(SpecifiedScale::ScaleXY(sx, sy)));
+                        } else {
+                            result.push(SpecifiedOperation::Scale(SpecifiedScale::Scale(sx)));
+                        };
                         Ok(())
                     }))
                 },
                 "scalex" => {
                     try!(input.parse_nested_block(|input| {
                         let sx = try!(specified::parse_number(input));
-                        result.push(SpecifiedOperation::Scale(sx, 1.0, 1.0));
+                        result.push(SpecifiedOperation::Scale(SpecifiedScale::ScaleX(sx)));
                         Ok(())
                     }))
                 },
                 "scaley" => {
                     try!(input.parse_nested_block(|input| {
                         let sy = try!(specified::parse_number(input));
-                        result.push(SpecifiedOperation::Scale(1.0, sy, 1.0));
+                        result.push(SpecifiedOperation::Scale(SpecifiedScale::ScaleY(sy)));
                         Ok(())
                     }))
                 },
                 "scalez" => {
                     try!(input.parse_nested_block(|input| {
                         let sz = try!(specified::parse_number(input));
-                        result.push(SpecifiedOperation::Scale(1.0, 1.0, sz));
+                        result.push(SpecifiedOperation::Scale(SpecifiedScale::ScaleZ(sz)));
                         Ok(())
                     }))
                 },
@@ -1450,35 +1769,35 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                         let sy = try!(specified::parse_number(input));
                         try!(input.expect_comma());
                         let sz = try!(specified::parse_number(input));
-                        result.push(SpecifiedOperation::Scale(sx, sy, sz));
+                        result.push(SpecifiedOperation::Scale(SpecifiedScale::Scale3D(sx, sy, sz)));
                         Ok(())
                     }))
                 },
                 "rotate" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta = try!(specified::Angle::parse(context,input));
-                        result.push(SpecifiedOperation::Rotate(0.0, 0.0, 1.0, theta));
+                        let theta = try!(SpecifiedAngle::parse(context,input));
+                        result.push(SpecifiedOperation::Rotate(SpecifiedRotate::Rotate(theta)));
                         Ok(())
                     }))
                 },
                 "rotatex" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta = try!(specified::Angle::parse(context,input));
-                        result.push(SpecifiedOperation::Rotate(1.0, 0.0, 0.0, theta));
+                        let theta = try!(SpecifiedAngle::parse(context,input));
+                        result.push(SpecifiedOperation::Rotate(SpecifiedRotate::RotateX(theta)));
                         Ok(())
                     }))
                 },
                 "rotatey" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta = try!(specified::Angle::parse(context,input));
-                        result.push(SpecifiedOperation::Rotate(0.0, 1.0, 0.0, theta));
+                        let theta = try!(SpecifiedAngle::parse(context,input));
+                        result.push(SpecifiedOperation::Rotate(SpecifiedRotate::RotateY(theta)));
                         Ok(())
                     }))
                 },
                 "rotatez" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta = try!(specified::Angle::parse(context,input));
-                        result.push(SpecifiedOperation::Rotate(0.0, 0.0, 1.0, theta));
+                        let theta = try!(SpecifiedAngle::parse(context,input));
+                        result.push(SpecifiedOperation::Rotate(SpecifiedRotate::RotateZ(theta)));
                         Ok(())
                     }))
                 },
@@ -1490,30 +1809,35 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                         try!(input.expect_comma());
                         let az = try!(specified::parse_number(input));
                         try!(input.expect_comma());
-                        let theta = try!(specified::Angle::parse(context,input));
+                        let theta = try!(SpecifiedAngle::parse(context,input));
                         // TODO(gw): Check the axis can be normalized!!
-                        result.push(SpecifiedOperation::Rotate(ax, ay, az, theta));
+                        result.push(SpecifiedOperation::Rotate(SpecifiedRotate::Rotate3D(ax, ay, az, theta)));
                         Ok(())
                     }))
                 },
                 "skew" => {
                     try!(input.parse_nested_block(|input| {
-                        let (theta_x, theta_y) = try!(parse_two_angles(context, input));
-                        result.push(SpecifiedOperation::Skew(theta_x, theta_y));
+                        let theta_x = try!(SpecifiedAngle::parse(context,input));
+                        if input.try(|input| input.expect_comma()).is_ok() {
+                            let theta_y = try!(SpecifiedAngle::parse(context,input));
+                            result.push(SpecifiedOperation::Skew(SpecifiedSkew::SkewXY(theta_x, theta_y)));
+                        } else {
+                            result.push(SpecifiedOperation::Skew(SpecifiedSkew::Skew(theta_x)));
+                        };
                         Ok(())
                     }))
                 },
                 "skewx" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta_x = try!(specified::Angle::parse(context,input));
-                        result.push(SpecifiedOperation::Skew(theta_x, specified::Angle(0.0)));
+                        let theta_x = try!(SpecifiedAngle::parse(context,input));
+                        result.push(SpecifiedOperation::Skew(SpecifiedSkew::SkewX(theta_x)));
                         Ok(())
                     }))
                 },
                 "skewy" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta_y = try!(specified::Angle::parse(context,input));
-                        result.push(SpecifiedOperation::Skew(specified::Angle(0.0), theta_y));
+                        let theta_y = try!(SpecifiedAngle::parse(context,input));
+                        result.push(SpecifiedOperation::Skew(SpecifiedSkew::SkewY(theta_y)));
                         Ok(())
                     }))
                 },
@@ -1547,23 +1871,66 @@ ${helpers.predefined_type("scroll-snap-coordinate",
             let mut result = vec!();
             for operation in &self.0 {
                 match *operation {
-                    SpecifiedOperation::Matrix(ref matrix) => {
-                        result.push(computed_value::ComputedOperation::Matrix(*matrix));
+                    SpecifiedOperation::Matrix(matrix) => {
+                        result.push(self::computed_value::ComputedOperation::Matrix(matrix.to_computed_value(context)));
                     }
-                    SpecifiedOperation::Translate(_, ref tx, ref ty, ref tz) => {
+                    SpecifiedOperation::Translate(ref translate) => {
+                        let zero_lop = specified::LengthOrPercentage::zero();
+                        let zero_length = specified::Length::zero();
+
+                        let (tx, ty, tz) = match *translate {
+                            SpecifiedTranslate::Translate(ref tx) | SpecifiedTranslate::TranslateX(ref tx) =>
+                                (tx, &zero_lop, &zero_length),
+                            SpecifiedTranslate::TranslateY(ref ty) =>
+                                (&zero_lop, ty, &zero_length),
+                            SpecifiedTranslate::TranslateZ(ref tz) =>
+                                (&zero_lop, &zero_lop, tz),
+                            SpecifiedTranslate::TranslateXY(ref tx, ref ty) =>
+                                (tx, ty, &zero_length),
+                            SpecifiedTranslate::Translate3D(ref tx, ref ty, ref tz) =>
+                                (tx, ty, tz),
+                        };
                         result.push(computed_value::ComputedOperation::Translate(tx.to_computed_value(context),
                                                                                  ty.to_computed_value(context),
                                                                                  tz.to_computed_value(context)));
                     }
-                    SpecifiedOperation::Scale(sx, sy, sz) => {
-                        result.push(computed_value::ComputedOperation::Scale(sx, sy, sz));
+                    SpecifiedOperation::Scale(scale) => {
+                        let op = match scale {
+                            SpecifiedScale::Scale(s) => computed_value::ComputedOperation::Scale(s, s, 1.0),
+                            SpecifiedScale::ScaleX(sx) => computed_value::ComputedOperation::Scale(sx, 1.0, 1.0),
+                            SpecifiedScale::ScaleY(sy) => computed_value::ComputedOperation::Scale(1.0, sy, 1.0),
+                            SpecifiedScale::ScaleZ(sz) => computed_value::ComputedOperation::Scale(1.0, 1.0, sz),
+                            SpecifiedScale::ScaleXY(sx, sy) => computed_value::ComputedOperation::Scale(sx,  sy, 1.0),
+                            SpecifiedScale::Scale3D(sx, sy, sz) => computed_value::ComputedOperation::Scale(sx, sy, sz),
+                        };
+                        result.push(op);
                     }
-                    SpecifiedOperation::Rotate(ax, ay, az, theta) => {
+                    SpecifiedOperation::Rotate(rotate) => {
+                        // TODO: SpecifiedRotate::Rotate
+                        let (ax, ay, az, theta) = match rotate {
+                            SpecifiedRotate::Rotate(theta) | SpecifiedRotate::RotateZ(theta) =>
+                                (0.0, 0.0, 1.0, theta),
+                            SpecifiedRotate::RotateX(theta) =>
+                                (1.0, 0.0, 0.0, theta),
+                            SpecifiedRotate::RotateY(theta) =>
+                                (0.0, 1.0, 0.0, theta),
+                            SpecifiedRotate::Rotate3D(ax, ay, az, theta) =>
+                                (ax, ay, az, theta),
+                        };
                         let len = (ax * ax + ay * ay + az * az).sqrt();
-                        result.push(computed_value::ComputedOperation::Rotate(ax / len, ay / len, az / len, theta));
+                        result.push(computed_value::ComputedOperation::Rotate(
+                            ax / len, ay / len, az / len, theta.to_computed_value(context)));
                     }
-                    SpecifiedOperation::Skew(theta_x, theta_y) => {
-                        result.push(computed_value::ComputedOperation::Skew(theta_x, theta_y));
+                    SpecifiedOperation::Skew(ref skew) => {
+                        let (ax, ay) = match *skew {
+                            SpecifiedSkew::SkewX(ax) | SpecifiedSkew::Skew(ax) =>
+                                (ax.to_computed_value(context), computed::Angle(0.0)),
+                            SpecifiedSkew::SkewY(ay) =>
+                                (computed::Angle(0.0), ay.to_computed_value(context)),
+                            SpecifiedSkew::SkewXY(ax, ay) =>
+                                (ax.to_computed_value(context), ay.to_computed_value(context)),
+                        };
+                        result.push(computed_value::ComputedOperation::Skew(ax, ay));
                     }
                     SpecifiedOperation::Perspective(ref d) => {
                         result.push(computed_value::ComputedOperation::Perspective(d.to_computed_value(context)));
@@ -1581,24 +1948,43 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                 for operation in computed {
                     match *operation {
                         computed_value::ComputedOperation::Matrix(ref matrix) => {
-                            result.push(SpecifiedOperation::Matrix(*matrix));
+                            result.push(SpecifiedOperation::Matrix(
+                                SpecifiedMatrix::from_computed_value(matrix)
+                            ));
                         }
                         computed_value::ComputedOperation::Translate(ref tx, ref ty, ref tz) => {
                             // XXXManishearth we lose information here; perhaps we should try to
                             // recover the original function? Not sure if this can be observed.
-                            result.push(SpecifiedOperation::Translate(TranslateKind::Translate,
-                                              ToComputedValue::from_computed_value(tx),
-                                              ToComputedValue::from_computed_value(ty),
-                                              ToComputedValue::from_computed_value(tz)));
+                            result.push(SpecifiedOperation::Translate(
+                                SpecifiedTranslate::Translate3D(
+                                    ToComputedValue::from_computed_value(tx),
+                                    ToComputedValue::from_computed_value(ty),
+                                    ToComputedValue::from_computed_value(tz)
+                                )
+                            ));
                         }
                         computed_value::ComputedOperation::Scale(sx, sy, sz) => {
-                            result.push(SpecifiedOperation::Scale(sx, sy, sz));
+                            result.push(SpecifiedOperation::Scale(
+                                SpecifiedScale::Scale3D(sx, sy, sz)
+                            ));
                         }
-                        computed_value::ComputedOperation::Rotate(ax, ay, az, theta) => {
-                            result.push(SpecifiedOperation::Rotate(ax, ay, az, theta));
+                        computed_value::ComputedOperation::Rotate(ax, ay, az, ref theta) => {
+                            result.push(SpecifiedOperation::Rotate(
+                                SpecifiedRotate::Rotate3D(
+                                    ax,
+                                    ay,
+                                    az,
+                                    SpecifiedAngle::from_computed_value(theta)
+                                )
+                            ));
                         }
-                        computed_value::ComputedOperation::Skew(theta_x, theta_y) => {
-                            result.push(SpecifiedOperation::Skew(theta_x, theta_y));
+                        computed_value::ComputedOperation::Skew(ref theta_x, ref theta_y) => {
+                            result.push(SpecifiedOperation::Skew(
+                                SpecifiedSkew::SkewXY(
+                                    SpecifiedAngle::from_computed_value(theta_x),
+                                    SpecifiedAngle::from_computed_value(theta_y)
+                                )
+                            ));
                         }
                         computed_value::ComputedOperation::Perspective(ref d) => {
                             result.push(SpecifiedOperation::Perspective(

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -1232,3 +1232,159 @@ mod shorthand_serialization {
         }
     }
 }
+
+mod longhand_serialization {
+    mod transform {
+        use style::properties::longhands::transform::{SpecifiedAngle, SpecifiedMatrix, SpecifiedRotate};
+        use style::properties::longhands::transform::{SpecifiedScale, SpecifiedSkew, SpecifiedTranslate};
+        use style::values::specified::{Length, LengthOrPercentage, ViewportPercentageLength};
+        use style::values::specified::NoCalcLength::ViewportPercentage;
+        use style_traits::ToCss;
+
+        #[inline(always)]
+        fn validate_serialization<T: ToCss>(op: &T, expected_string: &'static str) {
+            let css_string = op.to_css_string();
+
+            assert_eq!(css_string, expected_string);
+        }
+
+        #[test]
+        fn transform_specified_matrix_should_serialize_correctly() {
+            use style::properties::longhands::transform::computed_value::ComputedMatrix;
+
+            validate_serialization(
+                &SpecifiedMatrix::Matrix(0.0, 1.0, 2.0, 3.0, 4.0, 5.0),
+                "matrix(0, 1, 2, 3, 4, 5)"
+            );
+
+            validate_serialization(
+                &SpecifiedMatrix::Matrix3D(ComputedMatrix {
+                    m11: 0.00, m12: 0.25, m13: 0.50, m14: 0.75,
+                    m21: 1.00, m22: 1.25, m23: 1.50, m24: 1.75,
+                    m31: 2.00, m32: 2.25, m33: 2.50, m34: 2.75,
+                    m41: 3.00, m42: 3.25, m43: 3.50, m44: 3.75,
+                }),
+                "matrix3d(0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 2.75, 3, 3.25, 3.5, 3.75)"
+            );
+        }
+
+        #[test]
+        fn transform_specified_skew_should_serialize_correctly() {
+            validate_serialization(
+                &SpecifiedSkew::Skew(
+                    SpecifiedAngle::radians(-0.25)
+                ),
+                "skew(-0.25rad)"
+            );
+
+            validate_serialization(
+                &SpecifiedSkew::SkewX(
+                    SpecifiedAngle::turns(1.0)
+                ),
+                "skewX(1turn)"
+            );
+
+            validate_serialization(
+                &SpecifiedSkew::SkewY(
+                    SpecifiedAngle::gradians(1.0)
+                ),
+                "skewY(1grad)"
+            );
+
+            validate_serialization(
+                &SpecifiedSkew::SkewXY(
+                    SpecifiedAngle::degrees(-360.0),
+                    SpecifiedAngle::turns(0.5)
+                ),
+                "skew(-360deg, 0.5turn)"
+            );
+        }
+
+        #[test]
+        fn transform_specified_scale_should_serialize_correctly() {
+            validate_serialization(
+                &SpecifiedScale::Scale(2.0),
+                "scale(2)"
+            );
+
+            validate_serialization(
+                &SpecifiedScale::ScaleXY(10.5, -2.0),
+                "scale(10.5, -2)"
+            );
+
+            validate_serialization(
+                &SpecifiedScale::Scale3D(1.0, 2.0, 3.0),
+                "scale3d(1, 2, 3)"
+            );
+        }
+
+        #[test]
+        fn transform_specified_rotate_should_serialize_correctly() {
+            validate_serialization(
+                &SpecifiedRotate::Rotate(
+                    SpecifiedAngle::degrees(-45.0)
+                ),
+                "rotate(-45deg)"
+            );
+
+            validate_serialization(
+                &SpecifiedRotate::RotateX(
+                    SpecifiedAngle::degrees(45.0)
+                ),
+                "rotateX(45deg)"
+            );
+
+            validate_serialization(
+                &SpecifiedRotate::RotateY(
+                    SpecifiedAngle::radians(100.0),
+                ),
+                "rotateY(100rad)"
+            );
+
+            validate_serialization(
+                &SpecifiedRotate::RotateZ(
+                    SpecifiedAngle::gradians(-100.0)
+                ),
+                "rotateZ(-100grad)"
+            );
+
+            validate_serialization(
+                &SpecifiedRotate::Rotate3D(
+                    1.0,
+                    1.0,
+                    0.0,
+                    SpecifiedAngle::degrees(400.0)
+                ),
+                "rotate3d(1, 1, 0, 400deg)"
+            );
+        }
+
+        #[test]
+        fn transform_specified_translate_should_serialize_correctly() {
+            validate_serialization(
+                &SpecifiedTranslate::Translate(
+                    LengthOrPercentage::zero()
+                ),
+                "translate(0px)"
+            );
+
+            validate_serialization(
+                &SpecifiedTranslate::Translate3D(
+                    LengthOrPercentage::Length(ViewportPercentage(ViewportPercentageLength::Vw(3.0))),
+                    LengthOrPercentage::zero(),
+                    Length::from_px(1.0)
+                ),
+                "translate3d(3vw, 0px, 1px)"
+            );
+
+            validate_serialization(
+                &SpecifiedTranslate::Translate3D(
+                    LengthOrPercentage::Length(ViewportPercentage(ViewportPercentageLength::Vw(3.0))),
+                    LengthOrPercentage::zero(),
+                    Length::from_px(1.0)
+                ),
+                "translate3d(3vw, 0px, 1px)"
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -→
Added serialization for CSS transform functions [as per spec](https://drafts.csswg.org/css-transforms/#serialization-of-transform-functions). I added or modified data structures to hold the specified grammar needed to emit the serialization.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15194 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15508)
<!-- Reviewable:end -->
