### PR TITLE
stylo: Include -moz-transform and -moz-text-align-last

### DIFF
--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -250,6 +250,7 @@ ${helpers.single_keyword("text-align-last",
                          products="gecko",
                          gecko_constant_prefix="NS_STYLE_TEXT_ALIGN",
                          animation_value_type="none",
+                         extra_prefixes="moz",
                          spec="https://drafts.csswg.org/css-text/#propdef-text-align-last")}
 
 // TODO make this a shorthand and implement text-align-last/text-align-all


### PR DESCRIPTION
Gecko has these, we don't.

`-moz-transform` is used quite often in the tests.


https://treeherder.mozilla.org/#/jobs?repo=try&revision=b42def5940e5f8e11689987eb67098a378f86424

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16162)
<!-- Reviewable:end -->
