### PR TITLE
Show HTTP response headers in debug output.

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1095,6 +1095,13 @@ fn http_network_fetch(request: &Request,
         Err(error) => return Response::network_error(error),
     };
 
+    if log_enabled!(log::LogLevel::Info) {
+        info!("response for {}", url);
+        for header in res.response.headers.iter() {
+            info!(" - {}", header);
+        }
+    }
+
     let mut response = Response::new(url.clone());
     response.status = Some(res.response.status);
     response.raw_status = Some((res.response.status_raw().0,


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are changing informative debug output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16489)
<!-- Reviewable:end -->
