### PR TITLE
Stylo - support image-orientation property

### DIFF
--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -16,9 +16,11 @@ use gecko_bindings::structs::RawGeckoAnimationValueList;
 use gecko_bindings::structs::RawServoAnimationValue;
 use gecko_bindings::structs::RawServoAnimationValueMap;
 use gecko_bindings::structs::RawServoDeclarationBlock;
+use gecko_bindings::structs::RawServoStyleRule;
 use gecko_bindings::structs::RawGeckoPresContext;
 use gecko_bindings::structs::RawGeckoPresContextOwned;
 use gecko_bindings::structs::RawGeckoStyleAnimationList;
+use gecko_bindings::structs::RawGeckoServoStyleRuleList;
 use gecko_bindings::structs::RawGeckoURLExtraData;
 use gecko_bindings::structs::RefPtr;
 use gecko_bindings::structs::CSSPseudoClassType;
@@ -28,6 +30,7 @@ use gecko_bindings::structs::ComputedTimingFunction_BeforeFlag;
 use gecko_bindings::structs::FontFamilyList;
 use gecko_bindings::structs::FontFamilyType;
 use gecko_bindings::structs::FontSizePrefs;
+use gecko_bindings::structs::GeckoFontMetrics;
 use gecko_bindings::structs::Keyframe;
 use gecko_bindings::structs::ServoBundledURI;
 use gecko_bindings::structs::ServoElementSnapshot;
@@ -207,8 +210,6 @@ pub type RawServoDeclarationBlockBorrowedOrNull<'a> = Option<&'a RawServoDeclara
 pub type RawServoStyleRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoStyleRule>;
 pub type RawServoStyleRuleBorrowed<'a> = &'a RawServoStyleRule;
 pub type RawServoStyleRuleBorrowedOrNull<'a> = Option<&'a RawServoStyleRule>;
-enum RawServoStyleRuleVoid { }
-pub struct RawServoStyleRule(RawServoStyleRuleVoid);
 pub type RawServoImportRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoImportRule>;
 pub type RawServoImportRuleBorrowed<'a> = &'a RawServoImportRule;
 pub type RawServoImportRuleBorrowedOrNull<'a> = Option<&'a RawServoImportRule>;
@@ -306,6 +307,10 @@ pub type RawGeckoFontFaceRuleListBorrowed<'a> = &'a RawGeckoFontFaceRuleList;
 pub type RawGeckoFontFaceRuleListBorrowedOrNull<'a> = Option<&'a RawGeckoFontFaceRuleList>;
 pub type RawGeckoFontFaceRuleListBorrowedMut<'a> = &'a mut RawGeckoFontFaceRuleList;
 pub type RawGeckoFontFaceRuleListBorrowedMutOrNull<'a> = Option<&'a mut RawGeckoFontFaceRuleList>;
+pub type RawGeckoServoStyleRuleListBorrowed<'a> = &'a RawGeckoServoStyleRuleList;
+pub type RawGeckoServoStyleRuleListBorrowedOrNull<'a> = Option<&'a RawGeckoServoStyleRuleList>;
+pub type RawGeckoServoStyleRuleListBorrowedMut<'a> = &'a mut RawGeckoServoStyleRuleList;
+pub type RawGeckoServoStyleRuleListBorrowedMutOrNull<'a> = Option<&'a mut RawGeckoServoStyleRuleList>;
 
 extern "C" {
     pub fn Gecko_EnsureTArrayCapacity(aArray: *mut ::std::os::raw::c_void,
@@ -700,6 +705,18 @@ extern "C" {
     pub fn Gecko_CopyFontFamilyFrom(dst: *mut nsFont, src: *const nsFont);
 }
 extern "C" {
+    pub fn Gecko_SetImageOrientation(aVisibility: *mut nsStyleVisibility,
+                                     aRadians: f64, aFlip: bool);
+}
+extern "C" {
+    pub fn Gecko_SetImageOrientationAsFromImage(aVisibility:
+                                                    *mut nsStyleVisibility);
+}
+extern "C" {
+    pub fn Gecko_CopyImageOrientationFrom(aDst: *mut nsStyleVisibility,
+                                          aSrc: *const nsStyleVisibility);
+}
+extern "C" {
     pub fn Gecko_SetListStyleType(style_struct: *mut nsStyleList, type_: u32);
 }
 extern "C" {
@@ -1075,6 +1092,12 @@ extern "C" {
 }
 extern "C" {
     pub fn Gecko_GetBaseSize(lang: *mut nsIAtom) -> FontSizePrefs;
+}
+extern "C" {
+    pub fn Gecko_GetFontMetrics(pres_context: RawGeckoPresContextBorrowed,
+                                is_vertical: bool, font: *const nsStyleFont,
+                                font_size: nscoord, use_user_font_set: bool)
+     -> GeckoFontMetrics;
 }
 extern "C" {
     pub fn Gecko_GetMediaFeatures() -> *const nsMediaFeature;
@@ -1910,6 +1933,11 @@ extern "C" {
 extern "C" {
     pub fn Servo_Element_GetSnapshot(element: RawGeckoElementBorrowed)
      -> *mut ServoElementSnapshot;
+}
+extern "C" {
+    pub fn Servo_Element_GetStyleRuleList(element: RawGeckoElementBorrowed,
+                                          rules:
+                                              RawGeckoServoStyleRuleListBorrowedMut);
 }
 extern "C" {
     pub fn Servo_NoteExplicitHints(element: RawGeckoElementBorrowed,

--- a/components/style/gecko_bindings/structs_debug.rs
+++ b/components/style/gecko_bindings/structs_debug.rs
@@ -23700,6 +23700,8 @@ pub mod root {
         pub mModeFlags: root::nsStyleImageRequest_Mode,
         pub mResolved: bool,
     }
+    pub type nsStyleImageRequest_URLValueData =
+        root::mozilla::css::URLValueData;
     #[repr(u8)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub enum nsStyleImageRequest_Mode { Track = 1, Discard = 2, }
@@ -23758,6 +23760,7 @@ pub mod root {
         eStyleImageType_Image = 1,
         eStyleImageType_Gradient = 2,
         eStyleImageType_Element = 3,
+        eStyleImageType_URL = 4,
     }
     #[repr(C)]
     #[derive(Debug)]
@@ -23808,11 +23811,14 @@ pub mod root {
         pub mCropRect: root::mozilla::UniquePtr<root::nsStyleSides,
                                                 root::mozilla::DefaultDelete<root::nsStyleSides>>,
     }
+    pub type nsStyleImage_URLValue = root::mozilla::css::URLValue;
+    pub type nsStyleImage_URLValueData = root::mozilla::css::URLValueData;
     #[repr(C)]
     #[derive(Debug, Copy)]
     pub struct nsStyleImage__bindgen_ty_1 {
         pub mImage: root::__BindgenUnionField<*mut root::nsStyleImageRequest>,
         pub mGradient: root::__BindgenUnionField<*mut root::nsStyleGradient>,
+        pub mURLValue: root::__BindgenUnionField<*mut root::nsStyleImage_URLValue>,
         pub mElementId: root::__BindgenUnionField<*mut u16>,
         pub bindgen_union_field: u64,
     }
@@ -23838,6 +23844,12 @@ pub mod root {
                     "Alignment of field: " , stringify ! (
                     nsStyleImage__bindgen_ty_1 ) , "::" , stringify ! (
                     mGradient ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleImage__bindgen_ty_1 ) ) .
+                    mURLValue as * const _ as usize } , 0usize , concat ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleImage__bindgen_ty_1 ) , "::" , stringify ! (
+                    mURLValue ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImage__bindgen_ty_1 ) ) .
                     mElementId as * const _ as usize } , 0usize , concat ! (
@@ -24066,7 +24078,6 @@ pub mod root {
     #[derive(Debug)]
     pub struct nsStyleImageLayers_Layer {
         pub mImage: root::nsStyleImage,
-        pub mSourceURI: root::RefPtr<root::mozilla::css::URLValueData>,
         pub mPosition: root::mozilla::Position,
         pub mSize: root::nsStyleImageLayers_Size,
         pub mClip: root::nsStyleImageLayers_Layer_StyleGeometryBox,
@@ -24081,8 +24092,8 @@ pub mod root {
             nsStyleImageLayers_Layer_StyleGeometryBox;
     #[test]
     fn bindgen_test_layout_nsStyleImageLayers_Layer() {
-        assert_eq!(::std::mem::size_of::<nsStyleImageLayers_Layer>() ,
-                   104usize , concat ! (
+        assert_eq!(::std::mem::size_of::<nsStyleImageLayers_Layer>() , 96usize
+                   , concat ! (
                    "Size of: " , stringify ! ( nsStyleImageLayers_Layer ) ));
         assert_eq! (::std::mem::align_of::<nsStyleImageLayers_Layer>() ,
                     8usize , concat ! (
@@ -24096,61 +24107,55 @@ pub mod root {
                     ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mSourceURI as * const _ as usize } , 32usize , concat ! (
-                    "Alignment of field: " , stringify ! (
-                    nsStyleImageLayers_Layer ) , "::" , stringify ! (
-                    mSourceURI ) ));
-        assert_eq! (unsafe {
-                    & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mPosition as * const _ as usize } , 40usize , concat ! (
+                    mPosition as * const _ as usize } , 32usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! (
                     mPosition ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) . mSize
-                    as * const _ as usize } , 64usize , concat ! (
+                    as * const _ as usize } , 56usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! ( mSize )
                     ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) . mClip
-                    as * const _ as usize } , 92usize , concat ! (
+                    as * const _ as usize } , 84usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! ( mClip )
                     ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mOrigin as * const _ as usize } , 93usize , concat ! (
+                    mOrigin as * const _ as usize } , 85usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! ( mOrigin
                     ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mAttachment as * const _ as usize } , 94usize , concat ! (
+                    mAttachment as * const _ as usize } , 86usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! (
                     mAttachment ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mBlendMode as * const _ as usize } , 95usize , concat ! (
+                    mBlendMode as * const _ as usize } , 87usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! (
                     mBlendMode ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mComposite as * const _ as usize } , 96usize , concat ! (
+                    mComposite as * const _ as usize } , 88usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! (
                     mComposite ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mMaskMode as * const _ as usize } , 97usize , concat ! (
+                    mMaskMode as * const _ as usize } , 89usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! (
                     mMaskMode ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mRepeat as * const _ as usize } , 98usize , concat ! (
+                    mRepeat as * const _ as usize } , 90usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! ( mRepeat
                     ) ));
@@ -24167,7 +24172,7 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_nsStyleImageLayers() {
-        assert_eq!(::std::mem::size_of::<nsStyleImageLayers>() , 160usize ,
+        assert_eq!(::std::mem::size_of::<nsStyleImageLayers>() , 152usize ,
                    concat ! ( "Size of: " , stringify ! ( nsStyleImageLayers )
                    ));
         assert_eq! (::std::mem::align_of::<nsStyleImageLayers>() , 8usize ,
@@ -24248,7 +24253,7 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_nsStyleBackground() {
-        assert_eq!(::std::mem::size_of::<nsStyleBackground>() , 168usize ,
+        assert_eq!(::std::mem::size_of::<nsStyleBackground>() , 160usize ,
                    concat ! ( "Size of: " , stringify ! ( nsStyleBackground )
                    ));
         assert_eq! (::std::mem::align_of::<nsStyleBackground>() , 8usize ,
@@ -24261,7 +24266,7 @@ pub mod root {
                     , "::" , stringify ! ( mImage ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleBackground ) ) .
-                    mBackgroundColor as * const _ as usize } , 160usize ,
+                    mBackgroundColor as * const _ as usize } , 152usize ,
                     concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleBackground )
                     , "::" , stringify ! ( mBackgroundColor ) ));
@@ -26362,7 +26367,7 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_nsStyleSVGReset() {
-        assert_eq!(::std::mem::size_of::<nsStyleSVGReset>() , 200usize ,
+        assert_eq!(::std::mem::size_of::<nsStyleSVGReset>() , 192usize ,
                    concat ! ( "Size of: " , stringify ! ( nsStyleSVGReset )
                    ));
         assert_eq! (::std::mem::align_of::<nsStyleSVGReset>() , 8usize ,
@@ -26375,48 +26380,48 @@ pub mod root {
                     "::" , stringify ! ( mMask ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mClipPath as *
-                    const _ as usize } , 160usize , concat ! (
+                    const _ as usize } , 152usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mClipPath ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mStopColor as *
-                    const _ as usize } , 176usize , concat ! (
+                    const _ as usize } , 168usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mStopColor ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mFloodColor as
-                    * const _ as usize } , 180usize , concat ! (
+                    * const _ as usize } , 172usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mFloodColor ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mLightingColor
-                    as * const _ as usize } , 184usize , concat ! (
+                    as * const _ as usize } , 176usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mLightingColor ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mStopOpacity as
-                    * const _ as usize } , 188usize , concat ! (
+                    * const _ as usize } , 180usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mStopOpacity ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mFloodOpacity
-                    as * const _ as usize } , 192usize , concat ! (
+                    as * const _ as usize } , 184usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mFloodOpacity ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) .
-                    mDominantBaseline as * const _ as usize } , 196usize ,
+                    mDominantBaseline as * const _ as usize } , 188usize ,
                     concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mDominantBaseline ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mVectorEffect
-                    as * const _ as usize } , 197usize , concat ! (
+                    as * const _ as usize } , 189usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mVectorEffect ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mMaskType as *
-                    const _ as usize } , 198usize , concat ! (
+                    const _ as usize } , 190usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mMaskType ) ));
     }
@@ -26659,6 +26664,9 @@ pub mod root {
     pub struct RawServoDeclarationBlock([u8; 0]);
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
+    pub struct RawServoStyleRule([u8; 0]);
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
     pub struct RawServoAnimationValue([u8; 0]);
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
@@ -26680,6 +26688,8 @@ pub mod root {
     pub type RawGeckoAnimationPropertySegment =
         root::mozilla::AnimationPropertySegment;
     pub type RawGeckoComputedTiming = root::mozilla::ComputedTiming;
+    pub type RawGeckoServoStyleRuleList =
+        root::nsTArray<*const root::RawServoStyleRule>;
     pub type RawServoAnimationValueMapBorrowed =
         *const root::RawServoAnimationValueMap;
     pub type RawGeckoNodeBorrowed = *const root::RawGeckoNode;
@@ -26706,6 +26716,8 @@ pub mod root {
         *const root::RawGeckoAnimationPropertySegment;
     pub type RawGeckoComputedTimingBorrowed =
         *const root::RawGeckoComputedTiming;
+    pub type RawGeckoServoStyleRuleListBorrowedMut =
+        *mut root::RawGeckoServoStyleRuleList;
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
     pub struct nsSVGAngle([u8; 0]);
@@ -27210,6 +27222,33 @@ pub mod root {
                     "::" , stringify ! ( mDefaultFantasySize ) ));
     }
     impl Clone for FontSizePrefs {
+        fn clone(&self) -> Self { *self }
+    }
+    #[repr(C)]
+    #[derive(Debug, Copy)]
+    pub struct GeckoFontMetrics {
+        pub mChSize: root::nscoord,
+        pub mXSize: root::nscoord,
+    }
+    #[test]
+    fn bindgen_test_layout_GeckoFontMetrics() {
+        assert_eq!(::std::mem::size_of::<GeckoFontMetrics>() , 8usize , concat
+                   ! ( "Size of: " , stringify ! ( GeckoFontMetrics ) ));
+        assert_eq! (::std::mem::align_of::<GeckoFontMetrics>() , 4usize ,
+                    concat ! (
+                    "Alignment of " , stringify ! ( GeckoFontMetrics ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const GeckoFontMetrics ) ) . mChSize as *
+                    const _ as usize } , 0usize , concat ! (
+                    "Alignment of field: " , stringify ! ( GeckoFontMetrics )
+                    , "::" , stringify ! ( mChSize ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const GeckoFontMetrics ) ) . mXSize as *
+                    const _ as usize } , 4usize , concat ! (
+                    "Alignment of field: " , stringify ! ( GeckoFontMetrics )
+                    , "::" , stringify ! ( mXSize ) ));
+    }
+    impl Clone for GeckoFontMetrics {
         fn clone(&self) -> Self { *self }
     }
     #[repr(C)]

--- a/components/style/gecko_bindings/structs_release.rs
+++ b/components/style/gecko_bindings/structs_release.rs
@@ -23041,6 +23041,8 @@ pub mod root {
         pub mModeFlags: root::nsStyleImageRequest_Mode,
         pub mResolved: bool,
     }
+    pub type nsStyleImageRequest_URLValueData =
+        root::mozilla::css::URLValueData;
     #[repr(u8)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub enum nsStyleImageRequest_Mode { Track = 1, Discard = 2, }
@@ -23099,6 +23101,7 @@ pub mod root {
         eStyleImageType_Image = 1,
         eStyleImageType_Gradient = 2,
         eStyleImageType_Element = 3,
+        eStyleImageType_URL = 4,
     }
     #[repr(C)]
     #[derive(Debug)]
@@ -23149,11 +23152,14 @@ pub mod root {
         pub mCropRect: root::mozilla::UniquePtr<root::nsStyleSides,
                                                 root::mozilla::DefaultDelete<root::nsStyleSides>>,
     }
+    pub type nsStyleImage_URLValue = root::mozilla::css::URLValue;
+    pub type nsStyleImage_URLValueData = root::mozilla::css::URLValueData;
     #[repr(C)]
     #[derive(Debug, Copy)]
     pub struct nsStyleImage__bindgen_ty_1 {
         pub mImage: root::__BindgenUnionField<*mut root::nsStyleImageRequest>,
         pub mGradient: root::__BindgenUnionField<*mut root::nsStyleGradient>,
+        pub mURLValue: root::__BindgenUnionField<*mut root::nsStyleImage_URLValue>,
         pub mElementId: root::__BindgenUnionField<*mut u16>,
         pub bindgen_union_field: u64,
     }
@@ -23179,6 +23185,12 @@ pub mod root {
                     "Alignment of field: " , stringify ! (
                     nsStyleImage__bindgen_ty_1 ) , "::" , stringify ! (
                     mGradient ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleImage__bindgen_ty_1 ) ) .
+                    mURLValue as * const _ as usize } , 0usize , concat ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleImage__bindgen_ty_1 ) , "::" , stringify ! (
+                    mURLValue ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImage__bindgen_ty_1 ) ) .
                     mElementId as * const _ as usize } , 0usize , concat ! (
@@ -23407,7 +23419,6 @@ pub mod root {
     #[derive(Debug)]
     pub struct nsStyleImageLayers_Layer {
         pub mImage: root::nsStyleImage,
-        pub mSourceURI: root::RefPtr<root::mozilla::css::URLValueData>,
         pub mPosition: root::mozilla::Position,
         pub mSize: root::nsStyleImageLayers_Size,
         pub mClip: root::nsStyleImageLayers_Layer_StyleGeometryBox,
@@ -23422,8 +23433,8 @@ pub mod root {
             nsStyleImageLayers_Layer_StyleGeometryBox;
     #[test]
     fn bindgen_test_layout_nsStyleImageLayers_Layer() {
-        assert_eq!(::std::mem::size_of::<nsStyleImageLayers_Layer>() ,
-                   104usize , concat ! (
+        assert_eq!(::std::mem::size_of::<nsStyleImageLayers_Layer>() , 96usize
+                   , concat ! (
                    "Size of: " , stringify ! ( nsStyleImageLayers_Layer ) ));
         assert_eq! (::std::mem::align_of::<nsStyleImageLayers_Layer>() ,
                     8usize , concat ! (
@@ -23437,61 +23448,55 @@ pub mod root {
                     ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mSourceURI as * const _ as usize } , 32usize , concat ! (
-                    "Alignment of field: " , stringify ! (
-                    nsStyleImageLayers_Layer ) , "::" , stringify ! (
-                    mSourceURI ) ));
-        assert_eq! (unsafe {
-                    & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mPosition as * const _ as usize } , 40usize , concat ! (
+                    mPosition as * const _ as usize } , 32usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! (
                     mPosition ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) . mSize
-                    as * const _ as usize } , 64usize , concat ! (
+                    as * const _ as usize } , 56usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! ( mSize )
                     ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) . mClip
-                    as * const _ as usize } , 92usize , concat ! (
+                    as * const _ as usize } , 84usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! ( mClip )
                     ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mOrigin as * const _ as usize } , 93usize , concat ! (
+                    mOrigin as * const _ as usize } , 85usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! ( mOrigin
                     ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mAttachment as * const _ as usize } , 94usize , concat ! (
+                    mAttachment as * const _ as usize } , 86usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! (
                     mAttachment ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mBlendMode as * const _ as usize } , 95usize , concat ! (
+                    mBlendMode as * const _ as usize } , 87usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! (
                     mBlendMode ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mComposite as * const _ as usize } , 96usize , concat ! (
+                    mComposite as * const _ as usize } , 88usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! (
                     mComposite ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mMaskMode as * const _ as usize } , 97usize , concat ! (
+                    mMaskMode as * const _ as usize } , 89usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! (
                     mMaskMode ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleImageLayers_Layer ) ) .
-                    mRepeat as * const _ as usize } , 98usize , concat ! (
+                    mRepeat as * const _ as usize } , 90usize , concat ! (
                     "Alignment of field: " , stringify ! (
                     nsStyleImageLayers_Layer ) , "::" , stringify ! ( mRepeat
                     ) ));
@@ -23508,7 +23513,7 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_nsStyleImageLayers() {
-        assert_eq!(::std::mem::size_of::<nsStyleImageLayers>() , 160usize ,
+        assert_eq!(::std::mem::size_of::<nsStyleImageLayers>() , 152usize ,
                    concat ! ( "Size of: " , stringify ! ( nsStyleImageLayers )
                    ));
         assert_eq! (::std::mem::align_of::<nsStyleImageLayers>() , 8usize ,
@@ -23589,7 +23594,7 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_nsStyleBackground() {
-        assert_eq!(::std::mem::size_of::<nsStyleBackground>() , 168usize ,
+        assert_eq!(::std::mem::size_of::<nsStyleBackground>() , 160usize ,
                    concat ! ( "Size of: " , stringify ! ( nsStyleBackground )
                    ));
         assert_eq! (::std::mem::align_of::<nsStyleBackground>() , 8usize ,
@@ -23602,7 +23607,7 @@ pub mod root {
                     , "::" , stringify ! ( mImage ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleBackground ) ) .
-                    mBackgroundColor as * const _ as usize } , 160usize ,
+                    mBackgroundColor as * const _ as usize } , 152usize ,
                     concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleBackground )
                     , "::" , stringify ! ( mBackgroundColor ) ));
@@ -25703,7 +25708,7 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_nsStyleSVGReset() {
-        assert_eq!(::std::mem::size_of::<nsStyleSVGReset>() , 200usize ,
+        assert_eq!(::std::mem::size_of::<nsStyleSVGReset>() , 192usize ,
                    concat ! ( "Size of: " , stringify ! ( nsStyleSVGReset )
                    ));
         assert_eq! (::std::mem::align_of::<nsStyleSVGReset>() , 8usize ,
@@ -25716,48 +25721,48 @@ pub mod root {
                     "::" , stringify ! ( mMask ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mClipPath as *
-                    const _ as usize } , 160usize , concat ! (
+                    const _ as usize } , 152usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mClipPath ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mStopColor as *
-                    const _ as usize } , 176usize , concat ! (
+                    const _ as usize } , 168usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mStopColor ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mFloodColor as
-                    * const _ as usize } , 180usize , concat ! (
+                    * const _ as usize } , 172usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mFloodColor ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mLightingColor
-                    as * const _ as usize } , 184usize , concat ! (
+                    as * const _ as usize } , 176usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mLightingColor ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mStopOpacity as
-                    * const _ as usize } , 188usize , concat ! (
+                    * const _ as usize } , 180usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mStopOpacity ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mFloodOpacity
-                    as * const _ as usize } , 192usize , concat ! (
+                    as * const _ as usize } , 184usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mFloodOpacity ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) .
-                    mDominantBaseline as * const _ as usize } , 196usize ,
+                    mDominantBaseline as * const _ as usize } , 188usize ,
                     concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mDominantBaseline ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mVectorEffect
-                    as * const _ as usize } , 197usize , concat ! (
+                    as * const _ as usize } , 189usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mVectorEffect ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGReset ) ) . mMaskType as *
-                    const _ as usize } , 198usize , concat ! (
+                    const _ as usize } , 190usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGReset ) ,
                     "::" , stringify ! ( mMaskType ) ));
     }
@@ -26000,6 +26005,9 @@ pub mod root {
     pub struct RawServoDeclarationBlock([u8; 0]);
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
+    pub struct RawServoStyleRule([u8; 0]);
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
     pub struct RawServoAnimationValue([u8; 0]);
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
@@ -26021,6 +26029,8 @@ pub mod root {
     pub type RawGeckoAnimationPropertySegment =
         root::mozilla::AnimationPropertySegment;
     pub type RawGeckoComputedTiming = root::mozilla::ComputedTiming;
+    pub type RawGeckoServoStyleRuleList =
+        root::nsTArray<*const root::RawServoStyleRule>;
     pub type RawServoAnimationValueMapBorrowed =
         *const root::RawServoAnimationValueMap;
     pub type RawGeckoNodeBorrowed = *const root::RawGeckoNode;
@@ -26047,6 +26057,8 @@ pub mod root {
         *const root::RawGeckoAnimationPropertySegment;
     pub type RawGeckoComputedTimingBorrowed =
         *const root::RawGeckoComputedTiming;
+    pub type RawGeckoServoStyleRuleListBorrowedMut =
+        *mut root::RawGeckoServoStyleRuleList;
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
     pub struct nsSVGAngle([u8; 0]);
@@ -26551,6 +26563,33 @@ pub mod root {
                     "::" , stringify ! ( mDefaultFantasySize ) ));
     }
     impl Clone for FontSizePrefs {
+        fn clone(&self) -> Self { *self }
+    }
+    #[repr(C)]
+    #[derive(Debug, Copy)]
+    pub struct GeckoFontMetrics {
+        pub mChSize: root::nscoord,
+        pub mXSize: root::nscoord,
+    }
+    #[test]
+    fn bindgen_test_layout_GeckoFontMetrics() {
+        assert_eq!(::std::mem::size_of::<GeckoFontMetrics>() , 8usize , concat
+                   ! ( "Size of: " , stringify ! ( GeckoFontMetrics ) ));
+        assert_eq! (::std::mem::align_of::<GeckoFontMetrics>() , 4usize ,
+                    concat ! (
+                    "Alignment of " , stringify ! ( GeckoFontMetrics ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const GeckoFontMetrics ) ) . mChSize as *
+                    const _ as usize } , 0usize , concat ! (
+                    "Alignment of field: " , stringify ! ( GeckoFontMetrics )
+                    , "::" , stringify ! ( mChSize ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const GeckoFontMetrics ) ) . mXSize as *
+                    const _ as usize } , 4usize , concat ! (
+                    "Alignment of field: " , stringify ! ( GeckoFontMetrics )
+                    , "::" , stringify ! ( mXSize ) ));
+    }
+    impl Clone for GeckoFontMetrics {
         fn clone(&self) -> Self { *self }
     }
     #[repr(C)]

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -2776,6 +2776,34 @@ fn static_assert() {
     }
 </%self:impl_trait>
 
+<%self:impl_trait style_struct_name="InheritedBox"
+                  skip_longhands="image-orientation">
+    // FIXME: Gecko uses a tricky way to store computed value of image-orientation
+    //        within an u8. We could inline following glue codes by implementing all
+    //        those tricky parts for Servo as well. But, it's not done yet just for
+    //        convenience.
+    pub fn set_image_orientation(&mut self, v: longhands::image_orientation::computed_value::T) {
+        use properties::longhands::image_orientation::computed_value::T;
+        match v {
+            T::FromImage => {
+                unsafe {
+                    bindings::Gecko_SetImageOrientationAsFromImage(&mut self.gecko);
+                }
+            },
+            T::AngleWithFlipped(ref angle, flipped) => {
+                unsafe {
+                    bindings::Gecko_SetImageOrientation(&mut self.gecko, angle.radians() as f64, flipped);
+                }
+            }
+        }
+    }
+
+    pub fn copy_image_orientation_from(&mut self, other: &Self) {
+        unsafe {
+            bindings::Gecko_CopyImageOrientationFrom(&mut self.gecko, &other.gecko);
+        }
+    }
+</%self:impl_trait>
 
 <%self:impl_trait style_struct_name="InheritedTable"
                   skip_longhands="border-spacing">
@@ -2789,7 +2817,6 @@ fn static_assert() {
         self.gecko.mBorderSpacingCol = other.gecko.mBorderSpacingCol;
         self.gecko.mBorderSpacingRow = other.gecko.mBorderSpacingRow;
     }
-
 </%self:impl_trait>
 
 

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -1332,6 +1332,7 @@ ${helpers.predefined_type("scroll-snap-coordinate",
         computed_value::T(None)
     }
 
+    // Allow unitless zero angle for rotate() and skew() to align with gecko
     pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue,()> {
         if input.try(|input| input.expect_ident_matching("none")).is_ok() {
             return Ok(SpecifiedValue(Vec::new()))
@@ -1469,28 +1470,28 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                 },
                 "rotate" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta = try!(specified::Angle::parse(context,input));
+                        let theta = try!(specified::Angle::parse_with_unitless(context,input));
                         result.push(SpecifiedOperation::Rotate(theta));
                         Ok(())
                     }))
                 },
                 "rotatex" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta = try!(specified::Angle::parse(context,input));
+                        let theta = try!(specified::Angle::parse_with_unitless(context,input));
                         result.push(SpecifiedOperation::RotateX(theta));
                         Ok(())
                     }))
                 },
                 "rotatey" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta = try!(specified::Angle::parse(context,input));
+                        let theta = try!(specified::Angle::parse_with_unitless(context,input));
                         result.push(SpecifiedOperation::RotateY(theta));
                         Ok(())
                     }))
                 },
                 "rotatez" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta = try!(specified::Angle::parse(context,input));
+                        let theta = try!(specified::Angle::parse_with_unitless(context,input));
                         result.push(SpecifiedOperation::RotateZ(theta));
                         Ok(())
                     }))
@@ -1503,7 +1504,7 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                         try!(input.expect_comma());
                         let az = try!(specified::parse_number(input));
                         try!(input.expect_comma());
-                        let theta = try!(specified::Angle::parse(context,input));
+                        let theta = try!(specified::Angle::parse_with_unitless(context,input));
                         // TODO(gw): Check the axis can be normalized!!
                         result.push(SpecifiedOperation::Rotate3D(ax, ay, az, theta));
                         Ok(())
@@ -1511,9 +1512,9 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                 },
                 "skew" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta_x = try!(specified::Angle::parse(context, input));
+                        let theta_x = try!(specified::Angle::parse_with_unitless(context, input));
                         if input.try(|input| input.expect_comma()).is_ok() {
-                            let theta_y = try!(specified::Angle::parse(context, input));
+                            let theta_y = try!(specified::Angle::parse_with_unitless(context, input));
                             result.push(SpecifiedOperation::Skew(theta_x, Some(theta_y)));
                         } else {
                             result.push(SpecifiedOperation::Skew(theta_x, None));
@@ -1523,14 +1524,14 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                 },
                 "skewx" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta_x = try!(specified::Angle::parse(context,input));
+                        let theta_x = try!(specified::Angle::parse_with_unitless(context,input));
                         result.push(SpecifiedOperation::SkewX(theta_x));
                         Ok(())
                     }))
                 },
                 "skewy" => {
                     try!(input.parse_nested_block(|input| {
-                        let theta_y = try!(specified::Angle::parse(context,input));
+                        let theta_y = try!(specified::Angle::parse_with_unitless(context,input));
                         result.push(SpecifiedOperation::SkewY(theta_y));
                         Ok(())
                     }))

--- a/components/style/properties/longhand/inherited_box.mako.rs
+++ b/components/style/properties/longhand/inherited_box.mako.rs
@@ -83,7 +83,7 @@ ${helpers.single_keyword("image-rendering",
 
 // Image Orientation
 <%helpers:longhand name="image-orientation"
-                   products="None"
+                   products="gecko"
                    animation_type="none"
     spec="https://drafts.csswg.org/css-images/#propdef-image-orientation, \
       /// additional values in https://developer.mozilla.org/en-US/docs/Web/CSS/image-orientation">
@@ -199,21 +199,23 @@ ${helpers.single_keyword("image-rendering",
         }
     }
 
+    // from-image | <angle> | [<angle>? flip]
     pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
         if input.try(|input| input.expect_ident_matching("from-image")).is_ok() {
             // Handle from-image
             Ok(SpecifiedValue { angle: None, flipped: false })
+        } else if input.try(|input| input.expect_ident_matching("flip")).is_ok() {
+            // Handle flip
+            Ok(SpecifiedValue { angle: Some(Angle::zero()), flipped: true })
         } else {
-            // Handle <angle> | <angle>? flip
+            // Handle <angle> | <angle> flip
             let angle = input.try(|input| Angle::parse(context, input)).ok();
-            let flipped = input.try(|input| input.expect_ident_matching("flip")).is_ok();
-            let explicit_angle = if angle.is_none() && !flipped {
-                Some(Angle::zero())
-            } else {
-                angle
-            };
+            if angle.is_none() {
+                return Err(());
+            }
 
-            Ok(SpecifiedValue { angle: explicit_angle, flipped: flipped })
+            let flipped = input.try(|input| input.expect_ident_matching("flip")).is_ok();
+            Ok(SpecifiedValue { angle: angle, flipped: flipped })
         }
     }
 </%helpers:longhand>

--- a/tests/unit/style/parsing/inherited_box.rs
+++ b/tests/unit/style/parsing/inherited_box.rs
@@ -17,7 +17,7 @@ fn image_orientation_longhand_should_parse_properly() {
     assert_eq!(from_image, SpecifiedValue { angle: None, flipped: false });
 
     let flip = parse_longhand!(image_orientation, "flip");
-    assert_eq!(flip, SpecifiedValue { angle: None, flipped: true });
+    assert_eq!(flip, SpecifiedValue { angle: Some(Angle::from_degrees(0.0)), flipped: true });
 
     let zero = parse_longhand!(image_orientation, "0deg");
     assert_eq!(zero, SpecifiedValue { angle: Some(Angle::from_degrees(0.0)), flipped: false });


### PR DESCRIPTION
First, we need to make Servo's image-orientation parser to be agreed with Gecko's.
Numbers without any AngleUnit, including unitless 0 angle, should be invalid
for image-orientation. However, rotate() and skew() for transform properties
accept unitless 0 angle. In order to make all these properties work properly,
I fixed Angle::parse() to match Gecko. For the existing users of Angle::parse(),
I create Angle::parse_with_unitless() and use it as an alternative for them.
Once https://github.com/w3c/csswg-drafts/issues/1162 is resolved, we shall be
able to use an unified version of Angle::parse() then.

The parser of image-orientation is also fixed to report parsing errors on
empty string.

Then, with the newly added binding functions support in Gecko side, we shall
reuse the same methods from Gecko to pass the computed value from Servo to Gecko.

Gecko bug: Bug 1341758

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16334)
<!-- Reviewable:end -->
