### PR TITLE
layout: Fix intrinsic inline size calculating of inline blocks

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1547,31 +1547,29 @@ impl Fragment {
             }
         };
 
-        // Take borders and padding for parent inline fragments into account, if necessary.
-        if self.is_primary_fragment() {
-            let writing_mode = self.style.writing_mode;
-            if let Some(ref context) = self.inline_context {
-                for node in &context.nodes {
-                    let mut border_width = node.style.logical_border_width();
-                    let mut padding = model::padding_from_style(&*node.style, Au(0), writing_mode);
-                    let mut margin = model::specified_margin_from_style(&*node.style, writing_mode);
-                    if !node.flags.contains(FIRST_FRAGMENT_OF_ELEMENT) {
-                        border_width.inline_start = Au(0);
-                        padding.inline_start = Au(0);
-                        margin.inline_start = Au(0);
-                    }
-                    if !node.flags.contains(LAST_FRAGMENT_OF_ELEMENT) {
-                        border_width.inline_end = Au(0);
-                        padding.inline_end = Au(0);
-                        margin.inline_end = Au(0);
-                    }
-
-                    result.surrounding_size =
-                        result.surrounding_size +
-                        border_width.inline_start_end() +
-                        padding.inline_start_end() +
-                        margin.inline_start_end();
+        // Take borders and padding for parent inline fragments into account.
+        let writing_mode = self.style.writing_mode;
+        if let Some(ref context) = self.inline_context {
+            for node in &context.nodes {
+                let mut border_width = node.style.logical_border_width();
+                let mut padding = model::padding_from_style(&*node.style, Au(0), writing_mode);
+                let mut margin = model::specified_margin_from_style(&*node.style, writing_mode);
+                if !node.flags.contains(FIRST_FRAGMENT_OF_ELEMENT) {
+                    border_width.inline_start = Au(0);
+                    padding.inline_start = Au(0);
+                    margin.inline_start = Au(0);
                 }
+                if !node.flags.contains(LAST_FRAGMENT_OF_ELEMENT) {
+                    border_width.inline_end = Au(0);
+                    padding.inline_end = Au(0);
+                    margin.inline_end = Au(0);
+                }
+
+                result.surrounding_size =
+                    result.surrounding_size +
+                    border_width.inline_start_end() +
+                    padding.inline_start_end() +
+                    margin.inline_start_end();
             }
         }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2687,6 +2687,18 @@
      {}
     ]
    ],
+   "css/inline_block_nested_margin.html": [
+    [
+     "/_mozilla/css/inline_block_nested_margin.html",
+     [
+      [
+       "/_mozilla/css/inline_block_nested_margin_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/inline_block_opacity_change.html": [
     [
      "/_mozilla/css/inline_block_opacity_change.html",
@@ -7858,6 +7870,11 @@
     ]
    ],
    "css/inline_block_min_width_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "css/inline_block_nested_margin_ref.html": [
     [
      {}
     ]
@@ -21768,6 +21785,14 @@
   ],
   "css/inline_block_min_width_ref.html": [
    "ed6e0f503cb26c1091270ed0992a0a41553846d9",
+   "support"
+  ],
+  "css/inline_block_nested_margin.html": [
+   "b4114aa6421b4c9117e60e66ccc09868e05f3239",
+   "reftest"
+  ],
+  "css/inline_block_nested_margin_ref.html": [
+   "5e00c77f55a3d12e841e9c99395f4d3783664fd8",
    "support"
   ],
   "css/inline_block_opacity_change.html": [

--- a/tests/wpt/mozilla/tests/css/inline_block_nested_margin.html
+++ b/tests/wpt/mozilla/tests/css/inline_block_nested_margin.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="match" href="inline_block_nested_margin_ref.html">
+<style>
+ #outer {
+     margin: 0 50px;
+ }
+ #inner {
+     display: inline-block;
+     width: 200px;
+     height: 40px;
+     background: orange;
+ }
+</style>
+<span id="outer"><span id="inner"></span></span>

--- a/tests/wpt/mozilla/tests/css/inline_block_nested_margin_ref.html
+++ b/tests/wpt/mozilla/tests/css/inline_block_nested_margin_ref.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+ #inner {
+     display: inline-block;
+     width: 200px;
+     height: 40px;
+     background: orange;
+     margin: 0 50px;
+ }
+</style>
+<span id="inner"></span>


### PR DESCRIPTION
When calculating intrinsic inline sizes of an inline block, take its
nested inline parents into account.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #7636 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16337)
<!-- Reviewable:end -->
