### PR TITLE
Support vendor prefix keyframes rule.

### DIFF
--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -16,9 +16,9 @@ use gecko_bindings::structs::RawGeckoPresContextOwned;
 use media_queries::MediaType;
 use parser::ParserContext;
 use properties::ComputedValues;
-use std::ascii::AsciiExt;
 use std::fmt::{self, Write};
 use std::sync::Arc;
+use str::starts_with_ignore_ascii_case;
 use string_cache::Atom;
 use style_traits::ToCss;
 use style_traits::viewport::ViewportConstraints;
@@ -338,11 +338,6 @@ impl MediaExpressionValue {
             }
         }
     }
-}
-
-fn starts_with_ignore_ascii_case(string: &str, prefix: &str) -> bool {
-    string.len() > prefix.len() &&
-      string[0..prefix.len()].eq_ignore_ascii_case(prefix)
 }
 
 fn find_feature<F>(mut f: F) -> Option<&'static nsMediaFeature>

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -18,7 +18,7 @@ use shared_lock::{SharedRwLock, SharedRwLockReadGuard, Locked, ToCssWithGuard};
 use std::fmt;
 use std::sync::Arc;
 use style_traits::ToCss;
-use stylesheets::{CssRuleType, MemoryHoleReporter, Stylesheet};
+use stylesheets::{CssRuleType, MemoryHoleReporter, Stylesheet, VendorPrefix};
 
 /// A number from 0 to 1, indicating the percentage of the animation when this
 /// keyframe should run.
@@ -239,6 +239,8 @@ pub struct KeyframesAnimation {
     pub steps: Vec<KeyframesStep>,
     /// The properties that change in this animation.
     pub properties_changed: Vec<TransitionProperty>,
+    /// Vendor prefix type the @keyframes has.
+    pub vendor_prefix: Option<VendorPrefix>,
 }
 
 /// Get all the animated properties in a keyframes animation.
@@ -275,11 +277,14 @@ impl KeyframesAnimation {
     ///
     /// Otherwise, this will compute and sort the steps used for the animation,
     /// and return the animation object.
-    pub fn from_keyframes(keyframes: &[Arc<Locked<Keyframe>>], guard: &SharedRwLockReadGuard)
+    pub fn from_keyframes(keyframes: &[Arc<Locked<Keyframe>>],
+                          vendor_prefix: Option<VendorPrefix>,
+                          guard: &SharedRwLockReadGuard)
                           -> Self {
         let mut result = KeyframesAnimation {
             steps: vec![],
             properties_changed: vec![],
+            vendor_prefix: vendor_prefix,
         };
 
         if keyframes.is_empty() {

--- a/components/style/str.rs
+++ b/components/style/str.rs
@@ -7,6 +7,7 @@
 #![deny(missing_docs)]
 
 use num_traits::ToPrimitive;
+use std::ascii::AsciiExt;
 use std::convert::AsRef;
 use std::iter::{Filter, Peekable};
 use std::str::Split;
@@ -143,4 +144,10 @@ pub fn str_join<I, T>(strs: I, join: &str) -> String
         acc.push_str(s.as_ref());
         acc
     })
+}
+
+/// Returns true if a given string has a given prefix with case-insensitive match.
+pub fn starts_with_ignore_ascii_case(string: &str, prefix: &str) -> bool {
+    string.len() > prefix.len() &&
+      string[0..prefix.len()].eq_ignore_ascii_case(prefix)
 }

--- a/tests/unit/style/keyframes.rs
+++ b/tests/unit/style/keyframes.rs
@@ -14,10 +14,13 @@ use style::values::specified::{LengthOrPercentageOrAuto, NoCalcLength};
 fn test_empty_keyframe() {
     let shared_lock = SharedRwLock::new();
     let keyframes = vec![];
-    let animation = KeyframesAnimation::from_keyframes(&keyframes, &shared_lock.read());
+    let animation = KeyframesAnimation::from_keyframes(&keyframes,
+                                                       /* vendor_prefix = */ None,
+                                                       &shared_lock.read());
     let expected = KeyframesAnimation {
         steps: vec![],
         properties_changed: vec![],
+        vendor_prefix: None,
     };
 
     assert_eq!(format!("{:#?}", animation), format!("{:#?}", expected));
@@ -32,10 +35,13 @@ fn test_no_property_in_keyframe() {
             block: Arc::new(shared_lock.wrap(PropertyDeclarationBlock::new()))
         })),
     ];
-    let animation = KeyframesAnimation::from_keyframes(&keyframes, &shared_lock.read());
+    let animation = KeyframesAnimation::from_keyframes(&keyframes,
+                                                       /* vendor_prefix = */ None,
+                                                       &shared_lock.read());
     let expected = KeyframesAnimation {
         steps: vec![],
         properties_changed: vec![],
+        vendor_prefix: None,
     };
 
     assert_eq!(format!("{:#?}", animation), format!("{:#?}", expected));
@@ -78,7 +84,9 @@ fn test_missing_property_in_initial_keyframe() {
             block: declarations_on_final_keyframe.clone(),
         })),
     ];
-    let animation = KeyframesAnimation::from_keyframes(&keyframes, &shared_lock.read());
+    let animation = KeyframesAnimation::from_keyframes(&keyframes,
+                                                       /* vendor_prefix = */ None,
+                                                       &shared_lock.read());
     let expected = KeyframesAnimation {
         steps: vec![
             KeyframesStep {
@@ -93,6 +101,7 @@ fn test_missing_property_in_initial_keyframe() {
             },
         ],
         properties_changed: vec![TransitionProperty::Width, TransitionProperty::Height],
+        vendor_prefix: None,
     };
 
     assert_eq!(format!("{:#?}", animation), format!("{:#?}", expected));
@@ -135,7 +144,9 @@ fn test_missing_property_in_final_keyframe() {
             block: declarations_on_final_keyframe.clone(),
         })),
     ];
-    let animation = KeyframesAnimation::from_keyframes(&keyframes, &shared_lock.read());
+    let animation = KeyframesAnimation::from_keyframes(&keyframes,
+                                                       /* vendor_prefix = */ None,
+                                                       &shared_lock.read());
     let expected = KeyframesAnimation {
         steps: vec![
             KeyframesStep {
@@ -150,6 +161,7 @@ fn test_missing_property_in_final_keyframe() {
             },
         ],
         properties_changed: vec![TransitionProperty::Width, TransitionProperty::Height],
+        vendor_prefix: None,
     };
 
     assert_eq!(format!("{:#?}", animation), format!("{:#?}", expected));
@@ -184,7 +196,9 @@ fn test_missing_keyframe_in_both_of_initial_and_final_keyframe() {
             block: declarations.clone(),
         })),
     ];
-    let animation = KeyframesAnimation::from_keyframes(&keyframes, &shared_lock.read());
+    let animation = KeyframesAnimation::from_keyframes(&keyframes,
+                                                       /* vendor_prefix = */ None,
+                                                       &shared_lock.read());
     let expected = KeyframesAnimation {
         steps: vec![
             KeyframesStep {
@@ -209,6 +223,7 @@ fn test_missing_keyframe_in_both_of_initial_and_final_keyframe() {
             }
         ],
         properties_changed: vec![TransitionProperty::Width, TransitionProperty::Height],
+        vendor_prefix: None,
     };
 
     assert_eq!(format!("{:#?}", animation), format!("{:#?}", expected));

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -245,7 +245,8 @@ fn test_parse_stylesheet() {
                              Importance::Normal),
                         ]))),
                     })),
-                ]
+                ],
+                vendor_prefix: None,
             })))
 
         ], &stylesheet.shared_lock),


### PR DESCRIPTION
If there are multiple prefixed/non-prefixed @keyframes with the same name;

* non-prefixed rule overrides earlier rules.
* prefixed rule overrides earlier prefixed rules.

<!-- Please describe your changes on the following line: -->

This is PR of https://bugzilla.mozilla.org/show_bug.cgi?id=1356779

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16553)
<!-- Reviewable:end -->
