### PR TITLE
Implement access to CSSNamespaceRule for stylo

### DIFF
--- a/components/style/gecko/arc_types.rs
+++ b/components/style/gecko/arc_types.rs
@@ -8,7 +8,7 @@
 
 #![allow(non_snake_case, missing_docs)]
 
-use gecko_bindings::bindings::{RawServoMediaList, RawServoMediaRule};
+use gecko_bindings::bindings::{RawServoMediaList, RawServoMediaRule, RawServoNamespaceRule};
 use gecko_bindings::bindings::{RawServoStyleSheet, RawServoStyleRule, RawServoImportRule};
 use gecko_bindings::bindings::{ServoComputedValues, ServoCssRules};
 use gecko_bindings::structs::{RawServoAnimationValue, RawServoDeclarationBlock};
@@ -17,7 +17,7 @@ use media_queries::MediaList;
 use parking_lot::RwLock;
 use properties::{ComputedValues, PropertyDeclarationBlock};
 use properties::animated_properties::AnimationValue;
-use stylesheets::{CssRules, Stylesheet, StyleRule, ImportRule, MediaRule};
+use stylesheets::{CssRules, Stylesheet, StyleRule, ImportRule, MediaRule, NamespaceRule};
 
 macro_rules! impl_arc_ffi {
     ($servo_type:ty => $gecko_type:ty [$addref:ident, $release:ident]) => {
@@ -64,3 +64,6 @@ impl_arc_ffi!(RwLock<MediaList> => RawServoMediaList
 
 impl_arc_ffi!(RwLock<MediaRule> => RawServoMediaRule
               [Servo_MediaRule_AddRef, Servo_MediaRule_Release]);
+
+impl_arc_ffi!(RwLock<NamespaceRule> => RawServoNamespaceRule
+              [Servo_NamespaceRule_AddRef, Servo_NamespaceRule_Release]);

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -4,6 +4,11 @@ pub use nsstring::{nsACString, nsAString, nsString};
 type nsACString_internal = nsACString;
 type nsAString_internal = nsAString;
 use gecko_bindings::structs::mozilla::css::URLValue;
+pub type RawServoNamespaceRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoNamespaceRule>;
+pub type RawServoNamespaceRuleBorrowedOrNull<'a> = Option<&'a RawServoNamespaceRule>;
+pub type RawServoNamespaceRuleBorrowed<'a> = &'a RawServoNamespaceRule;
+enum RawServoNamespaceRuleVoid{ }
+pub struct RawServoNamespaceRule(RawServoNamespaceRuleVoid);
 use gecko_bindings::structs::RawGeckoDocument;
 use gecko_bindings::structs::RawGeckoElement;
 use gecko_bindings::structs::RawGeckoKeyframeList;
@@ -1384,6 +1389,11 @@ extern "C" {
      -> RawServoMediaRuleStrong;
 }
 extern "C" {
+    pub fn Servo_CssRules_GetNamespaceRuleAt(rules: ServoCssRulesBorrowed,
+                                             index: u32)
+     -> RawServoNamespaceRuleStrong;
+}
+extern "C" {
     pub fn Servo_CssRules_InsertRule(rules: ServoCssRulesBorrowed,
                                      sheet: RawServoStyleSheetBorrowed,
                                      rule: *const nsACString_internal,
@@ -1430,6 +1440,14 @@ extern "C" {
 extern "C" {
     pub fn Servo_MediaRule_GetCssText(rule: RawServoMediaRuleBorrowed,
                                       result: *mut nsAString_internal);
+}
+extern "C" {
+    pub fn Servo_NamespaceRule_Debug(rule: RawServoNamespaceRuleBorrowed,
+                                     result: *mut nsACString_internal);
+}
+extern "C" {
+    pub fn Servo_NamespaceRule_GetCssText(rule: RawServoNamespaceRuleBorrowed,
+                                          result: *mut nsAString_internal);
 }
 extern "C" {
     pub fn Servo_ParseProperty(property: *const nsACString_internal,

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -33,8 +33,8 @@ use style::gecko_bindings::bindings;
 use style::gecko_bindings::bindings::{RawGeckoKeyframeListBorrowed, RawGeckoKeyframeListBorrowedMut};
 use style::gecko_bindings::bindings::{RawServoDeclarationBlockBorrowed, RawServoDeclarationBlockStrong};
 use style::gecko_bindings::bindings::{RawServoMediaListBorrowed, RawServoMediaListStrong};
-use style::gecko_bindings::bindings::{RawServoMediaRuleBorrowed, RawServoMediaRuleStrong};
-use style::gecko_bindings::bindings::{RawServoStyleRuleBorrowed, RawServoStyleRuleStrong};
+use style::gecko_bindings::bindings::{RawServoMediaRule, RawServoMediaRuleBorrowed};
+use style::gecko_bindings::bindings::{RawServoStyleRule, RawServoStyleRuleBorrowed};
 use style::gecko_bindings::bindings::{RawServoStyleSetBorrowed, RawServoStyleSetOwned};
 use style::gecko_bindings::bindings::{RawServoStyleSheetBorrowed, ServoComputedValuesBorrowed};
 use style::gecko_bindings::bindings::{RawServoStyleSheetStrong, ServoComputedValuesStrong};
@@ -511,30 +511,6 @@ pub extern "C" fn Servo_CssRules_ListTypes(rules: ServoCssRulesBorrowed,
 }
 
 #[no_mangle]
-pub extern "C" fn Servo_CssRules_GetStyleRuleAt(rules: ServoCssRulesBorrowed, index: u32)
-                                                -> RawServoStyleRuleStrong {
-    let rules = RwLock::<CssRules>::as_arc(&rules).read();
-    match rules.0[index as usize] {
-        CssRule::Style(ref rule) => rule.clone().into_strong(),
-        _ => {
-            unreachable!("GetStyleRuleAt should only be called on a style rule");
-        }
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn Servo_CssRules_GetMediaRuleAt(rules: ServoCssRulesBorrowed, index: u32)
-                                                -> RawServoMediaRuleStrong {
-    let rules = RwLock::<CssRules>::as_arc(&rules).read();
-    match rules.0[index as usize] {
-        CssRule::Media(ref rule) => rule.clone().into_strong(),
-        _ => {
-            unreachable!("GetMediaRuleAt should only be called on a media rule");
-        }
-    }
-}
-
-#[no_mangle]
 pub extern "C" fn Servo_CssRules_InsertRule(rules: ServoCssRulesBorrowed, sheet: RawServoStyleSheetBorrowed,
                                             rule: *const nsACString, index: u32, nested: bool,
                                             rule_type: *mut u16) -> nsresult {
@@ -559,11 +535,49 @@ pub extern "C" fn Servo_CssRules_DeleteRule(rules: ServoCssRulesBorrowed, index:
     }
 }
 
-#[no_mangle]
-pub extern "C" fn Servo_StyleRule_Debug(rule: RawServoStyleRuleBorrowed, result: *mut nsACString) {
-    let rule = RwLock::<StyleRule>::as_arc(&rule);
-    let result = unsafe { result.as_mut().unwrap() };
-    write!(result, "{:?}", *rule.read()).unwrap();
+macro_rules! impl_basic_rule_funcs {
+    { ($name:ident, $rule_type:ty, $raw_type:ty),
+        getter: $getter:ident,
+        debug: $debug:ident,
+        to_css: $to_css:ident,
+    } => {
+        #[no_mangle]
+        pub extern "C" fn $getter(rules: ServoCssRulesBorrowed, index: u32) -> Strong<$raw_type> {
+            let rules = RwLock::<CssRules>::as_arc(&rules).read();
+            match rules.0[index as usize] {
+                CssRule::$name(ref rule) => rule.clone().into_strong(),
+                _ => {
+                    unreachable!(concat!(stringify!($getter), "should only be called ",
+                                         "on a ", stringify!($name), " rule"));
+                }
+            }
+        }
+
+        #[no_mangle]
+        pub extern "C" fn $debug(rule: &$raw_type, result: *mut nsACString) {
+            let rule = RwLock::<$rule_type>::as_arc(&rule);
+            let result = unsafe { result.as_mut().unwrap() };
+            write!(result, "{:?}", *rule.read()).unwrap();
+        }
+
+        #[no_mangle]
+        pub extern "C" fn $to_css(rule: &$raw_type, result: *mut nsAString) {
+            let rule = RwLock::<$rule_type>::as_arc(&rule);
+            rule.read().to_css(unsafe { result.as_mut().unwrap() }).unwrap();
+        }
+    }
+}
+
+impl_basic_rule_funcs! { (Style, StyleRule, RawServoStyleRule),
+    getter: Servo_CssRules_GetStyleRuleAt,
+    debug: Servo_StyleRule_Debug,
+    to_css: Servo_StyleRule_GetCssText,
+}
+
+impl_basic_rule_funcs! { (Media, MediaRule, RawServoMediaRule),
+    getter: Servo_CssRules_GetMediaRuleAt,
+    debug: Servo_MediaRule_Debug,
+    to_css: Servo_MediaRule_GetCssText,
 }
 
 #[no_mangle]
@@ -581,22 +595,9 @@ pub extern "C" fn Servo_StyleRule_SetStyle(rule: RawServoStyleRuleBorrowed,
 }
 
 #[no_mangle]
-pub extern "C" fn Servo_StyleRule_GetCssText(rule: RawServoStyleRuleBorrowed, result: *mut nsAString) {
-    let rule = RwLock::<StyleRule>::as_arc(&rule);
-    rule.read().to_css(unsafe { result.as_mut().unwrap() }).unwrap();
-}
-
-#[no_mangle]
 pub extern "C" fn Servo_StyleRule_GetSelectorText(rule: RawServoStyleRuleBorrowed, result: *mut nsAString) {
     let rule = RwLock::<StyleRule>::as_arc(&rule);
     rule.read().selectors.to_css(unsafe { result.as_mut().unwrap() }).unwrap();
-}
-
-#[no_mangle]
-pub extern "C" fn Servo_MediaRule_Debug(rule: RawServoMediaRuleBorrowed, result: *mut nsACString) {
-    let rule = RwLock::<MediaRule>::as_arc(&rule);
-    let result = unsafe { result.as_mut().unwrap() };
-    write!(result, "{:?}", *rule.read()).unwrap();
 }
 
 #[no_mangle]
@@ -609,12 +610,6 @@ pub extern "C" fn Servo_MediaRule_GetMedia(rule: RawServoMediaRuleBorrowed) -> R
 pub extern "C" fn Servo_MediaRule_GetRules(rule: RawServoMediaRuleBorrowed) -> ServoCssRulesStrong {
     let rule = RwLock::<MediaRule>::as_arc(&rule);
     rule.read().rules.clone().into_strong()
-}
-
-#[no_mangle]
-pub extern "C" fn Servo_MediaRule_GetCssText(rule: RawServoMediaRuleBorrowed, result: *mut nsAString) {
-    let rule = RwLock::<MediaRule>::as_arc(&rule);
-    rule.read().to_css(unsafe { result.as_mut().unwrap() }).unwrap();
 }
 
 #[no_mangle]

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -34,6 +34,7 @@ use style::gecko_bindings::bindings::{RawGeckoKeyframeListBorrowed, RawGeckoKeyf
 use style::gecko_bindings::bindings::{RawServoDeclarationBlockBorrowed, RawServoDeclarationBlockStrong};
 use style::gecko_bindings::bindings::{RawServoMediaListBorrowed, RawServoMediaListStrong};
 use style::gecko_bindings::bindings::{RawServoMediaRule, RawServoMediaRuleBorrowed};
+use style::gecko_bindings::bindings::{RawServoNamespaceRule, RawServoNamespaceRuleBorrowed};
 use style::gecko_bindings::bindings::{RawServoStyleRule, RawServoStyleRuleBorrowed};
 use style::gecko_bindings::bindings::{RawServoStyleSetBorrowed, RawServoStyleSetOwned};
 use style::gecko_bindings::bindings::{RawServoStyleSheetBorrowed, ServoComputedValuesBorrowed};
@@ -76,7 +77,8 @@ use style::restyle_hints::{self, RestyleHint};
 use style::selector_parser::PseudoElementCascadeType;
 use style::sequential;
 use style::string_cache::Atom;
-use style::stylesheets::{CssRule, CssRules, ImportRule, MediaRule, Origin, Stylesheet, StyleRule};
+use style::stylesheets::{CssRule, CssRules, ImportRule, MediaRule, NamespaceRule};
+use style::stylesheets::{Origin, Stylesheet, StyleRule};
 use style::stylesheets::StylesheetLoader as StyleStylesheetLoader;
 use style::supports::parse_condition_or_declaration;
 use style::thread_state;
@@ -580,6 +582,12 @@ impl_basic_rule_funcs! { (Media, MediaRule, RawServoMediaRule),
     to_css: Servo_MediaRule_GetCssText,
 }
 
+impl_basic_rule_funcs! { (Namespace, NamespaceRule, RawServoNamespaceRule),
+    getter: Servo_CssRules_GetNamespaceRuleAt,
+    debug: Servo_NamespaceRule_Debug,
+    to_css: Servo_NamespaceRule_GetCssText,
+}
+
 #[no_mangle]
 pub extern "C" fn Servo_StyleRule_GetStyle(rule: RawServoStyleRuleBorrowed) -> RawServoDeclarationBlockStrong {
     let rule = RwLock::<StyleRule>::as_arc(&rule);
@@ -610,6 +618,18 @@ pub extern "C" fn Servo_MediaRule_GetMedia(rule: RawServoMediaRuleBorrowed) -> R
 pub extern "C" fn Servo_MediaRule_GetRules(rule: RawServoMediaRuleBorrowed) -> ServoCssRulesStrong {
     let rule = RwLock::<MediaRule>::as_arc(&rule);
     rule.read().rules.clone().into_strong()
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_NamespaceRule_GetPrefix(rule: RawServoNamespaceRuleBorrowed) -> *mut nsIAtom {
+    let rule = RwLock::<NamespaceRule>::as_arc(&rule);
+    rule.read().prefix.as_ref().unwrap_or(&atom!("")).as_ptr()
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_NamespaceRule_GetURI(rule: RawServoNamespaceRuleBorrowed) -> *mut nsIAtom {
+    let rule = RwLock::<NamespaceRule>::as_arc(&rule);
+    rule.read().url.0.as_ptr()
 }
 
 #[no_mangle]

--- a/ports/geckolib/lib.rs
+++ b/ports/geckolib/lib.rs
@@ -15,7 +15,7 @@ extern crate parking_lot;
 extern crate rayon;
 extern crate selectors;
 extern crate servo_url;
-extern crate style;
+#[macro_use] extern crate style;
 extern crate style_traits;
 
 #[allow(non_snake_case)]

--- a/tests/unit/stylo/lib.rs
+++ b/tests/unit/stylo/lib.rs
@@ -15,7 +15,7 @@ extern crate parking_lot;
 extern crate rayon;
 extern crate selectors;
 extern crate servo_url;
-extern crate style;
+#[macro_use] extern crate style;
 extern crate style_traits;
 
 mod sanity_checks;


### PR DESCRIPTION
This is the Servo side changes of [bug 1345698](https://bugzilla.mozilla.org/show_bug.cgi?id=1345698).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15961)
<!-- Reviewable:end -->
