### PR TITLE
Check mime type properly in fetch

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -599,10 +599,10 @@ fn should_block_nosniff(request: &Request, response: &Response) -> bool {
             mime!(Text / ("x-javascript")),
         ];
 
-        javascript_mime_types.contains(mime_type)
+        javascript_mime_types.iter()
+            .any(|mime| mime.0 == mime_type.0 && mime.1 == mime_type.1)
     }
 
-    let text_css: Mime = mime!(Text / Css);
     // Assumes str::starts_with is equivalent to mime::TopLevel
     return match type_ {
         // Step 6
@@ -615,8 +615,8 @@ fn should_block_nosniff(request: &Request, response: &Response) -> bool {
         // Step 7
         Type::Style => {
             match content_type_header {
-                Some(&ContentType(ref mime_type)) => mime_type != &text_css,
-                None => true
+                Some(&ContentType(Mime(TopLevel::Text, SubLevel::Css, _))) => false,
+                _ => true
             }
         }
         // Step 8

--- a/tests/wpt/web-platform-tests/fetch/nosniff/image.html
+++ b/tests/wpt/web-platform-tests/fetch/nosniff/image.html
@@ -3,17 +3,25 @@
 <div id=log></div>
 <script>
   // Note: images get always sniffed, nosniff doesn't do anything
-  var passes = ["", "?type=", "?type=x", "?type=x/x", "?type=image/gif", "?type=image/png", "?type=image/png;blah"]
+  var passes = [null, "", "x", "x/x", "image/gif", "image/png", "image/png;blah"]
 
-  passes.forEach(function(urlpart) {
+  const get_url = (mime) => {
+    let url = "resources/image.py"
+    if (mime != null) {
+        url += "?type=" + encodeURIComponent(mime)
+    }
+    return url
+  }
+
+  passes.forEach(function(mime) {
     async_test(function(t) {
       var img = document.createElement("img")
       img.onerror = t.unreached_func("Unexpected error event")
       img.onload = t.step_func_done(function(){
         assert_equals(img.width, 96)
       })
-      img.src = "resources/image.py" + urlpart
+      img.src = get_url(mime)
       document.body.appendChild(img)
-    }, "URL query: " + urlpart)
+    }, "URL query: " + mime)
   })
 </script>

--- a/tests/wpt/web-platform-tests/fetch/nosniff/importscripts.js
+++ b/tests/wpt/web-platform-tests/fetch/nosniff/importscripts.js
@@ -3,15 +3,26 @@ function log(w) { this.postMessage(w) }
 function f() { log("FAIL") }
 function p() { log("PASS") }
 
-["", "?type=", "?type=x", "?type=x/x"].forEach(function(urlpart) {
+const get_url = (mime, outcome) => {
+  let url = "resources/js.py"
+  if (mime != null) {
+      url += "?type=" + encodeURIComponent(mime)
+  }
+  if (outcome) {
+    url += "&outcome=p"
+  }
+  return url
+}
+
+[null, "", "x", "x/x"].forEach(function(mime) {
   try {
-    importScripts("resources/js.py" + urlpart)
+    importScripts(get_url(mime))
   } catch(e) {
-    (e.name == "NetworkError") ? p() : log("FAIL (no NetworkError exception): " + urlpart)
+    (e.name == "NetworkError") ? p() : log("FAIL (no NetworkError exception): " + mime)
   }
 
 })
-importScripts("resources/js.py?type=text/javascript&outcome=p")
-importScripts("resources/js.py?type=text/ecmascript&outcome=p")
-importScripts("resources/js.py?type=text/ecmascript;blah&outcome=p")
+importScripts(get_url("text/javascript", true))
+importScripts(get_url("text/ecmascript", true))
+importScripts(get_url("text/ecmascript;blah", true))
 log("END")

--- a/tests/wpt/web-platform-tests/fetch/nosniff/script.html
+++ b/tests/wpt/web-platform-tests/fetch/nosniff/script.html
@@ -4,29 +4,40 @@
 <script>
   var log = function() {}, // see comment below
       p = function() {}, // see comment below
-      fails = ["", "?type=", "?type=x", "?type=x/x"],
-      passes = ["?type=text/javascript", "?type=text/ecmascript", "?type=text/ecmascript;blah"]
+      fails = [null, "", "x", "x/x"],
+      passes = ["text/javascript", "text/ecmascript", "text/ecmascript;blah"]
 
   // Ideally we'd also check whether the scripts in fact execute, but that would involve
   // timers and might get a bit racy without cross-browser support for the execute events.
 
-  fails.forEach(function(urlpart) {
+  const get_url = (mime, outcome) => {
+    let url = "resources/js.py"
+    if (mime != null) {
+        url += "?type=" + encodeURIComponent(mime)
+    }
+    if (outcome) {
+      url += "&outcome=p"
+    }
+    return url
+  }
+
+  fails.forEach(function(mime) {
     async_test(function(t) {
       var script = document.createElement("script")
       script.onerror = t.step_func_done(function(){})
       script.onload = t.unreached_func("Unexpected load event")
-      script.src = "resources/js.py" + urlpart
+      script.src = get_url(mime)
       document.body.appendChild(script)
-    }, "URL query: " + urlpart)
+    }, "URL query: " + mime)
   })
 
-  passes.forEach(function(urlpart) {
+  passes.forEach(function(mime) {
     async_test(function(t) {
       var script = document.createElement("script")
       script.onerror = t.unreached_func("Unexpected error event")
       script.onload = t.step_func_done(function(){})
-      script.src = "resources/js.py" + urlpart + "&outcome=p"
+      script.src = get_url(mime, true)
       document.body.appendChild(script)
-    }, "URL query: " + urlpart)
+    }, "URL query: " + mime)
   })
 </script>

--- a/tests/wpt/web-platform-tests/fetch/nosniff/stylesheet.html
+++ b/tests/wpt/web-platform-tests/fetch/nosniff/stylesheet.html
@@ -3,28 +3,36 @@
 <script src=/resources/testharnessreport.js></script>
 <div id=log></div>
 <script>
-  var fails = ["", "?type=", "?type=x", "?type=x/x"],
-      passes = ["?type=text/css", "?type=text/css;blah"]
+  var fails = [null, "", "x", "x/x"],
+      passes = ["text/css", "text/css;charset=utf-8"]
 
-  fails.forEach(function(urlpart) {
+  const get_url = (mime) => {
+    let url = "resources/css.py"
+    if (mime != null) {
+        url += "?type=" + encodeURIComponent(mime)
+    }
+    return url
+  }
+
+  fails.forEach(function(mime) {
     async_test(function(t) {
       var link = document.createElement("link")
       link.rel = "stylesheet"
       link.onerror = t.step_func_done(function(){})
       link.onload = t.unreached_func("Unexpected load event")
-      link.href = "resources/css.py" + urlpart
+      link.href = get_url(mime)
       document.body.appendChild(link)
-    }, "URL query: " + urlpart)
+    }, "URL query: " + mime)
   })
 
-  passes.forEach(function(urlpart) {
+  passes.forEach(function(mime) {
     async_test(function(t) {
       var link = document.createElement("link")
       link.rel = "stylesheet"
       link.onerror = t.unreached_func("Unexpected error event")
       link.onload = t.step_func_done(function(){})
-      link.href = "resources/css.py" + urlpart
+      link.href = get_url(mime)
       document.body.appendChild(link)
-    }, "URL query: " + urlpart)
+    }, "URL query: " + mime)
   })
 </script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

We were not comparing the mime types properly, and fixing that exposed issues with url parameters escaping in the wpt tests. I kept the test changes in their own commit in case that helps with upstreaming.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #16049 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16069)
<!-- Reviewable:end -->
