### PR TITLE
Fix #13400: Check the error code from a SIGKILL, and continue if the process has already ended.

### DIFF
--- a/tests/wpt/harness/wptrunner/executors/executorservo.py
+++ b/tests/wpt/harness/wptrunner/executors/executorservo.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import base64
+import errno
 import hashlib
 import httplib
 import json
@@ -53,6 +54,13 @@ def make_hosts_file():
         f.write(hosts_text)
     return hosts_path
 
+def terminate_proc(proc):
+    try:
+        proc.kill()
+    except OSError as e:
+        # This means proc has already ended (No such proc)
+        if e.errno != errno.ESRCH:
+            raise e
 
 class ServoTestharnessExecutor(ProcessTestExecutor):
     convert_result = testharness_result_converter
@@ -140,9 +148,9 @@ class ServoTestharnessExecutor(ProcessTestExecutor):
                     self.logger.info("Pausing until the browser exits")
                     self.proc.wait()
                 else:
-                    self.proc.kill()
+                    terminate_proc(self.proc)
         except KeyboardInterrupt:
-            self.proc.kill()
+            terminate_proc(self.proc)
             raise
 
         return result
@@ -249,7 +257,7 @@ class ServoRefTestExecutor(ProcessTestExecutor):
                     timeout = test.timeout * self.timeout_multiplier + 5
                     rv = self.proc.wait(timeout=timeout)
                 except KeyboardInterrupt:
-                    self.proc.kill()
+                    terminate_proc(self.proc)
                     raise
             else:
                 self.proc = subprocess.Popen(self.command,
@@ -257,11 +265,11 @@ class ServoRefTestExecutor(ProcessTestExecutor):
                 try:
                     rv = self.proc.wait()
                 except KeyboardInterrupt:
-                    self.proc.kill()
+                    terminate_proc(self.proc)
                     raise
 
             if rv is None:
-                self.proc.kill()
+                terminate_proc(self.proc)
                 return False, ("EXTERNAL-TIMEOUT", None)
 
             if rv != 0 or not os.path.exists(output_path):


### PR DESCRIPTION
As title.

Hopefully fixes #13400, at least, I'm not seeing anymore in a local run of the web page tests \o/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15579)
<!-- Reviewable:end -->
