### PR TITLE
Add std::atomic to opaque_types in build_gecko

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -439,6 +439,7 @@ mod bindings {
         let opaque_types = [
             "std::pair__PCCP",
             "std::namespace::atomic___base", "std::atomic__My_base",
+            "std::atomic",
             "std::atomic___base",
             "mozilla::gfx::.*",
             "FallibleTArray",


### PR DESCRIPTION
Recent change in bug 1277709 makes ThreadSafeAutoRefCnt start using std::atomic, which somehow doesn't not have #[derive(Debug)] on Windows, which makes all objects which includes ThreadSafeAutoRefCnt to stop having #[derive(Debug)]. This breaks stylo build on Windows.

By adding it as an opaque type, std::atomic would derive Debug again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16281)
<!-- Reviewable:end -->
