### PR TITLE
Remove heapsize for Stylo

### DIFF
--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 [features]
 gecko = ["nsstring_vendor", "rayon/unstable", "num_cpus"]
 use_bindgen = ["bindgen", "regex"]
-servo = ["serde/unstable", "serde", "serde_derive", "heapsize_derive",
+servo = ["serde/unstable", "serde", "serde_derive", "heapsize", "heapsize_derive",
          "style_traits/servo", "servo_atoms", "html5ever-atoms",
          "cssparser/heapsize", "cssparser/serde", "encoding",
          "rayon/unstable", "servo_url/servo"]
@@ -30,7 +30,7 @@ cssparser = "0.12"
 encoding = {version = "0.2", optional = true}
 euclid = "0.11"
 fnv = "1.0"
-heapsize = "0.3.0"
+heapsize = {version = "0.3.0", optional = true}
 heapsize_derive = {version = "0.1", optional = true}
 html5ever-atoms = {version = "0.2", optional = true}
 lazy_static = "0.2"

--- a/components/style/gecko_bindings/sugar/refptr.rs
+++ b/components/style/gecko_bindings/sugar/refptr.rs
@@ -6,7 +6,6 @@
 
 use gecko_bindings::structs;
 use gecko_bindings::sugar::ownership::HasArcFFI;
-use heapsize::HeapSizeOf;
 use std::{mem, ptr};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
@@ -220,10 +219,6 @@ impl<T: RefCounted> Clone for RefPtr<T> {
             _marker: PhantomData,
         }
     }
-}
-
-impl<T: RefCounted> HeapSizeOf for RefPtr<T> {
-    fn heap_size_of_children(&self) -> usize { 0 }
 }
 
 impl<T: RefCounted> PartialEq for RefPtr<T> {

--- a/components/style/gecko_string_cache/mod.rs
+++ b/components/style/gecko_string_cache/mod.rs
@@ -10,7 +10,6 @@ use gecko_bindings::bindings::Gecko_AddRefAtom;
 use gecko_bindings::bindings::Gecko_Atomize;
 use gecko_bindings::bindings::Gecko_ReleaseAtom;
 use gecko_bindings::structs::nsIAtom;
-use heapsize::HeapSizeOf;
 use std::borrow::{Cow, Borrow};
 use std::char::{self, DecodeUtf16};
 use std::fmt::{self, Write};
@@ -234,12 +233,6 @@ impl Default for Atom {
     #[inline]
     fn default() -> Self {
         atom!("")
-    }
-}
-
-impl HeapSizeOf for Atom {
-    fn heap_size_of_children(&self) -> usize {
-        0
     }
 }
 

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -46,7 +46,7 @@ extern crate bitflags;
 extern crate euclid;
 extern crate fnv;
 #[cfg(feature = "gecko")] #[macro_use] pub mod gecko_string_cache;
-extern crate heapsize;
+#[cfg(feature = "servo")] extern crate heapsize;
 #[cfg(feature = "servo")] #[macro_use] extern crate heapsize_derive;
 #[cfg(feature = "servo")] #[macro_use] extern crate html5ever_atoms;
 #[macro_use]


### PR DESCRIPTION
It doesn’t seem to be used, and is causing compilation trouble for Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1350581

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16169)
<!-- Reviewable:end -->
