### PR TITLE
Adds an `as_str()` method to WebIDL enums to hide slice of strings

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -3992,12 +3992,18 @@ pub const strings: &'static [&'static str] = &[
     %s,
 ];
 
+impl super::%s {
+    pub fn as_str(&self) -> &'static str {
+        strings[*self as usize]
+    }
+}
+
 impl ToJSValConvertible for super::%s {
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         strings[*self as usize].to_jsval(cx, rval);
     }
 }
-""" % (",\n    ".join(['"%s"' % val for val in enum.values()]), enum.identifier.name)
+""" % (",\n    ".join(['"%s"' % val for val in enum.values()]), enum.identifier.name, enum.identifier.name)
 
         self.cgRoot = CGList([
             CGGeneric(decl),

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -53,8 +53,7 @@ impl DOMParserMethods for DOMParser {
                        ty: DOMParserBinding::SupportedType)
                        -> Fallible<Root<Document>> {
         let url = self.window.get_url();
-        let content_type =
-            DOMString::from(DOMParserBinding::SupportedTypeValues::strings[ty as usize]);
+        let content_type = DOMString::from(ty.as_str());
         let doc = self.window.Document();
         let loader = DocumentLoader::new(&*doc.loader());
         match ty {

--- a/components/script/dom/permissionstatus.rs
+++ b/components/script/dom/permissionstatus.rs
@@ -4,7 +4,7 @@
 
 use dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use dom::bindings::codegen::Bindings::PermissionStatusBinding::{self, PermissionDescriptor, PermissionName};
-use dom::bindings::codegen::Bindings::PermissionStatusBinding::{PermissionNameValues, PermissionState};
+use dom::bindings::codegen::Bindings::PermissionStatusBinding::PermissionState;
 use dom::bindings::codegen::Bindings::PermissionStatusBinding::PermissionStatusMethods;
 use dom::bindings::js::Root;
 use dom::bindings::reflector::reflect_dom_object;
@@ -57,6 +57,6 @@ impl PermissionStatusMethods for PermissionStatus {
 
 impl Display for PermissionName {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", PermissionNameValues::strings[*self as usize].to_string())
+        write!(f, "{}", self.as_str())
     }
 }


### PR DESCRIPTION

<!-- Please describe your changes on the following line: -->
This PR adds an `as_str()` method to WebIDL enums to hide slice of strings from callers. It uses the new method in two places. It also eliminates a to_string() call that seemed unnecessary to me.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15586 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because github issue says no tests needed. 

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15590)
<!-- Reviewable:end -->
