### PR TITLE
Buildbot steps: move geckolib from mac-rel-css to mac-rel-wpt2.

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -12,6 +12,7 @@ mac-rel-wpt2:
   - ./mach build --release
   - ./mach test-wpt --release --processes 8 --total-chunks 2 --this-chunk 2 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --use-tracker
+  - ./mach build-geckolib --release
 
 mac-dev-unit:
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --dev
@@ -25,7 +26,6 @@ mac-rel-css:
   - ./mach build --release
   - ./mach test-css --release --processes 4 --log-raw test-css.log --log-errorsummary css-errorsummary.log --always-succeed
   - ./mach filter-intermittents css-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-css-errorsummary.log --use-tracker
-  - ./mach build-geckolib --release
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 


### PR DESCRIPTION
mac-rel-css is currently the job that takes the longest, and its geckolib step is independent from other jobs. Hopefully, this should reduce the overall CI cycle time.

This change was suggested by @mbrubeck.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15619)
<!-- Reviewable:end -->
