### PR TITLE
stylo: Destroy static Variables struct on shutdown.

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -26,6 +26,7 @@ use gecko_bindings::bindings::Gecko_CopyFontFamilyFrom;
 use gecko_bindings::bindings::Gecko_CopyImageValueFrom;
 use gecko_bindings::bindings::Gecko_CopyListStyleImageFrom;
 use gecko_bindings::bindings::Gecko_CopyListStyleTypeFrom;
+use gecko_bindings::bindings::Gecko_Destroy_nsStyleVariables;
 use gecko_bindings::bindings::Gecko_EnsureImageLayersLength;
 use gecko_bindings::bindings::Gecko_FontFamilyList_AppendGeneric;
 use gecko_bindings::bindings::Gecko_FontFamilyList_AppendNamed;
@@ -3077,19 +3078,25 @@ ${impl_style_struct(style_struct)}
 ${define_ffi_struct_accessor(style_struct)}
 % endfor
 
-lazy_static! {
-    static ref EMPTY_VARIABLES_STRUCT: nsStyleVariables = {
-        unsafe {
-            let mut variables: nsStyleVariables = unsafe { zeroed() };
-            Gecko_Construct_nsStyleVariables(&mut variables);
-            variables
-        }
-    };
-}
+// This is only accessed from the Gecko main thread.
+static mut EMPTY_VARIABLES_STRUCT: Option<nsStyleVariables> = None;
 
 #[no_mangle]
 #[allow(non_snake_case)]
 pub unsafe extern "C" fn Servo_GetStyleVariables(_cv: ServoComputedValuesBorrowedOrNull)
                                                  -> *const nsStyleVariables {
-    &*EMPTY_VARIABLES_STRUCT
+    EMPTY_VARIABLES_STRUCT.as_ref().unwrap()
+}
+
+pub fn initialize() {
+    unsafe {
+        EMPTY_VARIABLES_STRUCT = Some(zeroed());
+        Gecko_Construct_nsStyleVariables(EMPTY_VARIABLES_STRUCT.as_mut().unwrap());
+    }
+}
+
+pub fn shutdown() {
+    unsafe {
+        EMPTY_VARIABLES_STRUCT.take().as_mut().map(|v| Gecko_Destroy_nsStyleVariables(v));
+    }
 }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -61,7 +61,7 @@ use style::gecko_bindings::structs::nsresult;
 use style::gecko_bindings::sugar::ownership::{FFIArcHelpers, HasArcFFI, HasBoxFFI};
 use style::gecko_bindings::sugar::ownership::{HasSimpleFFI, Strong};
 use style::gecko_bindings::sugar::refptr::{GeckoArcPrincipal, GeckoArcURI};
-use style::gecko_properties::style_structs;
+use style::gecko_properties::{self, style_structs};
 use style::keyframes::KeyframesStepValue;
 use style::parallel;
 use style::parser::{ParserContext, ParserContextExtraData};
@@ -105,10 +105,15 @@ pub extern "C" fn Servo_Initialize() -> () {
 
     // Perform some debug-only runtime assertions.
     restyle_hints::assert_restyle_hints_match();
+
+    // Initialize some static data.
+    gecko_properties::initialize();
 }
 
 #[no_mangle]
 pub extern "C" fn Servo_Shutdown() -> () {
+    // Clear some static data to avoid shutdown leaks.
+    gecko_properties::shutdown();
 }
 
 fn create_shared_context(per_doc_data: &PerDocumentStyleDataImpl) -> SharedStyleContext {


### PR DESCRIPTION
Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1340457.

r? @emilio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15629)
<!-- Reviewable:end -->
