### PR TITLE
Don't create a new XHR until the previous one is complete.

### DIFF
--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_harness.js
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_harness.js
@@ -1,15 +1,16 @@
 function get_test_results(id) {
     async_test(function(test) {
-        var timer = window.setInterval(test.step_func(loop), 100);
+        test.step_timeout(loop, 100);
         function loop() {
             var xhr = new XMLHttpRequest();
             xhr.open('GET', 'stash.py?id=' + id);
-            xhr.onreadystatechange = test.step_func(function() {
+            xhr.onload = test.step_func(function() {
                 assert_equals(xhr.status, 200);
                 if (xhr.responseText) {
                     assert_equals(xhr.responseText, "OK");
                     test.done();
-                    window.clearTimeout(timer);
+                } else {
+                    test.step_timeout(loop, 100);
                 }
             });
             xhr.send();


### PR DESCRIPTION
This test often times out when run under rr, because the event loop gets flooded with timer events that initiate XHRs before the previous XHR has completed. Additionally, we're running the event handler up to three times per XHR, which is just silly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16087)
<!-- Reviewable:end -->
