### PR TITLE
Fix -moz-outline-radius shorthand serialization

### DIFF
--- a/components/style/properties/shorthand/outline.mako.rs
+++ b/components/style/properties/shorthand/outline.mako.rs
@@ -68,6 +68,7 @@
     for corner in ['topleft', 'topright', 'bottomright', 'bottomleft']
 )}" products="gecko" spec="Nonstandard (https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-outline-radius)">
     use properties::shorthands;
+    use values::specified::basic_shape::serialize_radius_values;
 
     pub fn parse_value(context: &ParserContext, input: &mut Parser) -> Result<Longhands, ()> {
         // Re-use border-radius parsing.
@@ -80,19 +81,14 @@
         })
     }
 
-    // TODO: Border radius for the radius shorthand is not implemented correctly yet
     impl<'a> ToCss for LonghandsToSerialize<'a>  {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            try!(self._moz_outline_radius_topleft.to_css(dest));
-            try!(write!(dest, " "));
-
-            try!(self._moz_outline_radius_topright.to_css(dest));
-            try!(write!(dest, " "));
-
-            try!(self._moz_outline_radius_bottomright.to_css(dest));
-            try!(write!(dest, " "));
-
-            self._moz_outline_radius_bottomleft.to_css(dest)
+            serialize_radius_values(dest,
+                &self._moz_outline_radius_topleft.0,
+                &self._moz_outline_radius_topright.0,
+                &self._moz_outline_radius_bottomright.0,
+                &self._moz_outline_radius_bottomleft.0,
+            )
         }
     }
 </%helpers:shorthand>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
These changes aim to solve #15169 correcting the `ToCss` implementation for `LonghandsToSerialize` for the `border-radius` shorthands. They also reduce redundant values like `1px 2px 1px 2px` to `1px 2px` to either sides of the slash.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15169 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes

## Update
#12655 Already deals with border radius, so this is going to be about `-moz-outline-radius` which needs the same implementation and uses the new features merged in #16383 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16340)
<!-- Reviewable:end -->
