### PR TITLE
Fix scroll root of absolutely positioned elements

### DIFF
--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-001.htm.ini
@@ -1,3 +1,0 @@
-[abspos-overflow-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-002.htm.ini
@@ -1,3 +1,0 @@
-[abspos-overflow-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-003.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-003.htm.ini
@@ -1,3 +1,0 @@
-[abspos-overflow-003.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-007.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-007.htm.ini
@@ -1,3 +1,0 @@
-[abspos-overflow-007.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-008.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-008.htm.ini
@@ -1,3 +1,0 @@
-[abspos-overflow-008.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-009.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-009.htm.ini
@@ -1,3 +1,0 @@
-[abspos-overflow-009.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-012.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-012.htm.ini
@@ -1,3 +1,0 @@
-[abspos-overflow-012.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
Absolutely positioned elements should be given the scroll root of their
containing block and not necessarily the scroll root of their parent.
This fixes several CSS tests, though others are still failing pending a
similar fix for inherited clipping rectangles.

Fixes #13530.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16146)
<!-- Reviewable:end -->
