### PR TITLE
Do not return an error for non-GET data: requests (fixes #13293)

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -395,18 +395,14 @@ fn basic_fetch(request: &mut Request,
         },
 
         "data" => {
-            if request.method == Method::Get {
-                match decode(&url) {
-                    Ok((mime, bytes)) => {
-                        let mut response = Response::new(url);
-                        *response.body.lock().unwrap() = ResponseBody::Done(bytes);
-                        response.headers.set(ContentType(mime));
-                        response
-                    },
-                    Err(_) => Response::network_error(NetworkError::Internal("Decoding data URL failed".into()))
-                }
-            } else {
-                Response::network_error(NetworkError::Internal("Unexpected method for data".into()))
+            match decode(&url) {
+                Ok((mime, bytes)) => {
+                    let mut response = Response::new(url);
+                    *response.body.lock().unwrap() = ResponseBody::Done(bytes);
+                    response.headers.set(ContentType(mime));
+                    response
+                },
+                Err(_) => Response::network_error(NetworkError::Internal("Decoding data URL failed".into()))
             }
         },
 

--- a/tests/wpt/metadata/XMLHttpRequest/data-uri.htm.ini
+++ b/tests/wpt/metadata/XMLHttpRequest/data-uri.htm.ini
@@ -3,3 +3,23 @@
   [XHR method GET with charset text/html;charset=UTF-8]
     expected: FAIL
 
+  [XHR method POST with charset text/plain]
+    bug: https://github.com/w3c/web-platform-tests/issues/3738
+    expected: FAIL
+
+  [XHR method PUT with charset text/plain]
+    bug: https://github.com/w3c/web-platform-tests/issues/3738
+    expected: FAIL
+
+  [XHR method DELETE with charset text/plain]
+    bug: https://github.com/w3c/web-platform-tests/issues/3738
+    expected: FAIL
+
+  [XHR method HEAD with charset text/plain]
+    bug: https://github.com/w3c/web-platform-tests/issues/3738
+    expected: FAIL
+
+  [XHR method UNICORN with charset text/plain]
+    bug: https://github.com/w3c/web-platform-tests/issues/3738
+    expected: FAIL
+


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16311)
<!-- Reviewable:end -->
