### PR TITLE
Implement gecko glue for clip property

### DIFF
--- a/components/style/properties/longhand/effects.mako.rs
+++ b/components/style/properties/longhand/effects.mako.rs
@@ -81,7 +81,6 @@ ${helpers.predefined_type("clip",
                           "ClipRectOrAuto",
                           "computed::ClipRectOrAuto::auto()",
                           animatable=False,
-                          products="servo",
                           boxed="True",
                           spec="https://drafts.fxtf.org/css-masking/#clip-property")}
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implemented gecko glue for clip property.

Clip property looks slightly different in gecko. `auto` top and left values are preserved as auto in [gecko](http://searchfox.org/mozilla-central/rev/39e4b25a076c59d2e7820297d62319f167871449/layout/style/nsRuleNode.cpp#10294,10316) but converted to 0 in [servo](https://dxr.mozilla.org/servo/rev/65624dbfc28442b58145215f524eb13aeb2cadf6/components/style/values/specified/mod.rs#942). Gecko is setting `NS_STYLE_CLIP_TOP_AUTO` and `NS_STYLE_CLIP_LEFT_AUTO` flags with that information. But I tried this property in stylo build and it is working correctly like this. It looks like it doesn't change the outcome of the property. 
~Do we really need to set these flags?~
Manishearth and bz said that auto and 0 values are same. 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1341728](https://bugzilla.mozilla.org/show_bug.cgi?id=1341728)

<!-- Either: -->
- [X] These changes do not require tests because this is stylo side change.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15710)
<!-- Reviewable:end -->
