### PR TITLE
stylo: Bug 1349149 - Fix build error in geckolib with rustc 1.16.0.

### DIFF
--- a/ports/geckolib/lib.rs
+++ b/ports/geckolib/lib.rs
@@ -7,7 +7,6 @@
 extern crate atomic_refcell;
 extern crate cssparser;
 extern crate env_logger;
-#[macro_use] extern crate lazy_static;
 extern crate libc;
 #[macro_use] extern crate log;
 extern crate parking_lot;


### PR DESCRIPTION
This fixed "error: unused `#[macro_use]` import" when building stylo on
mozilla-central.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16060)
<!-- Reviewable:end -->
