### PR TITLE
stylo: Change the animation_type of column-count to normal.

### DIFF
--- a/components/style/properties/longhand/column.mako.rs
+++ b/components/style/properties/longhand/column.mako.rs
@@ -23,7 +23,7 @@ ${helpers.predefined_type("column-count",
                           parse_method="parse_positive",
                           initial_specified_value="Either::Second(Auto)",
                           experimental="True",
-                          animation_type="none",
+                          animation_type="normal",
                           extra_prefixes="moz",
                           spec="https://drafts.csswg.org/css-multicol/#propdef-column-count")}
 


### PR DESCRIPTION
According to PR #16494, column-count should be animatable, so we should change the animation_type to "normal".

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix Bug 1355732 and PR #16494.
- [X] These changes do not require tests because we have tests in gecko already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16536)
<!-- Reviewable:end -->
