### PR TITLE
ParserContext::new_for_cssom is used for author origin, not user.

### DIFF
--- a/components/style/parser.rs
+++ b/components/style/parser.rs
@@ -39,7 +39,7 @@ impl<'a> ParserContext<'a> {
     pub fn new_for_cssom(url_data: &'a UrlExtraData,
                          error_reporter: &'a ParseErrorReporter)
                          -> ParserContext<'a> {
-        Self::new(Origin::User, url_data, error_reporter)
+        Self::new(Origin::Author, url_data, error_reporter)
     }
 }
 


### PR DESCRIPTION
This probably doesn’t make any difference since the only thing we do with this origin is test whether it is user-agent (for internal properties), but this is more correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16247)
<!-- Reviewable:end -->
