### PR TITLE
stylo: Add argument to Servo_ResolveStyle to allow stale styles to be returned.

### DIFF
--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1812,7 +1812,8 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_ResolveStyle(element: RawGeckoElementBorrowed,
-                              set: RawServoStyleSetBorrowed)
+                              set: RawServoStyleSetBorrowed,
+                              allow_stale: bool)
      -> ServoComputedValuesStrong;
 }
 extern "C" {


### PR DESCRIPTION
This is the Servo-side part of https://bugzilla.mozilla.org/show_bug.cgi?id=1350671.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16164)
<!-- Reviewable:end -->
