### PR TITLE
Add 'use statements with extraneous spaces' tidy check

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -612,6 +612,10 @@ def check_rust(file_name, lines):
             indent = len(original_line) - len(line)
             if not line.endswith(";") and '{' in line:
                 yield (idx + 1, "use statement spans multiple lines")
+            if '{ ' in line:
+                yield (idx + 1, "extra space after {")
+            if ' }' in line:
+                yield (idx + 1, "extra space before }")
             # strip "use" from the begin and ";" from the end
             current_use = line[4:-1]
             if prev_use:

--- a/python/tidy/servo_tidy_tests/rust_tidy.rs
+++ b/python/tidy/servo_tidy_tests/rust_tidy.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use    app_units::Au;
+use azure::azure_hl::{ AntialiasMode, Color, ColorPattern, CompositionOp };
 use azure::azure_hl::{AntialiasMode, Color,
 ColorPattern, CompositionOp};
 use euclid::size::Size2D;

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -95,6 +95,8 @@ class CheckTidiness(unittest.TestCase):
 
     def test_rust(self):
         errors = tidy.collect_errors_for_files(iterFile('rust_tidy.rs'), [], [tidy.check_rust], print_text=False)
+        self.assertEqual('extra space after {', errors.next()[2])
+        self.assertEqual('extra space before }', errors.next()[2])
         self.assertEqual('use statement spans multiple lines', errors.next()[2])
         self.assertEqual('missing space before }', errors.next()[2])
         self.assertTrue('use statement is not in alphabetical order' in errors.next()[2])

--- a/tests/unit/style/parsing/inherited_text.rs
+++ b/tests/unit/style/parsing/inherited_text.rs
@@ -74,7 +74,7 @@ fn text_emphasis_style_longhand_should_parse_properly() {
 #[test]
 fn test_text_emphasis_position() {
     use style::properties::longhands::text_emphasis_position;
-    use style::properties::longhands::text_emphasis_position::{HorizontalWritingModeValue, VerticalWritingModeValue };
+    use style::properties::longhands::text_emphasis_position::{HorizontalWritingModeValue, VerticalWritingModeValue};
     use style::properties::longhands::text_emphasis_position::SpecifiedValue;
 
     let over_right = parse_longhand!(text_emphasis_position, "over right");


### PR DESCRIPTION
Add 'use statements with extraneous spaces' tidy check

I added simple check routine for 'use statements with extraneous
spaces' and codes that breaks the check routine in rust_tidy.rs.

* Added a code that using 'use statements with extraneous spaces' code
  in rust_tidy.rs
* Added assertion code in test_tidy.py.
* check_rust function in tidy.py now recognizes the simple case in
  the 'use statements with extraneous spaces'.
* Ran tidy check on rust code and modified a
  code(tests/unit/style/parsing/inherited_text.rs) that is not passing
  on this new tidy check.

TODO: this code has to be refactored to support more general cases, such as tab or newline.

- [X] `./mach build -d` does not report any errors
- [X] ./mach test-tidy does not report any errors
- [X] These changes fix #14898 (github issue number if applicable).
- [X] These changes do not require tests because ./mach test-tidy itself is the test for the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15690)
<!-- Reviewable:end -->
