### PR TITLE
Avoid panics for empty or multibyte image usemap

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -422,6 +422,11 @@ impl HTMLImageElement {
         };
 
         let value = usemap_attr.value();
+
+        if value.len() == 0 || !value.is_char_boundary(1) {
+            return None
+        }
+
         let (first, last) = value.split_at(1);
 
         if first != "#" || last.len() == 0 {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12884,6 +12884,12 @@
      {}
     ]
    ],
+   "mozilla/htmlimageelement.html": [
+    [
+     "/_mozilla/mozilla/htmlimageelement.html",
+     {}
+    ]
+   ],
    "mozilla/htmllabel-activation.html": [
     [
      "/_mozilla/mozilla/htmllabel-activation.html",
@@ -25379,6 +25385,10 @@
   ],
   "mozilla/htmlfontelement_size_attribute.html": [
    "54fe6bbc1a7a35ceb14a3bf33f81ebed55beaf72",
+   "testharness"
+  ],
+  "mozilla/htmlimageelement.html": [
+   "f1857a8f413f444b34464f0a3bc6b46af13c1a5a",
    "testharness"
   ],
   "mozilla/htmllabel-activation.html": [

--- a/tests/wpt/mozilla/tests/mozilla/htmlimageelement.html
+++ b/tests/wpt/mozilla/tests/mozilla/htmlimageelement.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>HTMLImageElement usemap special cases</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<img id="empty" usemap>
+<img id="multibyte" usemap=&#x1F4A9;>
+<script>
+  test(function () {
+    document.querySelector("#empty").dispatchEvent(new Event("click"));
+    assert_true(true);
+  }, "Do not panic on empty usemap");
+
+  test(function () {
+    document.querySelector("#multibyte").dispatchEvent(new Event("click"));
+    assert_true(true);
+  }, "Do not panic on multibyte usemap");
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Some check were added to make sure we can call `split_at` with no risk of panics (when value is empty or the first char is multibyte).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15883 (github issue number if applicable).
- [x] There are tests for these changes 

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16063)
<!-- Reviewable:end -->
