### PR TITLE
Do not accept negative time values in transition durations

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -462,7 +462,7 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
     }
 
     pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue,()> {
-        Time::parse(context, input)
+        Time::parse_non_negative(context, input)
     }
 </%helpers:vector_longhand>
 

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -438,6 +438,18 @@ impl Time {
             Err(())
         }
     }
+
+    /// Parses a time, but errors on negative values
+    pub fn parse_non_negative(context: &ParserContext, input: &mut Parser) -> Result<Time, ()> {
+        let time = Self::parse(context, input)?;
+
+        // Negative values are invalid
+        if time.0 < 0.0 {
+            Err(())
+        } else {
+            Ok(time)
+        }
+    }
 }
 
 impl ComputedValueAsSpecified for Time {}

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -80,4 +80,5 @@ mod position;
 mod selectors;
 mod supports;
 mod text_overflow;
+mod transition_duration;
 mod transition_timing_function;

--- a/tests/unit/style/parsing/transition_duration.rs
+++ b/tests/unit/style/parsing/transition_duration.rs
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use parsing::parse;
+use style::properties::longhands::transition_duration;
+
+#[test]
+fn test_positive_transition_duration() {
+    assert!(parse(transition_duration::parse, "5s").is_ok());
+    assert!(parse(transition_duration::parse, "0s").is_ok());
+}
+
+#[test]
+fn test_negative_transition_duration() {
+    assert!(parse(transition_duration::parse, "-5s").is_err());
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Adds `Time::parse_non_negative` which errors on negative values. This new method is now used by `transition_duration::parse`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15343 

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15658)
<!-- Reviewable:end -->
