### PR TITLE
Rewrite TextEncoder::Encode to use typed array API. Fixes #15504

### DIFF
--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -14,8 +14,7 @@ use encoding::EncoderTrap;
 use encoding::Encoding;
 use encoding::all::UTF_8;
 use js::jsapi::{JSContext, JSObject};
-use js::jsapi::{JS_GetUint8ArrayData, JS_NewUint8Array};
-use libc::uint8_t;
+use js::typedarray::Uint8Array;
 use std::ptr;
 
 #[dom_struct]
@@ -52,13 +51,10 @@ impl TextEncoderMethods for TextEncoder {
     // https://encoding.spec.whatwg.org/#dom-textencoder-encode
     unsafe fn Encode(&self, cx: *mut JSContext, input: USVString) -> NonZero<*mut JSObject> {
         let encoded = UTF_8.encode(&input.0, EncoderTrap::Strict).unwrap();
-        let length = encoded.len() as u32;
-        rooted!(in(cx) let js_object = JS_NewUint8Array(cx, length));
-        assert!(!js_object.is_null());
-        let mut is_shared = false;
-        let js_object_data: *mut uint8_t = JS_GetUint8ArrayData(js_object.get(), &mut is_shared, ptr::null());
-        assert!(!is_shared);
-        ptr::copy_nonoverlapping(encoded.as_ptr(), js_object_data, length as usize);
+
+        rooted!(in(cx) let mut js_object = ptr::null_mut());
+        assert!(Uint8Array::create(cx, encoded.len() as u32, Some(encoded.as_slice()), js_object.handle_mut()).is_ok());
+
         NonZero::new(js_object.get())
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Rewrite TextEncoder::Encode to use typed array API. Fixes #15504

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15504 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the existing tests ensure the behaviour has not changed - `./mach test-wpt tests/wpt/web-platform-tests/encoding`

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15510)
<!-- Reviewable:end -->
