### PR TITLE
stylo: Don't leak nsStyleCoord::Calc objects when setting gradients.

### DIFF
--- a/components/style/gecko/conversions.rs
+++ b/components/style/gecko/conversions.rs
@@ -297,10 +297,10 @@ impl nsStyleImage {
             },
         };
 
-        let mut coord: nsStyleCoord = nsStyleCoord::null();
         for (index, stop) in gradient.stops.iter().enumerate() {
             // NB: stops are guaranteed to be none in the gecko side by
             // default.
+            let mut coord: nsStyleCoord = nsStyleCoord::null();
             coord.set(stop.position);
             let color = match stop.color {
                 CSSColor::CurrentColor => {
@@ -322,7 +322,7 @@ impl nsStyleImage {
 
             stop.mColor = color;
             stop.mIsInterpolationHint = false;
-            stop.mLocation.copy_from(&coord);
+            stop.mLocation.move_from(coord);
         }
 
         unsafe {

--- a/components/style/gecko_bindings/sugar/ns_style_coord.rs
+++ b/components/style/gecko_bindings/sugar/ns_style_coord.rs
@@ -265,6 +265,15 @@ pub trait CoordDataMut : CoordData {
     }
 
     #[inline]
+    /// Moves the unit and value from another `CoordData` type.
+    fn move_from<T: CoordData>(&mut self, other: T) {
+        unsafe {
+            self.reset();
+            self.copy_from_unchecked(&other);
+        }
+    }
+
+    #[inline]
     /// Copies the unit and value from another `CoordData` type without checking
     /// the type of the value (so refcounted values like calc may leak).
     unsafe fn copy_from_unchecked<T: CoordData>(&mut self, other: &T) {


### PR DESCRIPTION
Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1340509.  My initial inclination was to add a Drop impl to nsStyleCoord but I'm not sure if that's a good idea with the FFI types.

r? @Manishearth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15630)
<!-- Reviewable:end -->
