### PR TITLE
Improve behaviour of image elements that perform multiple requests

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -120,7 +120,7 @@ impl DocumentLoader {
     }
 
     /// Initiate a new fetch that does not block the document load event.
-    pub fn fetch_async_background(&mut self,
+    pub fn fetch_async_background(&self,
                                   request: RequestInit,
                                   fetch_target: IpcSender<FetchResponseMsg>) {
         self.resource_threads.sender().send(CoreResourceMsg::Fetch(request, fetch_target)).unwrap();

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -107,7 +107,7 @@ use net_traits::response::HttpsState;
 use num_traits::ToPrimitive;
 use script_layout_interface::message::{Msg, ReflowQueryType};
 use script_runtime::{CommonScriptMsg, ScriptThreadEventCategory};
-use script_thread::{MainThreadScriptMsg, Runnable};
+use script_thread::{MainThreadScriptMsg, Runnable, ScriptThread};
 use script_traits::{AnimationState, CompositorEvent, DocumentActivity};
 use script_traits::{MouseButton, MouseEventType, MozBrowserEvent};
 use script_traits::{ScriptMsg as ConstellationMsg, TouchpadPressurePhase};
@@ -1599,17 +1599,26 @@ impl Document {
         // Step 5 can be found in asap_script_loaded and
         // asap_in_order_script_loaded.
 
+        let loader = self.loader.borrow();
+        if loader.is_blocked() || loader.events_inhibited() {
+            // Step 6.
+            return;
+        }
+
+        ScriptThread::mark_document_with_no_blocked_loads(self);
+    }
+
+    // https://html.spec.whatwg.org/multipage/#the-end
+    pub fn maybe_queue_document_completion(&self) {
         if self.loader.borrow().is_blocked() {
             // Step 6.
             return;
         }
 
-        // The rest will ever run only once per document.
-        if self.loader.borrow().events_inhibited() {
-            return;
-        }
+        assert!(!self.loader.borrow().events_inhibited());
         self.loader.borrow_mut().inhibit_events();
 
+        // The rest will ever run only once per document.
         // Step 7.
         debug!("Document loads are complete.");
         let handler = box DocumentProgressHandler::new(Trusted::new(self));

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -296,7 +296,9 @@ impl HTMLImageElement {
             self.upcast::<EventTarget>().fire_event(atom!("error"));
         }
 
-        LoadBlocker::terminate(&mut self.current_request.borrow_mut().blocker);
+        if trigger_image_load || trigger_image_error {
+            LoadBlocker::terminate(&mut self.current_request.borrow_mut().blocker);
+        }
 
         // Trigger reflow
         let window = window_from_node(self);

--- a/components/script_plugins/unrooted_must_root.rs
+++ b/components/script_plugins/unrooted_must_root.rs
@@ -54,7 +54,8 @@ fn is_unrooted_ty(cx: &LateContext, ty: &ty::TyS, in_new_function: bool) -> bool
                         || match_def_path(cx, did.did, &["core", "slice", "Iter"])
                         || match_def_path(cx, did.did, &["std", "collections", "hash", "map", "Entry"])
                         || match_def_path(cx, did.did, &["std", "collections", "hash", "map", "OccupiedEntry"])
-                        || match_def_path(cx, did.did, &["std", "collections", "hash", "map", "VacantEntry"]) {
+                        || match_def_path(cx, did.did, &["std", "collections", "hash", "map", "VacantEntry"])
+                        || match_def_path(cx, did.did, &["std", "collections", "hash", "set", "Iter"]) {
                     // Structures which are semantically similar to an &ptr.
                     false
                 } else if did.is_box() && in_new_function {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12874,6 +12874,12 @@
      {}
     ]
    ],
+   "mozilla/img_multiple_request.html": [
+    [
+     "/_mozilla/mozilla/img_multiple_request.html",
+     {}
+    ]
+   ],
    "mozilla/img_width_height.html": [
     [
      "/_mozilla/mozilla/img_width_height.html",
@@ -25343,6 +25349,10 @@
   ],
   "mozilla/iframe_replacement.html": [
    "3c4f36abed83367c851d943b1f25b8394de6fe75",
+   "testharness"
+  ],
+  "mozilla/img_multiple_request.html": [
+   "0a6263ad87c9b3307f2dc694747b094a0517b79b",
    "testharness"
   ],
   "mozilla/img_width_height.html": [

--- a/tests/wpt/mozilla/tests/mozilla/img_multiple_request.html
+++ b/tests/wpt/mozilla/tests/mozilla/img_multiple_request.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    async_test(function(t) {
+        var i = new Image();
+        i.src = "2x2.png";
+        i.src = "2x2.png";
+        i.onload = t.step_func(function() {
+            i.onload = this.unreached_func("Load event for aborted request.");
+            t.step_timeout(t.step_func_done(), 100);
+        });
+    }, "Multiple requests for the same URL do not trigger multiple load events.");
+
+    async_test(function(t) {
+        var i = new Image();
+        i.src = "test.png";
+        i.src = "2x2.png";
+        i.onload = t.step_func(function() {
+            i.onload = this.unreached_func("Load event for aborted request.");
+            t.step_timeout(t.step_func_done(), 100);
+        });
+    }, "Multiple requests for different URL do not trigger multiple load events.");
+</script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/delay-load-event.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/delay-load-event.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+<title>Image element delays window's load event</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<img src="resources/cat.jpg?pipe=trickle(d2)">
+<script>
+    async_test(function(t) {
+        var saw_img_load = false;
+        document.querySelector('img').onload = t.step_func(function() {
+            saw_img_load = true;
+        });
+        addEventListener('load', t.step_func_done(function() {
+            assert_true(saw_img_load);
+        }));
+    });
+</script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/document-adopt-base-url.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/document-adopt-base-url.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<title>Document base URL adopted img test</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-img-element" />
+<link rel="match" href="document-base-url-ref.html">
+<base href="resources/" />
+<iframe></iframe>
+<script>
+  var iframe = document.querySelector('iframe');
+  var i = iframe.contentDocument.createElement('img');
+  i.src = "cat.jpg";
+  document.body.appendChild(i);
+  iframe.remove();
+</script>


### PR DESCRIPTION
This addresses cases where image elements end up making multiple requests, as well as makes the element respond to additional relevant mutations that trigger updating the image data.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15709 (github issue number if applicable).
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15771)
<!-- Reviewable:end -->
