### PR TITLE
Issue #15858: Don't crash if an image uses a map that is defined before it

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -12,6 +12,7 @@ use dom::bindings::codegen::Bindings::ElementBinding::ElementBinding::ElementMet
 use dom::bindings::codegen::Bindings::HTMLImageElementBinding;
 use dom::bindings::codegen::Bindings::HTMLImageElementBinding::HTMLImageElementMethods;
 use dom::bindings::codegen::Bindings::MouseEventBinding::MouseEventMethods;
+use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::error::Fallible;
 use dom::bindings::inheritance::Castable;
@@ -432,10 +433,18 @@ impl HTMLImageElement {
             _ => {},
         };
 
-        let map = self.upcast::<Node>()
-                      .following_siblings()
-                      .filter_map(Root::downcast::<HTMLMapElement>)
-                      .find(|n| n.upcast::<Element>().get_string_attribute(&LocalName::from("name")) == last);
+        let parent = match self.upcast::<Node>().GetParentNode() {
+            None => return None,
+            Some(p) => p,
+        };
+
+        let map = parent.children()
+                        .filter_map(Root::downcast::<HTMLMapElement>)
+                        .find(|n| n.upcast::<Element>().get_string_attribute(&LocalName::from("name")) == last);
+        match map {
+            None => return None,
+            _ => {},
+        };
 
         let elements: Vec<Root<HTMLAreaElement>> = map.unwrap().upcast::<Node>()
                       .children()

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12904,6 +12904,12 @@
      {}
     ]
    ],
+   "mozilla/img_usemap.html": [
+    [
+     "/_mozilla/mozilla/img_usemap.html",
+     {}
+    ]
+   ],
    "mozilla/img_width_height.html": [
     [
      "/_mozilla/mozilla/img_width_height.html",
@@ -25393,6 +25399,10 @@
   ],
   "mozilla/img_multiple_request.html": [
    "0a6263ad87c9b3307f2dc694747b094a0517b79b",
+   "testharness"
+  ],
+  "mozilla/img_usemap.html": [
+   "b4477c129d1a00f7d65bf298bedc976e0a42a622",
    "testharness"
   ],
   "mozilla/img_width_height.html": [

--- a/tests/wpt/mozilla/tests/mozilla/img_usemap.html
+++ b/tests/wpt/mozilla/tests/mozilla/img_usemap.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<meta charset="utf-8">
+<html>
+    <body>
+        <title>Test for issue #15858</title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <map name="my_map" id="my_map">
+            <area shape="rect" coords="0,0,100,100"/>
+        </map>
+        <img usemap="#my_map" src="2x2.png" id="my_img"/>
+        <img usemap="#my_unk_map" src="2x2.png" id="my_img_unk_map"/>
+
+        <script>
+            var test = async_test("ImageClickShouldNotCrash");
+            var img = document.getElementById('my_img');
+            var img_clicked = false;
+            img.onclick = function(e) { img_clicked = true; return true; };
+            document.addEventListener("DOMContentLoaded", function() {
+                test.step(function() {
+                    document.getElementById('my_img').click()
+                });
+            });
+            test.step_timeout(function() { assert_true(img_clicked, "Image click expected"); test.done(); }, 500);
+
+            var test_unkmap = async_test("ImageClickShouldNotCrashUnknownMap");
+            var img_unkmap = document.getElementById('my_img_unk_map');
+            var img_unk_clicked = false;
+            img_unkmap.onclick = function(e) { img_unk_clicked = true; return true; };
+            document.addEventListener("DOMContentLoaded", function() {
+                test_unkmap.step(function() {
+                    document.getElementById('my_img_unk_map').click()
+                });
+            });
+            test_unkmap.step_timeout(function() { assert_true(img_unk_clicked, "Image click expected"); test_unkmap.done(); }, 500);
+        </script>
+
+    </body>
+</html>


### PR DESCRIPTION
The map referenced in an img element might have been declared before, while the code expected it to always be after. This patch fixes this.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15858
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15914)
<!-- Reviewable:end -->
