### PR TITLE
Use libssl-dev as dependency for Debian stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,21 @@ If you've already partially compiled servo but forgot to do this step, run `./ma
 
 ``` sh
 sudo apt install git curl freeglut3-dev autoconf \
-    libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
-    gperf g++ build-essential cmake virtualenv python-pip \
-    libssl1.0-dev libbz2-dev libosmesa6-dev libxmu6 libxmu-dev \
-    libglu1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev
+	libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
+	gperf g++ build-essential cmake virtualenv python-pip \
+	libssl-dev libbz2-dev libosmesa6-dev libxmu6 libxmu-dev \
+	libglu1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev
 ```
 
-If you are on **Ubuntu 14.04** and encountered errors on installing these dependencies involving `libcheese`, see [#6158](https://github.com/servo/servo/issues/6158) for a workaround.
+If you are on **Debian stretch/testing**,
+you will want `libssl1.0-dev` instead of `libssl-dev`,
+for as long as [openssl-sys-extra](https://crates.io/crates/openssl-sys-extras)
+depends on libssl 1.0.0.
+
+If you are on **Ubuntu 14.04**
+and encountered errors on installing
+these dependencies involving `libcheese`,
+see [#6158](https://github.com/servo/servo/issues/6158) for a workaround.
 
 If `virtualenv` does not exist, try `python-virtualenv`.
 


### PR DESCRIPTION
Debian stretch/testing uses libssl1.0-dev for libssl 1.0.0, which is
required by openssl-sys-extra.  This will eventually become the right
package to depend on, but for as long as Debian jessie/stable and Ubuntu
only has libssl-dev (1.0.0) we should list that as our dependency and
add a note for the experimental distributions.

Fixes: https://github.com/servo/servo/issues/15759

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15759

- [ ] There are tests for these changes OR
- [x] These changes do not require tests because changes to README

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15764)
<!-- Reviewable:end -->
