### PR TITLE
stylo: Implement gecko glue for font-language-override.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,6 +2744,7 @@ dependencies = [
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bindgen 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -25,6 +25,7 @@ testing = []
 app_units = "0.4"
 atomic_refcell = "0.1"
 bitflags = "0.7"
+byteorder = "1.0"
 cfg-if = "0.1.0"
 cssparser = "0.12"
 encoding = {version = "0.2", optional = true}

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -41,6 +41,7 @@ extern crate app_units;
 extern crate atomic_refcell;
 #[macro_use]
 extern crate bitflags;
+#[allow(unused_extern_crates)] extern crate byteorder;
 #[cfg(feature = "gecko")] #[macro_use] #[no_link] extern crate cfg_if;
 #[macro_use] extern crate cssparser;
 extern crate euclid;

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1177,7 +1177,7 @@ fn static_assert() {
 </%self:impl_trait>
 
 <%self:impl_trait style_struct_name="Font"
-    skip_longhands="font-family font-size font-size-adjust font-weight font-synthesis -x-lang"
+    skip_longhands="font-family font-size font-size-adjust font-weight font-synthesis -x-lang font-language-override"
     skip_additionals="*">
 
     pub fn set_font_family(&mut self, v: longhands::font_family::computed_value::T) {
@@ -1315,6 +1315,11 @@ fn static_assert() {
             Gecko_nsStyleFont_CopyLangFrom(&mut self.gecko, &other.gecko);
         }
     }
+
+    pub fn set_font_language_override(&mut self, v: longhands::font_language_override::computed_value::T) {
+        self.gecko.mFont.languageOverride = v.0;
+    }
+    ${impl_simple_copy('font_language_override', 'mFont.languageOverride')}
 </%self:impl_trait>
 
 <%def name="impl_copy_animation_or_transition_value(type, ident, gecko_ffi_name)">

--- a/components/style/properties/shorthand/font.mako.rs
+++ b/components/style/properties/shorthand/font.mako.rs
@@ -4,21 +4,20 @@
 
 <%namespace name="helpers" file="/helpers.mako.rs" />
 
-<%helpers:shorthand name="font" sub_properties="font-style font-variant font-weight font-stretch
-                                                font-size line-height font-family
-                                                ${'font-size-adjust' if product == 'gecko' or data.testing else ''}
-                                                ${'font-kerning' if product == 'gecko' or data.testing else ''}
-                                                ${'font-variant-caps' if product == 'gecko' or data.testing else ''}
-                                                ${'font-variant-position' if product == 'gecko' or data.testing else ''}
-                                                ${'font-language-override' if data.testing else ''}"
+<%helpers:shorthand name="font"
+                    sub_properties="font-style font-variant font-weight font-stretch
+                                    font-size line-height font-family
+                                    ${'font-size-adjust' if product == 'gecko' or data.testing else ''}
+                                    ${'font-kerning' if product == 'gecko' or data.testing else ''}
+                                    ${'font-variant-caps' if product == 'gecko' or data.testing else ''}
+                                    ${'font-variant-position' if product == 'gecko' or data.testing else ''}
+                                    ${'font-language-override' if product == 'gecko' or data.testing else ''}"
                     spec="https://drafts.csswg.org/css-fonts-3/#propdef-font">
     use properties::longhands::{font_style, font_variant, font_weight, font_stretch};
     use properties::longhands::{font_size, line_height};
     % if product == "gecko" or data.testing:
-    use properties::longhands::{font_size_adjust, font_kerning, font_variant_caps, font_variant_position};
-    % endif
-    % if data.testing:
-    use properties::longhands::font_language_override;
+    use properties::longhands::{font_size_adjust, font_kerning, font_variant_caps, font_variant_position,
+                                font_language_override};
     % endif
     use properties::longhands::font_family::SpecifiedValue as FontFamily;
 
@@ -84,12 +83,9 @@
             line_height: unwrap_or_initial!(line_height),
             font_family: family,
             % if product == "gecko" or data.testing:
-                % for name in "size_adjust kerning variant_caps variant_position".split():
+                % for name in "size_adjust kerning variant_caps variant_position language_override".split():
                     font_${name}: font_${name}::get_initial_specified_value(),
                 % endfor
-            % endif
-            % if data.testing:
-                font_language_override: font_language_override::get_initial_specified_value(),
             % endif
         })
     }
@@ -99,17 +95,11 @@
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
 
     % if product == "gecko" or data.testing:
-        % for name in "size_adjust kerning variant_caps variant_position".split():
+        % for name in "size_adjust kerning variant_caps variant_position language_override".split():
             if self.font_${name} != &font_${name}::get_initial_specified_value() {
                 return Ok(());
             }
         % endfor
-    % endif
-
-    % if data.testing:
-            if self.font_language_override != &font_language_override::get_initial_specified_value() {
-                return Ok(());
-            }
     % endif
 
     % for name in "style variant weight stretch".split():


### PR DESCRIPTION
To be aligned with the implementation from Gecko side, we parse
font-language-override as Normal keyword or String. Then, we compute
and store it as a u32. So, as to the stylo glue, we can just pass the
u32 to Gecko.

The extra crate, byteorder, is used to simplify the computing and
serialization.

Since we now implement font-language-override for Gecko, we can remove
the additional branches for font-language-override in font shorthand.

ref: Gecko [Bug 1347821](https://bugzilla.mozilla.org/show_bug.cgi?id=1347821)

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16155)
<!-- Reviewable:end -->
