### PR TITLE
layout: Force reflow in the sequential fallback of block format context

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -43,6 +43,7 @@ use flow_list::FlowList;
 use fragment::{CoordinateSystem, Fragment, FragmentBorderBoxIterator, Overflow};
 use fragment::{IS_INLINE_FLEX_ITEM, IS_BLOCK_FLEX_ITEM};
 use gfx_traits::print_tree::PrintTree;
+use incremental::RelayoutMode;
 use layout_debug;
 use model::{AdjoiningMargins, CollapsibleMargins, IntrinsicISizes, MarginCollapseInfo, MaybeAuto};
 use model::{specified, specified_or_none};
@@ -1549,7 +1550,7 @@ impl BlockFlow {
             self.assign_inline_sizes(layout_context);
             // Re-run layout on our children.
             for child in flow::mut_base(self).children.iter_mut() {
-                sequential::traverse_flow_tree_preorder(child, layout_context);
+                sequential::traverse_flow_tree_preorder(child, layout_context, RelayoutMode::Force);
             }
             // Assign our final-final block size.
             self.assign_block_size(layout_context);

--- a/components/layout/incremental.rs
+++ b/components/layout/incremental.rs
@@ -7,6 +7,13 @@ use style::computed_values::float;
 use style::selector_parser::RestyleDamage;
 use style::servo::restyle_damage::{REFLOW, RECONSTRUCT_FLOW};
 
+/// Used in a flow traversal to indicate whether this re-layout should be incremental or not.
+#[derive(Clone, Copy, PartialEq)]
+pub enum RelayoutMode {
+    Incremental,
+    Force
+}
+
 bitflags! {
     pub flags SpecialRestyleDamage: u8 {
         #[doc = "If this flag is set, we need to reflow the entire document. This is more or less a \

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -60,7 +60,7 @@ use layout::context::heap_size_of_persistent_local_context;
 use layout::display_list_builder::ToGfxColor;
 use layout::flow::{self, Flow, ImmutableFlowUtils, MutableFlowUtils, MutableOwnedFlowUtils};
 use layout::flow_ref::FlowRef;
-use layout::incremental::{LayoutDamageComputation, REFLOW_ENTIRE_DOCUMENT};
+use layout::incremental::{LayoutDamageComputation, REFLOW_ENTIRE_DOCUMENT, RelayoutMode};
 use layout::layout_debug;
 use layout::opaque_node::OpaqueNodeMethods;
 use layout::parallel;
@@ -810,7 +810,7 @@ impl LayoutThread {
     fn solve_constraints(layout_root: &mut Flow,
                          layout_context: &LayoutContext) {
         let _scope = layout_debug_scope!("solve_constraints");
-        sequential::traverse_flow_tree_preorder(layout_root, layout_context);
+        sequential::traverse_flow_tree_preorder(layout_root, layout_context, RelayoutMode::Incremental);
     }
 
     /// Performs layout constraint solving in parallel.

--- a/tests/wpt/metadata-css/css21_dev/html4/floats-038.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/floats-038.htm.ini
@@ -1,3 +1,0 @@
-[floats-038.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/floats-wrap-bfc-002-left-table.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/floats-wrap-bfc-002-left-table.htm.ini
@@ -1,3 +1,0 @@
-[floats-wrap-bfc-002-left-table.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
When reflowing a block format context during the inorder traversal,
propagate restyle damage manually to its children since they were
already reflowed. Also, test the border box to see if it can fit into
floats according to CSS 2.1 § 9.5.

Improves reddit and yahoo.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16458)
<!-- Reviewable:end -->
