### PR TITLE
Presentation hints should not get applied to pseudo-elements.

### DIFF
--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -622,19 +622,21 @@ impl Stylist {
                                               CascadeLevel::UANormal);
         debug!("UA normal: {:?}", relations);
 
-        // Step 2: Presentational hints.
-        let length_before_preshints = applicable_declarations.len();
-        element.synthesize_presentational_hints_for_legacy_attributes(applicable_declarations);
-        if applicable_declarations.len() != length_before_preshints {
-            if cfg!(debug_assertions) {
-                for declaration in &applicable_declarations[length_before_preshints..] {
-                    assert_eq!(declaration.level, CascadeLevel::PresHints);
+        if pseudo_element.is_none() {
+            // Step 2: Presentational hints.
+            let length_before_preshints = applicable_declarations.len();
+            element.synthesize_presentational_hints_for_legacy_attributes(applicable_declarations);
+            if applicable_declarations.len() != length_before_preshints {
+                if cfg!(debug_assertions) {
+                    for declaration in &applicable_declarations[length_before_preshints..] {
+                        assert_eq!(declaration.level, CascadeLevel::PresHints);
+                    }
                 }
+                // Never share style for elements with preshints
+                relations |= AFFECTED_BY_PRESENTATIONAL_HINTS;
             }
-            // Never share style for elements with preshints
-            relations |= AFFECTED_BY_PRESENTATIONAL_HINTS;
+            debug!("preshints: {:?}", relations);
         }
-        debug!("preshints: {:?}", relations);
 
         if element.matches_user_and_author_rules() {
             // Step 3: User and author normal rules.


### PR DESCRIPTION
Servo side of https://bugzilla.mozilla.org/show_bug.cgi?id=1352464

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16205)
<!-- Reviewable:end -->
