### PR TITLE
Remove servo_url dependency for geckolib

### DIFF
--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -20,7 +20,7 @@ msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}
 profile_traits = {path = "../profile_traits"}
 script_traits = {path = "../script_traits"}
-servo_config = {path = "../config", features = ["servo"]}
+servo_config = {path = "../config"}
 servo_geometry = {path = "../geometry", features = ["servo"]}
 servo_url = {path = "../url", features = ["servo"]}
 style_traits = {path = "../style_traits"}

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -22,7 +22,7 @@ profile_traits = {path = "../profile_traits"}
 script_traits = {path = "../script_traits"}
 servo_config = {path = "../config"}
 servo_geometry = {path = "../geometry", features = ["servo"]}
-servo_url = {path = "../url", features = ["servo"]}
+servo_url = {path = "../url"}
 style_traits = {path = "../style_traits"}
 time = "0.1.17"
 webrender = {git = "https://github.com/servo/webrender"}

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -9,10 +9,6 @@ publish = false
 name = "servo_config"
 path = "lib.rs"
 
-[features]
-# servo as opposed to geckolib
-servo = ["serde", "serde_derive", "servo_url/servo"]
-
 [dependencies]
 euclid = "0.11"
 getopts = "0.2.11"
@@ -20,10 +16,10 @@ lazy_static = "0.2"
 log = "0.3.5"
 num_cpus = "1.1.0"
 rustc-serialize = "0.3"
-serde = {version = "0.9", optional = true}
-serde_derive = {version = "0.9", optional = true}
+serde = {version = "0.9"}
+serde_derive = {version = "0.9"}
 servo_geometry = {path = "../geometry"}
-servo_url = {path = "../url"}
+servo_url = {path = "../url", features = ["servo"]}
 url = "1.2"
 
 [dev-dependencies]

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -19,7 +19,7 @@ rustc-serialize = "0.3"
 serde = {version = "0.9"}
 serde_derive = {version = "0.9"}
 servo_geometry = {path = "../geometry"}
-servo_url = {path = "../url", features = ["servo"]}
+servo_url = {path = "../url"}
 url = "1.2"
 
 [dev-dependencies]

--- a/components/config/lib.rs
+++ b/components/config/lib.rs
@@ -10,7 +10,7 @@ extern crate getopts;
 #[macro_use] extern crate log;
 extern crate num_cpus;
 extern crate rustc_serialize;
-#[cfg(feature = "servo")] #[macro_use] extern crate serde_derive;
+#[macro_use] extern crate serde_derive;
 extern crate servo_geometry;
 extern crate servo_url;
 extern crate url;

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -25,8 +25,7 @@ use url::{self, Url};
 
 
 /// Global flags for Servo, currently set on the command line.
-#[derive(Clone)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct Opts {
     pub is_running_problem_test: bool,
 
@@ -446,8 +445,7 @@ fn print_debug_usage(app: &str) -> ! {
     process::exit(0)
 }
 
-#[derive(Clone)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum OutputOptions {
     FileName(String),
     Stdout(f64)

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -20,8 +20,7 @@ lazy_static! {
     };
 }
 
-#[derive(PartialEq, Clone, Debug)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub enum PrefValue {
     Boolean(bool),
     String(String),
@@ -92,8 +91,7 @@ impl ToJson for PrefValue {
     }
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Pref {
     NoDefault(Arc<PrefValue>),
     WithDefault(Arc<PrefValue>, Option<Arc<PrefValue>>)

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -36,7 +36,7 @@ style_traits = {path = "../style_traits"}
 servo_config = {path = "../config"}
 servo_rand = {path = "../rand"}
 servo_remutex = {path = "../remutex"}
-servo_url = {path = "../url", features = ["servo"]}
+servo_url = {path = "../url"}
 webvr_traits = {path = "../webvr_traits"}
 webrender_traits = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -33,7 +33,7 @@ script_traits = {path = "../script_traits"}
 serde = "0.9"
 serde_derive = "0.9"
 style_traits = {path = "../style_traits"}
-servo_config = {path = "../config", features = ["servo"]}
+servo_config = {path = "../config"}
 servo_rand = {path = "../rand"}
 servo_remutex = {path = "../remutex"}
 servo_url = {path = "../url", features = ["servo"]}

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -25,7 +25,7 @@ num-traits = "0.1.32"
 serde = "0.9"
 serde_derive = "0.9"
 servo_config = {path = "../config"}
-servo_url = {path = "../url", features = ["servo"]}
+servo_url = {path = "../url"}
 url = {version = "1.2", features = ["heap_size"]}
 uuid = {version = "0.4", features = ["v4", "serde"]}
 webrender_traits = {git = "https://github.com/servo/webrender", features = ["ipc"]}

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -24,7 +24,7 @@ msg = {path = "../msg"}
 num-traits = "0.1.32"
 serde = "0.9"
 serde_derive = "0.9"
-servo_config = {path = "../config", features = ["servo"]}
+servo_config = {path = "../config"}
 servo_url = {path = "../url", features = ["servo"]}
 url = {version = "1.2", features = ["heap_size"]}
 uuid = {version = "0.4", features = ["v4", "serde"]}

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.3.5"
 serde = "0.9"
 serde_derive = "0.9"
 serde_json = "0.9"
-servo_config = {path = "../config", features = ["servo"]}
+servo_config = {path = "../config"}
 time = "0.1.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -80,7 +80,7 @@ servo_atoms = {path = "../atoms"}
 servo_config = {path = "../config"}
 servo_geometry = {path = "../geometry" }
 servo_rand = {path = "../rand"}
-servo_url = {path = "../url", features = ["servo"]}
+servo_url = {path = "../url"}
 smallvec = "0.3"
 style = {path = "../style"}
 style_traits = {path = "../style_traits"}

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -77,7 +77,7 @@ script_traits = {path = "../script_traits"}
 selectors = { path = "../selectors" }
 serde = "0.9"
 servo_atoms = {path = "../atoms"}
-servo_config = {path = "../config", features = ["servo"] }
+servo_config = {path = "../config"}
 servo_geometry = {path = "../geometry" }
 servo_rand = {path = "../rand"}
 servo_url = {path = "../url", features = ["servo"]}

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -30,7 +30,7 @@ profile_traits = {path = "../profile_traits"}
 rustc-serialize = "0.3.4"
 serde = "0.9"
 serde_derive = "0.9"
-servo_url = {path = "../url", features = ["servo"]}
+servo_url = {path = "../url"}
 style_traits = {path = "../style_traits", features = ["servo"]}
 time = "0.1.12"
 url = {version = "1.2", features = ["heap_size"]}

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -18,7 +18,7 @@ use_bindgen = ["bindgen", "regex"]
 servo = ["serde/unstable", "serde", "serde_derive", "heapsize", "heapsize_derive",
          "style_traits/servo", "servo_atoms", "html5ever-atoms",
          "cssparser/heapsize", "cssparser/serde", "encoding",
-         "rayon/unstable", "servo_url/servo"]
+         "rayon/unstable", "servo_url", "servo_url/servo"]
 testing = []
 
 [dependencies]
@@ -52,7 +52,7 @@ servo_atoms = {path = "../atoms", optional = true}
 servo_config = {path = "../config"}
 smallvec = "0.3"
 style_traits = {path = "../style_traits"}
-servo_url = {path = "../url"}
+servo_url = {path = "../url", optional = true}
 time = "0.1"
 unicode-segmentation = "1.0"
 

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -18,7 +18,7 @@ use_bindgen = ["bindgen", "regex"]
 servo = ["serde/unstable", "serde", "serde_derive", "heapsize", "heapsize_derive",
          "style_traits/servo", "servo_atoms", "servo_config", "html5ever-atoms",
          "cssparser/heapsize", "cssparser/serde", "encoding",
-         "rayon/unstable", "servo_url", "servo_url/servo"]
+         "rayon/unstable", "servo_url"]
 testing = []
 
 [dependencies]

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 gecko = ["nsstring_vendor", "rayon/unstable", "num_cpus"]
 use_bindgen = ["bindgen", "regex"]
 servo = ["serde/unstable", "serde", "serde_derive", "heapsize", "heapsize_derive",
-         "style_traits/servo", "servo_atoms", "html5ever-atoms",
+         "style_traits/servo", "servo_atoms", "servo_config", "html5ever-atoms",
          "cssparser/heapsize", "cssparser/serde", "encoding",
          "rayon/unstable", "servo_url", "servo_url/servo"]
 testing = []
@@ -49,7 +49,7 @@ selectors = { path = "../selectors" }
 serde = {version = "0.9", optional = true}
 serde_derive = {version = "0.9", optional = true}
 servo_atoms = {path = "../atoms", optional = true}
-servo_config = {path = "../config"}
+servo_config = {path = "../config", optional = true}
 smallvec = "0.3"
 style_traits = {path = "../style_traits"}
 servo_url = {path = "../url", optional = true}

--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use str::{HTML_SPACE_CHARACTERS, read_exponent, read_fraction};
 use str::{read_numbers, split_commas, split_html_space_chars};
-#[cfg(not(feature = "gecko"))] use str::str_join;
+use str::str_join;
 use values::specified::Length;
 
 // Duplicated from script::dom::values.
@@ -166,7 +166,6 @@ impl AttrValue {
         AttrValue::TokenList(tokens, atoms)
     }
 
-    #[cfg(not(feature = "gecko"))] // Gecko can't borrow atoms as UTF-8.
     pub fn from_atomic_tokens(atoms: Vec<Atom>) -> AttrValue {
         // TODO(ajeffrey): effecient conversion of Vec<Atom> to String
         let tokens = String::from(str_join(&atoms, "\x20"));
@@ -335,7 +334,6 @@ impl AttrValue {
     }
 }
 
-#[cfg(not(feature = "gecko"))] // Gecko can't borrow atoms as UTF-8.
 impl ::std::ops::Deref for AttrValue {
     type Target = str;
 

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -17,10 +17,10 @@ use matching::StyleSharingCandidateCache;
 use parking_lot::RwLock;
 #[cfg(feature = "gecko")] use selector_parser::PseudoElement;
 use selectors::matching::ElementSelectorFlags;
-use servo_config::opts;
+#[cfg(feature = "servo")] use servo_config::opts;
 use shared_lock::StylesheetGuards;
 use std::collections::HashMap;
-use std::env;
+#[cfg(not(feature = "servo"))] use std::env;
 use std::fmt;
 use std::ops::Add;
 use std::sync::{Arc, Mutex};
@@ -170,6 +170,7 @@ impl fmt::Display for TraversalStatistics {
     }
 }
 
+#[cfg(not(feature = "servo"))]
 lazy_static! {
     /// Whether to dump style statistics, computed statically. We use an environmental
     /// variable so that this is easy to set for Gecko builds, and matches the
@@ -182,10 +183,20 @@ lazy_static! {
     };
 }
 
+#[cfg(feature = "servo")]
+fn shall_stat_style_sharing() -> bool {
+    opts::get().style_sharing_stats
+}
+
+#[cfg(not(feature = "servo"))]
+fn shall_stat_style_sharing() -> bool {
+    *DUMP_STYLE_STATISTICS
+}
+
 impl TraversalStatistics {
     /// Returns whether statistics dumping is enabled.
     pub fn should_dump() -> bool {
-        *DUMP_STYLE_STATISTICS || opts::get().style_sharing_stats
+        shall_stat_style_sharing()
     }
 
     /// Computes the traversal time given the start time in seconds.

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -71,7 +71,7 @@ extern crate selectors;
 #[cfg(feature = "servo")] #[macro_use] extern crate serde_derive;
 #[cfg(feature = "servo")] #[macro_use] extern crate servo_atoms;
 extern crate servo_config;
-extern crate servo_url;
+#[cfg(feature = "servo")] extern crate servo_url;
 extern crate smallvec;
 #[macro_use]
 extern crate style_traits;
@@ -81,7 +81,7 @@ extern crate unicode_segmentation;
 
 pub mod animation;
 #[allow(missing_docs)] // TODO.
-pub mod attr;
+#[cfg(feature = "servo")] pub mod attr;
 pub mod bezier;
 pub mod bloom;
 pub mod cache;

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -70,7 +70,7 @@ extern crate rayon;
 extern crate selectors;
 #[cfg(feature = "servo")] #[macro_use] extern crate serde_derive;
 #[cfg(feature = "servo")] #[macro_use] extern crate servo_atoms;
-extern crate servo_config;
+#[cfg(feature = "servo")] extern crate servo_config;
 #[cfg(feature = "servo")] extern crate servo_url;
 extern crate smallvec;
 #[macro_use]

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -23,7 +23,7 @@ use selector_parser::{PseudoElement, RestyleDamage, SelectorImpl};
 use selectors::bloom::BloomFilter;
 use selectors::matching::{ElementSelectorFlags, StyleRelations};
 use selectors::matching::AFFECTED_BY_PSEUDO_ELEMENTS;
-use servo_config::opts;
+#[cfg(feature = "servo")] use servo_config::opts;
 use sink::ForgetfulSink;
 use std::sync::Arc;
 use stylist::ApplicableDeclarationBlock;
@@ -783,6 +783,16 @@ pub enum StyleSharingBehavior {
     Disallow,
 }
 
+#[cfg(feature = "servo")]
+fn is_share_style_cache_disabled() -> bool {
+    opts::get().disable_share_style_cache
+}
+
+#[cfg(not(feature = "servo"))]
+fn is_share_style_cache_disabled() -> bool {
+    false
+}
+
 /// The public API that elements expose for selector matching.
 pub trait MatchMethods : TElement {
     /// Performs selector matching and property cascading on an element and its eager pseudos.
@@ -1069,7 +1079,7 @@ pub trait MatchMethods : TElement {
                                       shared_context: &SharedStyleContext,
                                       data: &mut AtomicRefMut<ElementData>)
                                       -> StyleSharingResult {
-        if opts::get().disable_share_style_cache {
+        if is_share_style_cache_disabled() {
             return StyleSharingResult::CannotShare
         }
 

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -27,6 +27,7 @@ use parser::{Parse, ParserContext, log_css_error};
 use properties::{PropertyDeclarationBlock, parse_property_declaration_list};
 use selector_parser::{SelectorImpl, SelectorParser};
 use selectors::parser::SelectorList;
+#[cfg(feature = "servo")]
 use servo_config::prefs::PREFS;
 #[cfg(not(feature = "gecko"))]
 use servo_url::ServoUrl;
@@ -997,6 +998,16 @@ impl<'a, 'b> NestedRuleParser<'a, 'b> {
     }
 }
 
+#[cfg(feature = "servo")]
+fn is_viewport_enabled() -> bool {
+    PREFS.get("layout.viewport.enabled").as_boolean().unwrap_or(false)
+}
+
+#[cfg(not(feature = "servo"))]
+fn is_viewport_enabled() -> bool {
+    true
+}
+
 impl<'a, 'b> AtRuleParser for NestedRuleParser<'a, 'b> {
     type Prelude = AtRulePrelude;
     type AtRule = CssRule;
@@ -1017,8 +1028,7 @@ impl<'a, 'b> AtRuleParser for NestedRuleParser<'a, 'b> {
                 Ok(AtRuleType::WithBlock(AtRulePrelude::FontFace))
             },
             "viewport" => {
-                if PREFS.get("layout.viewport.enabled").as_boolean().unwrap_or(false) ||
-                   cfg!(feature = "gecko") {
+                if is_viewport_enabled() {
                     Ok(AtRuleType::WithBlock(AtRulePrelude::Viewport))
                 } else {
                     Err(())

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -13,7 +13,7 @@ use dom::{DirtyDescendants, NodeInfo, TElement, TNode};
 use matching::{MatchMethods, StyleSharingBehavior};
 use restyle_hints::{RESTYLE_DESCENDANTS, RESTYLE_SELF};
 use selector_parser::RestyleDamage;
-use servo_config::opts;
+#[cfg(feature = "servo")] use servo_config::opts;
 use std::borrow::BorrowMut;
 use stylist::Stylist;
 
@@ -100,6 +100,16 @@ impl TraversalDriver {
     }
 }
 
+#[cfg(feature = "servo")]
+fn is_servo_nonincremental_layout() -> bool {
+    opts::get().nonincremental_layout
+}
+
+#[cfg(not(feature = "servo"))]
+fn is_servo_nonincremental_layout() -> bool {
+    false
+}
+
 /// A DOM Traversal trait, that is used to generically implement styling for
 /// Gecko and Servo.
 pub trait DomTraversal<E: TElement> : Sync {
@@ -175,7 +185,7 @@ pub trait DomTraversal<E: TElement> : Sync {
     /// Returns true if traversal is needed for the given node and subtree.
     fn node_needs_traversal(node: E::ConcreteNode, animation_only: bool) -> bool {
         // Non-incremental layout visits every node.
-        if cfg!(feature = "servo") && opts::get().nonincremental_layout {
+        if is_servo_nonincremental_layout() {
             return true;
         }
 

--- a/components/url/Cargo.toml
+++ b/components/url/Cargo.toml
@@ -9,15 +9,12 @@ publish = false
 name = "servo_url"
 path = "lib.rs"
 
-[features]
-servo = ["heapsize", "heapsize_derive", "serde", "serde_derive", "uuid/serde", "url/heap_size", "url_serde"]
-
 [dependencies]
-heapsize = {version = "0.3.0", optional = true}
-heapsize_derive = {version = "0.1", optional = true}
-serde = {version = "0.9", optional = true}
-serde_derive = {version = "0.9", optional = true}
+heapsize = {version = "0.3.0"}
+heapsize_derive = {version = "0.1"}
+serde = {version = "0.9"}
+serde_derive = {version = "0.9"}
 servo_rand = {path = "../rand"}
-url = "1.2"
-url_serde = {version = "0.1.3", optional = true}
-uuid = {version = "0.4.0", features = ["v4"]}
+url = {version = "1.2", features = ["heap_size"]}
+url_serde = {version = "0.1.3"}
+uuid = {version = "0.4.0", features = ["v4", "serde"]}

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -7,14 +7,13 @@
 #![crate_name = "servo_url"]
 #![crate_type = "rlib"]
 
-#[cfg(feature = "servo")] #[macro_use] extern crate heapsize;
-#[cfg(feature = "servo")] #[macro_use] extern crate heapsize_derive;
-#[cfg(feature = "servo")] extern crate serde;
-#[cfg(feature = "servo")] #[macro_use] extern crate serde_derive;
-#[cfg(feature = "servo")] extern crate url_serde;
-
+#[macro_use] extern crate heapsize;
+#[macro_use] extern crate heapsize_derive;
+extern crate serde;
+#[macro_use] extern crate serde_derive;
 extern crate servo_rand;
 extern crate url;
+extern crate url_serde;
 extern crate uuid;
 
 pub mod origin;
@@ -30,8 +29,7 @@ use url::{Url, Position};
 
 pub use url::Host;
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HeapSizeOf)]
 pub struct ServoUrl(Arc<Url>);
 
 impl ServoUrl {
@@ -203,7 +201,6 @@ impl From<Url> for ServoUrl {
     }
 }
 
-#[cfg(feature = "servo")]
 impl serde::Serialize for ServoUrl {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: serde::Serializer,
@@ -212,7 +209,6 @@ impl serde::Serialize for ServoUrl {
     }
 }
 
-#[cfg(feature = "servo")]
 impl serde::Deserialize for ServoUrl {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: serde::Deserializer,

--- a/components/url/origin.rs
+++ b/components/url/origin.rs
@@ -7,12 +7,11 @@ use servo_rand::Rng;
 use std::cell::RefCell;
 use std::rc::Rc;
 use url::{Host, Origin};
-#[cfg(feature = "servo")] use url_serde;
+use url_serde;
 use uuid::Uuid;
 
 /// The origin of an URL
-#[derive(PartialEq, Eq, Clone, Debug)]
-#[cfg_attr(feature = "servo", derive(HeapSizeOf, Deserialize, Serialize))]
+#[derive(PartialEq, Eq, Clone, Debug, HeapSizeOf, Deserialize, Serialize)]
 pub enum ImmutableOrigin {
     /// A globally unique identifier
     Opaque(OpaqueOrigin),
@@ -20,8 +19,7 @@ pub enum ImmutableOrigin {
     /// Consists of the URL's scheme, host and port
     Tuple(
         String,
-        #[cfg_attr(feature = "servo",
-                   serde(deserialize_with = "url_serde::deserialize", serialize_with = "url_serde::serialize"))]
+        #[serde(deserialize_with = "url_serde::deserialize", serialize_with = "url_serde::serialize")]
         Host,
         u16,
     )
@@ -97,18 +95,15 @@ impl ImmutableOrigin {
 }
 
 /// Opaque identifier for URLs that have file or other schemes
-#[derive(Eq, PartialEq, Clone, Debug)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub struct OpaqueOrigin(Uuid);
 
-#[cfg(feature = "servo")]
 known_heap_size!(0, OpaqueOrigin);
 
 /// A representation of an [origin](https://html.spec.whatwg.org/multipage/#origin-2).
 #[derive(Clone, Debug)]
 pub struct MutableOrigin(Rc<(ImmutableOrigin, RefCell<Option<Host>>)>);
 
-#[cfg(feature = "servo")]
 known_heap_size!(0, MutableOrigin);
 
 impl MutableOrigin {

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -23,7 +23,7 @@ regex = "0.2"
 rustc-serialize = "0.3.4"
 script_traits = {path = "../script_traits"}
 servo_config = {path = "../config"}
-servo_url = {path = "../url", features = ["servo"]}
+servo_url = {path = "../url"}
 url = {version = "1.2", features = ["heap_size"]}
 uuid = {version = "0.4", features = ["v4"]}
 webdriver = "0.22"

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -22,7 +22,7 @@ net_traits = {path = "../net_traits"}
 regex = "0.2"
 rustc-serialize = "0.3.4"
 script_traits = {path = "../script_traits"}
-servo_config = {path = "../config", features = ["servo"]}
+servo_config = {path = "../config"}
 servo_url = {path = "../url", features = ["servo"]}
 url = {version = "1.2", features = ["heap_size"]}
 uuid = {version = "0.4", features = ["v4"]}


### PR DESCRIPTION
It seems mod attr is not used for geckolib at all, and that is the only place where servo_url is still referenced for geckolib, so we can just remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16297)
<!-- Reviewable:end -->
