### PR TITLE
stylo: Use prefixed values in ExtremumLength

### DIFF
--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -201,7 +201,14 @@ ${helpers.predefined_type("flex-basis",
                     ${MinMax}Length::${initial}
                 }
                 fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-                    ${MinMax}Length::parse(context, input).map(SpecifiedValue)
+                    let ret = ${MinMax}Length::parse(context, input);
+                    // Keyword values don't make sense in the block direction; don't parse them
+                    % if "block" in size:
+                        if let Ok(${MinMax}Length::ExtremumLength(..)) = ret {
+                            return Err(())
+                        }
+                    % endif
+                    ret.map(SpecifiedValue)
                 }
 
                 impl ToCss for SpecifiedValue {

--- a/components/style/values/mod.rs
+++ b/components/style/values/mod.rs
@@ -192,7 +192,7 @@ impl<A: ToComputedValue, B: ToComputedValue> ToComputedValue for Either<A, B> {
 // A type for possible values for min- and max- flavors of width,
 // height, block-size, and inline-size.
 define_css_keyword_enum!(ExtremumLength:
-                         "max-content" => MaxContent,
-                         "min-content" => MinContent,
-                         "fit-content" => FitContent,
-                         "fill-available" => FillAvailable);
+                         "-moz-max-content" => MaxContent,
+                         "-moz-min-content" => MinContent,
+                         "-moz-fit-content" => FitContent,
+                         "-moz-available" => FillAvailable);


### PR DESCRIPTION
r=xidorn https://bugzilla.mozilla.org/show_bug.cgi?id=1355674

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16363)
<!-- Reviewable:end -->
