### PR TITLE
Use NativeFontHandle instead of CGFont

### DIFF
--- a/components/gfx/platform/macos/font_template.rs
+++ b/components/gfx/platform/macos/font_template.rs
@@ -18,6 +18,7 @@ use std::fs::File;
 use std::io::{Read, Error as IoError};
 use std::ops::Deref;
 use std::sync::Mutex;
+use webrender_traits::NativeFontHandle;
 
 /// Platform specific font representation for mac.
 /// The identifier is a PostScript font name. The
@@ -106,8 +107,8 @@ impl FontTemplateData {
     }
 
     /// Returns the native font that underlies this font template, if applicable.
-    pub fn native_font(&self) -> Option<CGFont> {
-        self.ctfont(0.0).map(|ctfont| ctfont.copy_to_CGFont())
+    pub fn native_font(&self) -> Option<NativeFontHandle> {
+        self.ctfont(0.0).map(|ctfont| NativeFontHandle(ctfont.copy_to_CGFont()))
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
```serde``` is removed from ```core-graphics```, ```NativeFontHandle``` implements serialization and we should use ```NativeFontHandle``` instead of ```CGFont```.

This PR depends on followings.
https://github.com/servo/core-graphics-rs/pull/82
https://github.com/servo/webrender/pull/1133

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X]  These changes fix #15607 (github issue number if applicable).

<!-- Either: -->
- [X] These changes do not require tests according to issue comment.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16512)
<!-- Reviewable:end -->
