### PR TITLE
Remove windows-gnu build code

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -100,20 +100,10 @@ arm64:
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 
-windows-gnu-dev:
-  - ./mach build --dev
-  - ./mach test-unit
-  - ./mach build-geckolib
-
 windows-msvc-dev:
   - mach.bat build --dev
   - mach.bat test-unit
   - mach.bat build-geckolib
-
-windows-gnu-nightly:
-  - ./mach build --release
-  - ./mach package --release
-  - ./etc/ci/upload_nightly.sh windows-gnu
 
 windows-msvc-nightly:
   - mach.bat build --release

--- a/etc/ci/upload_nightly.sh
+++ b/etc/ci/upload_nightly.sh
@@ -12,7 +12,7 @@ shopt -s failglob
 
 usage() {
     printf \
-        "usage: %s android|linux|mac|macbrew|windows-gnu|windows-msvc\n" \
+        "usage: %s android|linux|mac|macbrew|windows-msvc\n" \
         "${0}"
 }
 
@@ -89,8 +89,7 @@ main() {
     elif [[ "${platform}" == "macbrew" ]]; then
         extension=tar.gz
         package=target/release/brew/*."${extension}"
-    elif [[ "${platform}" == "windows-gnu" ||
-            "${platform}" == "windows-msvc" ]]; then
+    elif [[ "${platform}" == "windows-msvc" ]]; then
         extension=msi
         package=target/release/msi/*.msi
     else


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is a follow-up to servo/saltfs#620.

There are three other places `windows-gnu` is mentioned, I'm not sure if they can also be removed or not:
- `nightly-x86_64-pc-windows-gnu` is listed as a target in the `appveyor.yml` build matrix
- 2 uses inside `host_platform` in `python/servo/util.py`
- The `windows_gnu` bootstrapper in `python/servo/bootstrap.py`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they remove unused code

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16468)
<!-- Reviewable:end -->
