### PR TITLE
Fix initial value of align-content and justify-content

### DIFF
--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -88,13 +88,13 @@ ${helpers.single_keyword("flex-wrap", "nowrap wrap wrap-reverse",
     // FIXME: Update Servo to support the same Syntax as Gecko.
     ${helpers.single_keyword("justify-content", "stretch flex-start flex-end center space-between space-around",
                              extra_prefixes="webkit",
-                             spec="https://drafts.csswg.org/css-flexbox/#justify-content-property",
+                             spec="https://drafts.csswg.org/css-align/#propdef-justify-content",
                              animatable=False)}
 % else:
     ${helpers.predefined_type(name="justify-content",
                               type="AlignJustifyContent",
                               initial_value="specified::AlignJustifyContent::normal()",
-                              spec="https://drafts.csswg.org/css-flexbox/#justify-content-property",
+                              spec="https://drafts.csswg.org/css-align/#propdef-justify-content",
                               extra_prefixes="webkit",
                               animatable=False)}
 % endif
@@ -113,13 +113,13 @@ ${helpers.single_keyword("align-items", "stretch flex-start flex-end center base
     // FIXME: Update Servo to support the same Syntax as Gecko.
     ${helpers.single_keyword("align-content", "stretch flex-start flex-end center space-between space-around",
                              extra_prefixes="webkit",
-                             spec="https://drafts.csswg.org/css-flexbox/#align-content-property",
+                             spec="https://drafts.csswg.org/css-align/#propdef-align-content",
                              animatable=False)}
 % else:
     ${helpers.predefined_type(name="align-content",
                               type="AlignJustifyContent",
                               initial_value="specified::AlignJustifyContent::normal()",
-                              spec="https://drafts.csswg.org/css-flexbox/#align-content-property",
+                              spec="https://drafts.csswg.org/css-align/#propdef-align-content",
                               extra_prefixes="webkit",
                               animatable=False)}
 % endif

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -93,7 +93,7 @@ ${helpers.single_keyword("flex-wrap", "nowrap wrap wrap-reverse",
 % else:
     ${helpers.predefined_type(name="justify-content",
                               type="AlignJustifyContent",
-                              initial_value="specified::AlignJustifyContent::auto()",
+                              initial_value="specified::AlignJustifyContent::normal()",
                               spec="https://drafts.csswg.org/css-flexbox/#justify-content-property",
                               extra_prefixes="webkit",
                               animatable=False)}
@@ -118,7 +118,7 @@ ${helpers.single_keyword("align-items", "stretch flex-start flex-end center base
 % else:
     ${helpers.predefined_type(name="align-content",
                               type="AlignJustifyContent",
-                              initial_value="specified::AlignJustifyContent::auto()",
+                              initial_value="specified::AlignJustifyContent::normal()",
                               spec="https://drafts.csswg.org/css-flexbox/#align-content-property",
                               extra_prefixes="webkit",
                               animatable=False)}

--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -117,10 +117,10 @@ const ALIGN_ALL_SHIFT: u32 = structs::NS_STYLE_ALIGN_ALL_SHIFT;
 pub struct AlignJustifyContent(u16);
 
 impl AlignJustifyContent {
-    /// The initial value 'auto'
+    /// The initial value 'normal'
     #[inline]
-    pub fn auto() -> Self {
-        Self::new(ALIGN_AUTO)
+    pub fn normal() -> Self {
+        Self::new(ALIGN_NORMAL)
     }
 
     /// Construct a value with no fallback.


### PR DESCRIPTION
This fixes a trivial mistake in #15533, caused by me misreading the spec. r? @Manishearth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15594)
<!-- Reviewable:end -->
