### PR TITLE
Use AtomicRefCell instead of RwLock inside SharedRwLock for stylo

### DIFF
--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -172,9 +172,15 @@ longhand_properties_idents!(reexport_computed_values);
 /// FIXME: Remove this and use Arc::ptr_eq once we require Rust 1.17
 #[inline]
 pub fn arc_ptr_eq<T: 'static>(a: &Arc<T>, b: &Arc<T>) -> bool {
-    let a: &T = &**a;
-    let b: &T = &**b;
-    (a as *const T) == (b as *const T)
+    ptr_eq::<T>(&**a, &**b)
+}
+
+/// Pointer equality
+///
+/// FIXME: Remove this and use std::ptr::eq once we require Rust 1.17
+#[inline]
+pub fn ptr_eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
+    a == b
 }
 
 /// Serializes as CSS a comma-separated list of any `T` that supports being


### PR DESCRIPTION
@SimonSapin wrote the original patch in [1], and I tweaked it to conditionally compile. Just waiting for the try run to come back green before landing.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1348587

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16053)
<!-- Reviewable:end -->
