### PR TITLE
Use bitflags for multikeyword properties

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -2502,16 +2502,16 @@ fn static_assert() {
 
     pub fn set_text_decoration_line(&mut self, v: longhands::text_decoration_line::computed_value::T) {
         let mut bits: u8 = 0;
-        if v.underline {
+        if v.contains(longhands::text_decoration_line::UNDERLINE) {
             bits |= structs::NS_STYLE_TEXT_DECORATION_LINE_UNDERLINE as u8;
         }
-        if v.overline {
+        if v.contains(longhands::text_decoration_line::OVERLINE) {
             bits |= structs::NS_STYLE_TEXT_DECORATION_LINE_OVERLINE as u8;
         }
-        if v.line_through {
+        if v.contains(longhands::text_decoration_line::LINE_THROUGH) {
             bits |= structs::NS_STYLE_TEXT_DECORATION_LINE_LINE_THROUGH as u8;
         }
-        if v.blink {
+        if v.contains(longhands::text_decoration_line::BLINK) {
             bits |= structs::NS_STYLE_TEXT_DECORATION_LINE_BLINK as u8;
         }
         self.gecko.mTextDecorationLine = bits;

--- a/components/style/properties/longhand/text.mako.rs
+++ b/components/style/properties/longhand/text.mako.rs
@@ -114,13 +114,15 @@ ${helpers.single_keyword("unicode-bidi",
     impl ComputedValueAsSpecified for SpecifiedValue {}
     no_viewport_percentage!(SpecifiedValue);
 
-    #[derive(PartialEq, Eq, Copy, Clone, Debug)]
-    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    pub struct SpecifiedValue {
-        pub underline: bool,
-        pub overline: bool,
-        pub line_through: bool,
-        pub blink: bool,
+    bitflags! {
+        #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+        pub flags SpecifiedValue: u8 {
+            const NONE = 0,
+            const OVERLINE = 0x01,
+            const UNDERLINE = 0x02,
+            const LINE_THROUGH = 0x04,
+            const BLINK = 0x08,
+        }
     }
 
     impl ToCss for SpecifiedValue {
@@ -128,7 +130,7 @@ ${helpers.single_keyword("unicode-bidi",
             let mut has_any = false;
             macro_rules! write_value {
                 ($line:ident => $css:expr) => {
-                    if self.$line {
+                    if self.contains($line) {
                         if has_any {
                             dest.write_str(" ")?;
                         }
@@ -137,10 +139,10 @@ ${helpers.single_keyword("unicode-bidi",
                     }
                 }
             }
-            write_value!(underline => "underline");
-            write_value!(overline => "overline");
-            write_value!(line_through => "line-through");
-            write_value!(blink => "blink");
+            write_value!(UNDERLINE => "underline");
+            write_value!(OVERLINE => "overline");
+            write_value!(LINE_THROUGH => "line-through");
+            write_value!(BLINK => "blink");
             if !has_any {
                 dest.write_str("none")?;
             }
@@ -151,7 +153,7 @@ ${helpers.single_keyword("unicode-bidi",
         pub type T = super::SpecifiedValue;
         #[allow(non_upper_case_globals)]
         pub const none: T = super::SpecifiedValue {
-            underline: false, overline: false, line_through: false, blink: false
+            bits: 0
         };
     }
     #[inline] pub fn get_initial_value() -> computed_value::T {
@@ -159,9 +161,7 @@ ${helpers.single_keyword("unicode-bidi",
     }
     /// none | [ underline || overline || line-through || blink ]
     pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-        let mut result = SpecifiedValue {
-            underline: false, overline: false, line_through: false, blink: false
-        };
+        let mut result = SpecifiedValue::empty();
         if input.try(|input| input.expect_ident_matching("none")).is_ok() {
             return Ok(result)
         }
@@ -170,14 +170,14 @@ ${helpers.single_keyword("unicode-bidi",
         while input.try(|input| {
                 if let Ok(ident) = input.expect_ident() {
                     match_ignore_ascii_case! { ident,
-                        "underline" => if result.underline { return Err(()) }
-                                       else { empty = false; result.underline = true },
-                        "overline" => if result.overline { return Err(()) }
-                                      else { empty = false; result.overline = true },
-                        "line-through" => if result.line_through { return Err(()) }
-                                          else { empty = false; result.line_through = true },
-                        "blink" => if result.blink { return Err(()) }
-                                   else { empty = false; result.blink = true },
+                        "underline" => if result.contains(UNDERLINE) { return Err(()) }
+                                       else { empty = false; result.insert(UNDERLINE) },
+                        "overline" => if result.contains(OVERLINE) { return Err(()) }
+                                      else { empty = false; result.insert(OVERLINE) },
+                        "line-through" => if result.contains(LINE_THROUGH) { return Err(()) }
+                                          else { empty = false; result.insert(LINE_THROUGH) },
+                        "blink" => if result.contains(BLINK) { return Err(()) }
+                                   else { empty = false; result.insert(BLINK) },
                         _ => return Err(())
                     }
                 } else {

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1288,19 +1288,19 @@ pub mod style_structs {
                 /// Whether the text decoration has an underline.
                 #[inline]
                 pub fn has_underline(&self) -> bool {
-                    self.${text_decoration_field}.underline
+                    self.${text_decoration_field}.contains(longhands::${text_decoration_field}::UNDERLINE)
                 }
 
                 /// Whether the text decoration has an overline.
                 #[inline]
                 pub fn has_overline(&self) -> bool {
-                    self.${text_decoration_field}.overline
+                    self.${text_decoration_field}.contains(longhands::${text_decoration_field}::OVERLINE)
                 }
 
                 /// Whether the text decoration has a line through.
                 #[inline]
                 pub fn has_line_through(&self) -> bool {
-                    self.${text_decoration_field}.line_through
+                    self.${text_decoration_field}.contains(longhands::${text_decoration_field}::LINE_THROUGH)
                 }
             % endif
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Use bitflags for multikeyword properties

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15556 

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15595)
<!-- Reviewable:end -->
