### PR TITLE
Stylo: Add support for "font-family: -moz-fixed"

### DIFF
--- a/components/style/gecko_string_cache/atom_macro.rs
+++ b/components/style/gecko_string_cache/atom_macro.rs
@@ -4296,6 +4296,8 @@ cfg_if! {
             pub static nsGkAtoms_fantasy: *mut nsIAtom;
             #[link_name = "_ZN9nsGkAtoms9monospaceE"]
             pub static nsGkAtoms_monospace: *mut nsIAtom;
+            #[link_name = "_ZN9nsGkAtoms8mozfixedE"]
+            pub static nsGkAtoms_mozfixed: *mut nsIAtom;
             #[link_name = "_ZN9nsGkAtoms6RemoteE"]
             pub static nsGkAtoms_Remote: *mut nsIAtom;
             #[link_name = "_ZN9nsGkAtoms8RemoteIdE"]
@@ -9221,6 +9223,8 @@ cfg_if! {
             pub static nsGkAtoms_fantasy: *mut nsIAtom;
             #[link_name = "?monospace@nsGkAtoms@@2PEAVnsIAtom@@EA"]
             pub static nsGkAtoms_monospace: *mut nsIAtom;
+            #[link_name = "?mozfixed@nsGkAtoms@@2PEAVnsIAtom@@EA"]
+            pub static nsGkAtoms_mozfixed: *mut nsIAtom;
             #[link_name = "?Remote@nsGkAtoms@@2PEAVnsIAtom@@EA"]
             pub static nsGkAtoms_Remote: *mut nsIAtom;
             #[link_name = "?RemoteId@nsGkAtoms@@2PEAVnsIAtom@@EA"]
@@ -14146,6 +14150,8 @@ cfg_if! {
             pub static nsGkAtoms_fantasy: *mut nsIAtom;
             #[link_name = "\x01?monospace@nsGkAtoms@@2PAVnsIAtom@@A"]
             pub static nsGkAtoms_monospace: *mut nsIAtom;
+            #[link_name = "\x01?mozfixed@nsGkAtoms@@2PAVnsIAtom@@A"]
+            pub static nsGkAtoms_mozfixed: *mut nsIAtom;
             #[link_name = "\x01?Remote@nsGkAtoms@@2PAVnsIAtom@@A"]
             pub static nsGkAtoms_Remote: *mut nsIAtom;
             #[link_name = "\x01?RemoteId@nsGkAtoms@@2PAVnsIAtom@@A"]
@@ -19074,6 +19080,8 @@ macro_rules! atom {
   { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_fantasy as *mut _) } };
 ("monospace") =>
   { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_monospace as *mut _) } };
+("-moz-fixed") =>
+  { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_mozfixed as *mut _) } };
 ("remote") =>
   { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_Remote as *mut _) } };
 ("_remote_id") =>

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1183,6 +1183,7 @@ fn static_assert() {
                         else if name == &atom!("cursive") { FontFamilyType::eFamily_cursive }
                         else if name == &atom!("fantasy") { FontFamilyType::eFamily_fantasy }
                         else if name == &atom!("monospace") { FontFamilyType::eFamily_monospace }
+                        else if name == &atom!("-moz-fixed") { FontFamilyType::eFamily_moz_fixed }
                         else { panic!("Unknown generic font family") };
                     unsafe { Gecko_FontFamilyList_AppendGeneric(list, family_type); }
                 }

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -57,6 +57,9 @@
                     atom!("sans-serif") |
                     atom!("cursive") |
                     atom!("fantasy") |
+                    % if product == "gecko":
+                        atom!("-moz-fixed") |
+                    % endif
                     atom!("monospace") => {
                         return FontFamily::Generic(input)
                     }
@@ -67,6 +70,9 @@
                     "sans-serif" => return FontFamily::Generic(atom!("sans-serif")),
                     "cursive" => return FontFamily::Generic(atom!("cursive")),
                     "fantasy" => return FontFamily::Generic(atom!("fantasy")),
+                    % if product == "gecko":
+                        "-moz-fixed" => return FontFamily::Generic(atom!("-moz-fixed")),
+                    % endif
                     "monospace" => return FontFamily::Generic(atom!("monospace")),
                     _ => {}
                 }
@@ -90,6 +96,9 @@
                     "cursive" => return Ok(FontFamily::Generic(atom!("cursive"))),
                     "fantasy" => return Ok(FontFamily::Generic(atom!("fantasy"))),
                     "monospace" => return Ok(FontFamily::Generic(atom!("monospace"))),
+                    % if product == "gecko":
+                        "-moz-fixed" => return Ok(FontFamily::Generic(atom!("-moz-fixed"))),
+                    % endif
 
                     // https://drafts.csswg.org/css-fonts/#propdef-font-family
                     // "Font family names that happen to be the same as a keyword value
@@ -135,7 +144,17 @@
                     FontFamily::FamilyName(ref name) => name.to_css(dest),
 
                     // All generic values accepted by the parser are known to not require escaping.
-                    FontFamily::Generic(ref name) => write!(dest, "{}", name),
+                    FontFamily::Generic(ref name) => {
+                        % if product == "gecko":
+                            // We should treat -moz-fixed as monospace
+                            if name == &atom!("-moz-fixed") {
+                                return write!(dest, "monospace");
+                            }
+                            write!(dest, "{}", name)
+                        % else:
+                            write!(dest, "{}", name)
+                        % endif
+                    },
                 }
             }
         }


### PR DESCRIPTION
Added support for "font-family: -moz-fixed" for stylo 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1341637](https://bugzilla.mozilla.org/show_bug.cgi?id=1341637)

<!-- Either: -->
- [X] These changes do not require tests because it's stylo change

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15916)
<!-- Reviewable:end -->
