### PR TITLE
Switch SharedRwLock inside Element::style_attribute when transfering elements between documents.

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1388,6 +1388,15 @@ impl Element {
         let other = other.upcast::<Element>();
         self.root_element() == other.root_element()
     }
+
+    pub fn rebind_locked_style_attributes(&self, lock: &SharedRwLock) {
+        let mut maybe_attribute = self.style_attribute.borrow_mut();
+        if let Some(ref mut attribute) = *maybe_attribute {
+            let document = document_from_node(self);
+            let guard = document.style_shared_lock().read();
+            *attribute = Arc::new(lock.wrap(attribute.read_with(&guard).clone()));
+        }
+    }
 }
 
 impl ElementMethods for Element {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -746,6 +746,9 @@ impl Node {
     }
 
     pub fn set_owner_doc(&self, document: &Document) {
+        if let Some(element) = self.downcast::<Element>() {
+            element.rebind_locked_style_attributes(document.style_shared_lock());
+        }
         self.owner_doc.set(Some(document));
     }
 


### PR DESCRIPTION
Fixes #16097

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #16097 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16125)
<!-- Reviewable:end -->
