### PR TITLE
stylo: Assert that we have computed style in Servo_ResolveStyle when lazy computation is forbidden.

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1654,7 +1654,8 @@ pub extern "C" fn Servo_ResolveStyle(element: RawGeckoElementBorrowed,
     };
 
     if !valid_styles {
-        warn!("Resolving style on element without current styles with lazy computation forbidden.");
+        debug_assert!(false, "Resolving style on element without current styles with lazy \
+                              computation forbidden.");
         let per_doc_data = PerDocumentStyleData::from_ffi(raw_data).borrow();
         return per_doc_data.default_computed_values().clone().into_strong();
     }


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1345695.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16359)
<!-- Reviewable:end -->
