### PR TITLE
stylo: Drop Servo_RestyleWithAddedDeclaration

### DIFF
--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1272,14 +1272,6 @@ extern "C" {
      -> RawServoDeclarationBlockStrong;
 }
 extern "C" {
-    pub fn Servo_RestyleWithAddedDeclaration(set: RawServoStyleSetBorrowed,
-                                             declarations:
-                                                 RawServoDeclarationBlockBorrowed,
-                                             previous_style:
-                                                 ServoComputedValuesBorrowed)
-     -> ServoComputedValuesStrong;
-}
-extern "C" {
     pub fn Servo_AnimationValues_Populate(arg1:
                                               RawGeckoAnimationValueListBorrowedMut,
                                           arg2:


### PR DESCRIPTION
This is the servo-side change for [bug 1338087](https://bugzilla.mozilla.org/show_bug.cgi?id=1338087). r=@Manishearth

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] `./mach test-stylo` does not report any errors
- [X] These changes fix [bug 1338087](https://bugzilla.mozilla.org/show_bug.cgi?id=1338087).
- [X] These changes do not require tests because there are existing tests for this in mozilla-central

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15524)
<!-- Reviewable:end -->
