### PR TITLE
Do RestyleHint assertions at runtime so they use build-time bindgen.

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -68,7 +68,7 @@ use style::properties::{ComputedValues, Importance, PropertyDeclaration};
 use style::properties::{PropertyDeclarationParseResult, PropertyDeclarationBlock, PropertyId};
 use style::properties::animated_properties::{AnimationValue, Interpolate, TransitionProperty};
 use style::properties::parse_one_declaration;
-use style::restyle_hints::RestyleHint;
+use style::restyle_hints::{self, RestyleHint};
 use style::selector_parser::PseudoElementCascadeType;
 use style::sequential;
 use style::string_cache::Atom;
@@ -98,6 +98,9 @@ pub extern "C" fn Servo_Initialize() -> () {
 
     // Pretend that we're a Servo Layout thread, to make some assertions happy.
     thread_state::initialize(thread_state::LAYOUT);
+
+    // Perform some debug-only runtime assertions.
+    restyle_hints::assert_restyle_hints_match();
 }
 
 #[no_mangle]

--- a/tests/unit/stylo/sanity_checks.rs
+++ b/tests/unit/stylo/sanity_checks.rs
@@ -27,38 +27,6 @@ macro_rules! check_enum_value_non_static {
     }
 }
 
-#[test]
-fn assert_restyle_hints_match() {
-    use style::restyle_hints::*; // For flags
-    use style::gecko_bindings::structs;
-
-    macro_rules! check_restyle_hints {
-        ( $( $a:ident => $b:ident ),*, ) => {
-            {
-                let mut hints = RestyleHint::all();
-                $(
-                    check_enum_value_non_static!(structs::$a, $b.bits());
-                    hints.remove($b);
-                )*
-                assert_eq!(hints, RestyleHint::empty(), "all RestyleHint bits should have an assertion");
-            }
-        }
-    }
-
-    check_restyle_hints! {
-        nsRestyleHint_eRestyle_Self => RESTYLE_SELF,
-        // XXX This for Servo actually means something like an hypothetical
-        // Restyle_AllDescendants (but without running selector matching on the
-        // element). ServoRestyleManager interprets it like that, but in practice we
-        // should align the behavior with Gecko adding a new restyle hint, maybe?
-        //
-        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1291786
-        nsRestyleHint_eRestyle_SomeDescendants => RESTYLE_DESCENDANTS,
-        nsRestyleHint_eRestyle_LaterSiblings => RESTYLE_LATER_SIBLINGS,
-        nsRestyleHint_eRestyle_StyleAttribute => RESTYLE_STYLE_ATTRIBUTE,
-    }
-}
-
 // Note that we can't call each_pseudo_element, parse_pseudo_element, or
 // similar, because we'd need the foreign atom symbols to link.
 #[test]


### PR DESCRIPTION
Currently these assertions work off the in-tree bindings.

r? @bholley

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15538)
<!-- Reviewable:end -->
