### PR TITLE
layout: Ensure abs-pos elements establish block formatting contexts

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1429,6 +1429,9 @@ impl BlockFlow {
     /// Determines the type of formatting context this is. See the definition of
     /// `FormattingContextType`.
     pub fn formatting_context_type(&self) -> FormattingContextType {
+        if self.base.flags.contains(IS_ABSOLUTELY_POSITIONED) {
+            return FormattingContextType::Other
+        }
         let style = self.fragment.style();
         if style.get_box().float != float::T::none {
             return FormattingContextType::Other


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Per CSS 2.1 § 9.4.1, absolutely positioned elements establish new
block formatting contexts for their contents.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13495 (github issue number if applicable).

<!-- Either: -->
- [] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16310)
<!-- Reviewable:end -->
