### PR TITLE
Fix panic when font face name is not available

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -48,7 +48,7 @@ pub trait FontHandleMethods: Sized {
                     -> Result<Self, ()>;
     fn template(&self) -> Arc<FontTemplateData>;
     fn family_name(&self) -> String;
-    fn face_name(&self) -> String;
+    fn face_name(&self) -> Option<String>;
     fn is_italic(&self) -> bool;
     fn boldness(&self) -> font_weight::T;
     fn stretchiness(&self) -> font_stretch::T;
@@ -254,7 +254,7 @@ impl Font {
 
         debug!("{} font table[{}] with family={}, face={}",
                status, tag.tag_to_str(),
-               self.handle.family_name(), self.handle.face_name());
+               self.handle.family_name(), self.handle.face_name().unwrap_or("unavailable".to_owned()));
 
         result
     }

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -113,9 +113,15 @@ impl FontHandleMethods for FontHandle {
             c_str_to_string((*self.face).family_name as *const c_char)
         }
     }
-    fn face_name(&self) -> String {
+    fn face_name(&self) -> Option<String> {
         unsafe {
-            c_str_to_string(FT_Get_Postscript_Name(self.face) as *const c_char)
+            let name = FT_Get_Postscript_Name(self.face) as *const c_char;
+
+            if !name.is_null() {
+                Some(c_str_to_string(name))
+            } else {
+                None
+            }
         }
     }
     fn is_italic(&self) -> bool {

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -202,8 +202,8 @@ impl FontHandleMethods for FontHandle {
         self.ctfont.family_name()
     }
 
-    fn face_name(&self) -> String {
-        self.ctfont.face_name()
+    fn face_name(&self) -> Option<String> {
+        Some(self.ctfont.face_name())
     }
 
     fn is_italic(&self) -> bool {

--- a/components/gfx/platform/windows/font.rs
+++ b/components/gfx/platform/windows/font.rs
@@ -299,8 +299,8 @@ impl FontHandleMethods for FontHandle {
         self.info.family_name.clone()
     }
 
-    fn face_name(&self) -> String {
-        self.info.face_name.clone()
+    fn face_name(&self) -> Option<String> {
+        Some(self.info.face_name.clone())
     }
 
     fn is_italic(&self) -> bool {


### PR DESCRIPTION
I got a panic in Servo when I ran it with `RUST_LOG=debug`, which was due to `FT_Get_Postscript_Name` returning a null pointer.

I'm not sure how to add a test for this, so there is none right now.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16388)
<!-- Reviewable:end -->
