### PR TITLE
stylo: Get rid of one of the copies of the `expand` function.

### DIFF
--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -374,7 +374,7 @@ impl<'a> QualifiedRuleParser for KeyframeListParser<'a> {
         let mut block = PropertyDeclarationBlock::new();
         while let Some(declaration) = iter.next() {
             match declaration {
-                Ok(parsed) => parsed.expand(|d| block.push(d, Importance::Normal)),
+                Ok(parsed) => parsed.expand_into(&mut block, Importance::Normal),
                 Err(range) => {
                     let pos = range.start;
                     let message = format!("Unsupported keyframe property declaration: '{}'",

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -697,7 +697,9 @@ pub fn parse_property_declaration_list(context: &ParserContext,
     let mut iter = DeclarationListParser::new(input, parser);
     while let Some(declaration) = iter.next() {
         match declaration {
-            Ok((parsed, importance)) => parsed.expand(|d| block.push(d, importance)),
+            Ok((parsed, importance)) => {
+                parsed.expand_into(&mut block, importance)
+            },
             Err(range) => {
                 let pos = range.start;
                 let message = format!("Unsupported property declaration: '{}'",

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -886,6 +886,14 @@ pub enum ParsedDeclaration {
 }
 
 impl ParsedDeclaration {
+    /// Expand this declaration into a sequence of property declarations, and
+    /// add them to `block`, with a given importance.
+    pub fn expand_into(self,
+                       block: &mut PropertyDeclarationBlock,
+                       importance: Importance) {
+        self.expand(|d| block.push(d, importance));
+    }
+
     /// Transform this ParsedDeclaration into a sequence of PropertyDeclaration
     /// by expanding shorthand declarations into their corresponding longhands
     pub fn expand<F>(self, mut push: F) where F: FnMut(PropertyDeclaration) {

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -800,7 +800,7 @@ pub extern "C" fn Servo_ParseProperty(property: *const nsACString, value: *const
         Ok(parsed) => {
             let global_style_data = &*GLOBAL_STYLE_DATA;
             let mut block = PropertyDeclarationBlock::new();
-            parsed.expand(|d| block.push(d, Importance::Normal));
+            parsed.expand_into(&mut block, Importance::Normal));
             Arc::new(global_style_data.shared_lock.wrap(block)).into_strong()
         }
         Err(_) => RawServoDeclarationBlockStrong::null()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16182)
<!-- Reviewable:end -->
