### PR TITLE
Remove link to servo from treeherder job detail to reduce noise

### DIFF
--- a/etc/ci/performance/submit_to_perfherder.py
+++ b/etc/ci/performance/submit_to_perfherder.py
@@ -289,12 +289,6 @@ def submit(perf_data, failures, revision, summary, engine):
                         "blob": {
                             "job_details": [
                                 {
-                                    "content_type": "link",
-                                    "url": "https://www.github.com/servo/servo",
-                                    "value": "GitHub",
-                                    "title": "Source code"
-                                },
-                                {
                                     "content_type": "raw_html",
                                     "title": "Result Summary",
                                     "value": summary


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
(This PR was original created by wlach in the deprecated servo-perf repo: https://github.com/shinglyu/servo-perf/pull/27)

Quoting his original message:
> The servo repository is already linked to from the revision list, there is no need for each job to link to it as well.
>This came up in: https://bugzilla.mozilla.org/show_bug.cgi?id=1342296


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because need full treeherder setup to test

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15847)
<!-- Reviewable:end -->
