### PR TITLE
Rearrange PropertyDeclaration to avoid embedding DeclaredValue

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -103,8 +103,7 @@ use style::context::{QuirksMode, ReflowGoal};
 use style::element_state::*;
 use style::matching::{common_style_affecting_attributes, rare_style_affecting_attributes};
 use style::parser::ParserContextExtraData;
-use style::properties::{DeclaredValue, Importance};
-use style::properties::{PropertyDeclaration, PropertyDeclarationBlock, parse_style_attribute};
+use style::properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, parse_style_attribute};
 use style::properties::longhands::{self, background_image, border_spacing, font_family, font_size, overflow_x};
 use style::restyle_hints::RESTYLE_SELF;
 use style::rule_tree::CascadeLevel;
@@ -409,8 +408,8 @@ impl LayoutElementHelpers for LayoutJS<Element> {
 
         if let Some(color) = bgcolor {
             hints.push(from_declaration(
-                PropertyDeclaration::BackgroundColor(DeclaredValue::Value(
-                    CSSColor { parsed: Color::RGBA(color), authored: None }))));
+                PropertyDeclaration::BackgroundColor(
+                    CSSColor { parsed: Color::RGBA(color), authored: None })));
         }
 
         let background = if let Some(this) = self.downcast::<HTMLBodyElement>() {
@@ -421,12 +420,12 @@ impl LayoutElementHelpers for LayoutJS<Element> {
 
         if let Some(url) = background {
             hints.push(from_declaration(
-                PropertyDeclaration::BackgroundImage(DeclaredValue::Value(
+                PropertyDeclaration::BackgroundImage(
                     background_image::SpecifiedValue(vec![
                         background_image::single_value::SpecifiedValue(Some(
                             specified::Image::for_cascade(url.into(), specified::url::UrlExtraData { })
                         ))
-                    ])))));
+                    ]))));
         }
 
         let color = if let Some(this) = self.downcast::<HTMLFontElement>() {
@@ -443,12 +442,12 @@ impl LayoutElementHelpers for LayoutJS<Element> {
 
         if let Some(color) = color {
             hints.push(from_declaration(
-                PropertyDeclaration::Color(DeclaredValue::Value(
+                PropertyDeclaration::Color(
                     longhands::color::SpecifiedValue(CSSColor {
                         parsed: Color::RGBA(color),
                         authored: None,
                     })
-                ))
+                )
             ));
         }
 
@@ -461,19 +460,16 @@ impl LayoutElementHelpers for LayoutJS<Element> {
         if let Some(font_family) = font_family {
             hints.push(from_declaration(
                 PropertyDeclaration::FontFamily(
-                    DeclaredValue::Value(
                         font_family::computed_value::T(vec![
                             font_family::computed_value::FontFamily::from_atom(
-                                font_family)])))));
+                                font_family)]))));
         }
 
         let font_size = self.downcast::<HTMLFontElement>().and_then(|this| this.get_size());
 
         if let Some(font_size) = font_size {
             hints.push(from_declaration(
-                PropertyDeclaration::FontSize(
-                    DeclaredValue::Value(
-                        font_size::SpecifiedValue(font_size.into())))))
+                PropertyDeclaration::FontSize(font_size::SpecifiedValue(font_size.into()))))
         }
 
         let cellspacing = if let Some(this) = self.downcast::<HTMLTableElement>() {
@@ -485,11 +481,11 @@ impl LayoutElementHelpers for LayoutJS<Element> {
         if let Some(cellspacing) = cellspacing {
             let width_value = specified::Length::from_px(cellspacing as f32);
             hints.push(from_declaration(
-                PropertyDeclaration::BorderSpacing(DeclaredValue::Value(
+                PropertyDeclaration::BorderSpacing(
                     Box::new(border_spacing::SpecifiedValue {
                         horizontal: width_value.clone(),
                         vertical: width_value,
-                    })))));
+                    }))));
         }
 
 
@@ -518,8 +514,8 @@ impl LayoutElementHelpers for LayoutJS<Element> {
         if let Some(size) = size {
             let value = specified::NoCalcLength::ServoCharacterWidth(specified::CharacterWidth(size));
             hints.push(from_declaration(
-                PropertyDeclaration::Width(DeclaredValue::Value(
-                    specified::LengthOrPercentageOrAuto::Length(value)))));
+                PropertyDeclaration::Width(
+                    specified::LengthOrPercentageOrAuto::Length(value))));
         }
 
         let width = if let Some(this) = self.downcast::<HTMLIFrameElement>() {
@@ -543,13 +539,13 @@ impl LayoutElementHelpers for LayoutJS<Element> {
                 let width_value =
                     specified::LengthOrPercentageOrAuto::Percentage(specified::Percentage(percentage));
                 hints.push(from_declaration(
-                    PropertyDeclaration::Width(DeclaredValue::Value(width_value))));
+                    PropertyDeclaration::Width(width_value)));
             }
             LengthOrPercentageOrAuto::Length(length) => {
                 let width_value = specified::LengthOrPercentageOrAuto::Length(
                     specified::NoCalcLength::Absolute(length));
                 hints.push(from_declaration(
-                    PropertyDeclaration::Width(DeclaredValue::Value(width_value))));
+                    PropertyDeclaration::Width(width_value)));
             }
         }
 
@@ -568,13 +564,13 @@ impl LayoutElementHelpers for LayoutJS<Element> {
                 let height_value =
                     specified::LengthOrPercentageOrAuto::Percentage(specified::Percentage(percentage));
                 hints.push(from_declaration(
-                    PropertyDeclaration::Height(DeclaredValue::Value(height_value))));
+                    PropertyDeclaration::Height(height_value)));
             }
             LengthOrPercentageOrAuto::Length(length) => {
                 let height_value = specified::LengthOrPercentageOrAuto::Length(
                     specified::NoCalcLength::Absolute(length));
                 hints.push(from_declaration(
-                    PropertyDeclaration::Height(DeclaredValue::Value(height_value))));
+                    PropertyDeclaration::Height(height_value)));
             }
         }
 
@@ -596,8 +592,7 @@ impl LayoutElementHelpers for LayoutJS<Element> {
             // https://html.spec.whatwg.org/multipage/#textarea-effective-width
             let value = specified::NoCalcLength::ServoCharacterWidth(specified::CharacterWidth(cols));
             hints.push(from_declaration(
-                PropertyDeclaration::Width(DeclaredValue::Value(
-                    specified::LengthOrPercentageOrAuto::Length(value)))));
+                PropertyDeclaration::Width(specified::LengthOrPercentageOrAuto::Length(value))));
         }
 
         let rows = if let Some(this) = self.downcast::<HTMLTextAreaElement>() {
@@ -615,8 +610,7 @@ impl LayoutElementHelpers for LayoutJS<Element> {
             // https://html.spec.whatwg.org/multipage/#textarea-effective-height
             let value = specified::NoCalcLength::FontRelative(specified::FontRelativeLength::Em(rows as CSSFloat));
             hints.push(from_declaration(
-                PropertyDeclaration::Height(DeclaredValue::Value(
-                        specified::LengthOrPercentageOrAuto::Length(value)))));
+                PropertyDeclaration::Height(specified::LengthOrPercentageOrAuto::Length(value))));
         }
 
 
@@ -629,13 +623,13 @@ impl LayoutElementHelpers for LayoutJS<Element> {
         if let Some(border) = border {
             let width_value = specified::BorderWidth::from_length(specified::Length::from_px(border as f32));
             hints.push(from_declaration(
-                PropertyDeclaration::BorderTopWidth(DeclaredValue::Value(width_value.clone()))));
+                PropertyDeclaration::BorderTopWidth(width_value.clone())));
             hints.push(from_declaration(
-                PropertyDeclaration::BorderLeftWidth(DeclaredValue::Value(width_value.clone()))));
+                PropertyDeclaration::BorderLeftWidth(width_value.clone())));
             hints.push(from_declaration(
-                PropertyDeclaration::BorderBottomWidth(DeclaredValue::Value(width_value.clone()))));
+                PropertyDeclaration::BorderBottomWidth(width_value.clone())));
             hints.push(from_declaration(
-                PropertyDeclaration::BorderRightWidth(DeclaredValue::Value(width_value))));
+                PropertyDeclaration::BorderRightWidth(width_value)));
         }
     }
 

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -329,7 +329,7 @@ pub fn cascade<'a>(custom_properties: &mut Option<HashMap<&'a Name, BorrowedSpec
                    inherited: &'a Option<Arc<HashMap<Name, ComputedValue>>>,
                    seen: &mut HashSet<&'a Name>,
                    name: &'a Name,
-                   specified_value: &'a DeclaredValue<Box<SpecifiedValue>>) {
+                   specified_value: DeclaredValue<'a, Box<SpecifiedValue>>) {
     let was_already_present = !seen.insert(name);
     if was_already_present {
         return;
@@ -352,7 +352,7 @@ pub fn cascade<'a>(custom_properties: &mut Option<HashMap<&'a Name, BorrowedSpec
             custom_properties.as_mut().unwrap()
         }
     };
-    match *specified_value {
+    match specified_value {
         DeclaredValue::Value(ref specified_value) => {
             map.insert(name, BorrowedSpecifiedValue {
                 css: &specified_value.css,

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -11,7 +11,7 @@ use cssparser::{DeclarationListParser, DeclarationParser, parse_one_rule};
 use parking_lot::RwLock;
 use parser::{ParserContext, ParserContextExtraData, log_css_error};
 use properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, PropertyId};
-use properties::{PropertyDeclarationId, LonghandId, DeclaredValue, ParsedDeclaration};
+use properties::{PropertyDeclarationId, LonghandId, ParsedDeclaration};
 use properties::LonghandIdSet;
 use properties::animated_properties::TransitionProperty;
 use properties::longhands::transition_timing_function::single_value::SpecifiedValue as SpecifiedTimingFunction;
@@ -210,14 +210,11 @@ impl KeyframesStep {
                     guard.get(PropertyDeclarationId::Longhand(LonghandId::AnimationTimingFunction)).unwrap();
                 match *declaration {
                     PropertyDeclaration::AnimationTimingFunction(ref value) => {
-                        match *value {
-                            DeclaredValue::Value(ref value) => {
-                                // Use the first value.
-                                Some(value.0[0])
-                            },
-                            _ => None,
-                        }
+                        // Use the first value.
+                        Some(value.0[0])
                     },
+                    PropertyDeclaration::CSSWideKeyword(..) => None,
+                    PropertyDeclaration::WithVariables(..) => None,
                     _ => panic!(),
                 }
             },

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -53,7 +53,7 @@ use gecko::values::GeckoStyleCoordConvertible;
 use gecko::values::round_border_to_device_pixels;
 use logical_geometry::WritingMode;
 use properties::longhands;
-use properties::{DeclaredValue, Importance, LonghandId};
+use properties::{Importance, LonghandId};
 use properties::{PropertyDeclaration, PropertyDeclarationBlock, PropertyDeclarationId};
 use std::fmt::{self, Debug};
 use std::mem::{forget, transmute, zeroed};
@@ -169,7 +169,7 @@ impl ComputedValues {
                 % if prop.animatable:
                     PropertyDeclarationId::Longhand(LonghandId::${prop.camel_case}) => {
                          PropertyDeclarationBlock::with_one(
-                            PropertyDeclaration::${prop.camel_case}(DeclaredValue::Value(
+                            PropertyDeclaration::${prop.camel_case}(
                                 % if prop.boxed:
                                     Box::new(
                                 % endif
@@ -178,7 +178,7 @@ impl ComputedValues {
                                 % if prop.boxed:
                                     )
                                 % endif
-                            )),
+                            ),
                             Importance::Normal
                         )
                     },

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1008,7 +1008,7 @@ macro_rules! match_wrap_declared {
     ($longhand:ident, $($property:ident => $inner:expr,)*) => (
         match $longhand {
             $(
-                LonghandId::$property => PropertyDeclaration::$property(DeclaredValue::Value($inner)),
+                LonghandId::$property => PropertyDeclaration::$property($inner),
             )*
             _ => {
                 error!("stylo: Don't know how to handle presentation property {:?}", $longhand);
@@ -1036,7 +1036,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetIdentStringValue(declarations:
                                                              nsCSSPropertyID,
                                                              value:
                                                              *mut nsIAtom) {
-    use style::properties::{DeclaredValue, PropertyDeclaration, LonghandId};
+    use style::properties::{PropertyDeclaration, LonghandId};
     use style::properties::longhands::_x_lang::computed_value::T as Lang;
 
     let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
@@ -1053,7 +1053,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetKeywordValue(declarations:
                                                          RawServoDeclarationBlockBorrowed,
                                                          property: nsCSSPropertyID,
                                                          value: i32) {
-    use style::properties::{DeclaredValue, PropertyDeclaration, LonghandId};
+    use style::properties::{PropertyDeclaration, LonghandId};
     use style::properties::longhands;
     use style::values::specified::{BorderStyle, NoCalcLength};
 
@@ -1088,7 +1088,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetKeywordValue(declarations:
 pub extern "C" fn Servo_DeclarationBlock_SetIntValue(declarations: RawServoDeclarationBlockBorrowed,
                                                      property: nsCSSPropertyID,
                                                      value: i32) {
-    use style::properties::{DeclaredValue, PropertyDeclaration, LonghandId};
+    use style::properties::{PropertyDeclaration, LonghandId};
     use style::properties::longhands::_x_span::computed_value::T as Span;
 
     let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
@@ -1104,7 +1104,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetPixelValue(declarations:
                                                        RawServoDeclarationBlockBorrowed,
                                                        property: nsCSSPropertyID,
                                                        value: f32) {
-    use style::properties::{DeclaredValue, PropertyDeclaration, LonghandId};
+    use style::properties::{PropertyDeclaration, LonghandId};
     use style::properties::longhands::border_spacing::SpecifiedValue as BorderSpacing;
     use style::values::specified::BorderWidth;
     use style::values::specified::length::NoCalcLength;
@@ -1143,7 +1143,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetPercentValue(declarations:
                                                          RawServoDeclarationBlockBorrowed,
                                                          property: nsCSSPropertyID,
                                                          value: f32) {
-    use style::properties::{DeclaredValue, PropertyDeclaration, LonghandId};
+    use style::properties::{PropertyDeclaration, LonghandId};
     use style::values::specified::length::Percentage;
 
     let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
@@ -1165,7 +1165,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetPercentValue(declarations:
 pub extern "C" fn Servo_DeclarationBlock_SetAutoValue(declarations:
                                                       RawServoDeclarationBlockBorrowed,
                                                       property: nsCSSPropertyID) {
-    use style::properties::{DeclaredValue, PropertyDeclaration, LonghandId};
+    use style::properties::{PropertyDeclaration, LonghandId};
     use style::values::specified::LengthOrPercentageOrAuto;
 
     let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
@@ -1187,7 +1187,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetAutoValue(declarations:
 pub extern "C" fn Servo_DeclarationBlock_SetCurrentColor(declarations:
                                                          RawServoDeclarationBlockBorrowed,
                                                          property: nsCSSPropertyID) {
-    use style::properties::{DeclaredValue, PropertyDeclaration, LonghandId};
+    use style::properties::{PropertyDeclaration, LonghandId};
     use style::values::specified::{Color, CSSColor};
 
     let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
@@ -1209,7 +1209,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetColorValue(declarations:
                                                        property: nsCSSPropertyID,
                                                        value: structs::nscolor) {
     use style::gecko::values::convert_nscolor_to_rgba;
-    use style::properties::{DeclaredValue, PropertyDeclaration, LonghandId};
+    use style::properties::{PropertyDeclaration, LonghandId};
     use style::properties::longhands;
     use style::values::specified::{Color, CSSColor};
 
@@ -1234,7 +1234,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetFontFamily(declarations:
                                                        RawServoDeclarationBlockBorrowed,
                                                        value: *const nsAString) {
     use cssparser::Parser;
-    use style::properties::{DeclaredValue, PropertyDeclaration};
+    use style::properties::PropertyDeclaration;
     use style::properties::longhands::font_family::SpecifiedValue as FontFamily;
 
     let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
@@ -1242,7 +1242,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetFontFamily(declarations:
     let mut parser = Parser::new(&string);
     if let Ok(family) = FontFamily::parse(&mut parser) {
         if parser.is_exhausted() {
-            let decl = PropertyDeclaration::FontFamily(DeclaredValue::Value(family));
+            let decl = PropertyDeclaration::FontFamily(family);
             declarations.write().push(decl, Importance::Normal);
         }
     }
@@ -1251,13 +1251,13 @@ pub extern "C" fn Servo_DeclarationBlock_SetFontFamily(declarations:
 #[no_mangle]
 pub extern "C" fn Servo_DeclarationBlock_SetTextDecorationColorOverride(declarations:
                                                                 RawServoDeclarationBlockBorrowed) {
-    use style::properties::{DeclaredValue, PropertyDeclaration};
+    use style::properties::PropertyDeclaration;
     use style::properties::longhands::text_decoration_line;
 
     let declarations = RwLock::<PropertyDeclarationBlock>::as_arc(&declarations);
     let mut decoration = text_decoration_line::computed_value::none;
     decoration |= text_decoration_line::COLOR_OVERRIDE;
-    let decl = PropertyDeclaration::TextDecorationLine(DeclaredValue::Value(decoration));
+    let decl = PropertyDeclaration::TextDecorationLine(decoration);
     declarations.write().push(decl, Importance::Normal);
 }
 

--- a/tests/unit/style/keyframes.rs
+++ b/tests/unit/style/keyframes.rs
@@ -6,7 +6,7 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 use style::keyframes::{Keyframe, KeyframesAnimation, KeyframePercentage,  KeyframeSelector};
 use style::keyframes::{KeyframesStep, KeyframesStepValue};
-use style::properties::{DeclaredValue, PropertyDeclaration, PropertyDeclarationBlock, Importance};
+use style::properties::{PropertyDeclaration, PropertyDeclarationBlock, Importance};
 use style::properties::animated_properties::TransitionProperty;
 use style::values::specified::{LengthOrPercentageOrAuto, NoCalcLength};
 
@@ -44,7 +44,7 @@ fn test_missing_property_in_initial_keyframe() {
     let declarations_on_initial_keyframe =
         Arc::new(RwLock::new(PropertyDeclarationBlock::with_one(
             PropertyDeclaration::Width(
-                DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+                LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32))),
             Importance::Normal
         )));
 
@@ -53,12 +53,12 @@ fn test_missing_property_in_initial_keyframe() {
             let mut block = PropertyDeclarationBlock::new();
             block.push(
                 PropertyDeclaration::Width(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+                    LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32))),
                 Importance::Normal
             );
             block.push(
                 PropertyDeclaration::Height(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+                    LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32))),
                 Importance::Normal
             );
             block
@@ -102,12 +102,12 @@ fn test_missing_property_in_final_keyframe() {
             let mut block = PropertyDeclarationBlock::new();
             block.push(
                 PropertyDeclaration::Width(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+                    LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32))),
                 Importance::Normal
             );
             block.push(
                 PropertyDeclaration::Height(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+                    LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32))),
                 Importance::Normal
             );
             block
@@ -116,7 +116,7 @@ fn test_missing_property_in_final_keyframe() {
     let declarations_on_final_keyframe =
         Arc::new(RwLock::new(PropertyDeclarationBlock::with_one(
             PropertyDeclaration::Height(
-                DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+                LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32))),
             Importance::Normal,
         )));
 
@@ -158,12 +158,12 @@ fn test_missing_keyframe_in_both_of_initial_and_final_keyframe() {
             let mut block = PropertyDeclarationBlock::new();
             block.push(
                 PropertyDeclaration::Width(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+                    LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32))),
                 Importance::Normal
             );
             block.push(
                 PropertyDeclaration::Height(
-                    DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+                    LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32))),
                 Importance::Normal
             );
             block

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -7,8 +7,7 @@ use media_queries::CSSErrorReporterTest;
 use servo_url::ServoUrl;
 use style::computed_values::display::T::inline_block;
 use style::parser::ParserContext;
-use style::properties::{DeclaredValue, PropertyDeclaration};
-use style::properties::{PropertyDeclarationBlock, Importance, PropertyId};
+use style::properties::{PropertyDeclaration, PropertyDeclarationBlock, Importance, PropertyId};
 use style::properties::longhands::outline_color::computed_value::T as ComputedColor;
 use style::properties::parse_property_declaration_list;
 use style::stylesheets::Origin;
@@ -34,27 +33,27 @@ fn property_declaration_block_should_serialize_correctly() {
 
     let declarations = vec![
         (PropertyDeclaration::Width(
-            DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(70f32)))),
+            LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(70f32))),
          Importance::Normal),
 
         (PropertyDeclaration::MinHeight(
-            DeclaredValue::Value(LengthOrPercentage::Length(NoCalcLength::from_px(20f32)))),
+            LengthOrPercentage::Length(NoCalcLength::from_px(20f32))),
          Importance::Normal),
 
         (PropertyDeclaration::Height(
-            DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32)))),
+            LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(20f32))),
          Importance::Important),
 
         (PropertyDeclaration::Display(
-            DeclaredValue::Value(inline_block)),
+            inline_block),
          Importance::Normal),
 
         (PropertyDeclaration::OverflowX(
-            DeclaredValue::Value(OverflowXValue::auto)),
+            OverflowXValue::auto),
          Importance::Normal),
 
         (PropertyDeclaration::OverflowY(
-            DeclaredValue::Value(OverflowYContainer(OverflowXValue::auto))),
+            OverflowYContainer(OverflowXValue::auto)),
          Importance::Normal),
     ];
 
@@ -88,10 +87,10 @@ mod shorthand_serialization {
         fn equal_overflow_properties_should_serialize_to_single_value() {
             let mut properties = Vec::new();
 
-            let overflow_x = DeclaredValue::Value(OverflowXValue::auto);
+            let overflow_x = OverflowXValue::auto;
             properties.push(PropertyDeclaration::OverflowX(overflow_x));
 
-            let overflow_y = DeclaredValue::Value(OverflowYContainer(OverflowXValue::auto));
+            let overflow_y = OverflowYContainer(OverflowXValue::auto);
             properties.push(PropertyDeclaration::OverflowY(overflow_y));
 
             let serialization = shorthand_properties_to_string(properties);
@@ -102,10 +101,10 @@ mod shorthand_serialization {
         fn different_overflow_properties_should_serialize_to_two_values() {
             let mut properties = Vec::new();
 
-            let overflow_x = DeclaredValue::Value(OverflowXValue::scroll);
+            let overflow_x = OverflowXValue::scroll;
             properties.push(PropertyDeclaration::OverflowX(overflow_x));
 
-            let overflow_y = DeclaredValue::Value(OverflowYContainer(OverflowXValue::auto));
+            let overflow_y = OverflowYContainer(OverflowXValue::auto);
             properties.push(PropertyDeclaration::OverflowY(overflow_y));
 
             let serialization = shorthand_properties_to_string(properties);
@@ -122,12 +121,12 @@ mod shorthand_serialization {
         fn text_decoration_should_show_all_properties_when_set() {
             let mut properties = Vec::new();
 
-            let line = DeclaredValue::Value(TextDecorationLine::OVERLINE);
-            let style = DeclaredValue::Value(TextDecorationStyle::dotted);
-            let color = DeclaredValue::Value(CSSColor {
+            let line = TextDecorationLine::OVERLINE;
+            let style = TextDecorationStyle::dotted;
+            let color = CSSColor {
                 parsed: ComputedColor::RGBA(RGBA::new(128, 0, 128, 255)),
                 authored: None
-            });
+            };
 
             properties.push(PropertyDeclaration::TextDecorationLine(line));
             properties.push(PropertyDeclaration::TextDecorationStyle(style));
@@ -141,9 +140,9 @@ mod shorthand_serialization {
         fn text_decoration_should_not_serialize_initial_style_value() {
             let mut properties = Vec::new();
 
-            let line = DeclaredValue::Value(TextDecorationLine::UNDERLINE);
-            let style = DeclaredValue::Value(TextDecorationStyle::solid);
-            let color = DeclaredValue::Value(CSSColor::currentcolor());
+            let line = TextDecorationLine::UNDERLINE;
+            let style = TextDecorationStyle::solid;
+            let color = CSSColor::currentcolor();
 
             properties.push(PropertyDeclaration::TextDecorationLine(line));
             properties.push(PropertyDeclaration::TextDecorationStyle(style));
@@ -163,7 +162,7 @@ mod shorthand_serialization {
         fn all_equal_properties_should_serialize_to_one_value() {
             let mut properties = Vec::new();
 
-            let px_70 = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(70f32)));
+            let px_70 = LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(70f32));
             properties.push(PropertyDeclaration::MarginTop(px_70.clone()));
             properties.push(PropertyDeclaration::MarginRight(px_70.clone()));
             properties.push(PropertyDeclaration::MarginBottom(px_70.clone()));
@@ -177,8 +176,8 @@ mod shorthand_serialization {
         fn equal_vertical_and_equal_horizontal_properties_should_serialize_to_two_value() {
             let mut properties = Vec::new();
 
-            let vertical_px = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(10f32)));
-            let horizontal_px = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(5f32)));
+            let vertical_px = LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(10f32));
+            let horizontal_px = LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(5f32));
 
             properties.push(PropertyDeclaration::MarginTop(vertical_px.clone()));
             properties.push(PropertyDeclaration::MarginRight(horizontal_px.clone()));
@@ -193,9 +192,9 @@ mod shorthand_serialization {
         fn different_vertical_and_equal_horizontal_properties_should_serialize_to_three_values() {
             let mut properties = Vec::new();
 
-            let top_px = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(8f32)));
-            let bottom_px = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(10f32)));
-            let horizontal_px = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(5f32)));
+            let top_px = LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(8f32));
+            let bottom_px = LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(10f32));
+            let horizontal_px = LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(5f32));
 
             properties.push(PropertyDeclaration::MarginTop(top_px));
             properties.push(PropertyDeclaration::MarginRight(horizontal_px.clone()));
@@ -210,10 +209,10 @@ mod shorthand_serialization {
         fn different_properties_should_serialize_to_four_values() {
             let mut properties = Vec::new();
 
-            let top_px = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(8f32)));
-            let right_px = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(12f32)));
-            let bottom_px = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(10f32)));
-            let left_px = DeclaredValue::Value(LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(14f32)));
+            let top_px = LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(8f32));
+            let right_px = LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(12f32));
+            let bottom_px = LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(10f32));
+            let left_px = LengthOrPercentageOrAuto::Length(NoCalcLength::from_px(14f32));
 
             properties.push(PropertyDeclaration::MarginTop(top_px));
             properties.push(PropertyDeclaration::MarginRight(right_px));
@@ -228,25 +227,25 @@ mod shorthand_serialization {
         fn different_longhands_should_serialize_to_long_form() {
           let mut properties = Vec::new();
 
-          let solid = DeclaredValue::Value(BorderStyle::solid);
+          let solid = BorderStyle::solid;
 
           properties.push(PropertyDeclaration::BorderTopStyle(solid.clone()));
           properties.push(PropertyDeclaration::BorderRightStyle(solid.clone()));
           properties.push(PropertyDeclaration::BorderBottomStyle(solid.clone()));
           properties.push(PropertyDeclaration::BorderLeftStyle(solid.clone()));
 
-          let px_30 = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(30f32)));
-          let px_10 = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(10f32)));
+          let px_30 = BorderWidth::from_length(Length::from_px(30f32));
+          let px_10 = BorderWidth::from_length(Length::from_px(10f32));
 
           properties.push(PropertyDeclaration::BorderTopWidth(px_30.clone()));
           properties.push(PropertyDeclaration::BorderRightWidth(px_30.clone()));
           properties.push(PropertyDeclaration::BorderBottomWidth(px_30.clone()));
           properties.push(PropertyDeclaration::BorderLeftWidth(px_10.clone()));
 
-          let blue = DeclaredValue::Value(CSSColor {
+          let blue = CSSColor {
               parsed: ComputedColor::RGBA(RGBA::new(0, 0, 255, 255)),
               authored: None
-          });
+          };
 
           properties.push(PropertyDeclaration::BorderTopColor(blue.clone()));
           properties.push(PropertyDeclaration::BorderRightColor(blue.clone()));
@@ -262,24 +261,24 @@ mod shorthand_serialization {
         fn same_longhands_should_serialize_correctly() {
           let mut properties = Vec::new();
 
-          let solid = DeclaredValue::Value(BorderStyle::solid);
+          let solid = BorderStyle::solid;
 
           properties.push(PropertyDeclaration::BorderTopStyle(solid.clone()));
           properties.push(PropertyDeclaration::BorderRightStyle(solid.clone()));
           properties.push(PropertyDeclaration::BorderBottomStyle(solid.clone()));
           properties.push(PropertyDeclaration::BorderLeftStyle(solid.clone()));
 
-          let px_30 = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(30f32)));
+          let px_30 = BorderWidth::from_length(Length::from_px(30f32));
 
           properties.push(PropertyDeclaration::BorderTopWidth(px_30.clone()));
           properties.push(PropertyDeclaration::BorderRightWidth(px_30.clone()));
           properties.push(PropertyDeclaration::BorderBottomWidth(px_30.clone()));
           properties.push(PropertyDeclaration::BorderLeftWidth(px_30.clone()));
 
-          let blue = DeclaredValue::Value(CSSColor {
+          let blue = CSSColor {
               parsed: ComputedColor::RGBA(RGBA::new(0, 0, 255, 255)),
               authored: None
-          });
+          };
 
           properties.push(PropertyDeclaration::BorderTopColor(blue.clone()));
           properties.push(PropertyDeclaration::BorderRightColor(blue.clone()));
@@ -294,8 +293,8 @@ mod shorthand_serialization {
         fn padding_should_serialize_correctly() {
             let mut properties = Vec::new();
 
-            let px_10 = DeclaredValue::Value(LengthOrPercentage::Length(NoCalcLength::from_px(10f32)));
-            let px_15 = DeclaredValue::Value(LengthOrPercentage::Length(NoCalcLength::from_px(15f32)));
+            let px_10 = LengthOrPercentage::Length(NoCalcLength::from_px(10f32));
+            let px_15 = LengthOrPercentage::Length(NoCalcLength::from_px(15f32));
             properties.push(PropertyDeclaration::PaddingTop(px_10.clone()));
             properties.push(PropertyDeclaration::PaddingRight(px_15.clone()));
             properties.push(PropertyDeclaration::PaddingBottom(px_10));
@@ -309,11 +308,11 @@ mod shorthand_serialization {
         fn border_width_should_serialize_correctly() {
             let mut properties = Vec::new();
 
-            let top_px = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(10f32)));
-            let bottom_px = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(10f32)));
+            let top_px = BorderWidth::from_length(Length::from_px(10f32));
+            let bottom_px = BorderWidth::from_length(Length::from_px(10f32));
 
-            let right_px = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(15f32)));
-            let left_px = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(15f32)));
+            let right_px = BorderWidth::from_length(Length::from_px(15f32));
+            let left_px = BorderWidth::from_length(Length::from_px(15f32));
 
             properties.push(PropertyDeclaration::BorderTopWidth(top_px));
             properties.push(PropertyDeclaration::BorderRightWidth(right_px));
@@ -328,10 +327,10 @@ mod shorthand_serialization {
         fn border_width_with_keywords_should_serialize_correctly() {
             let mut properties = Vec::new();
 
-            let top_px = DeclaredValue::Value(BorderWidth::Thin);
-            let right_px = DeclaredValue::Value(BorderWidth::Medium);
-            let bottom_px = DeclaredValue::Value(BorderWidth::Thick);
-            let left_px = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(15f32)));
+            let top_px = BorderWidth::Thin;
+            let right_px = BorderWidth::Medium;
+            let bottom_px = BorderWidth::Thick;
+            let left_px = BorderWidth::from_length(Length::from_px(15f32));
 
             properties.push(PropertyDeclaration::BorderTopWidth(top_px));
             properties.push(PropertyDeclaration::BorderRightWidth(right_px));
@@ -346,15 +345,15 @@ mod shorthand_serialization {
         fn border_color_should_serialize_correctly() {
             let mut properties = Vec::new();
 
-            let red = DeclaredValue::Value(CSSColor {
+            let red = CSSColor {
                 parsed: ComputedColor::RGBA(RGBA::new(255, 0, 0, 255)),
                 authored: None
-            });
+            };
 
-            let blue = DeclaredValue::Value(CSSColor {
+            let blue = CSSColor {
                 parsed: ComputedColor::RGBA(RGBA::new(0, 0, 255, 255)),
                 authored: None
-            });
+            };
 
             properties.push(PropertyDeclaration::BorderTopColor(blue.clone()));
             properties.push(PropertyDeclaration::BorderRightColor(red.clone()));
@@ -371,8 +370,8 @@ mod shorthand_serialization {
         fn border_style_should_serialize_correctly() {
             let mut properties = Vec::new();
 
-            let solid = DeclaredValue::Value(BorderStyle::solid);
-            let dotted = DeclaredValue::Value(BorderStyle::dotted);
+            let solid = BorderStyle::solid;
+            let dotted = BorderStyle::dotted;
             properties.push(PropertyDeclaration::BorderTopStyle(solid.clone()));
             properties.push(PropertyDeclaration::BorderRightStyle(dotted.clone()));
             properties.push(PropertyDeclaration::BorderBottomStyle(solid));
@@ -394,12 +393,12 @@ mod shorthand_serialization {
         fn directional_border_should_show_all_properties_when_values_are_set() {
             let mut properties = Vec::new();
 
-            let width = DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32)));
-            let style = DeclaredValue::Value(BorderStyle::solid);
-            let color = DeclaredValue::Value(CSSColor {
+            let width = BorderWidth::from_length(Length::from_px(4f32));
+            let style = BorderStyle::solid;
+            let color = CSSColor {
                 parsed: ComputedColor::RGBA(RGBA::new(255, 0, 0, 255)),
                 authored: None
-            });
+            };
 
             properties.push(PropertyDeclaration::BorderTopWidth(width));
             properties.push(PropertyDeclaration::BorderTopStyle(style));
@@ -409,12 +408,10 @@ mod shorthand_serialization {
             assert_eq!(serialization, "border-top: 4px solid rgb(255, 0, 0);");
         }
 
-        fn get_border_property_values() -> (DeclaredValue<BorderWidth>,
-                                            DeclaredValue<BorderStyle>,
-                                            DeclaredValue<CSSColor>) {
-            (DeclaredValue::Value(BorderWidth::from_length(Length::from_px(4f32))),
-             DeclaredValue::Value(BorderStyle::solid),
-             DeclaredValue::Value(CSSColor::currentcolor()))
+        fn get_border_property_values() -> (BorderWidth, BorderStyle, CSSColor) {
+            (BorderWidth::from_length(Length::from_px(4f32)),
+             BorderStyle::solid,
+             CSSColor::currentcolor())
         }
 
         #[test]
@@ -501,10 +498,10 @@ mod shorthand_serialization {
         fn list_style_should_show_all_properties_when_values_are_set() {
             let mut properties = Vec::new();
 
-            let position = DeclaredValue::Value(ListStylePosition::inside);
-            let image = DeclaredValue::Value(Either::First(
-                SpecifiedUrl::new_for_testing("http://servo/test.png")));
-            let style_type = DeclaredValue::Value(ListStyleType::disc);
+            let position = ListStylePosition::inside;
+            let image = Either::First(
+                SpecifiedUrl::new_for_testing("http://servo/test.png"));
+            let style_type = ListStyleType::disc;
 
             properties.push(PropertyDeclaration::ListStylePosition(position));
             properties.push(PropertyDeclaration::ListStyleImage(image));
@@ -524,12 +521,12 @@ mod shorthand_serialization {
         fn outline_should_show_all_properties_when_set() {
             let mut properties = Vec::new();
 
-            let width = DeclaredValue::Value(WidthContainer(Length::from_px(4f32)));
-            let style = DeclaredValue::Value(Either::Second(BorderStyle::solid));
-            let color = DeclaredValue::Value(CSSColor {
+            let width = WidthContainer(Length::from_px(4f32));
+            let style = Either::Second(BorderStyle::solid);
+            let color = CSSColor {
                 parsed: ComputedColor::RGBA(RGBA::new(255, 0, 0, 255)),
                 authored: None
-            });
+            };
 
             properties.push(PropertyDeclaration::OutlineWidth(width));
             properties.push(PropertyDeclaration::OutlineStyle(style));
@@ -543,12 +540,12 @@ mod shorthand_serialization {
         fn outline_should_serialize_correctly_when_style_is_auto() {
             let mut properties = Vec::new();
 
-            let width = DeclaredValue::Value(WidthContainer(Length::from_px(4f32)));
-            let style = DeclaredValue::Value(Either::First(Auto));
-            let color = DeclaredValue::Value(CSSColor {
+            let width = WidthContainer(Length::from_px(4f32));
+            let style = Either::First(Auto);
+            let color = CSSColor {
                 parsed: ComputedColor::RGBA(RGBA::new(255, 0, 0, 255)),
                 authored: None
-            });
+            };
             properties.push(PropertyDeclaration::OutlineWidth(width));
             properties.push(PropertyDeclaration::OutlineStyle(style));
             properties.push(PropertyDeclaration::OutlineColor(color));
@@ -565,8 +562,8 @@ mod shorthand_serialization {
 
         let mut properties = Vec::new();
 
-        let width = DeclaredValue::Value(Either::Second(Auto));
-        let count = DeclaredValue::Value(ColumnCount::Auto);
+        let width = Either::Second(Auto);
+        let count = ColumnCount::Auto;
 
         properties.push(PropertyDeclaration::ColumnWidth(width));
         properties.push(PropertyDeclaration::ColumnCount(count));
@@ -582,11 +579,10 @@ mod shorthand_serialization {
 
         let mut properties = Vec::new();
 
-        let grow = DeclaredValue::Value(NumberContainer(2f32));
-        let shrink = DeclaredValue::Value(NumberContainer(3f32));
-        let basis = DeclaredValue::Value(
-            LengthOrPercentageOrAutoOrContent::Percentage(PercentageContainer(0.5f32))
-        );
+        let grow = NumberContainer(2f32);
+        let shrink = NumberContainer(3f32);
+        let basis =
+            LengthOrPercentageOrAutoOrContent::Percentage(PercentageContainer(0.5f32));
 
         properties.push(PropertyDeclaration::FlexGrow(grow));
         properties.push(PropertyDeclaration::FlexShrink(shrink));
@@ -603,8 +599,8 @@ mod shorthand_serialization {
 
         let mut properties = Vec::new();
 
-        let direction = DeclaredValue::Value(FlexDirection::row);
-        let wrap = DeclaredValue::Value(FlexWrap::wrap);
+        let direction = FlexDirection::row;
+        let wrap = FlexWrap::wrap;
 
         properties.push(PropertyDeclaration::FlexDirection(direction));
         properties.push(PropertyDeclaration::FlexWrap(wrap));
@@ -774,23 +770,23 @@ mod shorthand_serialization {
 
         macro_rules! single_vec_value_typedef {
             ($name:ident, $path:expr) => {
-                DeclaredValue::Value($name::SpecifiedValue(
+                $name::SpecifiedValue(
                     vec![$path]
-                ))
+                )
             };
         }
         macro_rules! single_vec_keyword_value {
             ($name:ident, $kw:ident) => {
-                DeclaredValue::Value($name::SpecifiedValue(
+                $name::SpecifiedValue(
                     vec![$name::single_value::SpecifiedValue::$kw]
-                ))
+                )
             };
         }
         macro_rules! single_vec_variant_value {
             ($name:ident, $variant:expr) => {
-                DeclaredValue::Value($name::SpecifiedValue(
+                $name::SpecifiedValue(
                         vec![$variant]
-                ))
+                )
             };
         }
 
@@ -913,9 +909,9 @@ mod shorthand_serialization {
         #[test]
         fn should_serialize_to_empty_string_if_sub_types_not_equal() {
             let declarations = vec![
-                (PropertyDeclaration::ScrollSnapTypeX(DeclaredValue::Value(ScrollSnapTypeXValue::mandatory)),
+                (PropertyDeclaration::ScrollSnapTypeX(ScrollSnapTypeXValue::mandatory),
                 Importance::Normal),
-                (PropertyDeclaration::ScrollSnapTypeY(DeclaredValue::Value(ScrollSnapTypeXValue::none)),
+                (PropertyDeclaration::ScrollSnapTypeY(ScrollSnapTypeXValue::none),
                 Importance::Normal)
             ];
 
@@ -933,9 +929,9 @@ mod shorthand_serialization {
         #[test]
         fn should_serialize_to_single_value_if_sub_types_are_equal() {
             let declarations = vec![
-                (PropertyDeclaration::ScrollSnapTypeX(DeclaredValue::Value(ScrollSnapTypeXValue::mandatory)),
+                (PropertyDeclaration::ScrollSnapTypeX(ScrollSnapTypeXValue::mandatory),
                 Importance::Normal),
-                (PropertyDeclaration::ScrollSnapTypeY(DeclaredValue::Value(ScrollSnapTypeXValue::mandatory)),
+                (PropertyDeclaration::ScrollSnapTypeY(ScrollSnapTypeXValue::mandatory),
                 Importance::Normal)
             ];
 

--- a/tests/unit/style/properties/viewport.rs
+++ b/tests/unit/style/properties/viewport.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
-use style::properties::{DeclaredValue, PropertyDeclaration};
+use style::properties::PropertyDeclaration;
 use style::properties::longhands::border_top_width;
 use style::values::HasViewportPercentage;
 use style::values::specified::{Length, NoCalcLength, ViewportPercentageLength};
@@ -12,16 +12,16 @@ use style::values::specified::{Length, NoCalcLength, ViewportPercentageLength};
 fn has_viewport_percentage_for_specified_value() {
     //TODO: test all specified value with a HasViewportPercentage impl
     let pvw = PropertyDeclaration::BorderTopWidth(
-        DeclaredValue::Value(border_top_width::SpecifiedValue::from_length(
+        border_top_width::SpecifiedValue::from_length(
             Length::NoCalc(NoCalcLength::ViewportPercentage(ViewportPercentageLength::Vw(100.)))
-        ))
+        )
     );
     assert!(pvw.has_viewport_percentage());
 
     let pabs = PropertyDeclaration::BorderTopWidth(
-        DeclaredValue::Value(border_top_width::SpecifiedValue::from_length(
+        border_top_width::SpecifiedValue::from_length(
             Length::NoCalc(NoCalcLength::Absolute(Au(100)))
-        ))
+        )
     );
     assert!(!pabs.has_viewport_percentage());
 }

--- a/tests/unit/style/rule_tree/bench.rs
+++ b/tests/unit/style/rule_tree/bench.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use style::error_reporting::ParseErrorReporter;
 use style::media_queries::MediaList;
 use style::parser::ParserContextExtraData;
-use style::properties::{longhands, DeclaredValue, Importance, PropertyDeclaration, PropertyDeclarationBlock};
+use style::properties::{longhands, Importance, PropertyDeclaration, PropertyDeclarationBlock};
 use style::rule_tree::{CascadeLevel, RuleTree, StrongRuleNode, StyleSource};
 use style::stylesheets::{Origin, Stylesheet, CssRule};
 use test::{self, Bencher};
@@ -65,8 +65,8 @@ fn test_insertion(rule_tree: &RuleTree, rules: Vec<(StyleSource, CascadeLevel)>)
 fn test_insertion_style_attribute(rule_tree: &RuleTree, rules: &[(StyleSource, CascadeLevel)]) -> StrongRuleNode {
     let mut rules = rules.to_vec();
     rules.push((StyleSource::Declarations(Arc::new(RwLock::new(PropertyDeclarationBlock::with_one(
-        PropertyDeclaration::Display(DeclaredValue::Value(
-            longhands::display::SpecifiedValue::block)),
+        PropertyDeclaration::Display(
+            longhands::display::SpecifiedValue::block),
         Importance::Normal
     )))), CascadeLevel::UserNormal));
     test_insertion(rule_tree, rules)

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -17,8 +17,8 @@ use style::error_reporting::ParseErrorReporter;
 use style::keyframes::{Keyframe, KeyframeSelector, KeyframePercentage};
 use style::parser::ParserContextExtraData;
 use style::properties::Importance;
-use style::properties::{CSSWideKeyword, PropertyDeclaration, PropertyDeclarationBlock};
-use style::properties::{DeclaredValue, longhands};
+use style::properties::{CSSWideKeyword, DeclaredValueOwned, PropertyDeclaration, PropertyDeclarationBlock};
+use style::properties::longhands;
 use style::properties::longhands::animation_play_state;
 use style::stylesheets::{Origin, Namespaces};
 use style::stylesheets::{Stylesheet, NamespaceRule, CssRule, CssRules, StyleRule, KeyframesRule};
@@ -108,11 +108,10 @@ fn test_parse_stylesheet() {
                     },
                 ]),
                 block: Arc::new(RwLock::new(block_from(vec![
-                    (PropertyDeclaration::Display(DeclaredValue::Value(
-                        longhands::display::SpecifiedValue::none)),
+                    (PropertyDeclaration::Display(longhands::display::SpecifiedValue::none),
                      Importance::Important),
                     (PropertyDeclaration::Custom(Atom::from("a"),
-                     DeclaredValue::CSSWideKeyword(CSSWideKeyword::Inherit)),
+                     DeclaredValueOwned::CSSWideKeyword(CSSWideKeyword::Inherit)),
                      Importance::Important),
                 ]))),
             }))),
@@ -154,8 +153,7 @@ fn test_parse_stylesheet() {
                     },
                 ]),
                 block: Arc::new(RwLock::new(block_from(vec![
-                    (PropertyDeclaration::Display(DeclaredValue::Value(
-                        longhands::display::SpecifiedValue::block)),
+                    (PropertyDeclaration::Display(longhands::display::SpecifiedValue::block),
                      Importance::Normal),
                 ]))),
             }))),
@@ -186,52 +184,52 @@ fn test_parse_stylesheet() {
                     },
                 ]),
                 block: Arc::new(RwLock::new(block_from(vec![
-                    (PropertyDeclaration::BackgroundColor(DeclaredValue::Value(
+                    (PropertyDeclaration::BackgroundColor(
                         longhands::background_color::SpecifiedValue {
                             authored: Some("blue".to_owned().into_boxed_str()),
                             parsed: cssparser::Color::RGBA(cssparser::RGBA::new(0, 0, 255, 255)),
                         }
-                     )),
+                     ),
                      Importance::Normal),
-                    (PropertyDeclaration::BackgroundPositionX(DeclaredValue::Value(
+                    (PropertyDeclaration::BackgroundPositionX(
                         longhands::background_position_x::SpecifiedValue(
                         vec![longhands::background_position_x::single_value
-                                                   ::get_initial_position_value()]))),
+                                                   ::get_initial_position_value()])),
                     Importance::Normal),
-                    (PropertyDeclaration::BackgroundPositionY(DeclaredValue::Value(
+                    (PropertyDeclaration::BackgroundPositionY(
                         longhands::background_position_y::SpecifiedValue(
                         vec![longhands::background_position_y::single_value
-                                                   ::get_initial_position_value()]))),
+                                                   ::get_initial_position_value()])),
                      Importance::Normal),
-                    (PropertyDeclaration::BackgroundRepeat(DeclaredValue::Value(
+                    (PropertyDeclaration::BackgroundRepeat(
                         longhands::background_repeat::SpecifiedValue(
                         vec![longhands::background_repeat::single_value
-                                                   ::get_initial_specified_value()]))),
+                                                   ::get_initial_specified_value()])),
                      Importance::Normal),
-                    (PropertyDeclaration::BackgroundAttachment(DeclaredValue::Value(
+                    (PropertyDeclaration::BackgroundAttachment(
                         longhands::background_attachment::SpecifiedValue(
                         vec![longhands::background_attachment::single_value
-                                                   ::get_initial_specified_value()]))),
+                                                   ::get_initial_specified_value()])),
                      Importance::Normal),
-                    (PropertyDeclaration::BackgroundImage(DeclaredValue::Value(
+                    (PropertyDeclaration::BackgroundImage(
                         longhands::background_image::SpecifiedValue(
                         vec![longhands::background_image::single_value
-                                                   ::get_initial_specified_value()]))),
+                                                   ::get_initial_specified_value()])),
                      Importance::Normal),
-                    (PropertyDeclaration::BackgroundSize(DeclaredValue::Value(
+                    (PropertyDeclaration::BackgroundSize(
                         longhands::background_size::SpecifiedValue(
                         vec![longhands::background_size::single_value
-                                                   ::get_initial_specified_value()]))),
+                                                   ::get_initial_specified_value()])),
                      Importance::Normal),
-                    (PropertyDeclaration::BackgroundOrigin(DeclaredValue::Value(
+                    (PropertyDeclaration::BackgroundOrigin(
                         longhands::background_origin::SpecifiedValue(
                         vec![longhands::background_origin::single_value
-                                                   ::get_initial_specified_value()]))),
+                                                   ::get_initial_specified_value()])),
                      Importance::Normal),
-                    (PropertyDeclaration::BackgroundClip(DeclaredValue::Value(
+                    (PropertyDeclaration::BackgroundClip(
                         longhands::background_clip::SpecifiedValue(
                         vec![longhands::background_clip::single_value
-                                                   ::get_initial_specified_value()]))),
+                                                   ::get_initial_specified_value()])),
                      Importance::Normal),
                 ]))),
             }))),
@@ -242,8 +240,8 @@ fn test_parse_stylesheet() {
                         selector: KeyframeSelector::new_for_unit_testing(
                                       vec![KeyframePercentage::new(0.)]),
                         block: Arc::new(RwLock::new(block_from(vec![
-                            (PropertyDeclaration::Width(DeclaredValue::Value(
-                                LengthOrPercentageOrAuto::Percentage(Percentage(0.)))),
+                            (PropertyDeclaration::Width(
+                                LengthOrPercentageOrAuto::Percentage(Percentage(0.))),
                              Importance::Normal),
                         ])))
                     })),
@@ -251,12 +249,12 @@ fn test_parse_stylesheet() {
                         selector: KeyframeSelector::new_for_unit_testing(
                                       vec![KeyframePercentage::new(1.)]),
                         block: Arc::new(RwLock::new(block_from(vec![
-                            (PropertyDeclaration::Width(DeclaredValue::Value(
-                                LengthOrPercentageOrAuto::Percentage(Percentage(1.)))),
+                            (PropertyDeclaration::Width(
+                                LengthOrPercentageOrAuto::Percentage(Percentage(1.))),
                              Importance::Normal),
-                            (PropertyDeclaration::AnimationPlayState(DeclaredValue::Value(
+                            (PropertyDeclaration::AnimationPlayState(
                                 animation_play_state::SpecifiedValue(
-                                    vec![animation_play_state::SingleSpecifiedValue::running]))),
+                                    vec![animation_play_state::SingleSpecifiedValue::running])),
                              Importance::Normal),
                         ]))),
                     })),

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -7,7 +7,7 @@ use parking_lot::RwLock;
 use selectors::parser::LocalName as LocalNameSelector;
 use servo_atoms::Atom;
 use std::sync::Arc;
-use style::properties::{PropertyDeclarationBlock, PropertyDeclaration, DeclaredValue};
+use style::properties::{PropertyDeclarationBlock, PropertyDeclaration};
 use style::properties::{longhands, Importance};
 use style::rule_tree::CascadeLevel;
 use style::selector_parser::SelectorParser;
@@ -24,8 +24,8 @@ fn get_mock_rules(css_selectors: &[&str]) -> Vec<Vec<Rule>> {
         let rule = Arc::new(RwLock::new(StyleRule {
             selectors: selectors,
             block: Arc::new(RwLock::new(PropertyDeclarationBlock::with_one(
-                PropertyDeclaration::Display(DeclaredValue::Value(
-                    longhands::display::SpecifiedValue::block)),
+                PropertyDeclaration::Display(
+                    longhands::display::SpecifiedValue::block),
                 Importance::Normal
             ))),
         }));


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1347719

This effectively combines the discriminants of the two enums and reduces the
size of PropertyDeclaration by one word.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/15997)
<!-- Reviewable:end -->
