### PR TITLE
Add `inline-axis` and `block-axis` aliases for `-moz-box-orient`.

### DIFF
--- a/components/style/properties/longhand/xul.mako.rs
+++ b/components/style/properties/longhand/xul.mako.rs
@@ -31,6 +31,7 @@ ${helpers.predefined_type("-moz-box-flex", "Number", "0.0", "parse_non_negative"
 
 ${helpers.single_keyword("-moz-box-orient", "horizontal vertical",
                          products="gecko", gecko_ffi_name="mBoxOrient",
+                         extra_gecko_aliases="inline-axis=horizontal block-axis=vertical",
                          gecko_enum_prefix="StyleBoxOrient",
                          animation_type="none",
                          alias="-webkit-box-orient",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This issue is reported at https://bugzilla.mozilla.org/show_bug.cgi?id=1355005.

spec: https://developer.mozilla.org/en-US/docs/Web/CSS/box-orient

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1355005](https://bugzilla.mozilla.org/show_bug.cgi?id=1355005)

<!-- Either: -->
- [X] These changes do not require tests in Gecko.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16537)
<!-- Reviewable:end -->
