### PR TITLE
switch gecko_bindings over to the gecko_debug feature

### DIFF
--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -20,7 +20,7 @@ servo = ["serde/unstable", "serde", "serde_derive", "heapsize", "heapsize_derive
          "cssparser/heapsize", "cssparser/serde", "encoding",
          "rayon/unstable", "servo_url"]
 testing = []
-gecko_debug = []
+gecko_debug = ["nsstring_vendor/gecko_debug"]
 
 [dependencies]
 app_units = "0.4"

--- a/components/style/gecko_bindings/mod.rs
+++ b/components/style/gecko_bindings/mod.rs
@@ -16,7 +16,7 @@ pub mod bindings {
 #[allow(dead_code, improper_ctypes, non_camel_case_types, non_snake_case, non_upper_case_globals, missing_docs)]
 pub mod structs {
     cfg_if! {
-        if #[cfg(debug_assertions)] {
+        if #[cfg(feature = "gecko_debug")] {
             include!(concat!(env!("OUT_DIR"), "/gecko/structs_debug.rs"));
         } else {
             include!(concat!(env!("OUT_DIR"), "/gecko/structs_release.rs"));

--- a/components/style/gecko_bindings/nsstring_vendor/Cargo.toml
+++ b/components/style/gecko_bindings/nsstring_vendor/Cargo.toml
@@ -10,3 +10,5 @@ description = "Rust bindings to xpcom string types"
 
 [dependencies]
 
+[features]
+gecko_debug = []

--- a/components/style/gecko_bindings/nsstring_vendor/src/lib.rs
+++ b/components/style/gecko_bindings/nsstring_vendor/src/lib.rs
@@ -899,12 +899,12 @@ macro_rules! ns_auto_string {
     }
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "gecko_debug"))]
 #[allow(non_snake_case)]
 unsafe fn Gecko_IncrementStringAdoptCount(_: *mut c_void) {}
 
 extern "C" {
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "gecko_debug")]
     fn Gecko_IncrementStringAdoptCount(data: *mut c_void);
 
     // Gecko implementation in nsSubstring.cpp

--- a/components/style/gecko_bindings/sugar/ns_com_ptr.rs
+++ b/components/style/gecko_bindings/sugar/ns_com_ptr.rs
@@ -8,14 +8,14 @@ use gecko_bindings::structs::nsCOMPtr;
 
 impl<T> nsCOMPtr<T> {
     /// Get this pointer as a raw pointer.
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "gecko_debug")]
     #[inline]
     pub fn raw(&self) -> *mut T {
         self.mRawPtr
     }
 
     /// Get this pointer as a raw pointer.
-    #[cfg(not(debug_assertions))]
+    #[cfg(not(feature = "gecko_debug"))]
     #[inline]
     pub fn raw(&self) -> *mut T {
         self._base.mRawPtr as *mut _

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1982,7 +1982,7 @@ pub extern "C" fn Servo_GetComputedKeyframeValues(keyframes: RawGeckoKeyframeLis
 
 #[no_mangle]
 pub extern "C" fn Servo_AssertTreeIsClean(root: RawGeckoElementBorrowed) {
-    if !cfg!(debug_assertions) {
+    if !cfg!(feature = "gecko_debug") {
         panic!("Calling Servo_AssertTreeIsClean in release build");
     }
 

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -417,8 +417,9 @@ class MachCommands(CommandBase):
 
         ret = None
         opts = []
+        features = []
         if with_gecko is not None:
-            opts += ["--features", "bindgen"]
+            features += ["bindgen"]
             env["MOZ_DIST"] = path.abspath(path.expanduser(with_gecko))
         if jobs is not None:
             opts += ["-j", jobs]
@@ -426,6 +427,11 @@ class MachCommands(CommandBase):
             opts += ["-v"]
         if release:
             opts += ["--release"]
+        else:
+            features += ["gecko_debug"]
+
+        if features:
+            opts += ["--features", ' '.join(features)]
 
         if with_gecko is not None:
             print("Generating atoms data...")


### PR DESCRIPTION
...so that they use the correct Gecko structs regardless of whether Rust
code is being compiled with debug assertions or not.

This is the second part of the Servo-side changes for https://bugzilla.mozilla.org/show_bug.cgi?id=1357556

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

- [X] These changes do not require tests because building is a sufficient test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16550)
<!-- Reviewable:end -->
