### PR TITLE
Make text decoration testable and do not serialize initial text-decoration-style

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -41,7 +41,7 @@ use std::collections::LinkedList;
 use std::sync::{Arc, Mutex};
 use style::arc_ptr_eq;
 use style::computed_values::{border_collapse, box_sizing, clear, color, display, mix_blend_mode};
-use style::computed_values::{overflow_wrap, overflow_x, position, text_decoration, transform};
+use style::computed_values::{overflow_wrap, overflow_x, position, text_decoration_line, transform};
 use style::computed_values::{transform_style, vertical_align, white_space, word_break, z_index};
 use style::computed_values::content::ContentItem;
 use style::logical_geometry::{Direction, LogicalMargin, LogicalRect, LogicalSize, WritingMode};
@@ -1419,15 +1419,15 @@ impl Fragment {
         self.style().get_color().color
     }
 
-    /// Returns the text decoration of this fragment, according to the style of the nearest ancestor
+    /// Returns the text decoration line of this fragment, according to the style of the nearest ancestor
     /// element.
     ///
-    /// NB: This may not be the actual text decoration, because of the override rules specified in
+    /// NB: This may not be the actual text decoration line, because of the override rules specified in
     /// CSS 2.1 § 16.3.1. Unfortunately, computing this properly doesn't really fit into Servo's
     /// model. Therefore, this is a best lower bound approximation, but the end result may actually
     /// have the various decoration flags turned on afterward.
-    pub fn text_decoration(&self) -> text_decoration::T {
-        self.style().get_text().text_decoration
+    pub fn text_decoration_line(&self) -> text_decoration_line::T {
+        self.style().get_text().text_decoration_line
     }
 
     /// Returns the inline-start offset from margin edge to content edge.
@@ -2297,7 +2297,7 @@ impl Fragment {
              &SpecificFragmentInfo::UnscannedText(_)) => {
                 // FIXME: Should probably use a whitelist of styles that can safely differ (#3165)
                 if self.style().get_font() != other.style().get_font() ||
-                        self.text_decoration() != other.text_decoration() ||
+                        self.text_decoration_line() != other.text_decoration_line() ||
                         self.white_space() != other.white_space() ||
                         self.color() != other.color() {
                     return false

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -257,6 +257,8 @@ partial interface CSSStyleDeclaration {
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString text-align;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString textDecoration;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString text-decoration;
+  [SetterThrows, TreatNullAs=EmptyString] attribute DOMString textDecorationLine;
+  [SetterThrows, TreatNullAs=EmptyString] attribute DOMString text-decoration-line;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString textIndent;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString text-indent;
   [SetterThrows, TreatNullAs=EmptyString] attribute DOMString textJustify;

--- a/components/style/properties/longhand/text.mako.rs
+++ b/components/style/properties/longhand/text.mako.rs
@@ -101,10 +101,9 @@ ${helpers.single_keyword("unicode-bidi",
                          spec="https://drafts.csswg.org/css-writing-modes/#propdef-unicode-bidi")}
 
 // FIXME: This prop should be animatable.
-<%helpers:longhand name="${'text-decoration' if product == 'servo' else 'text-decoration-line'}"
+<%helpers:longhand name="text-decoration-line"
                    custom_cascade="${product == 'servo'}"
                    animatable="False"
-                   disable_when_testing="True",
                    spec="https://drafts.csswg.org/css-text-decor/#propdef-text-decoration-line">
     use std::fmt;
     use style_traits::ToCss;
@@ -138,6 +137,7 @@ ${helpers.single_keyword("unicode-bidi",
     impl ToCss for SpecifiedValue {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             let mut has_any = false;
+
             macro_rules! write_value {
                 ($line:ident => $css:expr) => {
                     if self.contains($line) {
@@ -156,6 +156,7 @@ ${helpers.single_keyword("unicode-bidi",
             if !has_any {
                 dest.write_str("none")?;
             }
+
             Ok(())
         }
     }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1247,23 +1247,22 @@ pub mod style_structs {
                     self.outline_width != ::app_units::Au(0)
                 }
             % elif style_struct.name == "Text":
-                <% text_decoration_field = 'text_decoration' if product == 'servo' else 'text_decoration_line' %>
                 /// Whether the text decoration has an underline.
                 #[inline]
                 pub fn has_underline(&self) -> bool {
-                    self.${text_decoration_field}.contains(longhands::${text_decoration_field}::UNDERLINE)
+                    self.text_decoration_line.contains(longhands::text_decoration_line::UNDERLINE)
                 }
 
                 /// Whether the text decoration has an overline.
                 #[inline]
                 pub fn has_overline(&self) -> bool {
-                    self.${text_decoration_field}.contains(longhands::${text_decoration_field}::OVERLINE)
+                    self.text_decoration_line.contains(longhands::text_decoration_line::OVERLINE)
                 }
 
                 /// Whether the text decoration has a line through.
                 #[inline]
                 pub fn has_line_through(&self) -> bool {
-                    self.${text_decoration_field}.contains(longhands::${text_decoration_field}::LINE_THROUGH)
+                    self.text_decoration_line.contains(longhands::text_decoration_line::LINE_THROUGH)
                 }
             % endif
         }
@@ -1894,7 +1893,7 @@ pub fn apply_declarations<'a, F, I>(viewport_size: Size2D<Au>,
                 PropertyDeclaration::Color(_) |
                 PropertyDeclaration::Position(_) |
                 PropertyDeclaration::Float(_) |
-                PropertyDeclaration::TextDecoration${'' if product == 'servo' else 'Line'}(_) |
+                PropertyDeclaration::TextDecorationLine(_) |
                 PropertyDeclaration::WritingMode(_) |
                 PropertyDeclaration::Direction(_)
                 % if product == 'gecko':

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -204,7 +204,7 @@ fn compute_damage(old: &ServoComputedValues, new: &ServoComputedValues) -> Servo
         get_font.font_family, get_font.font_style, get_font.font_variant, get_font.font_weight,
         get_font.font_size, get_font.font_stretch,
         get_inheritedbox.direction, get_inheritedbox.writing_mode,
-        get_text.text_decoration, get_text.unicode_bidi,
+        get_text.text_decoration_line, get_text.unicode_bidi,
         get_inheritedtable.empty_cells, get_inheritedtable.caption_side,
         get_column.column_width, get_column.column_count
     ]) || (new.get_box().display == display::T::inline &&

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -117,6 +117,47 @@ mod shorthand_serialization {
         }
     }
 
+    mod text {
+        use style::properties::longhands::text_decoration_line as TextDecorationLine;
+        use style::properties::longhands::text_decoration_style::SpecifiedValue as TextDecorationStyle;
+        use super::*;
+
+        #[test]
+        fn text_decoration_should_show_all_properties_when_set() {
+            let mut properties = Vec::new();
+
+            let line = DeclaredValue::Value(TextDecorationLine::OVERLINE);
+            let style = DeclaredValue::Value(TextDecorationStyle::dotted);
+            let color = DeclaredValue::Value(CSSColor {
+                parsed: ComputedColor::RGBA(RGBA::new(128, 0, 128, 255)),
+                authored: None
+            });
+
+            properties.push(PropertyDeclaration::TextDecorationLine(line));
+            properties.push(PropertyDeclaration::TextDecorationStyle(style));
+            properties.push(PropertyDeclaration::TextDecorationColor(color));
+
+            let serialization = shorthand_properties_to_string(properties);
+            assert_eq!(serialization, "text-decoration: overline dotted rgb(128, 0, 128);");
+        }
+
+        #[test]
+        fn text_decoration_should_not_serialize_initial_style_value() {
+            let mut properties = Vec::new();
+
+            let line = DeclaredValue::Value(TextDecorationLine::UNDERLINE);
+            let style = DeclaredValue::Value(TextDecorationStyle::solid);
+            let color = DeclaredValue::Value(CSSColor::currentcolor());
+
+            properties.push(PropertyDeclaration::TextDecorationLine(line));
+            properties.push(PropertyDeclaration::TextDecorationStyle(style));
+            properties.push(PropertyDeclaration::TextDecorationColor(color));
+
+            let serialization = shorthand_properties_to_string(properties);
+            assert_eq!(serialization, "text-decoration: underline;");
+        }
+    }
+
     mod four_sides_shorthands {
         pub use super::*;
 


### PR DESCRIPTION
Servo now uses the same name for the text-decoration-line longhand property as Gecko. This was done to enable testing of the text-decoration shorthand.

The text-decoration shorthand has been fixed to not serialize initial text-decoration-style.

---

- [x ] `./mach build -d` does not report any errors
- [x ] `./mach test-tidy` does not report any errors
- [x ] These changes fix #15790 

---

- [x ] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15861)
<!-- Reviewable:end -->
