### PR TITLE
Fix Cargo.toml in servo_tidy_tests

### DIFF
--- a/python/tidy/servo_tidy_tests/Cargo.toml
+++ b/python/tidy/servo_tidy_tests/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
 name = "test"
-version = "*"
+version = "0.0.1"
 authors = ["The Servo Project Developers"]
 publish = false
+
+[dependencies]
+test-package = { version = "*" }


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15737

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15753)
<!-- Reviewable:end -->
