### PR TITLE
stylo: Sequentialize binding generation if logging is enabled.

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -772,17 +772,22 @@ mod bindings {
 
 pub fn generate() {
     use self::common::*;
-    use std::fs;
-    use std::thread;
+    use std::{env, fs, thread};
     println!("cargo:rerun-if-changed=build_gecko.rs");
     fs::create_dir_all(&*OUTDIR_PATH).unwrap();
     bindings::setup_logging();
-    let threads = vec![
-        thread::spawn(|| bindings::generate_structs(BuildType::Debug)),
-        thread::spawn(|| bindings::generate_structs(BuildType::Release)),
-        thread::spawn(|| bindings::generate_bindings()),
-    ];
-    for t in threads.into_iter() {
-        t.join().unwrap();
+    if env::var("STYLO_BUILD_LOG").is_ok() {
+        bindings::generate_structs(BuildType::Debug);
+        bindings::generate_structs(BuildType::Release);
+        bindings::generate_bindings();
+    } else {
+        let threads = vec![
+            thread::spawn(|| bindings::generate_structs(BuildType::Debug)),
+            thread::spawn(|| bindings::generate_structs(BuildType::Release)),
+            thread::spawn(|| bindings::generate_bindings()),
+        ];
+        for t in threads.into_iter() {
+            t.join().unwrap();
+        }
     }
 }


### PR DESCRIPTION
Otherwise the log is useless, and it's even slower than in parallel mode due to
the high lock contention.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16035)
<!-- Reviewable:end -->
