### PR TITLE
Access browsing context safely

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -390,7 +390,7 @@ impl Document {
     #[inline]
     pub fn browsing_context(&self) -> Option<Root<BrowsingContext>> {
         if self.has_browsing_context {
-            Some(self.window.browsing_context())
+            self.window.maybe_browsing_context()
         } else {
             None
         }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -319,8 +319,13 @@ impl Window {
         &self.image_cache_thread
     }
 
+    /// This can panic if it is called after the browsing context has been discarded
     pub fn browsing_context(&self) -> Root<BrowsingContext> {
         self.browsing_context.get().unwrap()
+    }
+
+    pub fn maybe_browsing_context(&self) -> Option<Root<BrowsingContext>> {
+        self.browsing_context.get()
     }
 
     pub fn bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
@@ -608,7 +613,7 @@ impl WindowMethods for Window {
     // https://html.spec.whatwg.org/multipage/#dom-parent
     fn GetParent(&self) -> Option<Root<BrowsingContext>> {
         // Steps 1. and 2.
-        if self.browsing_context().is_discarded() {
+        if self.maybe_browsing_context().map_or(true, |c| c.is_discarded()) {
             return None;
         }
         match self.parent() {
@@ -622,7 +627,7 @@ impl WindowMethods for Window {
     // https://html.spec.whatwg.org/multipage/#dom-top
     fn GetTop(&self) -> Option<Root<BrowsingContext>> {
         // Steps 1. and 2.
-        if self.browsing_context().is_discarded() {
+        if self.maybe_browsing_context().map_or(true, |c| c.is_discarded()) {
             return None;
         }
         // Step 5.


### PR DESCRIPTION
Current browsing context accessor in `Document` unwraps the browsing context `Option` which prevents document to handle correctly the case when there is no browsing context.

This is the reason servo panics with `session-history.max-length=1` (https://github.com/servo/servo/issues/15877).

As it is my first contribution, I added a `safe` method to retrieve the browsing context rather than change the existing method, but I am happy to change if you think this is the right approach. I did not as well replace all existing method call to the `safe` method, to focus on fixing the issue.

If someone can give me a bit of guidance for the test, I will try to contribute one.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [X] These changes fix #15877.
- [ ] There are tests for these changes 

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15906)
<!-- Reviewable:end -->
