### PR TITLE
style: Make the servo and gecko implementations of Element::note_descendants equivalent.

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -17,7 +17,7 @@
 use atomic_refcell::AtomicRefCell;
 use context::UpdateAnimationsTasks;
 use data::ElementData;
-use dom::{AnimationRules, LayoutIterator, NodeInfo, TElement, TNode, UnsafeNode};
+use dom::{self, AnimationRules, DescendantsBit, LayoutIterator, NodeInfo, TElement, TNode, UnsafeNode};
 use dom::{OpaqueNode, PresentationalHintsSynthetizer};
 use element_state::ElementState;
 use error_reporting::StdoutErrorReporter;
@@ -504,8 +504,16 @@ impl<'le> TElement for GeckoElement<'le> {
     }
 
     unsafe fn set_dirty_descendants(&self) {
+        debug_assert!(self.get_data().is_some());
         debug!("Setting dirty descendants: {:?}", self);
         self.set_flags(NODE_HAS_DIRTY_DESCENDANTS_FOR_SERVO as u32)
+    }
+
+    unsafe fn note_descendants<B: DescendantsBit<Self>>(&self) {
+        debug_assert!(self.get_data().is_some());
+        if dom::raw_note_descendants::<Self, B>(*self) {
+            bindings::Gecko_SetOwnerDocumentNeedsStyleFlush(self.0);
+        }
     }
 
     unsafe fn unset_dirty_descendants(&self) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16196)
<!-- Reviewable:end -->
