### PR TITLE
Implement HTMLAnchorElement.rel getter and setter

### DIFF
--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -113,11 +113,17 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
         self.upcast::<Node>().SetTextContent(Some(value))
     }
 
+    // https://html.spec.whatwg.org/multipage/#dom-a-rel
+    make_getter!(Rel, "rel");
+
+    // https://html.spec.whatwg.org/multipage/#dom-a-rel
+    fn SetRel(&self, rel: DOMString) {
+        self.upcast::<Element>().set_tokenlist_attribute(&local_name!("rel"), rel);
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-a-rellist
     fn RelList(&self) -> Root<DOMTokenList> {
-        self.rel_list.or_init(|| {
-            DOMTokenList::new(self.upcast(), &local_name!("rel"))
-        })
+        self.rel_list.or_init(|| DOMTokenList::new(self.upcast(), &local_name!("rel")))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-a-coords

--- a/components/script/dom/webidls/HTMLAnchorElement.webidl
+++ b/components/script/dom/webidls/HTMLAnchorElement.webidl
@@ -13,12 +13,12 @@
 // https://html.spec.whatwg.org/multipage/#htmlanchorelement
 interface HTMLAnchorElement : HTMLElement {
   attribute DOMString target;
-  //         attribute DOMString download;
-  //         attribute USVString ping;
-  //         attribute DOMString rel;
+  //       attribute DOMString download;
+  //       attribute USVString ping;
+           attribute DOMString rel;
   readonly attribute DOMTokenList relList;
-  //         attribute DOMString hreflang;
-  //         attribute DOMString type;
+  //       attribute DOMString hreflang;
+  //       attribute DOMString type;
 
   [Pure]
            attribute DOMString text;

--- a/tests/wpt/metadata/html/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.html.ini
@@ -1152,9 +1152,6 @@
   [HTMLAnchorElement interface: attribute ping]
     expected: FAIL
 
-  [HTMLAnchorElement interface: attribute rel]
-    expected: FAIL
-
   [HTMLAnchorElement interface: attribute hreflang]
     expected: FAIL
 
@@ -1168,9 +1165,6 @@
     expected: FAIL
 
   [HTMLAnchorElement interface: document.createElement("a") must inherit property "ping" with the proper type (2)]
-    expected: FAIL
-
-  [HTMLAnchorElement interface: document.createElement("a") must inherit property "rel" with the proper type (3)]
     expected: FAIL
 
   [HTMLAnchorElement interface: document.createElement("a") must inherit property "hreflang" with the proper type (5)]

--- a/tests/wpt/metadata/html/dom/reflection-text.html.ini
+++ b/tests/wpt/metadata/html/dom/reflection-text.html.ini
@@ -732,12 +732,6 @@
   [a.ping: IDL set to object "test-valueOf" followed by IDL get]
     expected: FAIL
 
-  [a.rel: typeof IDL attribute]
-    expected: FAIL
-
-  [a.rel: IDL get with DOM attribute unset]
-    expected: FAIL
-
   [a.rel: setAttribute() to "" followed by IDL get]
     expected: FAIL
 
@@ -24799,96 +24793,6 @@
     expected: FAIL
 
   [a.ping: IDL set to object "test-valueOf"]
-    expected: FAIL
-
-  [a.rel: setAttribute() to ""]
-    expected: FAIL
-
-  [a.rel: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
-    expected: FAIL
-
-  [a.rel: setAttribute() to undefined]
-    expected: FAIL
-
-  [a.rel: setAttribute() to 7]
-    expected: FAIL
-
-  [a.rel: setAttribute() to 1.5]
-    expected: FAIL
-
-  [a.rel: setAttribute() to true]
-    expected: FAIL
-
-  [a.rel: setAttribute() to false]
-    expected: FAIL
-
-  [a.rel: setAttribute() to object "[object Object\]"]
-    expected: FAIL
-
-  [a.rel: setAttribute() to NaN]
-    expected: FAIL
-
-  [a.rel: setAttribute() to Infinity]
-    expected: FAIL
-
-  [a.rel: setAttribute() to -Infinity]
-    expected: FAIL
-
-  [a.rel: setAttribute() to "\\0"]
-    expected: FAIL
-
-  [a.rel: setAttribute() to null]
-    expected: FAIL
-
-  [a.rel: setAttribute() to object "test-toString"]
-    expected: FAIL
-
-  [a.rel: setAttribute() to object "test-valueOf"]
-    expected: FAIL
-
-  [a.rel: IDL set to ""]
-    expected: FAIL
-
-  [a.rel: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
-    expected: FAIL
-
-  [a.rel: IDL set to undefined]
-    expected: FAIL
-
-  [a.rel: IDL set to 7]
-    expected: FAIL
-
-  [a.rel: IDL set to 1.5]
-    expected: FAIL
-
-  [a.rel: IDL set to true]
-    expected: FAIL
-
-  [a.rel: IDL set to false]
-    expected: FAIL
-
-  [a.rel: IDL set to object "[object Object\]"]
-    expected: FAIL
-
-  [a.rel: IDL set to NaN]
-    expected: FAIL
-
-  [a.rel: IDL set to Infinity]
-    expected: FAIL
-
-  [a.rel: IDL set to -Infinity]
-    expected: FAIL
-
-  [a.rel: IDL set to "\\0"]
-    expected: FAIL
-
-  [a.rel: IDL set to null]
-    expected: FAIL
-
-  [a.rel: IDL set to object "test-toString"]
-    expected: FAIL
-
-  [a.rel: IDL set to object "test-valueOf"]
     expected: FAIL
 
   [a.hreflang: setAttribute() to ""]

--- a/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/cross-origin/http-http/a-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/cross-origin/http-http/a-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,0 +1,5 @@
+[generic.keep-origin-redirect.http.html]
+  type: testharness
+  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via a-tag using the rel-noreferrer\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is cross-origin.]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/cross-origin/http-http/a-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/cross-origin/http-http/a-tag/generic.no-redirect.http.html.ini
@@ -1,0 +1,5 @@
+[generic.no-redirect.http.html]
+  type: testharness
+  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via a-tag using the rel-noreferrer\n                                 delivery method with no-redirect and when\n                                 the target request is cross-origin.]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/cross-origin/http-http/a-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/cross-origin/http-http/a-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,0 +1,5 @@
+[generic.swap-origin-redirect.http.html]
+  type: testharness
+  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via a-tag using the rel-noreferrer\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is cross-origin.]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/same-origin/http-http/a-tag/generic.keep-origin-redirect.http.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/same-origin/http-http/a-tag/generic.keep-origin-redirect.http.html.ini
@@ -1,0 +1,5 @@
+[generic.keep-origin-redirect.http.html]
+  type: testharness
+  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via a-tag using the rel-noreferrer\n                                 delivery method with keep-origin-redirect and when\n                                 the target request is same-origin.]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/same-origin/http-http/a-tag/generic.no-redirect.http.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/same-origin/http-http/a-tag/generic.no-redirect.http.html.ini
@@ -1,0 +1,5 @@
+[generic.no-redirect.http.html]
+  type: testharness
+  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via a-tag using the rel-noreferrer\n                                 delivery method with no-redirect and when\n                                 the target request is same-origin.]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/same-origin/http-http/a-tag/generic.swap-origin-redirect.http.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/referrer-policy/no-referrer/rel-noreferrer/same-origin/http-http/a-tag/generic.swap-origin-redirect.http.html.ini
@@ -1,0 +1,5 @@
+[generic.swap-origin-redirect.http.html]
+  type: testharness
+  [The referrer URL is omitted when a\n                                 document served over http requires an http\n                                 sub-resource via a-tag using the rel-noreferrer\n                                 delivery method with swap-origin-redirect and when\n                                 the target request is same-origin.]
+    expected: FAIL
+

--- a/tests/wpt/web-platform-tests/html/semantics/text-level-semantics/the-a-element/a.rel-getter-01.html
+++ b/tests/wpt/web-platform-tests/html/semantics/text-level-semantics/the-a-element/a.rel-getter-01.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>HTMLAnchorElement.rel getter</title>
+<link rel="author" title="TheKK" href="mailto:thumbd03803@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-a-rel">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<div>
+<a id="test" href="a" rel="noreferrer"></a>
+</div>
+<script>
+test(function() {
+  var a = document.getElementById("test");
+
+  test(function() {
+    assert_equals(a.rel, "noreferrer");
+  }, "Test anchor's rel getter");
+});
+</script>

--- a/tests/wpt/web-platform-tests/html/semantics/text-level-semantics/the-a-element/a.rel-setter-01.html
+++ b/tests/wpt/web-platform-tests/html/semantics/text-level-semantics/the-a-element/a.rel-setter-01.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>HTMLAnchorElement.rel setter</title>
+<link rel="author" title="TheKK" href="mailto:thumbd03803@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-a-rel">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<div>
+<a id="test" href="a"></a>
+</div>
+<script>
+test(function() {
+  var a = document.getElementById("test");
+
+  test(function() {
+    a.rel = "noreferrer"
+    assert_equals(a.rel, "noreferrer");
+  }, "Test anchor's rel setter");
+});
+</script>


### PR DESCRIPTION
This PR makes code below possible:

```javascript
a = document.createElement("a");
a.rel = "foo";
console.log(a.rel); // print out "foo"
```
---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16170)
<!-- Reviewable:end -->
