### PR TITLE
border-image no more accepting shorthand values

### DIFF
--- a/components/style/properties/shorthand/border.mako.rs
+++ b/components/style/properties/shorthand/border.mako.rs
@@ -246,7 +246,12 @@ pub fn parse_border(context: &ParserContext, input: &mut Parser)
                                 try!(input.expect_delim('/'));
                                 border_image_outset::parse(context, input)
                             }).ok();
-                            Ok((w, o))
+                            if w.is_none() && o.is_none() {
+                               Err(())
+                            }
+                            else {
+                               Ok((w, o))
+                            }
                         });
                         if let Ok((w, o)) = maybe_width_outset {
                             width = w;


### PR DESCRIPTION
#border-image no more accepting shorthand values

Fixes #15770 

Added a check in border.mako.rs, if `w` and `o` are not none before returning Ok status

---
- [x] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15770 

- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they fix the previous errors reported in #15770 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15820)
<!-- Reviewable:end -->