### PR TITLE
stylo: Correct computed value of mask-image.

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -2374,8 +2374,8 @@ fn static_assert() {
             % else:
                 use properties::longhands::mask_image::single_value::computed_value::T;
                 match image {
-                    T::Image(image) => geckoimage.mImage.set(image, false, cacheable),
-                    _ => () // we need to support url valeus
+                    T::Image(image) => geckoimage.mImage.set(image, true, cacheable),
+                    _ => ()
                 }
             % endif
 

--- a/components/style/properties/longhand/svg.mako.rs
+++ b/components/style/properties/longhand/svg.mako.rs
@@ -218,7 +218,6 @@ ${helpers.single_keyword("mask-composite",
         #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
         pub enum T {
             Image(computed::Image),
-            Url(SpecifiedUrl),
             None
         }
 
@@ -227,7 +226,6 @@ ${helpers.single_keyword("mask-composite",
                 match *self {
                     T::None => dest.write_str("none"),
                     T::Image(ref image) => image.to_css(dest),
-                    T::Url(ref url) => url.to_css(dest),
                 }
             }
         }
@@ -239,7 +237,6 @@ ${helpers.single_keyword("mask-composite",
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum SpecifiedValue {
         Image(Image),
-        Url(SpecifiedUrl),
         None
     }
 
@@ -247,7 +244,6 @@ ${helpers.single_keyword("mask-composite",
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self {
                 SpecifiedValue::Image(ref image) => image.to_css(dest),
-                SpecifiedValue::Url(ref url) => url.to_css(dest),
                 SpecifiedValue::None => dest.write_str("none"),
             }
         }
@@ -268,11 +264,7 @@ ${helpers.single_keyword("mask-composite",
             let image = try!(Image::parse(context, input));
             match image {
                 Image::Url(url_value) => {
-                    if url_value.is_fragment() {
-                        Ok(SpecifiedValue::Url(url_value))
-                    } else {
-                        Ok(SpecifiedValue::Image(Image::Url(url_value)))
-                    }
+                    Ok(SpecifiedValue::Image(Image::Url(url_value)))
                 }
                 image => Ok(SpecifiedValue::Image(image))
             }
@@ -287,8 +279,6 @@ ${helpers.single_keyword("mask-composite",
                 SpecifiedValue::None => computed_value::T::None,
                 SpecifiedValue::Image(ref image) =>
                     computed_value::T::Image(image.to_computed_value(context)),
-                SpecifiedValue::Url(ref url) =>
-                    computed_value::T::Url(url.clone()),
             }
         }
 
@@ -298,8 +288,6 @@ ${helpers.single_keyword("mask-composite",
                 computed_value::T::None => SpecifiedValue::None,
                 computed_value::T::Image(ref image) =>
                     SpecifiedValue::Image(ToComputedValue::from_computed_value(image)),
-                computed_value::T::Url(ref url) =>
-                    SpecifiedValue::Url(url.clone()),
             }
         }
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The patch is part of fix in Bug 1341667(stylo: Figure out why all the W3C masking reftests fail)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16345)
<!-- Reviewable:end -->
