### PR TITLE
Fix geckolib breakage caused by 1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,6 @@ dependencies = [
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -17,7 +17,6 @@ testing = ["style/testing"]
 atomic_refcell = "0.1"
 cssparser = "0.12"
 env_logger = {version = "0.4", default-features = false} # disable `regex` to reduce code size
-lazy_static = "0.2"
 libc = "0.2"
 log = {version = "0.3.5", features = ["release_max_level_info"]}
 parking_lot = "0.3"

--- a/ports/geckolib/lib.rs
+++ b/ports/geckolib/lib.rs
@@ -7,7 +7,6 @@
 extern crate atomic_refcell;
 extern crate cssparser;
 extern crate env_logger;
-#[macro_use] extern crate lazy_static;
 extern crate libc;
 #[macro_use] extern crate log;
 extern crate parking_lot;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16072)
<!-- Reviewable:end -->
