### PR TITLE
Correct unicode handling for text input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,6 +2296,7 @@ dependencies = [
  "style_traits 0.0.1",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinyfiledialogs 2.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_traits 0.23.1 (git+https://github.com/servo/webrender)",

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -85,6 +85,7 @@ smallvec = "0.1"
 style = {path = "../style"}
 style_traits = {path = "../style_traits"}
 time = "0.1.12"
+unicode-segmentation = "1.1.0"
 url = {version = "1.2", features = ["heap_size", "query_encoding"]}
 uuid = {version = "0.4", features = ["v4"]}
 xml5ever = {version = "0.4", features = ["unstable"]}

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1112,7 +1112,7 @@ impl VirtualMethods for HTMLInputElement {
                                     translated_y
                                 );
                                 if let Some(i) = index {
-                                    self.textinput.borrow_mut().edit_point.index = i as usize;
+                                    self.textinput.borrow_mut().set_edit_point_index(i as usize);
                                     // trigger redraw
                                     self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
                                     event.PreventDefault();

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -95,6 +95,7 @@ extern crate style_traits;
 extern crate time;
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 extern crate tinyfiledialogs;
+extern crate unicode_segmentation;
 extern crate url;
 extern crate uuid;
 extern crate webrender_traits;

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -14,6 +14,7 @@ use std::cmp::{max, min};
 use std::default::Default;
 use std::ops::Range;
 use std::usize;
+use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum Selection {
@@ -376,18 +377,16 @@ impl<T: ClipboardProvider> TextInput<T> {
         }
         let adjust = {
             let current_line = &self.lines[self.edit_point.line];
-            // FIXME: We adjust by one code point, but it proably should be one grapheme cluster
-            // https://github.com/unicode-rs/unicode-segmentation
             match direction {
                 Direction::Forward => {
-                    match current_line[self.edit_point.index..].chars().next() {
-                        Some(c) => c.len_utf8() as isize,
+                    match current_line[self.edit_point.index..].graphemes(true).next() {
+                        Some(c) => c.len() as isize,
                         None => 1,  // Going to the next line is a "one byte" offset
                     }
                 }
                 Direction::Backward => {
-                    match current_line[..self.edit_point.index].chars().next_back() {
-                        Some(c) => -(c.len_utf8() as isize),
+                    match current_line[..self.edit_point.index].graphemes(true).next_back() {
+                        Some(c) => -(c.len() as isize),
                         None => -1,  // Going to the previous line is a "one byte" offset
                     }
                 }
@@ -676,5 +675,13 @@ impl<T: ClipboardProvider> TextInput<T> {
         };
 
         selection_start as u32
+    }
+
+    pub fn set_edit_point_index(&mut self, index: usize) {
+        let byte_size = self.lines[self.edit_point.line]
+            .graphemes(true)
+            .take(index)
+            .fold(0, |acc, x| acc + x.len());
+        self.edit_point.index = byte_size;
     }
 }

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -496,3 +496,13 @@ fn test_textinput_set_selection_with_direction() {
     assert_eq!(textinput.selection_begin.unwrap().line, 0);
     assert_eq!(textinput.selection_begin.unwrap().index, 6);
 }
+
+#[test]
+fn test_textinput_unicode_handling() {
+    let mut textinput = text_input(Lines::Single, "éèùµ$£");
+    assert_eq!(textinput.edit_point.index, 0);
+    textinput.set_edit_point_index(1);
+    assert_eq!(textinput.edit_point.index, 2);
+    textinput.set_edit_point_index(4);
+    assert_eq!(textinput.edit_point.index, 8);
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Allow proprer handling of unicode sequence in text input.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15819 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15822)
<!-- Reviewable:end -->
