### PR TITLE
Remove jQuery from windowless elements' event handler behaviour test

### DIFF
--- a/tests/wpt/web-platform-tests/html/webappapis/scripting/events/body-exposed-window-event-handlers.html
+++ b/tests/wpt/web-platform-tests/html/webappapis/scripting/events/body-exposed-window-event-handlers.html
@@ -2,7 +2,6 @@
 <meta charset="utf-8">
 <title></title>
 <body></body>
-<script src="https://code.jquery.com/jquery-1.10.2.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
It's been [discovered](https://github.com/servo/servo/pull/15359#issuecomment-280324767) post-merge that I have accidentally included a jQuery import in the test. This PR removes that import

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this is a test fix PR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15593)
<!-- Reviewable:end -->
