### PR TITLE
Inherit 'text-overflow' and 'overflow' in text fragment

### DIFF
--- a/resources/servo.css
+++ b/resources/servo.css
@@ -171,6 +171,8 @@ svg > * {
 /* style for text node. */
 *|*::-servo-text {
     margin: 0;
+    text-overflow: inherit;
+    overflow: inherit;
 }
 
 /* style for text in input elements. */


### PR DESCRIPTION
This is an implementation detail that is necessary for 'text-overflow'
to work properly.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16265)
<!-- Reviewable:end -->
