### PR TITLE
Stop mach bootstrap from segfaulting

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -17,6 +17,7 @@ mac-rel-wpt2:
 mac-dev-unit:
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --dev
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach test-unit
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach package --dev
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build-cef
   - ./mach build-geckolib
   - bash ./etc/ci/lockfile_changed.sh
@@ -49,6 +50,7 @@ linux-dev:
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build --dev
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach test-compiletest
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach test-unit
+  - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach package --dev
   - env SERVO_RUSTC_LLVM_ASSERTIONS=1 ./mach build-cef
   - ./mach build-geckolib
   - ./mach test-stylo
@@ -103,6 +105,7 @@ arm64:
 windows-msvc-dev:
   - mach.bat build --dev
   - mach.bat test-unit
+  - mach.bat package --dev
   - mach.bat build-geckolib
 
 windows-msvc-nightly:

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -9,36 +9,30 @@
 
 from __future__ import print_function, unicode_literals
 
-import sys
-import os.path as path
-sys.path.append(path.join(path.dirname(sys.argv[0]), "components", "style", "properties", "Mako-0.9.1.zip"))
-
 import json
 import os
+import os.path as path
 import shutil
 import subprocess
-import mako.template
-
-from mach.registrar import Registrar
 
 from mach.decorators import (
     CommandArgument,
     CommandProvider,
     Command,
 )
-
-from mako.template import Template
+from mach.registrar import Registrar
+# Note: mako cannot be imported at the top level because it breaks mach bootstrap
 
 from servo.command_base import (
     archive_deterministically,
     BuildNotFound,
     cd,
     CommandBase,
+    find_dep_path_newest,
     is_macosx,
     is_windows,
     get_browserhtml_path,
 )
-from servo.command_base import find_dep_path_newest
 
 
 def delete(path):
@@ -221,6 +215,7 @@ class PackageCommands(CommandBase):
                 raise Exception("Error occurred when getting Servo version: " + stderr)
             version = "Nightly version: " + version
 
+            import mako.template
             template_path = path.join(dir_to_resources, 'Credits.rtf.mako')
             credits_path = path.join(dir_to_resources, 'Credits.rtf')
             with open(template_path) as template_file:
@@ -299,8 +294,9 @@ class PackageCommands(CommandBase):
             change_prefs(dir_to_resources, "windows")
 
             # generate Servo.wxs
+            import mako.template
             template_path = path.join(dir_to_root, "support", "windows", "Servo.wxs.mako")
-            template = Template(open(template_path).read())
+            template = mako.template.Template(open(template_path).read())
             wxs_path = path.join(dir_to_msi, "Servo.wxs")
             open(wxs_path, "w").write(template.render(
                 exe_path=target_dir,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

See the commit message for details; the top-level import of Mako causes `./mach bootstrap` to segfault in glibc while exiting, seems to have to do with the native `_speedups.so` library of MarkupSafe, a Mako dependency.

Needed for servo/saltfs#631.
cc @emilio to make sure this is OK for stylo (e.g. #13171)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #12103 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the test is part of servo/saltfs#631

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16505)
<!-- Reviewable:end -->
