### PR TITLE
Add functions for after-change style of CSS Transition 

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -472,7 +472,7 @@ trait PrivateMatchMethods: TElement {
     fn cascade_internal(&self,
                         context: &StyleContext<Self>,
                         primary_style: &ComputedStyle,
-                        pseudo_style: &mut Option<(&PseudoElement, &mut ComputedStyle)>,
+                        pseudo_style: &Option<(&PseudoElement, &mut ComputedStyle)>,
                         booleans: &CascadeBooleans)
                         -> Arc<ComputedValues> {
         let shared_context = context.shared;
@@ -570,7 +570,7 @@ trait PrivateMatchMethods: TElement {
 
         // Compute the new values.
         let mut new_values = self.cascade_internal(context, primary_style,
-                                                   &mut pseudo_style, &booleans);
+                                                   &pseudo_style, &booleans);
 
         // Handle animations.
         if booleans.animate {

--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -239,6 +239,16 @@ impl RuleTree {
         // necessary.
         Some(self.insert_ordered_rules_from(current, children.into_iter().rev()))
     }
+
+    /// Returns new rule nodes without Transitions level rule.
+    pub fn remove_transition_rule_if_applicable(&self, path: &StrongRuleNode) -> StrongRuleNode {
+        // Return a clone if there is no transition level.
+        if path.cascade_level() != CascadeLevel::Transitions {
+            return path.clone();
+        }
+
+        path.parent().unwrap().clone()
+    }
 }
 
 /// The number of RuleNodes added to the free list before we will consider

--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -249,6 +249,27 @@ impl RuleTree {
 
         path.parent().unwrap().clone()
     }
+
+    /// Returns new rule node without Animations and Transitions level rules.
+    pub fn remove_animation_and_transition_rules(&self, path: &StrongRuleNode) -> StrongRuleNode {
+        // Return a clone if there is neither animation nor transition level.
+        if !path.has_animation_or_transition_rules() {
+            return path.clone();
+        }
+
+        let iter = path.self_and_ancestors().take_while(|node| node.cascade_level() >= CascadeLevel::Animations);
+        let mut last = path;
+        let mut children = vec![];
+        for node in iter {
+            if node.cascade_level() != CascadeLevel::Animations &&
+               node.cascade_level() != CascadeLevel::Transitions {
+                children.push((node.get().source.clone().unwrap(), node.cascade_level()));
+            }
+            last = node;
+        }
+
+        self.insert_ordered_rules_from(last.parent().unwrap().clone(), children.into_iter().rev())
+    }
 }
 
 /// The number of RuleNodes added to the free list before we will consider
@@ -737,6 +758,13 @@ impl StrongRuleNode {
         if self.get().free_count.load(Ordering::SeqCst) > RULE_TREE_GC_INTERVAL {
             self.gc();
         }
+    }
+
+    /// Returns true if there is either animation or transition level rule.
+    pub fn has_animation_or_transition_rules(&self) -> bool {
+        self.self_and_ancestors()
+            .take_while(|node| node.cascade_level() >= CascadeLevel::Animations)
+            .any(|node| matches!(node.cascade_level(), CascadeLevel::Animations | CascadeLevel::Transitions))
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is a PR of https://bugzilla.mozilla.org/show_bug.cgi?id=1346663

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because it's for stylo

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16111)
<!-- Reviewable:end -->
