### PR TITLE
Avoid splitting a code point when parsing HTMLImageElement.usemap

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -422,16 +422,17 @@ impl HTMLImageElement {
         };
 
         let value = usemap_attr.value();
-        let (first, last) = value.split_at(1);
 
-        if first != "#" || last.len() == 0 {
+        if value.len() <= 1 || value.bytes()[0] != b'#' {
             return None
         }
+
+        let value = &value[1..];
 
         let map = self.upcast::<Node>()
                       .following_siblings()
                       .filter_map(Root::downcast::<HTMLMapElement>)
-                      .find(|n| n.upcast::<Element>().get_string_attribute(&LocalName::from("name")) == last);
+                      .find(|n| n.upcast::<Element>().get_string_attribute(&LocalName::from("name")) == value);
 
         let elements: Vec<Root<HTMLAreaElement>> = map.unwrap().upcast::<Node>()
                       .children()

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-test-data.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/image-maps/image-map-processing-model/hash-name-reference-test-data.html
@@ -12,6 +12,14 @@
  <body>
 
 <div data-expect="no match">
+ <img src="/images/threecolors.png" usemap="&#x1F4A9;"/>
+ <object data="/images/threecolors.png" usemap="&#x1F4A9;"></object>
+ <map name="&#x1F4A9;">
+  <area shape="rect" coords="0,0,99,50" href="#area-&#x1F4A9;"/>
+ </map>
+</div>
+
+<div data-expect="no match">
  <img src="/images/threecolors.png" usemap="no-hash-name"/>
  <object data="/images/threecolors.png" usemap="no-hash-name"></object>
  <map name="no-hash-name">


### PR DESCRIPTION
Fixes #15883

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16128)
<!-- Reviewable:end -->
