### PR TITLE
Make stylo recognize -moz-crisp-edges keyword.

### DIFF
--- a/components/style/properties/longhand/inherited_box.mako.rs
+++ b/components/style/properties/longhand/inherited_box.mako.rs
@@ -70,13 +70,14 @@ ${helpers.single_keyword("color-adjust",
                          animation_type="none",
                          spec="https://drafts.csswg.org/css-color/#propdef-color-adjust")}
 
-<% image_rendering_custom_consts = { "crisp-edges": "CRISPEDGES" } %>
+<% image_rendering_custom_consts = { "crisp-edges": "CRISPEDGES",
+                                     "-moz-crisp-edges": "CRISPEDGES" } %>
 // According to to CSS-IMAGES-3, `optimizespeed` and `optimizequality` are synonyms for `auto`
 // And, firefox doesn't support `pixelated` yet (https://bugzilla.mozilla.org/show_bug.cgi?id=856337)
 ${helpers.single_keyword("image-rendering",
-                         "auto crisp-edges",
-                         extra_gecko_values="optimizespeed optimizequality",
-                         extra_servo_values="pixelated",
+                         "auto",
+                         extra_gecko_values="optimizespeed optimizequality -moz-crisp-edges",
+                         extra_servo_values="pixelated crisp-edges",
                          custom_consts=image_rendering_custom_consts,
                          animation_type="none",
                          spec="https://drafts.csswg.org/css-images/#propdef-image-rendering")}


### PR DESCRIPTION

<!-- Please describe your changes on the following line: -->

See [Bug 1354000](https://bugzilla.mozilla.org/show_bug.cgi?id=1354000).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1354000](https://bugzilla.mozilla.org/show_bug.cgi?id=1354000)

<!-- Either: -->
- [X] These changes do not require tests because the they're in gecko.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16361)
<!-- Reviewable:end -->
