### PR TITLE
add the gecko_debug feature

### DIFF
--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -20,6 +20,7 @@ servo = ["serde/unstable", "serde", "serde_derive", "heapsize", "heapsize_derive
          "cssparser/heapsize", "cssparser/serde", "encoding",
          "rayon/unstable", "servo_url"]
 testing = []
+gecko_debug = []
 
 [dependencies]
 app_units = "0.4"

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["staticlib", "rlib"]
 [features]
 bindgen = ["style/use_bindgen"]
 testing = ["style/testing"]
+gecko_debug = ["style/gecko_debug"]
 
 [dependencies]
 atomic_refcell = "0.1"


### PR DESCRIPTION
debug_assertions is not a reliable guide to whether Gecko C++ code is
being compiled with debugging assertions, since we can now compile Gecko
with --enable-optimize --disable-debug --enable-rust-debug: Gecko will
be compiled without debugging assertions (and debugging struct layouts)
and Rust code will be compiled with debug_assertions.  The struct
mismatches in the binding layer lead to startup crashes.

This feature is not presently used, but will be set by some Gecko-side
changes and then used by some Servo-side changes.  These changes need to
be made first so that CI on both sides works correctly at all
intermediate stages along the way.

This is in service of https://bugzilla.mozilla.org/show_bug.cgi?id=1357556

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because no code is being changed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16545)
<!-- Reviewable:end -->
