### PR TITLE
Servo does not need to support -moz-keyframes

### DIFF
--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -1131,6 +1131,11 @@ impl<'a, 'b> AtRuleParser for NestedRuleParser<'a, 'b> {
                 } else {
                     None
                 };
+                if cfg!(feature = "servo") &&
+                   prefix.as_ref().map_or(false, |p| matches!(*p, VendorPrefix::Moz)) {
+                    // Servo should not support @-moz-keyframes.
+                    return Err(())
+                }
                 let name = match input.next() {
                     Ok(Token::Ident(ref value)) if value != "none" => Atom::from(&**value),
                     Ok(Token::QuotedString(value)) => Atom::from(&*value),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
In #16553 I did innocently add a support for @-moz-keyframes but as @SimonSapin pointed out, servo does not need to support -moz prefix one. 
Whereas, I think servo should support @-webkit-keyframes since it is described in web
compatibility [1].

[1] https://compat.spec.whatwg.org/#css-at-rules 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16557)
<!-- Reviewable:end -->
