### PR TITLE
Allow for redirects after a CORS-preflight

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -17,7 +17,7 @@ use hyper::mime::{Mime, SubLevel, TopLevel};
 use hyper::status::StatusCode;
 use mime_guess::guess_mime_type;
 use net_traits::{FetchTaskTarget, NetworkError, ReferrerPolicy};
-use net_traits::request::{RedirectMode, Referrer, Request, RequestMode, ResponseTainting};
+use net_traits::request::{Referrer, Request, RequestMode, ResponseTainting};
 use net_traits::request::{Type, Origin, Window};
 use net_traits::response::{Response, ResponseBody, ResponseType};
 use std::borrow::Cow;
@@ -240,7 +240,6 @@ pub fn main_fetch(request: Rc<Request>,
                  (!is_simple_method(&request.method.borrow()) ||
                   request.headers.borrow().iter().any(|h| !is_simple_header(&h)))) {
                 request.response_tainting.set(ResponseTainting::CorsTainting);
-                request.redirect_mode.set(RedirectMode::Error);
                 let response = http_fetch(request.clone(), cache, true, true, false,
                                           target, done_chan, context);
                 if response.is_network_error() {

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -746,11 +746,7 @@ fn http_redirect_fetch(request: Rc<Request>,
     request.redirect_count.set(request.redirect_count.get() + 1);
 
     // Step 7
-    let same_origin = if let Origin::Origin(ref origin) = *request.origin.borrow() {
-        *origin == request.current_url().origin()
-    } else {
-        false
-    };
+    let same_origin = location_url.origin()== request.current_url().origin();
     let has_credentials = has_credentials(&location_url);
 
     if request.mode == RequestMode::CorsMode && !same_origin && has_credentials {

--- a/tests/wpt/metadata/cors/redirect-preflight.htm.ini
+++ b/tests/wpt/metadata/cors/redirect-preflight.htm.ini
@@ -1,0 +1,17 @@
+[redirect-preflight.htm]
+  type: testharness
+  [Disallow redirect 301 after succesful (200) preflight]
+    expected: FAIL
+
+  [Disallow redirect 302 after succesful (200) preflight]
+    expected: FAIL
+
+  [Disallow redirect 303 after succesful (200) preflight]
+    expected: FAIL
+
+  [Disallow redirect 307 after succesful (200) preflight]
+    expected: FAIL
+
+  [Disallow redirect 308 after succesful (200) preflight]
+    expected: FAIL
+

--- a/tests/wpt/metadata/cors/redirect-userinfo.htm.ini
+++ b/tests/wpt/metadata/cors/redirect-userinfo.htm.ini
@@ -1,5 +1,0 @@
-[redirect-userinfo.htm]
-  type: testharness
-  [Allow redirect with userinfo (//@)]
-    expected: FAIL
-

--- a/tests/wpt/metadata/eventsource/eventsource-cross-origin.htm.ini
+++ b/tests/wpt/metadata/eventsource/eventsource-cross-origin.htm.ini
@@ -1,9 +1,5 @@
 [eventsource-cross-origin.htm]
   type: testharness
-  expected: TIMEOUT
-  [EventSource: cross-origin redirect use]
-    expected: TIMEOUT
-
   [EventSource: cross-origin allow-origin: http://example.org should fail]
     expected: FAIL
 

--- a/tests/wpt/metadata/fetch/api/request/request-init-001.sub.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-init-001.sub.html.ini
@@ -8,3 +8,4 @@
 
   [Check referrerPolicy init value of same-origin and associated getter]
     expected: FAIL
+

--- a/tests/wpt/metadata/fetch/api/request/request-structure.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-structure.html.ini
@@ -2,3 +2,4 @@
   type: testharness
   [Request has arrayBuffer method]
     expected: FAIL
+

--- a/tests/wpt/mozilla/meta/css/viewport_meta.html.ini
+++ b/tests/wpt/mozilla/meta/css/viewport_meta.html.ini
@@ -1,1 +1,3 @@
 prefs: [layout.viewport.enabled:true]
+[viewport_meta.html]
+  type: reftest

--- a/tests/wpt/mozilla/meta/css/viewport_rule.html.ini
+++ b/tests/wpt/mozilla/meta/css/viewport_rule.html.ini
@@ -1,1 +1,3 @@
 prefs: [layout.viewport.enabled:true]
+[viewport_rule.html]
+  type: reftest


### PR DESCRIPTION
~Continue the work done in #14811 and #15547~. And applies the Fetch [spec change](https://github.com/whatwg/fetch/commit/0d9a4db8bc02251cc9e391543bb3c1322fb882f2) about [allowing redirects after CORS preflights](https://github.com/whatwg/fetch/issues/204).

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix ~#14787 and~ #14519
- [X] There are tests for these changes. Several WPTs go from FAIL to SUCCESS. The new expected FAILs for the cors/redirect-preflight.htm tests are caused by the spec change done [here](https://github.com/whatwg/fetch/commit/0d9a4db8bc02251cc9e391543bb3c1322fb882f2), as suggested in the associated [issue](https://github.com/servo/servo/issues/14519#issuecomment-284384667).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15889)
<!-- Reviewable:end -->
