### PR TITLE
Require spaces around operators in calc() (fixes #15486)

### DIFF
--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -584,19 +584,33 @@ impl CalcLengthOrPercentage {
         let mut products = Vec::new();
         products.push(try!(CalcLengthOrPercentage::parse_product(input, expected_unit)));
 
-        while let Ok(token) = input.next() {
-            match token {
-                Token::Delim('+') => {
-                    products.push(try!(CalcLengthOrPercentage::parse_product(input, expected_unit)));
+        loop {
+          let position = input.position();
+          match input.next_including_whitespace() {
+            Ok(Token::WhiteSpace(_)) => {
+              match input.next() {
+                Ok(Token::Delim('+')) => {
+                  products.push(try!(CalcLengthOrPercentage::parse_product(input, expected_unit)));
                 }
-                Token::Delim('-') => {
-                    let mut right = try!(CalcLengthOrPercentage::parse_product(input, expected_unit));
-                    right.values.push(CalcValueNode::Number(-1.));
-                    products.push(right);
+
+                Ok(Token::Delim('-')) => {
+                  let mut right = try!(CalcLengthOrPercentage::parse_product(input, expected_unit));
+                  right.values.push(CalcValueNode::Number(-1.));
+                  products.push(right);
                 }
-                _ => return Err(())
+
+                _ => {
+                  return Err(());
+                }
+             }
             }
-        }
+            _ => {
+                input.reset(position);
+                break
+            }
+          }
+      }
+
 
         Ok(CalcSumNode { products: products })
     }

--- a/tests/unit/style/parsing/length.rs
+++ b/tests/unit/style/parsing/length.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use parsing::parse;
+use style::parser::Parse;
+use style::values::specified::length::Length;
+
+#[test]
+fn test_calc() {
+    assert!(parse(Length::parse, "calc(1px+ 2px)").is_err());
+}

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -87,6 +87,7 @@ mod font;
 mod image;
 mod inherited_box;
 mod inherited_text;
+mod length;
 mod mask;
 mod outline;
 mod position;

--- a/tests/unit/style/rule_tree/bench.rs
+++ b/tests/unit/style/rule_tree/bench.rs
@@ -17,7 +17,7 @@ use test::{self, Bencher};
 
 struct ErrorringErrorReporter;
 impl ParseErrorReporter for ErrorringErrorReporter {
-    fn report_error(&self, input: &mut Parser, position: SourcePosition, message: &str,
+    fn report_error(&self, _input: &mut Parser, position: SourcePosition, message: &str,
         url: &ServoUrl) {
         panic!("CSS error: {}\t\n{:?} {}", url.as_str(), position, message);
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15866)
<!-- Reviewable:end -->
