### PR TITLE
Create proper root ClipId when scrolling from script

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -797,7 +797,12 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                                 pipeline_id: PipelineId,
                                 scroll_root_id: ScrollRootId,
                                 point: Point2D<f32>) {
-        let id = ClipId::new(scroll_root_id.0 as u64, pipeline_id.to_webrender());
+        let id = if scroll_root_id.0 == 0 {
+            ClipId::root_scroll_node(pipeline_id.to_webrender())
+        } else {
+            ClipId::new(scroll_root_id.0 as u64, pipeline_id.to_webrender())
+        };
+
         self.webrender_api.scroll_node_with_id(LayoutPoint::from_untyped(&point), id);
     }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6485,6 +6485,18 @@
      {}
     ]
    ],
+   "mozilla/scroll_root.html": [
+    [
+     "/_mozilla/mozilla/scroll_root.html",
+     [
+      [
+       "/_mozilla/mozilla/scroll_root_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "mozilla/scrolling_div_background_borders.html": [
     [
      "/_mozilla/mozilla/scrolling_div_background_borders.html",
@@ -11003,6 +11015,11 @@
     ]
    ],
    "mozilla/restyle-out-of-document-ref.html": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/scroll_root_ref.html": [
     [
      {}
     ]
@@ -31288,6 +31305,14 @@
   "mozilla/scrollTo.html": [
    "b9917be5fed364dbc46264f641f54f275b5c054a",
    "testharness"
+  ],
+  "mozilla/scroll_root.html": [
+   "21c447dd041a77fb54e2b28c8b76de684afb9560",
+   "reftest"
+  ],
+  "mozilla/scroll_root_ref.html": [
+   "ce75eb73232617c77309aca879ba8d34461538a6",
+   "support"
   ],
   "mozilla/scroll_top_null_target.html": [
    "8e419c3f33fba1bc1444cf4c6dd3e5977f6fd841",

--- a/tests/wpt/mozilla/tests/mozilla/scroll_root.html
+++ b/tests/wpt/mozilla/tests/mozilla/scroll_root.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Verify that scrolling the root does actually do a visual scroll</title>
+        <link rel="match" href="scroll_root_ref.html">
+        <style>
+            body {
+                background: green;
+            }
+        </style>
+    </head>
+    <body onload="window.scrollBy(0, 2000);">
+        <div style="width: 100px; height: 100px; background: red;"></div>
+        <div style="height: 10000px"></div>
+    </body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/scroll_root_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/scroll_root_ref.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            body {
+                background: green;
+            }
+        </style>
+    </head>
+</html>


### PR DESCRIPTION
WebRender currently makes a distinction between an external ClipId with
id equal to 0 and the root scroll ClipId. We need to detect this
situation and properly form the ClipId for the root.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16529)
<!-- Reviewable:end -->
