### PR TITLE
stylo: Fix shorthand parser for transition none

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -777,7 +777,8 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
                           spec="https://drafts.csswg.org/css-transitions/#propdef-transition-delay">
     pub use properties::longhands::transition_duration::single_value::SpecifiedValue;
     pub use properties::longhands::transition_duration::single_value::computed_value;
-    pub use properties::longhands::transition_duration::single_value::{get_initial_value, parse};
+    pub use properties::longhands::transition_duration::single_value::{get_initial_value, get_initial_specified_value};
+    pub use properties::longhands::transition_duration::single_value::parse;
 </%helpers:vector_longhand>
 
 <%helpers:vector_longhand name="animation-name"


### PR DESCRIPTION
These changes fix [Bug 1347053](https://bugzilla.mozilla.org/show_bug.cgi?id=1347053) if we have the transition shorthand: `transition: none`.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because this is for stylo and Gecko side has enough tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15978)
<!-- Reviewable:end -->
