### PR TITLE
geckolib: remove std::mem::transmute usages

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -14,7 +14,6 @@ use servo_url::ServoUrl;
 use std::borrow::Cow;
 use std::env;
 use std::fmt::Write;
-use std::mem;
 use std::ptr;
 use std::sync::{Arc, Mutex};
 use style::arc_ptr_eq;
@@ -362,12 +361,10 @@ pub extern "C" fn Servo_StyleSheet_Empty(mode: SheetParsingMode) -> RawServoStyl
         SheetParsingMode::eUserSheetFeatures => Origin::User,
         SheetParsingMode::eAgentSheetFeatures => Origin::UserAgent,
     };
-    let sheet = Arc::new(Stylesheet::from_str(
+    Arc::new(Stylesheet::from_str(
         "", url, origin, Default::default(), None,
-        Box::new(StdoutErrorReporter), extra_data));
-    unsafe {
-        mem::transmute(sheet)
-    }
+        Box::new(StdoutErrorReporter), extra_data)
+    ).into_strong()
 }
 
 #[no_mangle]
@@ -407,12 +404,10 @@ pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(loader: *mut Loader,
         Some(ref s) => Some(s),
     };
 
-    let sheet = Arc::new(Stylesheet::from_str(
+    Arc::new(Stylesheet::from_str(
         input, url, origin, Default::default(), loader,
-        Box::new(StdoutErrorReporter), extra_data));
-    unsafe {
-        mem::transmute(sheet)
-    }
+        Box::new(StdoutErrorReporter), extra_data)
+    ).into_strong()
 }
 
 #[no_mangle]
@@ -1331,7 +1326,7 @@ pub extern "C" fn Servo_ImportRule_GetSheet(import_rule:
                                             RawServoImportRuleBorrowed)
                                             -> RawServoStyleSheetStrong {
     let import_rule = RwLock::<ImportRule>::as_arc(&import_rule);
-    unsafe { mem::transmute(import_rule.read().stylesheet.clone()) }
+    import_rule.read().stylesheet.clone().into_strong()
 }
 
 #[no_mangle]


### PR DESCRIPTION
We can make these look nicer with the FFIArcHelpers trait.

I think there are tests for these changes?  Not sure.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15707)
<!-- Reviewable:end -->
