### PR TITLE
Issue #15725: Skip git ignored files in ./mach update-manifest

### DIFF
--- a/tests/wpt/web-platform-tests/tools/manifest/manifest.py
+++ b/tests/wpt/web-platform-tests/tools/manifest/manifest.py
@@ -85,6 +85,10 @@ class Manifest(object):
                 else:
                     new_type, manifest_items = old_type, self._data[old_type][rel_path]
             else:
+                # Issue #15725: Skip git ignored files
+                from vcs import Git
+                if Git.is_ignored(source_file.tests_root, source_file.rel_path):
+                    continue
                 new_type, manifest_items = source_file.manifest_items()
 
             if new_type in ("reftest", "reftest_node"):

--- a/tests/wpt/web-platform-tests/tools/manifest/vcs.py
+++ b/tests/wpt/web-platform-tests/tools/manifest/vcs.py
@@ -25,6 +25,15 @@ class Git(object):
         except subprocess.CalledProcessError:
             return None
 
+    @staticmethod
+    def is_ignored(dir_base, rel_path):
+        git = Git.get_func(dir_base)
+        try:
+            git("check-ignore", "-q", rel_path)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
     def _local_changes(self):
         changes = {}
         cmd = ["status", "-z", "--ignore-submodules=all"]


### PR DESCRIPTION
This patch makes "./mach update-manifest" aware of .gitignore, and therefore avoids adding spurious entries, like for instance .DS_Store on MacOS, or .pyc files

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15725
- [X] These changes do not require tests because I'd like to have first feedback on the idea to rely on .gitignore before investing on mocking all that's needed to test this properly. For the moment I've just verified that "./mach update-manifest" adds spurious entries without the patch, and does not with the patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16562)
<!-- Reviewable:end -->
