### PR TITLE
test whitespace in pseudo-element selector throws syntax error

### DIFF
--- a/tests/wpt/web-platform-tests/dom/nodes/selectors.js
+++ b/tests/wpt/web-platform-tests/dom/nodes/selectors.js
@@ -37,6 +37,8 @@ var invalidSelectors = [
   {name: "Unknown pseudo-element",       selector: "div::example"},
   {name: "Unknown pseudo-element",       selector: "::example"},
   {name: "Invalid pseudo-element",       selector: ":::before"},
+  {name: "Invalid pseudo-element",	 selector: ": before"},
+  {name: "Invalid pseudo-element",       selector: ":: before"},
   {name: "Undeclared namespace",         selector: "ns|div"},
   {name: "Undeclared namespace",         selector: ":not(ns|div)"},
   {name: "Invalid namespace",            selector: "^|div"},

--- a/tests/wpt/web-platform-tests/dom/nodes/selectors.js
+++ b/tests/wpt/web-platform-tests/dom/nodes/selectors.js
@@ -37,7 +37,7 @@ var invalidSelectors = [
   {name: "Unknown pseudo-element",       selector: "div::example"},
   {name: "Unknown pseudo-element",       selector: "::example"},
   {name: "Invalid pseudo-element",       selector: ":::before"},
-  {name: "Invalid pseudo-element",	 selector: ": before"},
+  {name: "Invalid pseudo-element",	     selector: ": before"},
   {name: "Invalid pseudo-element",       selector: ":: before"},
   {name: "Undeclared namespace",         selector: "ns|div"},
   {name: "Undeclared namespace",         selector: ":not(ns|div)"},


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Issue #15448 - Land the test cases that should've landed with the selectors update. Tests that syntax error is thrown when pseudo-element selector contains whitespace - related to issue #15335 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X ] `./mach build -d` does not report any errors
- [X ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #15448  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X ] These changes do not require tests because implements a test not included when issue #15335 was fixed

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16228)
<!-- Reviewable:end -->
