### PR TITLE
Preserve restyle hints other than animation hints in propagate() duri…

### DIFF
--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -19,6 +19,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use stylist::Stylist;
 use thread_state;
+use traversal::TraversalFlags;
 
 /// The structure that represents the result of style computation. This is
 /// effectively a tuple of rules and computed values, that is, the rule node,
@@ -192,16 +193,21 @@ pub struct StoredRestyleHint(RestyleHint);
 
 impl StoredRestyleHint {
     /// Propagates this restyle hint to a child element.
-    pub fn propagate(&mut self) -> Self {
+    pub fn propagate(&mut self, traversal_flags: &TraversalFlags) -> Self {
         use std::mem;
 
-        // If we have RESTYLE_CSS_ANIMATIONS restyle hint, it means we are in
-        // the middle of an animation only restyle. In that case, we don't need
-        // to propagate any restyle hints, and we need to remove ourselves.
-        if self.0.contains(RESTYLE_CSS_ANIMATIONS) {
-            self.0.remove(RESTYLE_CSS_ANIMATIONS);
+        // In the middle of an animation only restyle, we don't need to
+        // propagate any restyle hints, and we need to remove ourselves.
+        if traversal_flags.for_animation_only() {
+            if self.0.contains(RESTYLE_CSS_ANIMATIONS) {
+                self.0.remove(RESTYLE_CSS_ANIMATIONS);
+            }
             return Self::empty();
         }
+
+        debug_assert!(!self.0.contains(RESTYLE_CSS_ANIMATIONS),
+                      "There should not be any animation restyle hints \
+                       during normal traversal");
 
         // Else we should clear ourselves, and return the propagated hint.
         let hint = mem::replace(&mut self.0, RestyleHint::empty());

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -601,7 +601,7 @@ pub fn recalc_style_at<E, D>(traversal: &D,
                           "animation restyle hint should be handled during \
                            animation-only restyles");
             r.recascade = false;
-            r.hint.propagate()
+            r.hint.propagate(&context.shared.traversal_flags)
         },
     };
     debug_assert!(data.has_current_styles() ||


### PR DESCRIPTION
…ng animation-only restyle.

<!-- Please describe your changes on the following line: -->

This is PR of https://bugzilla.mozilla.org/show_bug.cgi?id=1354487

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because for stylo.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16396)
<!-- Reviewable:end -->
