### PR TITLE
Remove unused servo_config imports in bluetooth and script crates

### DIFF
--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -7,7 +7,6 @@ extern crate bitflags;
 extern crate bluetooth_traits;
 extern crate device;
 extern crate ipc_channel;
-extern crate servo_config;
 extern crate servo_rand;
 #[cfg(target_os = "linux")]
 extern crate tinyfiledialogs;
@@ -23,7 +22,6 @@ use bluetooth_traits::scanfilter::{BluetoothScanfilter, BluetoothScanfilterSeque
 use device::bluetooth::{BluetoothAdapter, BluetoothDevice, BluetoothGATTCharacteristic};
 use device::bluetooth::{BluetoothGATTDescriptor, BluetoothGATTService};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
-use servo_config::opts;
 use servo_rand::Rng;
 use std::borrow::ToOwned;
 use std::collections::{HashMap, HashSet};

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -17,7 +17,6 @@ use dom_struct::dom_struct;
 use js::conversions::ConversionResult;
 use js::jsapi::{JSContext, JSObject};
 use js::jsval::{ObjectValue, UndefinedValue};
-use servo_config::opts;
 use servo_config::prefs::PREFS;
 use std::rc::Rc;
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because the patch is fixing build warnings only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16032)
<!-- Reviewable:end -->
