### PR TITLE
stylo: Add -moz-element support

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -657,6 +657,9 @@ impl FragmentDisplayListBuilding for Fragment {
                 Some(computed::Image::ImageRect(_)) => {
                     // TODO: Implement `-moz-image-rect`
                 }
+                Some(computed::Image::Element(_)) => {
+                    // TODO: Implement `-moz-element`
+                }
             }
         }
     }
@@ -1153,6 +1156,9 @@ impl FragmentDisplayListBuilding for Fragment {
             }
             Some(computed::Image::ImageRect(..)) => {
                 // TODO: Handle border-image with `-moz-image-rect`.
+            }
+            Some(computed::Image::Element(..)) => {
+                // TODO: Handle border-image with `-moz-element`.
             }
             Some(computed::Image::Url(ref image_url)) => {
                 if let Some(url) = image_url.url() {

--- a/components/style/gecko/conversions.rs
+++ b/components/style/gecko/conversions.rs
@@ -11,7 +11,7 @@
 use app_units::Au;
 use gecko::values::{convert_rgba_to_nscolor, GeckoStyleCoordConvertible};
 use gecko_bindings::bindings::{Gecko_CreateGradient, Gecko_SetGradientImageValue, Gecko_SetUrlImageValue};
-use gecko_bindings::bindings::Gecko_InitializeImageCropRect;
+use gecko_bindings::bindings::{Gecko_InitializeImageCropRect, Gecko_SetImageElement};
 use gecko_bindings::structs::{nsStyleCoord_CalcValue, nsStyleImage};
 use gecko_bindings::structs::{nsresult, SheetType};
 use gecko_bindings::sugar::ns_style_coord::{CoordDataValue, CoordDataMut};
@@ -141,6 +141,11 @@ impl nsStyleImage {
                     image_rect.left.to_gecko_style_coord(&mut rect.data_at_mut(3));
                 }
             }
+            Image::Element(ref element) => {
+                unsafe {
+                    Gecko_SetImageElement(self, element.as_ptr());
+                }
+            },
             _ => (),
         }
     }

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -702,6 +702,10 @@ extern "C" {
                                   uri: ServoBundledURI);
 }
 extern "C" {
+    pub fn Gecko_SetImageElement(image: *mut nsStyleImage,
+                                 atom: *mut nsIAtom);
+}
+extern "C" {
     pub fn Gecko_CopyImageValueFrom(image: *mut nsStyleImage,
                                     other: *const nsStyleImage);
 }


### PR DESCRIPTION
Implemented -moz-element for background property.
r=upsuper

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15443 and [Bug 1341761](https://bugzilla.mozilla.org/show_bug.cgi?id=1341761)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16319)
<!-- Reviewable:end -->
