### PR TITLE
Replace non_ts_pseudo_class_list include hack with higher order macro

### DIFF
--- a/components/style/gecko/mod.rs
+++ b/components/style/gecko/mod.rs
@@ -4,6 +4,9 @@
 
 //! Gecko-specific style-system bits.
 
+#[macro_use]
+mod non_ts_pseudo_class_list;
+
 pub mod arc_types;
 pub mod conversions;
 pub mod data;

--- a/components/style/gecko/non_ts_pseudo_class_list.rs
+++ b/components/style/gecko/non_ts_pseudo_class_list.rs
@@ -6,21 +6,20 @@
  * This file contains a helper macro includes all supported non-tree-structural
  * pseudo-classes.
  *
- * This file is NOT INTENDED to be compiled as a standalone module.
- *
+
  * FIXME: Find a way to autogenerate this file.
  *
  * Expected usage is as follows:
  * ```
  * fn use_pseudo_class() {
- *     macro_rules! pseudo_class_list {
+ *     macro_rules! use_pseudo_class_list {
  *         ( $(
  *             ($css:expr, $name:ident, $gecko_type:tt, $state:tt, $flags:tt),
  *         )* ) => {
  *             // Do stuff.
  *         }
  *     }
- *     include!("non_ts_pseudo_class_list.rs")
+ *     apply_non_ts_list!(use_pseudo_class_list)
  * }
  * ```
  *
@@ -30,21 +29,25 @@
  * see selector_parser.rs for more details.
  */
 
-pseudo_class_list! {
-    ("any-link", AnyLink, anyLink, _, _),
-    ("link", Link, link, _, _),
-    ("visited", Visited, visited, _, _),
-    ("active", Active, active, IN_ACTIVE_STATE, _),
-    ("focus", Focus, focus, IN_FOCUS_STATE, _),
-    ("fullscreen", Fullscreen, fullscreen, IN_FULLSCREEN_STATE, _),
-    ("hover", Hover, hover, IN_HOVER_STATE, _),
-    ("enabled", Enabled, enabled, IN_ENABLED_STATE, _),
-    ("disabled", Disabled, disabled, IN_DISABLED_STATE, _),
-    ("checked", Checked, checked, IN_CHECKED_STATE, _),
-    ("indeterminate", Indeterminate, indeterminate, IN_INDETERMINATE_STATE, _),
-    ("read-write", ReadWrite, _, IN_READ_WRITE_STATE, _),
-    ("read-only", ReadOnly, _, IN_READ_WRITE_STATE, _),
+macro_rules! apply_non_ts_list {
+    ($apply_macro:ident) => {
+        $apply_macro! {
+            ("any-link", AnyLink, anyLink, _, _),
+            ("link", Link, link, _, _),
+            ("visited", Visited, visited, _, _),
+            ("active", Active, active, IN_ACTIVE_STATE, _),
+            ("focus", Focus, focus, IN_FOCUS_STATE, _),
+            ("fullscreen", Fullscreen, fullscreen, IN_FULLSCREEN_STATE, _),
+            ("hover", Hover, hover, IN_HOVER_STATE, _),
+            ("enabled", Enabled, enabled, IN_ENABLED_STATE, _),
+            ("disabled", Disabled, disabled, IN_DISABLED_STATE, _),
+            ("checked", Checked, checked, IN_CHECKED_STATE, _),
+            ("indeterminate", Indeterminate, indeterminate, IN_INDETERMINATE_STATE, _),
+            ("read-write", ReadWrite, _, IN_READ_WRITE_STATE, _),
+            ("read-only", ReadOnly, _, IN_READ_WRITE_STATE, _),
 
-    ("-moz-browser-frame", MozBrowserFrame, mozBrowserFrame, _, PSEUDO_CLASS_INTERNAL),
-    ("-moz-table-border-nonzero", MozTableBorderNonzero, mozTableBorderNonzero, _, PSEUDO_CLASS_INTERNAL),
+            ("-moz-browser-frame", MozBrowserFrame, mozBrowserFrame, _, PSEUDO_CLASS_INTERNAL),
+            ("-moz-table-border-nonzero", MozTableBorderNonzero, mozTableBorderNonzero, _, PSEUDO_CLASS_INTERNAL),
+        }
+    }
 }


### PR DESCRIPTION
Cleaner, and easier to work with.

We may need to expand the functionality to support integer and string pseudo classes like -moz-system-metric

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15971)
<!-- Reviewable:end -->
