### PR TITLE
data-url.html is no longer intermittent.

### DIFF
--- a/tests/wpt/metadata/workers/data-url.html.ini
+++ b/tests/wpt/metadata/workers/data-url.html.ini
@@ -1,0 +1,4 @@
+[data-url.html]
+  expected: ERROR
+  [worker has opaque origin]
+    expected: FAIL


### PR DESCRIPTION
As far as I can tell this test consistently fails and the ini file was removed unintentionally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16332)
<!-- Reviewable:end -->
