### PR TITLE
Support running ./mach test-wpt /html.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -31,10 +31,6 @@ skip: true
   skip: false
 [html]
   skip: false
-  [editing]
-    skip: true
-    [activation]
-      skip: false
 [js]
   skip: false
 [navigation-timing]

--- a/tests/wpt/metadata/html/editing/assigning-keyboard-shortcuts/__dir__.ini
+++ b/tests/wpt/metadata/html/editing/assigning-keyboard-shortcuts/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/editing/dnd/__dir__.ini
+++ b/tests/wpt/metadata/html/editing/dnd/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/editing/editing-0/__dir__.ini
+++ b/tests/wpt/metadata/html/editing/editing-0/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/editing/focus/__dir__.ini
+++ b/tests/wpt/metadata/html/editing/focus/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/editing/inert-subtrees/__dir__.ini
+++ b/tests/wpt/metadata/html/editing/inert-subtrees/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now

--- a/tests/wpt/metadata/html/editing/the-hidden-attribute/__dir__.ini
+++ b/tests/wpt/metadata/html/editing/the-hidden-attribute/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: for now


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

At the moment, running `./mach test-wpt /html` fails, because it runs the tests blocked by `include.ini`. This PR replaces the `include.ini` entry by `__dir__.ini` files in each subdirectory of `html/editing` apart from `html/editing/activation`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because we don't watch the watchmen

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15674)
<!-- Reviewable:end -->
