### PR TITLE
Handle KeyboardEvent without virtual key code

### DIFF
--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -143,6 +143,8 @@ pub enum Key {
 
     NavigateBackward,
     NavigateForward,
+
+    Unidentified,
 }
 
 bitflags! {

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -336,6 +336,7 @@ pub fn key_value(ch: Option<char>, key: Key, mods: KeyModifiers) -> Cow<'static,
         Key::Menu => "ContextMenu",
         Key::NavigateForward => "BrowserForward",
         Key::NavigateBackward => "BrowserBack",
+        Key::Unidentified => "Unidentified",
     })
 }
 
@@ -636,6 +637,7 @@ fn code_value(key: Key) -> &'static str {
 
         Key::NavigateForward => "BrowserForward",
         Key::NavigateBackward => "BrowserBackward",
+        Key::Unidentified => "Unidentified",
     }
 }
 

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -361,12 +361,7 @@ impl Window {
                 let ch = self.get_keyboard_input_char(element_state, scan_code)
                     .and_then(|ch| filter_nonprintable(ch, virtual_key_code));
                 if let Ok(key) = Window::glutin_key_to_script_key(virtual_key_code) {
-                    let state = match element_state {
-                        ElementState::Pressed => KeyState::Pressed,
-                        ElementState::Released => KeyState::Released,
-                    };
-                    let modifiers = Window::glutin_mods_to_script_mods(self.key_modifiers.get());
-                    self.event_queue.borrow_mut().push(WindowEvent::KeyEvent(ch, key, state, modifiers));
+                    self.send_key_event(ch, key, element_state);
                 }
             }
             Event::KeyboardInput(_, _, None) => {
@@ -467,6 +462,15 @@ impl Window {
                 idx.map(|idx| self.pressed_key_map.borrow_mut().swap_remove(idx).1)
             }
         }
+    }
+
+    fn send_key_event(&self, ch: Option<char>, key: Key, element_state: ElementState) {
+        let state = match element_state {
+            ElementState::Pressed => KeyState::Pressed,
+            ElementState::Released => KeyState::Released,
+        };
+        let modifiers = Window::glutin_mods_to_script_mods(self.key_modifiers.get());
+        self.event_queue.borrow_mut().push(WindowEvent::KeyEvent(ch, key, state, modifiers));
     }
 
     /// Helper function to send a scroll event.

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -360,12 +360,13 @@ impl Window {
 
                 let ch = self.get_keyboard_input_char(element_state, scan_code)
                     .and_then(|ch| filter_nonprintable(ch, virtual_key_code));
-                if let Ok(key) = Window::glutin_key_to_script_key(virtual_key_code) {
-                    self.send_key_event(ch, key, element_state);
-                }
+
+                let key = Window::glutin_key_to_script_key(virtual_key_code);
+                self.send_key_event(ch, key, element_state);
             }
-            Event::KeyboardInput(_, _, None) => {
-                debug!("Keyboard input without virtual key.");
+            Event::KeyboardInput(element_state, scan_code, None) => {
+                let ch = self.get_keyboard_input_char(element_state, scan_code);
+                self.send_key_event(ch, Key::Unidentified, element_state)
             }
             Event::Resized(width, height) => {
                 self.event_queue.borrow_mut().push(WindowEvent::Resize(TypedSize2D::new(width, height)));
@@ -444,7 +445,8 @@ impl Window {
                 // Retrieve any previosly stored ReceivedCharacter value.
                 // Store the association between the scan code and the actual
                 // character value, if there is one.
-                let ch = self.pending_key_event_char.get();
+                let ch = self.pending_key_event_char
+                             .get();
                 self.pending_key_event_char.set(None);
                 if let Some(ch) = ch {
                     self.pressed_key_map.borrow_mut().push((scan_code, ch));
@@ -623,114 +625,114 @@ impl Window {
         G_NESTED_EVENT_LOOP_LISTENER = None
     }
 
-    fn glutin_key_to_script_key(key: glutin::VirtualKeyCode) -> Result<constellation_msg::Key, ()> {
+    fn glutin_key_to_script_key(key: glutin::VirtualKeyCode) -> constellation_msg::Key {
         // TODO(negge): add more key mappings
         match key {
-            VirtualKeyCode::A => Ok(Key::A),
-            VirtualKeyCode::B => Ok(Key::B),
-            VirtualKeyCode::C => Ok(Key::C),
-            VirtualKeyCode::D => Ok(Key::D),
-            VirtualKeyCode::E => Ok(Key::E),
-            VirtualKeyCode::F => Ok(Key::F),
-            VirtualKeyCode::G => Ok(Key::G),
-            VirtualKeyCode::H => Ok(Key::H),
-            VirtualKeyCode::I => Ok(Key::I),
-            VirtualKeyCode::J => Ok(Key::J),
-            VirtualKeyCode::K => Ok(Key::K),
-            VirtualKeyCode::L => Ok(Key::L),
-            VirtualKeyCode::M => Ok(Key::M),
-            VirtualKeyCode::N => Ok(Key::N),
-            VirtualKeyCode::O => Ok(Key::O),
-            VirtualKeyCode::P => Ok(Key::P),
-            VirtualKeyCode::Q => Ok(Key::Q),
-            VirtualKeyCode::R => Ok(Key::R),
-            VirtualKeyCode::S => Ok(Key::S),
-            VirtualKeyCode::T => Ok(Key::T),
-            VirtualKeyCode::U => Ok(Key::U),
-            VirtualKeyCode::V => Ok(Key::V),
-            VirtualKeyCode::W => Ok(Key::W),
-            VirtualKeyCode::X => Ok(Key::X),
-            VirtualKeyCode::Y => Ok(Key::Y),
-            VirtualKeyCode::Z => Ok(Key::Z),
+            VirtualKeyCode::A => Key::A,
+            VirtualKeyCode::B => Key::B,
+            VirtualKeyCode::C => Key::C,
+            VirtualKeyCode::D => Key::D,
+            VirtualKeyCode::E => Key::E,
+            VirtualKeyCode::F => Key::F,
+            VirtualKeyCode::G => Key::G,
+            VirtualKeyCode::H => Key::H,
+            VirtualKeyCode::I => Key::I,
+            VirtualKeyCode::J => Key::J,
+            VirtualKeyCode::K => Key::K,
+            VirtualKeyCode::L => Key::L,
+            VirtualKeyCode::M => Key::M,
+            VirtualKeyCode::N => Key::N,
+            VirtualKeyCode::O => Key::O,
+            VirtualKeyCode::P => Key::P,
+            VirtualKeyCode::Q => Key::Q,
+            VirtualKeyCode::R => Key::R,
+            VirtualKeyCode::S => Key::S,
+            VirtualKeyCode::T => Key::T,
+            VirtualKeyCode::U => Key::U,
+            VirtualKeyCode::V => Key::V,
+            VirtualKeyCode::W => Key::W,
+            VirtualKeyCode::X => Key::X,
+            VirtualKeyCode::Y => Key::Y,
+            VirtualKeyCode::Z => Key::Z,
 
-            VirtualKeyCode::Numpad0 => Ok(Key::Kp0),
-            VirtualKeyCode::Numpad1 => Ok(Key::Kp1),
-            VirtualKeyCode::Numpad2 => Ok(Key::Kp2),
-            VirtualKeyCode::Numpad3 => Ok(Key::Kp3),
-            VirtualKeyCode::Numpad4 => Ok(Key::Kp4),
-            VirtualKeyCode::Numpad5 => Ok(Key::Kp5),
-            VirtualKeyCode::Numpad6 => Ok(Key::Kp6),
-            VirtualKeyCode::Numpad7 => Ok(Key::Kp7),
-            VirtualKeyCode::Numpad8 => Ok(Key::Kp8),
-            VirtualKeyCode::Numpad9 => Ok(Key::Kp9),
+            VirtualKeyCode::Numpad0 => Key::Kp0,
+            VirtualKeyCode::Numpad1 => Key::Kp1,
+            VirtualKeyCode::Numpad2 => Key::Kp2,
+            VirtualKeyCode::Numpad3 => Key::Kp3,
+            VirtualKeyCode::Numpad4 => Key::Kp4,
+            VirtualKeyCode::Numpad5 => Key::Kp5,
+            VirtualKeyCode::Numpad6 => Key::Kp6,
+            VirtualKeyCode::Numpad7 => Key::Kp7,
+            VirtualKeyCode::Numpad8 => Key::Kp8,
+            VirtualKeyCode::Numpad9 => Key::Kp9,
 
-            VirtualKeyCode::Key0 => Ok(Key::Num0),
-            VirtualKeyCode::Key1 => Ok(Key::Num1),
-            VirtualKeyCode::Key2 => Ok(Key::Num2),
-            VirtualKeyCode::Key3 => Ok(Key::Num3),
-            VirtualKeyCode::Key4 => Ok(Key::Num4),
-            VirtualKeyCode::Key5 => Ok(Key::Num5),
-            VirtualKeyCode::Key6 => Ok(Key::Num6),
-            VirtualKeyCode::Key7 => Ok(Key::Num7),
-            VirtualKeyCode::Key8 => Ok(Key::Num8),
-            VirtualKeyCode::Key9 => Ok(Key::Num9),
+            VirtualKeyCode::Key0 => Key::Num0,
+            VirtualKeyCode::Key1 => Key::Num1,
+            VirtualKeyCode::Key2 => Key::Num2,
+            VirtualKeyCode::Key3 => Key::Num3,
+            VirtualKeyCode::Key4 => Key::Num4,
+            VirtualKeyCode::Key5 => Key::Num5,
+            VirtualKeyCode::Key6 => Key::Num6,
+            VirtualKeyCode::Key7 => Key::Num7,
+            VirtualKeyCode::Key8 => Key::Num8,
+            VirtualKeyCode::Key9 => Key::Num9,
 
-            VirtualKeyCode::Return => Ok(Key::Enter),
-            VirtualKeyCode::Space => Ok(Key::Space),
-            VirtualKeyCode::Escape => Ok(Key::Escape),
-            VirtualKeyCode::Equals => Ok(Key::Equal),
-            VirtualKeyCode::Minus => Ok(Key::Minus),
-            VirtualKeyCode::Back => Ok(Key::Backspace),
-            VirtualKeyCode::PageDown => Ok(Key::PageDown),
-            VirtualKeyCode::PageUp => Ok(Key::PageUp),
+            VirtualKeyCode::Return => Key::Enter,
+            VirtualKeyCode::Space => Key::Space,
+            VirtualKeyCode::Escape => Key::Escape,
+            VirtualKeyCode::Equals => Key::Equal,
+            VirtualKeyCode::Minus => Key::Minus,
+            VirtualKeyCode::Back => Key::Backspace,
+            VirtualKeyCode::PageDown => Key::PageDown,
+            VirtualKeyCode::PageUp => Key::PageUp,
 
-            VirtualKeyCode::Insert => Ok(Key::Insert),
-            VirtualKeyCode::Home => Ok(Key::Home),
-            VirtualKeyCode::Delete => Ok(Key::Delete),
-            VirtualKeyCode::End => Ok(Key::End),
+            VirtualKeyCode::Insert => Key::Insert,
+            VirtualKeyCode::Home => Key::Home,
+            VirtualKeyCode::Delete => Key::Delete,
+            VirtualKeyCode::End => Key::End,
 
-            VirtualKeyCode::Left => Ok(Key::Left),
-            VirtualKeyCode::Up => Ok(Key::Up),
-            VirtualKeyCode::Right => Ok(Key::Right),
-            VirtualKeyCode::Down => Ok(Key::Down),
+            VirtualKeyCode::Left => Key::Left,
+            VirtualKeyCode::Up => Key::Up,
+            VirtualKeyCode::Right => Key::Right,
+            VirtualKeyCode::Down => Key::Down,
 
-            VirtualKeyCode::LShift => Ok(Key::LeftShift),
-            VirtualKeyCode::LControl => Ok(Key::LeftControl),
-            VirtualKeyCode::LAlt => Ok(Key::LeftAlt),
-            VirtualKeyCode::LWin => Ok(Key::LeftSuper),
-            VirtualKeyCode::RShift => Ok(Key::RightShift),
-            VirtualKeyCode::RControl => Ok(Key::RightControl),
-            VirtualKeyCode::RAlt => Ok(Key::RightAlt),
-            VirtualKeyCode::RWin => Ok(Key::RightSuper),
+            VirtualKeyCode::LShift => Key::LeftShift,
+            VirtualKeyCode::LControl => Key::LeftControl,
+            VirtualKeyCode::LAlt => Key::LeftAlt,
+            VirtualKeyCode::LWin => Key::LeftSuper,
+            VirtualKeyCode::RShift => Key::RightShift,
+            VirtualKeyCode::RControl => Key::RightControl,
+            VirtualKeyCode::RAlt => Key::RightAlt,
+            VirtualKeyCode::RWin => Key::RightSuper,
 
-            VirtualKeyCode::Apostrophe => Ok(Key::Apostrophe),
-            VirtualKeyCode::Backslash => Ok(Key::Backslash),
-            VirtualKeyCode::Comma => Ok(Key::Comma),
-            VirtualKeyCode::Grave => Ok(Key::GraveAccent),
-            VirtualKeyCode::LBracket => Ok(Key::LeftBracket),
-            VirtualKeyCode::Period => Ok(Key::Period),
-            VirtualKeyCode::RBracket => Ok(Key::RightBracket),
-            VirtualKeyCode::Semicolon => Ok(Key::Semicolon),
-            VirtualKeyCode::Slash => Ok(Key::Slash),
-            VirtualKeyCode::Tab => Ok(Key::Tab),
-            VirtualKeyCode::Subtract => Ok(Key::Minus),
+            VirtualKeyCode::Apostrophe => Key::Apostrophe,
+            VirtualKeyCode::Backslash => Key::Backslash,
+            VirtualKeyCode::Comma => Key::Comma,
+            VirtualKeyCode::Grave => Key::GraveAccent,
+            VirtualKeyCode::LBracket => Key::LeftBracket,
+            VirtualKeyCode::Period => Key::Period,
+            VirtualKeyCode::RBracket => Key::RightBracket,
+            VirtualKeyCode::Semicolon => Key::Semicolon,
+            VirtualKeyCode::Slash => Key::Slash,
+            VirtualKeyCode::Tab => Key::Tab,
+            VirtualKeyCode::Subtract => Key::Minus,
 
-            VirtualKeyCode::F1 => Ok(Key::F1),
-            VirtualKeyCode::F2 => Ok(Key::F2),
-            VirtualKeyCode::F3 => Ok(Key::F3),
-            VirtualKeyCode::F4 => Ok(Key::F4),
-            VirtualKeyCode::F5 => Ok(Key::F5),
-            VirtualKeyCode::F6 => Ok(Key::F6),
-            VirtualKeyCode::F7 => Ok(Key::F7),
-            VirtualKeyCode::F8 => Ok(Key::F8),
-            VirtualKeyCode::F9 => Ok(Key::F9),
-            VirtualKeyCode::F10 => Ok(Key::F10),
-            VirtualKeyCode::F11 => Ok(Key::F11),
-            VirtualKeyCode::F12 => Ok(Key::F12),
+            VirtualKeyCode::F1 => Key::F1,
+            VirtualKeyCode::F2 => Key::F2,
+            VirtualKeyCode::F3 => Key::F3,
+            VirtualKeyCode::F4 => Key::F4,
+            VirtualKeyCode::F5 => Key::F5,
+            VirtualKeyCode::F6 => Key::F6,
+            VirtualKeyCode::F7 => Key::F7,
+            VirtualKeyCode::F8 => Key::F8,
+            VirtualKeyCode::F9 => Key::F9,
+            VirtualKeyCode::F10 => Key::F10,
+            VirtualKeyCode::F11 => Key::F11,
+            VirtualKeyCode::F12 => Key::F12,
 
-            VirtualKeyCode::NavigateBackward => Ok(Key::NavigateBackward),
-            VirtualKeyCode::NavigateForward => Ok(Key::NavigateForward),
-            _ => Err(()),
+            VirtualKeyCode::NavigateBackward => Key::NavigateBackward,
+            VirtualKeyCode::NavigateForward => Key::NavigateForward,
+            _ => Key::Unidentified
         }
     }
 

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -363,9 +363,7 @@ impl Window {
                         // Retrieve any previosly stored ReceivedCharacter value.
                         // Store the association between the scan code and the actual
                         // character value, if there is one.
-                        let ch = self.pending_key_event_char
-                                     .get()
-                                     .and_then(|ch| filter_nonprintable(ch, virtual_key_code));
+                        let ch = self.pending_key_event_char.get();
                         self.pending_key_event_char.set(None);
                         if let Some(ch) = ch {
                             self.pressed_key_map.borrow_mut().push((scan_code, ch));
@@ -383,6 +381,7 @@ impl Window {
                         idx.map(|idx| self.pressed_key_map.borrow_mut().swap_remove(idx).1)
                     }
                 };
+                let ch = ch.and_then(|ch| filter_nonprintable(ch, virtual_key_code));
 
                 if let Ok(key) = Window::glutin_key_to_script_key(virtual_key_code) {
                     let state = match element_state {

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -442,11 +442,10 @@ impl Window {
     fn get_keyboard_input_char(&self, element_state: ElementState, scan_code: ScanCode) -> Option<char> {
         match element_state {
             ElementState::Pressed => {
-                // Retrieve any previosly stored ReceivedCharacter value.
+                // Retrieve any previously stored ReceivedCharacter value.
                 // Store the association between the scan code and the actual
                 // character value, if there is one.
-                let ch = self.pending_key_event_char
-                             .get();
+                let ch = self.pending_key_event_char.get();
                 self.pending_key_event_char.set(None);
                 if let Some(ch) = ch {
                     self.pressed_key_map.borrow_mut().push((scan_code, ch));


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR allows to properly handling KeyboardEvent without a virtual key code. 

These PR is not completed *yet* but I prefer start a discussion to see if my approach is correct to you. (For exemple I have to remove the [```Result``` over here](https://github.com/servo/servo/compare/master...charlesvdv:fix-keyboard?expand=1#diff-f3afdd0d8092731ed5c423ce2e8dfd70R620)). 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15240 (github issue number if applicable).
- [ ] Theses changes *should* fix #12616

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15800)
<!-- Reviewable:end -->
