### PR TITLE
Make letter-spacing animatable.

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -2882,6 +2882,15 @@ fn static_assert() {
         }
     }
 
+    pub fn clone_letter_spacing(&self) -> longhands::letter_spacing::computed_value::T {
+        use properties::longhands::letter_spacing::computed_value::T;
+        match self.gecko.mLetterSpacing.as_value() {
+            CoordDataValue::Normal => T(None),
+            CoordDataValue::Coord(coord) => T(Some(Au(coord))),
+            _ => unreachable!("Unexpected computed value for letter-spacing"),
+        }
+    }
+
     <%call expr="impl_coord_copy('letter_spacing', 'mLetterSpacing')"></%call>
 
     pub fn set_word_spacing(&mut self, v: longhands::word_spacing::computed_value::T) {


### PR DESCRIPTION
This is a PR of https://bugzilla.mozilla.org/show_bug.cgi?id=1353921

From the spec: 'normal' value computes to zero.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes in web-platform-test (web-animations/animation-model/animation-types/interpolation-per-property.html)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16278)
<!-- Reviewable:end -->
