### PR TITLE
Wrap CGFont in NativeFontHandle

### DIFF
--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -26,7 +26,7 @@ use std::thread;
 use std::u32;
 use style::font_face::{EffectiveSources, Source};
 use style::properties::longhands::font_family::computed_value::{FontFamily, FamilyName};
-use webrender_traits;
+use webrender_traits::{self, NativeFontHandle};
 
 /// A list of font templates that make up a given font family.
 struct FontTemplates {
@@ -348,7 +348,7 @@ impl FontCache {
             font_key = Some(*webrender_fonts.entry(template.identifier.clone()).or_insert_with(|| {
                 match (template.bytes_if_in_memory(), template.native_font()) {
                     (Some(bytes), _) => webrender_api.add_raw_font(bytes),
-                    (None, Some(native_font)) => webrender_api.add_native_font(native_font),
+                    (None, Some(native_font)) => webrender_api.add_native_font(NativeFontHandle(native_font)),
                     (None, None) => webrender_api.add_raw_font(template.bytes().clone()),
                 }
             }));


### PR DESCRIPTION
Pull request https://github.com/servo/webrender/pull/896 makes `NativeFontHandle` a wrapper type (a newtype struct). This pull request wraps the cached `CGFont` in this newtype struct before passing it to webrender.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15607
- [x] These changes do not require tests because existing tests cover the functionality changed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15615)
<!-- Reviewable:end -->
