### PR TITLE
Bug 1340683 - stylo: Implement the :-moz-any pseudo-class

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -86,7 +86,7 @@ use parking_lot::RwLock;
 use ref_filter_map::ref_filter_map;
 use script_layout_interface::message::ReflowQueryType;
 use script_thread::Runnable;
-use selectors::matching::{ElementSelectorFlags, matches};
+use selectors::matching::{ElementSelectorFlags, StyleRelations, matches};
 use selectors::matching::{HAS_EDGE_CHILD_SELECTOR, HAS_SLOW_SELECTOR, HAS_SLOW_SELECTOR_LATER_SIBLINGS};
 use selectors::parser::{AttrSelector, NamespaceConstraint};
 use servo_atoms::Atom;
@@ -2398,7 +2398,10 @@ impl<'a> ::selectors::Element for Root<Element> {
         self.namespace()
     }
 
-    fn match_non_ts_pseudo_class(&self, pseudo_class: &NonTSPseudoClass) -> bool {
+    fn match_non_ts_pseudo_class(&self,
+                                 pseudo_class: &NonTSPseudoClass,
+                                 _: &mut StyleRelations,
+                                 _: &mut ElementSelectorFlags) -> bool {
         match *pseudo_class {
             // https://github.com/servo/servo/issues/8718
             NonTSPseudoClass::Link |

--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -50,7 +50,7 @@ use script_layout_interface::{HTMLCanvasData, LayoutNodeType, SVGSVGData, Truste
 use script_layout_interface::{OpaqueStyleAndLayoutData, PartialPersistentLayoutData};
 use script_layout_interface::wrapper_traits::{DangerousThreadSafeLayoutNode, GetLayoutData, LayoutNode};
 use script_layout_interface::wrapper_traits::{PseudoElementType, ThreadSafeLayoutElement, ThreadSafeLayoutNode};
-use selectors::matching::ElementSelectorFlags;
+use selectors::matching::{ElementSelectorFlags, StyleRelations};
 use selectors::parser::{AttrSelector, NamespaceConstraint};
 use servo_atoms::Atom;
 use servo_url::ServoUrl;
@@ -611,7 +611,10 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
         self.element.namespace()
     }
 
-    fn match_non_ts_pseudo_class(&self, pseudo_class: &NonTSPseudoClass) -> bool {
+    fn match_non_ts_pseudo_class(&self,
+                                 pseudo_class: &NonTSPseudoClass,
+                                 _: &mut StyleRelations,
+                                 _: &mut ElementSelectorFlags) -> bool {
         match *pseudo_class {
             // https://github.com/servo/servo/issues/8718
             NonTSPseudoClass::Link |
@@ -1106,7 +1109,10 @@ impl<'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
         self.element.get_namespace()
     }
 
-    fn match_non_ts_pseudo_class(&self, _: &NonTSPseudoClass) -> bool {
+    fn match_non_ts_pseudo_class(&self,
+                                 _: &NonTSPseudoClass,
+                                 _: &mut StyleRelations,
+                                 _: &mut ElementSelectorFlags) -> bool {
         // NB: This could maybe be implemented
         warn!("ServoThreadSafeLayoutElement::match_non_ts_pseudo_class called");
         false

--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -413,7 +413,7 @@ fn matches_simple_selector<E>(
             false
         }
         SimpleSelector::NonTSPseudoClass(ref pc) => {
-            relation_if!(element.match_non_ts_pseudo_class(pc),
+            relation_if!(element.match_non_ts_pseudo_class(pc, relations, flags),
                          AFFECTED_BY_STATE)
         }
         SimpleSelector::FirstChild => {

--- a/components/selectors/tree.rs
+++ b/components/selectors/tree.rs
@@ -5,6 +5,7 @@
 //! Traits that nodes must implement. Breaks the otherwise-cyclic dependency between layout and
 //! style.
 
+use matching::{ElementSelectorFlags, StyleRelations};
 use parser::{AttrSelector, SelectorImpl};
 use std::ascii::AsciiExt;
 
@@ -138,7 +139,10 @@ pub trait Element: MatchAttr + Sized {
     fn get_local_name(&self) -> &<Self::Impl as SelectorImpl>::BorrowedLocalName;
     fn get_namespace(&self) -> &<Self::Impl as SelectorImpl>::BorrowedNamespaceUrl;
 
-    fn match_non_ts_pseudo_class(&self, pc: &<Self::Impl as SelectorImpl>::NonTSPseudoClass) -> bool;
+    fn match_non_ts_pseudo_class(&self,
+                                 pc: &<Self::Impl as SelectorImpl>::NonTSPseudoClass,
+                                 relations: &mut StyleRelations,
+                                 flags: &mut ElementSelectorFlags) -> bool;
 
     fn get_id(&self) -> Option<<Self::Impl as SelectorImpl>::Identifier>;
     fn has_class(&self, name: &<Self::Impl as SelectorImpl>::ClassName) -> bool;

--- a/components/style/servo/selector_parser.rs
+++ b/components/style/servo/selector_parser.rs
@@ -14,7 +14,8 @@ use restyle_hints::ElementSnapshot;
 use selector_parser::{ElementExt, PseudoElementCascadeType, SelectorParser};
 use selector_parser::{attr_equals_selector_is_shareable, attr_exists_selector_is_shareable};
 use selectors::{Element, MatchAttrGeneric};
-use selectors::parser::AttrSelector;
+use selectors::matching::{ElementSelectorFlags, StyleRelations};
+use selectors::parser::{AttrSelector, SelectorMethods};
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
@@ -59,7 +60,6 @@ impl ToCss for PseudoElement {
         })
     }
 }
-
 
 impl PseudoElement {
     /// Whether the current pseudo element is :before or :after.
@@ -148,6 +148,13 @@ impl ToCss for NonTSPseudoClass {
             Visited => ":visited",
         })
     }
+}
+
+impl SelectorMethods for NonTSPseudoClass {
+    #[inline]
+    fn affects_siblings(&self) -> bool { false }
+    #[inline]
+    fn matches_non_common_style_affecting_attribute(&self) -> bool { false }
 }
 
 impl NonTSPseudoClass {
@@ -450,7 +457,9 @@ impl MatchAttrGeneric for ServoElementSnapshot {
 
 impl<E: Element<Impl=SelectorImpl> + Debug> ElementExt for E {
     fn is_link(&self) -> bool {
-        self.match_non_ts_pseudo_class(&NonTSPseudoClass::AnyLink)
+        self.match_non_ts_pseudo_class(&NonTSPseudoClass::AnyLink,
+                                       &mut StyleRelations::empty(),
+                                       &mut ElementSelectorFlags::empty())
     }
 
     #[inline]

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -27,6 +27,7 @@ use selectors::matching::{AFFECTED_BY_ANIMATIONS, AFFECTED_BY_TRANSITIONS};
 use selectors::matching::{AFFECTED_BY_STYLE_ATTRIBUTE, AFFECTED_BY_PRESENTATIONAL_HINTS};
 use selectors::matching::{ElementSelectorFlags, StyleRelations, matches_complex_selector};
 use selectors::parser::{Selector, SimpleSelector, LocalName as LocalNameSelector, ComplexSelector};
+use selectors::parser::SelectorMethods;
 use sink::Push;
 use smallvec::VecLike;
 use std::borrow::Borrow;


### PR DESCRIPTION
Adds support for the non-standard [:-moz-any](https://developer.mozilla.org/en-US/docs/Web/CSS/:any) selector.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix https://bugzilla.mozilla.org/show_bug.cgi?id=1340683
- [x] These changes do not require tests because they are gecko-only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15966)
<!-- Reviewable:end -->
