### PR TITLE
Don’t deduplicate declarations at parse time

### DIFF
--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -62,10 +62,7 @@ impl CSSStyleOwner {
                     let result = f(&mut pdb, &mut changed);
                     result
                 } else {
-                    let mut pdb = PropertyDeclarationBlock {
-                        important_count: 0,
-                        declarations: vec![],
-                    };
+                    let mut pdb = PropertyDeclarationBlock::empty();
                     let result = f(&mut pdb, &mut changed);
 
                     // Here `changed` is somewhat silly, because we know the
@@ -116,10 +113,7 @@ impl CSSStyleOwner {
                 match *el.style_attribute().borrow() {
                     Some(ref pdb) => f(&pdb.read()),
                     None => {
-                        let pdb = PropertyDeclarationBlock {
-                            important_count: 0,
-                            declarations: vec![],
-                        };
+                        let pdb = PropertyDeclarationBlock::empty();
                         f(&pdb)
                     }
                 }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -83,7 +83,7 @@ impl CSSStyleOwner {
                     //
                     // [1]: https://github.com/whatwg/html/issues/2306
                     if let Some(pdb) = attr {
-                        let serialization = pdb.read().to_css_string();
+                        let serialization = pdb.write().to_css_string();
                         el.set_attribute(&local_name!("style"),
                                          AttrValue::Declaration(serialization,
                                                                 pdb));
@@ -120,6 +120,29 @@ impl CSSStyleOwner {
             }
             CSSStyleOwner::CSSRule(_, ref pdb) => {
                 f(&pdb.read())
+            }
+        }
+    }
+
+    fn with_mut_block<F, R>(&self, f: F) -> R
+        where F: FnOnce(&mut PropertyDeclarationBlock) -> R,
+    {
+        match *self {
+            CSSStyleOwner::Element(ref el) => {
+                match *el.style_attribute().borrow_mut() {
+                    Some(ref pdb) => f(&mut pdb.write()),
+                    None => {
+                        let mut pdb = PropertyDeclarationBlock::empty();
+                        let result = f(&mut pdb);
+                        // with_mut_block is only used in cases where mutablility
+                        // is only required for deduplication.
+                        assert!(pdb.len() == 0);
+                        result
+                    }
+                }
+            }
+            CSSStyleOwner::CSSRule(_, ref pdb) => {
+                f(&mut pdb.write())
             }
         }
     }
@@ -276,7 +299,8 @@ impl CSSStyleDeclaration {
 impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-length
     fn Length(&self) -> u32 {
-        self.owner.with_block(|pdb| {
+        self.owner.with_mut_block(|pdb| {
+            pdb.deduplicate();
             pdb.len() as u32
         })
     }
@@ -401,7 +425,8 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
 
     // https://dev.w3.org/csswg/cssom/#the-cssstyledeclaration-interface
     fn IndexedGetter(&self, index: u32) -> Option<DOMString> {
-        self.owner.with_block(|pdb| {
+        self.owner.with_mut_block(|pdb| {
+            pdb.deduplicate();
             pdb.as_potentially_duplicated().get(index as usize).map(|entry| {
                 let (ref declaration, importance) = *entry;
                 let mut css = declaration.to_css_string();
@@ -415,7 +440,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
 
     // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-csstext
     fn CssText(&self) -> DOMString {
-        self.owner.with_block(|pdb| {
+        self.owner.with_mut_block(|pdb| {
             DOMString::from(pdb.to_css_string())
         })
     }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -67,7 +67,7 @@ impl CSSStyleOwner {
 
                     // Here `changed` is somewhat silly, because we know the
                     // exact conditions under it changes.
-                    changed = !pdb.declarations.is_empty();
+                    changed = pdb.len() > 0;
                     if changed {
                         attr = Some(Arc::new(RwLock::new(pdb)));
                     }
@@ -277,7 +277,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-length
     fn Length(&self) -> u32 {
         self.owner.with_block(|pdb| {
-            pdb.declarations.len() as u32
+            pdb.len() as u32
         })
     }
 
@@ -402,7 +402,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
     // https://dev.w3.org/csswg/cssom/#the-cssstyledeclaration-interface
     fn IndexedGetter(&self, index: u32) -> Option<DOMString> {
         self.owner.with_block(|pdb| {
-            pdb.declarations.get(index as usize).map(|entry| {
+            pdb.as_potentially_duplicated().get(index as usize).map(|entry| {
                 let (ref declaration, importance) = *entry;
                 let mut css = declaration.to_css_string();
                 if importance.important() {

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -250,29 +250,30 @@ impl CSSStyleDeclaration {
 
             // Step 6
             let window = self.owner.window();
-            let declarations =
+            let result =
                 parse_one_declaration(id, &value, &self.owner.base_url(),
                                       window.css_error_reporter(),
                                       ParserContextExtraData::default());
 
             // Step 7
-            let declarations = match declarations {
-                Ok(declarations) => declarations,
+            let mut new_block = match result {
+                Ok(new_block) => new_block,
                 Err(_) => {
                     *changed = false;
                     return Ok(());
                 }
             };
 
+            if importance.important() {
+                new_block.set_to_important_from(0)
+            }
+
             // Step 8
             // Step 9
             // We could try to be better I guess?
-            *changed = !declarations.is_empty();
-            for declaration in declarations {
-                // TODO(emilio): We could check it changed
-                pdb.set_parsed_declaration(declaration.0, importance);
-            }
-
+            *changed = new_block.len() > 0;
+            // TODO(emilio): We could check it changed
+            pdb.extend(new_block);
             Ok(())
         })
     }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -101,8 +101,8 @@ use style::context::{QuirksMode, ReflowGoal};
 use style::element_state::*;
 use style::matching::{common_style_affecting_attributes, rare_style_affecting_attributes};
 use style::parser::ParserContextExtraData;
-use style::properties::{DeclaredValue, Importance};
 use style::properties::{PropertyDeclaration, PropertyDeclarationBlock, parse_style_attribute};
+use style::properties::DeclaredValue;
 use style::properties::longhands::{background_image, border_spacing, font_family, font_size, overflow_x};
 use style::restyle_hints::RESTYLE_SELF;
 use style::rule_tree::CascadeLevel;
@@ -383,11 +383,10 @@ impl LayoutElementHelpers for LayoutJS<Element> {
     {
         #[inline]
         fn from_declaration(declaration: PropertyDeclaration) -> ApplicableDeclarationBlock {
+            let mut block = PropertyDeclarationBlock::empty();
+            block.push_normal(declaration);
             ApplicableDeclarationBlock::from_declarations(
-                Arc::new(RwLock::new(PropertyDeclarationBlock {
-                    declarations: vec![(declaration, Importance::Normal)],
-                    important_count: 0,
-                })),
+                Arc::new(RwLock::new(block)),
                 CascadeLevel::PresHints)
         }
 

--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -11,7 +11,7 @@ use context::SharedStyleContext;
 use dom::{OpaqueNode, UnsafeNode};
 use euclid::point::Point2D;
 use keyframes::{KeyframesStep, KeyframesStepValue};
-use properties::{self, CascadeFlags, ComputedValues, Importance};
+use properties::{self, CascadeFlags, ComputedValues};
 use properties::animated_properties::{AnimatedProperty, TransitionProperty};
 use properties::longhands::animation_direction::computed_value::single_value::T as AnimationDirection;
 use properties::longhands::animation_iteration_count::single_value::computed_value::T as AnimationIterationCount;
@@ -418,11 +418,10 @@ fn compute_style_for_animation_step(context: &SharedStyleContext,
             let guard = declarations.read();
 
             // No !important in keyframes.
-            debug_assert!(guard.declarations.iter()
-                            .all(|&(_, importance)| importance == Importance::Normal));
+            debug_assert!(!guard.any_important());
 
             let iter = || {
-                guard.declarations.iter().rev().map(|&(ref decl, _importance)| decl)
+                guard.as_potentially_duplicated().iter().rev().map(|&(ref decl, _importance)| decl)
             };
 
             let computed =

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -40,13 +40,17 @@ pub fn parse_name(s: &str) -> Result<&str, ()> {
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct SpecifiedValue {
-    css: String,
+    /// The value in CSS syntax
+    pub css: String,
 
-    first_token_type: TokenSerializationType,
-    last_token_type: TokenSerializationType,
+    /// The type of token on the left, to see if concatenation is safe or needs a /**/ comment
+    pub first_token_type: TokenSerializationType,
 
-    /// Custom property names in var() functions.
-    references: HashSet<Name>,
+    /// The type of token on the right, to see if concatenation is safe or needs a /**/ comment
+    pub last_token_type: TokenSerializationType,
+
+    /// Custom property names referenced in var() functions in this value.
+    pub references: HashSet<Name>,
 }
 
 impl ::values::HasViewportPercentage for SpecifiedValue {

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -185,7 +185,7 @@ impl KeyframesStep {
            value: KeyframesStepValue) -> Self {
         let declared_timing_function = match value {
             KeyframesStepValue::Declarations { ref block } => {
-                block.read().declarations.iter().any(|&(ref prop_decl, _)| {
+                block.read().as_potentially_duplicated().iter().any(|&(ref prop_decl, _)| {
                     match *prop_decl {
                         PropertyDeclaration::AnimationTimingFunction(..) => true,
                         _ => false,
@@ -253,7 +253,7 @@ fn get_animated_properties(keyframes: &[Arc<RwLock<Keyframe>>]) -> Vec<Transitio
     // it here.
     for keyframe in keyframes {
         let keyframe = keyframe.read();
-        for &(ref declaration, importance) in keyframe.block.read().declarations.iter() {
+        for &(ref declaration, importance) in keyframe.block.read().as_potentially_duplicated() {
             assert!(!importance.important());
 
             if let Some(property) = TransitionProperty::from_declaration(declaration) {

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -117,7 +117,7 @@ impl ToCss for Keyframe {
             try!(percentage.to_css(dest));
         }
         try!(dest.write_str(" { "));
-        try!(self.block.read().to_css(dest));
+        try!(self.block.write().to_css(dest));
         try!(dest.write_str(" }"));
         Ok(())
     }

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -54,8 +54,7 @@ pub struct PropertyDeclarationBlock {
     /// The group of declarations, along with their importance.
     ///
     /// Only deduplicated declarations appear here.
-    #[cfg_attr(feature = "servo", ignore_heap_size_of = "#7038")]
-    pub declarations: Vec<(PropertyDeclaration, Importance)>,
+    declarations: Vec<(PropertyDeclaration, Importance)>,
 
     /// The number of entries in `self.declaration` with `Importance::Important`
     important_count: usize,
@@ -109,6 +108,11 @@ impl PropertyDeclarationBlock {
     /// Push a declaration that is not !important
     pub fn push_normal(&mut self, declaration: PropertyDeclaration) {
         self.declarations.push((declaration, Importance::Normal))
+    }
+
+    /// Iterator the declarations as-is. There may be more than one for a given property.
+    pub fn as_potentially_duplicated(&self) -> &[(PropertyDeclaration, Importance)] {
+        &self.declarations
     }
 
     /// Returns wheather this block contains any declaration with `!important`.

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -168,23 +168,20 @@ impl ComputedValues {
             % for prop in data.longhands:
                 % if prop.animatable:
                     PropertyDeclarationId::Longhand(LonghandId::${prop.camel_case}) => {
-                        PropertyDeclarationBlock {
-                            declarations: vec![
-                                (PropertyDeclaration::${prop.camel_case}(DeclaredValue::Value(
-                                    % if prop.boxed:
-                                        Box::new(
-                                    % endif
-                                    longhands::${prop.ident}::SpecifiedValue::from_computed_value(
-                                      &self.get_${prop.style_struct.ident.strip("_")}().clone_${prop.ident}())
-                                    % if prop.boxed:
-                                        )
-                                    % endif
+                        PropertyDeclarationBlock::from(vec![
+                            (PropertyDeclaration::${prop.camel_case}(DeclaredValue::Value(
+                                % if prop.boxed:
+                                    Box::new(
+                                % endif
+                                longhands::${prop.ident}::SpecifiedValue::from_computed_value(
+                                  &self.get_${prop.style_struct.ident.strip("_")}().clone_${prop.ident}())
+                                % if prop.boxed:
+                                    )
+                                % endif
 
-                                 )),
-                                 Importance::Normal)
-                            ],
-                            important_count: 0
-                        }
+                             )),
+                             Importance::Normal)
+                        ])
                     },
                 % endif
             % endfor

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -490,7 +490,7 @@
         use parser::ParserContext;
         use properties::{DeclaredValue, PropertyDeclaration, UnparsedValue};
         use properties::{ShorthandId, longhands};
-        use properties::declaration_block::Importance;
+        use properties::declaration_block::PropertyDeclarationBlock;
         use std::fmt;
         use style_traits::ToCss;
         use super::{SerializeFlags, ALL_INHERIT, ALL_INITIAL, ALL_UNSET};
@@ -599,7 +599,7 @@
         /// `declarations` vector.
         pub fn parse(context: &ParserContext,
                      input: &mut Parser,
-                     declarations: &mut Vec<(PropertyDeclaration, Importance)>)
+                     declarations: &mut PropertyDeclarationBlock)
                      -> Result<(), ()> {
             input.look_for_var_functions();
             let start = input.position();
@@ -610,7 +610,7 @@
             let var = input.seen_var_functions();
             if let Ok(value) = value {
                 % for sub_property in shorthand.sub_properties:
-                    declarations.push((PropertyDeclaration::${sub_property.camel_case}(
+                    declarations.push_normal(PropertyDeclaration::${sub_property.camel_case}(
                         match value.${sub_property.ident} {
                             % if sub_property.boxed:
                                 Some(value) => DeclaredValue::Value(Box::new(value)),
@@ -619,7 +619,7 @@
                             % endif
                             None => DeclaredValue::Initial,
                         }
-                    ), Importance::Normal));
+                    ));
                 % endfor
                 Ok(())
             } else if var {
@@ -627,14 +627,14 @@
                 let (first_token_type, css) = try!(
                     ::custom_properties::parse_non_custom_with_var(input));
                 % for sub_property in shorthand.sub_properties:
-                    declarations.push((PropertyDeclaration::${sub_property.camel_case}(
+                    declarations.push_normal(PropertyDeclaration::${sub_property.camel_case}(
                         DeclaredValue::WithVariables(Box::new(UnparsedValue {
                             css: css.clone().into_owned(),
                             first_token_type: first_token_type,
                             base_url: context.base_url.clone(),
                             from_shorthand: Some(ShorthandId::${shorthand.camel_case}),
                         }))
-                    ), Importance::Normal));
+                    ));
                 % endfor
                 Ok(())
             } else {

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1729,7 +1729,8 @@ pub fn cascade(viewport_size: Size2D<Au>,
     }).collect::<Vec<_>>();
     let iter_declarations = || {
         lock_guards.iter().flat_map(|&(ref source, source_importance)| {
-            source.declarations.iter()
+            source.as_potentially_duplicated()
+            .iter()
             // Yield declarations later in source order (with more precedence) first.
             .rev()
             .filter_map(move |&(ref declaration, declaration_importance)| {

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -958,7 +958,7 @@ impl PropertyDeclaration {
     /// to Importance::Normal. Parsing Importance values is the job of PropertyDeclarationParser,
     /// we only set them here so that we don't have to reallocate
     pub fn parse(id: PropertyId, context: &ParserContext, input: &mut Parser,
-                 result_list: &mut Vec<(PropertyDeclaration, Importance)>,
+                 result_list: &mut PropertyDeclarationBlock,
                  in_keyframe_block: bool)
                  -> PropertyDeclarationParseResult {
         match id {
@@ -972,8 +972,7 @@ impl PropertyDeclaration {
                         Err(()) => return PropertyDeclarationParseResult::InvalidValue,
                     }
                 };
-                result_list.push((PropertyDeclaration::Custom(name, value),
-                                  Importance::Normal));
+                result_list.push_normal(PropertyDeclaration::Custom(name, value));
                 return PropertyDeclarationParseResult::ValidOrIgnoredDeclaration;
             }
             PropertyId::Longhand(id) => match id {
@@ -995,8 +994,7 @@ impl PropertyDeclaration {
 
                         match longhands::${property.ident}::parse_declared(context, input) {
                             Ok(value) => {
-                                result_list.push((PropertyDeclaration::${property.camel_case}(value),
-                                                  Importance::Normal));
+                                result_list.push_normal(PropertyDeclaration::${property.camel_case}(value));
                                 PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
                             },
                             Err(()) => PropertyDeclarationParseResult::InvalidValue,
@@ -1026,24 +1024,25 @@ impl PropertyDeclaration {
                     match input.try(|i| CSSWideKeyword::parse(context, i)) {
                         Ok(CSSWideKeyword::InheritKeyword) => {
                             % for sub_property in shorthand.sub_properties:
-                                result_list.push((
+                                result_list.push_normal(
                                     PropertyDeclaration::${sub_property.camel_case}(
-                                        DeclaredValue::Inherit), Importance::Normal));
+                                        DeclaredValue::Inherit));
                             % endfor
                             PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
                         },
                         Ok(CSSWideKeyword::InitialKeyword) => {
                             % for sub_property in shorthand.sub_properties:
-                                result_list.push((
+                                result_list.push_normal(
                                     PropertyDeclaration::${sub_property.camel_case}(
-                                        DeclaredValue::Initial), Importance::Normal));
+                                        DeclaredValue::Initial));
                             % endfor
                             PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
                         },
                         Ok(CSSWideKeyword::UnsetKeyword) => {
                             % for sub_property in shorthand.sub_properties:
-                                result_list.push((PropertyDeclaration::${sub_property.camel_case}(
-                                        DeclaredValue::Unset), Importance::Normal));
+                                result_list.push_normal(
+                                    PropertyDeclaration::${sub_property.camel_case}(
+                                        DeclaredValue::Unset));
                             % endfor
                             PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
                         },

--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -99,7 +99,7 @@ impl StyleSource {
             let _ = write!(writer, "{:?}", rule.read().selectors);
         }
 
-        let _ = write!(writer, "  -> {:?}", self.read().declarations);
+        let _ = write!(writer, "  -> {:?}", self.read().as_potentially_duplicated());
     }
 
     /// Read the style source guard, and obtain thus read access to the

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -532,7 +532,7 @@ impl ToCss for StyleRule {
         // Step 2
         try!(dest.write_str(" { "));
         // Step 3
-        let declaration_block = self.block.read();
+        let mut declaration_block = self.block.write();
         try!(declaration_block.to_css(dest));
         // Step 4
         if declaration_block.len() > 0 {

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -535,7 +535,7 @@ impl ToCss for StyleRule {
         let declaration_block = self.block.read();
         try!(declaration_block.to_css(dest));
         // Step 4
-        if declaration_block.declarations.len() > 0 {
+        if declaration_block.len() > 0 {
             try!(write!(dest, " "));
         }
         // Step 5

--- a/components/style/supports.rs
+++ b/components/style/supports.rs
@@ -7,6 +7,7 @@
 use cssparser::{parse_important, Parser, Token};
 use parser::ParserContext;
 use properties::{PropertyDeclaration, PropertyId};
+use properties::declaration_block::PropertyDeclarationBlock;
 use std::fmt;
 use style_traits::ToCss;
 
@@ -212,9 +213,9 @@ impl Declaration {
             return false
         };
         let mut input = Parser::new(&self.val);
-        let mut list = Vec::new();
+        let mut block = PropertyDeclarationBlock::empty();
         let res = PropertyDeclaration::parse(id, cx, &mut input,
-                                             &mut list, /* in_keyframe */ false);
+                                             &mut block, /* in_keyframe */ false);
         let _ = input.try(parse_important);
         if !input.is_exhausted() {
             return false;

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -749,7 +749,7 @@ pub extern "C" fn Servo_DeclarationBlock_Equals(a: RawServoDeclarationBlockBorro
 pub extern "C" fn Servo_DeclarationBlock_GetCssText(declarations: RawServoDeclarationBlockBorrowed,
                                                     result: *mut nsAString) {
     let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
-    declarations.read().to_css(unsafe { result.as_mut().unwrap() }).unwrap();
+    declarations.write().to_css(unsafe { result.as_mut().unwrap() }).unwrap();
 }
 
 #[no_mangle]
@@ -769,14 +769,18 @@ pub extern "C" fn Servo_DeclarationBlock_SerializeOneValue(
 #[no_mangle]
 pub extern "C" fn Servo_DeclarationBlock_Count(declarations: RawServoDeclarationBlockBorrowed) -> u32 {
      let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
-     declarations.read().declarations.len() as u32
+     let mut guard = declarations.write();
+     guard.deduplicate();
+     guard.len() as u32
 }
 
 #[no_mangle]
 pub extern "C" fn Servo_DeclarationBlock_GetNthProperty(declarations: RawServoDeclarationBlockBorrowed,
                                                         index: u32, result: *mut nsAString) -> bool {
     let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
-    if let Some(&(ref decl, _)) = declarations.read().declarations.get(index as usize) {
+    let mut guard = declarations.write();
+    guard.deduplicate();
+    if let Some(&(ref decl, _)) = guard.as_potentially_duplicated().get(index as usize) {
         let result = unsafe { result.as_mut().unwrap() };
         decl.id().to_css(result).unwrap();
         true
@@ -926,7 +930,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetIdentStringValue(declarations:
     let prop = match_wrap_declared! { long,
         XLang => Lang(Atom::from(value)),
     };
-    declarations.write().declarations.push((prop, Default::default()));
+    declarations.write().push_normal(prop);
 }
 
 #[no_mangle]
@@ -963,7 +967,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetKeywordValue(declarations:
         BorderBottomStyle => BorderStyle::from_gecko_keyword(value),
         BorderLeftStyle => BorderStyle::from_gecko_keyword(value),
     };
-    declarations.write().declarations.push((prop, Default::default()));
+    declarations.write().push_normal(prop);
 }
 
 #[no_mangle]
@@ -978,7 +982,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetIntValue(declarations: RawServoDecla
     let prop = match_wrap_declared! { long,
         XSpan => Span(value),
     };
-    declarations.write().declarations.push((prop, Default::default()));
+    declarations.write().push_normal(prop);
 }
 
 #[no_mangle]
@@ -1017,7 +1021,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetPixelValue(declarations:
             }
         ),
     };
-    declarations.write().declarations.push((prop, Default::default()));
+    declarations.write().push_normal(prop);
 }
 
 #[no_mangle]
@@ -1040,7 +1044,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetPercentValue(declarations:
         MarginBottom => pc.into(),
         MarginLeft => pc.into(),
     };
-    declarations.write().declarations.push((prop, Default::default()));
+    declarations.write().push_normal(prop);
 }
 
 #[no_mangle]
@@ -1062,7 +1066,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetAutoValue(declarations:
         MarginBottom => auto,
         MarginLeft => auto,
     };
-    declarations.write().declarations.push((prop, Default::default()));
+    declarations.write().push_normal(prop);
 }
 
 #[no_mangle]
@@ -1083,7 +1087,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetCurrentColor(declarations:
         BorderBottomColor => cc,
         BorderLeftColor => cc,
     };
-    declarations.write().declarations.push((prop, Default::default()));
+    declarations.write().push_normal(prop);
 }
 
 #[no_mangle]
@@ -1109,7 +1113,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetColorValue(declarations:
         Color => CSSRGBA { parsed: rgba, authored: None },
         BackgroundColor => color,
     };
-    declarations.write().declarations.push((prop, Default::default()));
+    declarations.write().push_normal(prop);
 }
 
 #[no_mangle]
@@ -1126,7 +1130,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetFontFamily(declarations:
     if let Ok(family) = FontFamily::parse(&mut parser) {
         if parser.is_exhausted() {
             let decl = PropertyDeclaration::FontFamily(DeclaredValue::Value(family));
-            declarations.write().declarations.push((decl, Default::default()));
+            declarations.write().push_normal(decl);
         }
     }
 }
@@ -1141,7 +1145,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetTextDecorationColorOverride(declarat
     let mut decoration = text_decoration_line::computed_value::none;
     decoration |= text_decoration_line::COLOR_OVERRIDE;
     let decl = PropertyDeclaration::TextDecorationLine(DeclaredValue::Value(decoration));
-    declarations.write().declarations.push((decl, Default::default()));
+    declarations.write().push_normal(decl);
 }
 
 #[no_mangle]
@@ -1358,10 +1362,14 @@ pub extern "C" fn Servo_GetComputedKeyframeValues(keyframes: RawGeckoKeyframeLis
                                            .filter(|&property| !property.mServoDeclarationBlock.mRawPtr.is_null());
         for property in iter {
             let declarations = unsafe { &*property.mServoDeclarationBlock.mRawPtr.clone() };
-            let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
-            let guard = declarations.read();
+            let block = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
 
-            let anim_iter = guard.declarations
+            // FIXME: https://github.com/servo/servo/issues/15558#issuecomment-282216242
+            // Conservatively we deduplicate here, but it might not be needed.
+            // If not, replace .write() with .read() and remove the deduplicate() line.
+            let mut guard = block.write();
+            guard.deduplicate();
+            let anim_iter = guard.as_potentially_duplicated()
                             .iter()
                             .filter_map(|&(ref decl, imp)| {
                                 if imp == Importance::Normal {
@@ -1465,10 +1473,15 @@ pub extern "C" fn Servo_StyleSet_FillKeyframesForName(raw_data: RawServoStyleSet
                   }
               },
               KeyframesStepValue::Declarations { ref block } => {
-                  let guard = block.read();
                   // Filter out non-animatable properties.
+
+                  // FIXME: https://github.com/servo/servo/issues/15558#issuecomment-282216242
+                  // Conservatively we deduplicate here, but it might not be needed.
+                  // If not, replace .write() with .read() and remove the deduplicate() line.
+                  let mut guard = block.write();
+                  guard.deduplicate();
                   let animatable =
-                      guard.declarations
+                      guard.as_potentially_duplicated()
                            .iter()
                            .filter(|&&(ref declaration, _)| {
                                declaration.is_animatable()

--- a/tests/unit/style/keyframes.rs
+++ b/tests/unit/style/keyframes.rs
@@ -27,10 +27,7 @@ fn test_no_property_in_keyframe() {
     let keyframes = vec![
         Arc::new(RwLock::new(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(1.)]),
-            block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                declarations: vec![],
-                important_count: 0,
-            }))
+            block: Arc::new(RwLock::new(PropertyDeclarationBlock::empty()))
         })),
     ];
     let animation = KeyframesAnimation::from_keyframes(&keyframes);
@@ -45,28 +42,22 @@ fn test_no_property_in_keyframe() {
 #[test]
 fn test_missing_property_in_initial_keyframe() {
     let declarations_on_initial_keyframe =
-        Arc::new(RwLock::new(PropertyDeclarationBlock {
-            declarations: vec![
-                (PropertyDeclaration::Width(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
-            ],
-            important_count: 0,
-        }));
+        Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+            (PropertyDeclaration::Width(
+                DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+             Importance::Normal),
+        ])));
 
     let declarations_on_final_keyframe =
-        Arc::new(RwLock::new(PropertyDeclarationBlock {
-            declarations: vec![
-                (PropertyDeclaration::Width(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
+        Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+            (PropertyDeclaration::Width(
+                DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+             Importance::Normal),
 
-                (PropertyDeclaration::Height(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
-            ],
-            important_count: 0,
-        }));
+            (PropertyDeclaration::Height(
+                DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+             Importance::Normal),
+        ])));
 
     let keyframes = vec![
         Arc::new(RwLock::new(Keyframe {
@@ -102,28 +93,22 @@ fn test_missing_property_in_initial_keyframe() {
 #[test]
 fn test_missing_property_in_final_keyframe() {
     let declarations_on_initial_keyframe =
-        Arc::new(RwLock::new(PropertyDeclarationBlock {
-            declarations: vec![
-                (PropertyDeclaration::Width(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
+        Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+            (PropertyDeclaration::Width(
+                DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+             Importance::Normal),
 
-                (PropertyDeclaration::Height(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
-            ],
-            important_count: 0,
-        }));
+            (PropertyDeclaration::Height(
+                DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+             Importance::Normal),
+        ])));
 
     let declarations_on_final_keyframe =
-        Arc::new(RwLock::new(PropertyDeclarationBlock {
-            declarations: vec![
-                (PropertyDeclaration::Height(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
-            ],
-            important_count: 0,
-        }));
+        Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+            (PropertyDeclaration::Height(
+                DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+             Importance::Normal),
+        ])));
 
     let keyframes = vec![
         Arc::new(RwLock::new(Keyframe {
@@ -159,26 +144,20 @@ fn test_missing_property_in_final_keyframe() {
 #[test]
 fn test_missing_keyframe_in_both_of_initial_and_final_keyframe() {
     let declarations =
-        Arc::new(RwLock::new(PropertyDeclarationBlock {
-            declarations: vec![
-                (PropertyDeclaration::Width(
-                        DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
+        Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+            (PropertyDeclaration::Width(
+                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+             Importance::Normal),
 
-                (PropertyDeclaration::Height(
-                        DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                Importance::Normal),
-            ],
-            important_count: 0,
-        }));
+            (PropertyDeclaration::Height(
+                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+            Importance::Normal),
+        ])));
 
     let keyframes = vec![
         Arc::new(RwLock::new(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(0.)]),
-            block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                declarations: vec![],
-                important_count: 0,
-            }))
+            block: Arc::new(RwLock::new(PropertyDeclarationBlock::empty()))
         })),
         Arc::new(RwLock::new(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(0.5)]),
@@ -191,11 +170,8 @@ fn test_missing_keyframe_in_both_of_initial_and_final_keyframe() {
             KeyframesStep {
                 start_percentage: KeyframePercentage(0.),
                 value: KeyframesStepValue::Declarations {
-                    block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                        // XXX: Should we use ComputedValues in this case?
-                        declarations: vec![],
-                        important_count: 0,
-                    }))
+                    // XXX: Should we use ComputedValues in this case?
+                    block: Arc::new(RwLock::new(PropertyDeclarationBlock::empty()))
                 },
                 declared_timing_function: false,
             },

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -18,7 +18,7 @@ fn property_declaration_block_should_serialize_correctly() {
     use style::properties::longhands::overflow_x::SpecifiedValue as OverflowXValue;
     use style::properties::longhands::overflow_y::SpecifiedValue as OverflowYContainer;
 
-    let declarations = vec![
+    let block = PropertyDeclarationBlock::from(vec![
         (PropertyDeclaration::Width(
             DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(70f32)))),
          Importance::Normal),
@@ -42,12 +42,7 @@ fn property_declaration_block_should_serialize_correctly() {
         (PropertyDeclaration::OverflowY(
             DeclaredValue::Value(OverflowYContainer(OverflowXValue::auto))),
          Importance::Normal),
-    ];
-
-    let block = PropertyDeclarationBlock {
-        declarations: declarations,
-        important_count: 0,
-    };
+    ]);
 
     let css_string = block.to_css_string();
 
@@ -61,10 +56,8 @@ mod shorthand_serialization {
     pub use super::*;
 
     pub fn shorthand_properties_to_string(properties: Vec<PropertyDeclaration>) -> String {
-        let block = PropertyDeclarationBlock {
-            declarations: properties.into_iter().map(|d| (d, Importance::Normal)).collect(),
-            important_count: 0,
-        };
+        let block = PropertyDeclarationBlock::from(
+            properties.into_iter().map(|d| (d, Importance::Normal)).collect::<Vec<_>>());
 
         block.to_css_string()
     }
@@ -1047,17 +1040,12 @@ mod shorthand_serialization {
 
         #[test]
         fn should_serialize_to_empty_string_if_sub_types_not_equal() {
-            let declarations = vec![
+            let block = PropertyDeclarationBlock::from(vec![
                 (PropertyDeclaration::ScrollSnapTypeX(DeclaredValue::Value(ScrollSnapTypeXValue::mandatory)),
                 Importance::Normal),
                 (PropertyDeclaration::ScrollSnapTypeY(DeclaredValue::Value(ScrollSnapTypeXValue::none)),
                 Importance::Normal)
-            ];
-
-            let block = PropertyDeclarationBlock {
-                declarations: declarations,
-                important_count: 0
-            };
+            ]);
 
             let mut s = String::new();
 
@@ -1070,17 +1058,12 @@ mod shorthand_serialization {
 
         #[test]
         fn should_serialize_to_single_value_if_sub_types_are_equal() {
-            let declarations = vec![
+            let block = PropertyDeclarationBlock::from(vec![
                 (PropertyDeclaration::ScrollSnapTypeX(DeclaredValue::Value(ScrollSnapTypeXValue::mandatory)),
                 Importance::Normal),
                 (PropertyDeclaration::ScrollSnapTypeY(DeclaredValue::Value(ScrollSnapTypeXValue::mandatory)),
                 Importance::Normal)
-            ];
-
-            let block = PropertyDeclarationBlock {
-                declarations: declarations,
-                important_count: 0
-            };
+            ]);
 
             let mut s = String::new();
 

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -18,7 +18,7 @@ fn property_declaration_block_should_serialize_correctly() {
     use style::properties::longhands::overflow_x::SpecifiedValue as OverflowXValue;
     use style::properties::longhands::overflow_y::SpecifiedValue as OverflowYContainer;
 
-    let block = PropertyDeclarationBlock::from(vec![
+    let mut block = PropertyDeclarationBlock::from(vec![
         (PropertyDeclaration::Width(
             DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(70f32)))),
          Importance::Normal),
@@ -56,7 +56,7 @@ mod shorthand_serialization {
     pub use super::*;
 
     pub fn shorthand_properties_to_string(properties: Vec<PropertyDeclaration>) -> String {
-        let block = PropertyDeclarationBlock::from(
+        let mut block = PropertyDeclarationBlock::from(
             properties.into_iter().map(|d| (d, Importance::Normal)).collect::<Vec<_>>());
 
         block.to_css_string()
@@ -1139,7 +1139,7 @@ mod shorthand_serialization {
 
         #[test]
         fn serialize_single_animation() {
-            let block = property_declaration_block("\
+            let mut block = property_declaration_block("\
                 animation-name: bounce;\
                 animation-duration: 1s;\
                 animation-timing-function: ease-in;\
@@ -1156,7 +1156,7 @@ mod shorthand_serialization {
 
         #[test]
         fn serialize_multiple_animations() {
-            let block = property_declaration_block("\
+            let mut block = property_declaration_block("\
                 animation-name: bounce, roll;\
                 animation-duration: 1s, 0.2s;\
                 animation-timing-function: ease-in, linear;\
@@ -1189,7 +1189,7 @@ mod shorthand_serialization {
                 animation-fill-mode: forwards, backwards; \
                 animation-iteration-count: infinite, 2; \
                 animation-play-state: paused, running;";
-            let block = property_declaration_block(block_text);
+            let mut block = property_declaration_block(block_text);
 
             let serialization = block.to_css_string();
 
@@ -1205,7 +1205,7 @@ mod shorthand_serialization {
                               animation-fill-mode: forwards, backwards; \
                               animation-iteration-count: infinite, 2; \
                               animation-play-state: paused, running;";
-            let block = property_declaration_block(block_text);
+            let mut block = property_declaration_block(block_text);
 
             let serialization = block.to_css_string();
 

--- a/tests/unit/style/rule_tree/bench.rs
+++ b/tests/unit/style/rule_tree/bench.rs
@@ -67,14 +67,11 @@ fn test_insertion(rule_tree: &RuleTree, rules: Vec<(StyleSource, CascadeLevel)>)
 
 fn test_insertion_style_attribute(rule_tree: &RuleTree, rules: &[(StyleSource, CascadeLevel)]) -> StrongRuleNode {
     let mut rules = rules.to_vec();
-    rules.push((StyleSource::Declarations(Arc::new(RwLock::new(PropertyDeclarationBlock {
-        declarations: vec![
-            (PropertyDeclaration::Display(DeclaredValue::Value(
-                longhands::display::SpecifiedValue::block)),
-            Importance::Normal),
-        ],
-        important_count: 0,
-    }))), CascadeLevel::UserNormal));
+    rules.push((StyleSource::Declarations(Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+        (PropertyDeclaration::Display(DeclaredValue::Value(
+            longhands::display::SpecifiedValue::block)),
+        Importance::Normal),
+    ])))), CascadeLevel::UserNormal));
     test_insertion(rule_tree, rules)
 }
 

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -97,16 +97,13 @@ fn test_parse_stylesheet() {
                         specificity: (0 << 20) + (1 << 10) + (1 << 0),
                     },
                 ]),
-                block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                    declarations: vec![
-                        (PropertyDeclaration::Display(DeclaredValue::Value(
-                            longhands::display::SpecifiedValue::none)),
-                         Importance::Important),
-                        (PropertyDeclaration::Custom(Atom::from("a"), DeclaredValue::Inherit),
-                         Importance::Important),
-                    ],
-                    important_count: 2,
-                })),
+                block: Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+                    (PropertyDeclaration::Display(DeclaredValue::Value(
+                        longhands::display::SpecifiedValue::none)),
+                     Importance::Important),
+                    (PropertyDeclaration::Custom(Atom::from("a"), DeclaredValue::Inherit),
+                     Importance::Important),
+                ]))),
             }))),
             CssRule::Style(Arc::new(RwLock::new(StyleRule {
                 selectors: SelectorList(vec![
@@ -145,14 +142,11 @@ fn test_parse_stylesheet() {
                         specificity: (0 << 20) + (0 << 10) + (1 << 0),
                     },
                 ]),
-                block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                    declarations: vec![
-                        (PropertyDeclaration::Display(DeclaredValue::Value(
-                            longhands::display::SpecifiedValue::block)),
-                         Importance::Normal),
-                    ],
-                    important_count: 0,
-                })),
+                block: Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+                    (PropertyDeclaration::Display(DeclaredValue::Value(
+                        longhands::display::SpecifiedValue::block)),
+                     Importance::Normal),
+                ]))),
             }))),
             CssRule::Style(Arc::new(RwLock::new(StyleRule {
                 selectors: SelectorList(vec![
@@ -180,58 +174,55 @@ fn test_parse_stylesheet() {
                         specificity: (1 << 20) + (1 << 10) + (0 << 0),
                     },
                 ]),
-                block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                    declarations: vec![
-                        (PropertyDeclaration::BackgroundColor(DeclaredValue::Value(
-                            longhands::background_color::SpecifiedValue {
-                                authored: Some("blue".to_owned().into_boxed_str()),
-                                parsed: cssparser::Color::RGBA(cssparser::RGBA::new(0, 0, 255, 255)),
-                            }
-                         )),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundPositionX(DeclaredValue::Value(
-                            longhands::background_position_x::SpecifiedValue(
-                            vec![longhands::background_position_x::single_value
-                                                       ::get_initial_position_value()]))),
-                        Importance::Normal),
-                        (PropertyDeclaration::BackgroundPositionY(DeclaredValue::Value(
-                            longhands::background_position_y::SpecifiedValue(
-                            vec![longhands::background_position_y::single_value
-                                                       ::get_initial_position_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundRepeat(DeclaredValue::Value(
-                            longhands::background_repeat::SpecifiedValue(
-                            vec![longhands::background_repeat::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundAttachment(DeclaredValue::Value(
-                            longhands::background_attachment::SpecifiedValue(
-                            vec![longhands::background_attachment::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundImage(DeclaredValue::Value(
-                            longhands::background_image::SpecifiedValue(
-                            vec![longhands::background_image::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundSize(DeclaredValue::Value(
-                            longhands::background_size::SpecifiedValue(
-                            vec![longhands::background_size::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundOrigin(DeclaredValue::Value(
-                            longhands::background_origin::SpecifiedValue(
-                            vec![longhands::background_origin::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundClip(DeclaredValue::Value(
-                            longhands::background_clip::SpecifiedValue(
-                            vec![longhands::background_clip::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                    ],
-                    important_count: 0,
-                })),
+                block: Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+                    (PropertyDeclaration::BackgroundColor(DeclaredValue::Value(
+                        longhands::background_color::SpecifiedValue {
+                            authored: Some("blue".to_owned().into_boxed_str()),
+                            parsed: cssparser::Color::RGBA(cssparser::RGBA::new(0, 0, 255, 255)),
+                        }
+                     )),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundPositionX(DeclaredValue::Value(
+                        longhands::background_position_x::SpecifiedValue(
+                        vec![longhands::background_position_x::single_value
+                                                   ::get_initial_position_value()]))),
+                    Importance::Normal),
+                    (PropertyDeclaration::BackgroundPositionY(DeclaredValue::Value(
+                        longhands::background_position_y::SpecifiedValue(
+                        vec![longhands::background_position_y::single_value
+                                                   ::get_initial_position_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundRepeat(DeclaredValue::Value(
+                        longhands::background_repeat::SpecifiedValue(
+                        vec![longhands::background_repeat::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundAttachment(DeclaredValue::Value(
+                        longhands::background_attachment::SpecifiedValue(
+                        vec![longhands::background_attachment::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundImage(DeclaredValue::Value(
+                        longhands::background_image::SpecifiedValue(
+                        vec![longhands::background_image::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundSize(DeclaredValue::Value(
+                        longhands::background_size::SpecifiedValue(
+                        vec![longhands::background_size::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundOrigin(DeclaredValue::Value(
+                        longhands::background_origin::SpecifiedValue(
+                        vec![longhands::background_origin::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundClip(DeclaredValue::Value(
+                        longhands::background_clip::SpecifiedValue(
+                        vec![longhands::background_clip::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                ]))),
             }))),
             CssRule::Keyframes(Arc::new(RwLock::new(KeyframesRule {
                 name: "foo".into(),
@@ -239,30 +230,24 @@ fn test_parse_stylesheet() {
                     Arc::new(RwLock::new(Keyframe {
                         selector: KeyframeSelector::new_for_unit_testing(
                                       vec![KeyframePercentage::new(0.)]),
-                        block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                            declarations: vec![
-                                (PropertyDeclaration::Width(DeclaredValue::Value(
-                                    LengthOrPercentageOrAuto::Percentage(Percentage(0.)))),
-                                 Importance::Normal),
-                            ],
-                            important_count: 0,
-                        }))
+                        block: Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+                            (PropertyDeclaration::Width(DeclaredValue::Value(
+                                LengthOrPercentageOrAuto::Percentage(Percentage(0.)))),
+                             Importance::Normal),
+                        ])))
                     })),
                     Arc::new(RwLock::new(Keyframe {
                         selector: KeyframeSelector::new_for_unit_testing(
                                       vec![KeyframePercentage::new(1.)]),
-                        block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                            declarations: vec![
-                                (PropertyDeclaration::Width(DeclaredValue::Value(
-                                    LengthOrPercentageOrAuto::Percentage(Percentage(1.)))),
-                                 Importance::Normal),
-                                (PropertyDeclaration::AnimationPlayState(DeclaredValue::Value(
-                                    animation_play_state::SpecifiedValue(
-                                        vec![animation_play_state::SingleSpecifiedValue::running]))),
-                                 Importance::Normal),
-                            ],
-                            important_count: 0,
-                        })),
+                        block: Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+                            (PropertyDeclaration::Width(DeclaredValue::Value(
+                                LengthOrPercentageOrAuto::Percentage(Percentage(1.)))),
+                             Importance::Normal),
+                            (PropertyDeclaration::AnimationPlayState(DeclaredValue::Value(
+                                animation_play_state::SpecifiedValue(
+                                    vec![animation_play_state::SingleSpecifiedValue::running]))),
+                             Importance::Normal),
+                        ]))),
                     })),
                 ]
             })))

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -23,14 +23,11 @@ fn get_mock_rules(css_selectors: &[&str]) -> Vec<Vec<Rule>> {
 
         let rule = Arc::new(RwLock::new(StyleRule {
             selectors: selectors,
-            block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                declarations: vec![
-                    (PropertyDeclaration::Display(DeclaredValue::Value(
-                        longhands::display::SpecifiedValue::block)),
-                     Importance::Normal),
-                ],
-                important_count: 0,
-            })),
+            block: Arc::new(RwLock::new(PropertyDeclarationBlock::from(vec![
+                (PropertyDeclaration::Display(DeclaredValue::Value(
+                    longhands::display::SpecifiedValue::block)),
+                 Importance::Normal),
+            ]))),
         }));
 
         let guard = rule.read();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Do it lazily when necessary, as described in https://github.com/servo/servo/issues/15558. This should improve parsing performance.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15558 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15721)
<!-- Reviewable:end -->
