### PR TITLE
Remove comment about text-combine-upright digits.

### DIFF
--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -1274,9 +1274,6 @@ ${helpers.single_keyword("ruby-position", "over under",
 // CSS Writing Modes Module Level 3
 // https://drafts.csswg.org/css-writing-modes-3/
 
-// The spec has "digits <integer>?" value in addition. But that value is
-// at-risk, and Gecko's layout code doesn't support that either. So we
-// can just take the easy way for now.
 ${helpers.single_keyword("text-combine-upright", "none all",
                          products="gecko", animation_type="none",
                          spec="https://drafts.csswg.org/css-writing-modes-3/#text-combine-upright")}


### PR DESCRIPTION
The digits value was never implemented and was dropped from the spec. Old issues like #13769 still discussed if this value should be implemented.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16466)
<!-- Reviewable:end -->
