### PR TITLE
Add env var for local saltfs root during bootstrap

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -78,18 +78,28 @@ def salt(context, force=False):
     # Hence, dynamically generate the config with an appropriate `root_dir`
     # and serialize it as JSON (which is valid YAML).
     config = {
-        'fileserver_backend': ['git'],
-        'gitfs_env_whitelist': 'base',
-        'gitfs_provider': 'gitpython',
-        'gitfs_remotes': [
-            'https://github.com/servo/saltfs.git',
-        ],
         'hash_type': 'sha384',
         'master': 'localhost',
         'root_dir': salt_root,
         'state_output': 'changes',
         'state_tabular': True,
     }
+    if 'SERVO_SALTFS_ROOT' in os.environ:
+        config.update({
+            'fileserver_backend': ['roots'],
+            'file_roots': {
+                'base': [os.path.abspath(os.environ['SERVO_SALTFS_ROOT'])],
+            },
+        })
+    else:
+        config.update({
+            'fileserver_backend': ['git'],
+            'gitfs_env_whitelist': 'base',
+            'gitfs_provider': 'gitpython',
+            'gitfs_remotes': [
+                'https://github.com/servo/saltfs.git',
+            ],
+        })
 
     if not os.path.exists(config_dir):
         os.makedirs(config_dir, mode=0o700)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This enables using the environment variable `SERVO_SALTFS_ROOT` to use a local copy of the saltfs tree for `./mach bootstrap`. The immediate use case is to add a test for `./mach bootstrap` to saltfs itself, to ensure Salt changes or refactors don't break `./mach bootstrap`.

I tested this locally in an Ubuntu Trusty VM.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the test will be added to saltfs

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16370)
<!-- Reviewable:end -->
