### PR TITLE
style: add missing semicolons for bindgen on BSDs and Solaris

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -137,15 +137,15 @@ mod bindings {
             if cfg!(target_os = "linux") {
                 builder = builder.clang_arg("-DOS_LINUX=1");
             } else if cfg!(target_os = "solaris") {
-                builder = builder.clang_arg("-DOS_SOLARIS=1")
+                builder = builder.clang_arg("-DOS_SOLARIS=1");
             } else if cfg!(target_os = "dragonfly") {
-                builder = builder.clang_arg("-DOS_BSD=1").clang_arg("-DOS_DRAGONFLY=1")
+                builder = builder.clang_arg("-DOS_BSD=1").clang_arg("-DOS_DRAGONFLY=1");
             } else if cfg!(target_os = "freebsd") {
-                builder = builder.clang_arg("-DOS_BSD=1").clang_arg("-DOS_FREEBSD=1")
+                builder = builder.clang_arg("-DOS_BSD=1").clang_arg("-DOS_FREEBSD=1");
             } else if cfg!(target_os = "netbsd") {
-                builder = builder.clang_arg("-DOS_BSD=1").clang_arg("-DOS_NETBSD=1")
+                builder = builder.clang_arg("-DOS_BSD=1").clang_arg("-DOS_NETBSD=1");
             } else if cfg!(target_os = "openbsd") {
-                builder = builder.clang_arg("-DOS_BSD=1").clang_arg("-DOS_OPENBSD=1")
+                builder = builder.clang_arg("-DOS_BSD=1").clang_arg("-DOS_OPENBSD=1");
             } else if cfg!(target_os = "macos") {
                 builder = builder.clang_arg("-DOS_MACOSX=1")
                     .clang_arg("-stdlib=libc++")


### PR DESCRIPTION
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix a typo in #15529
- [x] These changes do not require tests because Tier3 support is incomplete

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15534)
<!-- Reviewable:end -->
