### PR TITLE
Included block to handle application/xml

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -585,6 +585,9 @@ impl FetchResponseListener for ParserContext {
                 }
             },
             Some(ContentType(Mime(TopLevel::Text, SubLevel::Xml, _))) => {}, // Handle text/xml
+
+            Some(ContentType(Mime(TopLevel::Application, SubLevel::Xml, _))) => {}, // Handle application/xml
+
             Some(ContentType(Mime(toplevel, sublevel, _))) => {
                 if toplevel.as_str() == "application" && sublevel.as_str() == "xhtml+xml" {
                     // Handle xhtml (application/xhtml+xml).


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Hey @jdm, based on my understanding of the issue, I have added a new branch in the match to handle application/xml content type. So now when the block encounters application/xml, it  does nothing special and proceeds to process the rest of the page as usual.  The "Unknown content type" message is no longer displayed when application/xml is encountered.

Is this the update that was expected? It seems like a very simple fix and I was wondering if there was something that I was missing out on doing (like adding a new and more relevant message on encountering application/xml)
 
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15850 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16341)
<!-- Reviewable:end -->
