### PR TITLE
Fix "option `Z` is unstable" warning on geckolib with incremental=true

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -296,6 +296,11 @@ class CommandBase(object):
         if not self.config["tools"]["system-rust"]:
             self.config["tools"]["rust-root"] = path.join(
                 self.context.sharedir, "rust", self.rust_path())
+        if use_stable_rust:
+            # Cargo maintainer's position is that CARGO_INCREMENTAL is a nightly-only feature
+            # and should not be used on the stable channel.
+            # https://github.com/rust-lang/cargo/issues/3835
+            self.config["build"]["incremental"] = False
 
     def use_stable_rust(self):
         return self._use_stable_rust


### PR DESCRIPTION
`incremental = true` can be set in the `[build]` section of `.servobuild` to enable incremental compilation.

In `./mach build-geckolib`, which uses a stable version of the compiler, this would cause a warning repeated for each invocation of rustc:

```
warning: the option `Z` is unstable and should only be used on the nightly
compiler, but it is currently accepted for backwards compatibility;
this will soon change, see issue #31847 for more details
```

This PR disables incremental compilation for `build-geckolib`, regardless of `.servobuild` settings.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15996)
<!-- Reviewable:end -->
