### PR TITLE
Skip some parts of image-layer shorthands when they are initial

### DIFF
--- a/components/style/properties/shorthand/background.mako.rs
+++ b/components/style/properties/shorthand/background.mako.rs
@@ -158,31 +158,25 @@
                     try!(write!(dest, " "));
                 }
 
-                % for name in "image repeat attachment position_x position_y".split():
-                    try!(${name}.to_css(dest));
+                try!(image.to_css(dest));
+                % for name in "repeat attachment position_x position_y".split():
                     try!(write!(dest, " "));
+                    try!(${name}.to_css(dest));
                 % endfor
 
-                try!(write!(dest, "/ "));
-                try!(size.to_css(dest));
-                try!(write!(dest, " "));
+                if *size != background_size::single_value::get_initial_specified_value() {
+                    try!(write!(dest, " / "));
+                    try!(size.to_css(dest));
+                }
 
-                match (origin, clip) {
-                    (&Origin::padding_box, &Clip::padding_box) => {
-                        try!(origin.to_css(dest));
-                    },
-                    (&Origin::border_box, &Clip::border_box) => {
-                        try!(origin.to_css(dest));
-                    },
-                    (&Origin::content_box, &Clip::content_box) => {
-                        try!(origin.to_css(dest));
-                    },
-                    _ => {
-                        try!(origin.to_css(dest));
+                if *origin != Origin::padding_box || *clip != Clip::border_box {
+                    try!(write!(dest, " "));
+                    try!(origin.to_css(dest));
+                    if *clip != From::from(*origin) {
                         try!(write!(dest, " "));
                         try!(clip.to_css(dest));
                     }
-                };
+                }
             }
 
             Ok(())

--- a/components/style/properties/shorthand/mask.mako.rs
+++ b/components/style/properties/shorthand/mask.mako.rs
@@ -151,26 +151,19 @@
                 position_x.to_css(dest)?;
                 dest.write_str(" ")?;
                 position_y.to_css(dest)?;
-                dest.write_str(" / ")?;
-                size.to_css(dest)?;
+                if *size != mask_size::single_value::get_initial_specified_value() {
+                    dest.write_str(" / ")?;
+                    size.to_css(dest)?;
+                }
                 dest.write_str(" ")?;
                 repeat.to_css(dest)?;
-                dest.write_str(" ")?;
 
-                match (origin, clip) {
-                    (&Origin::padding_box, &Clip::padding_box) => {
-                        try!(origin.to_css(dest));
-                    },
-                    (&Origin::border_box, &Clip::border_box) => {
-                        try!(origin.to_css(dest));
-                    },
-                    (&Origin::content_box, &Clip::content_box) => {
-                        try!(origin.to_css(dest));
-                    },
-                    _ => {
-                        try!(origin.to_css(dest));
-                        try!(write!(dest, " "));
-                        try!(clip.to_css(dest));
+                if *origin != Origin::border_box || *clip != Clip::border_box {
+                    dest.write_str(" ")?;
+                    origin.to_css(dest)?;
+                    if *clip != From::from(*origin) {
+                        dest.write_str(" ")?;
+                        clip.to_css(dest)?;
                     }
                 }
 


### PR DESCRIPTION
To make it closer to Gecko's serialization algorithm.

Neither Servo nor Gecko currently perfectly matches the spec. Gecko has some test for this, but I don't think that's sufficient, so I'll add some later if there aren't any in Servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15951)
<!-- Reviewable:end -->
