### PR TITLE
Disable HTTP connection pooling

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -326,7 +326,8 @@ impl CoreResourceManager {
             hsts_list: group.hsts_list.clone(),
             cookie_jar: group.cookie_jar.clone(),
             auth_cache: group.auth_cache.clone(),
-            connector_pool: group.connector.clone(),
+            // FIXME(#15694): use group.connector.clone() instead.
+            connector_pool: create_http_connector("certs"),
         };
         let ua = self.user_agent.clone();
         let dc = self.devtools_chan.clone();


### PR DESCRIPTION
The intermittent failures in the nosniff tests appeared once more after #16209 merged, so we should disable this again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16225)
<!-- Reviewable:end -->
