### PR TITLE
Fix parsing of "center left" in parse_origin (fixes #15750)

### DIFF
--- a/components/style/properties/longhand/effects.mako.rs
+++ b/components/style/properties/longhand/effects.mako.rs
@@ -439,7 +439,7 @@ pub struct OriginParseResult {
 
 pub fn parse_origin(context: &ParserContext, input: &mut Parser) -> Result<OriginParseResult,()> {
     use values::specified::{LengthOrPercentage, Percentage};
-    let (mut horizontal, mut vertical, mut depth) = (None, None, None);
+    let (mut horizontal, mut vertical, mut depth, mut horizontal_is_center) = (None, None, None, false);
     loop {
         if let Err(_) = input.try(|input| {
             let token = try!(input.expect_ident());
@@ -448,12 +448,16 @@ pub fn parse_origin(context: &ParserContext, input: &mut Parser) -> Result<Origi
                 "left" => {
                     if horizontal.is_none() {
                         horizontal = Some(LengthOrPercentage::Percentage(Percentage(0.0)))
+                    } else if horizontal_is_center && vertical.is_none() {
+                        vertical = Some(LengthOrPercentage::Percentage(Percentage(0.5)));
+                        horizontal = Some(LengthOrPercentage::Percentage(Percentage(0.0)));
                     } else {
                         return Err(())
                     }
                 },
                 "center" => {
                     if horizontal.is_none() {
+                        horizontal_is_center = true;
                         horizontal = Some(LengthOrPercentage::Percentage(Percentage(0.5)))
                     } else if vertical.is_none() {
                         vertical = Some(LengthOrPercentage::Percentage(Percentage(0.5)))
@@ -464,6 +468,9 @@ pub fn parse_origin(context: &ParserContext, input: &mut Parser) -> Result<Origi
                 "right" => {
                     if horizontal.is_none() {
                         horizontal = Some(LengthOrPercentage::Percentage(Percentage(1.0)))
+                    } else if horizontal_is_center && vertical.is_none() {
+                        vertical = Some(LengthOrPercentage::Percentage(Percentage(0.5)));
+                        horizontal = Some(LengthOrPercentage::Percentage(Percentage(1.0)));
                     } else {
                         return Err(())
                     }

--- a/tests/unit/style/parsing/effects.rs
+++ b/tests/unit/style/parsing/effects.rs
@@ -51,10 +51,25 @@ fn test_longhands_parse_origin() {
     assert!(parsed.is_ok());
     assert_eq!(parser.is_exhausted(), true);
 
-    let mut parser = Parser::new("1px");
+    let mut parser = Parser::new("center left");
     let parsed = longhands::parse_origin(&context, &mut parser);
     assert!(parsed.is_ok());
     assert_eq!(parser.is_exhausted(), true);
+
+    let mut parser = Parser::new("center right");
+    let parsed = longhands::parse_origin(&context, &mut parser);
+    assert!(parsed.is_ok());
+    assert_eq!(parser.is_exhausted(), true);
+
+    let mut parser = Parser::new("center right 1px");
+    let parsed = longhands::parse_origin(&context, &mut parser);
+    assert!(parsed.is_ok());
+    assert_eq!(parser.is_exhausted(), true);
+
+    let mut parser = Parser::new("1% right");
+    let parsed = longhands::parse_origin(&context, &mut parser);
+    assert!(parsed.is_ok());
+    assert_eq!(parser.is_exhausted(), false);
 }
 
 #[test]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16435)
<!-- Reviewable:end -->
