### PR TITLE
Eliminate a mem::transmute in CodeGen

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -967,14 +967,11 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
             handleInvalidEnumValueCode = "return true;"
 
         template = (
-            "match find_enum_string_index(cx, ${val}, %(values)s) {\n"
+            "match find_enum_value(cx, ${val}, %(pairs)s) {\n"
             "    Err(_) => { %(exceptionCode)s },\n"
             "    Ok((None, search)) => { %(handleInvalidEnumValueCode)s },\n"
-            "    Ok((Some(index), _)) => {\n"
-            "        //XXXjdm need some range checks up in here.\n"
-            "        mem::transmute(index)\n"
-            "    },\n"
-            "}" % {"values": enum + "Values::strings",
+            "    Ok((Some(&value), _)) => value,\n"
+            "}" % {"pairs": enum + "Values::pairs",
                    "exceptionCode": exceptionCode,
                    "handleInvalidEnumValueCode": handleInvalidEnumValueCode})
 
@@ -3978,39 +3975,41 @@ class CGEnum(CGThing):
     def __init__(self, enum):
         CGThing.__init__(self)
 
+        ident = enum.identifier.name
         decl = """\
 #[repr(usize)]
 #[derive(JSTraceable, PartialEq, Copy, Clone, HeapSizeOf, Debug)]
 pub enum %s {
     %s
 }
-""" % (enum.identifier.name, ",\n    ".join(map(getEnumValueName, enum.values())))
+""" % (ident, ",\n    ".join(map(getEnumValueName, enum.values())))
+
+        pairs = ",\n    ".join(['("%s", super::%s::%s)' % (val, ident, getEnumValueName(val)) for val in enum.values()])
 
         inner = """\
 use dom::bindings::conversions::ToJSValConvertible;
 use js::jsapi::{JSContext, MutableHandleValue};
 use js::jsval::JSVal;
 
-pub const strings: &'static [&'static str] = &[
+pub const pairs: &'static [(&'static str, super::%s)] = &[
     %s,
 ];
 
 impl super::%s {
     pub fn as_str(&self) -> &'static str {
-        strings[*self as usize]
+        pairs[*self as usize].0
     }
 }
 
 impl ToJSValConvertible for super::%s {
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
-        strings[*self as usize].to_jsval(cx, rval);
+        pairs[*self as usize].0.to_jsval(cx, rval);
     }
 }
-""" % (",\n    ".join(['"%s"' % val for val in enum.values()]), enum.identifier.name, enum.identifier.name)
-
+    """ % (ident, pairs, ident, ident)
         self.cgRoot = CGList([
             CGGeneric(decl),
-            CGNamespace.build([enum.identifier.name + "Values"],
+            CGNamespace.build([ident + "Values"],
                               CGIndenter(CGGeneric(inner)), public=True),
         ])
 
@@ -5576,7 +5575,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'dom::bindings::utils::ProtoOrIfaceArray',
         'dom::bindings::utils::enumerate_global',
         'dom::bindings::utils::finalize_global',
-        'dom::bindings::utils::find_enum_string_index',
+        'dom::bindings::utils::find_enum_value',
         'dom::bindings::utils::generic_getter',
         'dom::bindings::utils::generic_lenient_getter',
         'dom::bindings::utils::generic_lenient_setter',

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -177,20 +177,20 @@ pub fn get_array_index_from_id(_cx: *mut JSContext, id: HandleId) -> Option<u32>
     }*/
 }
 
-/// Find the index of a string given by `v` in `values`.
+/// Find the enum equivelent of a string given by `v` in `pairs`.
 /// Returns `Err(())` on JSAPI failure (there is a pending exception), and
 /// `Ok((None, value))` if there was no matching string.
-pub unsafe fn find_enum_string_index(cx: *mut JSContext,
+pub unsafe fn find_enum_value<'a, T>(cx: *mut JSContext,
                                      v: HandleValue,
-                                     values: &[&'static str])
-                                     -> Result<(Option<usize>, DOMString), ()> {
+                                     pairs: &'a [(&'static str, T)])
+                                     -> Result<(Option<&'a T>, DOMString), ()> {
     let jsstr = ToString(cx, v);
     if jsstr.is_null() {
         return Err(());
     }
 
     let search = jsstring_to_str(cx, jsstr);
-    Ok((values.iter().position(|value| search == *value), search))
+    Ok((pairs.iter().find(|&&(key, _)| search == *key).map(|&(_, ref ev)| ev), search))
 }
 
 /// Returns wether `obj` is a platform object


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Eliminate a mem::transmute in CodeGen by changing the find_enum_string_index function to take a slice of pairs and return an enum value.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15587 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15659)
<!-- Reviewable:end -->
