### PR TITLE
Add rejection of out-of-range values for single-timing-functions

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -594,6 +594,10 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
                             p2y = try!(specified::parse_number(input));
                             Ok(())
                         }));
+                        if p1x < 0.0 || p1x > 1.0 || p2x < 0.0 || p2x > 1.0 {
+                            return Err(())
+                        }
+
                         let (p1, p2) = (Point2D::new(p1x, p1y), Point2D::new(p2x, p2y));
                         Ok(SpecifiedValue::CubicBezier(p1, p2))
                     },
@@ -601,6 +605,10 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
                         let (mut step_count, mut start_end) = (0, StartEnd::End);
                         try!(input.parse_nested_block(|input| {
                             step_count = try!(specified::parse_integer(input));
+                            if step_count < 1 {
+                                return Err(())
+                            }
+
                             if input.try(|input| input.expect_comma()).is_ok() {
                                 start_end = try!(match_ignore_ascii_case! {
                                     try!(input.expect_ident()),

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -80,3 +80,4 @@ mod position;
 mod selectors;
 mod supports;
 mod text_overflow;
+mod transition_timing_function;

--- a/tests/unit/style/parsing/transition_timing_function.rs
+++ b/tests/unit/style/parsing/transition_timing_function.rs
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use cssparser::Parser;
+use media_queries::CSSErrorReporterTest;
+use parsing::parse;
+use style::parser::ParserContext;
+use style::properties::longhands::transition_timing_function;
+use style::stylesheets::Origin;
+use style_traits::ToCss;
+
+#[test]
+fn test_cubic_bezier() {
+    assert_roundtrip_with_context!(transition_timing_function::parse, "cubic-bezier(0, 0, 0, 0)");
+    assert_roundtrip_with_context!(transition_timing_function::parse, "cubic-bezier(0.25, 0, 0.5, 0)");
+    assert_roundtrip_with_context!(transition_timing_function::parse, "cubic-bezier(1, 1, 1, 1)");
+
+    // p1x and p2x values must be in range [0, 1]
+    assert!(parse(transition_timing_function::parse, "cubic-bezier(-1, 0, 0, 0").is_err());
+    assert!(parse(transition_timing_function::parse, "cubic-bezier(0, 0, -1, 0").is_err());
+    assert!(parse(transition_timing_function::parse, "cubic-bezier(-1, 0, -1, 0").is_err());
+
+    assert!(parse(transition_timing_function::parse, "cubic-bezier(2, 0, 0, 0").is_err());
+    assert!(parse(transition_timing_function::parse, "cubic-bezier(0, 0, 2, 0").is_err());
+    assert!(parse(transition_timing_function::parse, "cubic-bezier(2, 0, 2, 0").is_err());
+}
+
+#[test]
+fn test_steps() {
+    assert_roundtrip_with_context!(transition_timing_function::parse, "steps(1)");
+
+    // Step interval value must be an integer greater than 0
+    assert!(parse(transition_timing_function::parse, "steps(0)").is_err());
+    assert!(parse(transition_timing_function::parse, "steps(0.5)").is_err());
+    assert!(parse(transition_timing_function::parse, "steps(-1)").is_err());
+}

--- a/tests/wpt/metadata-css/css-transitions-1_dev/html/transition-timing-function-001.htm.ini
+++ b/tests/wpt/metadata-css/css-transitions-1_dev/html/transition-timing-function-001.htm.ini
@@ -1,8 +1,0 @@
-[transition-timing-function-001.htm]
-  type: testharness
-  [parse 'cubic-bezier(-0.1, -0.2, -0.3, -0.4)']
-    expected: FAIL
-
-  [parse 'cubic-bezier(1.1, 1.2, 1.3, 1.4)']
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR fixes #15344, checking for the `cubic-bezier p1x/p2x` and `steps` first value after parsing. 

There are unit tests that check for parsing of invalid values - I was not sure if there was a more suitable place, so I created a file (name subject to change).

Q: I found this [test suite](https://github.com/servo/servo/blob/master/tests/unit/style/properties/serialization.rs#L592), and noticed that the `p2x` value is out of range, but the test does not fail - is this because there is no check when calling the function itself?

Thanks!

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15344

<!-- Either: -->
- [X] There are tests for these changes 

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15539)
<!-- Reviewable:end -->
