### PR TITLE
Use more idiomatic or_else construction

### DIFF
--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -953,19 +953,12 @@ impl<ConcreteNode> Iterator for ThreadSafeLayoutNodeChildrenIterator<ConcreteNod
                 if let Some(ref node) = node {
                     self.current_node = match node.get_pseudo_element_type() {
                         PseudoElementType::Before(_) => {
-                            let first = self.parent_node.get_details_summary_pseudo().or_else(|| unsafe {
-                                self.parent_node.dangerous_first_child()
-                            });
-                            match first {
-                                Some(first) => Some(first),
-                                None => self.parent_node.get_after_pseudo(),
-                            }
+                            self.parent_node.get_details_summary_pseudo()
+                                .or_else(|| unsafe { self.parent_node.dangerous_first_child() })
+                                .or_else(|| self.parent_node.get_after_pseudo())
                         },
                         PseudoElementType::Normal => {
-                            match unsafe { node.dangerous_next_sibling() } {
-                                Some(next) => Some(next),
-                                None => self.parent_node.get_after_pseudo(),
-                            }
+                            unsafe { node.dangerous_next_sibling() }.or_else(|| self.parent_node.get_after_pseudo())
                         },
                         PseudoElementType::DetailsSummary(_) => self.parent_node.get_details_content_pseudo(),
                         PseudoElementType::DetailsContent(_) => self.parent_node.get_after_pseudo(),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
or_else in more ideomatic rust construction than
match, where Some(x) => Some(x)
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15812 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15815)
<!-- Reviewable:end -->
