### PR TITLE
layout: Use the margin box of an inline block when computing the inline size

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2380,10 +2380,7 @@ impl Fragment {
     pub fn update_late_computed_replaced_inline_size_if_necessary(&mut self) {
         if let SpecificFragmentInfo::InlineBlock(ref mut inline_block_info) = self.specific {
             let block_flow = FlowRef::deref_mut(&mut inline_block_info.flow_ref).as_block();
-            let margin = block_flow.fragment.style.logical_margin();
-            self.border_box.size.inline = block_flow.fragment.border_box.size.inline +
-                MaybeAuto::from_style(margin.inline_start, Au(0)).specified_or_zero() +
-                MaybeAuto::from_style(margin.inline_end, Au(0)).specified_or_zero()
+            self.border_box.size.inline = block_flow.fragment.margin_box_inline_size();
         }
     }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2759,6 +2759,18 @@
      {}
     ]
    ],
+   "css/inline_block_percentage_margin.html": [
+    [
+     "/_mozilla/css/inline_block_percentage_margin.html",
+     [
+      [
+       "/_mozilla/css/inline_block_percentage_margin_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/inline_block_stacking_context_a.html": [
     [
      "/_mozilla/css/inline_block_stacking_context_a.html",
@@ -7871,6 +7883,11 @@
     ]
    ],
    "css/inline_block_percentage_height_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "css/inline_block_percentage_margin_ref.html": [
     [
      {}
     ]
@@ -21795,6 +21812,14 @@
   ],
   "css/inline_block_percentage_height_ref.html": [
    "bad4704435c74a3204925206802eb004f380500e",
+   "support"
+  ],
+  "css/inline_block_percentage_margin.html": [
+   "0b750acad3bcc6b5fabf9e625b6adf22e1e97640",
+   "reftest"
+  ],
+  "css/inline_block_percentage_margin_ref.html": [
+   "3726b3b2149b9e6584277fd33b77940d5f9d6800",
    "support"
   ],
   "css/inline_block_stacking_context_a.html": [

--- a/tests/wpt/mozilla/tests/css/inline_block_percentage_margin.html
+++ b/tests/wpt/mozilla/tests/css/inline_block_percentage_margin.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="match" href="inline_block_percentage_margin_ref.html">
+<style>
+ body {
+     width: 500px;
+ }
+ span {
+     display: inline-block;
+     width: 100px;
+     height: 30px;
+     background: orange;
+     margin: 0 10%;
+ }
+</style>
+<span></span>

--- a/tests/wpt/mozilla/tests/css/inline_block_percentage_margin_ref.html
+++ b/tests/wpt/mozilla/tests/css/inline_block_percentage_margin_ref.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+ body {
+     width: 500px;
+ }
+ span {
+     display: inline-block;
+     width: 100px;
+     height: 30px;
+     background: orange;
+     margin: 0 50px;
+ }
+</style>
+<span></span>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

When computing the inline size of an inline block in inline formating
context, use the margin box of the underling block.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12413 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16285)
<!-- Reviewable:end -->
