### PR TITLE
stylo: align RESTYLE_STYLE_ATTRIBUTE value with eRestyle_StyleAttribute

### DIFF
--- a/components/style/restyle_hints.rs
+++ b/components/style/restyle_hints.rs
@@ -29,6 +29,11 @@ bitflags! {
     /// id, class, and attribute selectors. Doing this conservatively is
     /// expensive, and so we use RestyleHints to short-circuit work we know is
     /// unnecessary.
+    ///
+    /// Note that the bit values here must be kept in sync with the Gecko
+    /// nsRestyleHint values.  If you add more bits with matching values,
+    /// please add assertions to assert_restyle_hints_match in
+    /// tests/unit/stylo/sanity_checks.rs.
     pub flags RestyleHint: u32 {
         /// Rerun selector matching on the element.
         const RESTYLE_SELF = 0x01,
@@ -46,7 +51,7 @@ bitflags! {
         /// Don't re-run selector-matching on the element, only the style
         /// attribute has changed, and this change didn't have any other
         /// dependencies.
-        const RESTYLE_STYLE_ATTRIBUTE = 0x10,
+        const RESTYLE_STYLE_ATTRIBUTE = 0x80,
     }
 }
 

--- a/tests/unit/stylo/sanity_checks.rs
+++ b/tests/unit/stylo/sanity_checks.rs
@@ -32,15 +32,31 @@ fn assert_restyle_hints_match() {
     use style::restyle_hints::*; // For flags
     use style::gecko_bindings::structs;
 
-    check_enum_value_non_static!(structs::nsRestyleHint_eRestyle_Self, RESTYLE_SELF.bits());
-    // XXX This for Servo actually means something like an hypothetical
-    // Restyle_AllDescendants (but without running selector matching on the
-    // element). ServoRestyleManager interprets it like that, but in practice we
-    // should align the behavior with Gecko adding a new restyle hint, maybe?
-    //
-    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1291786
-    check_enum_value_non_static!(structs::nsRestyleHint_eRestyle_SomeDescendants, RESTYLE_DESCENDANTS.bits());
-    check_enum_value_non_static!(structs::nsRestyleHint_eRestyle_LaterSiblings, RESTYLE_LATER_SIBLINGS.bits());
+    macro_rules! check_restyle_hints {
+        ( $( $a:ident => $b:ident ),*, ) => {
+            {
+                let mut hints = RestyleHint::all();
+                $(
+                    check_enum_value_non_static!(structs::$a, $b.bits());
+                    hints.remove($b);
+                )*
+                assert_eq!(hints, RestyleHint::empty(), "all RestyleHint bits should have an assertion");
+            }
+        }
+    }
+
+    check_restyle_hints! {
+        nsRestyleHint_eRestyle_Self => RESTYLE_SELF,
+        // XXX This for Servo actually means something like an hypothetical
+        // Restyle_AllDescendants (but without running selector matching on the
+        // element). ServoRestyleManager interprets it like that, but in practice we
+        // should align the behavior with Gecko adding a new restyle hint, maybe?
+        //
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1291786
+        nsRestyleHint_eRestyle_SomeDescendants => RESTYLE_DESCENDANTS,
+        nsRestyleHint_eRestyle_LaterSiblings => RESTYLE_LATER_SIBLINGS,
+        nsRestyleHint_eRestyle_StyleAttribute => RESTYLE_STYLE_ATTRIBUTE,
+    }
 }
 
 // Note that we can't call each_pseudo_element, parse_pseudo_element, or


### PR DESCRIPTION
This is the Servo-side part of https://bugzilla.mozilla.org/show_bug.cgi?id=1338461, which @bholley reviewed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15523)
<!-- Reviewable:end -->
