### PR TITLE
stylo: Bug 1357671 - Make animation_type of logical properties be None.

### DIFF
--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -176,8 +176,10 @@ class Longhand(object):
 
         self.animatable = animation_type != "none"
         if self.logical:
-            # Logical properties don't animate separately
+            # Logical properties will be animatable (i.e. the animation type is
+            # discrete). For now, it is still non-animatable.
             self.animatable = False
+            self.animation_type = None
         # NB: Animatable implies clone because a property animation requires a
         # copy of the computed value.
         #


### PR DESCRIPTION
Logical properties will be animatable (with discrete type), but for now, it is still non-animatable, so we assign "None" to the animation_type.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix Bug 1357671
- [X] These changes do not require tests because this is for code gen. If there is any problem, we will get compilation errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16526)
<!-- Reviewable:end -->
