### PR TITLE
Automatically clean old nightlies

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -1,4 +1,5 @@
 mac-rel-wpt1:
+  - ./mach clean-nightlies --keep 3 --force
   - ./mach build --release
   - ./mach test-wpt-failure
   - ./mach test-wpt --release --processes 8 --total-chunks 2 --this-chunk 1 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
@@ -9,12 +10,14 @@ mac-rel-wpt1:
   - bash ./etc/ci/manifest_changed.sh
 
 mac-rel-wpt2:
+  - ./mach clean-nightlies --keep 3 --force
   - ./mach build --release
   - ./mach test-wpt --release --processes 8 --total-chunks 2 --this-chunk 2 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --use-tracker
   - ./mach build-geckolib --release
 
 mac-dev-unit:
+  - ./mach clean-nightlies --keep 3 --force
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --dev
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach test-unit
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach package --dev
@@ -24,6 +27,7 @@ mac-dev-unit:
   - bash ./etc/ci/manifest_changed.sh
 
 mac-rel-css:
+  - ./mach clean-nightlies --keep 3 --force
   - ./mach build --release
   - ./mach test-css --release --processes 4 --log-raw test-css.log --log-errorsummary css-errorsummary.log --always-succeed
   - ./mach filter-intermittents css-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-css-errorsummary.log --use-tracker
@@ -31,20 +35,24 @@ mac-rel-css:
   - bash ./etc/ci/manifest_changed.sh
 
 mac-nightly:
+  - ./mach clean-nightlies --keep 3 --force
   - ./mach build --release
   - ./mach package --release
   - ./etc/ci/upload_nightly.sh mac
   - ./etc/ci/upload_nightly.sh macbrew
 
 linux-rel-intermittent:
+  - ./mach clean-nightlies --keep 3 --force
   - ./mach build --release
   - ./etc/ci/check_intermittents.sh --log-raw intermittents.log
 
 mac-rel-intermittent:
+  - ./mach clean-nightlies --keep 3 --force
   - ./mach build --release
   - ./etc/ci/check_intermittents.sh --log-raw intermittents.log
 
 linux-dev:
+  - ./mach clean-nightlies --keep 3 --force
   - ./mach test-tidy --no-progress --all
   - ./mach test-tidy --no-progress --self-test
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --dev
@@ -59,6 +67,7 @@ linux-dev:
   - bash ./etc/ci/check_no_panic.sh
 
 linux-rel-wpt:
+  - ./mach clean-nightlies --keep 3 --force
   - ./mach build --release --with-debug-assertions
   - ./mach test-wpt-failure
   - ./mach test-wpt --release --processes 24 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
@@ -66,6 +75,7 @@ linux-rel-wpt:
   - ./mach test-wpt --release --binary-arg=--multiprocess --processes 24 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
 
 linux-rel-css:
+  - ./mach clean-nightlies --keep 3 --force
   - ./mach build --release --with-debug-assertions
   - ./mach test-css --release --processes 16 --log-raw test-css.log --log-errorsummary css-errorsummary.log --always-succeed
   - ./mach filter-intermittents css-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-css-errorsummary.log --use-tracker
@@ -76,11 +86,13 @@ linux-rel-css:
   - bash ./etc/ci/manifest_changed.sh
 
 linux-nightly:
+  - ./mach clean-nightlies --keep 3 --force
   - ./mach build --release
   - ./mach package --release
   - ./etc/ci/upload_nightly.sh linux
 
 android:
+  - ./mach clean-nightlies --keep 3 --force
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --android --dev
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach package --android --dev
   - bash ./etc/ci/lockfile_changed.sh
@@ -88,27 +100,32 @@ android:
   - python ./etc/ci/check_dynamic_symbols.py
 
 android-nightly:
+  - ./mach clean-nightlies --keep 3 --force
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --android --release
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach package --android --release
   - ./etc/ci/upload_nightly.sh android
 
 arm32:
+  - ./mach clean-nightlies --keep 3 --force
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --rel --target=arm-unknown-linux-gnueabihf
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 
 arm64:
+  - ./mach clean-nightlies --keep 3 --force
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --rel --target=aarch64-unknown-linux-gnu
   - bash ./etc/ci/lockfile_changed.sh
   - bash ./etc/ci/manifest_changed.sh
 
 windows-msvc-dev:
+  - mach.bat clean-nightlies --keep 3 --force
   - mach.bat build --dev
   - mach.bat test-unit
   - mach.bat package --dev
   - mach.bat build-geckolib
 
 windows-msvc-nightly:
+  - mach.bat clean-nightlies --keep 3 --force
   - mach.bat build --release
   - mach.bat package --release
   - bash -l ./etc/ci/upload_nightly.sh windows-msvc

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -33,13 +33,7 @@ from servo.command_base import (
     is_windows,
     get_browserhtml_path,
 )
-
-
-def delete(path):
-    try:
-        os.remove(path)         # Succeeds if path was a file
-    except OSError:             # Or, if path was a directory...
-        shutil.rmtree(path)     # Remove it and all its contents.
+from servo.util import delete
 
 
 def otool(s):

--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -10,14 +10,22 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os
-import os.path as path
+import os.path
 import platform
-import sys
+import shutil
 from socket import error as socket_error
 import StringIO
+import sys
 import tarfile
 import zipfile
 import urllib2
+
+
+def delete(path):
+    if os.path.isdir(path) and not os.path.islink(path):
+        shutil.rmtree(path)
+    else:
+        os.remove(path)
 
 
 def host_platform():
@@ -126,7 +134,7 @@ def download_bytes(desc, src):
 def download_file(desc, src, dst):
     tmp_path = dst + ".part"
     try:
-        start_byte = path.getsize(tmp_path)
+        start_byte = os.path.getsize(tmp_path)
         with open(tmp_path, 'ab') as fd:
             download(desc, src, fd, start_byte=start_byte)
     except os.error:
@@ -143,8 +151,8 @@ def extract(src, dst, movedir=None):
 
     if movedir:
         for f in os.listdir(movedir):
-            frm = path.join(movedir, f)
-            to = path.join(dst, f)
+            frm = os.path.join(movedir, f)
+            to = os.path.join(dst, f)
             os.rename(frm, to)
         os.rmdir(movedir)
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Automatically clean old rustc and cargo nightlies on our builders up to preserve disk space.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #12103 and help with servo/saltfs#321 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because tested manually

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16487)
<!-- Reviewable:end -->
