### PR TITLE
to_css of counter-increment returns none when there are no properties.

### DIFF
--- a/components/style/properties/longhand/counters.mako.rs
+++ b/components/style/properties/longhand/counters.mako.rs
@@ -269,6 +269,10 @@
 
     impl ToCss for SpecifiedValue {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            if self.0.is_empty() {
+                return dest.write_str("none");
+            }
+
             let mut first = true;
             for pair in &self.0 {
                 if !first {
@@ -278,6 +282,7 @@
                 try!(serialize_identifier(&pair.0, dest));
                 try!(write!(dest, " {}", pair.1));
             }
+
             Ok(())
         }
     }

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -1170,4 +1170,30 @@ mod shorthand_serialization {
             assert_eq!(shadow.to_css_string(), shadow_css);
         }
     }
+
+    mod counter_increment {
+        pub use super::*;
+        pub use style::properties::longhands::counter_increment::SpecifiedValue as CounterIncrement;
+
+        #[test]
+        fn counter_increment_with_properties_should_serialize_correctly() {
+            let mut properties = Vec::new();
+
+            properties.push(("counter1".to_owned(), 1));
+            properties.push(("counter2".to_owned(), -4));
+
+            let counter_increment = CounterIncrement(properties);
+            let counter_increment_css = "counter1 1 counter2 -4";
+
+            assert_eq!(counter_increment.to_css_string(), counter_increment_css);
+        }
+
+        #[test]
+        fn counter_increment_without_properties_should_serialize_correctly() {
+            let counter_increment = CounterIncrement(Vec::new());
+            let counter_increment_css = "none";
+
+            assert_eq!(counter_increment.to_css_string(), counter_increment_css);
+        }
+    }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Changed to_css in style::properties::longhands::counter_increment returns "none" if there are no properties defined.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15977 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16136)
<!-- Reviewable:end -->
