### PR TITLE
Allow bootstrapping on Debian

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -270,7 +270,13 @@ def bootstrap(context, force=False):
         bootstrapper = windows_msvc
     elif "linux-gnu" in host_triple():
         distro, version, _ = platform.linux_distribution()
-        if distro in ['CentOS', 'CentOS Linux', 'Fedora', 'Ubuntu']:
+        if distro.lower() in [
+            'centos',
+            'centos linux',
+            'debian',
+            'fedora',
+            'ubuntu',
+        ]:
             context.distro = distro
             bootstrapper = salt
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is needed for servo/saltfs#631, since the Travis builders are detected as `'debian'` for some reason.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the test will be in saltfs

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16389)
<!-- Reviewable:end -->
