### PR TITLE
serialize font: to empty on non-default subprops

### DIFF
--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -608,51 +608,58 @@ mod shorthand_serialization {
         assert_eq!(serialization, "flex-flow: row wrap;");
     }
 
-    // TODO: Populate Atom Cache for testing so that the font shorthand can be tested
-    /*
     mod font {
         use super::*;
-        use style::properties::longhands::font_family::computed_value::T as FamilyContainer;
-        use style::properties::longhands::font_family::computed_value::FontFamily;
-        use style::properties::longhands::font_style::computed_value::T as FontStyle;
-        use style::properties::longhands::font_variant::computed_value::T as FontVariant;
-        use style::properties::longhands::font_weight::SpecifiedValue as FontWeight;
-        use style::properties::longhands::font_size::SpecifiedValue as FontSizeContainer;
-        use style::properties::longhands::font_stretch::computed_value::T as FontStretch;
-        use style::properties::longhands::line_height::SpecifiedValue as LineHeight;
+
+        #[test]
+        fn font_should_serialize_to_empty_if_there_are_nondefault_subproperties() {
+            // Test with non-default font-kerning value
+            let block_text = "font-style: italic; \
+                              font-variant: normal; \
+                              font-weight: bolder; \
+                              font-stretch: expanded; \
+                              font-size: 4px; \
+                              line-height: 3; \
+                              font-family: serif; \
+                              font-size-adjust: none; \
+                              font-variant-caps: normal; \
+                              font-variant-position: normal; \
+                              font-language-override: normal; \
+                              font-kerning: none";
+
+            let block = parse_declaration_block(block_text);
+
+            let mut s = String::new();
+            let id = PropertyId::parse("font".into()).unwrap();
+            let x = block.property_value_to_css(&id, &mut s);
+
+            assert_eq!(x.is_ok(), true);
+            assert_eq!(s, "");
+        }
 
         #[test]
         fn font_should_serialize_all_available_properties() {
-            let mut properties = Vec::new();
+            let block_text = "font-style: italic; \
+                              font-variant: normal; \
+                              font-weight: bolder; \
+                              font-stretch: expanded; \
+                              font-size: 4px; \
+                              line-height: 3; \
+                              font-family: serif; \
+                              font-size-adjust: none; \
+                              font-kerning: auto; \
+                              font-variant-caps: normal; \
+                              font-variant-position: normal; \
+                              font-language-override: normal;";
 
+            let block = parse_declaration_block(block_text);
 
-            let font_family = DeclaredValue::Value(
-                FamilyContainer(vec![FontFamily::Generic(atom!("serif"))])
-            );
+            let serialization = block.to_css_string();
 
-
-            let font_style = DeclaredValue::Value(FontStyle::italic);
-            let font_variant = DeclaredValue::Value(FontVariant::normal);
-            let font_weight = DeclaredValue::Value(FontWeight::Bolder);
-            let font_size = DeclaredValue::Value(FontSizeContainer(
-                LengthOrPercentage::Length(NoCalcLength::from_px(4f32)))
-            );
-            let font_stretch = DeclaredValue::Value(FontStretch::expanded);
-            let line_height = DeclaredValue::Value(LineHeight::Number(3f32));
-
-            properties.push(PropertyDeclaration::FontFamily(font_family));
-            properties.push(PropertyDeclaration::FontStyle(font_style));
-            properties.push(PropertyDeclaration::FontVariant(font_variant));
-            properties.push(PropertyDeclaration::FontWeight(font_weight));
-            properties.push(PropertyDeclaration::FontSize(font_size));
-            properties.push(PropertyDeclaration::FontStretch(font_stretch));
-            properties.push(PropertyDeclaration::LineHeight(line_height));
-
-            let serialization = shorthand_properties_to_string(properties);
-            assert_eq!(serialization, "font:;");
+            assert_eq!(serialization, "font: italic normal bolder expanded 4px/3 serif;");
         }
+
     }
-    */
 
     mod background {
         use super::*;


### PR DESCRIPTION
Fixes font shorthand serialization so that it serializes to "" when non-default subproperties are defined. These subproperties are those defined in #15033.

Adds tests:
- font_should_serialize_to_empty_if_there_are_nondefault_subproperties
- font_should_serialize_all_available_properties

The second test was previously commented out and underwent some cleanup to make it run.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15036

<!-- Either: -->
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15604)
<!-- Reviewable:end -->
