### PR TITLE
style: Allow trailing whitespace in a calc expression.

### DIFF
--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -588,6 +588,9 @@ impl CalcLengthOrPercentage {
             let position = input.position();
             match input.next_including_whitespace() {
                 Ok(Token::WhiteSpace(_)) => {
+                    if input.is_exhausted() {
+                        break; // allow trailing whitespace
+                    }
                     match input.next() {
                         Ok(Token::Delim('+')) => {
                             products.push(try!(CalcLengthOrPercentage::parse_product(input, expected_unit)));

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -585,33 +585,29 @@ impl CalcLengthOrPercentage {
         products.push(try!(CalcLengthOrPercentage::parse_product(input, expected_unit)));
 
         loop {
-          let position = input.position();
-          match input.next_including_whitespace() {
-            Ok(Token::WhiteSpace(_)) => {
-              match input.next() {
-                Ok(Token::Delim('+')) => {
-                  products.push(try!(CalcLengthOrPercentage::parse_product(input, expected_unit)));
+            let position = input.position();
+            match input.next_including_whitespace() {
+                Ok(Token::WhiteSpace(_)) => {
+                    match input.next() {
+                        Ok(Token::Delim('+')) => {
+                            products.push(try!(CalcLengthOrPercentage::parse_product(input, expected_unit)));
+                        }
+                        Ok(Token::Delim('-')) => {
+                            let mut right = try!(CalcLengthOrPercentage::parse_product(input, expected_unit));
+                            right.values.push(CalcValueNode::Number(-1.));
+                            products.push(right);
+                        }
+                        _ => {
+                            return Err(());
+                        }
+                    }
                 }
-
-                Ok(Token::Delim('-')) => {
-                  let mut right = try!(CalcLengthOrPercentage::parse_product(input, expected_unit));
-                  right.values.push(CalcValueNode::Number(-1.));
-                  products.push(right);
-                }
-
                 _ => {
-                  return Err(());
+                    input.reset(position);
+                    break
                 }
-             }
             }
-            _ => {
-                input.reset(position);
-                break
-            }
-          }
-      }
-
-
+        }
         Ok(CalcSumNode { products: products })
     }
 

--- a/tests/unit/style/parsing/length.rs
+++ b/tests/unit/style/parsing/length.rs
@@ -9,4 +9,7 @@ use style::values::specified::length::Length;
 #[test]
 fn test_calc() {
     assert!(parse(Length::parse, "calc(1px+ 2px)").is_err());
+    assert!(parse(Length::parse, "calc( 1px + 2px )").is_ok());
+    assert!(parse(Length::parse, "calc(1px + 2px )").is_ok());
+    assert!(parse(Length::parse, "calc( 1px + 2px)").is_ok());
 }


### PR DESCRIPTION
This should fix Gecko failures like: https://treeherder.mozilla.org/logviewer.html#?job_id=82470557&repo=autoland&lineNumber=1789

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15873)
<!-- Reviewable:end -->
