### PR TITLE
#15842 Add gecko glue for caret-color

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -43,7 +43,7 @@ use gecko_bindings::bindings::Gecko_SetNullImageValue;
 use gecko_bindings::bindings::ServoComputedValuesBorrowedOrNull;
 use gecko_bindings::bindings::{Gecko_ResetFilters, Gecko_CopyFiltersFrom};
 use gecko_bindings::bindings::RawGeckoPresContextBorrowed;
-use gecko_bindings::structs;
+use gecko_bindings::structs::{self, StyleComplexColor};
 use gecko_bindings::structs::nsStyleVariables;
 use gecko_bindings::sugar::ns_style_coord::{CoordDataValue, CoordData, CoordDataMut};
 use gecko_bindings::sugar::ownership::HasArcFFI;
@@ -3095,7 +3095,7 @@ clip-path
 </%self:impl_trait>
 
 <%self:impl_trait style_struct_name="Pointing"
-                  skip_longhands="cursor">
+                  skip_longhands="cursor caret-color">
     pub fn set_cursor(&mut self, v: longhands::cursor::computed_value::T) {
         use properties::longhands::cursor::computed_value::Keyword;
         use style_traits::cursor::Cursor;
@@ -3162,6 +3162,26 @@ clip-path
             Gecko_CopyCursorArrayFrom(&mut self.gecko, &other.gecko);
         }
     }
+
+    pub fn set_caret_color(&mut self, v: longhands::caret_color::computed_value::T){
+        use values::Either;
+
+        match v {
+            Either::First(color) => {
+                self.gecko.mCaretColor = StyleComplexColor::from(color);
+            }
+            Either::Second(_auto) => {
+                self.gecko.mCaretColor = StyleComplexColor::auto();
+            }
+        }
+    }
+
+    pub fn copy_caret_color_from(&mut self, other: &Self){
+        self.gecko.mCaretColor = other.gecko.mCaretColor;
+    }
+
+    <%call expr="impl_color_clone('caret_color', 'mCaretColor')"></%call>
+
 </%self:impl_trait>
 
 <%self:impl_trait style_struct_name="Column"

--- a/components/style/properties/longhand/pointing.mako.rs
+++ b/components/style/properties/longhand/pointing.mako.rs
@@ -170,3 +170,10 @@ ${helpers.single_keyword("-moz-user-focus",
                          gecko_inexhaustive=True,
                          animatable=False,
                          spec="Nonstandard (https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-user-focus)")}
+
+${helpers.predefined_type("caret-color",
+                          "ColorOrAuto",
+                          "Either::Second(Auto)",
+                          spec="https://drafts.csswg.org/css-ui/#caret-color",
+                          animatable="True",
+                          products="gecko")}

--- a/components/style/properties/longhand/ui.mako.rs
+++ b/components/style/properties/longhand/ui.mako.rs
@@ -30,10 +30,3 @@ ${helpers.single_keyword("-moz-window-dragging", "default drag no-drag", product
                          gecko_enum_prefix="StyleWindowDragging",
                          animatable=False,
                          spec="None (Nonstandard Firefox-only property)")}
-
-${helpers.predefined_type("caret-color",
-                          "ColorOrAuto",
-                          "Either::Second(Auto)",
-                          spec="https://drafts.csswg.org/css-ui/#caret-color",
-                          animatable="True",
-                          products="none")}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I've mostly followed the description of #15842, but on the last line, where `copy` is mentioned, I'm assuming that `clone` was meant instead. It doesn't run successfully `./mach build-geckolib` because

`/Users/stefano/dev/rust/servo/target/geckolib/debug/build/style-bea86181fb38deda/out/gecko_properties.rs:10990:36
      |
10990 |             self.gecko.mCaretColor.into()
      |                                    ^^^^ the trait
std::convert::From<gecko_bindings::structs::root::mozilla::StyleComplexColor> is not implemented for values::Either<cssparser::Color, values::Auto>`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [X] These changes fix #15842 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15970)
<!-- Reviewable:end -->
