### PR TITLE
Remove the unused :-moz-buttonlabel anonymous box.

### DIFF
--- a/components/style/gecko/generated/gecko_pseudo_element_helper.rs
+++ b/components/style/gecko/generated/gecko_pseudo_element_helper.rs
@@ -130,9 +130,6 @@
     pseudo_element!(":-moz-button-content",
                     atom!(":-moz-button-content"),
                     true);
-    pseudo_element!(":-moz-buttonlabel",
-                    atom!(":-moz-buttonlabel"),
-                    true);
     pseudo_element!(":-moz-cell-content",
                     atom!(":-moz-cell-content"),
                     true);

--- a/components/style/gecko_string_cache/atom_macro.rs
+++ b/components/style/gecko_string_cache/atom_macro.rs
@@ -4836,8 +4836,6 @@ cfg_if! {
             pub static nsCSSAnonBoxes_mozLineFrame: *mut nsICSSAnonBoxPseudo;
             #[link_name = "_ZN14nsCSSAnonBoxes13buttonContentE"]
             pub static nsCSSAnonBoxes_buttonContent: *mut nsICSSAnonBoxPseudo;
-            #[link_name = "_ZN14nsCSSAnonBoxes14mozButtonLabelE"]
-            pub static nsCSSAnonBoxes_mozButtonLabel: *mut nsICSSAnonBoxPseudo;
             #[link_name = "_ZN14nsCSSAnonBoxes11cellContentE"]
             pub static nsCSSAnonBoxes_cellContent: *mut nsICSSAnonBoxPseudo;
             #[link_name = "_ZN14nsCSSAnonBoxes12dropDownListE"]
@@ -9753,8 +9751,6 @@ cfg_if! {
             pub static nsCSSAnonBoxes_mozLineFrame: *mut nsICSSAnonBoxPseudo;
             #[link_name = "?buttonContent@nsCSSAnonBoxes@@2PEAVnsICSSAnonBoxPseudo@@EA"]
             pub static nsCSSAnonBoxes_buttonContent: *mut nsICSSAnonBoxPseudo;
-            #[link_name = "?mozButtonLabel@nsCSSAnonBoxes@@2PEAVnsICSSAnonBoxPseudo@@EA"]
-            pub static nsCSSAnonBoxes_mozButtonLabel: *mut nsICSSAnonBoxPseudo;
             #[link_name = "?cellContent@nsCSSAnonBoxes@@2PEAVnsICSSAnonBoxPseudo@@EA"]
             pub static nsCSSAnonBoxes_cellContent: *mut nsICSSAnonBoxPseudo;
             #[link_name = "?dropDownList@nsCSSAnonBoxes@@2PEAVnsICSSAnonBoxPseudo@@EA"]
@@ -14670,8 +14666,6 @@ cfg_if! {
             pub static nsCSSAnonBoxes_mozLineFrame: *mut nsICSSAnonBoxPseudo;
             #[link_name = "\x01?buttonContent@nsCSSAnonBoxes@@2PAVnsICSSAnonBoxPseudo@@A"]
             pub static nsCSSAnonBoxes_buttonContent: *mut nsICSSAnonBoxPseudo;
-            #[link_name = "\x01?mozButtonLabel@nsCSSAnonBoxes@@2PAVnsICSSAnonBoxPseudo@@A"]
-            pub static nsCSSAnonBoxes_mozButtonLabel: *mut nsICSSAnonBoxPseudo;
             #[link_name = "\x01?cellContent@nsCSSAnonBoxes@@2PAVnsICSSAnonBoxPseudo@@A"]
             pub static nsCSSAnonBoxes_cellContent: *mut nsICSSAnonBoxPseudo;
             #[link_name = "\x01?dropDownList@nsCSSAnonBoxes@@2PAVnsICSSAnonBoxPseudo@@A"]
@@ -19590,8 +19584,6 @@ macro_rules! atom {
   { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsCSSAnonBoxes_mozLineFrame as *mut _) } };
 (":-moz-button-content") =>
   { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsCSSAnonBoxes_buttonContent as *mut _) } };
-(":-moz-buttonlabel") =>
-  { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsCSSAnonBoxes_mozButtonLabel as *mut _) } };
 (":-moz-cell-content") =>
   { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsCSSAnonBoxes_cellContent as *mut _) } };
 (":-moz-dropdown-list") =>


### PR DESCRIPTION
The Gecko side is being removed in https://bugzilla.mozilla.org/show_bug.cgi?id=1340741
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because I'm not sure how to test dead code removal.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15624)
<!-- Reviewable:end -->
