### PR TITLE
Deduplicate declarations on insertion, not at the end of parsing a block

### DIFF
--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -62,10 +62,7 @@ impl CSSStyleOwner {
                     let result = f(&mut pdb, &mut changed);
                     result
                 } else {
-                    let mut pdb = PropertyDeclarationBlock {
-                        important_count: 0,
-                        declarations: vec![],
-                    };
+                    let mut pdb = PropertyDeclarationBlock::new();
                     let result = f(&mut pdb, &mut changed);
 
                     // Here `changed` is somewhat silly, because we know the
@@ -116,10 +113,7 @@ impl CSSStyleOwner {
                 match *el.style_attribute().borrow() {
                     Some(ref pdb) => f(&pdb.read()),
                     None => {
-                        let pdb = PropertyDeclarationBlock {
-                            important_count: 0,
-                            declarations: vec![],
-                        };
+                        let pdb = PropertyDeclarationBlock::new();
                         f(&pdb)
                     }
                 }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -67,7 +67,7 @@ impl CSSStyleOwner {
 
                     // Here `changed` is somewhat silly, because we know the
                     // exact conditions under it changes.
-                    changed = !pdb.declarations.is_empty();
+                    changed = !pdb.declarations().is_empty();
                     if changed {
                         attr = Some(Arc::new(RwLock::new(pdb)));
                     }
@@ -274,7 +274,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-length
     fn Length(&self) -> u32 {
         self.owner.with_block(|pdb| {
-            pdb.declarations.len() as u32
+            pdb.declarations().len() as u32
         })
     }
 
@@ -399,7 +399,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
     // https://dev.w3.org/csswg/cssom/#the-cssstyledeclaration-interface
     fn IndexedGetter(&self, index: u32) -> Option<DOMString> {
         self.owner.with_block(|pdb| {
-            pdb.declarations.get(index as usize).map(|entry| {
+            pdb.declarations().get(index as usize).map(|entry| {
                 let (ref declaration, importance) = *entry;
                 let mut css = declaration.to_css_string();
                 if importance.important() {

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -250,14 +250,14 @@ impl CSSStyleDeclaration {
 
             // Step 6
             let window = self.owner.window();
-            let declarations =
+            let result =
                 parse_one_declaration(id, &value, &self.owner.base_url(),
                                       window.css_error_reporter(),
                                       ParserContextExtraData::default());
 
             // Step 7
-            let declarations = match declarations {
-                Ok(declarations) => declarations,
+            let parsed = match result {
+                Ok(parsed) => parsed,
                 Err(_) => {
                     *changed = false;
                     return Ok(());
@@ -267,9 +267,9 @@ impl CSSStyleDeclaration {
             // Step 8
             // Step 9
             *changed = false;
-            for declaration in declarations {
-                *changed |= pdb.set_parsed_declaration(declaration.0, importance);
-            }
+            parsed.expand(|declaration| {
+                *changed |= pdb.set_parsed_declaration(declaration, importance);
+            });
 
             Ok(())
         })

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -385,10 +385,9 @@ impl LayoutElementHelpers for LayoutJS<Element> {
         #[inline]
         fn from_declaration(declaration: PropertyDeclaration) -> ApplicableDeclarationBlock {
             ApplicableDeclarationBlock::from_declarations(
-                Arc::new(RwLock::new(PropertyDeclarationBlock {
-                    declarations: vec![(declaration, Importance::Normal)],
-                    important_count: 0,
-                })),
+                Arc::new(RwLock::new(PropertyDeclarationBlock::with_one(
+                    declaration, Importance::Normal
+                ))),
                 CascadeLevel::PresHints)
         }
 

--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -418,11 +418,11 @@ fn compute_style_for_animation_step(context: &SharedStyleContext,
             let guard = declarations.read();
 
             // No !important in keyframes.
-            debug_assert!(guard.declarations.iter()
+            debug_assert!(guard.declarations().iter()
                             .all(|&(_, importance)| importance == Importance::Normal));
 
             let iter = || {
-                guard.declarations.iter().rev().map(|&(ref decl, _importance)| decl)
+                guard.declarations().iter().rev().map(|&(ref decl, _importance)| decl)
             };
 
             let computed =

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -21,7 +21,7 @@ use values::specified::url::SpecifiedUrl;
 
 /// A source for a font-face rule.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf, Deserialize, Serialize))]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 pub enum Source {
     /// A `url()` source.
     Url(UrlSource),
@@ -54,7 +54,7 @@ impl OneOrMoreCommaSeparated for Source {}
 ///
 /// https://drafts.csswg.org/css-fonts/#src-desc
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf, Deserialize, Serialize))]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 pub struct UrlSource {
     /// The specified url.
     pub url: SpecifiedUrl,
@@ -184,7 +184,6 @@ macro_rules! font_face_descriptors {
         ///
         /// https://drafts.csswg.org/css-fonts/#font-face-rule
         #[derive(Debug, PartialEq, Eq)]
-        #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
         pub struct FontFaceRule {
             $(
                 #[$m_doc]

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -70,8 +70,7 @@ impl KeyframePercentage {
 
 /// A keyframes selector is a list of percentages or from/to symbols, which are
 /// converted at parse time to percentages.
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+#[derive(Debug, PartialEq)]
 pub struct KeyframeSelector(Vec<KeyframePercentage>);
 impl KeyframeSelector {
     /// Return the list of percentages this selector contains.
@@ -93,8 +92,7 @@ impl KeyframeSelector {
 }
 
 /// A keyframe.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+#[derive(Debug)]
 pub struct Keyframe {
     /// The selector this keyframe was specified from.
     pub selector: KeyframeSelector,
@@ -103,7 +101,6 @@ pub struct Keyframe {
     ///
     /// Note that `!important` rules in keyframes don't apply, but we keep this
     /// `Arc` just for convenience.
-    #[cfg_attr(feature = "servo", ignore_heap_size_of = "Arc")]
     pub block: Arc<RwLock<PropertyDeclarationBlock>>,
 }
 
@@ -148,7 +145,7 @@ impl Keyframe {
 /// declarations to apply.
 ///
 /// TODO: Find a better name for this?
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum KeyframesStepValue {
     /// A step formed by a declaration block specified by the CSS.
@@ -163,7 +160,7 @@ pub enum KeyframesStepValue {
 }
 
 /// A single step from a keyframe animation.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct KeyframesStep {
     /// The percentage of the animation duration when this step starts.
@@ -235,7 +232,7 @@ impl KeyframesStep {
 /// of keyframes, in order.
 ///
 /// It only takes into account animable properties.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct KeyframesAnimation {
     /// The difference steps of the animation.

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -401,7 +401,7 @@ impl<'a, 'b> DeclarationParser for KeyframeDeclarationParser<'a, 'b> {
 
     fn parse_value(&mut self, name: &str, input: &mut Parser) -> Result<ParsedDeclaration, ()> {
         let id = try!(PropertyId::parse(name.into()));
-        match PropertyDeclaration::parse(id, self.context, input, true) {
+        match ParsedDeclaration::parse(id, self.context, input, true) {
             Ok(parsed) => {
                 // In case there is still unparsed text in the declaration, we should roll back.
                 if !input.is_exhausted() {

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -362,10 +362,10 @@ impl<'a> QualifiedRuleParser for KeyframeListParser<'a> {
             context: self.context,
         };
         let mut iter = DeclarationListParser::new(input, parser);
-        let mut declarations = Vec::new();
+        let mut block = PropertyDeclarationBlock::new();
         while let Some(declaration) = iter.next() {
             match declaration {
-                Ok(parsed) => parsed.expand(|d| declarations.push((d, Importance::Normal))),
+                Ok(parsed) => parsed.expand(|d| block.push(d, Importance::Normal)),
                 Err(range) => {
                     let pos = range.start;
                     let message = format!("Unsupported keyframe property declaration: '{}'",
@@ -377,10 +377,7 @@ impl<'a> QualifiedRuleParser for KeyframeListParser<'a> {
         }
         Ok(Arc::new(RwLock::new(Keyframe {
             selector: prelude,
-            block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                declarations: declarations,
-                important_count: 0,
-            })),
+            block: Arc::new(RwLock::new(block)),
         })))
     }
 }

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -181,7 +181,7 @@ impl KeyframesStep {
            value: KeyframesStepValue) -> Self {
         let declared_timing_function = match value {
             KeyframesStepValue::Declarations { ref block } => {
-                block.read().declarations.iter().any(|&(ref prop_decl, _)| {
+                block.read().declarations().iter().any(|&(ref prop_decl, _)| {
                     match *prop_decl {
                         PropertyDeclaration::AnimationTimingFunction(..) => true,
                         _ => false,
@@ -249,7 +249,7 @@ fn get_animated_properties(keyframes: &[Arc<RwLock<Keyframe>>]) -> Vec<Transitio
     // it here.
     for keyframe in keyframes {
         let keyframe = keyframe.read();
-        for &(ref declaration, importance) in keyframe.block.read().declarations.iter() {
+        for &(ref declaration, importance) in keyframe.block.read().declarations().iter() {
             assert!(!importance.important());
 
             if let Some(property) = TransitionProperty::from_declaration(declaration) {

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -13,7 +13,6 @@ use parser::{ParserContext, ParserContextExtraData, log_css_error};
 use properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, PropertyId};
 use properties::{PropertyDeclarationId, LonghandId, DeclaredValue};
 use properties::LonghandIdSet;
-use properties::PropertyDeclarationParseResult;
 use properties::animated_properties::TransitionProperty;
 use properties::longhands::transition_timing_function::single_value::SpecifiedValue as SpecifiedTimingFunction;
 use std::fmt;
@@ -407,12 +406,9 @@ impl<'a, 'b> DeclarationParser for KeyframeDeclarationParser<'a, 'b> {
     fn parse_value(&mut self, name: &str, input: &mut Parser) -> Result<(), ()> {
         let id = try!(PropertyId::parse(name.into()));
         let old_len = self.declarations.len();
-        match PropertyDeclaration::parse(id, self.context, input, &mut self.declarations, true) {
-            PropertyDeclarationParseResult::ValidOrIgnoredDeclaration => {}
-            _ => {
-                self.declarations.truncate(old_len);
-                return Err(());
-            }
+        if PropertyDeclaration::parse(id, self.context, input, &mut self.declarations, true).is_err() {
+            self.declarations.truncate(old_len);
+            return Err(())
         }
         // In case there is still unparsed text in the declaration, we should roll back.
         if !input.is_exhausted() {

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -393,7 +393,6 @@ impl<'a, 'b> AtRuleParser for KeyframeDeclarationParser<'a, 'b> {
 }
 
 impl<'a, 'b> DeclarationParser for KeyframeDeclarationParser<'a, 'b> {
-    /// We parse rules directly into the declarations object
     type Declaration = ParsedDeclaration;
 
     fn parse_value(&mut self, name: &str, input: &mut Parser) -> Result<ParsedDeclaration, ()> {

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -40,20 +40,13 @@ impl Importance {
     }
 }
 
-impl Default for Importance {
-    #[inline]
-    fn default() -> Self {
-        Importance::Normal
-    }
-}
-
 /// Overridden declarations are skipped.
 #[derive(Debug, PartialEq, Clone)]
 pub struct PropertyDeclarationBlock {
     /// The group of declarations, along with their importance.
     ///
     /// Only deduplicated declarations appear here.
-    pub declarations: Vec<(PropertyDeclaration, Importance)>,
+    declarations: Vec<(PropertyDeclaration, Importance)>,
 
     /// The number of entries in `self.declaration` with `Importance::Important`
     important_count: usize,
@@ -74,6 +67,11 @@ impl PropertyDeclarationBlock {
             declarations: vec![(declaration, importance)],
             important_count: if importance.important() { 1 } else { 0 },
         }
+    }
+
+    /// The declarations in this block
+    pub fn declarations(&self) -> &[(PropertyDeclaration, Importance)] {
+        &self.declarations
     }
 
     /// Returns wheather this block contains any declaration with `!important`.

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -49,12 +49,10 @@ impl Default for Importance {
 
 /// Overridden declarations are skipped.
 #[derive(Debug, PartialEq, Clone)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct PropertyDeclarationBlock {
     /// The group of declarations, along with their importance.
     ///
     /// Only deduplicated declarations appear here.
-    #[cfg_attr(feature = "servo", ignore_heap_size_of = "#7038")]
     pub declarations: Vec<(PropertyDeclaration, Importance)>,
 
     /// The number of entries in `self.declaration` with `Importance::Important`

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -56,7 +56,7 @@ pub struct PropertyDeclarationBlock {
     pub declarations: Vec<(PropertyDeclaration, Importance)>,
 
     /// The number of entries in `self.declaration` with `Importance::Important`
-    pub important_count: usize,
+    important_count: usize,
 }
 
 impl PropertyDeclarationBlock {
@@ -65,6 +65,14 @@ impl PropertyDeclarationBlock {
         PropertyDeclarationBlock {
             declarations: Vec::new(),
             important_count: 0,
+        }
+    }
+
+    /// Create a block with a single declaration
+    pub fn with_one(declaration: PropertyDeclaration, importance: Importance) -> Self {
+        PropertyDeclarationBlock {
+            declarations: vec![(declaration, importance)],
+            important_count: if importance.important() { 1 } else { 0 },
         }
     }
 

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -557,7 +557,7 @@ pub fn parse_one_declaration(id: PropertyId,
                              -> Result<ParsedDeclaration, ()> {
     let context = ParserContext::new_with_extra_data(Origin::Author, base_url, error_reporter, extra_data);
     Parser::new(input).parse_entirely(|parser| {
-        PropertyDeclaration::parse(id, &context, parser, false)
+        ParsedDeclaration::parse(id, &context, parser, false)
             .map_err(|_| ())
     })
 }
@@ -582,7 +582,7 @@ impl<'a, 'b> DeclarationParser for PropertyDeclarationParser<'a, 'b> {
                    -> Result<(ParsedDeclaration, Importance), ()> {
         let id = try!(PropertyId::parse(name.into()));
         let parsed = input.parse_until_before(Delimiter::Bang, |input| {
-            PropertyDeclaration::parse(id, self.context, input, false)
+            ParsedDeclaration::parse(id, self.context, input, false)
                 .map_err(|_| ())
         })?;
         let importance = match input.try(parse_important) {

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -41,7 +41,7 @@ impl Importance {
 }
 
 /// Overridden declarations are skipped.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone)]
 pub struct PropertyDeclarationBlock {
     /// The group of declarations, along with their importance.
     ///
@@ -50,6 +50,14 @@ pub struct PropertyDeclarationBlock {
 
     /// The number of entries in `self.declaration` with `Importance::Important`
     important_count: usize,
+
+    longhands: LonghandIdSet,
+}
+
+impl fmt::Debug for PropertyDeclarationBlock {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.declarations.fmt(f)
+    }
 }
 
 impl PropertyDeclarationBlock {
@@ -58,14 +66,20 @@ impl PropertyDeclarationBlock {
         PropertyDeclarationBlock {
             declarations: Vec::new(),
             important_count: 0,
+            longhands: LonghandIdSet::new(),
         }
     }
 
     /// Create a block with a single declaration
     pub fn with_one(declaration: PropertyDeclaration, importance: Importance) -> Self {
+        let mut longhands = LonghandIdSet::new();
+        if let PropertyDeclarationId::Longhand(id) = declaration.id() {
+            longhands.insert(id);
+        }
         PropertyDeclarationBlock {
             declarations: vec![(declaration, importance)],
             important_count: if importance.important() { 1 } else { 0 },
+            longhands: longhands,
         }
     }
 
@@ -198,28 +212,39 @@ impl PropertyDeclarationBlock {
 
     fn push_common(&mut self, declaration: PropertyDeclaration, importance: Importance,
                    overwrite_more_important: bool) -> bool {
-        for slot in &mut *self.declarations {
-            if slot.0.id() == declaration.id() {
-                match (slot.1, importance) {
-                    (Importance::Normal, Importance::Important) => {
-                        self.important_count += 1;
-                    }
-                    (Importance::Important, Importance::Normal) => {
-                        if overwrite_more_important {
-                            self.important_count -= 1;
-                        } else {
-                            return false
+        let definitely_new = if let PropertyDeclarationId::Longhand(id) = declaration.id() {
+            !self.longhands.contains(id)
+        } else {
+            false  // For custom properties, always scan
+        };
+
+        if !definitely_new {
+            for slot in &mut *self.declarations {
+                if slot.0.id() == declaration.id() {
+                    match (slot.1, importance) {
+                        (Importance::Normal, Importance::Important) => {
+                            self.important_count += 1;
+                        }
+                        (Importance::Important, Importance::Normal) => {
+                            if overwrite_more_important {
+                                self.important_count -= 1;
+                            } else {
+                                return false
+                            }
+                        }
+                        _ => if slot.0 == declaration {
+                            return false;
                         }
                     }
-                    _ => if slot.0 == declaration {
-                        return false;
-                    }
+                    *slot = (declaration, importance);
+                    return true
                 }
-                *slot = (declaration, importance);
-                return true;
             }
         }
 
+        if let PropertyDeclarationId::Longhand(id) = declaration.id() {
+            self.longhands.insert(id);
+        }
         self.declarations.push((declaration, importance));
         if importance.important() {
             self.important_count += 1;
@@ -256,6 +281,11 @@ impl PropertyDeclarationBlock {
     ///
     /// Returns whether any declaration was actually removed.
     pub fn remove_property(&mut self, property: &PropertyId) -> bool {
+        if let PropertyId::Longhand(id) = *property {
+            if !self.longhands.contains(id) {
+                return false
+            }
+        }
         let important_count = &mut self.important_count;
         let mut removed_at_least_one = false;
         self.declarations.retain(|&(ref declaration, importance)| {
@@ -269,6 +299,10 @@ impl PropertyDeclarationBlock {
             !remove
         });
 
+        if let PropertyId::Longhand(id) = *property {
+            debug_assert!(removed_at_least_one);
+            self.longhands.remove(id);
+        }
         removed_at_least_one
     }
 

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -561,8 +561,8 @@ pub fn parse_one_declaration(id: PropertyId,
     Parser::new(input).parse_entirely(|parser| {
         let mut results = vec![];
         match PropertyDeclaration::parse(id, &context, parser, &mut results, false) {
-            PropertyDeclarationParseResult::ValidOrIgnoredDeclaration => Ok(results),
-            _ => Err(())
+            Ok(()) => Ok(results),
+            Err(_) => Err(())
         }
     })
 }
@@ -592,10 +592,8 @@ impl<'a, 'b> DeclarationParser for PropertyDeclarationParser<'a, 'b> {
         let id = try!(PropertyId::parse(name.into()));
         let old_len = self.declarations.len();
         let parse_result = input.parse_until_before(Delimiter::Bang, |input| {
-            match PropertyDeclaration::parse(id, self.context, input, &mut self.declarations, false) {
-                PropertyDeclarationParseResult::ValidOrIgnoredDeclaration => Ok(()),
-                _ => Err(())
-            }
+            PropertyDeclaration::parse(id, self.context, input, &mut self.declarations, false)
+            .map_err(|_| ())
         });
         if let Err(_) = parse_result {
             // rollback

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -168,23 +168,19 @@ impl ComputedValues {
             % for prop in data.longhands:
                 % if prop.animatable:
                     PropertyDeclarationId::Longhand(LonghandId::${prop.camel_case}) => {
-                        PropertyDeclarationBlock {
-                            declarations: vec![
-                                (PropertyDeclaration::${prop.camel_case}(DeclaredValue::Value(
-                                    % if prop.boxed:
-                                        Box::new(
-                                    % endif
-                                    longhands::${prop.ident}::SpecifiedValue::from_computed_value(
-                                      &self.get_${prop.style_struct.ident.strip("_")}().clone_${prop.ident}())
-                                    % if prop.boxed:
-                                        )
-                                    % endif
-
-                                 )),
-                                 Importance::Normal)
-                            ],
-                            important_count: 0
-                        }
+                         PropertyDeclarationBlock::with_one(
+                            PropertyDeclaration::${prop.camel_case}(DeclaredValue::Value(
+                                % if prop.boxed:
+                                    Box::new(
+                                % endif
+                                longhands::${prop.ident}::SpecifiedValue::from_computed_value(
+                                  &self.get_${prop.style_struct.ident.strip("_")}().clone_${prop.ident}())
+                                % if prop.boxed:
+                                    )
+                                % endif
+                            )),
+                            Importance::Normal
+                        )
                     },
                 % endif
             % endfor

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -177,6 +177,7 @@ pub mod animated_properties {
 }
 
 /// A set of longhand properties
+#[derive(Clone)]
 pub struct LonghandIdSet {
     storage: [u32; (${len(data.longhands)} - 1 + 32) / 32]
 }
@@ -200,6 +201,13 @@ impl LonghandIdSet {
     pub fn insert(&mut self, id: LonghandId) {
         let bit = id as usize;
         self.storage[bit / 32] |= 1 << (bit % 32);
+    }
+
+    /// Remove the given property from the set
+    #[inline]
+    pub fn remove(&mut self, id: LonghandId) {
+        let bit = id as usize;
+        self.storage[bit / 32] &= !(1 << (bit % 32));
     }
 
     /// Set the corresponding bit of TransitionProperty.

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1817,7 +1817,7 @@ pub fn cascade(viewport_size: Size2D<Au>,
     }).collect::<Vec<_>>();
     let iter_declarations = || {
         lock_guards.iter().flat_map(|&(ref source, source_importance)| {
-            source.declarations.iter()
+            source.declarations().iter()
             // Yield declarations later in source order (with more precedence) first.
             .rev()
             .filter_map(move |&(ref declaration, declaration_importance)| {

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -563,7 +563,6 @@ impl ShorthandId {
 /// Servo's representation of a declared value for a given `T`, which is the
 /// declared value for that property.
 #[derive(Clone, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum DeclaredValue<T> {
     /// A known specified value from the stylesheet.
     Value(T),
@@ -574,8 +573,7 @@ pub enum DeclaredValue<T> {
 }
 
 /// An unparsed property value that contains `var()` functions.
-#[derive(Clone, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+#[derive(PartialEq, Eq, Debug)]
 pub struct UnparsedValue {
     /// The css serialization for this value.
     css: String,
@@ -854,7 +852,6 @@ impl ParsedDeclaration {
 
 /// Servo's representation for a property declaration.
 #[derive(PartialEq, Clone)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum PropertyDeclaration {
     % for property in data.longhands:
         /// ${property.name}

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -823,7 +823,7 @@ pub enum ParsedDeclaration {
 impl ParsedDeclaration {
     /// Transform this ParsedDeclaration into a sequence of PropertyDeclaration
     /// by expanding shorthand declarations into their corresponding longhands
-    pub fn expand<F>(self, mut f: F) where F: FnMut(PropertyDeclaration) {
+    pub fn expand<F>(self, mut push: F) where F: FnMut(PropertyDeclaration) {
         match self {
             % for shorthand in data.shorthands:
                 ParsedDeclaration::${shorthand.camel_case}(
@@ -834,7 +834,7 @@ impl ParsedDeclaration {
                     }
                 ) => {
                     % for sub_property in shorthand.sub_properties:
-                        f(PropertyDeclaration::${sub_property.camel_case}(
+                        push(PropertyDeclaration::${sub_property.camel_case}(
                             % if sub_property.boxed:
                                 DeclaredValue::Value(Box::new(${sub_property.ident}))
                             % else:
@@ -845,7 +845,7 @@ impl ParsedDeclaration {
                 }
                 ParsedDeclaration::${shorthand.camel_case}CSSWideKeyword(keyword) => {
                     % for sub_property in shorthand.sub_properties:
-                        f(PropertyDeclaration::${sub_property.camel_case}(
+                        push(PropertyDeclaration::${sub_property.camel_case}(
                             DeclaredValue::CSSWideKeyword(keyword)
                         ));
                     % endfor
@@ -856,13 +856,13 @@ impl ParsedDeclaration {
                         Some(ShorthandId::${shorthand.camel_case})
                     );
                     % for sub_property in shorthand.sub_properties:
-                        f(PropertyDeclaration::${sub_property.camel_case}(
+                        push(PropertyDeclaration::${sub_property.camel_case}(
                             DeclaredValue::WithVariables(value.clone())
                         ));
                     % endfor
                 }
             % endfor
-            ParsedDeclaration::LonghandOrCustom(declaration) => f(declaration),
+            ParsedDeclaration::LonghandOrCustom(declaration) => push(declaration),
         }
     }
 

--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -99,7 +99,7 @@ impl StyleSource {
             let _ = write!(writer, "{:?}", rule.read().selectors);
         }
 
-        let _ = write!(writer, "  -> {:?}", self.read().declarations);
+        let _ = write!(writer, "  -> {:?}", self.read().declarations());
     }
 
     /// Read the style source guard, and obtain thus read access to the

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -52,7 +52,6 @@ pub enum Origin {
 
 /// A set of namespaces applying to a given stylesheet.
 #[derive(Default, Debug)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[allow(missing_docs)]
 pub struct Namespaces {
     pub default: Option<Namespace>,
@@ -389,7 +388,6 @@ impl ToCss for CssRule {
 }
 
 #[derive(Debug, PartialEq)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[allow(missing_docs)]
 pub struct NamespaceRule {
     /// `None` for the default Namespace

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -534,7 +534,7 @@ impl ToCss for StyleRule {
         let declaration_block = self.block.read();
         try!(declaration_block.to_css(dest));
         // Step 4
-        if declaration_block.declarations.len() > 0 {
+        if declaration_block.declarations().len() > 0 {
             try!(write!(dest, " "));
         }
         // Step 5
@@ -952,7 +952,7 @@ impl<'a> QualifiedRuleParser for TopLevelRuleParser<'a> {
     }
 }
 
-#[derive(Clone)]  // shallow, relatively cheap clone
+#[derive(Clone)]  // shallow, relatively cheap .clone
 struct NestedRuleParser<'a, 'b: 'a> {
     stylesheet_origin: Origin,
     context: &'a ParserContext<'b>,

--- a/components/style/supports.rs
+++ b/components/style/supports.rs
@@ -205,7 +205,6 @@ impl Declaration {
     ///
     /// https://drafts.csswg.org/css-conditional-3/#support-definition
     pub fn eval(&self, cx: &ParserContext) -> bool {
-        use properties::PropertyDeclarationParseResult::*;
         let id = if let Ok(id) = PropertyId::parse((&*self.prop).into()) {
             id
         } else {
@@ -219,13 +218,6 @@ impl Declaration {
         if !input.is_exhausted() {
             return false;
         }
-        match res {
-            UnknownProperty => false,
-            ExperimentalProperty => false, // only happens for experimental props
-                                           // that haven't been enabled
-            InvalidValue => false,
-            AnimationPropertyInKeyframeBlock => unreachable!(),
-            ValidOrIgnoredDeclaration => true,
-        }
+        res.is_ok()
     }
 }

--- a/components/style/supports.rs
+++ b/components/style/supports.rs
@@ -211,13 +211,8 @@ impl Declaration {
             return false
         };
         let mut input = Parser::new(&self.val);
-        let mut list = Vec::new();
-        let res = PropertyDeclaration::parse(id, cx, &mut input,
-                                             &mut list, /* in_keyframe */ false);
+        let res = PropertyDeclaration::parse(id, cx, &mut input, /* in_keyframe */ false);
         let _ = input.try(parse_important);
-        if !input.is_exhausted() {
-            return false;
-        }
-        res.is_ok()
+        res.is_ok() && input.is_exhausted()
     }
 }

--- a/components/style/supports.rs
+++ b/components/style/supports.rs
@@ -6,7 +6,7 @@
 
 use cssparser::{parse_important, Parser, Token};
 use parser::ParserContext;
-use properties::{PropertyDeclaration, PropertyId};
+use properties::{PropertyId, ParsedDeclaration};
 use std::fmt;
 use style_traits::ToCss;
 
@@ -211,7 +211,7 @@ impl Declaration {
             return false
         };
         let mut input = Parser::new(&self.val);
-        let res = PropertyDeclaration::parse(id, cx, &mut input, /* in_keyframe */ false);
+        let res = ParsedDeclaration::parse(id, cx, &mut input, /* in_keyframe */ false);
         let _ = input.try(parse_important);
         res.is_ok() && input.is_exhausted()
     }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -738,7 +738,8 @@ pub extern "C" fn Servo_DeclarationBlock_Clone(declarations: RawServoDeclaration
 pub extern "C" fn Servo_DeclarationBlock_Equals(a: RawServoDeclarationBlockBorrowed,
                                                 b: RawServoDeclarationBlockBorrowed)
                                                 -> bool {
-    *RwLock::<PropertyDeclarationBlock>::as_arc(&a).read() == *RwLock::<PropertyDeclarationBlock>::as_arc(&b).read()
+    *RwLock::<PropertyDeclarationBlock>::as_arc(&a).read().declarations() ==
+    *RwLock::<PropertyDeclarationBlock>::as_arc(&b).read().declarations()
 }
 
 #[no_mangle]

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -67,7 +67,7 @@ use style::gecko_properties::{self, style_structs};
 use style::keyframes::KeyframesStepValue;
 use style::parallel;
 use style::parser::{ParserContext, ParserContextExtraData};
-use style::properties::{ComputedValues, Importance, PropertyDeclaration};
+use style::properties::{ComputedValues, Importance, ParsedDeclaration};
 use style::properties::{PropertyDeclarationBlock, PropertyId};
 use style::properties::animated_properties::{AnimationValue, Interpolate, TransitionProperty};
 use style::properties::parse_one_declaration;
@@ -713,7 +713,7 @@ pub extern "C" fn Servo_ParseProperty(property: *const nsACString, value: *const
                                                      Box::new(StdoutErrorReporter),
                                                      extra_data);
 
-    match PropertyDeclaration::parse(id, &context, &mut Parser::new(value), false) {
+    match ParsedDeclaration::parse(id, &context, &mut Parser::new(value), false) {
         Ok(parsed) => {
             let mut declarations = Vec::new();
             parsed.expand(|d| declarations.push((d, Importance::Normal)));

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -68,7 +68,7 @@ use style::keyframes::KeyframesStepValue;
 use style::parallel;
 use style::parser::{ParserContext, ParserContextExtraData};
 use style::properties::{ComputedValues, Importance, PropertyDeclaration};
-use style::properties::{PropertyDeclarationParseResult, PropertyDeclarationBlock, PropertyId};
+use style::properties::{PropertyDeclarationBlock, PropertyId};
 use style::properties::animated_properties::{AnimationValue, Interpolate, TransitionProperty};
 use style::properties::parse_one_declaration;
 use style::restyle_hints::{self, RestyleHint};
@@ -714,10 +714,11 @@ pub extern "C" fn Servo_ParseProperty(property: *const nsACString, value: *const
                                                      extra_data);
 
     let mut results = vec![];
-    match PropertyDeclaration::parse(id, &context, &mut Parser::new(value),
-                                     &mut results, false) {
-        PropertyDeclarationParseResult::ValidOrIgnoredDeclaration => {},
-        _ => return RawServoDeclarationBlockStrong::null(),
+    let result = PropertyDeclaration::parse(
+        id, &context, &mut Parser::new(value), &mut results, false
+    );
+    if result.is_err() {
+        return RawServoDeclarationBlockStrong::null()
     }
 
     Arc::new(RwLock::new(PropertyDeclarationBlock {

--- a/tests/unit/style/keyframes.rs
+++ b/tests/unit/style/keyframes.rs
@@ -27,10 +27,7 @@ fn test_no_property_in_keyframe() {
     let keyframes = vec![
         Arc::new(RwLock::new(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(1.)]),
-            block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                declarations: vec![],
-                important_count: 0,
-            }))
+            block: Arc::new(RwLock::new(PropertyDeclarationBlock::new()))
         })),
     ];
     let animation = KeyframesAnimation::from_keyframes(&keyframes);
@@ -45,27 +42,26 @@ fn test_no_property_in_keyframe() {
 #[test]
 fn test_missing_property_in_initial_keyframe() {
     let declarations_on_initial_keyframe =
-        Arc::new(RwLock::new(PropertyDeclarationBlock {
-            declarations: vec![
-                (PropertyDeclaration::Width(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
-            ],
-            important_count: 0,
-        }));
+        Arc::new(RwLock::new(PropertyDeclarationBlock::with_one(
+            PropertyDeclaration::Width(
+                DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+            Importance::Normal
+        )));
 
     let declarations_on_final_keyframe =
-        Arc::new(RwLock::new(PropertyDeclarationBlock {
-            declarations: vec![
-                (PropertyDeclaration::Width(
+        Arc::new(RwLock::new({
+            let mut block = PropertyDeclarationBlock::new();
+            block.push(
+                PropertyDeclaration::Width(
                     DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
-
-                (PropertyDeclaration::Height(
+                Importance::Normal
+            );
+            block.push(
+                PropertyDeclaration::Height(
                     DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
-            ],
-            important_count: 0,
+                Importance::Normal
+            );
+            block
         }));
 
     let keyframes = vec![
@@ -102,28 +98,27 @@ fn test_missing_property_in_initial_keyframe() {
 #[test]
 fn test_missing_property_in_final_keyframe() {
     let declarations_on_initial_keyframe =
-        Arc::new(RwLock::new(PropertyDeclarationBlock {
-            declarations: vec![
-                (PropertyDeclaration::Width(
+        Arc::new(RwLock::new({
+            let mut block = PropertyDeclarationBlock::new();
+            block.push(
+                PropertyDeclaration::Width(
                     DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
-
-                (PropertyDeclaration::Height(
+                Importance::Normal
+            );
+            block.push(
+                PropertyDeclaration::Height(
                     DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
-            ],
-            important_count: 0,
+                Importance::Normal
+            );
+            block
         }));
 
     let declarations_on_final_keyframe =
-        Arc::new(RwLock::new(PropertyDeclarationBlock {
-            declarations: vec![
-                (PropertyDeclaration::Height(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
-            ],
-            important_count: 0,
-        }));
+        Arc::new(RwLock::new(PropertyDeclarationBlock::with_one(
+            PropertyDeclaration::Height(
+                DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+            Importance::Normal,
+        )));
 
     let keyframes = vec![
         Arc::new(RwLock::new(Keyframe {
@@ -159,26 +154,25 @@ fn test_missing_property_in_final_keyframe() {
 #[test]
 fn test_missing_keyframe_in_both_of_initial_and_final_keyframe() {
     let declarations =
-        Arc::new(RwLock::new(PropertyDeclarationBlock {
-            declarations: vec![
-                (PropertyDeclaration::Width(
-                        DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                 Importance::Normal),
-
-                (PropertyDeclaration::Height(
-                        DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
-                Importance::Normal),
-            ],
-            important_count: 0,
+        Arc::new(RwLock::new({
+            let mut block = PropertyDeclarationBlock::new();
+            block.push(
+                PropertyDeclaration::Width(
+                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+                Importance::Normal
+            );
+            block.push(
+                PropertyDeclaration::Height(
+                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+                Importance::Normal
+            );
+            block
         }));
 
     let keyframes = vec![
         Arc::new(RwLock::new(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(0.)]),
-            block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                declarations: vec![],
-                important_count: 0,
-            }))
+            block: Arc::new(RwLock::new(PropertyDeclarationBlock::new()))
         })),
         Arc::new(RwLock::new(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(0.5)]),
@@ -191,11 +185,10 @@ fn test_missing_keyframe_in_both_of_initial_and_final_keyframe() {
             KeyframesStep {
                 start_percentage: KeyframePercentage(0.),
                 value: KeyframesStepValue::Declarations {
-                    block: Arc::new(RwLock::new(PropertyDeclarationBlock {
+                    block: Arc::new(RwLock::new(
                         // XXX: Should we use ComputedValues in this case?
-                        declarations: vec![],
-                        important_count: 0,
-                    }))
+                        PropertyDeclarationBlock::new()
+                    ))
                 },
                 declared_timing_function: false,
             },

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -17,6 +17,7 @@ use style::values::specified::{BorderStyle, BorderWidth, CSSColor, Length, NoCal
 use style::values::specified::{LengthOrPercentage, LengthOrPercentageOrAuto, LengthOrPercentageOrAutoOrContent};
 use style::values::specified::url::SpecifiedUrl;
 use style_traits::ToCss;
+use stylesheets::block_from;
 
 fn parse_declaration_block(css_properties: &str) -> PropertyDeclarationBlock {
     let url = ServoUrl::parse("http://localhost").unwrap();
@@ -56,10 +57,7 @@ fn property_declaration_block_should_serialize_correctly() {
          Importance::Normal),
     ];
 
-    let block = PropertyDeclarationBlock {
-        declarations: declarations,
-        important_count: 0,
-    };
+    let block = block_from(declarations);
 
     let css_string = block.to_css_string();
 
@@ -73,10 +71,7 @@ mod shorthand_serialization {
     pub use super::*;
 
     pub fn shorthand_properties_to_string(properties: Vec<PropertyDeclaration>) -> String {
-        let block = PropertyDeclarationBlock {
-            declarations: properties.into_iter().map(|d| (d, Importance::Normal)).collect(),
-            important_count: 0,
-        };
+        let block = block_from(properties.into_iter().map(|d| (d, Importance::Normal)));
 
         block.to_css_string()
     }
@@ -882,10 +877,7 @@ mod shorthand_serialization {
                 Importance::Normal)
             ];
 
-            let block = PropertyDeclarationBlock {
-                declarations: declarations,
-                important_count: 0
-            };
+            let block = block_from(declarations);
 
             let mut s = String::new();
 
@@ -905,10 +897,7 @@ mod shorthand_serialization {
                 Importance::Normal)
             ];
 
-            let block = PropertyDeclarationBlock {
-                declarations: declarations,
-                important_count: 0
-            };
+            let block = block_from(declarations);
 
             let mut s = String::new();
 

--- a/tests/unit/style/rule_tree/bench.rs
+++ b/tests/unit/style/rule_tree/bench.rs
@@ -17,7 +17,7 @@ use test::{self, Bencher};
 
 struct ErrorringErrorReporter;
 impl ParseErrorReporter for ErrorringErrorReporter {
-    fn report_error(&self, input: &mut Parser, position: SourcePosition, message: &str,
+    fn report_error(&self, _input: &mut Parser, position: SourcePosition, message: &str,
         url: &ServoUrl) {
         panic!("CSS error: {}\t\n{:?} {}", url.as_str(), position, message);
     }

--- a/tests/unit/style/rule_tree/bench.rs
+++ b/tests/unit/style/rule_tree/bench.rs
@@ -68,14 +68,11 @@ fn test_insertion(rule_tree: &RuleTree, rules: Vec<(StyleSource, CascadeLevel)>)
 
 fn test_insertion_style_attribute(rule_tree: &RuleTree, rules: &[(StyleSource, CascadeLevel)]) -> StrongRuleNode {
     let mut rules = rules.to_vec();
-    rules.push((StyleSource::Declarations(Arc::new(RwLock::new(PropertyDeclarationBlock {
-        declarations: vec![
-            (PropertyDeclaration::Display(DeclaredValue::Value(
-                longhands::display::SpecifiedValue::block)),
-            Importance::Normal),
-        ],
-        important_count: 0,
-    }))), CascadeLevel::UserNormal));
+    rules.push((StyleSource::Declarations(Arc::new(RwLock::new(PropertyDeclarationBlock::with_one(
+        PropertyDeclaration::Display(DeclaredValue::Value(
+            longhands::display::SpecifiedValue::block)),
+        Importance::Normal
+    )))), CascadeLevel::UserNormal));
     test_insertion(rule_tree, rules)
 }
 

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -24,6 +24,15 @@ use style::stylesheets::{Origin, Namespaces};
 use style::stylesheets::{Stylesheet, NamespaceRule, CssRule, CssRules, StyleRule, KeyframesRule};
 use style::values::specified::{LengthOrPercentageOrAuto, Percentage};
 
+pub fn block_from<I>(iterable: I) -> PropertyDeclarationBlock
+where I: IntoIterator<Item=(PropertyDeclaration, Importance)> {
+    let mut block = PropertyDeclarationBlock::new();
+    for (d, i) in iterable {
+        block.push(d, i)
+    }
+    block
+}
+
 #[test]
 fn test_parse_stylesheet() {
     let css = r"
@@ -98,17 +107,14 @@ fn test_parse_stylesheet() {
                         specificity: (0 << 20) + (1 << 10) + (1 << 0),
                     },
                 ]),
-                block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                    declarations: vec![
-                        (PropertyDeclaration::Display(DeclaredValue::Value(
-                            longhands::display::SpecifiedValue::none)),
-                         Importance::Important),
-                        (PropertyDeclaration::Custom(Atom::from("a"),
-                         DeclaredValue::CSSWideKeyword(CSSWideKeyword::Inherit)),
-                         Importance::Important),
-                    ],
-                    important_count: 2,
-                })),
+                block: Arc::new(RwLock::new(block_from(vec![
+                    (PropertyDeclaration::Display(DeclaredValue::Value(
+                        longhands::display::SpecifiedValue::none)),
+                     Importance::Important),
+                    (PropertyDeclaration::Custom(Atom::from("a"),
+                     DeclaredValue::CSSWideKeyword(CSSWideKeyword::Inherit)),
+                     Importance::Important),
+                ]))),
             }))),
             CssRule::Style(Arc::new(RwLock::new(StyleRule {
                 selectors: SelectorList(vec![
@@ -147,14 +153,11 @@ fn test_parse_stylesheet() {
                         specificity: (0 << 20) + (0 << 10) + (1 << 0),
                     },
                 ]),
-                block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                    declarations: vec![
-                        (PropertyDeclaration::Display(DeclaredValue::Value(
-                            longhands::display::SpecifiedValue::block)),
-                         Importance::Normal),
-                    ],
-                    important_count: 0,
-                })),
+                block: Arc::new(RwLock::new(block_from(vec![
+                    (PropertyDeclaration::Display(DeclaredValue::Value(
+                        longhands::display::SpecifiedValue::block)),
+                     Importance::Normal),
+                ]))),
             }))),
             CssRule::Style(Arc::new(RwLock::new(StyleRule {
                 selectors: SelectorList(vec![
@@ -182,58 +185,55 @@ fn test_parse_stylesheet() {
                         specificity: (1 << 20) + (1 << 10) + (0 << 0),
                     },
                 ]),
-                block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                    declarations: vec![
-                        (PropertyDeclaration::BackgroundColor(DeclaredValue::Value(
-                            longhands::background_color::SpecifiedValue {
-                                authored: Some("blue".to_owned().into_boxed_str()),
-                                parsed: cssparser::Color::RGBA(cssparser::RGBA::new(0, 0, 255, 255)),
-                            }
-                         )),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundPositionX(DeclaredValue::Value(
-                            longhands::background_position_x::SpecifiedValue(
-                            vec![longhands::background_position_x::single_value
-                                                       ::get_initial_position_value()]))),
-                        Importance::Normal),
-                        (PropertyDeclaration::BackgroundPositionY(DeclaredValue::Value(
-                            longhands::background_position_y::SpecifiedValue(
-                            vec![longhands::background_position_y::single_value
-                                                       ::get_initial_position_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundRepeat(DeclaredValue::Value(
-                            longhands::background_repeat::SpecifiedValue(
-                            vec![longhands::background_repeat::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundAttachment(DeclaredValue::Value(
-                            longhands::background_attachment::SpecifiedValue(
-                            vec![longhands::background_attachment::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundImage(DeclaredValue::Value(
-                            longhands::background_image::SpecifiedValue(
-                            vec![longhands::background_image::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundSize(DeclaredValue::Value(
-                            longhands::background_size::SpecifiedValue(
-                            vec![longhands::background_size::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundOrigin(DeclaredValue::Value(
-                            longhands::background_origin::SpecifiedValue(
-                            vec![longhands::background_origin::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                        (PropertyDeclaration::BackgroundClip(DeclaredValue::Value(
-                            longhands::background_clip::SpecifiedValue(
-                            vec![longhands::background_clip::single_value
-                                                       ::get_initial_specified_value()]))),
-                         Importance::Normal),
-                    ],
-                    important_count: 0,
-                })),
+                block: Arc::new(RwLock::new(block_from(vec![
+                    (PropertyDeclaration::BackgroundColor(DeclaredValue::Value(
+                        longhands::background_color::SpecifiedValue {
+                            authored: Some("blue".to_owned().into_boxed_str()),
+                            parsed: cssparser::Color::RGBA(cssparser::RGBA::new(0, 0, 255, 255)),
+                        }
+                     )),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundPositionX(DeclaredValue::Value(
+                        longhands::background_position_x::SpecifiedValue(
+                        vec![longhands::background_position_x::single_value
+                                                   ::get_initial_position_value()]))),
+                    Importance::Normal),
+                    (PropertyDeclaration::BackgroundPositionY(DeclaredValue::Value(
+                        longhands::background_position_y::SpecifiedValue(
+                        vec![longhands::background_position_y::single_value
+                                                   ::get_initial_position_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundRepeat(DeclaredValue::Value(
+                        longhands::background_repeat::SpecifiedValue(
+                        vec![longhands::background_repeat::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundAttachment(DeclaredValue::Value(
+                        longhands::background_attachment::SpecifiedValue(
+                        vec![longhands::background_attachment::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundImage(DeclaredValue::Value(
+                        longhands::background_image::SpecifiedValue(
+                        vec![longhands::background_image::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundSize(DeclaredValue::Value(
+                        longhands::background_size::SpecifiedValue(
+                        vec![longhands::background_size::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundOrigin(DeclaredValue::Value(
+                        longhands::background_origin::SpecifiedValue(
+                        vec![longhands::background_origin::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                    (PropertyDeclaration::BackgroundClip(DeclaredValue::Value(
+                        longhands::background_clip::SpecifiedValue(
+                        vec![longhands::background_clip::single_value
+                                                   ::get_initial_specified_value()]))),
+                     Importance::Normal),
+                ]))),
             }))),
             CssRule::Keyframes(Arc::new(RwLock::new(KeyframesRule {
                 name: "foo".into(),
@@ -241,30 +241,24 @@ fn test_parse_stylesheet() {
                     Arc::new(RwLock::new(Keyframe {
                         selector: KeyframeSelector::new_for_unit_testing(
                                       vec![KeyframePercentage::new(0.)]),
-                        block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                            declarations: vec![
-                                (PropertyDeclaration::Width(DeclaredValue::Value(
-                                    LengthOrPercentageOrAuto::Percentage(Percentage(0.)))),
-                                 Importance::Normal),
-                            ],
-                            important_count: 0,
-                        }))
+                        block: Arc::new(RwLock::new(block_from(vec![
+                            (PropertyDeclaration::Width(DeclaredValue::Value(
+                                LengthOrPercentageOrAuto::Percentage(Percentage(0.)))),
+                             Importance::Normal),
+                        ])))
                     })),
                     Arc::new(RwLock::new(Keyframe {
                         selector: KeyframeSelector::new_for_unit_testing(
                                       vec![KeyframePercentage::new(1.)]),
-                        block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                            declarations: vec![
-                                (PropertyDeclaration::Width(DeclaredValue::Value(
-                                    LengthOrPercentageOrAuto::Percentage(Percentage(1.)))),
-                                 Importance::Normal),
-                                (PropertyDeclaration::AnimationPlayState(DeclaredValue::Value(
-                                    animation_play_state::SpecifiedValue(
-                                        vec![animation_play_state::SingleSpecifiedValue::running]))),
-                                 Importance::Normal),
-                            ],
-                            important_count: 0,
-                        })),
+                        block: Arc::new(RwLock::new(block_from(vec![
+                            (PropertyDeclaration::Width(DeclaredValue::Value(
+                                LengthOrPercentageOrAuto::Percentage(Percentage(1.)))),
+                             Importance::Normal),
+                            (PropertyDeclaration::AnimationPlayState(DeclaredValue::Value(
+                                animation_play_state::SpecifiedValue(
+                                    vec![animation_play_state::SingleSpecifiedValue::running]))),
+                             Importance::Normal),
+                        ]))),
                     })),
                 ]
             })))

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -23,14 +23,11 @@ fn get_mock_rules(css_selectors: &[&str]) -> Vec<Vec<Rule>> {
 
         let rule = Arc::new(RwLock::new(StyleRule {
             selectors: selectors,
-            block: Arc::new(RwLock::new(PropertyDeclarationBlock {
-                declarations: vec![
-                    (PropertyDeclaration::Display(DeclaredValue::Value(
-                        longhands::display::SpecifiedValue::block)),
-                     Importance::Normal),
-                ],
-                important_count: 0,
-            })),
+            block: Arc::new(RwLock::new(PropertyDeclarationBlock::with_one(
+                PropertyDeclaration::Display(DeclaredValue::Value(
+                    longhands::display::SpecifiedValue::block)),
+                Importance::Normal
+            ))),
         }));
 
         let guard = rule.read();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15558 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15856)
<!-- Reviewable:end -->
