### PR TITLE
Properly parse alignment shorthands (fixes #16391)

### DIFF
--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -249,8 +249,14 @@
 
     pub fn parse_value(context: &ParserContext, input: &mut Parser) -> Result<Longhands, ()> {
         let align = align_content::parse(context, input)?;
+        if align.has_extra_flags() {
+            return Err(());
+        }
         let justify = input.try(|input| justify_content::parse(context, input))
                            .unwrap_or(justify_content::SpecifiedValue::from(align));
+        if justify.has_extra_flags() {
+            return Err(());
+        }
 
         Ok(Longhands {
             align_content: align,
@@ -279,7 +285,13 @@
 
     pub fn parse_value(context: &ParserContext, input: &mut Parser) -> Result<Longhands, ()> {
         let align = AlignJustifySelf::parse(context, input)?;
+        if align.has_extra_flags() {
+            return Err(());
+        }
         let justify = input.try(|input| AlignJustifySelf::parse(context, input)).unwrap_or(align.clone());
+        if justify.has_extra_flags() {
+            return Err(());
+        }
 
         Ok(Longhands {
             align_self: align,
@@ -314,8 +326,14 @@
 
     pub fn parse_value(context: &ParserContext, input: &mut Parser) -> Result<Longhands, ()> {
         let align = AlignItems::parse(context, input)?;
+        if align.has_extra_flags() {
+            return Err(());
+        }
         let justify = input.try(|input| JustifyItems::parse(context, input))
                            .unwrap_or(JustifyItems::from(align));
+        if justify.has_extra_flags() {
+            return Err(());
+        }
 
         Ok(Longhands {
             align_items: align,

--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -155,6 +155,12 @@ impl AlignJustifyContent {
         AlignFlags::from_bits((self.0 >> ALIGN_ALL_SHIFT) as u8)
             .expect("AlignJustifyContent must contain valid flags")
     }
+
+    /// Whether this value has extra flags.
+    #[inline]
+    pub fn has_extra_flags(self) -> bool {
+        self.primary().intersects(ALIGN_FLAG_BITS) || self.fallback().intersects(ALIGN_FLAG_BITS)
+    }
 }
 
 impl ToCss for AlignJustifyContent {
@@ -213,6 +219,12 @@ impl AlignJustifySelf {
     pub fn auto() -> Self {
         AlignJustifySelf(ALIGN_AUTO)
     }
+
+    /// Whether this value has extra flags.
+    #[inline]
+    pub fn has_extra_flags(self) -> bool {
+        self.0.intersects(ALIGN_FLAG_BITS)
+    }
 }
 
 no_viewport_percentage!(AlignJustifySelf);
@@ -251,6 +263,12 @@ impl AlignItems {
     pub fn normal() -> Self {
         AlignItems(ALIGN_NORMAL)
     }
+
+    /// Whether this value has extra flags.
+    #[inline]
+    pub fn has_extra_flags(self) -> bool {
+        self.0.intersects(ALIGN_FLAG_BITS)
+    }
 }
 
 no_viewport_percentage!(AlignItems);
@@ -288,6 +306,12 @@ impl JustifyItems {
     #[inline]
     pub fn auto() -> Self {
         JustifyItems(ALIGN_AUTO)
+    }
+
+    /// Whether this value has extra flags.
+    #[inline]
+    pub fn has_extra_flags(self) -> bool {
+        self.0.intersects(ALIGN_FLAG_BITS)
     }
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16558)
<!-- Reviewable:end -->
