### PR TITLE
style: Re-introduce the -webkit- prefix for the order property.

### DIFF
--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -131,6 +131,7 @@ ${helpers.predefined_type("flex-shrink", "Number",
 
 // https://drafts.csswg.org/css-flexbox/#propdef-order
 ${helpers.predefined_type("order", "Integer", "0",
+                          extra_prefixes="webkit",
                           animatable=True,
                           spec="https://drafts.csswg.org/css-flexbox/#order-property")}
 


### PR DESCRIPTION
I accidentally removed it while converting "order" to a predefined type
in #16144.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16151)
<!-- Reviewable:end -->
