### PR TITLE
Change the predefined type of flex-basis and make gecko glue auto-generate

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -612,12 +612,6 @@ impl Debug for ${style_struct.gecko_struct_name} {
     # These have unusual representations in gecko.
     force_stub += ["list-style-type"]
 
-    # These are part of shorthands so we must include them in stylo builds,
-    # but we haven't implemented the stylo glue for the longhand
-    # so we generate a stub
-    force_stub += ["flex-basis", # position
-                   ]
-
     # Types used with predefined_type()-defined properties that we can auto-generate.
     predefined_types = {
         "length::LengthOrAuto": impl_style_coord,

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -195,13 +195,16 @@ ${helpers.predefined_type("flex-shrink", "Number",
     }
 </%helpers:longhand>
 
+// FIXME: Gecko doesn't support content value yet.
 // FIXME: This property should be animatable.
 ${helpers.predefined_type("flex-basis",
+                          "LengthOrPercentageOrAuto" if product == "gecko" else
                           "LengthOrPercentageOrAutoOrContent",
+                          "computed::LengthOrPercentageOrAuto::Auto" if product == "gecko" else
                           "computed::LengthOrPercentageOrAutoOrContent::Auto",
                           spec="https://drafts.csswg.org/css-flexbox/#flex-basis-property",
                           extra_prefixes="webkit",
-                          animatable=False)}
+                          animatable=True if product == "gecko" else False)}
 
 % for (size, logical) in ALL_SIZES:
     <%

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -49,7 +49,12 @@
 <%helpers:shorthand name="flex" sub_properties="flex-grow flex-shrink flex-basis" extra_prefixes="webkit"
                     spec="https://drafts.csswg.org/css-flexbox/#flex-property">
     use parser::Parse;
-    use values::specified::{Number, NoCalcLength, LengthOrPercentageOrAutoOrContent};
+    use values::specified::{Number, NoCalcLength};
+    % if product == "gecko":
+        use values::specified::LengthOrPercentageOrAuto;
+    % else:
+        use values::specified::LengthOrPercentageOrAutoOrContent;
+    % endif
 
     pub fn parse_flexibility(input: &mut Parser)
                              -> Result<(Number, Option<Number>),()> {
@@ -67,7 +72,12 @@
             return Ok(Longhands {
                 flex_grow: Number(0.0),
                 flex_shrink: Number(0.0),
-                flex_basis: LengthOrPercentageOrAutoOrContent::Auto
+                % if product == "gecko":
+                    flex_basis: LengthOrPercentageOrAuto::Auto
+                % else:
+                    flex_basis: LengthOrPercentageOrAutoOrContent::Auto
+                % endif
+
             })
         }
         loop {
@@ -79,7 +89,11 @@
                 }
             }
             if basis.is_none() {
-                if let Ok(value) = input.try(|i| LengthOrPercentageOrAutoOrContent::parse(context, i)) {
+                % if product == "gecko":
+                    if let Ok(value) = input.try(|i| LengthOrPercentageOrAuto::parse(context, i)) {
+                % else:
+                    if let Ok(value) = input.try(|i| LengthOrPercentageOrAutoOrContent::parse(context, i)) {
+                % endif
                     basis = Some(value);
                     continue
                 }
@@ -93,7 +107,11 @@
         Ok(Longhands {
             flex_grow: grow.unwrap_or(Number(1.0)),
             flex_shrink: shrink.unwrap_or(Number(1.0)),
-            flex_basis: basis.unwrap_or(LengthOrPercentageOrAutoOrContent::Length(NoCalcLength::zero()))
+            % if product == "gecko":
+                flex_basis: basis.unwrap_or(LengthOrPercentageOrAuto::Length(NoCalcLength::zero()))
+            % else:
+                flex_basis: basis.unwrap_or(LengthOrPercentageOrAutoOrContent::Length(NoCalcLength::zero()))
+            % endif
         })
     }
 


### PR DESCRIPTION
Gecko [doesn't support](https://bugzilla.mozilla.org/show_bug.cgi?id=1105111) content value in flex-basis yet. We had to change the predefined type to `LengthOrPercentageOrAuto` in stylo build.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1331529](https://bugzilla.mozilla.org/show_bug.cgi?id=1331529)

<!-- Either: -->
- [X] These changes do not require tests because it's stylo glue change.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15896)
<!-- Reviewable:end -->
