### PR TITLE
Bug 1348487 - stylo: Don't allow combinators in :-moz-any.

### DIFF
--- a/components/style/gecko/selector_parser.rs
+++ b/components/style/gecko/selector_parser.rs
@@ -341,6 +341,10 @@ impl<'a> ::selectors::Parser for SelectorParser<'a> {
                         let selectors = parser.parse_comma_separated(|input| {
                             ComplexSelector::parse(self, input)
                         })?;
+                        // Selectors inside `:-moz-any` may not include combinators.
+                        if selectors.iter().any(|s| s.next.is_some()) {
+                            return Err(())
+                        }
                         NonTSPseudoClass::MozAny(selectors)
                     }
                     _ => return Err(())


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1348487

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16045)
<!-- Reviewable:end -->
