### PR TITLE
Use servo_config::opts only on linux target.

### DIFF
--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -7,6 +7,7 @@ extern crate bitflags;
 extern crate bluetooth_traits;
 extern crate device;
 extern crate ipc_channel;
+#[cfg(target_os = "linux")]
 extern crate servo_config;
 extern crate servo_rand;
 #[cfg(target_os = "linux")]
@@ -23,6 +24,7 @@ use bluetooth_traits::scanfilter::{BluetoothScanfilter, BluetoothScanfilterSeque
 use device::bluetooth::{BluetoothAdapter, BluetoothDevice, BluetoothGATTCharacteristic};
 use device::bluetooth::{BluetoothGATTDescriptor, BluetoothGATTService};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
+#[cfg(target_os = "linux")]
 use servo_config::opts;
 use servo_rand::Rng;
 use std::borrow::ToOwned;

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -17,6 +17,7 @@ use dom_struct::dom_struct;
 use js::conversions::ConversionResult;
 use js::jsapi::{JSContext, JSObject};
 use js::jsval::{ObjectValue, UndefinedValue};
+#[cfg(target_os = "linux")]
 use servo_config::opts;
 use servo_config::prefs::PREFS;
 use std::rc::Rc;


### PR DESCRIPTION
It's not used for other architectures and triggers warnings.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #16058
- [x] These changes do not require tests because it's purely refactoring task

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16061)
<!-- Reviewable:end -->
