### PR TITLE
Add as_void_ptr helper method to &T

### DIFF
--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -8,6 +8,7 @@ use dom::bindings::error::{Error, Fallible, report_pending_exception};
 use dom::bindings::js::{JS, Root};
 use dom::bindings::reflector::DomObject;
 use dom::bindings::settings_stack::{AutoEntryScript, AutoIncumbentScript};
+use dom::bindings::utils::AsCCharPtrPtr;
 use dom::globalscope::GlobalScope;
 use js::jsapi::{Heap, MutableHandleObject};
 use js::jsapi::{IsCallable, JSContext, JSObject, JS_WrapObject, AddRawValueRoot};
@@ -81,7 +82,7 @@ impl CallbackObject {
         self.callback.set(callback);
         self.permanent_js_root.set(ObjectValue(callback));
         assert!(AddRawValueRoot(cx, self.permanent_js_root.get_unsafe(),
-                                b"CallbackObject::root\n" as *const _ as *const _));
+                                b"CallbackObject::root\n".as_c_char_ptr()));
     }
 }
 

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -3086,7 +3086,7 @@ let traps = ProxyTraps {
     isConstructor: None,
 };
 
-CreateProxyHandler(&traps, &Class as *const _ as *const _)\
+CreateProxyHandler(&traps, Class.as_void_ptr())\
 """ % args)
 
 
@@ -5565,6 +5565,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'dom::bindings::namespace::create_namespace_object',
         'dom::bindings::reflector::MutDomObject',
         'dom::bindings::reflector::DomObject',
+        'dom::bindings::utils::AsVoidPtr',
         'dom::bindings::utils::DOMClass',
         'dom::bindings::utils::DOMJSClass',
         'dom::bindings::utils::DOM_PROTO_UNFORGEABLE_HOLDER_SLOT',

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -33,7 +33,7 @@ use js::jsval::{JSVal, UndefinedValue};
 use js::rust::{GCMethods, ToString, get_object_class, is_dom_class};
 use libc;
 use std::ffi::CString;
-use std::os::raw::c_void;
+use std::os::raw::{c_char, c_void};
 use std::ptr;
 use std::slice;
 
@@ -513,3 +513,24 @@ unsafe extern "C" fn instance_class_has_proto_at_depth(clasp: *const js::jsapi::
 pub const DOM_CALLBACKS: DOMCallbacks = DOMCallbacks {
     instanceClassMatchesProto: Some(instance_class_has_proto_at_depth),
 };
+
+// Generic method for returning libc::c_void from caller
+pub trait AsVoidPtr {
+    fn as_void_ptr(&self) -> *const libc::c_void;
+}
+impl<T> AsVoidPtr for T {
+    fn as_void_ptr(&self) -> *const libc::c_void {
+        self as *const T as *const libc::c_void
+    }
+}
+
+// Generic method for returning c_char from caller
+pub trait AsCCharPtrPtr {
+    fn as_c_char_ptr(&self) -> *const c_char;
+}
+
+impl AsCCharPtrPtr for [u8] {
+    fn as_c_char_ptr(&self) -> *const c_char {
+        self as *const [u8] as *const c_char
+    }
+}

--- a/components/script/dom/browsingcontext.rs
+++ b/components/script/dom/browsingcontext.rs
@@ -9,8 +9,7 @@ use dom::bindings::js::{JS, Root, RootedReference};
 use dom::bindings::proxyhandler::{fill_property_descriptor, get_property_descriptor};
 use dom::bindings::reflector::{DomObject, Reflector};
 use dom::bindings::trace::JSTraceable;
-use dom::bindings::utils::WindowProxyHandler;
-use dom::bindings::utils::get_array_index_from_id;
+use dom::bindings::utils::{WindowProxyHandler, get_array_index_from_id, AsVoidPtr};
 use dom::dissimilaroriginwindow::DissimilarOriginWindow;
 use dom::element::Element;
 use dom::globalscope::GlobalScope;
@@ -112,7 +111,7 @@ impl BrowsingContext {
 
             // The window proxy owns the browsing context.
             // When we finalize the window proxy, it drops the browsing context it owns.
-            SetProxyExtra(window_proxy.get(), 0, &PrivateValue(&*browsing_context as *const _ as *const _));
+            SetProxyExtra(window_proxy.get(), 0, &PrivateValue((&*browsing_context).as_void_ptr()));
 
             // Notify the JS engine about the new window proxy binding.
             SetWindowProxy(cx, window_jsobject, window_proxy.handle());
@@ -152,7 +151,7 @@ impl BrowsingContext {
 
             // The window proxy owns the browsing context.
             // When we finalize the window proxy, it drops the browsing context it owns.
-            SetProxyExtra(window_proxy.get(), 0, &PrivateValue(&*browsing_context as *const _ as *const _));
+            SetProxyExtra(window_proxy.get(), 0, &PrivateValue((&*browsing_context).as_void_ptr()));
 
             // Notify the JS engine about the new window proxy binding.
             SetWindowProxy(cx, window_jsobject, window_proxy.handle());
@@ -225,7 +224,7 @@ impl BrowsingContext {
             debug!("Transplanted window proxy is {:p}.", new_window_proxy.get());
 
             // Transfer ownership of this browsing context from the old window proxy to the new one.
-            SetProxyExtra(new_window_proxy.get(), 0, &PrivateValue(self as *const _ as *const _));
+            SetProxyExtra(new_window_proxy.get(), 0, &PrivateValue(self.as_void_ptr()));
 
             // Notify the JS engine about the new window proxy binding.
             SetWindowProxy(cx, window_jsobject, new_window_proxy.handle());
@@ -601,4 +600,3 @@ unsafe extern fn trace(trc: *mut JSTracer, obj: *mut JSObject) {
     }
     (*this).trace(trc);
 }
-

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -16,6 +16,7 @@ use dom::bindings::codegen::Bindings::PromiseBinding::AnyCallback;
 use dom::bindings::conversions::root_from_object;
 use dom::bindings::error::{Error, Fallible};
 use dom::bindings::reflector::{DomObject, MutDomObject, Reflector};
+use dom::bindings::utils::AsCCharPtrPtr;
 use dom::globalscope::GlobalScope;
 use dom::promisenativehandler::PromiseNativeHandler;
 use dom_struct::dom_struct;
@@ -55,7 +56,7 @@ impl PromiseHelper for Rc<Promise> {
         self.permanent_js_root.set(ObjectValue(*obj));
         assert!(AddRawValueRoot(cx,
                                 self.permanent_js_root.get_unsafe(),
-                                b"Promise::root\0" as *const _ as *const _));
+                                b"Promise::root\0".as_c_char_ptr()));
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
r? @jdm 
issue https://github.com/servo/servo/issues/15252
The primary goal of this PR is to add add a generic trait method that returns a void ptr.

In addition to that change, I made the casting explicit in `components/script/dom/bindings/callback.rs`  and `components/script/dom/promise.rs`. I did not use the new trait method because `AddRawValueRoot` is not looking for a `c_void`. It's looking for `std::os::raw::c_char`.
```rust
pub fn AddRawValueRoot(cx: *mut JSContext, vp: *mut Value,
                                          name: *const ::std::os::raw::c_char) -> bool;
``` 
So I replace the `as *const _ ` with a more specific cast. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15252 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because 
 This seems like code cleanup. It shouldn't change behaviour.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16234)
<!-- Reviewable:end -->
