### PR TITLE
Use less fragile and more readable numbering for ElementState.

### DIFF
--- a/components/style/element_state.rs
+++ b/components/style/element_state.rs
@@ -13,51 +13,51 @@ bitflags! {
         #[doc = "The mouse is down on this element. \
                  https://html.spec.whatwg.org/multipage/#selector-active \
                  FIXME(#7333): set/unset this when appropriate"]
-        const IN_ACTIVE_STATE = 0x01,
+        const IN_ACTIVE_STATE = 1 << 0,
         #[doc = "This element has focus. \
                  https://html.spec.whatwg.org/multipage/#selector-focus"]
-        const IN_FOCUS_STATE = 0x02,
+        const IN_FOCUS_STATE = 1 << 1,
         #[doc = "The mouse is hovering over this element. \
                  https://html.spec.whatwg.org/multipage/#selector-hover"]
-        const IN_HOVER_STATE = 0x04,
+        const IN_HOVER_STATE = 1 << 2,
         #[doc = "Content is enabled (and can be disabled). \
                  http://www.whatwg.org/html/#selector-enabled"]
-        const IN_ENABLED_STATE = 0x08,
+        const IN_ENABLED_STATE = 1 << 3,
         #[doc = "Content is disabled. \
                  http://www.whatwg.org/html/#selector-disabled"]
-        const IN_DISABLED_STATE = 0x10,
+        const IN_DISABLED_STATE = 1 << 4,
         #[doc = "Content is checked. \
                  https://html.spec.whatwg.org/multipage/#selector-checked"]
-        const IN_CHECKED_STATE = 0x20,
+        const IN_CHECKED_STATE = 1 << 5,
         #[doc = "https://html.spec.whatwg.org/multipage/#selector-indeterminate"]
-        const IN_INDETERMINATE_STATE = 0x40,
+        const IN_INDETERMINATE_STATE = 1 << 6,
         #[doc = "https://html.spec.whatwg.org/multipage/#selector-placeholder-shown"]
-        const IN_PLACEHOLDER_SHOWN_STATE = 0x80,
+        const IN_PLACEHOLDER_SHOWN_STATE = 1 << 7,
         #[doc = "https://html.spec.whatwg.org/multipage/#selector-target"]
-        const IN_TARGET_STATE = 0x100,
+        const IN_TARGET_STATE = 1 << 8,
         #[doc = "https://fullscreen.spec.whatwg.org/#%3Afullscreen-pseudo-class"]
-        const IN_FULLSCREEN_STATE = 0x200,
+        const IN_FULLSCREEN_STATE = 1 << 9,
         #[doc = "https://html.spec.whatwg.org/multipage/#selector-valid"]
-        const IN_VALID_STATE = 0x400,
+        const IN_VALID_STATE = 1 << 10,
         #[doc = "https://html.spec.whatwg.org/multipage/#selector-invalid"]
-        const IN_INVALID_STATE = 0x800,
+        const IN_INVALID_STATE = 1 << 11,
         #[doc = "Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-ui-valid"]
-        const IN_MOZ_UI_VALID_STATE = 0x1000,
+        const IN_MOZ_UI_VALID_STATE = 1 << 12,
         #[doc = "Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-broken"]
-        const IN_BROKEN_STATE = 0x2000,
+        const IN_BROKEN_STATE = 1 << 13,
         #[doc = "Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-user-disabled"]
-        const IN_USER_DISABLED_STATE = 0x4000,
+        const IN_USER_DISABLED_STATE = 1 << 14,
         #[doc = "Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-suppressed"]
-        const IN_SUPPRESSED_STATE = 0x8000,
+        const IN_SUPPRESSED_STATE = 1 << 15,
         #[doc = "Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-loading"]
-        const IN_LOADING_STATE = 0x10000,
+        const IN_LOADING_STATE = 1 << 16,
         #[doc = "Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-handler-blocked"]
-        const IN_HANDLER_BLOCKED_STATE = 0x20000,
+        const IN_HANDLER_BLOCKED_STATE = 1 << 17,
         #[doc = "Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-handler-disabled"]
-        const IN_HANDLER_DISABLED_STATE = 0x40000,
+        const IN_HANDLER_DISABLED_STATE = 1 << 18,
         #[doc = "Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-handler-crashed"]
-        const IN_HANDLER_CRASHED_STATE = 0x80000,
+        const IN_HANDLER_CRASHED_STATE = 1 << 19,
         #[doc = "https://html.spec.whatwg.org/multipage/#selector-read-write"]
-        const IN_READ_WRITE_STATE = 0x100000,
+        const IN_READ_WRITE_STATE = 1 << 20,
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's just cleanup preliminary to another change I'm working on.

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16085)
<!-- Reviewable:end -->
