### PR TITLE
Let the embedder decide if servo should follow a link or not

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -554,6 +554,13 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 self.window.load_end(back, forward, root);
             }
 
+            (Msg::AllowNavigation(url, response_chan), ShutdownState::NotShuttingDown) => {
+                let allow = self.window.allow_navigation(url);
+                if let Err(e) = response_chan.send(allow) {
+                    warn!("Failed to send allow_navigation result ({}).", e);
+                }
+            }
+
             (Msg::DelayedCompositionTimeout(timestamp), ShutdownState::NotShuttingDown) => {
                 if let CompositionRequest::DelayedComposite(this_timestamp) =
                     self.composition_request {

--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -86,6 +86,8 @@ pub enum Msg {
     LoadStart(bool, bool),
     /// The load of a page has completed: (can go back, can go forward, is root frame).
     LoadComplete(bool, bool, bool),
+    /// Wether or not to follow a link
+    AllowNavigation(ServoUrl, IpcSender<bool>),
     /// We hit the delayed composition timeout. (See `delayed_composition.rs`.)
     DelayedCompositionTimeout(u64),
     /// Composite.
@@ -144,6 +146,7 @@ impl Debug for Msg {
             Msg::ChangePageUrl(..) => write!(f, "ChangePageUrl"),
             Msg::SetFrameTree(..) => write!(f, "SetFrameTree"),
             Msg::LoadComplete(..) => write!(f, "LoadComplete"),
+            Msg::AllowNavigation(..) => write!(f, "AllowNavigation"),
             Msg::LoadStart(..) => write!(f, "LoadStart"),
             Msg::DelayedCompositionTimeout(..) => write!(f, "DelayedCompositionTimeout"),
             Msg::Recomposite(..) => write!(f, "Recomposite"),

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -134,6 +134,8 @@ pub trait WindowMethods {
     fn load_end(&self, back: bool, forward: bool, root: bool);
     /// Called when the browser encounters an error while loading a URL
     fn load_error(&self, code: NetError, url: String);
+    /// Wether or not to follow a link
+    fn allow_navigation(&self, url: ServoUrl) -> bool;
     /// Called when the <head> tag has finished parsing
     fn head_parsed(&self);
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1575,6 +1575,13 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
     }
 
     fn load_url(&mut self, source_id: PipelineId, load_data: LoadData, replace: bool) -> Option<PipelineId> {
+        // Allow the embedder to handle the url itself
+        let (chan, port) = ipc::channel().expect("Failed to create IPC channel!");
+        self.compositor_proxy.send(ToCompositorMsg::AllowNavigation(load_data.url.clone(), chan));
+        if let Ok(false) = port.recv() {
+            return None;
+        }
+
         debug!("Loading {} in pipeline {}.", load_data.url, source_id);
         // If this load targets an iframe, its framing element may exist
         // in a separate script thread than the framed document that initiated

--- a/ports/cef/window.rs
+++ b/ports/cef/window.rs
@@ -477,6 +477,10 @@ impl WindowMethods for Window {
         }
     }
 
+    fn allow_navigation(&self, _: ServoUrl) -> bool {
+        true
+    }
+
     fn supports_clipboard(&self) -> bool {
         false
     }

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -1100,6 +1100,10 @@ impl WindowMethods for Window {
         }
     }
 
+    fn allow_navigation(&self, _: ServoUrl) -> bool {
+        true
+    }
+
     fn supports_clipboard(&self) -> bool {
         false
     }


### PR DESCRIPTION
We want to give a chance to the embedder to handle a link itself.
Is it a problem that this will add a round trip to the main thread every time `load_url` is called?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15655

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because I'm not sure how to test that

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15795)
<!-- Reviewable:end -->
