### PR TITLE
text-overflow accepts only valid values for the second part of value

### DIFF
--- a/components/style/properties/longhand/text.mako.rs
+++ b/components/style/properties/longhand/text.mako.rs
@@ -51,7 +51,7 @@
     }
     pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
         let first = try!(Side::parse(context, input));
-        let second = Side::parse(context, input).ok();
+        let second = input.try(|input| Side::parse(context, input)).ok();
         Ok(SpecifiedValue {
             first: first,
             second: second,

--- a/tests/unit/style/parsing/text_overflow.rs
+++ b/tests/unit/style/parsing/text_overflow.rs
@@ -22,3 +22,13 @@ fn test_text_overflow() {
     assert_roundtrip_with_context!(text_overflow::parse, r#""x" "y""#);
 
 }
+
+#[test]
+fn test_text_overflow_parser_exhaustion() {
+    use style::properties::longhands::text_overflow;
+
+    assert_parser_exhausted!(text_overflow, r#"clip rubbish"#, false);
+    assert_parser_exhausted!(text_overflow, r#"clip"#, true);
+    assert_parser_exhausted!(text_overflow, r#"ellipsis"#, true);
+    assert_parser_exhausted!(text_overflow, r#"clip ellipsis"#, true);
+}


### PR DESCRIPTION
… value #15491

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15491.

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15598)
<!-- Reviewable:end -->
