### PR TITLE
Fix #15513: Stop spacebar scrolling directly from the glutin window.

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -1042,8 +1042,7 @@ impl WindowMethods for Window {
                 self.event_queue.borrow_mut().push(WindowEvent::Navigation(WindowNavigateMsg::Back));
             }
 
-            (NONE, None, Key::PageDown) |
-            (NONE, Some(' '), _) => {
+            (NONE, None, Key::PageDown) => {
                let scroll_location = ScrollLocation::Delta(TypedPoint2D::new(0.0,
                                    -self.framebuffer_size()
                                         .to_f32()
@@ -1052,8 +1051,7 @@ impl WindowMethods for Window {
                 self.scroll_window(scroll_location,
                                    TouchEventType::Move);
             }
-            (NONE, None, Key::PageUp) |
-            (SHIFT, Some(' '), _) => {
+            (NONE, None, Key::PageUp) => {
                 let scroll_location = ScrollLocation::Delta(TypedPoint2D::new(0.0,
                                    self.framebuffer_size()
                                        .to_f32()


### PR DESCRIPTION
This completely removes spacebar scrolling using the current method, fixing #15513.

See #15513 for a discussion, as the _right thing to do_ is perhaps a UX problem - and perhaps worth a follow up.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15513.

No tests for these changes yet, as I'm just kicking off a discussion about how this should work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15568)
<!-- Reviewable:end -->
