### PR TITLE
Add support for skipping display fixup for pseudos.

### DIFF
--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -21,7 +21,7 @@ use style::context::SharedStyleContext;
 use style::data::ElementData;
 use style::dom::{LayoutIterator, NodeInfo, PresentationalHintsSynthetizer, TNode};
 use style::dom::OpaqueNode;
-use style::properties::ServoComputedValues;
+use style::properties::{CascadeFlags, ServoComputedValues};
 use style::selector_parser::{PseudoElement, PseudoElementCascadeType, SelectorImpl};
 
 #[derive(Copy, PartialEq, Clone, Debug)]
@@ -408,7 +408,7 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
                                     &style_pseudo,
                                     Some(data.styles().primary.values()),
                                     &context.default_computed_values,
-                                    false);
+                                    CascadeFlags::empty());
                             data.styles_mut().pseudos
                                 .insert(style_pseudo.clone(), new_style);
                         }

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1666,6 +1666,7 @@ extern "C" {
     pub fn Servo_ComputedValues_GetForAnonymousBox(parent_style_or_null:
                                                        ServoComputedValuesBorrowedOrNull,
                                                    pseudoTag: *mut nsIAtom,
+                                                   skip_display_fixup: bool,
                                                    set:
                                                        RawServoStyleSetBorrowed)
      -> ServoComputedValuesStrong;


### PR DESCRIPTION
This is needed for https://bugzilla.mozilla.org/show_bug.cgi?id=1346481

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because will be tested on the Gecko side

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15910)
<!-- Reviewable:end -->
