### PR TITLE
Negative filter check

### DIFF
--- a/components/style/properties/longhand/effects.mako.rs
+++ b/components/style/properties/longhand/effects.mako.rs
@@ -367,8 +367,8 @@ ${helpers.predefined_type("clip",
     fn parse_factor(input: &mut Parser) -> Result<::values::CSSFloat, ()> {
         use cssparser::Token;
         match input.next() {
-            Ok(Token::Number(value)) => Ok(value.value),
-            Ok(Token::Percentage(value)) => Ok(value.unit_value),
+            Ok(Token::Number(value)) if value.value.is_sign_positive() => Ok(value.value),
+            Ok(Token::Percentage(value)) if value.unit_value.is_sign_positive() => Ok(value.unit_value),
             _ => Err(())
         }
     }

--- a/tests/unit/style/parsing/effects.rs
+++ b/tests/unit/style/parsing/effects.rs
@@ -63,3 +63,51 @@ fn test_effects_parser_exhaustion() {
     assert_parser_exhausted!(perspective_origin, "1px some-rubbish", false);
     assert_parser_exhausted!(transform_origin, "1px some-rubbish", false);
 }
+
+#[test]
+fn test_parse_factor() {
+    use parsing::parse;
+    use style::properties::longhands::filter;
+    
+
+
+    assert!(parse(filter::parse, "brightness(0)").is_ok());
+    assert!(parse(filter::parse, "brightness(55)").is_ok());
+    assert!(parse(filter::parse, "brightness(100)").is_ok());
+
+    assert!(parse(filter::parse, "contrast(0)").is_ok());
+    assert!(parse(filter::parse, "contrast(55)").is_ok());
+    assert!(parse(filter::parse, "contrast(100)").is_ok());
+
+    assert!(parse(filter::parse, "grayscale(0)").is_ok());
+    assert!(parse(filter::parse, "grayscale(55)").is_ok());
+    assert!(parse(filter::parse, "grayscale(100)").is_ok());
+
+    assert!(parse(filter::parse, "invert(0)").is_ok());
+    assert!(parse(filter::parse, "invert(55)").is_ok());
+    assert!(parse(filter::parse, "invert(100)").is_ok());
+
+    assert!(parse(filter::parse, "opacity(0)").is_ok());
+    assert!(parse(filter::parse, "opacity(55)").is_ok());
+    assert!(parse(filter::parse, "opacity(100)").is_ok());
+
+    assert!(parse(filter::parse, "sepia(0)").is_ok());
+    assert!(parse(filter::parse, "sepia(55)").is_ok());
+    assert!(parse(filter::parse, "sepia(100)").is_ok());
+
+    assert!(parse(filter::parse, "saturate(0)").is_ok());
+    assert!(parse(filter::parse, "saturate(55)").is_ok());
+    assert!(parse(filter::parse, "saturate(100)").is_ok());
+
+    // Negative numbers are invalid for certain filters
+    assert!(parse(filter::parse, "brightness(-1)").is_err());
+    assert!(parse(filter::parse, "contrast(-1)").is_err());
+    assert!(parse(filter::parse, "grayscale(-1)").is_err());
+    assert!(parse(filter::parse, "invert(-1)").is_err());
+    assert!(parse(filter::parse, "opacity(-1)").is_err());
+    assert!(parse(filter::parse, "sepia(-1)").is_err());
+    assert!(parse(filter::parse, "saturate(-1)").is_err());
+
+
+
+}

--- a/tests/unit/style/parsing/effects.rs
+++ b/tests/unit/style/parsing/effects.rs
@@ -68,8 +68,6 @@ fn test_effects_parser_exhaustion() {
 fn test_parse_factor() {
     use parsing::parse;
     use style::properties::longhands::filter;
-    
-
 
     assert!(parse(filter::parse, "brightness(0)").is_ok());
     assert!(parse(filter::parse, "brightness(55)").is_ok());


### PR DESCRIPTION
Fixes #15494 

Added a negative value check in the `parse_factor ` function in `style/properties/longhand/effects.mako.rs` the test file `tests/unit/style/parsing/effects.rs` was also modified with a new function: `test_parse_factor` to test valid values and invalid values for the affected functions in issue #15494 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15494 
---
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15859)
<!-- Reviewable:end -->
