### PR TITLE
Disabled tinyfiledialogs when running headless

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "bluetooth_traits 0.0.1",
  "device 0.0.1 (git+https://github.com/servo/devices)",
  "ipc-channel 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo_config 0.0.1",
  "servo_rand 0.0.1",
  "tinyfiledialogs 2.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -14,6 +14,7 @@ bitflags = "0.7"
 bluetooth_traits = {path = "../bluetooth_traits"}
 device = {git = "https://github.com/servo/devices", features = ["bluetooth-test"]}
 ipc-channel = "0.7"
+servo_config = {path = "../config"}
 servo_rand = {path = "../rand"}
 uuid = {version = "0.4", features = ["v4"]}
 

--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -7,6 +7,7 @@ extern crate bitflags;
 extern crate bluetooth_traits;
 extern crate device;
 extern crate ipc_channel;
+extern crate servo_config;
 extern crate servo_rand;
 #[cfg(target_os = "linux")]
 extern crate tinyfiledialogs;
@@ -22,6 +23,7 @@ use bluetooth_traits::scanfilter::{BluetoothScanfilter, BluetoothScanfilterSeque
 use device::bluetooth::{BluetoothAdapter, BluetoothDevice, BluetoothGATTCharacteristic};
 use device::bluetooth::{BluetoothGATTDescriptor, BluetoothGATTService};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
+use servo_config::opts;
 use servo_rand::Rng;
 use std::borrow::ToOwned;
 use std::collections::{HashMap, HashSet};
@@ -363,7 +365,7 @@ impl BluetoothManager {
 
     #[cfg(target_os = "linux")]
     fn select_device(&mut self, devices: Vec<BluetoothDevice>, adapter: &BluetoothAdapter) -> Option<String> {
-        if is_mock_adapter(adapter) {
+        if is_mock_adapter(adapter) || opts::get().headless {
             for device in devices {
                 if let Ok(address) = device.get_address() {
                     return Some(address);

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -7,6 +7,7 @@ use mime_guess::guess_mime_type_opt;
 use net_traits::blob_url_store::{BlobBuf, BlobURLStoreError};
 use net_traits::filemanager_thread::{FileManagerResult, FileManagerThreadMsg, FileOrigin, FilterPattern};
 use net_traits::filemanager_thread::{FileManagerThreadError, ReadFileProgress, RelativePos, SelectedFile};
+use servo_config::opts;
 use servo_config::prefs::PREFS;
 use std::collections::HashMap;
 use std::fs::File;
@@ -35,6 +36,10 @@ pub struct TFDProvider;
 impl UIProvider for TFDProvider {
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     fn open_file_dialog(&self, path: &str, patterns: Vec<FilterPattern>) -> Option<String> {
+        if opts::get().headless {
+            return None;
+        }
+
         let mut filter = vec![];
         for p in patterns {
             let s = "*.".to_string() + &p.0;
@@ -50,6 +55,10 @@ impl UIProvider for TFDProvider {
 
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     fn open_file_dialog_multi(&self, path: &str, patterns: Vec<FilterPattern>) -> Option<Vec<String>> {
+        if opts::get().headless {
+            return None;
+        }
+
         let mut filter = vec![];
         for p in patterns {
             let s = "*.".to_string() + &p.0;

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -17,6 +17,7 @@ use dom_struct::dom_struct;
 use js::conversions::ConversionResult;
 use js::jsapi::{JSContext, JSObject};
 use js::jsval::{ObjectValue, UndefinedValue};
+use servo_config::opts;
 use servo_config::prefs::PREFS;
 use std::rc::Rc;
 #[cfg(target_os = "linux")]
@@ -308,6 +309,9 @@ pub fn get_descriptor_permission_state(permission_name: PermissionName,
 
 #[cfg(target_os = "linux")]
 fn prompt_user(message: &str) -> PermissionState {
+    if opts::get().headless {
+        return PermissionState::Denied;
+    }
     match tinyfiledialogs::message_box_yes_no(DIALOG_TITLE,
                                               message,
                                               MessageBoxIcon::Question,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -379,7 +379,9 @@ impl Window {
 
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 fn display_alert_dialog(message: &str) {
-    tinyfiledialogs::message_box_ok("Alert!", message, MessageBoxIcon::Warning);
+    if !opts::get().headless {
+        tinyfiledialogs::message_box_ok("Alert!", message, MessageBoxIcon::Warning);
+    }
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Disable tinyfiledialogs when running in headless mode.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15965 and #15962.
- [X] These changes do not require tests because we don't test tinyfiledialog pop-ups.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15967)
<!-- Reviewable:end -->
