### PR TITLE
Added WPT test case for same-origin-domain checking after adopting a node

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11369,6 +11369,12 @@
      {}
     ]
    ],
+   "mozilla/adopted_node_is_same_origin_domain.html": [
+    [
+     "/_mozilla/mozilla/adopted_node_is_same_origin_domain.html",
+     {}
+    ]
+   ],
    "mozilla/binding_keyword.html": [
     [
      "/_mozilla/mozilla/binding_keyword.html",
@@ -24491,6 +24497,10 @@
   "mozilla/adopt-panic.css": [
    "170d51460da58c16f5cf94ecda18f18a1c18c116",
    "support"
+  ],
+  "mozilla/adopted_node_is_same_origin_domain.html": [
+   "3f2e6af92f9391aa1892e485c61c9e92c7661194",
+   "testharness"
   ],
   "mozilla/binding_keyword.html": [
    "c79aa6d506fbabbed0f6f31d1b8600ea6ba8ff41",

--- a/tests/wpt/mozilla/meta/mozilla/adopted_node_is_same_origin_domain.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/adopted_node_is_same_origin_domain.html.ini
@@ -1,0 +1,4 @@
+[adopted_node_is_same_origin_domain.html]
+  type: testharness
+  [Adopting a node should make it same-origin-domain.]
+    expected: FAIL

--- a/tests/wpt/mozilla/tests/mozilla/adopted_node_is_same_origin_domain.html
+++ b/tests/wpt/mozilla/tests/mozilla/adopted_node_is_same_origin_domain.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Ensure that adopted nodes pass the same-origin-domain checks</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-document-adoptnode">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+async_test(function(t) {
+  // This tests that adopting a node changes its same-origin-domain checks.
+  var iframe = document.createElement("iframe");
+  iframe.src = "/common/blank.html";
+  iframe.onload = t.step_func(function() {
+    // Create two nodes in the iframe's content document.
+    var nodeToAdopt = iframe.contentDocument.createElement("div");
+    var nodeToLeaveUnadopted = iframe.contentDocument.createElement("div");
+    document.adoptNode(nodeToAdopt);
+    assert_equals(nodeToAdopt.ownerDocument, document);
+    assert_equals(nodeToLeaveUnadopted.ownerDocument, iframe.contentDocument);
+    // Setting the iframe's document.domain causes it not to be same-origin-domain
+    iframe.contentDocument.domain = document.domain;
+    // We can still access the adopted node, since it is still same-origin-domain,
+    // but accessing the unadopted node throws a security exception.
+    assert_equals(nodeToAdopt.ownerDocument, document);
+    assert_throws(null, function() { nodeToLeaveUnadopted.ownerDocument; });
+    t.done();
+  });
+  document.body.appendChild(iframe);
+}, "Adopting a node should make it same-origin-domain.")
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This adds a WPT test case to make sure that after adopting a node, accessing it does not cause a security error.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16520)
<!-- Reviewable:end -->
