### PR TITLE
Avoid deduplicate property declarations when unnecessary

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -180,7 +180,8 @@ pub mod animated_properties {
 
 // TODO(SimonSapin): Convert this to a syntax extension rather than a Mako template.
 // Maybe submit for inclusion in libstd?
-mod property_bit_field {
+#[allow(missing_docs)]
+pub mod property_bit_field {
     use logical_geometry::WritingMode;
 
     /// A bitfield for all longhand properties, in order to quickly test whether
@@ -342,7 +343,7 @@ mod property_bit_field {
 /// any given property, by importance then source order.
 ///
 /// The input and output are in source order
-fn deduplicate_property_declarations(block: &mut PropertyDeclarationBlock) {
+pub fn deduplicate_property_declarations(block: &mut PropertyDeclarationBlock) {
     let mut deduplicated = Vec::with_capacity(block.declarations.len());
     let mut seen_normal = PropertyBitField::new();
     let mut seen_important = PropertyBitField::new();
@@ -1024,10 +1025,12 @@ impl PropertyDeclaration {
     /// we only set them here so that we don't have to reallocate
     pub fn parse(id: PropertyId, context: &ParserContext, input: &mut Parser,
                  result_list: &mut Vec<(PropertyDeclaration, Importance)>,
+                 properties_seen: &mut PropertyBitField, possibly_duplicated: &mut bool,
                  in_keyframe_block: bool)
                  -> PropertyDeclarationParseResult {
         match id {
             PropertyId::Custom(name) => {
+                *possibly_duplicated = true;
                 let value = match input.try(|i| CSSWideKeyword::parse(context, i)) {
                     Ok(CSSWideKeyword::UnsetKeyword) => DeclaredValue::Unset,
                     Ok(CSSWideKeyword::InheritKeyword) => DeclaredValue::Inherit,
@@ -1060,6 +1063,8 @@ impl PropertyDeclaration {
 
                         match longhands::${property.ident}::parse_declared(context, input) {
                             Ok(value) => {
+                                *possibly_duplicated |= properties_seen.get_${property.ident}();
+                                properties_seen.set_${property.ident}();
                                 result_list.push((PropertyDeclaration::${property.camel_case}(value),
                                                   Importance::Normal));
                                 PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
@@ -1091,6 +1096,8 @@ impl PropertyDeclaration {
                     match input.try(|i| CSSWideKeyword::parse(context, i)) {
                         Ok(CSSWideKeyword::InheritKeyword) => {
                             % for sub_property in shorthand.sub_properties:
+                                *possibly_duplicated |= properties_seen.get_${sub_property.ident}();
+                                properties_seen.set_${sub_property.ident}();
                                 result_list.push((
                                     PropertyDeclaration::${sub_property.camel_case}(
                                         DeclaredValue::Inherit), Importance::Normal));
@@ -1099,6 +1106,8 @@ impl PropertyDeclaration {
                         },
                         Ok(CSSWideKeyword::InitialKeyword) => {
                             % for sub_property in shorthand.sub_properties:
+                                *possibly_duplicated |= properties_seen.get_${sub_property.ident}();
+                                properties_seen.set_${sub_property.ident}();
                                 result_list.push((
                                     PropertyDeclaration::${sub_property.camel_case}(
                                         DeclaredValue::Initial), Importance::Normal));
@@ -1107,13 +1116,21 @@ impl PropertyDeclaration {
                         },
                         Ok(CSSWideKeyword::UnsetKeyword) => {
                             % for sub_property in shorthand.sub_properties:
+                                *possibly_duplicated |= properties_seen.get_${sub_property.ident}();
+                                properties_seen.set_${sub_property.ident}();
                                 result_list.push((PropertyDeclaration::${sub_property.camel_case}(
                                         DeclaredValue::Unset), Importance::Normal));
                             % endfor
                             PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
                         },
                         Err(()) => match shorthands::${shorthand.ident}::parse(context, input, result_list) {
-                            Ok(()) => PropertyDeclarationParseResult::ValidOrIgnoredDeclaration,
+                            Ok(()) => {
+                                % for sub_property in shorthand.sub_properties:
+                                    *possibly_duplicated |= properties_seen.get_${sub_property.ident}();
+                                    properties_seen.set_${sub_property.ident}();
+                                % endfor
+                                PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
+                            },
                             Err(()) => PropertyDeclarationParseResult::InvalidValue,
                         }
                     }

--- a/components/style/supports.rs
+++ b/components/style/supports.rs
@@ -7,6 +7,7 @@
 use cssparser::{parse_important, Parser, Token};
 use parser::ParserContext;
 use properties::{PropertyDeclaration, PropertyId};
+use properties::property_bit_field::PropertyBitField;
 use std::fmt;
 use style_traits::ToCss;
 
@@ -213,8 +214,11 @@ impl Declaration {
         };
         let mut input = Parser::new(&self.val);
         let mut list = Vec::new();
+        let mut properties_seen = PropertyBitField::new();
+        let mut possibly_duplicated = false;
         let res = PropertyDeclaration::parse(id, cx, &mut input,
-                                             &mut list, /* in_keyframe */ false);
+                                             &mut list, &mut properties_seen, &mut possibly_duplicated,
+                                             /* in_keyframe */ false);
         let _ = input.try(parse_important);
         if !input.is_exhausted() {
             return false;

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -68,6 +68,7 @@ use style::properties::{ComputedValues, Importance, PropertyDeclaration};
 use style::properties::{PropertyDeclarationParseResult, PropertyDeclarationBlock, PropertyId};
 use style::properties::animated_properties::{AnimationValue, Interpolate, TransitionProperty};
 use style::properties::parse_one_declaration;
+use style::properties::property_bit_field::PropertyBitField;
 use style::restyle_hints::{self, RestyleHint};
 use style::selector_parser::PseudoElementCascadeType;
 use style::sequential;
@@ -776,7 +777,8 @@ pub extern "C" fn Servo_ParseProperty(property: *const nsACString, value: *const
 
     let mut results = vec![];
     match PropertyDeclaration::parse(id, &context, &mut Parser::new(value),
-                                     &mut results, false) {
+                                     &mut results, &mut PropertyBitField::new(),
+                                     &mut false, false) {
         PropertyDeclarationParseResult::ValidOrIgnoredDeclaration => {},
         _ => return RawServoDeclarationBlockStrong::null(),
     }

--- a/tests/unit/style/properties/mod.rs
+++ b/tests/unit/style/properties/mod.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 mod background;
+mod parse;
 mod scaffolding;
 mod serialization;
 mod viewport;

--- a/tests/unit/style/properties/parse.rs
+++ b/tests/unit/style/properties/parse.rs
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub use cssparser::Parser;
+pub use media_queries::CSSErrorReporterTest;
+pub use servo_url::ServoUrl;
+pub use style::parser::ParserContext;
+pub use style::properties::{DeclaredValue, PropertyDeclaration, PropertyDeclarationBlock, Importance, PropertyId};
+pub use style::properties::parse_property_declaration_list;
+pub use style::properties::property_bit_field::PropertyBitField;
+pub use style::stylesheets::Origin;
+pub use style::values::specified::{Length, NoCalcLength};
+pub use style::values::specified::LengthOrPercentageOrAuto;
+
+#[test]
+fn property_declaration_list_should_parse_and_deduplicate_correctly() {
+    let px_10 = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(10f32)));
+    let px_20 = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)));
+
+    let url = ServoUrl::parse("http://localhost").unwrap();
+    let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+
+    let mut parser = Parser::new("width: 20px !important; width: 10px; height: 20px; height: 10px;");
+
+    let block = parse_property_declaration_list(&context, &mut parser);
+
+    assert_eq!(
+        block,
+        PropertyDeclarationBlock {
+            declarations: vec![
+                (PropertyDeclaration::Width(px_20),
+                 Importance::Important),
+
+                (PropertyDeclaration::Height(px_10),
+                 Importance::Normal),
+            ],
+            important_count: 1,
+        }
+    );
+}
+
+#[test]
+fn property_declaration_parse_seen_before_should_set_flag() {
+    let mut results = vec![];
+    let mut possibly_duplicated = false;
+    let mut seen_properties = PropertyBitField::new();
+    let url = ServoUrl::parse("http://localhost").unwrap();
+    let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+
+    let mut parser = Parser::new("initial");
+    let id = PropertyId::parse("width".into()).unwrap();
+    seen_properties.set_width();
+
+    PropertyDeclaration::parse(id, &context, &mut parser, &mut results, &mut seen_properties,
+                               &mut possibly_duplicated, false);
+
+    assert_eq!(true, possibly_duplicated);
+}
+
+#[test]
+fn property_declaration_parse_custom_should_set_flag() {
+    let mut results = vec![];
+    let mut possibly_duplicated = false;
+    let mut seen_properties = PropertyBitField::new();
+    let url = ServoUrl::parse("http://localhost").unwrap();
+    let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+
+    let mut parser = Parser::new("initial");
+    let id = PropertyId::parse("--custom-property".into()).unwrap();
+
+    PropertyDeclaration::parse(id, &context, &mut parser, &mut results, &mut seen_properties,
+                               &mut possibly_duplicated, false);
+
+    assert_eq!(true, possibly_duplicated);
+}
+
+#[test]
+fn property_declaration_parse_shorthand_wide_should_mark_subproperties() {
+    let mut results = vec![];
+    let mut possibly_duplicated = false;
+    let mut seen_properties = PropertyBitField::new();
+    let url = ServoUrl::parse("http://localhost").unwrap();
+    let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+
+    let mut parser = Parser::new("initial");
+    let id = PropertyId::parse("border-color".into()).unwrap();
+
+    PropertyDeclaration::parse(id, &context, &mut parser, &mut results, &mut seen_properties,
+                               &mut possibly_duplicated, false);
+
+    assert_eq!(true, seen_properties.get_border_top_color());
+    assert_eq!(true, seen_properties.get_border_right_color());
+    assert_eq!(true, seen_properties.get_border_bottom_color());
+    assert_eq!(true, seen_properties.get_border_left_color());
+}
+
+#[test]
+fn property_declaration_parse_shorthand_should_mark_subproperties() {
+    let mut results = vec![];
+    let mut possibly_duplicated = false;
+    let mut seen_properties = PropertyBitField::new();
+    let url = ServoUrl::parse("http://localhost").unwrap();
+    let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+
+    let mut parser = Parser::new("#000");
+    let id = PropertyId::parse("border-color".into()).unwrap();
+
+    PropertyDeclaration::parse(id, &context, &mut parser, &mut results, &mut seen_properties,
+                               &mut possibly_duplicated, false);
+
+    assert_eq!(true, seen_properties.get_border_top_color());
+    assert_eq!(true, seen_properties.get_border_right_color());
+    assert_eq!(true, seen_properties.get_border_bottom_color());
+    assert_eq!(true, seen_properties.get_border_left_color());
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Added a `PropertyBitField` and a bool to `PropertyDeclaration::parse()` to detect possible duplicates.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15320 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15531)
<!-- Reviewable:end -->
