### PR TITLE
Fix writing-mode display fixup to check the right condition.

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2178,7 +2178,9 @@ pub fn apply_declarations<'a, F, I>(device: &Device,
         //
         // www-style mail regarding above spec: https://lists.w3.org/Archives/Public/www-style/2017Mar/0045.html
         // See https://github.com/servo/servo/issues/15754
-        if context.layout_parent_style.writing_mode != style.writing_mode &&
+        let our_writing_mode = style.get_inheritedbox().clone_writing_mode();
+        let parent_writing_mode = context.layout_parent_style.get_inheritedbox().clone_writing_mode();
+        if our_writing_mode != parent_writing_mode &&
            style.get_box().clone_display() == display::inline {
             style.mutate_box().set_display(display::inline_block);
         }


### PR DESCRIPTION
It should be checking the value of the 'writing-mode' property, not the value of
the "writing mode" concept.  The latter is influenced by other properties like
'direction' and whatnot.  That was causing this code to convert inlines to
inline-blocks if they just had a different direction from their parent, which is
not correct

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there are tons of tests on the Gecko side.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16123)
<!-- Reviewable:end -->
