### PR TITLE
Make HTMLOptionsCollection constructor accept a HTMLSelectElement argument. Fixes #15521

### DIFF
--- a/components/script/dom/htmloptionscollection.rs
+++ b/components/script/dom/htmloptionscollection.rs
@@ -16,6 +16,7 @@ use dom::bindings::str::DOMString;
 use dom::element::Element;
 use dom::htmlcollection::{CollectionFilter, HTMLCollection};
 use dom::htmloptionelement::HTMLOptionElement;
+use dom::htmlselectelement::HTMLSelectElement;
 use dom::node::{document_from_node, Node};
 use dom::window::Window;
 
@@ -25,16 +26,16 @@ pub struct HTMLOptionsCollection {
 }
 
 impl HTMLOptionsCollection {
-    fn new_inherited(root: &Node, filter: Box<CollectionFilter + 'static>) -> HTMLOptionsCollection {
+    fn new_inherited(select: &HTMLSelectElement, filter: Box<CollectionFilter + 'static>) -> HTMLOptionsCollection {
         HTMLOptionsCollection {
-            collection: HTMLCollection::new_inherited(root, filter),
+            collection: HTMLCollection::new_inherited(select.upcast(), filter),
         }
     }
 
-    pub fn new(window: &Window, root: &Node, filter: Box<CollectionFilter + 'static>)
+    pub fn new(window: &Window, select: &HTMLSelectElement, filter: Box<CollectionFilter + 'static>)
         -> Root<HTMLOptionsCollection>
     {
-        reflect_dom_object(box HTMLOptionsCollection::new_inherited(root, filter),
+        reflect_dom_object(box HTMLOptionsCollection::new_inherited(select, filter),
                            window,
                            HTMLOptionsCollectionBinding::Wrap)
     }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -243,7 +243,7 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
         self.options.or_init(|| {
             let window = window_from_node(self);
             HTMLOptionsCollection::new(
-                &window, self.upcast(), box OptionsFilter)
+                &window, self, box OptionsFilter)
         })
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Moves the `HTMLSelectElement.upcast()` call into the `HTMLOptionsCollection` constructors, replacing their signatures with `&HTMLSelectElement` references. This limits the surface area for misuse by only allowing `HTMLSelectElement` instances to be passed in rather than `Node` instances.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15521.

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because: the linked issue explicitly says building without errors is good enough.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15527)
<!-- Reviewable:end -->
