### PR TITLE
stylo: Remove useless traverse_subtree call warning.

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -140,7 +140,6 @@ fn traverse_subtree(element: GeckoElement, raw_data: RawServoStyleSetBorrowed,
 
     let token = RecalcStyleOnly::pre_traverse(element, &per_doc_data.stylist, unstyled_children_only);
     if !token.should_traverse() {
-        error!("Unnecessary call to traverse_subtree");
         return;
     }
 


### PR DESCRIPTION
This warning isn't useful now that we call into traverse_subtree to do the check of the dirty bits, rather than checking them up on the Gecko side.  The crashtest job is currently failing in part due to the log file exceeding 50MB because of this warning.

r? @bholley

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15509)
<!-- Reviewable:end -->
