### PR TITLE
Use the bloom filter for child selectors

### DIFF
--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -122,6 +122,7 @@ fn may_match<E>(mut selector: &ComplexSelector<E::Impl>,
     loop {
          match selector.next {
              None => break,
+             Some((ref cs, Combinator::Child)) |
              Some((ref cs, Combinator::Descendant)) => selector = &**cs,
              Some((ref cs, _)) => {
                  selector = &**cs;


### PR DESCRIPTION
This speeds up bloom-basic-ref.html by 4x on my machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16456)
<!-- Reviewable:end -->
