### PR TITLE
Cleanup arraybufferview type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "js"
 version = "0.1.4"
-source = "git+https://github.com/servo/rust-mozjs#93e59ef1263e451143d0ed431f1aa564ea101ab8"
+source = "git+https://github.com/servo/rust-mozjs#101c6b6b58e0b7c5ed1ef2b6b676a7497f90df2f"
 dependencies = [
  "cmake 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -37,7 +37,7 @@ use dom::window::Window;
 use euclid::size::Size2D;
 use ipc_channel::ipc::{self, IpcSender};
 use js::conversions::ConversionBehavior;
-use js::jsapi::{JSContext, JSObject, JS_GetArrayBufferViewType, Type, Rooted};
+use js::jsapi::{JSContext, JSObject, Type, Rooted};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, JSVal, NullValue, UndefinedValue};
 use js::typedarray::{TypedArray, TypedArrayElement, Float32, Int32};
 use net_traits::image::base::PixelFormat;
@@ -2080,8 +2080,8 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         }
 
         typedarray!(in(cx) let mut pixels_data: ArrayBufferView = pixels);
-        let mut data = match { pixels_data.as_mut() } {
-            Ok(data) => data.as_mut_slice(),
+        let (array_type, mut data) = match { pixels_data.as_mut() } {
+            Ok(data) => (data.get_array_type(), data.as_mut_slice()),
             Err(_) => return Err(Error::Type("Not an ArrayBufferView".to_owned())),
         };
 
@@ -2089,7 +2089,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             return Ok(());
         }
 
-        match { JS_GetArrayBufferViewType(pixels) } {
+        match array_type {
             Type::Uint8 => (),
             _ => return Ok(self.webgl_error(InvalidOperation)),
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Replace uses of spidermonkey-specific JS_GetArrayBufferViewType with ArrayBufferView impl's method get_array_type().

Tests pass:
./mach test-wpt tests/wpt/web-platform-tests/WebCrypto
./mach test-wpt tests/wpt/web-platform-tests/webgl

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15605 (github issue number if applicable).
- [x] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15653)
<!-- Reviewable:end -->
