### PR TITLE
Add back in last keydown fixes

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -372,9 +372,9 @@ impl Window {
             self.event_queue.borrow_mut().push(event);
         } else {
             // Only send the character if we can print it (by ignoring characters like backspace)
-            if ch >= ' ' {
+            if !ch.is_control() {
                 let event = WindowEvent::KeyEvent(Some(ch),
-                                                  Key::A /* unused */,
+                                                  Window::char_to_script_key(ch).unwrap(),
                                                   KeyState::Pressed,
                                                   modifiers);
                 self.event_queue.borrow_mut().push(event);
@@ -433,7 +433,6 @@ impl Window {
                 ElementState::Released => KeyState::Released,
             };
             let modifiers = Window::glutin_mods_to_script_mods(self.key_modifiers.get());
-            //self.event_queue.borrow_mut().push(WindowEvent::KeyEvent(None, key, state, modifiers));
             self.event_queue.borrow_mut().push(WindowEvent::KeyEvent(ch, key, state, modifiers));
         }
     }
@@ -687,6 +686,107 @@ impl Window {
 
     pub unsafe fn remove_nested_event_loop_listener(&self) {
         G_NESTED_EVENT_LOOP_LISTENER = None
+    }
+
+    fn char_to_script_key(c: char) -> Option<constellation_msg::Key> {
+        match c {
+            ' ' => Some(Key::Space),
+            '"' => Some(Key::Apostrophe),
+            '\'' => Some(Key::Apostrophe),
+            '<' => Some(Key::Comma),
+            ',' => Some(Key::Comma),
+            '_' => Some(Key::Minus),
+            '-' => Some(Key::Minus),
+            '>' => Some(Key::Period),
+            '.' => Some(Key::Period),
+            '?' => Some(Key::Slash),
+            '/' => Some(Key::Slash),
+            '~' => Some(Key::GraveAccent),
+            '`' => Some(Key::GraveAccent),
+            ')' => Some(Key::Num0),
+            '0' => Some(Key::Num0),
+            '!' => Some(Key::Num1),
+            '1' => Some(Key::Num1),
+            '@' => Some(Key::Num2),
+            '2' => Some(Key::Num2),
+            '#' => Some(Key::Num3),
+            '3' => Some(Key::Num3),
+            '$' => Some(Key::Num4),
+            '4' => Some(Key::Num4),
+            '%' => Some(Key::Num5),
+            '5' => Some(Key::Num5),
+            '^' => Some(Key::Num6),
+            '6' => Some(Key::Num6),
+            '&' => Some(Key::Num7),
+            '7' => Some(Key::Num7),
+            '*' => Some(Key::Num8),
+            '8' => Some(Key::Num8),
+            '(' => Some(Key::Num9),
+            '9' => Some(Key::Num9),
+            ':' => Some(Key::Semicolon),
+            ';' => Some(Key::Semicolon),
+            '+' => Some(Key::Equal),
+            '=' => Some(Key::Equal),
+            'A' => Some(Key::A),
+            'a' => Some(Key::A),
+            'B' => Some(Key::B),
+            'b' => Some(Key::B),
+            'C' => Some(Key::C),
+            'c' => Some(Key::C),
+            'D' => Some(Key::D),
+            'd' => Some(Key::D),
+            'E' => Some(Key::E),
+            'e' => Some(Key::E),
+            'F' => Some(Key::F),
+            'f' => Some(Key::F),
+            'G' => Some(Key::G),
+            'g' => Some(Key::G),
+            'H' => Some(Key::H),
+            'h' => Some(Key::H),
+            'I' => Some(Key::I),
+            'i' => Some(Key::I),
+            'J' => Some(Key::J),
+            'j' => Some(Key::J),
+            'K' => Some(Key::K),
+            'k' => Some(Key::K),
+            'L' => Some(Key::L),
+            'l' => Some(Key::L),
+            'M' => Some(Key::M),
+            'm' => Some(Key::M),
+            'N' => Some(Key::N),
+            'n' => Some(Key::N),
+            'O' => Some(Key::O),
+            'o' => Some(Key::O),
+            'P' => Some(Key::P),
+            'p' => Some(Key::P),
+            'Q' => Some(Key::Q),
+            'q' => Some(Key::Q),
+            'R' => Some(Key::R),
+            'r' => Some(Key::R),
+            'S' => Some(Key::S),
+            's' => Some(Key::S),
+            'T' => Some(Key::T),
+            't' => Some(Key::T),
+            'U' => Some(Key::U),
+            'u' => Some(Key::U),
+            'V' => Some(Key::V),
+            'v' => Some(Key::V),
+            'W' => Some(Key::W),
+            'w' => Some(Key::W),
+            'X' => Some(Key::X),
+            'x' => Some(Key::X),
+            'Y' => Some(Key::Y),
+            'y' => Some(Key::Y),
+            'Z' => Some(Key::Z),
+            'z' => Some(Key::Z),
+            '{' => Some(Key::LeftBracket),
+            '[' => Some(Key::LeftBracket),
+            '|' => Some(Key::Backslash),
+            '\\' => Some(Key::Backslash),
+            '}' => Some(Key::RightBracket),
+            ']' => Some(Key::RightBracket),
+            _ => None
+        }
     }
 
     fn glutin_key_to_script_key(key: glutin::VirtualKeyCode) -> Result<constellation_msg::Key, ()> {
@@ -1303,6 +1403,8 @@ fn is_printable(key_code: VirtualKeyCode) -> bool {
         _ => true,
     }
 }
+
+#[cfg(not(target_os = "windows"))]
 fn filter_nonprintable(ch: char, key_code: VirtualKeyCode) -> Option<char> {
     if is_printable(key_code) {
         Some(ch)

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -373,11 +373,16 @@ impl Window {
         } else {
             // Only send the character if we can print it (by ignoring characters like backspace)
             if !ch.is_control() {
-                let event = WindowEvent::KeyEvent(Some(ch),
-                                                  Window::char_to_script_key(ch).unwrap(),
-                                                  KeyState::Pressed,
-                                                  modifiers);
-                self.event_queue.borrow_mut().push(event);
+                match Window::char_to_script_key(ch) {
+                    Some(key) => {
+                        let event = WindowEvent::KeyEvent(Some(ch),
+                                                          key,
+                                                          KeyState::Pressed,
+                                                          modifiers);
+                        self.event_queue.borrow_mut().push(event);
+                    }
+                    None => {}
+                }
             }
         }
         self.last_pressed_key.set(None);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is a follow-up PR to https://github.com/servo/servo/pull/16198

The approved patch included these changes as well, but I accidentally excluded them from the squash that landed.

r? @jdm 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they are part of previously reviewed code

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16390)
<!-- Reviewable:end -->
