### PR TITLE
Fix iframe.onload being fired twice on about:blank.

### DIFF
--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -202,7 +202,7 @@ impl HTMLIFrameElement {
                 };
 
                 self.pipeline_id.set(Some(new_pipeline_id));
-                ScriptThread::process_attach_layout(new_layout_info, document.origin().clone());
+                ScriptThread::process_attach_layout(new_layout_info, document.origin().clone(), true);
             },
             NavigationType::Regular => {
                 let load_info = IFrameLoadInfoWithData {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Supress the load event in the script thread when the iframe doesn't have a src attribute.
In that case, a load event is already fired when binding the iframe to the tree.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15727 (github issue number if applicable).

- [X] There are tests for these changes OR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16091)
<!-- Reviewable:end -->
