### PR TITLE
Assert that `domain_match` is operating on lowercase text

### DIFF
--- a/components/net/cookie.rs
+++ b/components/net/cookie.rs
@@ -139,6 +139,8 @@ impl Cookie {
 
     // http://tools.ietf.org/html/rfc6265#section-5.1.3
     pub fn domain_match(string: &str, domain_string: &str) -> bool {
+        debug_assert!(string.to_lowercase() == string);
+        debug_assert!(domain_string.to_lowercase() == domain_string);
         string == domain_string ||
         (string.ends_with(domain_string) &&
          string.as_bytes()[string.len()-domain_string.len()-1] == b'.' &&


### PR DESCRIPTION
> (Note that both the domain string and the string will have been
> canonicalized to lower case at this point.)

Related to #15789

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15844)
<!-- Reviewable:end -->
