### PR TITLE
stylo: Add glue for contain property

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1641,7 +1641,7 @@ fn static_assert() {
                           scroll-snap-points-x scroll-snap-points-y transform
                           scroll-snap-type-y scroll-snap-coordinate
                           perspective-origin transform-origin -moz-binding will-change
-                          shape-outside""" %>
+                          shape-outside contain""" %>
 <%self:impl_trait style_struct_name="Box" skip_longhands="${skip_box_longhands}">
 
     // We manually-implement the |display| property until we get general
@@ -2257,6 +2257,71 @@ fn static_assert() {
     }
 
     <% impl_shape_source("shape_outside", "mShapeOutside") %>
+
+    pub fn set_contain(&mut self, v: longhands::contain::computed_value::T) {
+        use gecko_bindings::structs::NS_STYLE_CONTAIN_NONE;
+        use gecko_bindings::structs::NS_STYLE_CONTAIN_STRICT;
+        use gecko_bindings::structs::NS_STYLE_CONTAIN_LAYOUT;
+        use gecko_bindings::structs::NS_STYLE_CONTAIN_STYLE;
+        use gecko_bindings::structs::NS_STYLE_CONTAIN_PAINT;
+        use gecko_bindings::structs::NS_STYLE_CONTAIN_ALL_BITS;
+        use properties::longhands::contain;
+
+        if v.is_empty() {
+            self.gecko.mContain = NS_STYLE_CONTAIN_NONE as u8;
+            return;
+        }
+
+        if v.contains(contain::STRICT) {
+            self.gecko.mContain = (NS_STYLE_CONTAIN_STRICT | NS_STYLE_CONTAIN_ALL_BITS) as u8;
+            return;
+        }
+
+        let mut bitfield = 0;
+        if v.contains(contain::LAYOUT) {
+            bitfield |= NS_STYLE_CONTAIN_LAYOUT;
+        }
+        if v.contains(contain::STYLE) {
+            bitfield |= NS_STYLE_CONTAIN_STYLE;
+        }
+        if v.contains(contain::PAINT) {
+            bitfield |= NS_STYLE_CONTAIN_PAINT;
+        }
+
+        self.gecko.mContain = bitfield as u8;
+    }
+
+    pub fn clone_contain(&self) -> longhands::contain::computed_value::T {
+        use gecko_bindings::structs::NS_STYLE_CONTAIN_STRICT;
+        use gecko_bindings::structs::NS_STYLE_CONTAIN_LAYOUT;
+        use gecko_bindings::structs::NS_STYLE_CONTAIN_STYLE;
+        use gecko_bindings::structs::NS_STYLE_CONTAIN_PAINT;
+        use gecko_bindings::structs::NS_STYLE_CONTAIN_ALL_BITS;
+        use properties::longhands::contain;
+
+        let mut servo_flags = contain::computed_value::T::empty();
+        let gecko_flags = self.gecko.mContain;
+
+        if gecko_flags & (NS_STYLE_CONTAIN_STRICT as u8) != 0 &&
+           gecko_flags & (NS_STYLE_CONTAIN_ALL_BITS as u8) != 0 {
+            servo_flags.insert(contain::STRICT | contain::STRICT_BITS);
+            return servo_flags;
+        }
+
+        if gecko_flags & (NS_STYLE_CONTAIN_LAYOUT as u8) != 0 {
+            servo_flags.insert(contain::LAYOUT);
+        }
+        if gecko_flags & (NS_STYLE_CONTAIN_STYLE as u8) != 0{
+            servo_flags.insert(contain::STYLE);
+        }
+        if gecko_flags & (NS_STYLE_CONTAIN_PAINT as u8) != 0 {
+            servo_flags.insert(contain::PAINT);
+        }
+
+        return servo_flags;
+    }
+
+    ${impl_simple_copy("contain", "mContain")}
 </%self:impl_trait>
 
 <%def name="simple_image_array_property(name, shorthand, field_name)">

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -2096,8 +2096,10 @@ ${helpers.single_keyword("transform-style",
             const LAYOUT = 0x02,
             const STYLE = 0x04,
             const PAINT = 0x08,
-            const STRICT = SIZE.bits | LAYOUT.bits | STYLE.bits | PAINT.bits,
-            const CONTENT = LAYOUT.bits | STYLE.bits | PAINT.bits,
+            const STRICT = 0x10,
+            const STRICT_BITS = SIZE.bits | LAYOUT.bits | STYLE.bits | PAINT.bits,
+            const CONTENT = 0x20,
+            const CONTENT_BITS = LAYOUT.bits | STYLE.bits | PAINT.bits,
         }
     }
 
@@ -2148,11 +2150,11 @@ ${helpers.single_keyword("transform-style",
             return Ok(result)
         }
         if input.try(|input| input.expect_ident_matching("strict")).is_ok() {
-            result.insert(STRICT);
+            result.insert(STRICT | STRICT_BITS);
             return Ok(result)
         }
         if input.try(|input| input.expect_ident_matching("content")).is_ok() {
-            result.insert(CONTENT);
+            result.insert(CONTENT | CONTENT_BITS);
             return Ok(result)
         }
 

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -353,6 +353,7 @@ ${helpers.single_keyword("overflow-clip-box", "padding-box content-box",
 
 // FIXME(pcwalton, #2742): Implement scrolling for `scroll` and `auto`.
 ${helpers.single_keyword("overflow-x", "visible hidden scroll auto",
+                         extra_gecko_values="clip",
                          need_clone=True, animation_type="none",
                          gecko_constant_prefix="NS_STYLE_OVERFLOW",
                          spec="https://drafts.csswg.org/css-overflow/#propdef-overflow-x")}

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -2076,7 +2076,7 @@ ${helpers.single_keyword("transform-style",
     }
 </%helpers:longhand>
 
-<%helpers:longhand name="contain" animation_type="none" products="none"
+<%helpers:longhand name="contain" animation_type="none" products="none" need_clone="True"
                    spec="https://drafts.csswg.org/css-contain/#contain-property">
     use std::fmt;
     use style_traits::ToCss;

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2407,8 +2407,11 @@ pub fn apply_declarations<'a, F, I>(device: &Device,
     {
         use computed_values::overflow_x::T as overflow;
         use computed_values::overflow_y;
-        match (style.get_box().clone_overflow_x() == longhands::overflow_x::computed_value::T::visible,
-               style.get_box().clone_overflow_y().0 == longhands::overflow_x::computed_value::T::visible) {
+
+        let overflow_x = style.get_box().clone_overflow_x();
+        let overflow_y = style.get_box().clone_overflow_y().0;
+        match (overflow_x == longhands::overflow_x::computed_value::T::visible,
+               overflow_y == longhands::overflow_x::computed_value::T::visible) {
             (true, true) => {}
             (true, _) => {
                 style.mutate_box().set_overflow_x(overflow::auto);
@@ -2418,7 +2421,35 @@ pub fn apply_declarations<'a, F, I>(device: &Device,
             }
             _ => {}
         }
+
+        % if product == "gecko":
+            use properties::longhands::contain;
+            // When 'contain: paint', update overflow from 'visible' to 'clip'.
+            let contain = style.get_box().clone_contain();
+            if contain.contains(contain::PAINT) {
+                if let longhands::overflow_x::computed_value::T::visible = overflow_x {
+                    style.mutate_box().set_overflow_x(overflow::clip);
+                }
+                if let longhands::overflow_x::computed_value::T::visible = overflow_y {
+                    style.mutate_box().set_overflow_y(overflow_y::T(overflow::clip));
+                }
+            }
+        % endif
     }
+
+    % if product == "gecko":
+        {
+            use computed_values::display::T as display;
+            use properties::longhands::contain;
+            // An element with contain:paint or contain:layout needs to "be a
+            // formatting context"
+            let contain = style.get_box().clone_contain();
+            if contain.contains(contain::PAINT) &&
+               style.get_box().clone_display() == display::inline {
+                style.mutate_box().set_adjusted_display(display::inline_block);
+            }
+        }
+    % endif
 
     // CSS 2.1 section 9.7:
     //

--- a/tests/unit/style/parsing/containment.rs
+++ b/tests/unit/style/parsing/containment.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use parsing::parse;
+use style_traits::ToCss;
 
 #[test]
 fn contain_longhand_should_parse_correctly() {
@@ -13,10 +14,19 @@ fn contain_longhand_should_parse_correctly() {
     assert_eq!(none, SpecifiedValue::empty());
 
     let strict = parse_longhand!(contain, "strict");
-    assert_eq!(strict, contain::STRICT);
+    assert_eq!(strict, contain::STRICT | contain::STRICT_BITS);
+
+    let strict = parse_longhand!(contain, "content");
+    assert_eq!(strict, contain::CONTENT | contain::CONTENT_BITS);
 
     let style_paint = parse_longhand!(contain, "style paint");
     assert_eq!(style_paint, contain::STYLE | contain::PAINT);
+
+    assert_roundtrip_with_context!(contain::parse, "strict");
+    assert_roundtrip_with_context!(contain::parse, "size layout style paint");
+
+    assert_roundtrip_with_context!(contain::parse, "content");
+    assert_roundtrip_with_context!(contain::parse, "layout style paint");
 
     // Assert that the `2px` is not consumed, which would trigger parsing failure in real use
     assert_parser_exhausted!(contain::parse, "layout 2px", false);

--- a/tests/unit/style/parsing/containment.rs
+++ b/tests/unit/style/parsing/containment.rs
@@ -16,16 +16,10 @@ fn contain_longhand_should_parse_correctly() {
     let strict = parse_longhand!(contain, "strict");
     assert_eq!(strict, contain::STRICT | contain::STRICT_BITS);
 
-    let strict = parse_longhand!(contain, "content");
-    assert_eq!(strict, contain::CONTENT | contain::CONTENT_BITS);
-
     let style_paint = parse_longhand!(contain, "style paint");
     assert_eq!(style_paint, contain::STYLE | contain::PAINT);
 
     assert_roundtrip_with_context!(contain::parse, "strict");
-    assert_roundtrip_with_context!(contain::parse, "size layout style paint");
-
-    assert_roundtrip_with_context!(contain::parse, "content");
     assert_roundtrip_with_context!(contain::parse, "layout style paint");
 
     // Assert that the `2px` is not consumed, which would trigger parsing failure in real use


### PR DESCRIPTION
In gecko, `size` and `content` values aren't implemented yet. So I had to disable these parts with mako. We will need to update the property and the glue once these are implemented in gecko.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1354998](https://bugzilla.mozilla.org/show_bug.cgi?id=1354998)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so tha
t we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16467)
<!-- Reviewable:end -->
