### PR TITLE
Don't serialize shorthand if some but not all its longhands have CSS-wide keyword

### DIFF
--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -9,7 +9,7 @@
 use Atom;
 use cssparser::{Delimiter, Parser, SourcePosition, Token, TokenSerializationType};
 use parser::ParserContext;
-use properties::DeclaredValue;
+use properties::{CSSWideKeyword, DeclaredValue};
 use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
@@ -362,11 +362,13 @@ pub fn cascade<'a>(custom_properties: &mut Option<HashMap<&'a Name, BorrowedSpec
             });
         },
         DeclaredValue::WithVariables(_) => unreachable!(),
-        DeclaredValue::Initial => {
-            map.remove(&name);
+        DeclaredValue::CSSWideKeyword(keyword) => match keyword {
+            CSSWideKeyword::Initial => {
+                map.remove(&name);
+            }
+            CSSWideKeyword::Unset | // Custom properties are inherited by default.
+            CSSWideKeyword::Inherit => {} // The inherited value is what we already have.
         }
-        DeclaredValue::Unset | // Custom properties are inherited by default.
-        DeclaredValue::Inherit => {}  // The inherited value is what we already have.
     }
 }
 

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -324,9 +324,9 @@
                                    -> Result<DeclaredValue<SpecifiedValue>, ()> {
                                % endif
                 match input.try(|i| CSSWideKeyword::parse(context, i)) {
-                    Ok(CSSWideKeyword::InheritKeyword) => Ok(DeclaredValue::Inherit),
-                    Ok(CSSWideKeyword::InitialKeyword) => Ok(DeclaredValue::Initial),
-                    Ok(CSSWideKeyword::UnsetKeyword) => Ok(DeclaredValue::Unset),
+                    Ok(CSSWideKeyword::Inherit) => Ok(DeclaredValue::Inherit),
+                    Ok(CSSWideKeyword::Initial) => Ok(DeclaredValue::Initial),
+                    Ok(CSSWideKeyword::Unset) => Ok(DeclaredValue::Unset),
                     Err(()) => {
                         input.look_for_var_functions();
                         let start = input.position();

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -554,15 +554,6 @@
             }
         }
 
-        impl<'a> ToCss for LonghandsToSerialize<'a> {
-            fn to_css<W>(&self, dest: &mut W) -> fmt::Result
-                where W: fmt::Write,
-            {
-                self.to_css_declared(dest)
-            }
-        }
-
-
         /// Parse the given shorthand and fill the result into the
         /// `declarations` vector.
         pub fn parse(context: &ParserContext,
@@ -635,8 +626,8 @@
             })
         }
 
-        impl<'a> LonghandsToSerialize<'a> {
-            fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        impl<'a> ToCss for LonghandsToSerialize<'a> {
+            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
                 super::serialize_four_sides(
                     dest,
                     self.${to_rust_ident(sub_property_pattern % 'top')},

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -8,7 +8,7 @@ use app_units::Au;
 use cssparser::{Color as CSSParserColor, Parser, RGBA};
 use euclid::{Point2D, Size2D};
 #[cfg(feature = "gecko")] use gecko_bindings::structs::nsCSSPropertyID;
-use properties::{DeclaredValue, PropertyDeclaration};
+use properties::{CSSWideKeyword, DeclaredValue, PropertyDeclaration};
 use properties::longhands;
 use properties::longhands::background_size::computed_value::T as BackgroundSize;
 use properties::longhands::font_weight::computed_value::T as FontWeight;
@@ -287,21 +287,23 @@ impl AnimationValue {
                             // https://bugzilla.mozilla.org/show_bug.cgi?id=1326131
                             DeclaredValue::WithVariables(_) => unimplemented!(),
                             DeclaredValue::Value(ref val) => val.to_computed_value(context),
-                            % if not prop.style_struct.inherited:
-                                DeclaredValue::Unset |
-                            % endif
-                            DeclaredValue::Initial => {
-                                let initial_struct = initial.get_${prop.style_struct.name_lower}();
-                                initial_struct.clone_${prop.ident}()
-                            },
-                            % if prop.style_struct.inherited:
-                                DeclaredValue::Unset |
-                            % endif
-                            DeclaredValue::Inherit => {
-                                let inherit_struct = context.inherited_style
-                                                            .get_${prop.style_struct.name_lower}();
-                                inherit_struct.clone_${prop.ident}()
-                            },
+                            DeclaredValue::CSSWideKeyword(keyword) => match keyword {
+                                % if not prop.style_struct.inherited:
+                                    CSSWideKeyword::Unset |
+                                % endif
+                                CSSWideKeyword::Initial => {
+                                    let initial_struct = initial.get_${prop.style_struct.name_lower}();
+                                    initial_struct.clone_${prop.ident}()
+                                },
+                                % if prop.style_struct.inherited:
+                                    CSSWideKeyword::Unset |
+                                % endif
+                                CSSWideKeyword::Inherit => {
+                                    let inherit_struct = context.inherited_style
+                                                                .get_${prop.style_struct.name_lower}();
+                                    inherit_struct.clone_${prop.ident}()
+                                },
+                            }
                         };
                         Some(AnimationValue::${prop.camel_case}(computed))
                     }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -102,14 +102,6 @@ pub mod shorthands {
     use parser::{Parse, ParserContext};
     use values::specified;
 
-    bitflags! {
-        flags SerializeFlags: u8 {
-            const ALL_INHERIT = 0b001,
-            const ALL_INITIAL = 0b010,
-            const ALL_UNSET   = 0b100,
-        }
-    }
-
     /// Parses a property for four different sides per CSS syntax.
     ///
     ///  * Zero or more than four values is invalid.

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -376,11 +376,11 @@ impl PropertyDeclarationIdSet {
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum CSSWideKeyword {
     /// The `initial` keyword.
-    InitialKeyword,
+    Initial,
     /// The `inherit` keyword.
-    InheritKeyword,
+    Inherit,
     /// The `unset` keyword.
-    UnsetKeyword,
+    Unset,
 }
 
 impl Parse for CSSWideKeyword {
@@ -388,9 +388,9 @@ impl Parse for CSSWideKeyword {
         let ident = input.expect_ident()?;
         input.expect_exhausted()?;
         match_ignore_ascii_case! { &ident,
-            "initial" => Ok(CSSWideKeyword::InitialKeyword),
-            "inherit" => Ok(CSSWideKeyword::InheritKeyword),
-            "unset" => Ok(CSSWideKeyword::UnsetKeyword),
+            "initial" => Ok(CSSWideKeyword::Initial),
+            "inherit" => Ok(CSSWideKeyword::Inherit),
+            "unset" => Ok(CSSWideKeyword::Unset),
             _ => Err(())
         }
     }
@@ -969,9 +969,9 @@ impl PropertyDeclaration {
         match id {
             PropertyId::Custom(name) => {
                 let value = match input.try(|i| CSSWideKeyword::parse(context, i)) {
-                    Ok(CSSWideKeyword::UnsetKeyword) => DeclaredValue::Unset,
-                    Ok(CSSWideKeyword::InheritKeyword) => DeclaredValue::Inherit,
-                    Ok(CSSWideKeyword::InitialKeyword) => DeclaredValue::Initial,
+                    Ok(CSSWideKeyword::Unset) => DeclaredValue::Unset,
+                    Ok(CSSWideKeyword::Inherit) => DeclaredValue::Inherit,
+                    Ok(CSSWideKeyword::Initial) => DeclaredValue::Initial,
                     Err(()) => match ::custom_properties::SpecifiedValue::parse(context, input) {
                         Ok(value) => DeclaredValue::Value(value),
                         Err(()) => return PropertyDeclarationParseResult::InvalidValue,
@@ -1029,7 +1029,7 @@ impl PropertyDeclaration {
                     ${property_pref_check(shorthand)}
 
                     match input.try(|i| CSSWideKeyword::parse(context, i)) {
-                        Ok(CSSWideKeyword::InheritKeyword) => {
+                        Ok(CSSWideKeyword::Inherit) => {
                             % for sub_property in shorthand.sub_properties:
                                 result_list.push((
                                     PropertyDeclaration::${sub_property.camel_case}(
@@ -1037,7 +1037,7 @@ impl PropertyDeclaration {
                             % endfor
                             PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
                         },
-                        Ok(CSSWideKeyword::InitialKeyword) => {
+                        Ok(CSSWideKeyword::Initial) => {
                             % for sub_property in shorthand.sub_properties:
                                 result_list.push((
                                     PropertyDeclaration::${sub_property.camel_case}(
@@ -1045,7 +1045,7 @@ impl PropertyDeclaration {
                             % endfor
                             PropertyDeclarationParseResult::ValidOrIgnoredDeclaration
                         },
-                        Ok(CSSWideKeyword::UnsetKeyword) => {
+                        Ok(CSSWideKeyword::Unset) => {
                             % for sub_property in shorthand.sub_properties:
                                 result_list.push((PropertyDeclaration::${sub_property.camel_case}(
                                         DeclaredValue::Unset), Importance::Normal));

--- a/components/style/properties/shorthand/background.mako.rs
+++ b/components/style/properties/shorthand/background.mako.rs
@@ -127,8 +127,8 @@
          })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             let len = self.background_image.0.len();
             // There should be at least one declared value
             if len == 0 {
@@ -224,8 +224,8 @@
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             let len = self.background_position_x.0.len();
             if len == 0 || len != self.background_position_y.0.len() {
                 return Ok(());

--- a/components/style/properties/shorthand/background.mako.rs
+++ b/components/style/properties/shorthand/background.mako.rs
@@ -129,61 +129,34 @@
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            // mako doesn't like ampersands following `<`
-            fn extract_value<T>(x: &DeclaredValue<T>) -> Option< &T> {
-                match *x {
-                    DeclaredValue::Value(ref val) => Some(val),
-                    _ => None,
-                }
-            }
-
-            let len = extract_value(self.background_image).map(|i| i.0.len()).unwrap_or(0);
+            let len = self.background_image.0.len();
             // There should be at least one declared value
             if len == 0 {
-                return dest.write_str("")
+                return Ok(());
             }
 
             // If a value list length is differs then we don't do a shorthand serialization.
             // The exceptions to this is color which appears once only and is serialized
             // with the last item.
             % for name in "image position_x position_y size repeat origin clip attachment".split():
-                if len != extract_value(self.background_${name}).map(|i| i.0.len()).unwrap_or(0) {
-                    return dest.write_str("")
+                if len != self.background_${name}.0.len() {
+                    return Ok(());
                 }
             % endfor
 
-            let mut first = true;
             for i in 0..len {
                 % for name in "image position_x position_y repeat size attachment origin clip".split():
-                    let ${name} = if let DeclaredValue::Value(ref arr) = *self.background_${name} {
-                        &arr.0[i]
-                    } else {
-                        unreachable!()
-                    };
+                    let ${name} = &self.background_${name}.0[i];
                 % endfor
 
-                let color = if i == len - 1 {
-                    Some(self.background_color)
-                } else {
-                    None
-                };
-
-                if first {
-                    first = false;
-                } else {
+                if i != 0 {
                     try!(write!(dest, ", "));
                 }
-                match color {
-                    Some(&DeclaredValue::Value(ref color)) => {
-                        try!(color.to_css(dest));
-                        try!(write!(dest, " "));
-                    },
-                    Some(_) => {
-                        try!(write!(dest, "transparent "));
-                    }
-                    // Not yet the last one
-                    None => ()
-                };
+
+                if i == len - 1 {
+                    try!(self.background_color.to_css(dest));
+                    try!(write!(dest, " "));
+                }
 
                 % for name in "image repeat attachment position_x position_y".split():
                     try!(${name}.to_css(dest));
@@ -253,47 +226,15 @@
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            // mako doesn't like ampersands following `<`
-            fn extract_value<T>(x: &DeclaredValue<T>) -> Option< &T> {
-                match *x {
-                    DeclaredValue::Value(ref val) => Some(val),
-                    _ => None,
-                }
+            let len = self.background_position_x.0.len();
+            if len == 0 || len != self.background_position_y.0.len() {
+                return Ok(());
             }
-            use std::cmp;
-            let mut len = 0;
-            % for name in "x y".split():
-                len = cmp::max(len, extract_value(self.background_position_${name})
-                                                      .map(|i| i.0.len())
-                                                      .unwrap_or(0));
-            % endfor
-
-            // There should be at least one declared value
-            if len == 0 {
-                return dest.write_str("")
-            }
-
             for i in 0..len {
-                % for name in "x y".split():
-                    let position_${name} = if let DeclaredValue::Value(ref arr) =
-                                           *self.background_position_${name} {
-                        arr.0.get(i % arr.0.len())
-                    } else {
-                        None
-                    };
-                % endfor
-
-                try!(position_x.unwrap_or(&background_position_x::single_value
-                                                                ::get_initial_position_value())
-                               .to_css(dest));
-
-                try!(write!(dest, " "));
-
-                try!(position_y.unwrap_or(&background_position_y::single_value
-                                                                ::get_initial_position_value())
-                               .to_css(dest));
+                self.background_position_x.0[i].to_css(dest)?;
+                dest.write_str(" ")?;
+                self.background_position_y.0[i].to_css(dest)?;
             }
-
             Ok(())
         }
     }

--- a/components/style/properties/shorthand/border.mako.rs
+++ b/components/style/properties/shorthand/border.mako.rs
@@ -291,53 +291,15 @@ pub fn parse_border(context: &ParserContext, input: &mut Parser)
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            % for name in "outset repeat slice source width".split():
-                let ${name} = if let DeclaredValue::Value(ref value) = *self.border_image_${name} {
-                    Some(value)
-                } else {
-                    None
-                };
-            % endfor
-
-            if let Some(source) = source {
-                try!(source.to_css(dest));
-            } else {
-                try!(write!(dest, "none"));
-            }
-
-            try!(write!(dest, " "));
-
-            if let Some(slice) = slice {
-                try!(slice.to_css(dest));
-            } else {
-                try!(write!(dest, "100%"));
-            }
-
-            try!(write!(dest, " / "));
-
-            if let Some(width) = width {
-                try!(width.to_css(dest));
-            } else {
-                try!(write!(dest, "1"));
-            }
-
-            try!(write!(dest, " / "));
-
-            if let Some(outset) = outset {
-                try!(outset.to_css(dest));
-            } else {
-                try!(write!(dest, "0"));
-            }
-
-            try!(write!(dest, " "));
-
-            if let Some(repeat) = repeat {
-                try!(repeat.to_css(dest));
-            } else {
-                try!(write!(dest, "stretch"));
-            }
-
-            Ok(())
+            self.border_image_source.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.border_image_slice.to_css(dest)?;
+            dest.write_str(" / ")?;
+            self.border_image_width.to_css(dest)?;
+            dest.write_str(" / ")?;
+            self.border_image_outset.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.border_image_repeat.to_css(dest)
         }
     }
 </%helpers:shorthand>

--- a/components/style/properties/shorthand/border.mako.rs
+++ b/components/style/properties/shorthand/border.mako.rs
@@ -29,8 +29,8 @@ ${helpers.four_sides_shorthand("border-style", "border-%s-style",
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             % for side in ["top", "right", "bottom", "left"]:
                 let ${side} = self.border_${side}_width.clone();
             % endfor
@@ -108,8 +108,8 @@ pub fn parse_border(context: &ParserContext, input: &mut Parser)
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             super::serialize_directional_border(
                 dest,
                 self.border_${to_rust_ident(side)}_width,
@@ -139,8 +139,8 @@ pub fn parse_border(context: &ParserContext, input: &mut Parser)
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             let all_equal = {
                 % for side in PHYSICAL_SIDES:
                   let border_${side}_width = self.border_${side}_width;
@@ -198,8 +198,8 @@ pub fn parse_border(context: &ParserContext, input: &mut Parser)
     // TODO: I do not understand how border radius works with respect to the slashes /,
     // so putting a default generic impl for now
     // https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             try!(self.border_top_left_radius.to_css(dest));
             try!(write!(dest, " "));
 
@@ -289,8 +289,8 @@ pub fn parse_border(context: &ParserContext, input: &mut Parser)
          })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             self.border_image_source.to_css(dest)?;
             dest.write_str(" ")?;
             self.border_image_slice.to_css(dest)?;

--- a/components/style/properties/shorthand/box.mako.rs
+++ b/components/style/properties/shorthand/box.mako.rs
@@ -23,9 +23,8 @@
                     *x_value == y_container.0
                 },
                 (&DeclaredValue::WithVariables(_), &DeclaredValue::WithVariables(_)) => true,
-                (&DeclaredValue::Initial, &DeclaredValue::Initial) => true,
-                (&DeclaredValue::Inherit, &DeclaredValue::Inherit) => true,
-                (&DeclaredValue::Unset, &DeclaredValue::Unset) => true,
+                (&DeclaredValue::CSSWideKeyword(x_keyword),
+                 &DeclaredValue::CSSWideKeyword(y_keyword)) => x_keyword == y_keyword,
                 _ => false
             };
 
@@ -359,9 +358,8 @@ macro_rules! try_parse_one {
                 (&DeclaredValue::Value(ref x_value), &DeclaredValue::Value(ref y_value)) => {
                     *x_value == *y_value
                 },
-                (&DeclaredValue::Initial, &DeclaredValue::Initial) => true,
-                (&DeclaredValue::Inherit, &DeclaredValue::Inherit) => true,
-                (&DeclaredValue::Unset, &DeclaredValue::Unset) => true,
+                (&DeclaredValue::CSSWideKeyword(x_keyword),
+                 &DeclaredValue::CSSWideKeyword(y_keyword)) => x_keyword == y_keyword,
                 (x, y) => { *x == *y },
             };
 

--- a/components/style/properties/shorthand/box.mako.rs
+++ b/components/style/properties/shorthand/box.mako.rs
@@ -16,8 +16,8 @@
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             if *self.overflow_x == self.overflow_y.0 {
                 self.overflow_x.to_css(dest)
             } else {
@@ -115,8 +115,8 @@ macro_rules! try_parse_one {
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             let len = self.transition_property.0.len();
             // There should be at least one declared value
             if len == 0 {
@@ -257,8 +257,8 @@ macro_rules! try_parse_one {
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             let len = self.animation_name.0.len();
             // There should be at least one declared value
             if len == 0 {
@@ -307,10 +307,10 @@ macro_rules! try_parse_one {
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
         // Serializes into the single keyword value if both scroll-snap-type and scroll-snap-type-y are same.
         // Otherwise into an empty string. This is done to match Gecko's behaviour.
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             if self.scroll_snap_type_x == self.scroll_snap_type_y {
                 self.scroll_snap_type_x.to_css(dest)
             } else {

--- a/components/style/properties/shorthand/column.mako.rs
+++ b/components/style/properties/shorthand/column.mako.rs
@@ -98,28 +98,11 @@
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            let mut need_space = false;
-
-            if let DeclaredValue::Value(ref width) = *self.column_rule_width {
-                try!(width.to_css(dest));
-                need_space = true;
-            }
-
-            if let DeclaredValue::Value(ref style) = *self.column_rule_style {
-                if need_space {
-                    try!(write!(dest, " "));
-                }
-                try!(style.to_css(dest));
-                need_space = true;
-            }
-
-            if let DeclaredValue::Value(ref color) = *self.column_rule_color {
-                if need_space {
-                    try!(write!(dest, " "));
-                }
-                try!(color.to_css(dest));
-            }
-            Ok(())
+            self.column_rule_width.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.column_rule_style.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.column_rule_color.to_css(dest)
         }
     }
 </%helpers:shorthand>

--- a/components/style/properties/shorthand/column.mako.rs
+++ b/components/style/properties/shorthand/column.mako.rs
@@ -49,8 +49,8 @@
         }
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             try!(self.column_width.to_css(dest));
             try!(write!(dest, " "));
 
@@ -96,8 +96,8 @@
         }
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             self.column_rule_width.to_css(dest)?;
             dest.write_str(" ")?;
             self.column_rule_style.to_css(dest)?;

--- a/components/style/properties/shorthand/font.mako.rs
+++ b/components/style/properties/shorthand/font.mako.rs
@@ -95,8 +95,8 @@
     }
 
     // This may be a bit off, unsure, possibly needs changes
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             self.font_style.to_css(dest)?;
             dest.write_str(" ")?;
             self.font_variant.to_css(dest)?;

--- a/components/style/properties/shorthand/font.mako.rs
+++ b/components/style/properties/shorthand/font.mako.rs
@@ -97,39 +97,25 @@
     // This may be a bit off, unsure, possibly needs changes
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            if let DeclaredValue::Value(ref style) = *self.font_style {
-                try!(style.to_css(dest));
-                try!(write!(dest, " "));
-            }
+            self.font_style.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.font_variant.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.font_weight.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.font_stretch.to_css(dest)?;
+            dest.write_str(" ")?;
 
-            if let DeclaredValue::Value(ref variant) = *self.font_variant {
-                try!(variant.to_css(dest));
-                try!(write!(dest, " "));
-            }
-
-            if let DeclaredValue::Value(ref weight) = *self.font_weight {
-                try!(weight.to_css(dest));
-                try!(write!(dest, " "));
-            }
-
-            if let DeclaredValue::Value(ref stretch) = *self.font_stretch {
-                try!(stretch.to_css(dest));
-                try!(write!(dest, " "));
-            }
-
-            try!(self.font_size.to_css(dest));
-            if let DeclaredValue::Value(ref height) = *self.line_height {
-                match *height {
-                    line_height::SpecifiedValue::Normal => {},
-                    _ => {
-                        try!(write!(dest, "/"));
-                        try!(height.to_css(dest));
-                    }
+            self.font_size.to_css(dest)?;
+            match *self.line_height {
+                line_height::SpecifiedValue::Normal => {},
+                _ => {
+                    dest.write_str("/")?;
+                    self.line_height.to_css(dest)?;
                 }
             }
 
-            try!(write!(dest, " "));
-
+            dest.write_str(" ")?;
             self.font_family.to_css(dest)
         }
     }

--- a/components/style/properties/shorthand/inherited_svg.mako.rs
+++ b/components/style/properties/shorthand/inherited_svg.mako.rs
@@ -20,8 +20,8 @@
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             if self.marker_start == self.marker_mid && self.marker_mid == self.marker_end {
                 self.marker_start.to_css(dest)
             } else {

--- a/components/style/properties/shorthand/inherited_svg.mako.rs
+++ b/components/style/properties/shorthand/inherited_svg.mako.rs
@@ -22,16 +22,11 @@
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            if let DeclaredValue::Value(ref start) = *self.marker_start {
-                if let DeclaredValue::Value(ref mid) = *self.marker_mid {
-                    if let DeclaredValue::Value(ref end) = *self.marker_end {
-                        if start == mid && mid == end {
-                            start.to_css(dest)?;
-                        }
-                    }
-                }
+            if self.marker_start == self.marker_mid && self.marker_mid == self.marker_end {
+                self.marker_start.to_css(dest)
+            } else {
+                Ok(())
             }
-            Ok(())
         }
     }
 </%helpers:shorthand>

--- a/components/style/properties/shorthand/inherited_text.mako.rs
+++ b/components/style/properties/shorthand/inherited_text.mako.rs
@@ -40,19 +40,9 @@
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            let mut style_present = false;
-            if let DeclaredValue::Value(ref value) = *self.text_emphasis_style {
-                style_present = true;
-                try!(value.to_css(dest));
-            }
-
-            if let DeclaredValue::Value(ref color) = *self.text_emphasis_color {
-                if style_present {
-                    try!(write!(dest, " "));
-                }
-                try!(color.to_css(dest));
-            }
-            Ok(())
+            self.text_emphasis_style.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.text_emphasis_color.to_css(dest)
         }
     }
 </%helpers:shorthand>
@@ -98,20 +88,9 @@
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            let mut style_present = false;
-            if let DeclaredValue::Value(ref width) = *self._webkit_text_stroke_width {
-                style_present = true;
-                try!(width.to_css(dest));
-            }
-
-            if let DeclaredValue::Value(ref color) = *self._webkit_text_stroke_color {
-                if style_present {
-                    try!(write!(dest, " "));
-                }
-                try!(color.to_css(dest));
-            }
-
-            Ok(())
+            self._webkit_text_stroke_width.to_css(dest)?;
+            dest.write_str(" ")?;
+            self._webkit_text_stroke_color.to_css(dest)
         }
     }
 </%helpers:shorthand>

--- a/components/style/properties/shorthand/inherited_text.mako.rs
+++ b/components/style/properties/shorthand/inherited_text.mako.rs
@@ -38,8 +38,8 @@
         }
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             self.text_emphasis_style.to_css(dest)?;
             dest.write_str(" ")?;
             self.text_emphasis_color.to_css(dest)
@@ -86,8 +86,8 @@
         }
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             self._webkit_text_stroke_width.to_css(dest)?;
             dest.write_str(" ")?;
             self._webkit_text_stroke_color.to_css(dest)

--- a/components/style/properties/shorthand/list.mako.rs
+++ b/components/style/properties/shorthand/list.mako.rs
@@ -99,21 +99,24 @@
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self.list_style_position {
-                DeclaredValue::Initial => try!(write!(dest, "outside")),
+                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
+                    try!(write!(dest, "outside")),
                 _ => try!(self.list_style_position.to_css(dest))
             }
 
             try!(write!(dest, " "));
 
             match *self.list_style_image {
-                DeclaredValue::Initial => try!(write!(dest, "none")),
+                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
+                    try!(write!(dest, "none")),
                 _ => try!(self.list_style_image.to_css(dest))
             };
 
             try!(write!(dest, " "));
 
             match *self.list_style_type {
-                DeclaredValue::Initial => write!(dest, "disc"),
+                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
+                    write!(dest, "disc"),
                 _ => self.list_style_type.to_css(dest)
             }
         }

--- a/components/style/properties/shorthand/list.mako.rs
+++ b/components/style/properties/shorthand/list.mako.rs
@@ -96,8 +96,8 @@
         }
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             self.list_style_position.to_css(dest)?;
             dest.write_str(" ")?;
             self.list_style_image.to_css(dest)?;

--- a/components/style/properties/shorthand/list.mako.rs
+++ b/components/style/properties/shorthand/list.mako.rs
@@ -98,27 +98,11 @@
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match *self.list_style_position {
-                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
-                    try!(write!(dest, "outside")),
-                _ => try!(self.list_style_position.to_css(dest))
-            }
-
-            try!(write!(dest, " "));
-
-            match *self.list_style_image {
-                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
-                    try!(write!(dest, "none")),
-                _ => try!(self.list_style_image.to_css(dest))
-            };
-
-            try!(write!(dest, " "));
-
-            match *self.list_style_type {
-                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
-                    write!(dest, "disc"),
-                _ => self.list_style_type.to_css(dest)
-            }
+            self.list_style_position.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.list_style_image.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.list_style_type.to_css(dest)
         }
     }
 </%helpers:shorthand>

--- a/components/style/properties/shorthand/mask.mako.rs
+++ b/components/style/properties/shorthand/mask.mako.rs
@@ -120,8 +120,8 @@
          })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             use properties::longhands::mask_origin::single_value::computed_value::T as Origin;
             use properties::longhands::mask_clip::single_value::computed_value::T as Clip;
 
@@ -217,8 +217,8 @@
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             let len = self.mask_position_x.0.len();
             if len == 0 || self.mask_position_y.0.len() != len {
                 return Ok(());

--- a/components/style/properties/shorthand/mask.mako.rs
+++ b/components/style/properties/shorthand/mask.mako.rs
@@ -122,111 +122,60 @@
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            // mako doesn't like ampersands following `<`
-            fn extract_value<T>(x: &DeclaredValue<T>) -> Option< &T> {
-                match *x {
-                    DeclaredValue::Value(ref val) => Some(val),
-                    _ => None,
-                }
-            }
-            use std::cmp;
-            let mut len = 0;
-            % for name in "image mode position_x position_y size repeat origin clip composite".split():
-                len = cmp::max(len, extract_value(self.mask_${name}).map(|i| i.0.len())
-                                                                   .unwrap_or(0));
-            % endfor
+            use properties::longhands::mask_origin::single_value::computed_value::T as Origin;
+            use properties::longhands::mask_clip::single_value::computed_value::T as Clip;
 
-            // There should be at least one declared value
+            let len = self.mask_image.0.len();
             if len == 0 {
-                return dest.write_str("")
+                return Ok(());
             }
+            % for name in "mode position_x position_y size repeat origin clip composite".split():
+                if self.mask_${name}.0.len() != len {
+                    return Ok(());
+                }
+            % endfor
 
             for i in 0..len {
                 if i > 0 {
-                    try!(dest.write_str(", "));
+                    dest.write_str(", ")?;
                 }
 
                 % for name in "image mode position_x position_y size repeat origin clip composite".split():
-                    let ${name} = if let DeclaredValue::Value(ref arr) = *self.mask_${name} {
-                        arr.0.get(i % arr.0.len())
-                    } else {
-                        None
-                    };
+                    let ${name} = &self.mask_${name}.0[i];
                 % endfor
 
-                if let Some(image) = image {
-                    try!(image.to_css(dest));
-                } else {
-                    try!(write!(dest, "none"));
-                }
-
-                try!(write!(dest, " "));
-
-                if let Some(mode) = mode {
-                    try!(mode.to_css(dest));
-                } else {
-                    try!(write!(dest, "match-source"));
-                }
-
-                try!(write!(dest, " "));
-
-                try!(position_x.unwrap_or(&mask_position_x::single_value
-                                                      ::get_initial_position_value())
-                     .to_css(dest));
-
-                try!(write!(dest, " "));
-
-                try!(position_y.unwrap_or(&mask_position_y::single_value
-                                                      ::get_initial_position_value())
-                     .to_css(dest));
-
-                if let Some(size) = size {
-                    try!(write!(dest, " / "));
-                    try!(size.to_css(dest));
-                }
-
-                try!(write!(dest, " "));
-
-                if let Some(repeat) = repeat {
-                    try!(repeat.to_css(dest));
-                } else {
-                    try!(write!(dest, "repeat"));
-                }
+                image.to_css(dest)?;
+                dest.write_str(" ")?;
+                mode.to_css(dest)?;
+                dest.write_str(" ")?;
+                position_x.to_css(dest)?;
+                dest.write_str(" ")?;
+                position_y.to_css(dest)?;
+                dest.write_str(" / ")?;
+                size.to_css(dest)?;
+                dest.write_str(" ")?;
+                repeat.to_css(dest)?;
+                dest.write_str(" ")?;
 
                 match (origin, clip) {
-                    (Some(origin), Some(clip)) => {
-                        use properties::longhands::mask_origin::single_value::computed_value::T as Origin;
-                        use properties::longhands::mask_clip::single_value::computed_value::T as Clip;
-
-                        try!(write!(dest, " "));
-
-                        match (origin, clip) {
-                            (&Origin::padding_box, &Clip::padding_box) => {
-                                try!(origin.to_css(dest));
-                            },
-                            (&Origin::border_box, &Clip::border_box) => {
-                                try!(origin.to_css(dest));
-                            },
-                            (&Origin::content_box, &Clip::content_box) => {
-                                try!(origin.to_css(dest));
-                            },
-                            _ => {
-                                try!(origin.to_css(dest));
-                                try!(write!(dest, " "));
-                                try!(clip.to_css(dest));
-                            }
-                        }
+                    (&Origin::padding_box, &Clip::padding_box) => {
+                        try!(origin.to_css(dest));
                     },
-                    _ => {}
-                };
-
-                try!(write!(dest, " "));
-
-                if let Some(composite) = composite {
-                    try!(composite.to_css(dest));
-                } else {
-                    try!(write!(dest, "add"));
+                    (&Origin::border_box, &Clip::border_box) => {
+                        try!(origin.to_css(dest));
+                    },
+                    (&Origin::content_box, &Clip::content_box) => {
+                        try!(origin.to_css(dest));
+                    },
+                    _ => {
+                        try!(origin.to_css(dest));
+                        try!(write!(dest, " "));
+                        try!(clip.to_css(dest));
+                    }
                 }
+
+                dest.write_str(" ")?;
+                composite.to_css(dest)?;
             }
 
             Ok(())
@@ -270,45 +219,14 @@
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            // mako doesn't like ampersands following `<`
-            fn extract_value<T>(x: &DeclaredValue<T>) -> Option< &T> {
-                match *x {
-                    DeclaredValue::Value(ref val) => Some(val),
-                    _ => None,
-                }
-            }
-            use std::cmp;
-            let mut len = 0;
-            % for name in "x y".split():
-                len = cmp::max(len, extract_value(self.mask_position_${name})
-                                                      .map(|i| i.0.len())
-                                                      .unwrap_or(0));
-            % endfor
-
-            // There should be at least one declared value
-            if len == 0 {
-                return dest.write_str("")
+            let len = self.mask_position_x.0.len();
+            if len == 0 || self.mask_position_y.0.len() != len {
+                return Ok(());
             }
 
             for i in 0..len {
-                % for name in "x y".split():
-                    let position_${name} = if let DeclaredValue::Value(ref arr) =
-                                           *self.mask_position_${name} {
-                        arr.0.get(i % arr.0.len())
-                    } else {
-                        None
-                    };
-                % endfor
-
-                try!(position_x.unwrap_or(&mask_position_x::single_value
-                                                                ::get_initial_position_value())
-                               .to_css(dest));
-
-                try!(write!(dest, " "));
-
-                try!(position_y.unwrap_or(&mask_position_y::single_value
-                                                                ::get_initial_position_value())
-                               .to_css(dest));
+                self.mask_position_x.0[i].to_css(dest)?;
+                self.mask_position_y.0[i].to_css(dest)?;
             }
 
             Ok(())

--- a/components/style/properties/shorthand/outline.mako.rs
+++ b/components/style/properties/shorthand/outline.mako.rs
@@ -51,8 +51,8 @@
         }
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             try!(self.outline_width.to_css(dest));
             try!(write!(dest, " "));
             try!(self.outline_style.to_css(dest));
@@ -81,8 +81,8 @@
     }
 
     // TODO: Border radius for the radius shorthand is not implemented correctly yet
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             try!(self._moz_outline_radius_topleft.to_css(dest));
             try!(write!(dest, " "));
 

--- a/components/style/properties/shorthand/outline.mako.rs
+++ b/components/style/properties/shorthand/outline.mako.rs
@@ -55,20 +55,9 @@
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             try!(self.outline_width.to_css(dest));
             try!(write!(dest, " "));
-
-            match *self.outline_style {
-                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
-                    try!(write!(dest, "none")),
-                _ => try!(self.outline_style.to_css(dest))
-            };
-
-            match *self.outline_color {
-                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) => Ok(()),
-                _ => {
-                    try!(write!(dest, " "));
-                    self.outline_color.to_css(dest)
-                }
-            }
+            try!(self.outline_style.to_css(dest));
+            try!(write!(dest, " "));
+            self.outline_color.to_css(dest)
         }
     }
 </%helpers:shorthand>

--- a/components/style/properties/shorthand/outline.mako.rs
+++ b/components/style/properties/shorthand/outline.mako.rs
@@ -57,12 +57,13 @@
             try!(write!(dest, " "));
 
             match *self.outline_style {
-                DeclaredValue::Initial => try!(write!(dest, "none")),
+                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
+                    try!(write!(dest, "none")),
                 _ => try!(self.outline_style.to_css(dest))
             };
 
             match *self.outline_color {
-                DeclaredValue::Initial => Ok(()),
+                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) => Ok(()),
                 _ => {
                     try!(write!(dest, " "));
                     self.outline_color.to_css(dest)

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -39,19 +39,9 @@
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match *self.flex_direction {
-                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
-                    try!(write!(dest, "row")),
-                _ => try!(self.flex_direction.to_css(dest))
-            };
-
-            try!(write!(dest, " "));
-
-            match *self.flex_wrap {
-                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
-                    write!(dest, "nowrap"),
-                _ => self.flex_wrap.to_css(dest)
-            }
+            self.flex_direction.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.flex_wrap.to_css(dest)
         }
     }
 </%helpers:shorthand>

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -37,8 +37,8 @@
     }
 
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             self.flex_direction.to_css(dest)?;
             dest.write_str(" ")?;
             self.flex_wrap.to_css(dest)
@@ -97,8 +97,8 @@
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             try!(self.flex_grow.to_css(dest));
             try!(write!(dest, " "));
 

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -40,14 +40,16 @@
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self.flex_direction {
-                DeclaredValue::Initial => try!(write!(dest, "row")),
+                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
+                    try!(write!(dest, "row")),
                 _ => try!(self.flex_direction.to_css(dest))
             };
 
             try!(write!(dest, " "));
 
             match *self.flex_wrap {
-                DeclaredValue::Initial => write!(dest, "nowrap"),
+                DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial) =>
+                    write!(dest, "nowrap"),
                 _ => self.flex_wrap.to_css(dest)
             }
         }

--- a/components/style/properties/shorthand/serialize.mako.rs
+++ b/components/style/properties/shorthand/serialize.mako.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use cssparser::Color;
-use properties::DeclaredValue;
 use style_traits::ToCss;
 use values::specified::{BorderStyle, CSSColor};
 use std::fmt;
@@ -60,35 +59,16 @@ pub fn serialize_four_sides<W, I>(dest: &mut W,
 }
 
 fn serialize_directional_border<W, I,>(dest: &mut W,
-                                                width: &DeclaredValue<I>,
-                                                style: &DeclaredValue<BorderStyle>,
-                                                color: &DeclaredValue<CSSColor>)
-                                                -> fmt::Result where W: fmt::Write, I: ToCss {
-    match *width {
-        DeclaredValue::Value(ref width) => {
-            try!(width.to_css(dest));
-        },
-        _ => {
-            try!(write!(dest, "medium"));
-        }
-    };
-
-    try!(write!(dest, " "));
-
-    match *style {
-        DeclaredValue::Value(ref style) => {
-            try!(style.to_css(dest));
-        },
-        _ => {
-            try!(write!(dest, "none"));
-        }
-    };
-
-    match *color {
-        DeclaredValue::Value(ref color) if color.parsed != Color::CurrentColor => {
-            try!(write!(dest, " "));
-            color.to_css(dest)
-        },
-        _ => Ok(())
+                                       width: &I,
+                                       style: &BorderStyle,
+                                       color: &CSSColor)
+    -> fmt::Result where W: fmt::Write, I: ToCss {
+    width.to_css(dest)?;
+    dest.write_str(" ")?;
+    style.to_css(dest)?;
+    if color.parsed != Color::CurrentColor {
+        dest.write_str(" ")?;
+        color.to_css(dest)?;
     }
+    Ok(())
 }

--- a/components/style/properties/shorthand/text.mako.rs
+++ b/components/style/properties/shorthand/text.mako.rs
@@ -46,8 +46,8 @@
         })
     }
 
-    impl<'a> LonghandsToSerialize<'a>  {
-        fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+    impl<'a> ToCss for LonghandsToSerialize<'a>  {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             self.text_decoration_line.to_css(dest)?;
             dest.write_str(" ")?;
             self.text_decoration_style.to_css(dest)?;

--- a/components/style/properties/shorthand/text.mako.rs
+++ b/components/style/properties/shorthand/text.mako.rs
@@ -48,29 +48,13 @@
 
     impl<'a> LonghandsToSerialize<'a>  {
         fn to_css_declared<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match *self.text_decoration_line {
-                DeclaredValue::Value(ref line) => {
-                    try!(line.to_css(dest));
-                },
-                _ => {
-                    try!(write!(dest, "none"));
-                }
-            };
-
-            if let DeclaredValue::Value(ref style) = *self.text_decoration_style {
-                if *style != text_decoration_style::computed_value::T::solid {
-                    try!(write!(dest, " "));
-                    try!(style.to_css(dest));
-                }
+            self.text_decoration_line.to_css(dest)?;
+            dest.write_str(" ")?;
+            self.text_decoration_style.to_css(dest)?;
+            if self.text_decoration_color.parsed != CSSParserColor::CurrentColor {
+                dest.write_str(" ")?;
+                self.text_decoration_color.to_css(dest)?;
             }
-
-            if let DeclaredValue::Value(ref color) = *self.text_decoration_color {
-                if color.parsed != CSSParserColor::CurrentColor {
-                    try!(write!(dest, " "));
-                    try!(color.to_css(dest));
-                }
-            }
-
             Ok(())
         }
     }

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -7,7 +7,7 @@ use media_queries::CSSErrorReporterTest;
 use servo_url::ServoUrl;
 use style::computed_values::display::T::inline_block;
 use style::parser::ParserContext;
-use style::properties::{CSSWideKeyword, DeclaredValue, PropertyDeclaration};
+use style::properties::{DeclaredValue, PropertyDeclaration};
 use style::properties::{PropertyDeclarationBlock, Importance, PropertyId};
 use style::properties::longhands::outline_color::computed_value::T as ComputedColor;
 use style::properties::parse_property_declaration_list;
@@ -372,33 +372,18 @@ mod shorthand_serialization {
             assert_eq!(serialization, "border-top: 4px solid rgb(255, 0, 0);");
         }
 
-        #[test]
-        fn directional_border_with_no_specified_style_will_show_style_as_none() {
-            let mut properties = Vec::new();
-
-            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
-            let style = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
-            let color = DeclaredValue::Value(CSSColor {
-                parsed: ComputedColor::RGBA(RGBA::new(255, 0, 0, 255)),
-                authored: None
-            });
-
-            properties.push(PropertyDeclaration::BorderTopWidth(width));
-            properties.push(PropertyDeclaration::BorderTopStyle(style));
-            properties.push(PropertyDeclaration::BorderTopColor(color));
-
-            let serialization = shorthand_properties_to_string(properties);
-            assert_eq!(serialization, "border-top: 4px none rgb(255, 0, 0);");
+        fn get_border_property_values() -> (DeclaredValue<BorderWidth>,
+                                            DeclaredValue<BorderStyle>,
+                                            DeclaredValue<CSSColor>) {
+            (DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32))),
+             DeclaredValue::Value(BorderStyle::solid),
+             DeclaredValue::Value(CSSColor::currentcolor()))
         }
 
         #[test]
-        fn directional_border_with_no_specified_color_will_not_show_color() {
+        fn border_top_should_serialize_correctly() {
             let mut properties = Vec::new();
-
-            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
-            let style = DeclaredValue::Value(BorderStyle::solid);
-            let color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
-
+            let (width, style, color) = get_border_property_values();
             properties.push(PropertyDeclaration::BorderTopWidth(width));
             properties.push(PropertyDeclaration::BorderTopStyle(style));
             properties.push(PropertyDeclaration::BorderTopColor(color));
@@ -410,11 +395,7 @@ mod shorthand_serialization {
         #[test]
         fn border_right_should_serialize_correctly() {
             let mut properties = Vec::new();
-
-            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
-            let style = DeclaredValue::Value(BorderStyle::solid);
-            let color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
-
+            let (width, style, color) = get_border_property_values();
             properties.push(PropertyDeclaration::BorderRightWidth(width));
             properties.push(PropertyDeclaration::BorderRightStyle(style));
             properties.push(PropertyDeclaration::BorderRightColor(color));
@@ -426,11 +407,7 @@ mod shorthand_serialization {
         #[test]
         fn border_bottom_should_serialize_correctly() {
             let mut properties = Vec::new();
-
-            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
-            let style = DeclaredValue::Value(BorderStyle::solid);
-            let color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
-
+            let (width, style, color) = get_border_property_values();
             properties.push(PropertyDeclaration::BorderBottomWidth(width));
             properties.push(PropertyDeclaration::BorderBottomStyle(style));
             properties.push(PropertyDeclaration::BorderBottomColor(color));
@@ -442,11 +419,7 @@ mod shorthand_serialization {
         #[test]
         fn border_left_should_serialize_correctly() {
             let mut properties = Vec::new();
-
-            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
-            let style = DeclaredValue::Value(BorderStyle::solid);
-            let color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
-
+            let (width, style, color) = get_border_property_values();
             properties.push(PropertyDeclaration::BorderLeftWidth(width));
             properties.push(PropertyDeclaration::BorderLeftStyle(style));
             properties.push(PropertyDeclaration::BorderLeftColor(color));
@@ -458,38 +431,23 @@ mod shorthand_serialization {
         #[test]
         fn border_should_serialize_correctly() {
             let mut properties = Vec::new();
+            let (width, style, color) = get_border_property_values();
 
-            let top_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
-            let top_style = DeclaredValue::Value(BorderStyle::solid);
-            let top_color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
+            properties.push(PropertyDeclaration::BorderTopWidth(width.clone()));
+            properties.push(PropertyDeclaration::BorderTopStyle(style.clone()));
+            properties.push(PropertyDeclaration::BorderTopColor(color.clone()));
 
-            properties.push(PropertyDeclaration::BorderTopWidth(top_width));
-            properties.push(PropertyDeclaration::BorderTopStyle(top_style));
-            properties.push(PropertyDeclaration::BorderTopColor(top_color));
+            properties.push(PropertyDeclaration::BorderRightWidth(width.clone()));
+            properties.push(PropertyDeclaration::BorderRightStyle(style.clone()));
+            properties.push(PropertyDeclaration::BorderRightColor(color.clone()));
 
-            let right_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
-            let right_style = DeclaredValue::Value(BorderStyle::solid);
-            let right_color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
+            properties.push(PropertyDeclaration::BorderBottomWidth(width.clone()));
+            properties.push(PropertyDeclaration::BorderBottomStyle(style.clone()));
+            properties.push(PropertyDeclaration::BorderBottomColor(color.clone()));
 
-            properties.push(PropertyDeclaration::BorderRightWidth(right_width));
-            properties.push(PropertyDeclaration::BorderRightStyle(right_style));
-            properties.push(PropertyDeclaration::BorderRightColor(right_color));
-
-            let bottom_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
-            let bottom_style = DeclaredValue::Value(BorderStyle::solid);
-            let bottom_color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
-
-            properties.push(PropertyDeclaration::BorderBottomWidth(bottom_width));
-            properties.push(PropertyDeclaration::BorderBottomStyle(bottom_style));
-            properties.push(PropertyDeclaration::BorderBottomColor(bottom_color));
-
-            let left_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
-            let left_style = DeclaredValue::Value(BorderStyle::solid);
-            let left_color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
-
-            properties.push(PropertyDeclaration::BorderLeftWidth(left_width));
-            properties.push(PropertyDeclaration::BorderLeftStyle(left_style));
-            properties.push(PropertyDeclaration::BorderLeftColor(left_color));
+            properties.push(PropertyDeclaration::BorderLeftWidth(width.clone()));
+            properties.push(PropertyDeclaration::BorderLeftStyle(style.clone()));
+            properties.push(PropertyDeclaration::BorderLeftColor(color.clone()));
 
             let serialization = shorthand_properties_to_string(properties);
             assert_eq!(serialization, "border: 4px solid;");
@@ -518,22 +476,6 @@ mod shorthand_serialization {
             let serialization = shorthand_properties_to_string(properties);
             assert_eq!(serialization, "list-style: inside url(\"http://servo/test.png\") disc;");
         }
-
-        #[test]
-        fn list_style_should_show_all_properties_even_if_only_one_is_set() {
-            let mut properties = Vec::new();
-
-            let position = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
-            let image = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
-            let style_type = DeclaredValue::Value(ListStyleType::disc);
-
-            properties.push(PropertyDeclaration::ListStylePosition(position));
-            properties.push(PropertyDeclaration::ListStyleImage(image));
-            properties.push(PropertyDeclaration::ListStyleType(style_type));
-
-            let serialization = shorthand_properties_to_string(properties);
-            assert_eq!(serialization, "list-style: outside none disc;");
-        }
     }
 
     mod outline {
@@ -558,40 +500,6 @@ mod shorthand_serialization {
 
             let serialization = shorthand_properties_to_string(properties);
             assert_eq!(serialization, "outline: 4px solid rgb(255, 0, 0);");
-        }
-
-        #[test]
-        fn outline_should_not_show_color_if_not_set() {
-            let mut properties = Vec::new();
-
-            let width = DeclaredValue::Value(WidthContainer(Length::from_px(4f32)));
-            let style = DeclaredValue::Value(Either::Second(BorderStyle::solid));
-            let color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
-
-            properties.push(PropertyDeclaration::OutlineWidth(width));
-            properties.push(PropertyDeclaration::OutlineStyle(style));
-            properties.push(PropertyDeclaration::OutlineColor(color));
-
-            let serialization = shorthand_properties_to_string(properties);
-            assert_eq!(serialization, "outline: 4px solid;");
-        }
-
-        #[test]
-        fn outline_should_serialize_correctly_when_style_is_not_set() {
-            let mut properties = Vec::new();
-
-            let width = DeclaredValue::Value(WidthContainer(Length::from_px(4f32)));
-            let style = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
-            let color = DeclaredValue::Value(CSSColor {
-                parsed: ComputedColor::RGBA(RGBA::new(255, 0, 0, 255)),
-                authored: None
-            });
-            properties.push(PropertyDeclaration::OutlineWidth(width));
-            properties.push(PropertyDeclaration::OutlineStyle(style));
-            properties.push(PropertyDeclaration::OutlineColor(color));
-
-            let serialization = shorthand_properties_to_string(properties);
-            assert_eq!(serialization, "outline: 4px none rgb(255, 0, 0);");
         }
 
         #[test]

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -7,7 +7,8 @@ use media_queries::CSSErrorReporterTest;
 use servo_url::ServoUrl;
 use style::computed_values::display::T::inline_block;
 use style::parser::ParserContext;
-use style::properties::{DeclaredValue, PropertyDeclaration, PropertyDeclarationBlock, Importance, PropertyId};
+use style::properties::{CSSWideKeyword, DeclaredValue, PropertyDeclaration};
+use style::properties::{PropertyDeclarationBlock, Importance, PropertyId};
 use style::properties::longhands::outline_color::computed_value::T as ComputedColor;
 use style::properties::parse_property_declaration_list;
 use style::stylesheets::Origin;
@@ -376,7 +377,7 @@ mod shorthand_serialization {
             let mut properties = Vec::new();
 
             let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
-            let style = DeclaredValue::Initial;
+            let style = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
             let color = DeclaredValue::Value(CSSColor {
                 parsed: ComputedColor::RGBA(RGBA::new(255, 0, 0, 255)),
                 authored: None
@@ -396,7 +397,7 @@ mod shorthand_serialization {
 
             let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let style = DeclaredValue::Value(BorderStyle::solid);
-            let color = DeclaredValue::Initial;
+            let color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
 
             properties.push(PropertyDeclaration::BorderTopWidth(width));
             properties.push(PropertyDeclaration::BorderTopStyle(style));
@@ -412,7 +413,7 @@ mod shorthand_serialization {
 
             let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let style = DeclaredValue::Value(BorderStyle::solid);
-            let color = DeclaredValue::Initial;
+            let color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
 
             properties.push(PropertyDeclaration::BorderRightWidth(width));
             properties.push(PropertyDeclaration::BorderRightStyle(style));
@@ -428,7 +429,7 @@ mod shorthand_serialization {
 
             let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let style = DeclaredValue::Value(BorderStyle::solid);
-            let color = DeclaredValue::Initial;
+            let color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
 
             properties.push(PropertyDeclaration::BorderBottomWidth(width));
             properties.push(PropertyDeclaration::BorderBottomStyle(style));
@@ -444,7 +445,7 @@ mod shorthand_serialization {
 
             let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let style = DeclaredValue::Value(BorderStyle::solid);
-            let color = DeclaredValue::Initial;
+            let color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
 
             properties.push(PropertyDeclaration::BorderLeftWidth(width));
             properties.push(PropertyDeclaration::BorderLeftStyle(style));
@@ -460,7 +461,7 @@ mod shorthand_serialization {
 
             let top_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let top_style = DeclaredValue::Value(BorderStyle::solid);
-            let top_color = DeclaredValue::Initial;
+            let top_color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
 
             properties.push(PropertyDeclaration::BorderTopWidth(top_width));
             properties.push(PropertyDeclaration::BorderTopStyle(top_style));
@@ -468,7 +469,7 @@ mod shorthand_serialization {
 
             let right_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let right_style = DeclaredValue::Value(BorderStyle::solid);
-            let right_color = DeclaredValue::Initial;
+            let right_color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
 
             properties.push(PropertyDeclaration::BorderRightWidth(right_width));
             properties.push(PropertyDeclaration::BorderRightStyle(right_style));
@@ -476,7 +477,7 @@ mod shorthand_serialization {
 
             let bottom_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let bottom_style = DeclaredValue::Value(BorderStyle::solid);
-            let bottom_color = DeclaredValue::Initial;
+            let bottom_color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
 
             properties.push(PropertyDeclaration::BorderBottomWidth(bottom_width));
             properties.push(PropertyDeclaration::BorderBottomStyle(bottom_style));
@@ -484,7 +485,7 @@ mod shorthand_serialization {
 
             let left_width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
             let left_style = DeclaredValue::Value(BorderStyle::solid);
-            let left_color = DeclaredValue::Initial;
+            let left_color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
 
             properties.push(PropertyDeclaration::BorderLeftWidth(left_width));
             properties.push(PropertyDeclaration::BorderLeftStyle(left_style));
@@ -522,8 +523,8 @@ mod shorthand_serialization {
         fn list_style_should_show_all_properties_even_if_only_one_is_set() {
             let mut properties = Vec::new();
 
-            let position = DeclaredValue::Initial;
-            let image = DeclaredValue::Initial;
+            let position = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
+            let image = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
             let style_type = DeclaredValue::Value(ListStyleType::disc);
 
             properties.push(PropertyDeclaration::ListStylePosition(position));
@@ -565,7 +566,7 @@ mod shorthand_serialization {
 
             let width = DeclaredValue::Value(WidthContainer(Length::from_px(4f32)));
             let style = DeclaredValue::Value(Either::Second(BorderStyle::solid));
-            let color = DeclaredValue::Initial;
+            let color = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
 
             properties.push(PropertyDeclaration::OutlineWidth(width));
             properties.push(PropertyDeclaration::OutlineStyle(style));
@@ -580,7 +581,7 @@ mod shorthand_serialization {
             let mut properties = Vec::new();
 
             let width = DeclaredValue::Value(WidthContainer(Length::from_px(4f32)));
-            let style = DeclaredValue::Initial;
+            let style = DeclaredValue::CSSWideKeyword(CSSWideKeyword::Initial);
             let color = DeclaredValue::Value(CSSColor {
                 parsed: ComputedColor::RGBA(RGBA::new(255, 0, 0, 255)),
                 authored: None

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -17,7 +17,8 @@ use style::error_reporting::ParseErrorReporter;
 use style::keyframes::{Keyframe, KeyframeSelector, KeyframePercentage};
 use style::parser::ParserContextExtraData;
 use style::properties::Importance;
-use style::properties::{PropertyDeclaration, PropertyDeclarationBlock, DeclaredValue, longhands};
+use style::properties::{CSSWideKeyword, PropertyDeclaration, PropertyDeclarationBlock};
+use style::properties::{DeclaredValue, longhands};
 use style::properties::longhands::animation_play_state;
 use style::stylesheets::{Origin, Namespaces};
 use style::stylesheets::{Stylesheet, NamespaceRule, CssRule, CssRules, StyleRule, KeyframesRule};
@@ -102,7 +103,8 @@ fn test_parse_stylesheet() {
                         (PropertyDeclaration::Display(DeclaredValue::Value(
                             longhands::display::SpecifiedValue::none)),
                          Importance::Important),
-                        (PropertyDeclaration::Custom(Atom::from("a"), DeclaredValue::Inherit),
+                        (PropertyDeclaration::Custom(Atom::from("a"),
+                         DeclaredValue::CSSWideKeyword(CSSWideKeyword::Inherit)),
                          Importance::Important),
                     ],
                     important_count: 2,


### PR DESCRIPTION
This also changes `LonghandsToSerialize` to store references to specified value directly rather than declared value, which significantly simplify many serialization code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15779)
<!-- Reviewable:end -->
