### PR TITLE
Disable LLVM assertions by default, on supported platforms

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -14,9 +14,9 @@ mac-rel-wpt2:
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --use-tracker
 
 mac-dev-unit:
-  - ./mach build --dev
-  - ./mach test-unit
-  - ./mach build-cef
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --dev
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach test-unit
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build-cef
   - ./mach build-geckolib
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
@@ -46,10 +46,10 @@ mac-rel-intermittent:
 linux-dev:
   - ./mach test-tidy --no-progress --all
   - ./mach test-tidy --no-progress --self-test
-  - ./mach build --dev
-  - ./mach test-compiletest
-  - ./mach test-unit
-  - ./mach build-cef
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --dev
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach test-compiletest
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach test-unit
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build-cef
   - ./mach build-geckolib
   - ./mach test-stylo
   - bash ./etc/ci/lockfile_changed.sh

--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -79,24 +79,24 @@ linux-nightly:
   - ./etc/ci/upload_nightly.sh linux
 
 android:
-  - ./mach build --android --dev
-  - ./mach package --android --dev
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --android --dev
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach package --android --dev
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
   - python ./etc/ci/check_dynamic_symbols.py
 
 android-nightly:
-  - ./mach build --android --release
-  - ./mach package --android --release
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --android --release
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach package --android --release
   - ./etc/ci/upload_nightly.sh android
 
 arm32:
-  - ./mach build --rel --target=arm-unknown-linux-gnueabihf
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --rel --target=arm-unknown-linux-gnueabihf
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 
 arm64:
-  - ./mach build --rel --target=aarch64-unknown-linux-gnu
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --rel --target=aarch64-unknown-linux-gnu
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -23,7 +23,7 @@ from mach.registrar import Registrar
 import toml
 
 from servo.packages import WINDOWS_MSVC as msvc_deps
-from servo.util import host_triple
+from servo.util import host_triple, host_platform
 
 BIN_SUFFIX = ".exe" if sys.platform == "win32" else ""
 
@@ -263,10 +263,15 @@ class CommandBase(object):
                 context.sharedir, "cargo", self.cargo_build_id())
         self.config["tools"].setdefault("rustc-with-gold", get_env_bool("SERVO_RUSTC_WITH_GOLD", True))
 
+        # https://github.com/rust-lang/rust/pull/39754
+        platforms_with_rustc_alt_builds = ["unknown-linux-gnu", "apple-darwin", "pc-windows-msvc"]
+        llvm_assertions_default = ("SERVO_RUSTC_LLVM_ASSERTIONS" in os.environ
+                                   or host_platform() not in platforms_with_rustc_alt_builds)
+
         self.config.setdefault("build", {})
         self.config["build"].setdefault("android", False)
         self.config["build"].setdefault("mode", "")
-        self.config["build"].setdefault("llvm-assertions", True)
+        self.config["build"].setdefault("llvm-assertions", llvm_assertions_default)
         self.config["build"].setdefault("debug-mozjs", False)
         self.config["build"].setdefault("ccache", "")
         self.config["build"].setdefault("rustflags", "")

--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -20,7 +20,7 @@ import zipfile
 import urllib2
 
 
-def host_triple():
+def host_platform():
     os_type = platform.system().lower()
     if os_type == "linux":
         os_type = "unknown-linux-gnu"
@@ -42,7 +42,11 @@ def host_triple():
         os_type = "unknown-freebsd"
     else:
         os_type = "unknown"
+    return os_type
 
+
+def host_triple():
+    os_type = host_platform()
     cpu_type = platform.machine().lower()
     if os_type.endswith("-msvc"):
         # vcvars*.bat should set it properly

--- a/servobuild.example
+++ b/servobuild.example
@@ -40,7 +40,7 @@ rustc-with-gold = true
 #mode = "dev"
 
 # Whether to enable LLVM assertions in rustc.
-#llvm-assertions = true
+#llvm-assertions = false
 
 # Set "android = true" or use `mach build --android` to build the Android app.
 android = false


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

https://github.com/servo/servo/pull/15559#issuecomment-280003926

> With an empty incremental compilation cache (or, presumably, with incremental compilation disabled), LLVM assertions add 16% to the compilation time in debug mode, 53% (!) in release mode.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15548 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15564)
<!-- Reviewable:end -->
