### PR TITLE
Invalid three value positions are no longer accepted

### DIFF
--- a/components/style/values/specified/position.rs
+++ b/components/style/values/specified/position.rs
@@ -187,13 +187,11 @@ impl Parse for Position {
             } else {
                 // Handle 3 value background position there are several options:
                 if let PositionCategory::LengthOrPercentage = category(&first) {
-                    // "length keyword length"
-                    Position::new(Some(first), Some(third), None, Some(second))
+                    Err(())
                 } else {
                     if let PositionCategory::LengthOrPercentage = category(&second) {
                         if let PositionCategory::LengthOrPercentage = category(&third) {
-                            // "keyword length length"
-                            Position::new(Some(second), Some(third), Some(first), None)
+                            Err(())
                         } else {
                             // "keyword length keyword"
                             Position::new(Some(second), None, Some(first), Some(third))

--- a/tests/unit/style/parsing/basic_shape.rs
+++ b/tests/unit/style/parsing/basic_shape.rs
@@ -112,9 +112,8 @@ fn test_circle() {
                                                 "circle(at 95% 100%)");
     assert_roundtrip_basicshape!(Circle::parse, "circle(at right 5% bottom 1px)",
                                                 "circle(at right 5% bottom 1px)");
-    assert_roundtrip_basicshape!(Circle::parse, "circle(at 5% bottom 1px)",
-                                                "circle(at left 5% bottom 1px)");
 
+    assert!(parse(Circle::parse, "circle(at 5% bottom 1px)").is_err());
     assert!(parse(Circle::parse, "circle(at top 40%)").is_err());
     assert!(parse(Circle::parse, "circle(-10px)").is_err());
 }

--- a/tests/unit/style/parsing/position.rs
+++ b/tests/unit/style/parsing/position.rs
@@ -48,6 +48,11 @@ fn test_position() {
     assert_roundtrip_with_context!(Position::parse, "center right 10px", "right 10px center");
     assert_roundtrip_with_context!(Position::parse, "center bottom 10px", "center bottom 10px");
 
+    // Invalid 3 value positions
+    assert!(parse(Position::parse, "20px 30px 20px").is_err());
+    assert!(parse(Position::parse, "top 30px 20px").is_err());
+    assert!(parse(Position::parse, "50% bottom 20%").is_err());
+
     // Only horizontal and vertical keywords can have positions
     assert!(parse(Position::parse, "center 10px left 15px").is_err());
     assert!(parse(Position::parse, "center 10px 15px").is_err());


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
- Position parse no longer accepts invalid three value positions

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15488 .

<!-- Either: -->
- [X] There are tests for these changes OR

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15702)
<!-- Reviewable:end -->
