### PR TITLE
Set each control points when converting specified keyworded timing fu…

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -671,17 +671,7 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
                 SpecifiedValue::Steps(count, start_end) => {
                     computed_value::T::Steps(count.to_computed_value(context) as u32, start_end)
                 },
-                SpecifiedValue::Keyword(keyword) => {
-                    match keyword {
-                        FunctionKeyword::Ease => ease(),
-                        FunctionKeyword::Linear => linear(),
-                        FunctionKeyword::EaseIn => ease_in(),
-                        FunctionKeyword::EaseOut => ease_out(),
-                        FunctionKeyword::EaseInOut => ease_in_out(),
-                        FunctionKeyword::StepStart => STEP_START,
-                        FunctionKeyword::StepEnd => STEP_END,
-                    }
-                },
+                SpecifiedValue::Keyword(keyword) => keyword.to_computed_value(),
             }
         }
         #[inline]
@@ -698,6 +688,21 @@ ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
                     let int_count = count as i32;
                     SpecifiedValue::Steps(specified::Integer::from_computed_value(&int_count), start_end)
                 },
+            }
+        }
+    }
+
+    impl FunctionKeyword {
+        #[inline]
+        pub fn to_computed_value(&self) -> computed_value::T {
+            match *self {
+                FunctionKeyword::Ease => ease(),
+                FunctionKeyword::Linear => linear(),
+                FunctionKeyword::EaseIn => ease_in(),
+                FunctionKeyword::EaseOut => ease_out(),
+                FunctionKeyword::EaseInOut => ease_in_out(),
+                FunctionKeyword::StepStart => STEP_START,
+                FunctionKeyword::StepEnd => STEP_END,
             }
         }
     }


### PR DESCRIPTION
…nction to nsTimingFunction.

Gecko's timing function (nsTimingFunction) needs to be specified
each control points if timing function can be represented as cubic-bezier
function. To avoid scattering control points values (e.g. 0.25, 0.1, ...)
we convert specified value to computed value and then use control points
values of the computed value.

<!-- Please describe your changes on the following line: -->

This is a PR of  https://bugzilla.mozilla.org/show_bug.cgi?id=1352891

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it's for stylo.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16233)
<!-- Reviewable:end -->
