### PR TITLE
Add support for remaining keyword values of -moz-user-select property

### DIFF
--- a/components/style/properties/longhand/ui.mako.rs
+++ b/components/style/properties/longhand/ui.mako.rs
@@ -16,8 +16,9 @@ ${helpers.single_keyword("ime-mode", "normal auto active disabled inactive",
                          animatable=False,
                          spec="https://drafts.csswg.org/css-ui/#input-method-editor")}
 
-${helpers.single_keyword("-moz-user-select", "auto text none all element elements
-                            toggle tri_state -moz-all -moz-none -moz-text", products="gecko",
+${helpers.single_keyword("-moz-user-select", "auto text none all element elements" +
+                            "toggle tri_state -moz-all -moz-none -moz-text",
+                         products="gecko",
                          alias="-webkit-user-select",
                          gecko_ffi_name="mUserSelect",
                          gecko_enum_prefix="StyleUserSelect",

--- a/components/style/properties/longhand/ui.mako.rs
+++ b/components/style/properties/longhand/ui.mako.rs
@@ -17,7 +17,7 @@ ${helpers.single_keyword("ime-mode", "normal auto active disabled inactive",
                          spec="https://drafts.csswg.org/css-ui/#input-method-editor")}
 
 ${helpers.single_keyword("-moz-user-select", "auto text none all element elements" +
-                            "toggle tri_state -moz-all -moz-none -moz-text",
+                            " toggle tri_state -moz-all -moz-none -moz-text",
                          products="gecko",
                          alias="-webkit-user-select",
                          gecko_ffi_name="mUserSelect",

--- a/components/style/properties/longhand/ui.mako.rs
+++ b/components/style/properties/longhand/ui.mako.rs
@@ -16,7 +16,8 @@ ${helpers.single_keyword("ime-mode", "normal auto active disabled inactive",
                          animatable=False,
                          spec="https://drafts.csswg.org/css-ui/#input-method-editor")}
 
-${helpers.single_keyword("-moz-user-select", "auto text none all", products="gecko",
+${helpers.single_keyword("-moz-user-select", "auto text none all element elements
+                            toggle tri_state -moz-all -moz-none -moz-text", products="gecko",
                          alias="-webkit-user-select",
                          gecko_ffi_name="mUserSelect",
                          gecko_enum_prefix="StyleUserSelect",

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -82,3 +82,4 @@ mod selectors;
 mod supports;
 mod text_overflow;
 mod transition_timing_function;
+mod ui;

--- a/tests/unit/style/parsing/ui.rs
+++ b/tests/unit/style/parsing/ui.rs
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use cssparser::Parser;
+use media_queries::CSSErrorReporterTest;
+use servo_url::ServoUrl;
+use style::parser::ParserContext;
+use style::stylesheets::Origin;
+use style_traits::ToCss;
+
+#[test]
+fn test_moz_user_select() {
+    use style::properties::longhands::_moz_user_select;
+
+    assert_roundtrip_with_context!(_moz_user_select::parse, "auto");
+    assert_roundtrip_with_context!(_moz_user_select::parse, "text");
+    assert_roundtrip_with_context!(_moz_user_select::parse, "none");
+    assert_roundtrip_with_context!(_moz_user_select::parse, "element");
+    assert_roundtrip_with_context!(_moz_user_select::parse, "elements");
+    assert_roundtrip_with_context!(_moz_user_select::parse, "toggle");
+    assert_roundtrip_with_context!(_moz_user_select::parse, "tri_state");
+    assert_roundtrip_with_context!(_moz_user_select::parse, "-moz-all");
+    assert_roundtrip_with_context!(_moz_user_select::parse, "-moz-none");
+    assert_roundtrip_with_context!(_moz_user_select::parse, "-moz-text");
+
+    let url = ServoUrl::parse("http://localhost").unwrap();
+    let context = ParserContext::new(Origin::Author, &url, Box::new(CSSErrorReporterTest));
+
+    let mut negative = Parser::new("potato");
+    assert!(_moz_user_select::parse(&context, &mut negative).is_err());
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Added remaining keywords element, elements, toggle, tri_state, -moz-all, -moz-none, and -moz-text to -moz-user-select and unit tests.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X ] `./mach build -d` does not report any errors
- [X ] `./mach test-tidy` does not report any errors
- [X ] These changes fix #15197 (github issue number if applicable).

<!-- Either: -->
- [ X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15711)
<!-- Reviewable:end -->
