### PR TITLE
Skip travis when upstreaming wpt commits.

### DIFF
--- a/tests/wpt/update/upstream.py
+++ b/tests/wpt/update/upstream.py
@@ -42,16 +42,14 @@ def rewrite_patch(patch, strip_dir):
     return Patch(patch.author, patch.email, rewrite_message(patch), new_diff)
 
 def rewrite_message(patch):
-    rest = patch.message.body
-
     if patch.message.bug is not None:
         return "\n".join([patch.message.summary,
                           patch.message.body,
                           "",
-                          "Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=%s" %
+                          "Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=%s [ci skip]" %
                           patch.message.bug])
 
-    return "\n".join([patch.message.full_summary, rest])
+    return "\n".join([patch.message.full_summary, "%s\n[ci skip]\n" % patch.message.body])
 
 
 class SyncToUpstream(Step):


### PR DESCRIPTION
Since we currently just delete the branch before CI runs causing errors
and unnneccessary resource usage.
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because [we don't test the upstreaming code anyway]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15886)
<!-- Reviewable:end -->
