### PR TITLE
Properly parse background-size in background longhand (fixes #15199)

### DIFF
--- a/components/style/properties/longhand/background.mako.rs
+++ b/components/style/properties/longhand/background.mako.rs
@@ -494,11 +494,9 @@ ${helpers.single_keyword("background-origin",
         let width =
             try!(specified::LengthOrPercentageOrAuto::parse_non_negative(context, input));
 
-        let height = if input.is_exhausted() {
-            specified::LengthOrPercentageOrAuto::Auto
-        } else {
-            try!(specified::LengthOrPercentageOrAuto::parse_non_negative(context, input))
-        };
+        let height = input.try(|input| {
+            specified::LengthOrPercentageOrAuto::parse_non_negative(context, input)
+        }).unwrap_or(specified::LengthOrPercentageOrAuto::Auto);
 
         Ok(SpecifiedValue::Explicit(ExplicitSize {
             width: width,

--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-332.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-332.htm.ini
@@ -12,12 +12,6 @@
   [background_specified_repeat]
     expected: FAIL
 
-  [background_specified_attachment]
-    expected: FAIL
-
-  [background_specified_origin]
-    expected: FAIL
-
   [background_specified_color]
     expected: FAIL
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16513)
<!-- Reviewable:end -->
