### PR TITLE
Compute scriptminsize against the parent font base size

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1476,6 +1476,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetLengthValue(declarations:
                                                         value: f32,
                                                         unit: structs::nsCSSUnit) {
     use style::properties::{PropertyDeclaration, LonghandId};
+    use style::properties::longhands::_moz_script_min_size::SpecifiedValue as MozScriptMinSize;
     use style::values::specified::length::{AbsoluteLength, FontRelativeLength};
     use style::values::specified::length::{LengthOrPercentage, NoCalcLength};
 
@@ -1496,7 +1497,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetLengthValue(declarations:
     let prop = match_wrap_declared! { long,
         Width => nocalc.into(),
         FontSize => LengthOrPercentage::from(nocalc).into(),
-        MozScriptMinSize => nocalc.into(),
+        MozScriptMinSize => MozScriptMinSize(nocalc),
     };
     write_locked_arc(declarations, |decls: &mut PropertyDeclarationBlock| {
         decls.push(prop, Importance::Normal);


### PR DESCRIPTION
It's supposed to be, because it is used in the computation of the font size, so we can't have the current font size as a dependency.


http://searchfox.org/mozilla-central/rev/7aa21f3b531ddee90a353215bd86e97d6974e25b/layout/style/nsRuleNode.cpp#3842

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16570)
<!-- Reviewable:end -->
