### PR TITLE
Fix macOS nightly creation.

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -256,6 +256,10 @@ class PackageCommands(CommandBase):
             os.symlink('/Applications', path.join(dir_to_dmg, 'Applications'))
             dmg_path = path.join(target_dir, "servo-tech-demo.dmg")
 
+            if path.exists(dmg_path):
+                print("Deleting existing dmg")
+                os.remove(dmg_path)
+
             try:
                 subprocess.check_call(['hdiutil', 'create', '-volname', 'Servo', dmg_path, '-srcfolder', dir_to_dmg])
             except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Our change to keep around build artifacts broke the macOS nightly generation process, since hdiutil can't cope with the dmg file already existing.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #16218
- [X] These changes do not require tests because I tested manually and we build every night

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16219)
<!-- Reviewable:end -->
