### PR TITLE
Set initial values for animation and transition property.

### DIFF
--- a/components/style/properties/shorthand/box.mako.rs
+++ b/components/style/properties/shorthand/box.mako.rs
@@ -116,6 +116,15 @@ macro_rules! try_parse_one {
             }
         }
 
+        % for name in "duration delay".split():
+            if ${name}s.is_empty() {
+                ${name}s.push(transition_${name}::single_value::get_initial_value());
+            }
+        % endfor
+        if timing_functions.is_empty() {
+            timing_functions.push(transition_timing_function::single_value::get_initial_specified_value());
+        }
+
         Ok(Longhands {
             transition_property: transition_property::SpecifiedValue(properties),
             transition_duration: transition_duration::SpecifiedValue(durations),
@@ -273,6 +282,15 @@ macro_rules! try_parse_one {
                 fill_modes.push(result.animation_fill_mode);
                 play_states.push(result.animation_play_state);
             }
+        }
+
+        % for name in "duration delay direction fill_mode iteration_count play_state".split():
+            if ${name}s.is_empty() {
+                ${name}s.push(animation_${name}::single_value::get_initial_value());
+            }
+        % endfor
+        if timing_functions.is_empty() {
+            timing_functions.push(animation_timing_function::single_value::get_initial_specified_value());
         }
 
         Ok(Longhands {


### PR DESCRIPTION
These properties are not allowed to set empty vector.
This is a follow up fix for #15761.
Also this fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1343168

r? @Manishearth 

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [] There are tests for these changes OR
- [X] These changes do not require tests because I am not sure we should write test cases for this , anyway gecko has some test cases.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15780)
<!-- Reviewable:end -->
