### PR TITLE
Trigger reflow on document.elementsFromPoint

### DIFF
--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -73,7 +73,7 @@ mod linked_list;
 mod list_item;
 mod model;
 mod multicol;
-mod opaque_node;
+pub mod opaque_node;
 pub mod parallel;
 mod persistent_list;
 pub mod query;

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -147,7 +147,7 @@ impl LayoutRPC for LayoutRPCImpl {
         }
     }
 
-    fn nodes_from_point(&self) -> Vec<UntrustedNodeAddress> {
+    fn nodes_from_point_response(&self) -> Vec<UntrustedNodeAddress> {
         let &LayoutRPCImpl(ref rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         rw_data.nodes_from_point_response.clone()

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -94,6 +94,9 @@ pub struct LayoutThreadData {
 
     /// A list of images requests that need to be initiated.
     pub pending_images: Vec<PendingImage>,
+
+    /// A queued response for the list of nodes at a given point.
+    pub nodes_from_point_response: Vec<UntrustedNodeAddress>,
 }
 
 pub struct LayoutRPCImpl(pub Arc<Mutex<LayoutThreadData>>);
@@ -144,33 +147,10 @@ impl LayoutRPC for LayoutRPCImpl {
         }
     }
 
-    fn nodes_from_point(&self,
-                        page_point: Point2D<f32>,
-                        client_point: Point2D<f32>) -> Vec<UntrustedNodeAddress> {
-        let page_point = Point2D::new(Au::from_f32_px(page_point.x),
-                                      Au::from_f32_px(page_point.y));
-        let client_point = Point2D::new(Au::from_f32_px(client_point.x),
-                                        Au::from_f32_px(client_point.y));
-
-        let nodes_from_point_list = {
-            let &LayoutRPCImpl(ref rw_data) = self;
-            let rw_data = rw_data.lock().unwrap();
-            let result = match rw_data.display_list {
-                None => panic!("Tried to hit test without a DisplayList"),
-                Some(ref display_list) => {
-                    display_list.hit_test(&page_point,
-                                          &client_point,
-                                          &rw_data.stacking_context_scroll_offsets)
-                }
-            };
-
-            result
-        };
-
-        nodes_from_point_list.iter()
-           .rev()
-           .map(|metadata| metadata.node.to_untrusted_node_address())
-           .collect()
+    fn nodes_from_point(&self) -> Vec<UntrustedNodeAddress> {
+        let &LayoutRPCImpl(ref rw_data) = self;
+        let rw_data = rw_data.lock().unwrap();
+        rw_data.nodes_from_point_response.clone()
     }
 
     fn node_geometry(&self) -> NodeGeometryResponse {
@@ -193,8 +173,8 @@ impl LayoutRPC for LayoutRPCImpl {
 
     fn node_scroll_root_id(&self) -> NodeScrollRootIdResponse {
         NodeScrollRootIdResponse(self.0.lock()
-                                        .unwrap().scroll_root_id_response
-                                        .expect("scroll_root_id is not correctly fetched"))
+                                       .unwrap().scroll_root_id_response
+                                       .expect("scroll_root_id is not correctly fetched"))
     }
 
     /// Retrieves the resolved value for a CSS style property.

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1883,7 +1883,7 @@ impl Document {
             return vec!();
         };
 
-        self.window.layout().nodes_from_point()
+        self.window.layout().nodes_from_point_response()
     }
 }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1877,7 +1877,13 @@ impl Document {
             Point2D::new(client_point.x + self.window.PageXOffset() as f32,
                          client_point.y + self.window.PageYOffset() as f32);
 
-        self.window.layout().nodes_from_point(page_point, *client_point)
+        if !self.window.reflow(ReflowGoal::ForScriptQuery,
+                               ReflowQueryType::NodesFromPoint(page_point, *client_point),
+                               ReflowReason::Query) {
+            return vec!();
+        };
+
+        self.window.layout().nodes_from_point()
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1811,6 +1811,7 @@ fn debug_reflow_events(id: PipelineId, goal: &ReflowGoal, query_type: &ReflowQue
         ReflowQueryType::ContentBoxQuery(_n) => "\tContentBoxQuery",
         ReflowQueryType::ContentBoxesQuery(_n) => "\tContentBoxesQuery",
         ReflowQueryType::HitTestQuery(..) => "\tHitTestQuery",
+        ReflowQueryType::NodesFromPoint(..) => "\tNodesFromPoint",
         ReflowQueryType::NodeGeometryQuery(_n) => "\tNodeGeometryQuery",
         ReflowQueryType::NodeOverflowQuery(_n) => "\tNodeOverFlowQuery",
         ReflowQueryType::NodeScrollGeometryQuery(_n) => "\tNodeScrollGeometryQuery",

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -101,6 +101,7 @@ pub enum ReflowQueryType {
     OffsetParentQuery(TrustedNodeAddress),
     MarginStyleQuery(TrustedNodeAddress),
     TextIndexQuery(TrustedNodeAddress, i32, i32),
+    NodesFromPoint(Point2D<f32>, Point2D<f32>),
 }
 
 /// Information needed for a reflow.

--- a/components/script_layout_interface/rpc.rs
+++ b/components/script_layout_interface/rpc.rs
@@ -41,7 +41,7 @@ pub trait LayoutRPC {
     /// Requests the list of not-yet-loaded images that were encountered in the last reflow.
     fn pending_images(&self) -> Vec<PendingImage>;
     /// Requests the list of nodes from the given point.
-    fn nodes_from_point(&self) -> Vec<UntrustedNodeAddress>;
+    fn nodes_from_point_response(&self) -> Vec<UntrustedNodeAddress>;
 
     fn text_index(&self) -> TextIndexResponse;
 }

--- a/components/script_layout_interface/rpc.rs
+++ b/components/script_layout_interface/rpc.rs
@@ -40,7 +40,8 @@ pub trait LayoutRPC {
     fn margin_style(&self) -> MarginStyleResponse;
     /// Requests the list of not-yet-loaded images that were encountered in the last reflow.
     fn pending_images(&self) -> Vec<PendingImage>;
-    fn nodes_from_point(&self, page_point: Point2D<f32>, client_point: Point2D<f32>) -> Vec<UntrustedNodeAddress>;
+    /// Requests the list of nodes from the given point.
+    fn nodes_from_point(&self) -> Vec<UntrustedNodeAddress>;
 
     fn text_index(&self) -> TextIndexResponse;
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6341,6 +6341,18 @@
      {}
     ]
    ],
+   "mozilla/document_elementsFromPoint.html": [
+    [
+     "/_mozilla/mozilla/document_elementsFromPoint.html",
+     [
+      [
+       "/_mozilla/mozilla/document_elementsFromPoint_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "mozilla/iframe/resize_after_load.html": [
     [
      "/_mozilla/mozilla/iframe/resize_after_load.html",
@@ -9384,6 +9396,11 @@
     ]
    ],
    "mozilla/details_ui_opened_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/document_elementsFromPoint_ref.html": [
     [
      {}
     ]
@@ -25136,6 +25153,14 @@
   "mozilla/document_defaultView.html": [
    "12eef74e9ba1a62b0302df79633cab5c48f4977f",
    "testharness"
+  ],
+  "mozilla/document_elementsFromPoint.html": [
+   "2349e1d102552a46bb8e3dd36c0b3396e0d6530b",
+   "reftest"
+  ],
+  "mozilla/document_elementsFromPoint_ref.html": [
+   "4d1a1d0acc16bcb123781cbed47184ff308f3097",
+   "support"
   ],
   "mozilla/document_getElementById.html": [
    "ae5270afde878c8fbe9b4a89c5c3f8ff609220dc",

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6341,18 +6341,6 @@
      {}
     ]
    ],
-   "mozilla/document_elementsFromPoint.html": [
-    [
-     "/_mozilla/mozilla/document_elementsFromPoint.html",
-     [
-      [
-       "/_mozilla/mozilla/document_elementsFromPoint_ref.html",
-       "=="
-      ]
-     ],
-     {}
-    ]
-   ],
    "mozilla/iframe/resize_after_load.html": [
     [
      "/_mozilla/mozilla/iframe/resize_after_load.html",
@@ -9396,11 +9384,6 @@
     ]
    ],
    "mozilla/details_ui_opened_ref.html": [
-    [
-     {}
-    ]
-   ],
-   "mozilla/document_elementsFromPoint_ref.html": [
     [
      {}
     ]
@@ -12612,6 +12595,12 @@
    "mozilla/document_defaultView.html": [
     [
      "/_mozilla/mozilla/document_defaultView.html",
+     {}
+    ]
+   ],
+   "mozilla/document_elementsFromPoint.html": [
+    [
+     "/_mozilla/mozilla/document_elementsFromPoint.html",
      {}
     ]
    ],
@@ -25155,12 +25144,8 @@
    "testharness"
   ],
   "mozilla/document_elementsFromPoint.html": [
-   "2349e1d102552a46bb8e3dd36c0b3396e0d6530b",
-   "reftest"
-  ],
-  "mozilla/document_elementsFromPoint_ref.html": [
-   "4d1a1d0acc16bcb123781cbed47184ff308f3097",
-   "support"
+   "00da2141b1143619351c6fbb66d677ca9002a4a8",
+   "testharness"
   ],
   "mozilla/document_getElementById.html": [
    "ae5270afde878c8fbe9b4a89c5c3f8ff609220dc",

--- a/tests/wpt/mozilla/tests/mozilla/document_elementsFromPoint.html
+++ b/tests/wpt/mozilla/tests/mozilla/document_elementsFromPoint.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<link rel="match" href="document_elementsFromPoint_ref.html">
+<script>
+    var elements = document.elementsFromPoint(10, 10);
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/document_elementsFromPoint.html
+++ b/tests/wpt/mozilla/tests/mozilla/document_elementsFromPoint.html
@@ -1,7 +1,10 @@
 <!doctype html>
 <meta charset="utf-8">
-<title></title>
-<link rel="match" href="document_elementsFromPoint_ref.html">
+<title>document.elementsFromPoint does not crash due to a missing display list</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <script>
-    var elements = document.elementsFromPoint(10, 10);
+test(function() {
+    document.elementsFromPoint(10, 10);
+}, "doesn't crash");
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/document_elementsFromPoint_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/document_elementsFromPoint_ref.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>

--- a/tests/wpt/mozilla/tests/mozilla/document_elementsFromPoint_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/document_elementsFromPoint_ref.html
@@ -1,3 +1,0 @@
-<!doctype html>
-<meta charset="utf-8">
-<title></title>


### PR DESCRIPTION
As [suggested](https://github.com/servo/servo/issues/15592#issuecomment-280379805) by @jdm `Document::nodes_from_point` now triggers a reflow.

I added a new reftest that panics with `ERROR:servo: Tried to hit test without a DisplayList` if this patch is not applied.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15592.
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15768)
<!-- Reviewable:end -->
