### PR TITLE
Avoid a constellation roundtrip when a same-origin iframe finishes loading

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -68,7 +68,7 @@ use dom::location::Location;
 use dom::messageevent::MessageEvent;
 use dom::mouseevent::MouseEvent;
 use dom::node::{self, CloneChildrenFlag, Node, NodeDamage, window_from_node, IS_IN_DOC, LayoutNodeHelpers};
-use dom::node::VecPreOrderInsertionHelper;
+use dom::node::{VecPreOrderInsertionHelper, document_from_node};
 use dom::nodeiterator::NodeIterator;
 use dom::nodelist::NodeList;
 use dom::pagetransitionevent::PageTransitionEvent;
@@ -1864,10 +1864,13 @@ impl Document {
         }
     }
 
-    pub fn notify_constellation_load(&self) {
+    pub fn notify_constellation_load(&self, parent_notified: bool) {
         let global_scope = self.window.upcast::<GlobalScope>();
         let pipeline_id = global_scope.pipeline_id();
-        let load_event = ConstellationMsg::LoadComplete(pipeline_id);
+        let load_event = ConstellationMsg::LoadComplete {
+            loaded_pipeline: pipeline_id,
+            parent_has_been_notified: parent_notified
+        };
         global_scope.constellation_chan().send(load_event).unwrap();
     }
 
@@ -3846,7 +3849,33 @@ impl DocumentProgressHandler {
                       ReflowQueryType::NoQuery,
                       ReflowReason::DocumentLoaded);
 
-        document.notify_constellation_load();
+        let mut parent_notified = false;
+        // If we can synchronously reach the parent document, we can notify it more efficiently
+        // that its child document has loaded. Otherwise, we leave it up to the constellation.
+        if let Some(browsing_context) = document.browsing_context() {
+            if let Some(pipeline) = browsing_context.currently_active() {
+                if pipeline == document.global().pipeline_id() {
+                    let frame_id = browsing_context.frame_id();
+                    // N.B. it's important to retrieve the document for the iframe, then
+                    //      the window via this document. If the iframe has been adopted into
+                    //      a different global than its associated global, the pipeline retrieved
+                    //      will be incorrect if the associated global is used.
+                    let containing_document = browsing_context
+                        .frame_element()
+                        .map(|e| document_from_node(e));
+                    if let Some(containing_document) = containing_document {
+                        let parent_pipeline = containing_document
+                            .window()
+                            .upcast::<GlobalScope>()
+                            .pipeline_id();
+                        ScriptThread::notify_document_loaded(frame_id, parent_pipeline, pipeline);
+                        parent_notified = true;
+                    }
+                }
+            }
+        }
+
+        document.notify_constellation_load(parent_notified);
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -583,6 +583,16 @@ impl ScriptThread {
         })
     }
 
+    pub fn notify_document_loaded(frame: FrameId, parent: PipelineId, child: PipelineId) {
+        SCRIPT_THREAD_ROOT.with(|root| {
+            let script_thread = unsafe { &*root.get().unwrap() };
+            let _ = script_thread.control_chan.send(
+                ConstellationControlMsg::DispatchFrameLoadEvent {
+                    target: frame, parent: parent, child: child
+                });
+        })
+    }
+
     pub fn mark_document_with_no_blocked_loads(doc: &Document) {
         SCRIPT_THREAD_ROOT.with(|root| {
             let script_thread = unsafe { &*root.get().unwrap() };

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -94,7 +94,12 @@ pub enum ScriptMsg {
     HeadParsed,
     /// All pending loads are complete, and the `load` event for this pipeline
     /// has been dispatched.
-    LoadComplete(PipelineId),
+    LoadComplete {
+        ///  The pipeline that has completed loading.
+        loaded_pipeline: PipelineId,
+        /// Whether the parent document has already been notified about the load.
+        parent_has_been_notified: bool
+    },
     /// A new load has been requested, with an option to replace the current entry once loaded
     /// instead of adding a new entry.
     LoadUrl(PipelineId, LoadData, bool),


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #16108 
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16109)
<!-- Reviewable:end -->
