### PR TITLE
stylo: Make specified::parse_number() return finite f32.

### DIFF
--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -195,7 +195,16 @@ pub fn parse_integer(input: &mut Parser) -> Result<CSSInteger, ()> {
 #[allow(missing_docs)]
 pub fn parse_number(input: &mut Parser) -> Result<f32, ()> {
     match try!(input.next()) {
-        Token::Number(ref value) => Ok(value.value),
+        Token::Number(ref value) => {
+            use std::f32;
+            if value.value.is_finite() {
+                Ok(value.value)
+            } else if value.value.is_sign_positive() {
+                Ok(f32::MAX)
+            } else {
+                Ok(f32::MIN)
+            }
+        },
         Token::Function(ref name) if name.eq_ignore_ascii_case("calc") => {
             let ast = try!(input.parse_nested_block(|i| CalcLengthOrPercentage::parse_sum(i, CalcUnit::Number)));
 


### PR DESCRIPTION
We need to clamp the float numbers to avoid positive/negative infinity in timing functions, transform functions, and other possible css values to avoid undefined behaviors and assertions.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1343153](https://bugzilla.mozilla.org/show_bug.cgi?id=1343153) and [Bug 1336769](https://bugzilla.mozilla.org/show_bug.cgi?id=1336769)
- [X] These changes do not require tests because gecko has related tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16062)
<!-- Reviewable:end -->
