### PR TITLE
Fix parsing of ClipRect

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1259,8 +1259,10 @@ impl FragmentDisplayListBuilding for Fragment {
         };
 
         // FIXME(pcwalton, #2795): Get the real container size.
-        let clip_origin = Point2D::new(stacking_relative_border_box.origin.x + style_clip_rect.left,
-                                       stacking_relative_border_box.origin.y + style_clip_rect.top);
+        let clip_origin = Point2D::new(stacking_relative_border_box.origin.x +
+                                           style_clip_rect.left.unwrap_or(Au(0)),
+                                       stacking_relative_border_box.origin.y +
+                                           style_clip_rect.top.unwrap_or(Au(0)));
         let right = style_clip_rect.right.unwrap_or(stacking_relative_border_box.size.width);
         let bottom = style_clip_rect.bottom.unwrap_or(stacking_relative_border_box.size.height);
         let clip_size = Size2D::new(right - clip_origin.x, bottom - clip_origin.y);

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -2286,8 +2286,8 @@ fn static_assert() {
                 self.gecko.mImageRegion.height = 0;
             }
             Either::First(rect) => {
-                self.gecko.mImageRegion.x = rect.left.0;
-                self.gecko.mImageRegion.y = rect.top.0;
+                self.gecko.mImageRegion.x = rect.left.unwrap_or(Au(0)).0;
+                self.gecko.mImageRegion.y = rect.top.unwrap_or(Au(0)).0;
                 self.gecko.mImageRegion.height = rect.bottom.unwrap_or(Au(0)).0 - self.gecko.mImageRegion.y;
                 self.gecko.mImageRegion.width = rect.right.unwrap_or(Au(0)).0 - self.gecko.mImageRegion.x;
             }
@@ -2356,6 +2356,8 @@ fn static_assert() {
     pub fn set_clip(&mut self, v: longhands::clip::computed_value::T) {
         use gecko_bindings::structs::NS_STYLE_CLIP_AUTO;
         use gecko_bindings::structs::NS_STYLE_CLIP_RECT;
+        use gecko_bindings::structs::NS_STYLE_CLIP_LEFT_AUTO;
+        use gecko_bindings::structs::NS_STYLE_CLIP_TOP_AUTO;
         use gecko_bindings::structs::NS_STYLE_CLIP_RIGHT_AUTO;
         use gecko_bindings::structs::NS_STYLE_CLIP_BOTTOM_AUTO;
         use values::Either;
@@ -2363,8 +2365,19 @@ fn static_assert() {
         match v {
             Either::First(rect) => {
                 self.gecko.mClipFlags = NS_STYLE_CLIP_RECT as u8;
-                self.gecko.mClip.x = rect.left.0;
-                self.gecko.mClip.y = rect.top.0;
+                if let Some(left) = rect.left {
+                    self.gecko.mClip.x = left.0;
+                } else {
+                    self.gecko.mClip.x = 0;
+                    self.gecko.mClipFlags |= NS_STYLE_CLIP_LEFT_AUTO as u8;
+                }
+
+                if let Some(top) = rect.top {
+                    self.gecko.mClip.y = top.0;
+                } else {
+                    self.gecko.mClip.y = 0;
+                    self.gecko.mClipFlags |= NS_STYLE_CLIP_TOP_AUTO as u8;
+                }
 
                 if let Some(bottom) = rect.bottom {
                     self.gecko.mClip.height = bottom.0 - self.gecko.mClip.y;

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -294,17 +294,22 @@ pub type LoPOrNumber = Either<LengthOrPercentage, Number>;
 #[allow(missing_docs)]
 /// A computed cliprect for clip and image-region
 pub struct ClipRect {
-    pub top: Au,
+    pub top: Option<Au>,
     pub right: Option<Au>,
     pub bottom: Option<Au>,
-    pub left: Au,
+    pub left: Option<Au>,
 }
 
 impl ToCss for ClipRect {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         try!(dest.write_str("rect("));
-        try!(self.top.to_css(dest));
-        try!(dest.write_str(", "));
+        if let Some(top) = self.top {
+            try!(top.to_css(dest));
+            try!(dest.write_str(", "));
+        } else {
+            try!(dest.write_str("auto, "));
+        }
+
         if let Some(right) = self.right {
             try!(right.to_css(dest));
             try!(dest.write_str(", "));
@@ -319,7 +324,11 @@ impl ToCss for ClipRect {
             try!(dest.write_str("auto, "));
         }
 
-        try!(self.left.to_css(dest));
+        if let Some(left) = self.left {
+            try!(left.to_css(dest));
+        } else {
+            try!(dest.write_str("auto"));
+        }
         dest.write_str(")")
     }
 }

--- a/tests/unit/style/parsing/effects.rs
+++ b/tests/unit/style/parsing/effects.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use cssparser::Parser;
+use media_queries::CSSErrorReporterTest;
+use servo_url::ServoUrl;
+use style::parser::ParserContext;
+use style::stylesheets::Origin;
+use style_traits::ToCss;
+
+#[test]
+fn test_clip() {
+    use style::properties::longhands::clip;
+
+    assert_roundtrip_with_context!(clip::parse, "auto");
+    assert_roundtrip_with_context!(clip::parse, "rect(1px, 2px, 3px, 4px)");
+    assert_roundtrip_with_context!(clip::parse, "rect(1px, auto, auto, 4px)");
+    assert_roundtrip_with_context!(clip::parse, "rect(auto, auto, auto, auto)");
+
+    // Non-standard syntax
+    assert_roundtrip_with_context!(clip::parse,
+                                   "rect(1px 2px 3px 4px)",
+                                   "rect(1px, 2px, 3px, 4px)");
+    assert_roundtrip_with_context!(clip::parse,
+                                   "rect(auto 2px 3px auto)",
+                                   "rect(auto, 2px, 3px, auto)");
+    assert_roundtrip_with_context!(clip::parse,
+                                   "rect(1px auto auto 4px)",
+                                   "rect(1px, auto, auto, 4px)");
+    assert_roundtrip_with_context!(clip::parse,
+                                   "rect(auto auto auto auto)",
+                                   "rect(auto, auto, auto, auto)");
+}
+

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -82,6 +82,7 @@ mod background;
 mod basic_shape;
 mod border;
 mod column;
+mod effects;
 mod font;
 mod image;
 mod inherited_box;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fix parsing of ClipRect for clip property.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15728 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15732)
<!-- Reviewable:end -->
