### PR TITLE
Block scripts with text/csv, audio/*, video/* and image/* mime types

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -271,6 +271,8 @@ pub fn main_fetch(request: &mut Request,
         let response_is_network_error = response.is_network_error();
         let should_replace_with_nosniff_error =
             !response_is_network_error && should_be_blocked_due_to_nosniff(request.type_, &response.headers);
+        let should_replace_with_mime_type_error =
+            !response_is_network_error && should_be_blocked_due_to_mime_type(request.type_, &response.headers);
 
         // Step 15.
         let mut network_error_response = response.get_network_error().cloned().map(Response::network_error);
@@ -288,12 +290,15 @@ pub fn main_fetch(request: &mut Request,
         // Step 17.
         // TODO: handle blocking as mixed content.
         // TODO: handle blocking by content security policy.
-        // TODO: handle blocking due to MIME type.
         let blocked_error_response;
         let internal_response =
             if should_replace_with_nosniff_error {
                 // Defer rebinding result
                 blocked_error_response = Response::network_error(NetworkError::Internal("Blocked by nosniff".into()));
+                &blocked_error_response
+            } else if should_replace_with_mime_type_error {
+                // Defer rebinding result
+                blocked_error_response = Response::network_error(NetworkError::Internal("Blocked by mime type".into()));
                 &blocked_error_response
             } else {
                 internal_response
@@ -623,6 +628,21 @@ pub fn should_be_blocked_due_to_nosniff(request_type: Type, response_headers: &H
         // Step 8
         _ => false
     };
+}
+
+/// https://fetch.spec.whatwg.org/#should-response-to-request-be-blocked-due-to-mime-type?
+fn should_be_blocked_due_to_mime_type(request_type: Type, response_headers: &Headers) -> bool {
+    let mime_type = match response_headers.get::<ContentType>() {
+        Some(header) => header,
+        None => return false,
+    };
+    request_type == Type::Script && match *mime_type {
+        ContentType(Mime(TopLevel::Audio, _, _)) |
+        ContentType(Mime(TopLevel::Video, _, _)) |
+        ContentType(Mime(TopLevel::Image, _, _)) => true,
+        ContentType(Mime(TopLevel::Text, SubLevel::Ext(ref ext), _)) => ext == "csv",
+        _ => false,
+    }
 }
 
 /// https://fetch.spec.whatwg.org/#block-bad-port

--- a/tests/wpt/web-platform-tests/fetch/api/basic/block-mime-as-script.html
+++ b/tests/wpt/web-platform-tests/fetch/api/basic/block-mime-as-script.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Block mime type as script</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div></div>
+<script>
+  var noop = function() {};
+
+  ["text/csv",
+   "audio/aiff",
+   "audio/midi",
+   "audio/whatever",
+   "video/avi",
+   "video/fli",
+   "video/whatever",
+   "image/jpeg",
+   "image/gif",
+   "image/whatever"].forEach(function(test_case) {
+    async_test(function(t) {
+      var script = document.createElement("script");
+      script.onerror = t.step_func_done(noop);
+      script.onload = t.unreached_func("Unexpected load event");
+      script.src = "../resources/script-with-header.py?mime=" + test_case;
+      document.body.appendChild(script);
+    }, "Should fail loading script with " + test_case + " MIME type");
+  });
+
+  ["html", "plain"].forEach(function(test_case) {
+    async_test(function(t) {
+      var script = document.createElement("script");
+      script.onerror = t.unreached_func("Unexpected error event");
+      script.onload = t.step_func_done(noop);
+      script.src = "../resources/script-with-header.py?mime=text/" + test_case;
+      document.body.appendChild(script);
+    }, "Should load script with text/" + test_case + " MIME type");
+  });
+
+</script>

--- a/tests/wpt/web-platform-tests/fetch/api/resources/script-with-header.py
+++ b/tests/wpt/web-platform-tests/fetch/api/resources/script-with-header.py
@@ -1,0 +1,4 @@
+def main(request, response):
+    headers = [("Content-type", request.GET.first("mime"))]
+    content = "console.log('Script loaded')"
+    return 200, headers, content


### PR DESCRIPTION
This patch implements step 12 of the Main Fetch section of the Fetch API standard. It blocks the load of scripts with `text/csv`, `audio/*`, `video/*` and `image/*` mime types.

Credit for the logic of `should_block_mime_type` function should go to the author of #14770.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14520
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16126)
<!-- Reviewable:end -->
