### PR TITLE
Remove obsolete step from Text::SplitText

### DIFF
--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1214,12 +1214,6 @@ impl WeakRangeVec {
         }
     }
 
-    /// Used for steps 9.1-2. when splitting a text node.
-    /// https://dom.spec.whatwg.org/#concept-text-split
-    pub fn clamp_above(&self, node: &Node, offset: u32) {
-        self.map_offset_above(node, offset, |_| offset);
-    }
-
     fn map_offset_above<F: FnMut(u32) -> u32>(&self, node: &Node, offset: u32, mut f: F) {
         unsafe {
             (*self.cell.get()).update(|entry| {

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -43,7 +43,8 @@ impl Text {
 }
 
 impl TextMethods for Text {
-    // https://dom.spec.whatwg.org/#dom-text-splittextoffset
+    // https://dom.spec.whatwg.org/#dom-text-splittext
+    // https://dom.spec.whatwg.org/#concept-text-split
     fn SplitText(&self, offset: u32) -> Fallible<Root<Text>> {
         let cdata = self.upcast::<CharacterData>();
         // Step 1.
@@ -72,11 +73,7 @@ impl TextMethods for Text {
         }
         // Step 8.
         cdata.DeleteData(offset, count).unwrap();
-        if parent.is_none() {
-            // Step 9.
-            node.ranges().clamp_above(&node, offset);
-        }
-        // Step 10.
+        // Step 9.
         Ok(new_node)
     }
 


### PR DESCRIPTION
https://github.com/whatwg/dom/pull/419

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15851)
<!-- Reviewable:end -->
