### PR TITLE
 Cascade: skip duplicated properties before rather than after a virtual call

### DIFF
--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -218,7 +218,7 @@ impl CSSStyleDeclaration {
 
         let mut string = String::new();
 
-        self.owner.with_block(|ref pdb| {
+        self.owner.with_block(|pdb| {
             pdb.property_value_to_css(&id, &mut string).unwrap();
         });
 
@@ -281,7 +281,7 @@ impl CSSStyleDeclaration {
 impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-length
     fn Length(&self) -> u32 {
-        self.owner.with_block(|ref pdb| {
+        self.owner.with_block(|pdb| {
             pdb.declarations.len() as u32
         })
     }
@@ -311,7 +311,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
             return DOMString::new()
         };
 
-        self.owner.with_block(|ref pdb| {
+        self.owner.with_block(|pdb| {
             if pdb.property_priority(&id).important() {
                 DOMString::from("important")
             } else {
@@ -406,7 +406,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
 
     // https://dev.w3.org/csswg/cssom/#the-cssstyledeclaration-interface
     fn IndexedGetter(&self, index: u32) -> Option<DOMString> {
-        self.owner.with_block(|ref pdb| {
+        self.owner.with_block(|pdb| {
             pdb.declarations.get(index as usize).map(|entry| {
                 let (ref declaration, importance) = *entry;
                 let mut css = declaration.to_css_string();
@@ -420,7 +420,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
 
     // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-csstext
     fn CssText(&self) -> DOMString {
-        self.owner.with_block(|ref pdb| {
+        self.owner.with_block(|pdb| {
             DOMString::from(pdb.to_css_string())
         })
     }

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -15,7 +15,7 @@ use properties::{PropertyDeclarationId, LonghandId, DeclaredValue};
 use properties::PropertyDeclarationParseResult;
 use properties::animated_properties::TransitionProperty;
 use properties::longhands::transition_timing_function::single_value::SpecifiedValue as SpecifiedTimingFunction;
-use properties::property_bit_field::PropertyBitField;
+use properties::PropertyBitField;
 use std::fmt;
 use std::sync::Arc;
 use style_traits::ToCss;

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -12,10 +12,10 @@ use parking_lot::RwLock;
 use parser::{ParserContext, ParserContextExtraData, log_css_error};
 use properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, PropertyId};
 use properties::{PropertyDeclarationId, LonghandId, DeclaredValue};
+use properties::LonghandIdSet;
 use properties::PropertyDeclarationParseResult;
 use properties::animated_properties::TransitionProperty;
 use properties::longhands::transition_timing_function::single_value::SpecifiedValue as SpecifiedTimingFunction;
-use properties::PropertyBitField;
 use std::fmt;
 use std::sync::Arc;
 use style_traits::ToCss;
@@ -248,7 +248,7 @@ pub struct KeyframesAnimation {
 /// Get all the animated properties in a keyframes animation.
 fn get_animated_properties(keyframes: &[Arc<RwLock<Keyframe>>]) -> Vec<TransitionProperty> {
     let mut ret = vec![];
-    let mut seen = PropertyBitField::new();
+    let mut seen = LonghandIdSet::new();
     // NB: declarations are already deduplicated, so we don't have to check for
     // it here.
     for keyframe in keyframes {

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -159,10 +159,6 @@ impl ComputedValues {
         !self.get_box().gecko.mBinding.mRawPtr.is_null()
     }
 
-    pub fn root_font_size(&self) -> Au { self.root_font_size }
-    pub fn set_root_font_size(&mut self, s: Au) { self.root_font_size = s; }
-    pub fn set_writing_mode(&mut self, mode: WritingMode) { self.writing_mode = mode; }
-
     // FIXME(bholley): Implement this properly.
     #[inline]
     pub fn is_multicol(&self) -> bool { false }

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1247,9 +1247,6 @@ fn static_assert() {
         unsafe { transmute(self.gecko.mFont.weight) }
     }
 
-    // This is used for PartialEq, which we don't implement for gecko style structs.
-    pub fn compute_font_hash(&mut self) {}
-
     pub fn set_font_synthesis(&mut self, v: longhands::font_synthesis::computed_value::T) {
         use gecko_bindings::structs::{NS_FONT_SYNTHESIS_WEIGHT, NS_FONT_SYNTHESIS_STYLE};
 

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -230,7 +230,7 @@
         use cascade_info::CascadeInfo;
         use error_reporting::ParseErrorReporter;
         use properties::longhands;
-        use properties::PropertyBitField;
+        use properties::LonghandIdSet;
         use properties::{ComputedValues, PropertyDeclaration};
         use properties::style_structs;
         use std::boxed::Box as StdBox;

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -230,7 +230,7 @@
         use cascade_info::CascadeInfo;
         use error_reporting::ParseErrorReporter;
         use properties::longhands;
-        use properties::property_bit_field::PropertyBitField;
+        use properties::PropertyBitField;
         use properties::{ComputedValues, PropertyDeclaration};
         use properties::style_structs;
         use std::boxed::Box as StdBox;

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -245,7 +245,6 @@
                                 inherited_style: &ComputedValues,
                                 default_style: &Arc<ComputedValues>,
                                 context: &mut computed::Context,
-                                seen: &mut PropertyBitField,
                                 cacheable: &mut bool,
                                 cascade_info: &mut Option<<&mut CascadeInfo>,
                                 error_reporter: &mut StdBox<ParseErrorReporter + Send>) {
@@ -256,16 +255,7 @@
                 _ => panic!("entered the wrong cascade_property() implementation"),
             };
 
-            % if property.logical:
-                let wm = context.style.writing_mode;
-            % endif
-            <% maybe_wm = "wm" if property.logical else "" %>
-            <% maybe_physical = "_physical" if property.logical else "" %>
             % if not property.derived_from:
-                if seen.get${maybe_physical}_${property.ident}(${maybe_wm}) {
-                    return
-                }
-                seen.set${maybe_physical}_${property.ident}(${maybe_wm});
                 {
                     let custom_props = context.style().custom_properties();
                     ::properties::substitute_variables_${property.ident}(
@@ -275,6 +265,9 @@
                             cascade_info.on_cascade_property(&declaration,
                                                              &value);
                         }
+                        % if property.logical:
+                            let wm = context.style.writing_mode;
+                        % endif
                         <% maybe_wm = ", wm" if property.logical else "" %>
                         match *value {
                             DeclaredValue::Value(ref specified_value) => {
@@ -321,7 +314,6 @@
                     cascade_property_custom(declaration,
                                             inherited_style,
                                             context,
-                                            seen,
                                             cacheable,
                                             error_reporter);
                 % endif

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -84,7 +84,6 @@
         fn cascade_property_custom(_declaration: &PropertyDeclaration,
                                    _inherited_style: &ComputedValues,
                                    context: &mut computed::Context,
-                                   _seen: &mut PropertyBitField,
                                    _cacheable: &mut bool,
                                    _error_reporter: &mut StdBox<ParseErrorReporter + Send>) {
             longhands::_servo_display_for_hypothetical_box::derive_from_display(context);

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -6,8 +6,7 @@
 <% from data import Method %>
 
 <% data.new_style_struct("Font",
-                         inherited=True,
-                         additional_methods=[Method("compute_font_hash", is_mut=True)]) %>
+                         inherited=True) %>
 <%helpers:longhand name="font-family" animatable="False" need_index="True"
                    spec="https://drafts.csswg.org/css-fonts/#propdef-font-family">
     use self::computed_value::{FontFamily, FamilyName};

--- a/components/style/properties/longhand/text.mako.rs
+++ b/components/style/properties/longhand/text.mako.rs
@@ -204,7 +204,6 @@ ${helpers.single_keyword("unicode-bidi",
         fn cascade_property_custom(_declaration: &PropertyDeclaration,
                                    _inherited_style: &ComputedValues,
                                    context: &mut computed::Context,
-                                   _seen: &mut PropertyBitField,
                                    _cacheable: &mut bool,
                                    _error_reporter: &mut StdBox<ParseErrorReporter + Send>) {
                 longhands::_servo_text_decorations_in_effect::derive_from_text_decoration(context);

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2044,12 +2044,14 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
         style.set_root_font_size(s);
     }
 
-    if seen.contains(LonghandId::FontStyle) ||
-       seen.contains(LonghandId::FontWeight) ||
-       seen.contains(LonghandId::FontStretch) ||
-       seen.contains(LonghandId::FontFamily) {
-        style.mutate_font().compute_font_hash();
-    }
+    % if product == "servo":
+        if seen.contains(LonghandId::FontStyle) ||
+           seen.contains(LonghandId::FontWeight) ||
+           seen.contains(LonghandId::FontStretch) ||
+           seen.contains(LonghandId::FontFamily) {
+            style.mutate_font().compute_font_hash();
+        }
+    % endif
 
     style
 }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1384,14 +1384,6 @@ impl ComputedValues {
     /// Since this isn't supported in Servo, this is always false for Servo.
     pub fn is_display_contents(&self) -> bool { false }
 
-    /// Get the root font size.
-    fn root_font_size(&self) -> Au { self.root_font_size }
-
-    /// Set the root font size.
-    fn set_root_font_size(&mut self, size: Au) { self.root_font_size = size }
-    /// Set the writing mode for this style.
-    pub fn set_writing_mode(&mut self, mode: WritingMode) { self.writing_mode = mode; }
-
     /// Whether the current style is multicolumn.
     #[inline]
     pub fn is_multicol(&self) -> bool {
@@ -1800,7 +1792,7 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
         ComputedValues::new(custom_properties,
                             flags.contains(SHAREABLE),
                             WritingMode::empty(),
-                            inherited_style.root_font_size(),
+                            inherited_style.root_font_size,
                             % for style_struct in data.active_style_structs():
                                 % if style_struct.inherited:
                                     inherited_style.clone_${style_struct.name_lower}(),
@@ -1813,7 +1805,7 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
         ComputedValues::new(custom_properties,
                             flags.contains(SHAREABLE),
                             WritingMode::empty(),
-                            inherited_style.root_font_size(),
+                            inherited_style.root_font_size,
                             % for style_struct in data.active_style_structs():
                                 inherited_style.clone_${style_struct.name_lower}(),
                             % endfor
@@ -1903,7 +1895,7 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
         }
         % if category_to_cascade_now == "early":
             let writing_mode = get_writing_mode(context.style.get_inheritedbox());
-            context.style.set_writing_mode(writing_mode);
+            context.style.writing_mode = writing_mode;
         % endif
     % endfor
 
@@ -2041,7 +2033,7 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
 
     if is_root_element {
         let s = style.get_font().clone_font_size();
-        style.set_root_font_size(s);
+        style.root_font_size = s;
     }
 
     % if product == "servo":

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -209,21 +209,6 @@ pub mod property_bit_field {
             self.storage[bit / 32] |= 1 << (bit % 32);
         }
 
-        % for property in data.longhands:
-            % if not property.derived_from:
-                #[allow(non_snake_case, missing_docs)]
-                #[inline]
-                pub fn get_${property.ident}(&self) -> bool {
-                    self.contains(LonghandId::${property.camel_case})
-                }
-                #[allow(non_snake_case, missing_docs)]
-                #[inline]
-                pub fn set_${property.ident}(&mut self) {
-                    self.insert(LonghandId::${property.camel_case})
-                }
-            % endif
-        % endfor
-
         /// Set the corresponding bit of TransitionProperty.
         /// This function will panic if TransitionProperty::All is given.
         pub fn set_transition_property_bit(&mut self, property: &TransitionProperty) {
@@ -2065,8 +2050,10 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
         style.set_root_font_size(s);
     }
 
-    if seen.get_font_style() || seen.get_font_weight() || seen.get_font_stretch() ||
-       seen.get_font_family() {
+    if seen.contains(LonghandId::FontStyle) ||
+       seen.contains(LonghandId::FontWeight) ||
+       seen.contains(LonghandId::FontStretch) ||
+       seen.contains(LonghandId::FontFamily) {
         style.mutate_font().compute_font_hash();
     }
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -179,15 +179,15 @@ pub mod animated_properties {
 }
 
 /// A set of longhand properties
-pub struct PropertyBitField {
+pub struct LonghandIdSet {
     storage: [u32; (${len(data.longhands)} - 1 + 32) / 32]
 }
 
-impl PropertyBitField {
+impl LonghandIdSet {
     /// Create an empty set
     #[inline]
-    pub fn new() -> PropertyBitField {
-        PropertyBitField { storage: [0; (${len(data.longhands)} - 1 + 32) / 32] }
+    pub fn new() -> LonghandIdSet {
+        LonghandIdSet { storage: [0; (${len(data.longhands)} - 1 + 32) / 32] }
     }
 
     /// Return whether the given property is in the set
@@ -233,7 +233,7 @@ impl PropertyBitField {
 
 /// A specialized set of PropertyDeclarationId
 pub struct PropertyDeclarationIdSet {
-    longhands: PropertyBitField,
+    longhands: LonghandIdSet,
 
     // FIXME: Use a HashSet instead? This Vec is usually small, so linear scan might be ok.
     custom: Vec<::custom_properties::Name>,
@@ -243,7 +243,7 @@ impl PropertyDeclarationIdSet {
     /// Empty set
     pub fn new() -> Self {
         PropertyDeclarationIdSet {
-            longhands: PropertyBitField::new(),
+            longhands: LonghandIdSet::new(),
             custom: Vec::new(),
         }
     }
@@ -1835,7 +1835,7 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
     // NB: The cacheable boolean is not used right now, but will be once we
     // start caching computed values in the rule nodes.
     let mut cacheable = true;
-    let mut seen = PropertyBitField::new();
+    let mut seen = LonghandIdSet::new();
 
     // Declaration blocks are stored in increasing precedence order, we want
     // them in decreasing order here.

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -407,42 +407,6 @@ impl PropertyDeclarationIdSet {
     % endif
 % endfor
 
-/// Given a property declaration block, only keep the "winning" declaration for
-/// any given property, by importance then source order.
-///
-/// The input and output are in source order
-fn deduplicate_property_declarations(block: &mut PropertyDeclarationBlock) {
-    let mut deduplicated = Vec::with_capacity(block.declarations.len());
-    let mut seen_normal = PropertyDeclarationIdSet::new();
-    let mut seen_important = PropertyDeclarationIdSet::new();
-
-    for (declaration, importance) in block.declarations.drain(..).rev() {
-        if importance.important() {
-            let id = declaration.id();
-            if seen_important.contains(id) {
-                block.important_count -= 1;
-                continue
-            }
-            if seen_normal.contains(id) {
-                let previous_len = deduplicated.len();
-                deduplicated.retain(|&(ref d, _)| PropertyDeclaration::id(d) != id);
-                debug_assert_eq!(deduplicated.len(), previous_len - 1);
-            }
-            seen_important.insert(id);
-        } else {
-            let id = declaration.id();
-            if seen_normal.contains(id) ||
-               seen_important.contains(id) {
-                continue
-            }
-            seen_normal.insert(id)
-        }
-        deduplicated.push((declaration, importance))
-    }
-    deduplicated.reverse();
-    block.declarations = deduplicated;
-}
-
 /// An enum to represent a CSS Wide keyword.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum CSSWideKeyword {

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1339,7 +1339,7 @@ pub extern "C" fn Servo_GetComputedKeyframeValues(keyframes: RawGeckoKeyframeLis
                                                   computed_keyframes: RawGeckoComputedKeyframeValuesListBorrowedMut)
 {
     use style::properties::declaration_block::Importance;
-    use style::properties::property_bit_field::PropertyBitField;
+    use style::properties::PropertyBitField;
     use style::values::computed::Context;
 
     let style = ComputedValues::as_arc(&style);
@@ -1429,7 +1429,7 @@ pub extern "C" fn Servo_StyleSet_FillKeyframesForName(raw_data: RawServoStyleSet
                                                       style: ServoComputedValuesBorrowed,
                                                       keyframes: RawGeckoKeyframeListBorrowedMut) -> bool {
     use style::gecko_bindings::structs::Keyframe;
-    use style::properties::property_bit_field::PropertyBitField;
+    use style::properties::PropertyBitField;
 
     let data = PerDocumentStyleData::from_ffi(raw_data).borrow_mut();
     let name = unsafe { Atom::from(name.as_ref().unwrap().as_str_unchecked()) };

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1338,8 +1338,8 @@ pub extern "C" fn Servo_GetComputedKeyframeValues(keyframes: RawGeckoKeyframeLis
                                                   pres_context: RawGeckoPresContextBorrowed,
                                                   computed_keyframes: RawGeckoComputedKeyframeValuesListBorrowedMut)
 {
+    use style::properties::LonghandIdSet;
     use style::properties::declaration_block::Importance;
-    use style::properties::PropertyBitField;
     use style::values::computed::Context;
 
     let style = ComputedValues::as_arc(&style);
@@ -1359,7 +1359,7 @@ pub extern "C" fn Servo_GetComputedKeyframeValues(keyframes: RawGeckoKeyframeLis
     for (index, keyframe) in keyframes.iter().enumerate() {
         let ref mut animation_values = computed_keyframes[index];
 
-        let mut seen = PropertyBitField::new();
+        let mut seen = LonghandIdSet::new();
 
         // mServoDeclarationBlock is null in the case where we have an invalid css property.
         let iter = keyframe.mPropertyValues.iter()
@@ -1429,7 +1429,7 @@ pub extern "C" fn Servo_StyleSet_FillKeyframesForName(raw_data: RawServoStyleSet
                                                       style: ServoComputedValuesBorrowed,
                                                       keyframes: RawGeckoKeyframeListBorrowedMut) -> bool {
     use style::gecko_bindings::structs::Keyframe;
-    use style::properties::PropertyBitField;
+    use style::properties::LonghandIdSet;
 
     let data = PerDocumentStyleData::from_ffi(raw_data).borrow_mut();
     let name = unsafe { Atom::from(name.as_ref().unwrap().as_str_unchecked()) };
@@ -1482,7 +1482,7 @@ pub extern "C" fn Servo_StyleSet_FillKeyframesForName(raw_data: RawServoStyleSet
                                declaration.is_animatable()
                            });
 
-                  let mut seen = PropertyBitField::new();
+                  let mut seen = LonghandIdSet::new();
 
                   for (index, &(ref declaration, _)) in animatable.enumerate() {
                       unsafe {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is a subset of #15721. It fixes part of #15558, and refactors a couple things along the way.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15745)
<!-- Reviewable:end -->
