### PR TITLE
Trigger WindowEvent::Resize when resizing in headless mode

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -834,7 +834,10 @@ impl WindowMethods for Window {
             WindowKind::Window(ref window) => {
                 window.set_inner_size(size.width as u32, size.height as u32)
             }
-            WindowKind::Headless(..) => {}
+            WindowKind::Headless(..) => {
+                let dimensions = TypedSize2D::new(size.width as u32, size.height as u32);
+                self.event_queue.borrow_mut().push(WindowEvent::Resize(dimensions));
+            }
         }
     }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -30930,7 +30930,7 @@
    "support"
   ],
   "mozilla/resizeTo.html": [
-   "d5e1649c88102f27da5fe1ac16715cfee7f70f84",
+   "7baa224e1fefd5c288e5bf3a671bfdda13281e18",
    "testharness"
   ],
   "mozilla/resources/background-green.css": [

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -19540,6 +19540,12 @@
      {}
     ]
    ],
+   "mozilla/resizeTo.html": [
+    [
+     "/_mozilla/mozilla/resizeTo.html",
+     {}
+    ]
+   ],
    "mozilla/response-data-brotli.htm": [
     [
      "/_mozilla/mozilla/response-data-brotli.htm",
@@ -30922,6 +30928,10 @@
   "mozilla/reparse_style_elements_ref.html": [
    "df273cf90396cc2d3d3159ce72176122ab9518e5",
    "support"
+  ],
+  "mozilla/resizeTo.html": [
+   "d5e1649c88102f27da5fe1ac16715cfee7f70f84",
+   "testharness"
   ],
   "mozilla/resources/background-green.css": [
    "bb230110dd1cf4647e020d7172bc375e972c7b41",

--- a/tests/wpt/mozilla/tests/mozilla/resizeTo.html
+++ b/tests/wpt/mozilla/tests/mozilla/resizeTo.html
@@ -6,6 +6,8 @@
 <script>
 async_test(function(t) {
   window.onresize = t.step_func(function() {
+    assert_equals(window.innerWidth, 200);
+    assert_equals(window.innerHeight, 200);
     t.done();
   });
 

--- a/tests/wpt/mozilla/tests/mozilla/resizeTo.html
+++ b/tests/wpt/mozilla/tests/mozilla/resizeTo.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(function(t) {
+  window.onresize = t.step_func(function() {
+    t.done();
+  });
+
+  window.resizeTo(200, 200);
+}, "onresize");
+</script>


### PR DESCRIPTION
When resizing in headless mode a resize event is now fired

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15621 

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15818)
<!-- Reviewable:end -->
