### PR TITLE
Do not pool HTTP connections.

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -325,7 +325,8 @@ impl CoreResourceManager {
             cookie_jar: group.cookie_jar.clone(),
             auth_cache: group.auth_cache.clone(),
             blocked_content: BLOCKED_CONTENT_RULES.clone(),
-            connector_pool: group.connector.clone(),
+            // FIXME(#15694): use group.connector.clone() instead.
+            connector_pool: create_http_connector("certs"),
         };
         let ua = self.user_agent.clone();
         let dc = self.devtools_chan.clone();


### PR DESCRIPTION
HTTP connection pooling triggers consistent failures in #14620. Let's disable it until there's more time to solve the underlying problem in #15694.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15696)
<!-- Reviewable:end -->
