### PR TITLE
style: Prevent reframing in Gecko when we don't find a pseudo-element's style context more often.

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -1160,9 +1160,11 @@ pub trait MatchMethods : TElement {
         }
 
         // If there's no style source, that likely means that Gecko
-        // couldn't find a style context. This happens with display:none
-        // elements, and probably a number of other edge cases that
-        // we don't handle well yet (like display:contents).
+        // couldn't find a style context.
+        //
+        // This happens with display:none elements, and also a number of
+        // other cases, like pseudos that end up matching rules but not
+        // producing a frame.
         if new_values.get_box().clone_display() == display::T::none &&
             old_values.get_box().clone_display() == display::T::none {
             // The style remains display:none. No need for damage.

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -159,6 +159,10 @@ impl ComputedValues {
         self.custom_properties.as_ref().map(|x| x.clone())
     }
 
+    pub fn ineffective_content_property(&self) -> bool {
+        self.get_counters().ineffective_content_property()
+    }
+
     #[allow(non_snake_case)]
     pub fn has_moz_binding(&self) -> bool {
         !self.get_box().gecko.mBinding.mPtr.mRawPtr.is_null()
@@ -3397,6 +3401,10 @@ clip-path
 
 <%self:impl_trait style_struct_name="Counters"
                   skip_longhands="content counter-increment counter-reset">
+    pub fn ineffective_content_property(&self) -> bool {
+        self.gecko.mContents.is_empty()
+    }
+
     pub fn set_content(&mut self, v: longhands::content::computed_value::T) {
         use properties::longhands::content::computed_value::T;
         use properties::longhands::content::computed_value::ContentItem;

--- a/components/style/properties/longhand/counters.mako.rs
+++ b/components/style/properties/longhand/counters.mako.rs
@@ -19,6 +19,8 @@
     pub use self::computed_value::T as SpecifiedValue;
     pub use self::computed_value::ContentItem;
 
+    // FIXME(emilio): This is wrong, content: normal should compute to "none" if
+    // it's for a pseudo, and to "contents" if it's for an element.
     impl ComputedValueAsSpecified for SpecifiedValue {}
     no_viewport_percentage!(SpecifiedValue);
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1624,6 +1624,17 @@ impl ComputedValues {
     /// Since this isn't supported in Servo, this is always false for Servo.
     pub fn is_display_contents(&self) -> bool { false }
 
+    /// Returns whether the "content" property for the given style is completely
+    /// ineffective.
+    pub fn ineffective_content_property(&self) -> bool {
+        use properties::longhands::content::computed_value::T;
+        match self.get_counters().content {
+            T::normal |
+            T::none => true,
+            T::Content(ref items) => items.is_empty(),
+        }
+    }
+
     /// Whether the current style is multicolumn.
     #[inline]
     pub fn is_multicol(&self) -> bool {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16207)
<!-- Reviewable:end -->
