### PR TITLE
Try to fix the font rendering issue on redit on Windows

### DIFF
--- a/components/gfx/platform/windows/font.rs
+++ b/components/gfx/platform/windows/font.rs
@@ -356,6 +356,13 @@ impl FontHandleMethods for FontHandle {
         let au_from_du = |du| -> Au { Au::from_f32_px(du as f32 * self.du_to_px) };
         let au_from_du_s = |du| -> Au { Au:: from_f32_px(du as f32 * self.scaled_du_to_px) };
 
+        // For some reason the line gap is 0 on Windows.
+        // This cause rendering issues on some site like Reddit for example.
+        let line_gap = match dm.lineGap {
+            0 => au_from_em(1 as f64),
+            _ => au_from_du(dm.lineGap as i32),
+        };
+
         // anything that we calculate and don't just pull out of self.face.metrics
         // is pulled out here for clarity
         let leading = dm.ascent - dm.capHeight;
@@ -372,7 +379,7 @@ impl FontHandleMethods for FontHandle {
             descent:          au_from_du_s(dm.descent as i32),
             max_advance:      au_from_pt(0.0), // FIXME
             average_advance:  au_from_pt(0.0), // FIXME
-            line_gap:         au_from_du(dm.lineGap as i32),
+            line_gap:         line_gap,
         };
         debug!("Font metrics (@{} pt): {:?}", self.em_size * 12., metrics);
         metrics


### PR DESCRIPTION
This is quick "fix" for #15698. I am quite sure that the fix only fix the effect and not the cause. As such the PR serve more as a discussion as jonathandturner suggested. I suggest reviewer to start reading the short issue's history first.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15698

About the test I do not have one but I was able to reproduce the issue with the following :
```html
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
   <head>
      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   </head>
   <body>
        <div>a</div>
        <div>b</div>
        <div>c</div>
   </body>
</html>
``` 
Whereas in FF and Chrome each character a,b and c are one below the others, in Servo on Windows they are overlapping.
So if the problem come from the line gap with the default font I think that we can add some test to ensure that line gaps for default font are not 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15937)
<!-- Reviewable:end -->


EDIT : issue number