### PR TITLE
Store style system options in the global style data and shared style context.

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -107,7 +107,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::thread;
 use style::animation::Animation;
-use style::context::{QuirksMode, ReflowGoal, SharedStyleContext, ThreadLocalStyleContextCreationInfo};
+use style::context::{QuirksMode, ReflowGoal, SharedStyleContext};
+use style::context::{StyleSystemOptions, ThreadLocalStyleContextCreationInfo};
 use style::data::StoredRestyleHint;
 use style::dom::{ShowSubtree, ShowSubtreeDataAndPrimaryValues, TElement, TNode};
 use style::error_reporting::StdoutErrorReporter;
@@ -516,6 +517,7 @@ impl LayoutThread {
         LayoutContext {
             style_context: SharedStyleContext {
                 stylist: rw_data.stylist.clone(),
+                options: StyleSystemOptions::default(),
                 guards: guards,
                 running_animations: self.running_animations.clone(),
                 expired_animations: self.expired_animations.clone(),

--- a/components/style/gecko/global_style_data.rs
+++ b/components/style/gecko/global_style_data.rs
@@ -4,6 +4,7 @@
 
 //! Global style data
 
+use context::StyleSystemOptions;
 use num_cpus;
 use rayon;
 use shared_lock::SharedRwLock;
@@ -20,6 +21,9 @@ pub struct GlobalStyleData {
 
     /// Shared RWLock for CSSOM objects
     pub shared_lock: SharedRwLock,
+
+    /// Global style system options determined by env vars.
+    pub options: StyleSystemOptions,
 }
 
 lazy_static! {
@@ -45,6 +49,7 @@ lazy_static! {
             num_threads: num_threads,
             style_thread_pool: pool,
             shared_lock: SharedRwLock::new(),
+            options: StyleSystemOptions::default(),
         }
     };
 }

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -25,7 +25,6 @@ use selector_parser::{PseudoElement, RestyleDamage, SelectorImpl};
 use selectors::bloom::BloomFilter;
 use selectors::matching::{ElementSelectorFlags, StyleRelations};
 use selectors::matching::AFFECTED_BY_PSEUDO_ELEMENTS;
-#[cfg(feature = "servo")] use servo_config::opts;
 use sink::ForgetfulSink;
 use std::sync::Arc;
 use stylist::ApplicableDeclarationBlock;
@@ -727,16 +726,6 @@ pub enum StyleSharingBehavior {
     Disallow,
 }
 
-#[cfg(feature = "servo")]
-fn is_share_style_cache_disabled() -> bool {
-    opts::get().disable_share_style_cache
-}
-
-#[cfg(not(feature = "servo"))]
-fn is_share_style_cache_disabled() -> bool {
-    false
-}
-
 /// The public API that elements expose for selector matching.
 pub trait MatchMethods : TElement {
     /// Performs selector matching and property cascading on an element and its eager pseudos.
@@ -1033,7 +1022,7 @@ pub trait MatchMethods : TElement {
                                       context: &mut StyleContext<Self>,
                                       data: &mut AtomicRefMut<ElementData>)
                                       -> StyleSharingResult {
-        if is_share_style_cache_disabled() {
+        if context.shared.options.disable_style_sharing_cache {
             debug!("{:?} Cannot share style: style sharing cache disabled", self);
             return StyleSharingResult::CannotShare
         }

--- a/components/style/parallel.rs
+++ b/components/style/parallel.rs
@@ -44,7 +44,7 @@ pub fn traverse_dom<E, D>(traversal: &D,
     where E: TElement,
           D: DomTraversal<E>,
 {
-    let dump_stats = TraversalStatistics::should_dump();
+    let dump_stats = traversal.shared_context().options.dump_style_statistics;
     let start_time = if dump_stats { Some(time::precise_time_s()) } else { None };
 
     debug_assert!(traversal.is_parallel());

--- a/components/style/sequential.rs
+++ b/components/style/sequential.rs
@@ -6,7 +6,6 @@
 
 #![deny(missing_docs)]
 
-use context::TraversalStatistics;
 use dom::{TElement, TNode};
 use std::borrow::BorrowMut;
 use std::collections::VecDeque;
@@ -22,7 +21,7 @@ pub fn traverse_dom<E, D>(traversal: &D,
     where E: TElement,
           D: DomTraversal<E>,
 {
-    let dump_stats = TraversalStatistics::should_dump();
+    let dump_stats = traversal.shared_context().options.dump_style_statistics;
     let start_time = if dump_stats { Some(time::precise_time_s()) } else { None };
 
     debug_assert!(!traversal.is_parallel());


### PR DESCRIPTION
I wanted to add an environmental variable to disable the style sharing
cache for gecko, but the current pattern involves lazy_static!, which
involves an atomic operation on lookup, which is a bit hot to do each
time we try to share styles. This makes that work happen once per
process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16369)
<!-- Reviewable:end -->
