### PR TITLE
Fix fmt::Display vs fmt::Debug URL

### DIFF
--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -177,7 +177,7 @@ Use `RUST_BACKTRACE=1` to dump the backtrace when Servo panics.
 
 ### println!()
 
-You will want to add your own logs. Luckily, many structures [implement the `fmt::Debug` trait](https://doc.rust-lang.org/std/fmt/#fmt::display-vs-fmt::debug), so adding:
+You will want to add your own logs. Luckily, many structures [implement the `fmt::Debug` trait](https://doc.rust-lang.org/std/fmt/#fmtdisplay-vs-fmtdebug), so adding:
 
 ``` rust
 println!("foobar: {:?}", foobar)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed a Rust documentation link in [`HACKING_QUICKSTART.md`](https://github.com/servo/servo/blob/44e808b5cfd6756a5fb44951575035bf9451932c/docs/HACKING_QUICKSTART.md)
---
The link to Rust's documentation comparing `fmt::Display` and `fmt::Debug` no longer points to the right section of the page.

- [x] These changes do not require tests because it's simply changing a URL in the documentation.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15511)
<!-- Reviewable:end -->
