### PR TITLE
fixes quote transform: none serialization

### DIFF
--- a/components/style/properties/longhand/list.mako.rs
+++ b/components/style/properties/longhand/list.mako.rs
@@ -54,6 +54,10 @@ ${helpers.predefined_type("list-style-image", "UrlOrNone", "Either::Second(None_
 
     impl ToCss for SpecifiedValue {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            if self.0.is_empty() {
+                return dest.write_str("none")
+            }
+
             let mut first = true;
             for pair in &self.0 {
                 if !first {

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -1114,4 +1114,28 @@ mod shorthand_serialization {
             assert_eq!(s, "none");
         }
     }
+
+    mod quotes {
+        pub use super::*;
+
+        #[test]
+        fn should_serialize_none_correctly() {
+            use cssparser::Parser;
+            use media_queries::CSSErrorReporterTest;
+            use style::parser::ParserContext;
+            use style::properties::longhands::quotes;
+            use style::stylesheets::Origin;
+
+            let mut s = String::new();
+            let url = ::servo_url::ServoUrl::parse("http://localhost").unwrap();
+            let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+
+            let parsed = quotes::parse(&context, &mut Parser::new("none")).unwrap();
+            let try_serialize = parsed.to_css(&mut s);
+
+            assert_eq!(try_serialize.is_ok(), true);
+            assert_eq!(s, "none");
+        }
+
+    }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Adds a unit test to reproduce faulty behaviour, and serializes "none" correctly when provided an empty list.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15209 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15546)
<!-- Reviewable:end -->
