### PR TITLE
Used shared clips for overflow:hidden and CSS clip

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -29,13 +29,12 @@ use app_units::Au;
 use block::{BlockFlow, FormattingContextType};
 use context::LayoutContext;
 use display_list_builder::DisplayListBuildState;
-use euclid::{Matrix4D, Point2D, Size2D};
+use euclid::{Matrix4D, Point2D, Rect, Size2D};
 use flex::FlexFlow;
 use floats::{Floats, SpeculatedFloatPlacement};
 use flow_list::{FlowList, MutFlowListIterator};
 use flow_ref::{FlowRef, WeakFlowRef};
-use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
-use gfx::display_list::ClippingRegion;
+use fragment::{CoordinateSystem, Fragment, FragmentBorderBoxIterator, Overflow};
 use gfx_traits::{ScrollRootId, StackingContextId};
 use gfx_traits::print_tree::PrintTree;
 use inline::InlineFlow;
@@ -43,7 +42,7 @@ use model::{CollapsibleMargins, IntrinsicISizes, MarginCollapseInfo};
 use multicol::MulticolFlow;
 use parallel::FlowParallelInfo;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
-use servo_geometry::{au_rect_to_f32_rect, f32_rect_to_au_rect};
+use servo_geometry::{au_rect_to_f32_rect, f32_rect_to_au_rect, max_rect};
 use std::{fmt, mem, raw};
 use std::iter::Zip;
 use std::slice::IterMut;
@@ -264,6 +263,24 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
             }
         }
 
+        let border_box = self.as_block().fragment.stacking_relative_border_box(
+            &base(self).stacking_relative_position,
+            &base(self).early_absolute_position_info.relative_containing_block_size,
+            base(self).early_absolute_position_info.relative_containing_block_mode,
+            CoordinateSystem::Own);
+        if overflow_x::T::visible != self.as_block().fragment.style.get_box().overflow_x {
+            overflow.paint.origin.x = Au(0);
+            overflow.paint.size.width = border_box.size.width;
+            overflow.scroll.origin.x = Au(0);
+            overflow.scroll.size.width = border_box.size.width;
+        }
+        if overflow_x::T::visible != self.as_block().fragment.style.get_box().overflow_y.0 {
+            overflow.paint.origin.y = Au(0);
+            overflow.paint.size.height = border_box.size.height;
+            overflow.scroll.origin.y = Au(0);
+            overflow.scroll.size.height = border_box.size.height;
+        }
+
         if !self.as_block().fragment.establishes_stacking_context() ||
            self.as_block().fragment.style.get_box().transform.0.is_none() {
             overflow.translate(&position.origin);
@@ -311,40 +328,8 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
             FlowClass::Block |
             FlowClass::TableCaption |
             FlowClass::TableCell => {
-                let overflow_x = self.as_block().fragment.style.get_box().overflow_x;
-                let overflow_y = self.as_block().fragment.style.get_box().overflow_y;
-
                 for kid in mut_base(self).children.iter_mut() {
-                    let mut kid_overflow = kid.get_overflow_in_parent_coordinates();
-
-                    // If the overflow for this flow is hidden on a given axis, just
-                    // put the existing overflow in the kid rect, so that the union
-                    // has no effect on this axis.
-                    match overflow_x {
-                        overflow_x::T::hidden => {
-                            kid_overflow.paint.origin.x = overflow.paint.origin.x;
-                            kid_overflow.paint.size.width = overflow.paint.size.width;
-                            kid_overflow.scroll.origin.x = overflow.scroll.origin.x;
-                            kid_overflow.scroll.size.width = overflow.scroll.size.width;
-                        }
-                        overflow_x::T::scroll |
-                        overflow_x::T::auto |
-                        overflow_x::T::visible => {}
-                    }
-
-                    match overflow_y.0 {
-                        overflow_x::T::hidden => {
-                            kid_overflow.paint.origin.y = overflow.paint.origin.y;
-                            kid_overflow.paint.size.height = overflow.paint.size.height;
-                            kid_overflow.scroll.origin.y = overflow.scroll.origin.y;
-                            kid_overflow.scroll.size.height = overflow.scroll.size.height;
-                        }
-                        overflow_x::T::scroll |
-                        overflow_x::T::auto |
-                        overflow_x::T::visible => {}
-                    }
-
-                    overflow.union(&kid_overflow)
+                    overflow.union(&kid.get_overflow_in_parent_coordinates());
                 }
             }
             _ => {}
@@ -957,10 +942,10 @@ pub struct BaseFlow {
     /// assignment.
     pub late_absolute_position_info: LateAbsolutePositionInfo,
 
-    /// The clipping region for this flow and its descendants, in the coordinate system of the
+    /// The clipping rectangle for this flow and its descendants, in the coordinate system of the
     /// nearest ancestor stacking context. If this flow itself represents a stacking context, then
     /// this is in the flow's own coordinate system.
-    pub clip: ClippingRegion,
+    pub clip: Rect<Au>,
 
     /// The writing mode for this flow.
     pub writing_mode: WritingMode,
@@ -1115,7 +1100,7 @@ impl BaseFlow {
             absolute_cb: ContainingBlockLink::new(),
             early_absolute_position_info: EarlyAbsolutePositionInfo::new(writing_mode),
             late_absolute_position_info: LateAbsolutePositionInfo::new(),
-            clip: ClippingRegion::max(),
+            clip: max_rect(),
             flags: flags,
             writing_mode: writing_mode,
             thread_id: 0,

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -425,11 +425,16 @@ impl WebRenderDisplayItemConverter for DisplayItem {
             }
             DisplayItem::PopStackingContext(_) => builder.pop_stacking_context(),
             DisplayItem::PushScrollRoot(ref item) => {
-                let our_id = ClipId::new(item.scroll_root.id.0 as u64, builder.pipeline_id);
+                let pipeline_id = builder.pipeline_id;
+                builder.push_clip_id(item.scroll_root.parent_id.convert_to_webrender(pipeline_id));
+
+                let our_id = item.scroll_root.id.convert_to_webrender(pipeline_id);
                 let clip = item.scroll_root.clip.to_clip_region(builder);
                 let content_rect = item.scroll_root.content_rect.to_rectf();
                 let webrender_id = builder.define_clip(content_rect, clip, Some(our_id));
                 debug_assert!(our_id == webrender_id);
+
+                builder.pop_clip_id();
             }
             DisplayItem::PopScrollRoot(_) => {} //builder.pop_scroll_layer(),
         }

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -45,8 +45,7 @@ use euclid::rect::Rect;
 use euclid::scale_factor::ScaleFactor;
 use euclid::size::Size2D;
 use fnv::FnvHasher;
-use gfx::display_list::{ClippingRegion, OpaqueNode};
-use gfx::display_list::WebRenderImageInfo;
+use gfx::display_list::{OpaqueNode, WebRenderImageInfo};
 use gfx::font;
 use gfx::font_cache_thread::FontCacheThread;
 use gfx::font_context;
@@ -854,8 +853,7 @@ impl LayoutThread {
                 LogicalPoint::zero(writing_mode).to_physical(writing_mode,
                                                              self.viewport_size);
 
-            flow::mut_base(layout_root).clip =
-                ClippingRegion::from_rect(&data.page_clip_rect);
+            flow::mut_base(layout_root).clip = data.page_clip_rect;
 
             if flow::base(layout_root).restyle_damage.contains(REPOSITION) {
                 layout_root.traverse_preorder(&ComputeAbsolutePositions {

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-image-6.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/attachment-local-clipping-image-6.htm.ini
@@ -1,3 +1,0 @@
-[attachment-local-clipping-image-6.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-004.htm.ini
@@ -1,3 +1,0 @@
-[abspos-overflow-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-005.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-005.htm.ini
@@ -1,3 +1,0 @@
-[abspos-overflow-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-006.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-overflow-006.htm.ini
@@ -1,3 +1,0 @@
-[abspos-overflow-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/overflow-applies-to-014.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/overflow-applies-to-014.htm.ini
@@ -1,3 +1,0 @@
-[overflow-applies-to-014.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/overflow-applies-to-015.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/overflow-applies-to-015.htm.ini
@@ -1,3 +1,0 @@
-[overflow-applies-to-015.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -20601,7 +20601,7 @@
    "support"
   ],
   "css/border_radius_in_border_radius_a.html": [
-   "ee5099078e3403236fafbe82879c203f4c13cf50",
+   "64ad2121d35db22286fbea2d0835f2a36aa90570",
    "reftest"
   ],
   "css/border_radius_in_border_radius_ref.html": [
@@ -22813,11 +22813,11 @@
    "support"
   ],
   "css/overflow_clipping.html": [
-   "f87d3c74c15393fb490e3855c88f6331fce9e077",
+   "3e8eb236afa8013c19adbfa807b674a393fc1eed",
    "reftest"
   ],
   "css/overflow_clipping_ref.html": [
-   "d9a6a3b4fa21742d0f4ddd3f348534ec35ab8579",
+   "f645ece68f6c7afe273daee4d1ec172c7d245632",
    "support"
   ],
   "css/overflow_position_abs_inline_block.html": [

--- a/tests/wpt/mozilla/meta/css/overflow_position_abs_inside_normal_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/overflow_position_abs_inside_normal_a.html.ini
@@ -1,4 +1,0 @@
-[overflow_position_abs_inside_normal_a.html]
-  type: reftest
-  expected: FAIL
-  bug: https://github.com/servo/servo/issues/8780

--- a/tests/wpt/mozilla/tests/css/border_radius_in_border_radius_a.html
+++ b/tests/wpt/mozilla/tests/css/border_radius_in_border_radius_a.html
@@ -8,7 +8,6 @@ html, body {
 }
 
 .green {
-    overflow: hidden;
     border-radius: 50px;
     background: green;
     padding: 50px;

--- a/tests/wpt/mozilla/tests/css/overflow_clipping.html
+++ b/tests/wpt/mozilla/tests/css/overflow_clipping.html
@@ -18,7 +18,6 @@
         </style>
     </head>
     <body>
-
         <div class="test grayest box" style="overflow: scroll">
             <div style="position: relative;">
                 <div class="overflowing-absolute-child grayer"></div>
@@ -35,5 +34,52 @@
         </div>
         -->
 
+        <div style="height: 30px; clear: both;"> </div>
+
+        <div class="test grayest box" style="overflow: auto;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: fixed;"></div>
+        </div>
+        <div class="test grayest box" style="overflow: hidden;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: fixed;"></div>
+        </div>
+        <div class="test grayest box" style="overflow: scroll;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: fixed;"></div>
+        </div>
+
+        <div style="height: 30px; clear: both;"> </div>
+
+        <div class="test grayest box" style="overflow: auto;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: absolute;"></div>
+        </div>
+        <div class="test grayest box" style="overflow: hidden;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: absolute;"></div>
+        </div>
+        <div class="test grayest box" style="overflow: scroll;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: absolute;"></div>
+        </div>
+
+        <div style="height: 30px; clear: both;"> </div>
+
+        <div class="test grayest box" style="overflow: auto;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: relative;"></div>
+        </div>
+        <div class="test grayest box" style="overflow: hidden;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: relative;"></div>
+        </div>
+        <div class="test grayest box" style="overflow: scroll;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px; position: relative;"></div>
+        </div>
+
+        <div style="height: 30px; clear: both;"> </div>
+
+        <div class="test grayest box" style="overflow: auto;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+        <div class="test grayest box" style="overflow: hidden;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+        <div class="test grayest box" style="overflow: scroll;">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
     </body>
 </html>

--- a/tests/wpt/mozilla/tests/css/overflow_clipping_ref.html
+++ b/tests/wpt/mozilla/tests/css/overflow_clipping_ref.html
@@ -22,5 +22,53 @@
             <div class="grayer smallbox" style="margin-left: 10px; margin-top: 25px; height: 25px;"></div>
         </div>
         -->
+
+        <div style="height: 30px; clear: both;"> </div>
+
+        <div class="test grayest box">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+        <div class="test grayest box">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+        <div class="test grayest box">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+
+        <div style="height: 30px; clear: both;"> </div>
+
+        <div class="test grayest box">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+        <div class="test grayest box">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+        <div class="test grayest box">
+            <div class="grayer box" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+
+        <div style="height: 30px; clear: both;"> </div>
+
+        <div class="test grayest box">
+            <div class="grayer smallbox" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+        <div class="test grayest box">
+            <div class="grayer smallbox" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+        <div class="test grayest box">
+            <div class="grayer smallbox" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+
+        <div style="height: 30px; clear: both;"> </div>
+
+        <div class="test grayest box">
+            <div class="grayer smallbox" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+        <div class="test grayest box">
+            <div class="grayer smallbox" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
+        <div class="test grayest box">
+            <div class="grayer smallbox" style="margin-left: 10px; margin-top: 10px;"></div>
+        </div>
     </body>
 </html>


### PR DESCRIPTION
Instead of passing down a complex clipping region to each item, used
shared clipping to handle overflow:hidden and CSS clips. In addition to
being more efficient, this should also fix quite a few issues related
to absolutely positioned elements.

One existing reftest is slightly modified to avoid tickling a quirk
with the way that WebRender rasterizes masks. We are working out how to
best express these combined masks with the API or need to. The change
does not affect the original subject of the reftest.

Fixes #13109.
Fixes #10151.
Fixes #7575.
Fixes #8074.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13109, #10151, #7575, #8074.

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16336)
<!-- Reviewable:end -->
