### PR TITLE
PropertyDeclaration with CSSWideKeyword is parsed

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1174,7 +1174,9 @@ impl PropertyDeclaration {
     pub fn value_is_unparsed(&self) -> bool {
       match *self {
           PropertyDeclaration::WithVariables(..) => true,
-          PropertyDeclaration::Custom(..) => true,
+          PropertyDeclaration::Custom(_, ref value) => {
+            !matches!(value.borrow(), DeclaredValue::CSSWideKeyword(..))
+          }
           _ => false,
       }
     }

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -1124,4 +1124,25 @@ mod shorthand_serialization {
             assert_eq!(serialization, block_text);
         }
     }
+
+    mod keywords {
+        pub use super::*;
+        #[test]
+        fn css_wide_keywords_should_be_parsed() {
+            let block_text = "--a:inherit;";
+            let block = parse_declaration_block(block_text);
+
+            let serialization = block.to_css_string();
+            assert_eq!(serialization, "--a: inherit;");
+        }
+
+        #[test]
+        fn non_keyword_custom_property_should_be_unparsed() {
+            let block_text = "--main-color: #06c;";
+            let block = parse_declaration_block(block_text);
+
+            let serialization = block.to_css_string();
+            assert_eq!(serialization, block_text);
+        }
+    }
 }


### PR DESCRIPTION
Addresses #15401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15918)
<!-- Reviewable:end -->
