### PR TITLE
Make writing-mode affect computed display

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2115,6 +2115,21 @@ pub fn apply_declarations<'a, F, I>(device: &Device,
     }
 
     {
+        use computed_values::display::T as display;
+        // CSS writing modes spec (https://drafts.csswg.org/css-writing-modes-3/#block-flow):
+        //
+        //  If a box has a different writing-mode value than its containing block:
+        //  - If the box has a specified display of inline, its display computes to inline-block. [CSS21]
+        //
+        // www-style mail regarding above spec: https://lists.w3.org/Archives/Public/www-style/2017Mar/0045.html
+        // See https://github.com/servo/servo/issues/15754
+        if context.layout_parent_style.writing_mode != style.writing_mode &&
+           style.get_box().clone_display() == display::inline {
+            style.mutate_box().set_display(display::inline_block);
+        }
+    }
+
+    {
         use computed_values::overflow_x::T as overflow;
         use computed_values::overflow_y;
         match (style.get_box().clone_overflow_x() == longhands::overflow_x::computed_value::T::visible,

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11142,6 +11142,12 @@
      {}
     ]
    ],
+   "css/writing-mode_change_display.html": [
+    [
+     "/_mozilla/css/writing-mode_change_display.html",
+     {}
+    ]
+   ],
    "mozilla/DOMParser.html": [
     [
      "/_mozilla/mozilla/DOMParser.html",
@@ -24144,6 +24150,10 @@
   "css/word_break_ref.html": [
    "b16bf3e07cb3c45f7d630ca35bae1012d38d1b6b",
    "support"
+  ],
+  "css/writing-mode_change_display.html": [
+   "9ac1f9756a4cd44196242beb80621b9bc8cbe2ff",
+   "testharness"
   ],
   "mozilla/2x2.png": [
    "c67d3f646e86413722833d2308a9bfc793a916bf",

--- a/tests/wpt/mozilla/meta/css/writing-mode_change_display.html.ini
+++ b/tests/wpt/mozilla/meta/css/writing-mode_change_display.html.ini
@@ -1,0 +1,1 @@
+prefs: [layout.writing-mode.enabled:true]

--- a/tests/wpt/mozilla/tests/css/writing-mode_change_display.html
+++ b/tests/wpt/mozilla/tests/css/writing-mode_change_display.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>writing-mode test</title>
+  <script src=/resources/testharness.js></script>
+  <script src=/resources/testharnessreport.js></script>
+</head>
+<body>
+  <div>
+    <span style="writing-mode: vertical-rl; border: 20px solid green">Text</span>
+  </div>
+
+  <script>
+    test(function() {
+      assert_equals(getComputedStyle(document.querySelector("span")).display, "inline-block");
+    }, "The span's `display` should change from `inline` to `inline-block`, because of its writing-mode.");
+  </script>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The first manual test-case in #15754 passes now, but the second test-case still renders "Text" horizontally, which is apparently because of servo's experimental support for writing-mode.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15754 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16044)
<!-- Reviewable:end -->
