### PR TITLE
Make tidy check for merge commits

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -1051,7 +1051,7 @@ def run_lint_scripts(only_changed_files=False, progress=True, stylo=False):
 
 
 def check_commits(path='.'):
-    """Gets all commits since the last merge."""
+    """Gets all commits since the last merge.."""
     args = ['git', 'log', '-n1', '--merges', '--format=%H']
     last_merge = subprocess.check_output(args, cwd=path).strip()
     args = ['git', 'log', '{}..HEAD'.format(last_merge), '--format=%s']

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -1051,7 +1051,7 @@ def run_lint_scripts(only_changed_files=False, progress=True, stylo=False):
 
 
 def check_commits(path='.'):
-    """Gets all commits since the last merge.."""
+    """Gets all commits since the last merge."""
     args = ['git', 'log', '-n1', '--merges', '--format=%H']
     last_merge = subprocess.check_output(args, cwd=path).strip()
     args = ['git', 'log', '{}..HEAD'.format(last_merge), '--format=%s']
@@ -1061,6 +1061,9 @@ def check_commits(path='.'):
         # .split() to only match entire words
         if 'wip' in commit.split():
             yield ('.', 0, 'no commits should contain WIP')
+
+    if len(commits) > 1:
+        yield ('.', 0, 'multiple commits should be squashed into one commit.')
 
     raise StopIteration
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Makes tidy check commit messages since the latest merge, failing if
there are multiple commits(meaning not squashed).

This commit on TravisCI should report an error, because there are two commits on this pull request.
I checked that these commits are reporting error.

bjkim@bjkim-ubuntu:~/github/servo$ ./mach test-tidy
Checking the config file...
Checking directories for correct file extensions...
Checking files for tidiness...
.:0: multiple commits should be squashed into one commit.

bjkim@bjkim-ubuntu:~/github/servo$ 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #15673 (github issue number if applicable).

<!-- Either: -->
- [ ] These changes do not require tests because these code itself is testing code.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15984)
<!-- Reviewable:end -->
