### PR TITLE
Added test documentation link to wpt's README.md

### DIFF
--- a/tests/wpt/README.md
+++ b/tests/wpt/README.md
@@ -1,5 +1,6 @@
 This folder contains the web platform tests, CSS WG tests, and the
-code required to integrate them with Servo.
+code required to integrate them with Servo. 
+To learn how to write tests, go [here](http://web-platform-tests.org/writing-tests/index.html).
 
 Contents
 ========
@@ -116,17 +117,19 @@ The simplest way to create a new test is to use the following command:
     ./mach create-wpt tests/wpt/path/to/new/test.html
 
 This will create test.html in the appropriate directory using the WPT
-template for JavaScript tests. To create a new reference test instead,
-use the following:
+template for JavaScript tests. Tests are written using [testharness.js](https://github.com/w3c/testharness.js/). Documentation can be found [here](http://testthewebforward.org/docs/testharness-library.html).
+To create a new reference test instead, use the following:
 
     ./mach create-wpt --reftest tests/wpt/path/to/new/reftest.html --reference tests/wpt/path/to/reference.html
 
 `reference.html` will be created if it does not exist, and `reftest.html`
-will be created using the WPT reftest template. These new tests can then
-be run in the following manner like any other WPT test:
+will be created using the WPT reftest template. To know more about reftests, check [this](http://web-platform-tests.org/writing-tests/reftests.html).
+These new tests can then be run in the following manner like any other WPT test:
 
     ./mach test-wpt tests/wpt/path/to/new/test.html
     ./mach test-wpt tests/wpt/path/to/new/reftest.html
+
+
 
 Editing tests
 =============


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
For the sake of convenience, the documentation for writing web platform tests can be provided in the wpt README file.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15603  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because of documentation change.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15608)
<!-- Reviewable:end -->
