### PR TITLE
stylo: Bug 1343753 - Use ComputedValues while updating transitions in Gecko

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -678,6 +678,7 @@ impl<'le> TElement for GeckoElement<'le> {
         let atom_ptr = PseudoElement::ns_atom_or_null_from_opt(pseudo);
         unsafe {
             Gecko_UpdateAnimations(self.0, atom_ptr,
+                                   None,
                                    computed_values_opt,
                                    parent_values_opt,
                                    tasks.bits());

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1685,6 +1685,10 @@ extern "C" {
      -> RawServoAnimationValueStrong;
 }
 extern "C" {
+    pub fn Servo_Property_IsDiscreteAnimatable(property: nsCSSPropertyID)
+     -> bool;
+}
+extern "C" {
     pub fn Servo_AnimationValues_Interpolate(from:
                                                  RawServoAnimationValueBorrowed,
                                              to:

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -630,6 +630,8 @@ extern "C" {
 extern "C" {
     pub fn Gecko_UpdateAnimations(aElement: RawGeckoElementBorrowed,
                                   aPseudoTagOrNull: *mut nsIAtom,
+                                  aOldComputedValues:
+                                      ServoComputedValuesBorrowedOrNull,
                                   aComputedValues:
                                       ServoComputedValuesBorrowedOrNull,
                                   aParentComputedValues:

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1693,6 +1693,13 @@ extern "C" {
      -> RawServoAnimationValueStrong;
 }
 extern "C" {
+    pub fn Servo_AnimationValues_IsInterpolable(from:
+                                                    RawServoAnimationValueBorrowed,
+                                                to:
+                                                    RawServoAnimationValueBorrowed)
+     -> bool;
+}
+extern "C" {
     pub fn Servo_AnimationValue_Serialize(value:
                                               RawServoAnimationValueBorrowed,
                                           property: nsCSSPropertyID,

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1717,6 +1717,11 @@ extern "C" {
      -> bool;
 }
 extern "C" {
+    pub fn Servo_AnimationValue_Uncompute(value:
+                                              RawServoAnimationValueBorrowed)
+     -> RawServoDeclarationBlockStrong;
+}
+extern "C" {
     pub fn Servo_ParseStyleAttribute(data: *const nsACString,
                                      extra_data: *mut RawGeckoURLExtraData)
      -> RawServoDeclarationBlockStrong;

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1687,6 +1687,9 @@ extern "C" {
      -> RawServoAnimationValueStrong;
 }
 extern "C" {
+    pub fn Servo_Property_IsAnimatable(property: nsCSSPropertyID) -> bool;
+}
+extern "C" {
     pub fn Servo_Property_IsDiscreteAnimatable(property: nsCSSPropertyID)
      -> bool;
 }

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -104,6 +104,18 @@ impl TransitionProperty {
             _ => None,
         }
     }
+
+    /// Returns true if this TransitionProperty is one of the discrete animatable properties.
+    pub fn is_discrete(&self) -> bool {
+        match *self {
+            % for prop in data.longhands:
+                % if prop.animation_type == "discrete":
+                    TransitionProperty::${prop.camel_case} => true,
+                % endif
+            % endfor
+            _ => false
+        }
+    }
 }
 
 impl ToCss for TransitionProperty {

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -118,6 +118,19 @@ impl TransitionProperty {
     }
 }
 
+/// Returns true if this nsCSSPropertyID is one of the animatable properties.
+#[cfg(feature = "gecko")]
+pub fn nscsspropertyid_is_animatable(property: nsCSSPropertyID) -> bool {
+    match property {
+        % for prop in data.longhands:
+            % if prop.animatable:
+                ${helpers.to_nscsspropertyid(prop.ident)} => true,
+            % endif
+        % endfor
+        _ => false
+    }
+}
+
 impl ToCss for TransitionProperty {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result
         where W: fmt::Write,

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -462,6 +462,12 @@ pub extern "C" fn Servo_ComputedValues_ExtractAnimationValue(computed_values: Se
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_Property_IsDiscreteAnimatable(property: nsCSSPropertyID) -> bool {
+    let property: TransitionProperty = property.into();
+    property.is_discrete()
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_StyleWorkerThreadCount() -> u32 {
     GLOBAL_STYLE_DATA.num_threads as u32
 }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -402,6 +402,15 @@ pub extern "C" fn Servo_AnimationValue_DeepEqual(this: RawServoAnimationValueBor
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_AnimationValue_Uncompute(value: RawServoAnimationValueBorrowed)
+                                                 -> RawServoDeclarationBlockStrong {
+    let value = AnimationValue::as_arc(&value);
+    let global_style_data = &*GLOBAL_STYLE_DATA;
+    Arc::new(global_style_data.shared_lock.wrap(
+        PropertyDeclarationBlock::with_one(value.uncompute(), Importance::Normal))).into_strong()
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_StyleSet_GetBaseComputedValuesForElement(raw_data: RawServoStyleSetBorrowed,
                                                                  element: RawGeckoElementBorrowed,
                                                                  pseudo_tag: *mut nsIAtom)

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -257,6 +257,15 @@ pub extern "C" fn Servo_AnimationValues_Interpolate(from: RawServoAnimationValue
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_AnimationValues_IsInterpolable(from: RawServoAnimationValueBorrowed,
+                                                       to: RawServoAnimationValueBorrowed)
+                                                       -> bool {
+    let from_value = AnimationValue::as_arc(&from);
+    let to_value = AnimationValue::as_arc(&to);
+    from_value.interpolate(to_value, 0.5).is_ok()
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_AnimationValueMap_Push(value_map: RawServoAnimationValueMapBorrowed,
                                                property: nsCSSPropertyID,
                                                value: RawServoAnimationValueBorrowed)

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -462,6 +462,12 @@ pub extern "C" fn Servo_ComputedValues_ExtractAnimationValue(computed_values: Se
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_Property_IsAnimatable(property: nsCSSPropertyID) -> bool {
+    use style::properties::animated_properties;
+    animated_properties::nscsspropertyid_is_animatable(property)
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_Property_IsDiscreteAnimatable(property: nsCSSPropertyID) -> bool {
     let property: TransitionProperty = property.into();
     property.is_discrete()


### PR DESCRIPTION
These are interdependent patches of Bug 1343753. We want to use ComputedValues and AnimationValues to start/update/stop the transitions.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix Bug 1343753.
- [X] These changes do not require tests because we have tests in Gecko already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16381)
<!-- Reviewable:end -->
