### PR TITLE
Remove the show-compositor-borders debug option

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -86,10 +86,6 @@ pub struct Opts {
     /// browser engines.
     pub bubble_inline_sizes_separately: bool,
 
-    /// True if we should show borders on all layers and tiles for
-    /// debugging purposes (`--show-debug-borders`).
-    pub show_debug_borders: bool,
-
     /// True if we should show borders on all fragments for debugging purposes
     /// (`--show-debug-fragment-borders`).
     pub show_debug_fragment_borders: bool,
@@ -285,9 +281,6 @@ pub struct DebugOptions {
     /// Enable all heartbeats for profiling.
     pub profile_heartbeats: bool,
 
-    /// Paint borders along layer and tile boundaries.
-    pub show_compositor_borders: bool,
-
     /// Paint borders along fragment boundaries.
     pub show_fragment_borders: bool,
 
@@ -369,7 +362,6 @@ impl DebugOptions {
                 "relayout-event" => self.relayout_event = true,
                 "profile-script-events" => self.profile_script_events = true,
                 "profile-heartbeats" => self.profile_heartbeats = true,
-                "show-compositor-borders" => self.show_compositor_borders = true,
                 "show-fragment-borders" => self.show_fragment_borders = true,
                 "show-parallel-paint" => self.show_parallel_paint = true,
                 "show-parallel-layout" => self.show_parallel_layout = true,
@@ -525,7 +517,6 @@ pub fn default_opts() -> Opts {
         headless: true,
         hard_fail: true,
         bubble_inline_sizes_separately: false,
-        show_debug_borders: false,
         show_debug_fragment_borders: false,
         show_debug_parallel_paint: false,
         show_debug_parallel_layout: false,
@@ -841,7 +832,6 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         sandbox: opt_match.opt_present("S"),
         random_pipeline_closure_probability: random_pipeline_closure_probability,
         random_pipeline_closure_seed: random_pipeline_closure_seed,
-        show_debug_borders: debug_options.show_compositor_borders,
         show_debug_fragment_borders: debug_options.show_fragment_borders,
         show_debug_parallel_paint: debug_options.show_parallel_paint,
         show_debug_parallel_layout: debug_options.show_parallel_layout,


### PR DESCRIPTION
This was used by the old compositor of which only the ghostly echoes of
old commits remain. Since it's been unused for quite some time, it is
probably safe to remove it.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they do not change functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16350)
<!-- Reviewable:end -->
