### PR TITLE
Fix wrong initial values in various single keyword properties

### DIFF
--- a/components/style/properties/longhand/column.mako.rs
+++ b/components/style/properties/longhand/column.mako.rs
@@ -114,9 +114,9 @@ ${helpers.predefined_type("column-gap",
                           animatable=False,
                           spec="https://drafts.csswg.org/css-multicol/#propdef-column-gap")}
 
-${helpers.single_keyword("column-fill", "auto balance", extra_prefixes="moz",
+${helpers.single_keyword("column-fill", "balance auto", extra_prefixes="moz",
                          products="gecko", animatable=False,
-                         spec="https://drafts.csswg.org/css-multicol/#propdef-column-gap")}
+                         spec="https://drafts.csswg.org/css-multicol/#propdef-column-fill")}
 
 // https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-width
 <%helpers:longhand name="column-rule-width" products="gecko" animatable="True" extra_prefixes="moz"

--- a/components/style/properties/longhand/inherited_svg.mako.rs
+++ b/components/style/properties/longhand/inherited_svg.mako.rs
@@ -22,12 +22,12 @@ ${helpers.single_keyword("text-anchor",
 
 // Section 11 - Painting: Filling, Stroking and Marker Symbols
 ${helpers.single_keyword("color-interpolation",
-                         "auto srgb linearrgb",
+                         "srgb auto linearrgb",
                          products="gecko",
                          animatable=False,
                          spec="https://www.w3.org/TR/SVG11/painting.html#ColorInterpolationProperty")}
 
-${helpers.single_keyword("color-interpolation-filters", "auto srgb linearrgb",
+${helpers.single_keyword("color-interpolation-filters", "linearrgb auto srgb",
                          products="gecko",
                          gecko_constant_prefix="NS_STYLE_COLOR_INTERPOLATION",
                          animatable=False,

--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -164,7 +164,7 @@ ${helpers.single_keyword("text-transform",
                          animatable=False,
                          spec="https://drafts.csswg.org/css-text/#propdef-text-transform")}
 
-${helpers.single_keyword("hyphens", "none manual auto",
+${helpers.single_keyword("hyphens", "manual none auto",
                          gecko_enum_prefix="StyleHyphens",
                          products="gecko", animatable=False, extra_prefixes="moz",
                          spec="https://drafts.csswg.org/css-text/#propdef-hyphens")}
@@ -1133,7 +1133,7 @@ ${helpers.predefined_type(
 
 // CSS Ruby Layout Module Level 1
 // https://drafts.csswg.org/css-ruby/
-${helpers.single_keyword("ruby-align", "start center space-between space-around",
+${helpers.single_keyword("ruby-align", "space-around start center space-between",
                          products="gecko", animatable=False,
                          spec="https://drafts.csswg.org/css-ruby/#ruby-align-property")}
 

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -86,7 +86,7 @@ ${helpers.single_keyword("flex-wrap", "nowrap wrap wrap-reverse",
 
 % if product == "servo":
     // FIXME: Update Servo to support the same Syntax as Gecko.
-    ${helpers.single_keyword("justify-content", "stretch flex-start flex-end center space-between space-around",
+    ${helpers.single_keyword("justify-content", "flex-start stretch flex-end center space-between space-around",
                              extra_prefixes="webkit",
                              spec="https://drafts.csswg.org/css-align/#propdef-justify-content",
                              animatable=False)}

--- a/components/style/properties/longhand/svg.mako.rs
+++ b/components/style/properties/longhand/svg.mako.rs
@@ -87,7 +87,7 @@ ${helpers.single_keyword("mask-type", "luminance alpha",
 </%helpers:longhand>
 
 ${helpers.single_keyword("mask-mode",
-                         "alpha luminance match-source",
+                         "match-source alpha luminance",
                          vector=True,
                          products="gecko",
                          animatable=False,
@@ -146,7 +146,7 @@ ${helpers.single_keyword("mask-repeat",
 </%helpers:vector_longhand>
 
 ${helpers.single_keyword("mask-clip",
-                         "content-box padding-box border-box",
+                         "border-box content-box padding-box",
                          extra_gecko_values="fill-box stroke-box view-box no-clip",
                          vector=True,
                          products="gecko",
@@ -155,7 +155,7 @@ ${helpers.single_keyword("mask-clip",
                          spec="https://drafts.fxtf.org/css-masking/#propdef-mask-clip")}
 
 ${helpers.single_keyword("mask-origin",
-                         "content-box padding-box border-box",
+                         "border-box content-box padding-box",
                          extra_gecko_values="fill-box stroke-box view-box",
                          vector=True,
                          products="gecko",

--- a/components/style/properties/longhand/ui.mako.rs
+++ b/components/style/properties/longhand/ui.mako.rs
@@ -11,7 +11,7 @@
 
 // TODO spec says that UAs should not support this
 // we should probably remove from gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1328331)
-${helpers.single_keyword("ime-mode", "normal auto active disabled inactive",
+${helpers.single_keyword("ime-mode", "auto normal active disabled inactive",
                          products="gecko", gecko_ffi_name="mIMEMode",
                          animatable=False,
                          spec="https://drafts.csswg.org/css-ui/#input-method-editor")}


### PR DESCRIPTION
In `single_properties` helper, first values set as initial value. But it seems like a problem here because it's not clear to anyone who don't know the working mechanism of this helper or it can be easily forgotten. Maybe we should make it explicit. I was fixing Bug 1331516 but expanded to cover all single keyword properties.

Also discovered that mask-repeat's initial value is [wrong](https://bugzilla.mozilla.org/show_bug.cgi?id=1346193) in gecko.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] This PR started to fix [Bug 1331516](https://bugzilla.mozilla.org/show_bug.cgi?id=1331516) but expanded to cover all single keyword properties afterwards.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15908)
<!-- Reviewable:end -->
