### PR TITLE
Call process_animation only if it's not animation-only restyles

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -906,11 +906,11 @@ pub trait MatchMethods : TElement {
 
     /// Updates the rule nodes without re-running selector matching, using just
     /// the rule tree. Returns true if the rule nodes changed.
-    fn cascade_with_replacements(&self,
-                                 hint: RestyleHint,
-                                 context: &StyleContext<Self>,
-                                 data: &mut AtomicRefMut<ElementData>)
-                                 -> bool {
+    fn replace_rules(&self,
+                     hint: RestyleHint,
+                     context: &StyleContext<Self>,
+                     data: &mut AtomicRefMut<ElementData>)
+                     -> bool {
         use properties::PropertyDeclarationBlock;
         use shared_lock::Locked;
 

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -433,7 +433,7 @@ trait PrivateMatchMethods: TElement {
                                                    &pseudo_style);
 
         // Handle animations.
-        if animate {
+        if animate && !context.shared.traversal_flags.for_animation_only() {
             self.process_animations(context,
                                     &mut old_values,
                                     &mut new_values,

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -711,7 +711,7 @@ fn compute_style<E, D>(_traversal: &D,
         }
         CascadeWithReplacements(hint) => {
             let _rule_nodes_changed =
-                element.cascade_with_replacements(hint, context, &mut data);
+                element.replace_rules(hint, context, &mut data);
             element.cascade_primary_and_pseudos(context, &mut data);
         }
         CascadeOnly => {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is a PR of https://bugzilla.mozilla.org/show_bug.cgi?id=1354426

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's for stylo.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16344)
<!-- Reviewable:end -->
