### PR TITLE
Reorder startNotifications steps

### DIFF
--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -886,7 +886,7 @@ impl BluetoothManager {
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-startnotifications
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-stopnotifications
     fn enable_notification(&mut self, id: String, enable: bool) -> BluetoothResponseResult {
-        // (StartNotifications) Step 2 - 3.
+        // (StartNotifications) Step 3 - 4.
         // (StopNotifications) Step 1 - 2.
         if !self.characteristic_is_cached(&id) {
             return Err(BluetoothError::InvalidState);
@@ -909,11 +909,11 @@ impl BluetoothManager {
                     // (StopNotification)  Step 5.
                     Ok(_) => return Ok(BluetoothResponse::EnableNotification(())),
 
-                    // (StartNotification) Step 4.
+                    // (StartNotification) Step 5.
                     Err(_) => return Err(BluetoothError::NotSupported),
                 }
             },
-            // (StartNotification) Step 3.
+            // (StartNotification) Step 4.
             None => return Err(BluetoothError::InvalidState),
         }
     }

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -209,22 +209,22 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
             return p;
         }
 
-        // Step 4.
+        // Step 2.
+        if !self.Service().Device().Gatt().Connected() {
+            p.reject_error(p_cx, Network);
+            return p;
+        }
+
+        // Step 5.
         if !(self.Properties().Notify() ||
              self.Properties().Indicate()) {
             p.reject_error(p_cx, NotSupported);
             return p;
         }
 
-        // TODO: Step 5: Implement `active notification context set` for BluetoothRemoteGATTCharacteristic.
+        // TODO: Step 6: Implement `active notification context set` for BluetoothRemoteGATTCharacteristic.
 
-        // Step 6.
-        if !self.Service().Device().Gatt().Connected() {
-            p.reject_error(p_cx, Network);
-            return p;
-        }
-
-        // Note: Steps 2 - 3, 7 - 11 are implemented in components/bluetooth/lib.rs in enable_notification function
+        // Note: Steps 3 - 4, 7 - 11 are implemented in components/bluetooth/lib.rs in enable_notification function
         // and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
https://github.com/WebBluetoothCG/web-bluetooth/pull/355 changed the step order in startNotifications.
The connection check is now Step 2 instead of Step 6.
Link for the current spec state: https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-startnotifications
Step annotations are also updated for this function.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15525)
<!-- Reviewable:end -->
