### PR TITLE
style: Fix dynamic changes of attributes when combined with :not.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
          - bash etc/ci/lockfile_changed.sh
          - bash etc/ci/manifest_changed.sh
          - ./mach cargo test -p selectors
+         - ./mach cargo test -p style
       cache:
         directories:
           - .cargo

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -184,6 +184,9 @@ impl<Impl: SelectorImpl> SelectorMethods for SimpleSelector<Impl> {
         where V: SelectorVisitor<Impl = Impl>,
     {
         use self::SimpleSelector::*;
+        if !visitor.visit_simple_selector(self) {
+            return false;
+        }
 
         match *self {
             Negation(ref negated) => {

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -1164,7 +1164,7 @@ pub mod tests {
     impl SelectorMethods for PseudoClass {
         type Impl = DummySelectorImpl;
 
-        fn visit<V>(&self, visitor: &mut V) -> bool
+        fn visit<V>(&self, _visitor: &mut V) -> bool
             where V: SelectorVisitor<Impl = Self::Impl> { true }
     }
 
@@ -1500,5 +1500,27 @@ pub mod tests {
             pseudo_element: None,
             specificity: specificity(1, 1, 0),
         }))));
+    }
+
+    struct TestVisitor {
+        seen: Vec<String>,
+    }
+
+    impl SelectorVisitor for TestVisitor {
+        type Impl = DummySelectorImpl;
+
+        fn visit_simple_selector(&mut self, s: &SimpleSelector<DummySelectorImpl>) -> bool {
+            let mut dest = String::new();
+            s.to_css(&mut dest).unwrap();
+            self.seen.push(dest);
+            true
+        }
+    }
+
+    #[test]
+    fn visitor() {
+        let mut test_visitor = TestVisitor { seen: vec![], };
+        parse(":not(:hover) ~ label").unwrap().0[0].visit(&mut test_visitor);
+        assert!(test_visitor.seen.contains(&":hover".into()));
     }
 }

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -145,7 +145,7 @@ impl<Impl: SelectorImpl> SelectorMethods for Selector<Impl> {
     }
 }
 
-impl<Impl: SelectorImpl> SelectorMethods for Arc<ComplexSelector<Impl>> {
+impl<Impl: SelectorImpl> SelectorMethods for ComplexSelector<Impl> {
     type Impl = Impl;
 
     fn visit<V>(&self, visitor: &mut V) -> bool

--- a/components/selectors/visitor.rs
+++ b/components/selectors/visitor.rs
@@ -6,7 +6,7 @@
 
 #![deny(missing_docs)]
 
-use parser::{AttrSelector, Combinator, ComplexSelector, SelectorImpl};
+use parser::{AttrSelector, Combinator, ComplexSelector, SelectorImpl, SimpleSelector};
 use std::sync::Arc;
 
 /// A trait to visit selector properties.
@@ -21,6 +21,11 @@ pub trait SelectorVisitor {
     /// that may never match, like those containing whitespace or the empty
     /// string).
     fn visit_attribute_selector(&mut self, _: &AttrSelector<Self::Impl>) -> bool {
+        true
+    }
+
+    /// Visit a simple selector.
+    fn visit_simple_selector(&mut self, _: &SimpleSelector<Self::Impl>) -> bool {
         true
     }
 

--- a/components/selectors/visitor.rs
+++ b/components/selectors/visitor.rs
@@ -7,7 +7,6 @@
 #![deny(missing_docs)]
 
 use parser::{AttrSelector, Combinator, ComplexSelector, SelectorImpl, SimpleSelector};
-use std::sync::Arc;
 
 /// A trait to visit selector properties.
 ///

--- a/components/selectors/visitor.rs
+++ b/components/selectors/visitor.rs
@@ -34,7 +34,7 @@ pub trait SelectorVisitor {
     /// Gets the combinator to the right of the selector, or `None` if the
     /// selector is the leftmost one.
     fn visit_complex_selector(&mut self,
-                              _: &Arc<ComplexSelector<Self::Impl>>,
+                              _: &ComplexSelector<Self::Impl>,
                               _combinator_to_right: Option<Combinator>)
                               -> bool {
         true

--- a/components/style/gecko/selector_parser.rs
+++ b/components/style/gecko/selector_parser.rs
@@ -8,7 +8,6 @@ use cssparser::{Parser, ToCss};
 use element_state::ElementState;
 use gecko_bindings::structs::CSSPseudoClassType;
 use gecko_bindings::structs::nsIAtom;
-use restyle_hints::complex_selector_to_state;
 use selector_parser::{SelectorParser, PseudoElementCascadeType};
 use selectors::parser::{ComplexSelector, SelectorMethods};
 use selectors::visitor::SelectorVisitor;
@@ -313,11 +312,7 @@ impl NonTSPseudoClass {
                 match *self {
                     $(NonTSPseudoClass::$name => flag!($state),)*
                     $(NonTSPseudoClass::$s_name(..) => flag!($s_state),)*
-                    NonTSPseudoClass::MozAny(ref selectors) => {
-                        selectors.iter().fold(ElementState::empty(), |state, s| {
-                            state | complex_selector_to_state(s)
-                        })
-                    }
+                    NonTSPseudoClass::MozAny(..) => ElementState::empty(),
                 }
             }
         }

--- a/components/style/restyle_hints.rs
+++ b/components/style/restyle_hints.rs
@@ -684,7 +684,7 @@ impl DependencySet {
             debug_assert!((!state_changes.is_empty() && !dep.sensitivities.states.is_empty()) ||
                           (attrs_changed && dep.sensitivities.attrs),
                           "Testing a known ineffective dependency?");
-            if (attrs_changed || state_changes.intersects(dep.sensitivities.states)) && !hint.intersects(dep.hint) {
+            if (attrs_changed || state_changes.intersects(dep.sensitivities.states)) && !hint.contains(dep.hint) {
                 // We can ignore the selector flags, since they would have already been set during
                 // original matching for any element that might change its matching behavior here.
                 let matched_then =

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -3743,6 +3743,18 @@
      {}
     ]
    ],
+   "css/negation-attr-dependence.html": [
+    [
+     "/_mozilla/css/negation-attr-dependence.html",
+     [
+      [
+       "/_mozilla/css/negation-attr-dependence-ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/negative-calc-cv.html": [
     [
      "/_mozilla/css/negative-calc-cv.html",
@@ -8295,6 +8307,11 @@
     ]
    ],
    "css/multiple_css_class_b.html": [
+    [
+     {}
+    ]
+   ],
+   "css/negation-attr-dependence-ref.html": [
     [
      {}
     ]
@@ -22500,6 +22517,14 @@
   "css/multiple_css_class_b.html": [
    "a82c94a9a4a18cda6009e467993cace8babe7591",
    "support"
+  ],
+  "css/negation-attr-dependence-ref.html": [
+   "560c5d8b523f6d4cad6e15e5604f51646647d487",
+   "support"
+  ],
+  "css/negation-attr-dependence.html": [
+   "27bec4af590a2e6d5e88b54ed37fd254ef0f0a99",
+   "reftest"
   ],
   "css/negative-calc-cv-ref.html": [
    "a42f34470ead45d5865562618f6538fde263a359",

--- a/tests/wpt/mozilla/tests/css/negation-attr-dependence-ref.html
+++ b/tests/wpt/mozilla/tests/css/negation-attr-dependence-ref.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<style>
+  .foo + div { background: green; width: 100px; height: 100px; }
+</style>
+<div class="foo"></div>
+<div>Should be green</div>

--- a/tests/wpt/mozilla/tests/css/negation-attr-dependence.html
+++ b/tests/wpt/mozilla/tests/css/negation-attr-dependence.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: Negation with attribute dependence correctly restyle siblings.</title>
+<link rel="match" href="negation-attr-dependence-ref.html">
+<style>
+  :not(.foo) + div { background: green; width: 100px; height: 100px; }
+</style>
+<link rel="matches" href="negation-attr-dependence-ref.html">
+<div class="foo"></div>
+<div>Should be green</div>
+<script>
+window.onload = function() {
+  document.querySelector('div').className = "";
+}
+</script>


### PR DESCRIPTION
This makes the dependency tracker properly recurse into simple selectors inside the current complex selector to find the appropriate dependencies.

We can't still remove the outer visitor because we need it for stuff like `:not(.foo + bar)`, but I plan to get rid of it in a followup as long as try comes back green.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16364)
<!-- Reviewable:end -->
