### PR TITLE
Fix namespaces of elements created in XML documents

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2772,7 +2772,14 @@ impl DocumentMethods for Document {
         if self.is_html_document {
             local_name.make_ascii_lowercase();
         }
-        let name = QualName::new(ns!(html), LocalName::from(local_name));
+
+        let ns = if self.is_html_document || self.content_type == "application/xhtml+xml" {
+            ns!(html)
+        } else {
+            ns!()
+        };
+
+        let name = QualName::new(ns, LocalName::from(local_name));
         Ok(Element::create(name, None, self, ElementCreator::ScriptCreated))
     }
 

--- a/tests/wpt/metadata/dom/nodes/Document-constructor.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-constructor.html.ini
@@ -1,0 +1,4 @@
+[Document-constructor.html]
+  type: testharness
+  [new Document(): URL parsing]
+    expected: FAIL

--- a/tests/wpt/metadata/dom/nodes/Node-properties.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Node-properties.html.ini
@@ -1,8 +1,0 @@
-[Node-properties.html]
-  type: testharness
-  [xmlElement.namespaceURI]
-    expected: FAIL
-
-  [detachedXmlElement.namespaceURI]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -25384,7 +25384,7 @@
    "testharness"
   ],
   "mozilla/document_head.html": [
-   "31892b141aba3b317502e38a4a38fcd8531cb8aa",
+   "b861fe5a1159ba5fba44d3aee048cdb27d378be9",
    "testharness"
   ],
   "mozilla/document_images_cache.html": [

--- a/tests/wpt/mozilla/tests/mozilla/document_head.html
+++ b/tests/wpt/mozilla/tests/mozilla/document_head.html
@@ -13,8 +13,8 @@
 
             test(function() {
                 var new_document = new Document();
-                new_document.appendChild(new_document.createElement("html"));
-                var new_head = new_document.createElement("head");
+                new_document.appendChild(new_document.createElementNS('http://www.w3.org/1999/xhtml', "html"));
+                var new_head = new_document.createElementNS('http://www.w3.org/1999/xhtml', 'head');
 
                 assert_not_equals(new_head, null, "test2-0, append head to a new document");
                 assert_true(new_head instanceof HTMLHeadElement, "test2-1, append head to a new document: should be HTMLHeadElement");
@@ -30,9 +30,9 @@
 
             test(function() {
                 var new_document = new Document();
-                var html = new_document.createElement("html");
-                var foo = new_document.createElement("foo");
-                var head = new_document.createElement("head");
+                var html = new_document.createElementNS('http://www.w3.org/1999/xhtml', "html");
+                var foo = new_document.createElementNS('http://www.w3.org/1999/xhtml', "foo");
+                var head = new_document.createElementNS('http://www.w3.org/1999/xhtml', "head");
                 new_document.appendChild(html);
                 html.appendChild(foo);
                 foo.appendChild(head);


### PR DESCRIPTION
Correctly implement following step of [Dom Document Spec](https://dom.spec.whatwg.org/#dom-document-createelement):
> Let namespace be the HTML namespace, if the context object is an HTML document or context object’s content type is "application/xhtml+xml", and null otherwise.

Note, this will make following test in `tests/wpt/web-platform-tests/dom/nodes/Document-constructor.html` to fail, so related .ini file added to mark it as such:
```
test(function() {
  var doc = new Document();
  var a = doc.createElement("a");
  // In UTF-8: 0xC3 0xA4
  a.href = "http://example.org/?\u00E4";
  assert_equals(a.href, "http://example.org/?%C3%A4");
}, "new Document(): URL parsing")
```
I'm not very familiar with specs, but from quick look at it, I'm doubtfull that it is valid in the first place. This is an "application/xml" document, so I don't see why it should encode a.href. Firefox also fails that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14095 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because because there are already tests which were being ignored

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16472)
<!-- Reviewable:end -->
