### PR TITLE
Fix unsafe Heap constructor usage in DOM objects

### DIFF
--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -35,7 +35,7 @@ impl ExtendableMessageEvent {
                -> Root<ExtendableMessageEvent> {
         let ev = box ExtendableMessageEvent {
             event: ExtendableEvent::new_inherited(),
-            data: Heap::new(data.get()),
+            data: Heap::default(),
             origin: origin,
             lastEventId: lastEventId,
         };
@@ -44,6 +44,8 @@ impl ExtendableMessageEvent {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);
         }
+        ev.data.set(data.get());
+
         ev
     }
 

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -41,11 +41,14 @@ impl MessageEvent {
                            lastEventId: DOMString) -> Root<MessageEvent> {
         let ev = box MessageEvent {
             event: Event::new_inherited(),
-            data: Heap::new(data.get()),
+            data: Heap::default(),
             origin: origin,
             lastEventId: lastEventId,
         };
-        reflect_dom_object(ev, global, MessageEventBinding::Wrap)
+        let ev = reflect_dom_object(ev, global, MessageEventBinding::Wrap);
+        ev.data.set(data.get());
+
+        ev
     }
 
     pub fn new(global: &GlobalScope, type_: Atom,

--- a/components/script/dom/vreyeparameters.rs
+++ b/components/script/dom/vreyeparameters.rs
@@ -28,29 +28,29 @@ pub struct VREyeParameters {
 unsafe_no_jsmanaged_fields!(WebVREyeParameters);
 
 impl VREyeParameters {
-    #[allow(unsafe_code)]
-    #[allow(unrooted_must_root)]
-    fn new_inherited(parameters: WebVREyeParameters, global: &GlobalScope) -> VREyeParameters {
-        let fov = VRFieldOfView::new(&global, parameters.field_of_view.clone());
-        let result = VREyeParameters {
+    fn new_inherited(parameters: WebVREyeParameters, fov: &VRFieldOfView) -> VREyeParameters {
+        VREyeParameters {
             reflector_: Reflector::new(),
             parameters: DOMRefCell::new(parameters),
             offset: Heap::default(),
             fov: JS::from_ref(&*fov)
-        };
-
-        unsafe {
-            let _ = Float32Array::create(global.get_cx(),
-                                         CreateWith::Slice(&result.parameters.borrow().offset),
-                                         result.offset.handle_mut());
         }
-        result
     }
 
+    #[allow(unsafe_code)]
     pub fn new(parameters: WebVREyeParameters, global: &GlobalScope) -> Root<VREyeParameters> {
-        reflect_dom_object(box VREyeParameters::new_inherited(parameters, global),
-                           global,
-                           VREyeParametersBinding::Wrap)
+        let fov = VRFieldOfView::new(&global, parameters.field_of_view.clone());
+
+        let eye_parameters = reflect_dom_object(box VREyeParameters::new_inherited(parameters, &fov),
+                                                global,
+                                                VREyeParametersBinding::Wrap);
+        unsafe {
+            let _ = Float32Array::create(global.get_cx(),
+                                         CreateWith::Slice(&eye_parameters.parameters.borrow().offset),
+                                         eye_parameters.offset.handle_mut());
+        }
+
+        eye_parameters
     }
 }
 

--- a/components/script/dom/vrframedata.rs
+++ b/components/script/dom/vrframedata.rs
@@ -31,16 +31,8 @@ pub struct VRFrameData {
 }
 
 impl VRFrameData {
-    #[allow(unsafe_code)]
-    #[allow(unrooted_must_root)]
-    fn new(global: &GlobalScope) -> Root<VRFrameData> {
-        let matrix = [1.0, 0.0, 0.0, 0.0,
-                      0.0, 1.0, 0.0, 0.0,
-                      0.0, 0.0, 1.0, 0.0,
-                      0.0, 0.0, 0.0, 1.0f32];
-        let pose = VRPose::new(&global, &Default::default());
-
-        let framedata = VRFrameData {
+    fn new_inherited(pose: &VRPose) -> VRFrameData {
+        VRFrameData {
             reflector_: Reflector::new(),
             left_proj: Heap::default(),
             left_view: Heap::default(),
@@ -49,23 +41,25 @@ impl VRFrameData {
             pose: JS::from_ref(&*pose),
             timestamp: Cell::new(0.0),
             first_timestamp: Cell::new(0.0)
-        };
-
-        let root = reflect_dom_object(box framedata,
-                           global,
-                           VRFrameDataBinding::Wrap);
-
-        unsafe {
-            let ref framedata = *root;
-            let _ = Float32Array::create(global.get_cx(), CreateWith::Slice(&matrix),
-                                         framedata.left_proj.handle_mut());
-            let _ = Float32Array::create(global.get_cx(), CreateWith::Slice(&matrix),
-                                         framedata.left_view.handle_mut());
-            let _ = Float32Array::create(global.get_cx(), CreateWith::Slice(&matrix),
-                                         framedata.right_proj.handle_mut());
-            let _ = Float32Array::create(global.get_cx(), CreateWith::Slice(&matrix),
-                                         framedata.right_view.handle_mut());
         }
+    }
+
+    #[allow(unsafe_code)]
+    fn new(global: &GlobalScope) -> Root<VRFrameData> {
+        let matrix = [1.0, 0.0, 0.0, 0.0,
+                      0.0, 1.0, 0.0, 0.0,
+                      0.0, 0.0, 1.0, 0.0,
+                      0.0, 0.0, 0.0, 1.0f32];
+        let pose = VRPose::new(&global, &Default::default());
+
+        let root = reflect_dom_object(box VRFrameData::new_inherited(&pose),
+                                      global,
+                                      VRFrameDataBinding::Wrap);
+        let cx = global.get_cx();
+        create_typed_array(cx, &matrix, &root.left_proj);
+        create_typed_array(cx, &matrix, &root.left_view);
+        create_typed_array(cx, &matrix, &root.right_proj);
+        create_typed_array(cx, &matrix, &root.right_view);
 
         root
     }
@@ -75,6 +69,13 @@ impl VRFrameData {
     }
 }
 
+
+#[allow(unsafe_code)]
+fn create_typed_array(cx: *mut JSContext, src: &[f32], dst: &Heap<*mut JSObject>) {
+    unsafe {
+        let _ = Float32Array::create(cx, CreateWith::Slice(src), dst.handle_mut());
+    }
+}
 
 impl VRFrameData {
     #[allow(unsafe_code)]

--- a/components/script/dom/vrpose.rs
+++ b/components/script/dom/vrpose.rs
@@ -32,9 +32,7 @@ unsafe fn update_or_create_typed_array(cx: *mut JSContext,
     match src {
         Some(data) => {
             if dst.get().is_null() {
-                rooted!(in (cx) let mut array = ptr::null_mut());
-                let _ = Float32Array::create(cx, CreateWith::Slice(data), array.handle_mut());
-                (*dst).set(array.get());
+                let _ = Float32Array::create(cx, CreateWith::Slice(data), dst.handle_mut());
             } else {
                 typedarray!(in(cx) let array: Float32Array = dst.get());
                 if let Ok(mut array) = array {

--- a/components/script/dom/vrstageparameters.rs
+++ b/components/script/dom/vrstageparameters.rs
@@ -26,28 +26,28 @@ pub struct VRStageParameters {
 unsafe_no_jsmanaged_fields!(WebVRStageParameters);
 
 impl VRStageParameters {
-    #[allow(unsafe_code)]
-    #[allow(unrooted_must_root)]
-    fn new_inherited(parameters: WebVRStageParameters, global: &GlobalScope) -> VRStageParameters {
-        let stage = VRStageParameters {
+    fn new_inherited(parameters: WebVRStageParameters) -> VRStageParameters {
+        VRStageParameters {
             reflector_: Reflector::new(),
             parameters: DOMRefCell::new(parameters),
             transform: Heap::default()
-        };
-        // XXX unsound!
-        unsafe {
-            let _ = Float32Array::create(global.get_cx(),
-                                         CreateWith::Slice(&stage.parameters.borrow().sitting_to_standing_transform),
-                                         stage.transform.handle_mut());
         }
-
-        stage
     }
 
+    #[allow(unsafe_code)]
     pub fn new(parameters: WebVRStageParameters, global: &GlobalScope) -> Root<VRStageParameters> {
-        reflect_dom_object(box VRStageParameters::new_inherited(parameters, global),
-                           global,
-                           VRStageParametersBinding::Wrap)
+        let cx = global.get_cx();
+        let stage_parameters  = reflect_dom_object(box VRStageParameters::new_inherited(parameters),
+                                                   global,
+                                                   VRStageParametersBinding::Wrap);
+        unsafe {
+           let source = &stage_parameters.parameters.borrow().sitting_to_standing_transform;
+           let _ = Float32Array::create(cx,
+                                        CreateWith::Slice(source),
+                                        stage_parameters.transform.handle_mut());
+        }
+
+        stage_parameters
     }
 
     #[allow(unsafe_code)]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

See https://github.com/servo/rust-mozjs/issues/343#issuecomment-294513870

Heap::new() constructor is unsafe. Heap should be set after reflect_dom_object call in order to prevent potential GC crashes.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16500)
<!-- Reviewable:end -->
