### PR TITLE
Revert #15793 for crashes and test failures on stylo

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -398,9 +398,7 @@ impl<E: TElement> StyleSharingCandidateCache<E> {
             return;
         }
 
-        let animation_count = box_style.animation_name_count();
-        debug_assert!(animation_count > 0);
-        if animation_count > 1 || box_style.animation_name_at(0).0 != atom!("") {
+        if box_style.animation_name_count() > 0 {
             debug!("Failing to insert to the cache: animations");
             return;
         }

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1324,7 +1324,7 @@ fn static_assert() {
 <%def name="impl_animation_time_value(ident, gecko_ffi_name)">
     #[allow(non_snake_case)]
     pub fn set_animation_${ident}(&mut self, v: longhands::animation_${ident}::computed_value::T) {
-        debug_assert!(!v.0.is_empty());
+        assert!(v.0.len() > 0);
         unsafe { self.gecko.mAnimations.ensure_len(v.0.len()) };
 
         self.gecko.mAnimation${gecko_ffi_name}Count = v.0.len() as u32;
@@ -1348,7 +1348,7 @@ fn static_assert() {
         use properties::longhands::animation_${ident}::single_value::computed_value::T as Keyword;
         use gecko_bindings::structs;
 
-        debug_assert!(!v.0.is_empty());
+        assert!(v.0.len() > 0);
         unsafe { self.gecko.mAnimations.ensure_len(v.0.len()) };
 
         self.gecko.mAnimation${gecko_ffi_name}Count = v.0.len() as u32;
@@ -1727,14 +1727,15 @@ fn static_assert() {
 
     pub fn set_animation_name(&mut self, v: longhands::animation_name::computed_value::T) {
         use nsstring::nsCString;
-
-        debug_assert!(!v.0.is_empty());
         unsafe { self.gecko.mAnimations.ensure_len(v.0.len()) };
 
-        self.gecko.mAnimationNameCount = v.0.len() as u32;
-        for (servo, gecko) in v.0.into_iter().zip(self.gecko.mAnimations.iter_mut()) {
-            // TODO This is inefficient. We should fix this in bug 1329169.
-            gecko.mName.assign_utf8(&nsCString::from(servo.0.to_string()));
+        if v.0.len() > 0 {
+            self.gecko.mAnimationNameCount = v.0.len() as u32;
+            for (servo, gecko) in v.0.into_iter().zip(self.gecko.mAnimations.iter_mut()) {
+                gecko.mName.assign_utf8(&nsCString::from(servo.0.to_string()));
+            }
+        } else {
+            unsafe { self.gecko.mAnimations[0].mName.truncate(); }
         }
     }
     pub fn animation_name_at(&self, index: usize)
@@ -1772,7 +1773,7 @@ fn static_assert() {
         use std::f32;
         use properties::longhands::animation_iteration_count::single_value::SpecifiedValue as AnimationIterationCount;
 
-        debug_assert!(!v.0.is_empty());
+        assert!(v.0.len() > 0);
         unsafe { self.gecko.mAnimations.ensure_len(v.0.len()) };
 
         self.gecko.mAnimationIterationCountCount = v.0.len() as u32;
@@ -1798,7 +1799,7 @@ fn static_assert() {
     ${impl_copy_animation_value('iteration_count', 'IterationCount')}
 
     pub fn set_animation_timing_function(&mut self, v: longhands::animation_timing_function::computed_value::T) {
-        debug_assert!(!v.0.is_empty());
+        assert!(v.0.len() > 0);
         unsafe { self.gecko.mAnimations.ensure_len(v.0.len()) };
 
         self.gecko.mAnimationTimingFunctionCount = v.0.len() as u32;

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -460,11 +460,6 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
         Time(0.0)
     }
 
-    #[inline]
-    pub fn get_initial_specified_value() -> SpecifiedValue {
-        SpecifiedValue(0.0)
-    }
-
     pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue,()> {
         Time::parse(context, input)
     }
@@ -732,7 +727,7 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
 
     #[inline]
     pub fn get_initial_specified_value() -> SpecifiedValue {
-        SpecifiedValue::Keyword(FunctionKeyword::Ease)
+        ToComputedValue::from_computed_value(&ease())
     }
 
     pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue,()> {
@@ -781,6 +776,7 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
 </%helpers:vector_longhand>
 
 <%helpers:vector_longhand name="animation-name"
+                          allow_empty="True"
                           need_index="True"
                           animatable="False",
                           extra_prefixes="moz webkit"
@@ -801,16 +797,6 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub struct SpecifiedValue(pub Atom);
 
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        get_initial_specified_value()
-    }
-
-    #[inline]
-    pub fn get_initial_specified_value() -> SpecifiedValue {
-        SpecifiedValue(atom!(""))
-    }
-
     impl fmt::Display for SpecifiedValue {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             self.0.fmt(f)
@@ -819,11 +805,7 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
 
     impl ToCss for SpecifiedValue {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            if self.0 == atom!("") {
-                dest.write_str("none")
-            } else {
-                dest.write_str(&*self.0.to_string())
-            }
+            dest.write_str(&*self.0.to_string())
         }
     }
 
@@ -831,11 +813,7 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
         fn parse(_context: &ParserContext, input: &mut ::cssparser::Parser) -> Result<Self, ()> {
             use cssparser::Token;
             Ok(match input.next() {
-                Ok(Token::Ident(ref value)) => SpecifiedValue(if value == "none" {
-                    atom!("")
-                } else {
-                    Atom::from(&**value)
-                }),
+                Ok(Token::Ident(ref value)) if value != "none" => SpecifiedValue(Atom::from(&**value)),
                 Ok(Token::QuotedString(value)) => SpecifiedValue(Atom::from(&*value)),
                 _ => return Err(()),
             })
@@ -857,7 +835,6 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
                           spec="https://drafts.csswg.org/css-animations/#propdef-animation-duration",
                           allowed_in_keyframe_block="False">
     pub use properties::longhands::transition_duration::single_value::computed_value;
-    pub use properties::longhands::transition_duration::single_value::get_initial_specified_value;
     pub use properties::longhands::transition_duration::single_value::{get_initial_value, parse};
     pub use properties::longhands::transition_duration::single_value::SpecifiedValue;
 </%helpers:vector_longhand>
@@ -926,12 +903,7 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
 
     #[inline]
     pub fn get_initial_value() -> computed_value::T {
-        get_initial_specified_value()
-    }
-
-    #[inline]
-    pub fn get_initial_specified_value() -> SpecifiedValue {
-        SpecifiedValue::Number(1.0)
+        computed_value::T::Number(1.0)
     }
 
     #[inline]
@@ -983,7 +955,6 @@ ${helpers.single_keyword("animation-fill-mode",
                           spec="https://drafts.csswg.org/css-animations/#propdef-animation-delay",
                           allowed_in_keyframe_block="False">
     pub use properties::longhands::transition_duration::single_value::computed_value;
-    pub use properties::longhands::transition_duration::single_value::get_initial_specified_value;
     pub use properties::longhands::transition_duration::single_value::{get_initial_value, parse};
     pub use properties::longhands::transition_duration::single_value::SpecifiedValue;
 </%helpers:vector_longhand>

--- a/tests/unit/style/lib.rs
+++ b/tests/unit/style/lib.rs
@@ -14,7 +14,7 @@ extern crate parking_lot;
 extern crate rayon;
 extern crate rustc_serialize;
 extern crate selectors;
-#[macro_use] extern crate servo_atoms;
+extern crate servo_atoms;
 extern crate servo_config;
 extern crate servo_url;
 extern crate style;

--- a/tests/unit/style/parsing/animation.rs
+++ b/tests/unit/style/parsing/animation.rs
@@ -5,26 +5,10 @@
 use cssparser::Parser;
 use media_queries::CSSErrorReporterTest;
 use parsing::parse;
-use servo_atoms::Atom;
 use style::parser::{Parse, ParserContext};
 use style::properties::longhands::animation_iteration_count::single_value::computed_value::T as AnimationIterationCount;
-use style::properties::longhands::animation_name;
 use style::stylesheets::Origin;
 use style_traits::ToCss;
-
-#[test]
-fn test_animation_name() {
-    use self::animation_name::single_value::SpecifiedValue as SingleValue;
-    let other_name = Atom::from("other-name");
-    assert_eq!(parse_longhand!(animation_name, "none"),
-               animation_name::SpecifiedValue(vec![SingleValue(atom!(""))]));
-    assert_eq!(parse_longhand!(animation_name, "other-name, none, 'other-name', \"other-name\""),
-               animation_name::SpecifiedValue(
-                   vec![SingleValue(other_name.clone()),
-                        SingleValue(atom!("")),
-                        SingleValue(other_name.clone()),
-                        SingleValue(other_name.clone())]));
-}
 
 #[test]
 fn test_animation_iteration() {

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -983,7 +983,7 @@ mod shorthand_serialization {
 
             let serialization = block.to_css_string();
 
-            assert_eq!(serialization, "animation: 1s ease-in 0s infinite normal forwards paused bounce;")
+            assert_eq!(serialization, "animation: 1s ease-in 0s normal forwards infinite paused bounce;")
         }
 
         #[test]
@@ -1001,8 +1001,8 @@ mod shorthand_serialization {
             let serialization = block.to_css_string();
 
             assert_eq!(serialization,
-                       "animation: 1s ease-in 0s infinite normal forwards paused bounce, \
-                                   0.2s linear 1s 2 reverse backwards running roll;");
+                       "animation: 1s ease-in 0s normal forwards infinite paused bounce, \
+                                   0.2s linear 1s reverse backwards 2 running roll;");
         }
 
         #[test]


### PR DESCRIPTION
Looks like #15793 busted autoland. Given that it's the weekend for Xidorn I'm going to back out the patch.

CC @upsuper

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15814)
<!-- Reviewable:end -->
