### PR TITLE
Support line number offsets for inline stylesheets

### DIFF
--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -40,6 +40,7 @@ pub struct HTMLStyleElement {
     in_stack_of_open_elements: Cell<bool>,
     pending_loads: Cell<u32>,
     any_failed_load: Cell<bool>,
+    line_number: u64,
 }
 
 impl HTMLStyleElement {
@@ -55,6 +56,7 @@ impl HTMLStyleElement {
             in_stack_of_open_elements: Cell::new(creator.is_parser_created()),
             pending_loads: Cell::new(0),
             any_failed_load: Cell::new(false),
+            line_number: creator.return_line_number(),
         }
     }
 
@@ -92,7 +94,8 @@ impl HTMLStyleElement {
         let loader = StylesheetLoader::for_element(self.upcast());
         let sheet = Stylesheet::from_str(&data, win.get_url(), Origin::Author, mq,
                                          shared_lock, Some(&loader),
-                                         win.css_error_reporter());
+                                         win.css_error_reporter(),
+                                         self.line_number);
 
         let sheet = Arc::new(sheet);
 

--- a/components/script_layout_interface/reporter.rs
+++ b/components/script_layout_interface/reporter.rs
@@ -26,12 +26,14 @@ impl ParseErrorReporter for CSSErrorReporter {
                      input: &mut Parser,
                      position: SourcePosition,
                      message: &str,
-                     url: &ServoUrl) {
+                     url: &ServoUrl,
+                     line_number_offset: u64) {
         let location = input.source_location(position);
+        let line_offset = location.line + line_number_offset as usize;
         if log_enabled!(log::LogLevel::Info) {
              info!("Url:\t{}\n{}:{} {}",
                    url.as_str(),
-                   location.line,
+                   line_offset,
                    location.column,
                    message)
         }

--- a/components/style/encoding_support.rs
+++ b/components/style/encoding_support.rs
@@ -66,7 +66,8 @@ impl Stylesheet {
                              Arc::new(shared_lock.wrap(media)),
                              shared_lock,
                              stylesheet_loader,
-                             error_reporter)
+                             error_reporter,
+                             0u64)
     }
 
     /// Updates an empty stylesheet with a set of bytes that reached over the

--- a/components/style/error_reporting.rs
+++ b/components/style/error_reporting.rs
@@ -12,7 +12,7 @@ use stylesheets::UrlExtraData;
 
 /// A generic trait for an error reporter.
 pub trait ParseErrorReporter : Sync + Send {
-    /// Called the style engine detects an error.
+    /// Called when the style engine detects an error.
     ///
     /// Returns the current input being parsed, the source position it was
     /// reported from, and a message.
@@ -20,7 +20,8 @@ pub trait ParseErrorReporter : Sync + Send {
                     input: &mut Parser,
                     position: SourcePosition,
                     message: &str,
-                    url: &UrlExtraData);
+                    url: &UrlExtraData,
+                    line_number_offset: u64);
 }
 
 /// An error reporter that reports the errors to the `info` log channel.
@@ -32,10 +33,12 @@ impl ParseErrorReporter for StdoutErrorReporter {
                     input: &mut Parser,
                     position: SourcePosition,
                     message: &str,
-                    url: &UrlExtraData) {
+                    url: &UrlExtraData,
+                    line_number_offset: u64) {
         if log_enabled!(log::LogLevel::Info) {
             let location = input.source_location(position);
-            info!("Url:\t{}\n{}:{} {}", url.as_str(), location.line, location.column, message)
+            let line_offset = location.line + line_number_offset as usize;
+            info!("Url:\t{}\n{}:{} {}", url.as_str(), line_offset, location.column, message)
         }
     }
 }

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -328,7 +328,8 @@ impl ParseErrorReporter for MemoryHoleReporter {
             _: &mut Parser,
             _: SourcePosition,
             _: &str,
-            _: &UrlExtraData) {
+            _: &UrlExtraData,
+            _: u64) {
         // do nothing
     }
 }
@@ -666,7 +667,7 @@ impl Stylesheet {
         let (rules, dirty_on_viewport_size_change) = Stylesheet::parse_rules(
             css, url_data, existing.origin, &mut namespaces,
             &existing.shared_lock, stylesheet_loader, error_reporter,
-        );
+            0u64);
 
         *existing.namespaces.write() = namespaces;
         existing.dirty_on_viewport_size_change
@@ -683,7 +684,8 @@ impl Stylesheet {
                    namespaces: &mut Namespaces,
                    shared_lock: &SharedRwLock,
                    stylesheet_loader: Option<&StylesheetLoader>,
-                   error_reporter: &ParseErrorReporter)
+                   error_reporter: &ParseErrorReporter,
+                   line_number_offset: u64)
                    -> (Vec<CssRule>, bool) {
         let mut rules = Vec::new();
         let mut input = Parser::new(css);
@@ -692,7 +694,8 @@ impl Stylesheet {
             namespaces: namespaces,
             shared_lock: shared_lock,
             loader: stylesheet_loader,
-            context: ParserContext::new(origin, url_data, error_reporter, None),
+            context: ParserContext::new_with_line_number_offset(origin, url_data, error_reporter,
+                                                                line_number_offset),
             state: Cell::new(State::Start),
         };
 
@@ -726,11 +729,12 @@ impl Stylesheet {
                     media: Arc<Locked<MediaList>>,
                     shared_lock: SharedRwLock,
                     stylesheet_loader: Option<&StylesheetLoader>,
-                    error_reporter: &ParseErrorReporter) -> Stylesheet {
+                    error_reporter: &ParseErrorReporter,
+                    line_number_offset: u64) -> Stylesheet {
         let mut namespaces = Namespaces::default();
         let (rules, dirty_on_viewport_size_change) = Stylesheet::parse_rules(
             css, &url_data, origin, &mut namespaces,
-            &shared_lock, stylesheet_loader, error_reporter,
+            &shared_lock, stylesheet_loader, error_reporter, line_number_offset
         );
         Stylesheet {
             origin: origin,

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -496,7 +496,7 @@ pub extern "C" fn Servo_StyleSheet_Empty(mode: SheetParsingMode) -> RawServoStyl
     Arc::new(Stylesheet::from_str(
         "", unsafe { dummy_url_data() }.clone(), origin,
         Arc::new(shared_lock.wrap(MediaList::empty())),
-        shared_lock, None, &StdoutErrorReporter)
+        shared_lock, None, &StdoutErrorReporter, 0u64)
     ).into_strong()
 }
 
@@ -539,7 +539,7 @@ pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(loader: *mut Loader,
 
     Arc::new(Stylesheet::from_str(
         input, url_data.clone(), origin, media,
-        shared_lock, loader, &StdoutErrorReporter)
+        shared_lock, loader, &StdoutErrorReporter, 0u64)
     ).into_strong()
 }
 

--- a/tests/unit/style/media_queries.rs
+++ b/tests/unit/style/media_queries.rs
@@ -19,8 +19,12 @@ use style_traits::ToCss;
 pub struct CSSErrorReporterTest;
 
 impl ParseErrorReporter for CSSErrorReporterTest {
-    fn report_error(&self, _input: &mut Parser, _position: SourcePosition, _message: &str,
-        _url: &ServoUrl) {
+    fn report_error(&self,
+                    _input: &mut Parser,
+                    _position: SourcePosition,
+                    _message: &str,
+                    _url: &ServoUrl,
+                    _line_number_offset: u64) {
     }
 }
 
@@ -33,7 +37,7 @@ fn test_media_rule<F>(css: &str, callback: F)
     let media_list = Arc::new(lock.wrap(MediaList::empty()));
     let stylesheet = Stylesheet::from_str(
         css, url, Origin::Author, media_list, lock,
-        None, &CSSErrorReporterTest);
+        None, &CSSErrorReporterTest, 0u64);
     let mut rule_count = 0;
     let guard = stylesheet.shared_lock.read();
     media_queries(&guard, &stylesheet.rules.read_with(&guard).0, &mut |mq| {
@@ -62,7 +66,7 @@ fn media_query_test(device: &Device, css: &str, expected_rule_count: usize) {
     let media_list = Arc::new(lock.wrap(MediaList::empty()));
     let ss = Stylesheet::from_str(
         css, url, Origin::Author, media_list, lock,
-        None, &CSSErrorReporterTest);
+        None, &CSSErrorReporterTest, 0u64);
     let mut rule_count = 0;
     ss.effective_style_rules(device, &ss.shared_lock.read(), |_| rule_count += 1);
     assert!(rule_count == expected_rule_count, css.to_owned());

--- a/tests/unit/style/rule_tree/bench.rs
+++ b/tests/unit/style/rule_tree/bench.rs
@@ -16,9 +16,15 @@ use test::{self, Bencher};
 
 struct ErrorringErrorReporter;
 impl ParseErrorReporter for ErrorringErrorReporter {
-    fn report_error(&self, _input: &mut Parser, position: SourcePosition, message: &str,
-        url: &ServoUrl) {
-        panic!("CSS error: {}\t\n{:?} {}", url.as_str(), position, message);
+    fn report_error(&self,
+                    input: &mut Parser,
+                    position: SourcePosition,
+                    message: &str,
+                    url: &ServoUrl,
+                    line_number_offset: u64) {
+        let location = input.source_location(position);
+        let line_offset = location.line + line_number_offset as usize;
+        panic!("CSS error: {}\t\n{}:{} {}", url.as_str(), line_offset, location.column, message);
     }
 }
 
@@ -51,7 +57,8 @@ fn parse_rules(css: &str) -> Vec<(StyleSource, CascadeLevel)> {
                                  media,
                                  lock,
                                  None,
-                                 &ErrorringErrorReporter);
+                                 &ErrorringErrorReporter,
+                                 0u64);
     let guard = s.shared_lock.read();
     let rules = s.rules.read_with(&guard);
     rules.0.iter().filter_map(|rule| {

--- a/tests/unit/style/viewport.rs
+++ b/tests/unit/style/viewport.rs
@@ -31,7 +31,8 @@ macro_rules! stylesheet {
             Arc::new($shared_lock.wrap(MediaList::empty())),
             $shared_lock,
             None,
-            &$error_reporter
+            &$error_reporter,
+            0u64
         ))
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This allows accurate line numbers when reporting stylesheet errors. 

@jdm This is going to require some effort to merge my changes with other recent changes to `ParserContext`. Because of that I would appreciate a quick sanity check before I put the time into performing the merge. 
For example, should I store the `offset` as a u64, or should it be an Option? 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15693 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16394)
<!-- Reviewable:end -->
