### PR TITLE
Fix compiler warnings in stylo unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,7 +2808,6 @@ dependencies = [
 name = "stylo_tests"
 version = "0.0.1"
 dependencies = [
- "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2817,9 +2816,7 @@ dependencies = [
  "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.18.0",
  "servo_url 0.0.1",
  "style 0.0.1",

--- a/tests/unit/stylo/Cargo.toml
+++ b/tests/unit/stylo/Cargo.toml
@@ -15,7 +15,6 @@ doctest = false
 testing = ["style/testing"]
 
 [dependencies]
-app_units = "0.4"
 atomic_refcell = "0.1"
 cssparser = "0.12"
 env_logger = "0.4"
@@ -23,9 +22,7 @@ euclid = "0.11"
 lazy_static = "0.2"
 libc = "0.2"
 log = {version = "0.3.5", features = ["release_max_level_info"]}
-num_cpus = "1.1.0"
 parking_lot = "0.3"
-rayon = "0.6"
 selectors = {path = "../../../components/selectors"}
 servo_url = {path = "../../../components/url"}
 style_traits = {path = "../../../components/style_traits"}

--- a/tests/unit/stylo/lib.rs
+++ b/tests/unit/stylo/lib.rs
@@ -2,17 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate app_units;
 extern crate atomic_refcell;
 extern crate cssparser;
 extern crate env_logger;
-extern crate euclid;
 extern crate geckoservo;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
-extern crate num_cpus;
 extern crate parking_lot;
-extern crate rayon;
 extern crate selectors;
 extern crate servo_url;
 #[macro_use] extern crate style;

--- a/tests/unit/stylo/sanity_checks.rs
+++ b/tests/unit/stylo/sanity_checks.rs
@@ -31,8 +31,8 @@ macro_rules! check_enum_value_non_static {
 // similar, because we'd need the foreign atom symbols to link.
 #[test]
 fn assert_basic_pseudo_elements() {
-    let mut saw_before = false;
-    let mut saw_after = false;
+    let saw_before;
+    let saw_after;
 
     macro_rules! pseudo_element {
         (":before", $atom:expr, false) => {


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16080)
<!-- Reviewable:end -->
