### PR TITLE
style: Adjust float if the element is positioned per CSS 2.1 section 9.7

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1953,10 +1953,14 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
         % endif
         computed_values::display::T::flex |
         computed_values::display::T::inline_flex);
-    let (blockify_root, blockify_item) = match flags.contains(SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP) {
-        false => (is_root_element, is_item),
-        true => (false, false),
-    };
+
+    let (blockify_root, blockify_item) =
+        if flags.contains(SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP) {
+            (false, false)
+        } else {
+            (is_root_element, is_item)
+        };
+
     if positioned || floated || blockify_root || blockify_item {
         use computed_values::display::T;
 
@@ -2011,6 +2015,15 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
             }
             _ => {}
         }
+    }
+
+    // CSS 2.1 section 9.7:
+    //
+    //    If 'position' has the value 'absolute' or 'fixed', [...] the computed
+    //    value of 'float' is 'none'.
+    //
+    if positioned && floated {
+        style.mutate_box().set_float(longhands::float::computed_value::T::none);
     }
 
     // This implements an out-of-date spec. The new spec moves the handling of

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11036,6 +11036,12 @@
      {}
     ]
    ],
+   "css/float-abspos.html": [
+    [
+     "/_mozilla/css/float-abspos.html",
+     {}
+    ]
+   ],
    "css/float_relative_to_position.html": [
     [
      "/_mozilla/css/float_relative_to_position.html",
@@ -20894,6 +20900,10 @@
   "css/flex_row_direction_ref.html": [
    "2712a0a76b5eeb4d0f2b4a45277d04791a8ff206",
    "support"
+  ],
+  "css/float-abspos.html": [
+   "d34a9ce0be290bc3c46aa80eb136a91460957346",
+   "testharness"
   ],
   "css/float_clearance_a.html": [
    "372652bf4c345098f864cfc52ad0fb274308b22c",

--- a/tests/wpt/mozilla/tests/css/float-abspos.html
+++ b/tests/wpt/mozilla/tests/css/float-abspos.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>A positioned element's float value computes to "none"</title>
+<link rel="help" href="https://www.w3.org/TR/CSS21/visuren.html#dis-pos-flo">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="test" style="float: left"></div>
+<script>
+test(function() {
+  var elem = document.getElementById('test');
+  assert_equals(getComputedStyle(elem).float, "left");
+  elem.style.position = "absolute";
+  assert_equals(getComputedStyle(elem).float, "none");
+  elem.style.position = "";
+  assert_equals(getComputedStyle(elem).float, "left");
+  elem.style.position = "fixed";
+  assert_equals(getComputedStyle(elem).float, "none");
+}, "A positioned element's float value computes to none");
+</script>


### PR DESCRIPTION
We've found crashes related to this in Gecko.

r? @simonsapin or @heycam

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15730)
<!-- Reviewable:end -->
