### PR TITLE
Replace manual host parsing code with parse-host crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,6 +1657,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "multistr"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "net"
 version = "0.0.1"
 dependencies = [
@@ -1741,6 +1746,7 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parse-hosts 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-websocket 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1960,6 +1966,14 @@ dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parse-hosts"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "multistr 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3440,6 +3454,7 @@ dependencies = [
 "checksum mozjs_sys 0.0.0 (git+https://github.com/servo/mozjs)" = "<none>"
 "checksum mp3-metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2f61cf32f7fc3cec83a15a255ac60bceb6cac59a7ce190cb824ca25c0fce0feb"
 "checksum mp4parse 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7b81651f9ede53d59281b54c7eb51ae50a868ac4765dd3bdfbbc79ce3d8aca7a"
+"checksum multistr 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "948d1285dd39981f6a5b1a72624c323312d29e2121682a742a87a773dd723bef"
 "checksum net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "5edf9cb6be97212423aed9413dd4729d62b370b5e1c571750e882cebbbc1e3e2"
 "checksum nodrop 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbadd3f4c98dea0bd3d9b4be4c0cdaf1ab57035cb2e41fce3983db5add7cc5"
 "checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
@@ -3464,6 +3479,7 @@ dependencies = [
 "checksum owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9d52571ddcb42e9c900c901a18d8d67e393df723fcd51dd59c5b1a85d0acb6cc"
 "checksum parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fa12d706797d42551663426a45e2db2e0364bd1dbf6aeada87e89c5f981f43e9"
 "checksum parking_lot_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb1b97670a2ffadce7c397fb80a3d687c4f3060140b885621ef1653d0e5d5068"
+"checksum parse-hosts 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7626e29ef8f479f10d9a753f1fca914506663ecc9ec2dedb8cffc610a3d1f705"
 "checksum pdqsort 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ceca1642c89148ca05611cc775a0c383abef355fc4907c4e95f49f7b09d6287c"
 "checksum phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "cb325642290f28ee14d8c6201159949a872f220c62af6e110a56ea914fbe42fc"
 "checksum phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d62594c0bb54c464f633175d502038177e90309daf2e0158be42ed5f023ce88f"

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = "0.2"
 log = "0.3.5"
 msg = {path = "../msg"}
 num-traits = "0.1.32"
+parse-hosts = "0.3.0"
 serde = "0.9"
 serde_derive = "0.9"
 servo_config = {path = "../config", features = ["servo"]}

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -22,6 +22,7 @@ extern crate lazy_static;
 extern crate log;
 extern crate msg;
 extern crate num_traits;
+extern crate parse_hosts;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
This patch is replacing the code to parse the hosts file with the [parse-hosts](https://crates.io/crates/parse-hosts) crate. This crate has a [CC0 1.0 Universal License](https://creativecommons.org/publicdomain/zero/1.0/deed.en).

I could have used [HostsFile::load()](https://clarcharr.github.io/parse-hosts/parse_hosts/struct.HostsFile.html#method.load) directly, but this method loads `/etc/hosts` by default and does not allow to override the default path (for example with [env::var("HOST_FILE")](https://dxr.mozilla.org/servo/source/components/net_traits/hosts.rs#19)), so I kept the existing code to open and read the content of `env::var("HOST_FILE")` and also kept the [parse_hostsfile](https://dxr.mozilla.org/servo/source/components/net_traits/hosts.rs#42) method (used by the unit tests), but I modified it to use [HostsFile::read_buffered](https://clarcharr.github.io/parse-hosts/parse_hosts/struct.HostsFile.html#method.read_buffered), which is doing the actual hosts parsing for a given string buffer.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15756 .
- [X] There are tests for these changes (tests/unit/net/resource_thread.rs and tests/unit/net/http_loader.rs)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15783)
<!-- Reviewable:end -->
