### PR TITLE
Implement access to CSSMediaRule for stylo

### DIFF
--- a/components/style/gecko/arc_types.rs
+++ b/components/style/gecko/arc_types.rs
@@ -8,14 +8,16 @@
 
 #![allow(non_snake_case, missing_docs)]
 
+use gecko_bindings::bindings::{RawServoMediaList, RawServoMediaRule};
 use gecko_bindings::bindings::{RawServoStyleSheet, RawServoStyleRule, RawServoImportRule};
 use gecko_bindings::bindings::{ServoComputedValues, ServoCssRules};
 use gecko_bindings::structs::{RawServoAnimationValue, RawServoDeclarationBlock};
 use gecko_bindings::sugar::ownership::{HasArcFFI, HasFFI};
+use media_queries::MediaList;
 use parking_lot::RwLock;
 use properties::{ComputedValues, PropertyDeclarationBlock};
 use properties::animated_properties::AnimationValue;
-use stylesheets::{CssRules, Stylesheet, StyleRule, ImportRule};
+use stylesheets::{CssRules, Stylesheet, StyleRule, ImportRule, MediaRule};
 
 macro_rules! impl_arc_ffi {
     ($servo_type:ty => $gecko_type:ty [$addref:ident, $release:ident]) => {
@@ -56,3 +58,9 @@ impl_arc_ffi!(RwLock<ImportRule> => RawServoImportRule
 
 impl_arc_ffi!(AnimationValue => RawServoAnimationValue
               [Servo_AnimationValue_AddRef, Servo_AnimationValue_Release]);
+
+impl_arc_ffi!(RwLock<MediaList> => RawServoMediaList
+              [Servo_MediaList_AddRef, Servo_MediaList_Release]);
+
+impl_arc_ffi!(RwLock<MediaRule> => RawServoMediaRule
+              [Servo_MediaRule_AddRef, Servo_MediaRule_Release]);

--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -137,8 +137,15 @@ impl ToCss for Expression {
     }
 }
 
+impl PartialEq for Expression {
+    fn eq(&self, other: &Expression) -> bool {
+        self.feature.mName == other.feature.mName &&
+            self.value == other.value && self.range == other.range
+    }
+}
+
 /// A resolution.
-#[derive(Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Resolution {
     /// Dots per inch.
     Dpi(CSSFloat),
@@ -200,7 +207,7 @@ unsafe fn string_from_ns_string_buffer(buffer: *const nsStringBuffer) -> String 
 }
 
 /// A value found or expected in a media expression.
-#[derive(Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum MediaExpressionValue {
     /// A length.
     Length(specified::Length),

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -4,6 +4,16 @@ pub use nsstring::{nsACString, nsAString, nsString};
 type nsACString_internal = nsACString;
 type nsAString_internal = nsAString;
 use gecko_bindings::structs::mozilla::css::URLValue;
+pub type RawServoMediaListStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoMediaList>;
+pub type RawServoMediaListBorrowedOrNull<'a> = Option<&'a RawServoMediaList>;
+pub type RawServoMediaListBorrowed<'a> = &'a RawServoMediaList;
+enum RawServoMediaListVoid{ }
+pub struct RawServoMediaList(RawServoMediaListVoid);
+pub type RawServoMediaRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoMediaRule>;
+pub type RawServoMediaRuleBorrowedOrNull<'a> = Option<&'a RawServoMediaRule>;
+pub type RawServoMediaRuleBorrowed<'a> = &'a RawServoMediaRule;
+enum RawServoMediaRuleVoid{ }
+pub struct RawServoMediaRule(RawServoMediaRuleVoid);
 use gecko_bindings::structs::RawGeckoDocument;
 use gecko_bindings::structs::RawGeckoElement;
 use gecko_bindings::structs::RawGeckoKeyframeList;
@@ -287,10 +297,22 @@ extern "C" {
                                               RawServoDeclarationBlockBorrowed);
 }
 extern "C" {
+    pub fn Servo_MediaList_AddRef(ptr: RawServoMediaListBorrowed);
+}
+extern "C" {
+    pub fn Servo_MediaList_Release(ptr: RawServoMediaListBorrowed);
+}
+extern "C" {
     pub fn Servo_StyleRule_AddRef(ptr: RawServoStyleRuleBorrowed);
 }
 extern "C" {
     pub fn Servo_StyleRule_Release(ptr: RawServoStyleRuleBorrowed);
+}
+extern "C" {
+    pub fn Servo_MediaRule_AddRef(ptr: RawServoMediaRuleBorrowed);
+}
+extern "C" {
+    pub fn Servo_MediaRule_Release(ptr: RawServoMediaRuleBorrowed);
 }
 extern "C" {
     pub fn Servo_ImportRule_AddRef(ptr: RawServoImportRuleBorrowed);
@@ -1329,6 +1351,11 @@ extern "C" {
      -> RawServoStyleRuleStrong;
 }
 extern "C" {
+    pub fn Servo_CssRules_GetMediaRuleAt(rules: ServoCssRulesBorrowed,
+                                         index: u32)
+     -> RawServoMediaRuleStrong;
+}
+extern "C" {
     pub fn Servo_CssRules_InsertRule(rules: ServoCssRulesBorrowed,
                                      sheet: RawServoStyleSheetBorrowed,
                                      rule: *const nsACString_internal,
@@ -1359,6 +1386,22 @@ extern "C" {
 extern "C" {
     pub fn Servo_StyleRule_GetSelectorText(rule: RawServoStyleRuleBorrowed,
                                            result: *mut nsAString_internal);
+}
+extern "C" {
+    pub fn Servo_MediaRule_Debug(rule: RawServoMediaRuleBorrowed,
+                                 result: *mut nsACString_internal);
+}
+extern "C" {
+    pub fn Servo_MediaRule_GetMedia(rule: RawServoMediaRuleBorrowed)
+     -> RawServoMediaListStrong;
+}
+extern "C" {
+    pub fn Servo_MediaRule_GetRules(rule: RawServoMediaRuleBorrowed)
+     -> ServoCssRulesStrong;
+}
+extern "C" {
+    pub fn Servo_MediaRule_GetCssText(rule: RawServoMediaRuleBorrowed,
+                                      result: *mut nsAString_internal);
 }
 extern "C" {
     pub fn Servo_ParseProperty(property: *const nsACString_internal,

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1628,6 +1628,34 @@ extern "C" {
                                                                      RawServoDeclarationBlockBorrowed);
 }
 extern "C" {
+    pub fn Servo_MediaList_GetText(list: RawServoMediaListBorrowed,
+                                   result: *mut nsAString_internal);
+}
+extern "C" {
+    pub fn Servo_MediaList_SetText(list: RawServoMediaListBorrowed,
+                                   text: *const nsACString_internal);
+}
+extern "C" {
+    pub fn Servo_MediaList_GetLength(list: RawServoMediaListBorrowed) -> u32;
+}
+extern "C" {
+    pub fn Servo_MediaList_GetMediumAt(list: RawServoMediaListBorrowed,
+                                       index: u32,
+                                       result: *mut nsAString_internal)
+     -> bool;
+}
+extern "C" {
+    pub fn Servo_MediaList_AppendMedium(list: RawServoMediaListBorrowed,
+                                        new_medium:
+                                            *const nsACString_internal);
+}
+extern "C" {
+    pub fn Servo_MediaList_DeleteMedium(list: RawServoMediaListBorrowed,
+                                        old_medium:
+                                            *const nsACString_internal)
+     -> bool;
+}
+extern "C" {
     pub fn Servo_CSSSupports2(name: *const nsACString_internal,
                               value: *const nsACString_internal) -> bool;
 }

--- a/components/style/media_queries.rs
+++ b/components/style/media_queries.rs
@@ -66,7 +66,7 @@ impl ToCss for Qualifier {
 /// A [media query][mq].
 ///
 /// [mq]: https://drafts.csswg.org/mediaqueries/
-#[derive(Clone, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct MediaQuery {
     /// The qualifier for this query.
@@ -298,5 +298,38 @@ impl MediaList {
     /// Whether this `MediaList` contains no media queries.
     pub fn is_empty(&self) -> bool {
         self.media_queries.is_empty()
+    }
+
+    /// Append a new media query item to the media list.
+    /// https://drafts.csswg.org/cssom/#dom-medialist-appendmedium
+    ///
+    /// Returns true if added, false if fail to parse the medium string.
+    pub fn append_medium(&mut self, new_medium: &str) -> bool {
+        let mut parser = Parser::new(new_medium);
+        let new_query = match MediaQuery::parse(&mut parser) {
+            Ok(query) => query,
+            Err(_) => { return false; }
+        };
+        // This algorithm doesn't actually matches the current spec,
+        // but it matches the behavior of Gecko and Edge.
+        // See https://github.com/w3c/csswg-drafts/issues/697
+        self.media_queries.retain(|query| query != &new_query);
+        self.media_queries.push(new_query);
+        true
+    }
+
+    /// Delete a media query from the media list.
+    /// https://drafts.csswg.org/cssom/#dom-medialist-deletemedium
+    ///
+    /// Returns true if found and deleted, false otherwise.
+    pub fn delete_medium(&mut self, old_medium: &str) -> bool {
+        let mut parser = Parser::new(old_medium);
+        let old_query = match MediaQuery::parse(&mut parser) {
+            Ok(query) => query,
+            Err(_) => { return false; }
+        };
+        let old_len = self.media_queries.len();
+        self.media_queries.retain(|query| query != &old_query);
+        old_len != self.media_queries.len()
     }
 }


### PR DESCRIPTION
This is the Servo part of [bug 1315601](https://bugzilla.mozilla.org/show_bug.cgi?id=1315601).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15924)
<!-- Reviewable:end -->
