### PR TITLE
Make transform perspective reject negative lengths.

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -1213,6 +1213,8 @@ ${helpers.predefined_type("scroll-snap-coordinate",
         ///
         /// Part of CSS Transform Module Level 2 and defined at
         /// [§ 13.1. 3D Transform Function](https://drafts.csswg.org/css-transforms-2/#funcdef-perspective).
+        ///
+        /// The value must be greater than or equal to zero.
         Perspective(specified::Length),
     }
 
@@ -1535,7 +1537,7 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                 },
                 "perspective" => {
                     try!(input.parse_nested_block(|input| {
-                        let d = try!(specified::Length::parse(context, input));
+                        let d = try!(specified::Length::parse_non_negative(input));
                         result.push(SpecifiedOperation::Perspective(d));
                         Ok(())
                     }))

--- a/tests/unit/style/parsing/box_.rs
+++ b/tests/unit/style/parsing/box_.rs
@@ -33,4 +33,5 @@ fn test_transform_translate() {
     assert_roundtrip_with_context!(transform::parse, "translate(2px)");
     assert_roundtrip_with_context!(transform::parse, "translate(2px, 5px)");
     assert!(parse(transform::parse, "translate(2px foo)").is_err());
+    assert!(parse(transform::parse, "perspective(-10px)").is_err());
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`transform: perspective(-10px)` is invalid per spec. This patch prevents negative values from being parsed. There is an issue if zero should be allowed: https://github.com/w3c/fxtf-drafts/issues/126

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://github.com/servo/servo/pull/16242#issuecomment-291639340

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16300)
<!-- Reviewable:end -->
