### PR TITLE
Make ImageData::new return Fallible instead of unwrapping a result

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -998,15 +998,15 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
 
         let sw = cmp::max(1, sw.abs().to_u32().unwrap());
         let sh = cmp::max(1, sh.abs().to_u32().unwrap());
-        Ok(ImageData::new(&self.global(), sw, sh, None))
+        ImageData::new(&self.global(), sw, sh, None)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata
     fn CreateImageData_(&self, imagedata: &ImageData) -> Fallible<Root<ImageData>> {
-        Ok(ImageData::new(&self.global(),
-                          imagedata.Width(),
-                          imagedata.Height(),
-                          None))
+        ImageData::new(&self.global(),
+                       imagedata.Width(),
+                       imagedata.Height(),
+                       None)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-getimagedata
@@ -1059,7 +1059,7 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
             chunk[2] = UNPREMULTIPLY_TABLE[256 * alpha + chunk[2] as usize];
         }
 
-        Ok(ImageData::new(&self.global(), sw, sh, Some(data)))
+        ImageData::new(&self.global(), sw, sh, Some(data))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -28,7 +28,11 @@ pub struct ImageData {
 
 impl ImageData {
     #[allow(unsafe_code)]
-    pub fn new(global: &GlobalScope, width: u32, height: u32, mut data: Option<Vec<u8>>) -> Root<ImageData> {
+    pub fn new(global: &GlobalScope,
+               width: u32,
+               height: u32,
+               mut data: Option<Vec<u8>>)
+               -> Fallible<Root<ImageData>> {
         let len = width * height * 4;
         unsafe {
             let cx = global.get_cx();
@@ -41,7 +45,7 @@ impl ImageData {
                 None => CreateWith::Length(len),
             };
             Uint8ClampedArray::create(cx, data, js_object.handle_mut()).unwrap();
-            Self::new_with_jsobject(global, width, Some(height), Some(js_object.get())).unwrap()
+            Self::new_with_jsobject(global, width, Some(height), Some(js_object.get()))
         }
     }
 


### PR DESCRIPTION
Instead of unwrapping `new_with_jsobject` result, `ImageData::new` will just pass the error along.

It required tweaking `canvasrenderingcontext2d` as it no longer needs to assume the result is `Ok`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #16043 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this is small and purely refactoring change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16051)
<!-- Reviewable:end -->
