### PR TITLE
Overwrite default RunInfo values with the first real ones encountered.

### DIFF
--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -234,17 +234,22 @@ impl TextRunScanner {
                     let flush_run = run_info.font_index != font_index ||
                                     run_info.bidi_level != bidi_level ||
                                     !compatible_script;
-                    let flush_mapping = flush_run || mapping.selected != selected;
+                    let new_mapping_needed = flush_run || mapping.selected != selected;
 
-                    if flush_mapping {
-                        mapping.flush(&mut mappings,
-                                      &mut run_info,
-                                      &**text,
-                                      compression,
-                                      text_transform,
-                                      &mut last_whitespace,
-                                      &mut start_position,
-                                      end_position);
+                    if new_mapping_needed {
+                        // We ignore empty mappings at the very start of a fragment.
+                        // The run info values are uninitialized at this point so
+                        // flushing an empty mapping is pointless.
+                        if end_position > 0 {
+                            mapping.flush(&mut mappings,
+                                          &mut run_info,
+                                          &**text,
+                                          compression,
+                                          text_transform,
+                                          &mut last_whitespace,
+                                          &mut start_position,
+                                          end_position);
+                        }
                         if run_info.text.len() > 0 {
                             if flush_run {
                                 run_info.flush(&mut run_info_list, &mut insertion_point);

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1451,6 +1451,18 @@
      {}
     ]
    ],
+   "css/ellipsis_font_panic.html": [
+    [
+     "/_mozilla/css/ellipsis_font_panic.html",
+     [
+      [
+       "/_mozilla/css/ellipsis_font_panic-ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/empty_cells_a.html": [
     [
      "/_mozilla/css/empty_cells_a.html",
@@ -7325,6 +7337,11 @@
     ]
    ],
    "css/display_table_cell_intrinsic_width_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "css/ellipsis_font_panic-ref.html": [
     [
      {}
     ]
@@ -20918,6 +20935,14 @@
   "css/display_table_cell_intrinsic_width_ref.html": [
    "24dfcfa8ac401233d287631e57ea64edb94883cc",
    "support"
+  ],
+  "css/ellipsis_font_panic-ref.html": [
+   "21988e7f477117e23eb0d6770eec3896bac3b4a2",
+   "support"
+  ],
+  "css/ellipsis_font_panic.html": [
+   "037c81c6f2f550b6d7e415b0fc7f3d0476202b76",
+   "reftest"
   ],
   "css/empty-keyframes.html": [
    "366edc7d29168809b6385ce7139786a0446ba560",

--- a/tests/wpt/mozilla/tests/css/ellipsis_font_panic-ref.html
+++ b/tests/wpt/mozilla/tests/css/ellipsis_font_panic-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<style>
+  @font-face {
+      font-family: "Roboto";
+      src: url("fonts/octicons/octicons.ttf");
+  }
+  #foo {
+      font-family: Roboto;
+  }
+</style>
+<div id="foo">E…</div>

--- a/tests/wpt/mozilla/tests/css/ellipsis_font_panic.html
+++ b/tests/wpt/mozilla/tests/css/ellipsis_font_panic.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<link rel="match" href="ellipsis_font_panic-ref.html">
+<style>
+  @font-face {
+      font-family: "Roboto";
+      src: url("fonts/octicons/octicons.ttf");
+  }
+  #foo {
+      max-width: 30px;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      font-family: Roboto;
+  }
+</style>
+<div id="foo">English</div>


### PR DESCRIPTION
TextRunScanner::flush_clump_to_list compares the values in the RunInfo object against the ones determined from the current fragment, but these values can be arbitrary defaults that don't mean anything useful.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14783
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16258)
<!-- Reviewable:end -->
