### PR TITLE
Root nodes for the duration of their CSS transitions

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -26,7 +26,7 @@ pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
                               script_chan: &IpcSender<ConstellationControlMsg>,
                               running_animations: &mut HashMap<OpaqueNode, Vec<Animation>>,
                               expired_animations: &mut HashMap<OpaqueNode, Vec<Animation>>,
-                              newly_transitioning_nodes: &mut Vec<UntrustedNodeAddress>,
+                              mut newly_transitioning_nodes: Option<&mut Vec<UntrustedNodeAddress>>,
                               new_animations_receiver: &Receiver<Animation>,
                               pipeline_id: PipelineId,
                               timer: &Timer) {
@@ -115,8 +115,11 @@ pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
 
     // Add new running animations.
     for new_running_animation in new_running_animations {
-        if new_running_animation.is_transition() {
-            newly_transitioning_nodes.push(new_running_animation.node().to_untrusted_node_address());
+        match newly_transitioning_nodes {
+            Some(ref mut nodes) if new_running_animation.is_transition() => {
+                nodes.push(new_running_animation.node().to_untrusted_node_address());
+            }
+            _ => ()
         }
 
         running_animations.entry(*new_running_animation.node())

--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -115,11 +115,15 @@ pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
 
     // Add new running animations.
     for new_running_animation in new_running_animations {
-        match newly_transitioning_nodes {
-            Some(ref mut nodes) if new_running_animation.is_transition() => {
-                nodes.push(new_running_animation.node().to_untrusted_node_address());
+        if new_running_animation.is_transition() {
+            match newly_transitioning_nodes {
+                Some(ref mut nodes) => {
+                    nodes.push(new_running_animation.node().to_untrusted_node_address());
+                }
+                None => {
+                    warn!("New transition encountered from compositor-initiated layout.");
+                }
             }
-            _ => ()
         }
 
         running_animations.entry(*new_running_animation.node())

--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -9,7 +9,9 @@ use flow::{self, Flow};
 use gfx::display_list::OpaqueNode;
 use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::PipelineId;
+use opaque_node::OpaqueNodeMethods;
 use script_traits::{AnimationState, ConstellationControlMsg, LayoutMsg as ConstellationMsg};
+use script_traits::UntrustedNodeAddress;
 use std::collections::HashMap;
 use std::sync::mpsc::Receiver;
 use style::animation::{Animation, update_style_for_animation};
@@ -24,6 +26,7 @@ pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
                               script_chan: &IpcSender<ConstellationControlMsg>,
                               running_animations: &mut HashMap<OpaqueNode, Vec<Animation>>,
                               expired_animations: &mut HashMap<OpaqueNode, Vec<Animation>>,
+                              newly_transitioning_nodes: &mut Vec<UntrustedNodeAddress>,
                               new_animations_receiver: &Receiver<Animation>,
                               pipeline_id: PipelineId,
                               timer: &Timer) {
@@ -71,7 +74,7 @@ pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
         let mut animations_still_running = vec![];
         for mut running_animation in running_animations.drain(..) {
             let still_running = !running_animation.is_expired() && match running_animation {
-                Animation::Transition(_, _, started_at, ref frame, _expired) => {
+                Animation::Transition(_, started_at, ref frame, _expired) => {
                     now < started_at + frame.duration
                 }
                 Animation::Keyframes(_, _, ref mut state) => {
@@ -86,8 +89,8 @@ pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
                 continue
             }
 
-            if let Animation::Transition(_, unsafe_node, _, ref frame, _) = running_animation {
-                script_chan.send(ConstellationControlMsg::TransitionEnd(unsafe_node,
+            if let Animation::Transition(node, _, ref frame, _) = running_animation {
+                script_chan.send(ConstellationControlMsg::TransitionEnd(node.to_untrusted_node_address(),
                                                                         frame.property_animation
                                                                              .property_name().into(),
                                                                         frame.duration))
@@ -112,6 +115,10 @@ pub fn update_animation_state(constellation_chan: &IpcSender<ConstellationMsg>,
 
     // Add new running animations.
     for new_running_animation in new_running_animations {
+        if new_running_animation.is_transition() {
+            newly_transitioning_nodes.push(new_running_animation.node().to_untrusted_node_address());
+        }
+
         running_animations.entry(*new_running_animation.node())
                           .or_insert_with(Vec::new)
                           .push(new_running_animation)

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -15,6 +15,7 @@ use net_traits::image_cache::{ImageOrMetadataAvailable, UsePlaceholder};
 use opaque_node::OpaqueNodeMethods;
 use parking_lot::RwLock;
 use script_layout_interface::{PendingImage, PendingImageState};
+use script_traits::UntrustedNodeAddress;
 use servo_url::ServoUrl;
 use std::borrow::{Borrow, BorrowMut};
 use std::cell::{RefCell, RefMut};
@@ -96,7 +97,11 @@ pub struct LayoutContext<'a> {
 
     /// A list of in-progress image loads to be shared with the script thread.
     /// A None value means that this layout was not initiated by the script thread.
-    pub pending_images: Option<Mutex<Vec<PendingImage>>>
+    pub pending_images: Option<Mutex<Vec<PendingImage>>>,
+
+    /// A list of nodes that have just initiated a CSS transition.
+    /// A None value means that this layout was not initiated by the script thread.
+    pub newly_transitioning_nodes: Option<Mutex<Vec<UntrustedNodeAddress>>>,
 }
 
 impl<'a> Drop for LayoutContext<'a> {

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -94,6 +94,9 @@ pub struct LayoutThreadData {
 
     /// A queued response for the list of nodes at a given point.
     pub nodes_from_point_response: Vec<UntrustedNodeAddress>,
+
+    /// A list of nodes that have just started a CSS transition.
+    pub newly_transitioning_nodes: Vec<UntrustedNodeAddress>,
 }
 
 pub struct LayoutRPCImpl(pub Arc<Mutex<LayoutThreadData>>);
@@ -203,6 +206,12 @@ impl LayoutRPC for LayoutRPCImpl {
         let &LayoutRPCImpl(ref rw_data) = self;
         let mut rw_data = rw_data.lock().unwrap();
         mem::replace(&mut rw_data.pending_images, vec![])
+    }
+
+    fn newly_transitioning_nodes(&self) -> Vec<UntrustedNodeAddress> {
+        let &LayoutRPCImpl(ref rw_data) = self;
+        let mut rw_data = rw_data.lock().unwrap();
+        mem::replace(&mut rw_data.newly_transitioning_nodes, vec![])
     }
 }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -17,7 +17,6 @@ use inline::LAST_FRAGMENT_OF_ELEMENT;
 use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::PipelineId;
 use opaque_node::OpaqueNodeMethods;
-use script_layout_interface::PendingImage;
 use script_layout_interface::rpc::{ContentBoxResponse, ContentBoxesResponse};
 use script_layout_interface::rpc::{HitTestResponse, LayoutRPC};
 use script_layout_interface::rpc::{MarginStyleResponse, NodeGeometryResponse};
@@ -28,7 +27,6 @@ use script_traits::LayoutMsg as ConstellationMsg;
 use script_traits::UntrustedNodeAddress;
 use sequential;
 use std::cmp::{min, max};
-use std::mem;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use style::computed_values;
@@ -89,14 +87,8 @@ pub struct LayoutThreadData {
     /// Index in a text fragment. We need this do determine the insertion point.
     pub text_index_response: TextIndexResponse,
 
-    /// A list of images requests that need to be initiated.
-    pub pending_images: Vec<PendingImage>,
-
     /// A queued response for the list of nodes at a given point.
     pub nodes_from_point_response: Vec<UntrustedNodeAddress>,
-
-    /// A list of nodes that have just started a CSS transition.
-    pub newly_transitioning_nodes: Vec<UntrustedNodeAddress>,
 }
 
 pub struct LayoutRPCImpl(pub Arc<Mutex<LayoutThreadData>>);
@@ -200,18 +192,6 @@ impl LayoutRPC for LayoutRPCImpl {
         let &LayoutRPCImpl(ref rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         rw_data.text_index_response.clone()
-    }
-
-    fn pending_images(&self) -> Vec<PendingImage> {
-        let &LayoutRPCImpl(ref rw_data) = self;
-        let mut rw_data = rw_data.lock().unwrap();
-        mem::replace(&mut rw_data.pending_images, vec![])
-    }
-
-    fn newly_transitioning_nodes(&self) -> Vec<UntrustedNodeAddress> {
-        let &LayoutRPCImpl(ref rw_data) = self;
-        let mut rw_data = rw_data.lock().unwrap();
-        mem::replace(&mut rw_data.newly_transitioning_nodes, vec![])
     }
 }
 

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -478,6 +478,7 @@ impl LayoutThread {
                     text_index_response: TextIndexResponse(None),
                     pending_images: vec![],
                     nodes_from_point_response: vec![],
+                    newly_transitioning_nodes: vec![],
                 })),
             error_reporter: CSSErrorReporter {
                 pipelineid: id,
@@ -1436,11 +1437,14 @@ impl LayoutThread {
                                                document: Option<&ServoLayoutDocument>,
                                                rw_data: &mut LayoutThreadData,
                                                context: &mut LayoutContext) {
+        assert!(rw_data.newly_transitioning_nodes.is_empty());
+
         // Kick off animations if any were triggered, expire completed ones.
         animation::update_animation_state(&self.constellation_chan,
                                           &self.script_chan,
                                           &mut *self.running_animations.write(),
                                           &mut *self.expired_animations.write(),
+                                          &mut rw_data.newly_transitioning_nodes,
                                           &self.new_animations_receiver,
                                           self.id,
                                           &self.timer);

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -514,7 +514,7 @@ impl LayoutThread {
     // Create a layout context for use in building display lists, hit testing, &c.
     fn build_layout_context<'a>(&'a self,
                                 guards: StylesheetGuards<'a>,
-                                request_images: bool,
+                                script_initiated_layout: bool,
                                 snapshot_map: &'a SnapshotMap)
                                 -> LayoutContext<'a> {
         let thread_local_style_context_creation_data =
@@ -538,7 +538,8 @@ impl LayoutThread {
             image_cache: self.image_cache.clone(),
             font_cache_thread: Mutex::new(self.font_cache_thread.clone()),
             webrender_image_cache: self.webrender_image_cache.clone(),
-            pending_images: if request_images { Some(Mutex::new(vec![])) } else { None },
+            pending_images: if script_initiated_layout { Some(Mutex::new(vec![])) } else { None },
+            newly_transitioning_nodes: if script_initiated_layout { Some(Mutex::new(vec![])) } else { None },
         }
     }
 
@@ -1252,6 +1253,12 @@ impl LayoutThread {
         };
         rw_data.pending_images = pending_images;
 
+        let newly_transitioning_nodes = match context.newly_transitioning_nodes {
+            Some(ref nodes) => std_mem::replace(&mut *nodes.lock().unwrap(), vec![]),
+            None => vec![],
+        };
+        rw_data.newly_transitioning_nodes = newly_transitioning_nodes;
+
         let mut root_flow = match self.root_flow.borrow().clone() {
             Some(root_flow) => root_flow,
             None => return,
@@ -1427,6 +1434,7 @@ impl LayoutThread {
                                                          &mut *rw_data,
                                                          &mut layout_context);
             assert!(layout_context.pending_images.is_none());
+            assert!(layout_context.newly_transitioning_nodes.is_none());
         }
     }
 
@@ -1437,17 +1445,24 @@ impl LayoutThread {
                                                document: Option<&ServoLayoutDocument>,
                                                rw_data: &mut LayoutThreadData,
                                                context: &mut LayoutContext) {
-        assert!(rw_data.newly_transitioning_nodes.is_empty());
-
-        // Kick off animations if any were triggered, expire completed ones.
-        animation::update_animation_state(&self.constellation_chan,
-                                          &self.script_chan,
-                                          &mut *self.running_animations.write(),
-                                          &mut *self.expired_animations.write(),
-                                          &mut rw_data.newly_transitioning_nodes,
-                                          &self.new_animations_receiver,
-                                          self.id,
-                                          &self.timer);
+        {
+            let mut newly_transitioning_nodes = context
+                .newly_transitioning_nodes
+                .as_ref()
+                .map(|nodes| nodes.lock().unwrap());
+            let newly_transitioning_nodes = newly_transitioning_nodes
+                .as_mut()
+                .map(|nodes| &mut **nodes);
+            // Kick off animations if any were triggered, expire completed ones.
+            animation::update_animation_state(&self.constellation_chan,
+                                              &self.script_chan,
+                                              &mut *self.running_animations.write(),
+                                              &mut *self.expired_animations.write(),
+                                              newly_transitioning_nodes,
+                                              &self.new_animations_receiver,
+                                              self.id,
+                                              &self.timer);
+        }
 
         profile(time::ProfilerCategory::LayoutRestyleDamagePropagation,
                 self.profiler_metadata(),

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -927,20 +927,18 @@ fn first_node_not_in<I>(mut nodes: I, not_in: &[NodeOrString]) -> Option<Root<No
 /// If the given untrusted node address represents a valid DOM node in the given runtime,
 /// returns it.
 #[allow(unsafe_code)]
-pub fn from_untrusted_node_address(_runtime: *mut JSRuntime, candidate: UntrustedNodeAddress)
+pub unsafe fn from_untrusted_node_address(_runtime: *mut JSRuntime, candidate: UntrustedNodeAddress)
     -> Root<Node> {
-    unsafe {
-        // https://github.com/servo/servo/issues/6383
-        let candidate: uintptr_t = mem::transmute(candidate.0);
+    // https://github.com/servo/servo/issues/6383
+    let candidate: uintptr_t = mem::transmute(candidate.0);
 //        let object: *mut JSObject = jsfriendapi::bindgen::JS_GetAddressableObject(runtime,
 //                                                                                  candidate);
-        let object: *mut JSObject = mem::transmute(candidate);
-        if object.is_null() {
-            panic!("Attempted to create a `JS<Node>` from an invalid pointer!")
-        }
-        let boxed_node = conversions::private_from_object(object) as *const Node;
-        Root::from_ref(&*boxed_node)
+    let object: *mut JSObject = mem::transmute(candidate);
+    if object.is_null() {
+        panic!("Attempted to create a `JS<Node>` from an invalid pointer!")
     }
+    let boxed_node = conversions::private_from_object(object) as *const Node;
+    Root::from_ref(&*boxed_node)
 }
 
 #[allow(unsafe_code)]

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -76,7 +76,7 @@ use script_layout_interface::rpc::{MarginStyleResponse, NodeScrollRootIdResponse
 use script_layout_interface::rpc::{ResolvedStyleResponse, TextIndexResponse};
 use script_runtime::{CommonScriptMsg, ScriptChan, ScriptPort, ScriptThreadEventCategory};
 use script_thread::{MainThreadScriptChan, MainThreadScriptMsg, Runnable, RunnableWrapper};
-use script_thread::{SendableMainThreadScriptChan, ImageCacheMsg};
+use script_thread::{SendableMainThreadScriptChan, ImageCacheMsg, ScriptThread};
 use script_traits::{ConstellationControlMsg, LoadData, MozBrowserEvent, UntrustedNodeAddress};
 use script_traits::{DocumentState, TimerEvent, TimerEventId};
 use script_traits::{ScriptMsg as ConstellationMsg, TimerSchedulerMsg, WindowSizeData, WindowSizeType};
@@ -1150,6 +1150,7 @@ impl Window {
     /// off-main-thread layout.
     ///
     /// Returns true if layout actually happened, false otherwise.
+    #[allow(unsafe_code)]
     pub fn force_reflow(&self,
                         goal: ReflowGoal,
                         query_type: ReflowQueryType,
@@ -1260,6 +1261,9 @@ impl Window {
                 nodes.push(JS::from_ref(&*node));
             }
         }
+
+        let newly_transitioning_nodes = self.layout_rpc.newly_transitioning_nodes();
+        ScriptThread::note_newly_transitioning_nodes(newly_transitioning_nodes);
 
         true
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1241,7 +1241,7 @@ impl Window {
             let id = image.id;
             let js_runtime = self.js_runtime.borrow();
             let js_runtime = js_runtime.as_ref().unwrap();
-            let node = from_untrusted_node_address(js_runtime.rt(), image.node);
+            let node = unsafe { from_untrusted_node_address(js_runtime.rt(), image.node) };
 
             if let PendingImageState::Unrequested(ref url) = image.state {
                 fetch_image_for_layout(url.clone(), &*node, id, self.image_cache.clone());
@@ -1261,7 +1261,9 @@ impl Window {
             }
         }
 
-        ScriptThread::note_newly_transitioning_nodes(complete.newly_transitioning_nodes);
+        unsafe {
+            ScriptThread::note_newly_transitioning_nodes(complete.newly_transitioning_nodes);
+        }
 
         true
     }
@@ -1457,6 +1459,7 @@ impl Window {
         DOMString::from(resolved)
     }
 
+    #[allow(unsafe_code)]
     pub fn offset_parent_query(&self, node: TrustedNodeAddress) -> (Option<Root<Element>>, Rect<Au>) {
         if !self.reflow(ReflowGoal::ForScriptQuery,
                         ReflowQueryType::OffsetParentQuery(node),
@@ -1468,7 +1471,7 @@ impl Window {
         let js_runtime = self.js_runtime.borrow();
         let js_runtime = js_runtime.as_ref().unwrap();
         let element = response.node_address.and_then(|parent_node_address| {
-            let node = from_untrusted_node_address(js_runtime.rt(), parent_node_address);
+            let node = unsafe { from_untrusted_node_address(js_runtime.rt(), parent_node_address) };
             Root::downcast(node)
         });
         (element, response.rect)

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -576,9 +576,9 @@ impl ScriptThreadFactory for ScriptThread {
 }
 
 impl ScriptThread {
-    pub fn note_newly_transitioning_nodes(nodes: Vec<UntrustedNodeAddress>) {
+    pub unsafe fn note_newly_transitioning_nodes(nodes: Vec<UntrustedNodeAddress>) {
         SCRIPT_THREAD_ROOT.with(|root| {
-            let script_thread = unsafe { &*root.get().unwrap() };
+            let script_thread = &*root.get().unwrap();
             let js_runtime = script_thread.js_runtime.rt();
             let new_nodes = nodes
                 .into_iter()
@@ -1619,7 +1619,9 @@ impl ScriptThread {
     /// Handles firing of transition events.
     fn handle_transition_event(&self, unsafe_node: UntrustedNodeAddress, name: String, duration: f64) {
         let js_runtime = self.js_runtime.rt();
-        let node = from_untrusted_node_address(js_runtime, unsafe_node);
+        let node = unsafe {
+            from_untrusted_node_address(js_runtime, unsafe_node)
+        };
 
         let idx = self.transitioning_nodes
             .borrow()

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -47,7 +47,7 @@ use dom::globalscope::GlobalScope;
 use dom::htmlanchorelement::HTMLAnchorElement;
 use dom::htmliframeelement::{HTMLIFrameElement, NavigationType};
 use dom::mutationobserver::MutationObserver;
-use dom::node::{Node, NodeDamage, window_from_node};
+use dom::node::{Node, NodeDamage, window_from_node, from_untrusted_node_address};
 use dom::serviceworker::TrustedServiceWorkerAddress;
 use dom::serviceworkerregistration::ServiceWorkerRegistration;
 use dom::servoparser::{ParserContext, ServoParser};
@@ -69,7 +69,6 @@ use js::jsapi::{JSAutoCompartment, JSContext, JS_SetWrapObjectCallbacks};
 use js::jsapi::{JSTracer, SetWindowProxyClass};
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
-use layout_wrapper::ServoLayoutNode;
 use mem::heap_size_of_self_and_children;
 use microtask::{MicrotaskQueue, Microtask};
 use msg::constellation_msg::{FrameId, FrameType, PipelineId, PipelineNamespace};
@@ -109,7 +108,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Select, Sender, channel};
 use std::thread;
 use style::context::ReflowGoal;
-use style::dom::{TNode, UnsafeNode};
 use style::thread_state;
 use task_source::dom_manipulation::{DOMManipulationTask, DOMManipulationTaskSource};
 use task_source::file_reading::FileReadingTaskSource;
@@ -490,6 +488,10 @@ pub struct ScriptThread {
     /// A list of pipelines containing documents that finished loading all their blocking
     /// resources during a turn of the event loop.
     docs_with_no_blocking_loads: DOMRefCell<HashSet<JS<Document>>>,
+
+    /// A list of nodes with in-progress CSS transitions, which roots them for the duration
+    /// of the transition.
+    transitioning_nodes: DOMRefCell<Vec<JS<Node>>>,
 }
 
 /// In the event of thread panic, all data on the stack runs its destructor. However, there
@@ -574,6 +576,17 @@ impl ScriptThreadFactory for ScriptThread {
 }
 
 impl ScriptThread {
+    pub fn note_newly_transitioning_nodes(nodes: Vec<UntrustedNodeAddress>) {
+        SCRIPT_THREAD_ROOT.with(|root| {
+            let script_thread = unsafe { &*root.get().unwrap() };
+            let js_runtime = script_thread.js_runtime.rt();
+            let new_nodes = nodes
+                .into_iter()
+                .map(|n| JS::from_ref(&*from_untrusted_node_address(js_runtime, n)));
+            script_thread.transitioning_nodes.borrow_mut().extend(new_nodes);
+        })
+    }
+
     pub fn add_mutation_observer(observer: &MutationObserver) {
         SCRIPT_THREAD_ROOT.with(|root| {
             let script_thread = unsafe { &*root.get().unwrap() };
@@ -742,6 +755,8 @@ impl ScriptThread {
             webvr_thread: state.webvr_thread,
 
             docs_with_no_blocking_loads: Default::default(),
+
+            transitioning_nodes: Default::default(),
         }
     }
 
@@ -1602,11 +1617,27 @@ impl ScriptThread {
     }
 
     /// Handles firing of transition events.
-    #[allow(unsafe_code)]
-    fn handle_transition_event(&self, unsafe_node: UnsafeNode, name: String, duration: f64) {
-        let node = unsafe { ServoLayoutNode::from_unsafe(&unsafe_node) };
-        let node = unsafe { node.get_jsmanaged().get_for_script() };
-        let window = window_from_node(node);
+    fn handle_transition_event(&self, unsafe_node: UntrustedNodeAddress, name: String, duration: f64) {
+        let js_runtime = self.js_runtime.rt();
+        let node = from_untrusted_node_address(js_runtime, unsafe_node);
+
+        let idx = self.transitioning_nodes
+            .borrow()
+            .iter()
+            .position(|n| &**n as *const _ == &*node as *const _);
+        match idx {
+            Some(idx) => {
+                self.transitioning_nodes.borrow_mut().remove(idx);
+            }
+            None => {
+                // If no index is found, we can't know whether this node is safe to use.
+                // It's better not to fire a DOM event than crash.
+                warn!("Ignoring transition end notification for unknown node.");
+                return;
+            }
+        }
+
+        let window = window_from_node(&*node);
 
         // Not quite the right thing - see #13865.
         node.dirty(NodeDamage::NodeStyleDamaged);

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use {OpaqueStyleAndLayoutData, TrustedNodeAddress};
+use {OpaqueStyleAndLayoutData, TrustedNodeAddress, PendingImage};
 use app_units::Au;
 use euclid::point::Point2D;
 use euclid::rect::Rect;
@@ -12,7 +12,7 @@ use msg::constellation_msg::PipelineId;
 use net_traits::image_cache::ImageCache;
 use profile_traits::mem::ReportsChan;
 use rpc::LayoutRPC;
-use script_traits::{ConstellationControlMsg, LayoutControlMsg};
+use script_traits::{ConstellationControlMsg, LayoutControlMsg, UntrustedNodeAddress};
 use script_traits::{LayoutMsg as ConstellationMsg, StackingContextScrollState, WindowSizeData};
 use servo_url::ServoUrl;
 use std::sync::Arc;
@@ -109,6 +109,15 @@ pub struct Reflow {
     pub page_clip_rect: Rect<Au>,
 }
 
+/// Information derived from a layout pass that needs to be returned to the script thread.
+#[derive(Default)]
+pub struct ReflowComplete {
+    /// The list of images that were encountered that are in progress.
+    pub pending_images: Vec<PendingImage>,
+    /// The list of nodes that initiated a CSS transition.
+    pub newly_transitioning_nodes: Vec<UntrustedNodeAddress>,
+}
+
 /// Information needed for a script-initiated reflow.
 pub struct ScriptReflow {
     /// General reflow data.
@@ -122,17 +131,11 @@ pub struct ScriptReflow {
     /// The current window size.
     pub window_size: WindowSizeData,
     /// The channel that we send a notification to.
-    pub script_join_chan: Sender<()>,
+    pub script_join_chan: Sender<ReflowComplete>,
     /// The type of query if any to perform during this reflow.
     pub query_type: ReflowQueryType,
     /// The number of objects in the dom #10110
     pub dom_count: u32,
-}
-
-impl Drop for ScriptReflow {
-    fn drop(&mut self) {
-        self.script_join_chan.send(()).unwrap();
-    }
 }
 
 pub struct NewLayoutThreadInfo {

--- a/components/script_layout_interface/rpc.rs
+++ b/components/script_layout_interface/rpc.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use PendingImage;
 use app_units::Au;
 use euclid::point::Point2D;
 use euclid::rect::Rect;
@@ -38,12 +37,8 @@ pub trait LayoutRPC {
     fn offset_parent(&self) -> OffsetParentResponse;
     /// Query layout for the resolve values of the margin properties for an element.
     fn margin_style(&self) -> MarginStyleResponse;
-    /// Requests the list of not-yet-loaded images that were encountered in the last reflow.
-    fn pending_images(&self) -> Vec<PendingImage>;
     /// Requests the list of nodes from the given point.
     fn nodes_from_point_response(&self) -> Vec<UntrustedNodeAddress>;
-    /// Requests the list of nodes that have just started CSS transitions in the last reflow.
-    fn newly_transitioning_nodes(&self) -> Vec<UntrustedNodeAddress>;
 
     fn text_index(&self) -> TextIndexResponse;
 }

--- a/components/script_layout_interface/rpc.rs
+++ b/components/script_layout_interface/rpc.rs
@@ -42,6 +42,8 @@ pub trait LayoutRPC {
     fn pending_images(&self) -> Vec<PendingImage>;
     /// Requests the list of nodes from the given point.
     fn nodes_from_point_response(&self) -> Vec<UntrustedNodeAddress>;
+    /// Requests the list of nodes that have just started CSS transitions in the last reflow.
+    fn newly_transitioning_nodes(&self) -> Vec<UntrustedNodeAddress>;
 
     fn text_index(&self) -> TextIndexResponse;
 }

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -69,7 +69,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, Sender};
-use style_traits::{CSSPixel, UnsafeNode};
+use style_traits::CSSPixel;
 use webdriver_msg::{LoadStatus, WebDriverScriptCommand};
 use webrender_traits::ClipId;
 use webvr_traits::{WebVREvent, WebVRMsg};
@@ -274,7 +274,7 @@ pub enum ConstellationControlMsg {
     /// Notifies script thread that all animations are done
     TickAllAnimations(PipelineId),
     /// Notifies the script thread of a transition end
-    TransitionEnd(UnsafeNode, String, f64),
+    TransitionEnd(UntrustedNodeAddress, String, f64),
     /// Notifies the script thread that a new Web font has been loaded, and thus the page should be
     /// reflowed.
     WebFontLoaded(PipelineId),

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -745,7 +745,6 @@ trait PrivateMatchMethods: TElement {
             animation::start_transitions_if_applicable(
                 new_animations_sender,
                 this_opaque,
-                self.as_node().to_unsafe(),
                 &**values,
                 new_values,
                 &shared_context.timer,
@@ -843,7 +842,7 @@ trait PrivateMatchMethods: TElement {
                                                           running_animation,
                                                           style,
                                                           font_metrics);
-                    if let Animation::Transition(_, _, _, ref frame, _) = *running_animation {
+                    if let Animation::Transition(_, _, ref frame, _) = *running_animation {
                         possibly_expired_animations.push(frame.property_animation.clone())
                     }
                 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -19897,6 +19897,12 @@
      {}
     ]
    ],
+   "mozilla/transitionend_safety.html": [
+    [
+     "/_mozilla/mozilla/transitionend_safety.html",
+     {}
+    ]
+   ],
    "mozilla/union.html": [
     [
      "/_mozilla/mozilla/union.html",
@@ -31542,6 +31548,10 @@
   ],
   "mozilla/track_line.html": [
    "38d8991444d05c40f1d0168bfce8472e378b603c",
+   "testharness"
+  ],
+  "mozilla/transitionend_safety.html": [
+   "778e43b049aa421bad7f86eb03d0955576a84ce0",
    "testharness"
   ],
   "mozilla/union.html": [

--- a/tests/wpt/mozilla/tests/mozilla/transitionend_safety.html
+++ b/tests/wpt/mozilla/tests/mozilla/transitionend_safety.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Asynchronous transitionend event is not a GC hazard</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+  async_test(function(t) {
+    var elem = document.createElement('div');
+    document.body.appendChild(elem);
+    elem.textContent = 'hi there';
+    elem.style.transition = 'color 10ms';
+    elem.style.color = 'black';
+    elem.ontransitionend = t.step_func_done();
+
+    t.step_timeout(function() {
+      elem.style.color = 'red';
+
+      t.step_timeout(function() {
+        document.body.removeChild(elem);
+        elem = null;
+        window.gc();
+      }, 0);
+    }, 0);
+  }, 'Nodes cannot be GCed while a CSS transition is in effect.');
+</script>
+</body>


### PR DESCRIPTION
This ensures that we can pass a node address as part of the asynchronous
transition end notification, making it safe to fire the corresponding
DOM event on the node from the script thread. Without explicitly rooting
this node when the transition starts, we risk the node being GCed before
the transition is complete.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14972
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16295)
<!-- Reviewable:end -->
