### PR TITLE
style: Add <keyword>::from_ident helper to avoid tokenizing the same value multiple times.

### DIFF
--- a/components/style_traits/values.rs
+++ b/components/style_traits/values.rs
@@ -117,7 +117,12 @@ macro_rules! __define_css_keyword_enum__actual {
             /// Parse this property from a CSS input stream.
             pub fn parse(input: &mut ::cssparser::Parser) -> Result<$name, ()> {
                 let ident = input.expect_ident()?;
-                match_ignore_ascii_case! { &ident,
+                Self::from_ident(&ident)
+            }
+
+            /// Parse this property from an already-tokenized identifier.
+            pub fn from_ident(ident: &str) -> Result<$name, ()> {
+                match_ignore_ascii_case! { ident,
                                            $( $css => Ok($name::$variant), )+
                                            _ => Err(())
                 }


### PR DESCRIPTION
We can use this to avoid tokenizing multiple times in some places, like #16127.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16141)
<!-- Reviewable:end -->
