### PR TITLE
Use real clips when generating scroll roots

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -508,7 +508,7 @@ pub struct ScrollRoot {
     pub parent_id: ScrollRootId,
 
     /// The position of this scroll root's frame in the parent stacking context.
-    pub clip: Rect<Au>,
+    pub clip: ClippingRegion,
 
     /// The rect of the contents that can be scrolled inside of the scroll root.
     pub content_rect: Rect<Au>,

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -421,15 +421,11 @@ impl WebRenderDisplayItemConverter for DisplayItem {
             }
             DisplayItem::PopStackingContext(_) => builder.pop_stacking_context(),
             DisplayItem::PushScrollRoot(ref item) => {
-                let clip = builder.new_clip_region(&item.scroll_root.clip.to_rectf(),
-                                                   vec![],
-                                                   None);
-
-                let provided_id = ScrollLayerId::new(item.scroll_root.id.0 as u64, builder.pipeline_id);
-                let id = builder.define_clip(item.scroll_root.content_rect.to_rectf(),
-                                             clip,
-                                             Some(provided_id));
-                debug_assert!(provided_id == id);
+                let our_id = ScrollLayerId::new(item.scroll_root.id.0 as u64, builder.pipeline_id);
+                let clip = item.scroll_root.clip.to_clip_region(builder);
+                let content_rect = item.scroll_root.content_rect.to_rectf();
+                let webrender_id = builder.define_clip(content_rect, clip, Some(our_id));
+                debug_assert!(our_id == webrender_id);
             }
             DisplayItem::PopScrollRoot(_) => {} //builder.pop_scroll_layer(),
         }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -4079,6 +4079,18 @@
      {}
     ]
    ],
+   "css/overflow_border_radius.html": [
+    [
+     "/_mozilla/css/overflow_border_radius.html",
+     [
+      [
+       "/_mozilla/css/overflow_border_radius_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/overflow_position_abs_inline_block.html": [
     [
      "/_mozilla/css/overflow_position_abs_inline_block.html",
@@ -8411,6 +8423,11 @@
     ]
    ],
    "css/overflow_auto_stacking_order_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "css/overflow_border_radius_ref.html": [
     [
      {}
     ]
@@ -22687,6 +22704,14 @@
   ],
   "css/overflow_auto_stacking_order_ref.html": [
    "195201950fd56bd139e71971d66f92ee4fef815d",
+   "support"
+  ],
+  "css/overflow_border_radius.html": [
+   "2c8a650f518ccff78517556540416f7e0e798033",
+   "reftest"
+  ],
+  "css/overflow_border_radius_ref.html": [
+   "3798d0efb1b9858ad47ecf6f09357c3c0dae1b80",
    "support"
   ],
   "css/overflow_position_abs_inline_block.html": [

--- a/tests/wpt/mozilla/tests/css/overflow_border_radius.html
+++ b/tests/wpt/mozilla/tests/css/overflow_border_radius.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+<meta charset="utf-8">
+<title>Test to ensure that clipped overflow is clipped to border radius</title>
+<link rel="match" href="overflow_border_radius_ref.html">
+
+<body>
+    <style>
+        .box {
+            width: 50px;
+            height: 50px;
+            border-radius: 20px;
+            border: 5px transparent solid;
+            margin-right: 10px;
+            float: left;
+        }
+
+        .overflowingbox {
+            margin-left: -25px;
+            margin-top: -25px;
+            width: 100px;
+            height: 100px;
+            background: gray;
+        }
+    </style>
+
+    <div class="box border" style="overflow: auto;">
+        <div class="overflowingbox"></div>
+    </div>
+
+    <div class="box border" style="overflow: scroll;">
+        <div class="overflowingbox"></div>
+    </div>
+</body>
+
+</html>

--- a/tests/wpt/mozilla/tests/css/overflow_border_radius_ref.html
+++ b/tests/wpt/mozilla/tests/css/overflow_border_radius_ref.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<meta charset="utf-8">
+<title></title>
+
+<body>
+    <style>
+        .box {
+            width: 50px;
+            height: 50px;
+            margin-left: 5px;
+            margin-top: 5px;
+
+            border-radius: 15px;
+            background: gray;
+            float: left;
+
+            margin-right: 15px;
+        }
+    </style>
+
+    <div class="box"></div>
+    <div class="box"></div>
+</body>
+
+</html>


### PR DESCRIPTION
This is the first step toward removing inherited clips in favor of
scroll roots for handling overflow and CSS clipping. This will allow us
to more easily handle elements that should not be clipped. While we are
still using inherited clips here, we now properly clip some types of
content that wasn't clipped before.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16284)
<!-- Reviewable:end -->
