### PR TITLE
Check for merge commits with tidy

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -1052,16 +1052,29 @@ def run_lint_scripts(only_changed_files=False, progress=True, stylo=False):
 
 
 def check_commits(path='.'):
+    """ Checks if the test is being run under Travis CI environment
+        This is necessary since, after travis clones the branch for a PR, it merges
+        the branch against master, creating a merge commit. Hence, as a workaround,
+        we have to check if the second last merge commit is done by the author of
+        the pull request.
+        """
+    is_travis = os.environ.get('TRAVIS') == 'true'
+    number_commits = '-n2' if is_travis else '-n1'
+
     """Gets all commits since the last merge."""
-    args = ['git', 'log', '-n1', '--merges', '--format=%H']
-    last_merge = subprocess.check_output(args, cwd=path).strip()
-    args = ['git', 'log', '{}..HEAD'.format(last_merge), '--format=%s']
+    args = ['git', 'log', number_commits, '--merges', '--format=%H:%an']
+    # last_merge stores both the commit hash and the author name of the last merge in the output
+    last_merge_hash, last_merge_author = subprocess.check_output(args, cwd=path).strip().splitlines()[-1].split(':')
+    args = ['git', 'log', '{}..HEAD'.format(last_merge_hash), '--format=%s']
     commits = subprocess.check_output(args, cwd=path).lower().splitlines()
 
     for commit in commits:
         # .split() to only match entire words
         if 'wip' in commit.split():
-            yield ('.', 0, 'no commits should contain WIP')
+            yield (':', ':', 'no commits should contain WIP')
+
+    if last_merge_author != 'bors-servo':
+        yield (':', ':', 'no merge commits allowed, please rebase your commits over the upstream master branch')
 
     raise StopIteration
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Tidy checks the last merge commit and their author and reports an error if the **last merge commit**'s author is not `bors-servo`.

In case the tidy test is run under Travis (checked by looking at the [value of the `TRAVIS` environment variable](https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables), the number of commits looked at from `git log --merges` is two, and the second last merge commit is checked, since, from the [Travis docs](https://docs.travis-ci.com/user/pull-requests/#My-Pull-Request-isn%E2%80%99t-being-built):
> We rely on the merge commit that GitHub transparently creates between the changes in the source branch and the upstream branch the pull request is sent against.

So this is the test that I did:
```
$ git pull upstream master
...
$ git log --merges
commit 8262c109378dfe5452535e77ec6a5eb9f8e82f77
Merge: e2c7e3d1e2 7ba3f1e4f3
Author: Sadman Kazi <sadman@sadmansk.com>
Date:   Wed Apr 12 01:07:30 2017 -0400

    Merge branch 'master' of github.com:servo/servo into check-merge-commits

commit 7ba3f1e4f3064ec3054b2346062758375b8ab117
Merge: 7262270990 90697ab8e6
Author: bors-servo <lbergstrom+bors@mozilla.com>
Date:   Tue Apr 11 22:52:23 2017 -0500

    Auto merge of #16358 - bholley:style_sharing_fixes, r=emilio
...
$ ./mach test-tidy
Checking the config file...
Checking directories for correct file extensions...
:::: no merge commits allowed by authors other than bors-servo
```
Obviously I didn't push the HEAD with the merge commit 😅 , it was just for testing.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix  #15673

<!-- Either: -->
- [X] These changes do not require tests because I'm not really sure how one would go about automating this test

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16366)
<!-- Reviewable:end -->
