### PR TITLE
Support non-negative parsing of lengths for Either<Length, T> types

### DIFF
--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -587,34 +587,12 @@ impl Parse for Length {
     }
 }
 
-impl Either<Length, None_> {
-    /// Parse a non-negative length or none
+impl<T: Parse> Either<Length, T> {
+    /// Parse a non-negative length
     #[inline]
     pub fn parse_non_negative_length(context: &ParserContext, input: &mut Parser) -> Result<Self, ()> {
-        if input.try(|input| None_::parse(context, input)).is_ok() {
-            return Ok(Either::Second(None_));
-        }
-        Length::parse_non_negative(context, input).map(Either::First)
-    }
-}
-
-impl Either<Length, Normal> {
-    #[inline]
-    #[allow(missing_docs)]
-    pub fn parse_non_negative_length(context: &ParserContext, input: &mut Parser) -> Result<Self, ()> {
-        if input.try(|input| Normal::parse(context, input)).is_ok() {
-            return Ok(Either::Second(Normal));
-        }
-        Length::parse_internal(context, input, AllowedLengthType::NonNegative).map(Either::First)
-    }
-}
-
-impl Either<Length, Auto> {
-    #[inline]
-    #[allow(missing_docs)]
-    pub fn parse_non_negative_length(context: &ParserContext, input: &mut Parser) -> Result<Self, ()> {
-        if input.try(|input| Auto::parse(context, input)).is_ok() {
-            return Ok(Either::Second(Auto));
+        if let Ok(v) = input.try(|input| T::parse(context, input)) {
+            return Ok(Either::Second(v));
         }
         Length::parse_internal(context, input, AllowedLengthType::NonNegative).map(Either::First)
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implemented a generic `impl<T> Either<Length, T>` which has a `parse_non_negative_length` method.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #16423 

<!-- Either: -->
- [x] These changes do not require tests because this functionality makes code more modular and doesn't change any existing implementation.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16478)
<!-- Reviewable:end -->
