### PR TITLE
Add separate specified value for keyword font sizes

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -478,7 +478,10 @@ impl LayoutElementHelpers for LayoutJS<Element> {
         if let Some(font_size) = font_size {
             hints.push(from_declaration(
                 shared_lock,
-                PropertyDeclaration::FontSize(font_size::SpecifiedValue(font_size.into()))))
+                PropertyDeclaration::FontSize(
+                    font_size::SpecifiedValue::from_html_size(font_size as u8)
+                )
+            ))
         }
 
         let cellspacing = if let Some(this) = self.downcast::<HTMLTableElement>() {

--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -18,7 +18,6 @@ use html5ever_atoms::LocalName;
 use servo_atoms::Atom;
 use style::attr::AttrValue;
 use style::str::{HTML_SPACE_CHARACTERS, read_numbers};
-use style::values::specified;
 
 #[dom_struct]
 pub struct HTMLFontElement {
@@ -62,8 +61,7 @@ impl HTMLFontElementMethods for HTMLFontElement {
     // https://html.spec.whatwg.org/multipage/#dom-font-size
     fn SetSize(&self, value: DOMString) {
         let element = self.upcast::<Element>();
-        let length = parse_length(&value);
-        element.set_attribute(&local_name!("size"), AttrValue::Length(value.into(), length));
+        element.set_attribute(&local_name!("size"), parse_size(&value));
     }
 }
 
@@ -76,10 +74,7 @@ impl VirtualMethods for HTMLFontElement {
         match name {
             &local_name!("face") => AttrValue::from_atomic(value.into()),
             &local_name!("color") => AttrValue::from_legacy_color(value.into()),
-            &local_name!("size") => {
-                let length = parse_length(&value);
-                AttrValue::Length(value.into(), length)
-            },
+            &local_name!("size") => parse_size(&value),
             _ => self.super_type().unwrap().parse_plain_attribute(name, value),
         }
     }
@@ -88,7 +83,7 @@ impl VirtualMethods for HTMLFontElement {
 pub trait HTMLFontElementLayoutHelpers {
     fn get_color(&self) -> Option<RGBA>;
     fn get_face(&self) -> Option<Atom>;
-    fn get_size(&self) -> Option<specified::Length>;
+    fn get_size(&self) -> Option<u32>;
 }
 
 impl HTMLFontElementLayoutHelpers for LayoutJS<HTMLFontElement> {
@@ -113,18 +108,21 @@ impl HTMLFontElementLayoutHelpers for LayoutJS<HTMLFontElement> {
     }
 
     #[allow(unsafe_code)]
-    fn get_size(&self) -> Option<specified::Length> {
-        unsafe {
+    fn get_size(&self) -> Option<u32> {
+        let size = unsafe {
             (*self.upcast::<Element>().unsafe_get())
                 .get_attr_for_layout(&ns!(), &local_name!("size"))
-                .and_then(AttrValue::as_length)
-                .cloned()
+        };
+        match size {
+            Some(&AttrValue::UInt(_, s)) => Some(s),
+            _ => None,
         }
     }
 }
 
 /// https://html.spec.whatwg.org/multipage/#rules-for-parsing-a-legacy-font-size
-fn parse_length(mut input: &str) -> Option<specified::Length> {
+fn parse_size(mut input: &str) -> AttrValue {
+    let original_input = input;
     // Steps 1 & 2 are not relevant
 
     // Step 3
@@ -138,7 +136,7 @@ fn parse_length(mut input: &str) -> Option<specified::Length> {
     let mut input_chars = input.chars().peekable();
     let parse_mode = match input_chars.peek() {
         // Step 4
-        None => return None,
+        None => return AttrValue::String(original_input.into()),
 
         // Step 5
         Some(&'+') => {
@@ -155,7 +153,7 @@ fn parse_length(mut input: &str) -> Option<specified::Length> {
     // Steps 6, 7, 8
     let mut value = match read_numbers(input_chars) {
         (Some(v), _) if v >= 0 => v,
-        _ => return None,
+        _ => return AttrValue::String(original_input.into()),
     };
 
     // Step 9
@@ -166,5 +164,5 @@ fn parse_length(mut input: &str) -> Option<specified::Length> {
     }
 
     // Steps 10, 11, 12
-    Some(specified::Length::from_font_size_int(value as u8))
+    AttrValue::UInt(original_input.into(), value as u32)
 }

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -276,38 +276,6 @@ impl Mul<CSSFloat> for NoCalcLength {
 }
 
 impl NoCalcLength {
-    /// https://drafts.csswg.org/css-fonts-3/#font-size-prop
-    pub fn from_str(s: &str) -> Option<NoCalcLength> {
-        Some(match_ignore_ascii_case! { s,
-            "xx-small" => NoCalcLength::Absolute(Au::from_px(FONT_MEDIUM_PX) * 3 / 5),
-            "x-small" => NoCalcLength::Absolute(Au::from_px(FONT_MEDIUM_PX) * 3 / 4),
-            "small" => NoCalcLength::Absolute(Au::from_px(FONT_MEDIUM_PX) * 8 / 9),
-            "medium" => NoCalcLength::Absolute(Au::from_px(FONT_MEDIUM_PX)),
-            "large" => NoCalcLength::Absolute(Au::from_px(FONT_MEDIUM_PX) * 6 / 5),
-            "x-large" => NoCalcLength::Absolute(Au::from_px(FONT_MEDIUM_PX) * 3 / 2),
-            "xx-large" => NoCalcLength::Absolute(Au::from_px(FONT_MEDIUM_PX) * 2),
-
-            // https://github.com/servo/servo/issues/3423#issuecomment-56321664
-            "smaller" => NoCalcLength::FontRelative(FontRelativeLength::Em(0.85)),
-            "larger" => NoCalcLength::FontRelative(FontRelativeLength::Em(1.2)),
-            _ => return None
-        })
-    }
-
-    /// https://drafts.csswg.org/css-fonts-3/#font-size-prop
-    pub fn from_font_size_int(i: u8) -> Self {
-        let au = match i {
-            0 | 1 => Au::from_px(FONT_MEDIUM_PX) * 3 / 4,
-            2 => Au::from_px(FONT_MEDIUM_PX) * 8 / 9,
-            3 => Au::from_px(FONT_MEDIUM_PX),
-            4 => Au::from_px(FONT_MEDIUM_PX) * 6 / 5,
-            5 => Au::from_px(FONT_MEDIUM_PX) * 3 / 2,
-            6 => Au::from_px(FONT_MEDIUM_PX) * 2,
-            _ => Au::from_px(FONT_MEDIUM_PX) * 3,
-        };
-        NoCalcLength::Absolute(au)
-    }
-
     /// Parse a given absolute or relative dimension.
     pub fn parse_dimension(value: CSSFloat, unit: &str) -> Result<NoCalcLength, ()> {
         match_ignore_ascii_case! { unit,
@@ -444,19 +412,9 @@ impl Length {
         Length::NoCalc(NoCalcLength::zero())
     }
 
-    /// https://drafts.csswg.org/css-fonts-3/#font-size-prop
-    pub fn from_str(s: &str) -> Option<Length> {
-        NoCalcLength::from_str(s).map(Length::NoCalc)
-    }
-
     /// Parse a given absolute or relative dimension.
     pub fn parse_dimension(value: CSSFloat, unit: &str) -> Result<Length, ()> {
         NoCalcLength::parse_dimension(value, unit).map(Length::NoCalc)
-    }
-
-    /// https://drafts.csswg.org/css-fonts-3/#font-size-prop
-    pub fn from_font_size_int(i: u8) -> Self {
-        Length::NoCalc(NoCalcLength::from_font_size_int(i))
     }
 
     #[inline]

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1111,7 +1111,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetKeywordValue(declarations:
                                                          value: i32) {
     use style::properties::{PropertyDeclaration, LonghandId};
     use style::properties::longhands;
-    use style::values::specified::{BorderStyle, NoCalcLength};
+    use style::values::specified::BorderStyle;
 
     let declarations = Locked::<PropertyDeclarationBlock>::as_arc(&declarations);
     let long = get_longhand_from_id!(property);
@@ -1127,7 +1127,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetKeywordValue(declarations:
         Clear => longhands::clear::SpecifiedValue::from_gecko_keyword(value),
         FontSize => {
             // We rely on Gecko passing in font-size values (0...7) here.
-            longhands::font_size::SpecifiedValue(NoCalcLength::from_font_size_int(value as u8).into())
+            longhands::font_size::SpecifiedValue::from_html_size(value as u8)
         },
         ListStyleType => longhands::list_style_type::SpecifiedValue::from_gecko_keyword(value),
         WhiteSpace => longhands::white_space::SpecifiedValue::from_gecko_keyword(value),

--- a/tests/wpt/metadata/cssom/serialize-values.html.ini
+++ b/tests/wpt/metadata/cssom/serialize-values.html.ini
@@ -27,33 +27,6 @@
   [font-family: Arial]
     expected: FAIL
 
-  [font-size: xx-small]
-    expected: FAIL
-
-  [font-size: x-small]
-    expected: FAIL
-
-  [font-size: small]
-    expected: FAIL
-
-  [font-size: medium]
-    expected: FAIL
-
-  [font-size: large]
-    expected: FAIL
-
-  [font-size: x-large]
-    expected: FAIL
-
-  [font-size: xx-large]
-    expected: FAIL
-
-  [font-size: larger]
-    expected: FAIL
-
-  [font-size: smaller]
-    expected: FAIL
-
   [list-style-type: decimal-leading-zero]
     expected: FAIL
 


### PR DESCRIPTION
In Gecko, these keywords compute to different values depending on the
font.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1341775

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16016)
<!-- Reviewable:end -->
