### PR TITLE
stylo: various fixes to improve style logging in opt builds

### DIFF
--- a/components/style/parallel.rs
+++ b/components/style/parallel.rs
@@ -27,6 +27,7 @@ use dom::{OpaqueNode, SendNode, TElement, TNode};
 use rayon;
 use scoped_tls::ScopedTLS;
 use std::borrow::Borrow;
+use time;
 use traversal::{DomTraversal, PerLevelTraversalData, PreTraverseToken};
 
 /// The chunk size used to split the parallel traversal nodes.
@@ -44,6 +45,9 @@ pub fn traverse_dom<E, D>(traversal: &D,
     where E: TElement,
           D: DomTraversal<E>,
 {
+    let dump_stats = TraversalStatistics::should_dump();
+    let start_time = if dump_stats { Some(time::precise_time_s()) } else { None };
+
     debug_assert!(traversal.is_parallel());
     // Handle Gecko's eager initial styling. We don't currently support it
     // in conjunction with bottom-up traversal. If we did, we'd need to put
@@ -74,14 +78,15 @@ pub fn traverse_dom<E, D>(traversal: &D,
     });
 
     // Dump statistics to stdout if requested.
-    if TraversalStatistics::should_dump() {
+    if dump_stats {
         let slots = unsafe { tls.unsafe_get() };
-        let aggregate = slots.iter().fold(TraversalStatistics::default(), |acc, t| {
+        let mut aggregate = slots.iter().fold(TraversalStatistics::default(), |acc, t| {
             match *t.borrow() {
                 None => acc,
                 Some(ref cx) => &cx.borrow().statistics + &acc,
             }
         });
+        aggregate.compute_traversal_time(start_time.unwrap());
         println!("{}", aggregate);
     }
 }

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -610,15 +610,11 @@ impl ${style_struct.gecko_struct_name} {
     % for longhand in stub_longhands:
     #[allow(non_snake_case)]
     pub fn set_${longhand.ident}(&mut self, _: longhands::${longhand.ident}::computed_value::T) {
-        if cfg!(debug_assertions) {
-            println!("stylo: Unimplemented property setter: ${longhand.name}");
-        }
+        warn!("stylo: Unimplemented property setter: ${longhand.name}");
     }
     #[allow(non_snake_case)]
     pub fn copy_${longhand.ident}_from(&mut self, _: &Self) {
-        if cfg!(debug_assertions) {
-            println!("stylo: Unimplemented property setter: ${longhand.name}");
-        }
+        warn!("stylo: Unimplemented property setter: ${longhand.name}");
     }
     % if longhand.need_clone:
     #[allow(non_snake_case)]
@@ -2628,7 +2624,7 @@ clip-path
         clip_path.mType = StyleShapeSourceType::None;
 
         match v {
-            ShapeSource::Url(..) => println!("stylo: clip-path: url() not yet implemented"),
+            ShapeSource::Url(..) => warn!("stylo: clip-path: url() not yet implemented"),
             ShapeSource::None => {} // don't change the type
             ShapeSource::Box(reference) => {
                 clip_path.mReferenceBox = reference.into();

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -119,7 +119,7 @@
                         % if allow_empty:
                             try!(dest.write_str("none"));
                         % else:
-                            error!("Found empty value for property ${name}");
+                            warn!("Found empty value for property ${name}");
                         % endif
                     }
                     for i in iter {
@@ -146,7 +146,7 @@
                         % if allow_empty:
                             try!(dest.write_str("none"));
                         % else:
-                            error!("Found empty value for property ${name}");
+                            warn!("Found empty value for property ${name}");
                         % endif
                     }
                     for i in iter {

--- a/components/style/restyle_hints.rs
+++ b/components/style/restyle_hints.rs
@@ -103,7 +103,7 @@ impl From<nsRestyleHint> for RestyleHint {
         // FIXME(bholley): Finish aligning the binary representations here and
         // then .expect() the result of the checked version.
         if Self::from_bits(raw_bits).is_none() {
-            error!("stylo: dropping unsupported restyle hint bits");
+            warn!("stylo: dropping unsupported restyle hint bits");
         }
 
         Self::from_bits_truncate(raw_bits)

--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -471,7 +471,7 @@ impl RuleNode {
             }
             None => {
                 if indent != 0 {
-                    error!("How has this happened?");
+                    warn!("How has this happened?");
                 }
                 let _ = write!(writer, "(root)");
             }

--- a/components/style/values/specified/url.rs
+++ b/components/style/values/specified/url.rs
@@ -101,7 +101,7 @@ impl SpecifiedUrl {
                 // FIXME(heycam) should ensure we always have a principal, etc.,
                 // when parsing style attributes and re-parsing due to CSS
                 // Variables.
-                println!("stylo: skipping declaration without ParserContextExtraData");
+                warn!("stylo: skipping declaration without ParserContextExtraData");
                 return Err(())
             },
         };


### PR DESCRIPTION
This adds a traversal time entry to the style statistics, and switches to warn! as discussed in [1].

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1339176

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15557)
<!-- Reviewable:end -->
