### PR TITLE
stylo: Implement 'align-self' and 'justify-self'

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -864,7 +864,7 @@ fn static_assert() {
 <% skip_position_longhands = " ".join(x.ident for x in SIDES + GRID_LINES) %>
 <%self:impl_trait style_struct_name="Position"
                   skip_longhands="${skip_position_longhands} z-index box-sizing order align-content
-                                  justify-content">
+                                  justify-content align-self justify-self">
     % for side in SIDES:
     <% impl_split_style_coord("%s" % side.ident,
                               "mOffset",
@@ -913,6 +913,18 @@ fn static_assert() {
     }
 
     ${impl_simple_copy('justify_content', 'mJustifyContent')}
+
+    pub fn set_align_self(&mut self, v: longhands::align_self::computed_value::T) {
+        self.gecko.mAlignSelf = v.0.bits()
+    }
+
+    ${impl_simple_copy('align_self', 'mAlignSelf')}
+
+    pub fn set_justify_self(&mut self, v: longhands::justify_self::computed_value::T) {
+        self.gecko.mJustifySelf = v.0.bits()
+    }
+
+    ${impl_simple_copy('justify_self', 'mJustifySelf')}
 
     pub fn set_box_sizing(&mut self, v: longhands::box_sizing::computed_value::T) {
         use computed_values::box_sizing::T;

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -140,14 +140,27 @@ ${helpers.predefined_type("flex-shrink", "Number",
                           animatable=True)}
 
 // https://drafts.csswg.org/css-align/#align-self-property
-// FIXME: We don't support the Gecko value 'normal' yet.
-${helpers.single_keyword("align-self", "auto stretch flex-start flex-end center baseline",
-                         need_clone=True,
-                         extra_prefixes="webkit",
-                         extra_gecko_values="normal",
-                         gecko_constant_prefix="NS_STYLE_ALIGN",
-                         spec="https://drafts.csswg.org/css-flexbox/#propdef-align-self",
-                         animatable=False)}
+% if product == "servo":
+    // FIXME: Update Servo to support the same syntax as Gecko.
+    ${helpers.single_keyword("align-self", "auto stretch flex-start flex-end center baseline",
+                             need_clone=True,
+                             extra_prefixes="webkit",
+                             spec="https://drafts.csswg.org/css-flexbox/#propdef-align-self",
+                             animatable=False)}
+% else:
+    ${helpers.predefined_type(name="align-self",
+                              type="AlignJustifySelf",
+                              initial_value="specified::AlignJustifySelf::auto()",
+                              spec="https://drafts.csswg.org/css-align/#align-self-property",
+                              extra_prefixes="webkit",
+                              animatable=False)}
+
+    ${helpers.predefined_type(name="justify-self",
+                              type="AlignJustifySelf",
+                              initial_value="specified::AlignJustifySelf::auto()",
+                              spec="https://drafts.csswg.org/css-align/#justify-self-property",
+                              animatable=False)}
+% endif
 
 // https://drafts.csswg.org/css-flexbox/#propdef-order
 <%helpers:longhand name="order" animatable="True" extra_prefixes="webkit"

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -17,7 +17,7 @@ pub use self::image::{AngleOrCorner, EndingShape as GradientShape, Gradient, Gra
 pub use self::image::{LengthOrKeyword, LengthOrPercentageOrKeyword};
 pub use super::{Auto, Either, None_};
 #[cfg(feature = "gecko")]
-pub use super::specified::AlignJustifyContent;
+pub use super::specified::{AlignJustifyContent, AlignJustifySelf};
 pub use super::specified::{Angle, BorderStyle, GridLine, Time, UrlOrNone};
 pub use super::specified::url::UrlExtraData;
 pub use self::length::{CalcLengthOrPercentage, Length, LengthOrNumber, LengthOrPercentage, LengthOrPercentageOrAuto};
@@ -124,6 +124,8 @@ impl ToComputedValue for specified::CSSColor {
 
 #[cfg(feature = "gecko")]
 impl ComputedValueAsSpecified for specified::AlignJustifyContent {}
+#[cfg(feature = "gecko")]
+impl ComputedValueAsSpecified for specified::AlignJustifySelf {}
 impl ComputedValueAsSpecified for specified::BorderStyle {}
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -21,7 +21,7 @@ use super::computed::{ComputedValueAsSpecified, Context, ToComputedValue};
 use super::computed::Shadow as ComputedShadow;
 
 #[cfg(feature = "gecko")]
-pub use self::align::AlignJustifyContent;
+pub use self::align::{AlignJustifyContent, AlignJustifySelf};
 pub use self::grid::GridLine;
 pub use self::image::{AngleOrCorner, ColorStop, EndingShape as GradientEndingShape, Gradient};
 pub use self::image::{GradientKind, HorizontalDirection, Image, LengthOrKeyword, LengthOrPercentageOrKeyword};


### PR DESCRIPTION
Stylo-only patch to match Gecko property support. Part of #15001. r? @Manishearth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15576)
<!-- Reviewable:end -->
