### PR TITLE
Fix wrong index for missing properties in keyframes

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1504,9 +1504,11 @@ pub extern "C" fn Servo_StyleSet_FillKeyframesForName(raw_data: RawServoStyleSet
                   // Append missing property values in the initial or the finial keyframes.
                   if step.start_percentage.0 == 0. ||
                      step.start_percentage.0 == 1. {
-                      for (index, property) in animation.properties_changed.iter().enumerate() {
+                      let mut index = unsafe { (*keyframe).mPropertyValues.len() };
+                      for property in animation.properties_changed.iter() {
                           if !seen.has_transition_property_bit(&property) {
                               add_computed_property_value(keyframe, index, style, property);
+                              index += 1;
                           }
                       }
                   }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is PR of https://bugzilla.mozilla.org/show_bug.cgi?id=1342323 , reviewed by @emilio.  Thank you Emilio!

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's for stylo.

I think we have test cases for this in gecko tree.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15747)
<!-- Reviewable:end -->
