### PR TITLE
Font variants

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -973,6 +973,7 @@ ${helpers.single_keyword("font-variant-position",
 <%helpers:longhand name="-x-lang" products="gecko" animatable="False" internal="True"
                    spec="Internal (not web-exposed)"
                    internal="True">
+    use cssparser::serialize_identifier;
     use values::HasViewportPercentage;
     use values::computed::ComputedValueAsSpecified;
     pub use self::computed_value::T as SpecifiedValue;
@@ -1066,7 +1067,7 @@ ${helpers.single_keyword("font-variant-position",
                             }
                             first = false;
 
-                            try!(dest.write_str(arg));
+                            try!(serialize_identifier(arg, dest));
                         }
 
                         try!(dest.write_str(")"));
@@ -1088,7 +1089,7 @@ ${helpers.single_keyword("font-variant-position",
                             }
                             first = false;
 
-                            try!(dest.write_str(&arg));
+                            try!(serialize_identifier(arg, dest));
                         }
 
                         try!(dest.write_str(")"));
@@ -1101,7 +1102,9 @@ ${helpers.single_keyword("font-variant-position",
                             try!(dest.write_str(" "));
                         }
 
-                        try!(write!(dest, "swash({})", arg));
+                        try!(dest.write_str("swash("));
+                        try!(serialize_identifier(arg, dest));
+                        try!(dest.write_str(")"));
 
                         is_empty = false;
                     }
@@ -1111,7 +1114,9 @@ ${helpers.single_keyword("font-variant-position",
                             try!(dest.write_str(" "));
                         }
 
-                        try!(write!(dest, "ornaments({})", arg));
+                        try!(dest.write_str("ornaments("));
+                        try!(serialize_identifier(arg, dest));
+                        try!(dest.write_str(")"));
 
                         is_empty = false;
                     }
@@ -1121,7 +1126,9 @@ ${helpers.single_keyword("font-variant-position",
                             try!(dest.write_str(" "));
                         }
 
-                        try!(write!(dest, "annotation({})", arg));
+                        try!(dest.write_str("annotation("));
+                        try!(serialize_identifier(arg, dest));
+                        try!(dest.write_str(")"));
 
                         is_empty = false;
                     }

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -1218,7 +1218,7 @@ ${helpers.single_keyword("font-variant-position",
                             Ok(())
                         }));
                     },
-                    _ => break, 
+                    _ => break,
                 };
             } else {
                 break;
@@ -1342,8 +1342,6 @@ ${helpers.single_keyword("font-variant-position",
                 }
             }
         }
- 
-
     }
 
     pub fn parse(_context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
@@ -1439,7 +1437,7 @@ ${helpers.single_keyword("font-variant-position",
     }
 </%helpers:longhand>
 
-<%helpers:longhand name="font-variant-ligatures" products="none" 
+<%helpers:longhand name="font-variant-ligatures" products="none"
                    animatable="False" spec="https://drafts.csswg.org/css-fonts-3/#font-variant-ligatures-prop">
     use std::fmt;
     use style_traits::ToCss;
@@ -1453,7 +1451,6 @@ ${helpers.single_keyword("font-variant-position",
         pub use super::SpecifiedValue as T;
     }
 
-    
     #[derive(Debug, Clone, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub struct Style {
@@ -1647,7 +1644,7 @@ ${helpers.single_keyword("font-variant-position",
     }
 </%helpers:longhand>
 
-<%helpers:longhand name="font-variant-numeric" products="none" 
+<%helpers:longhand name="font-variant-numeric" products="none"
                    animatable="False"
                    spec="https://drafts.csswg.org/css-fonts-3/#font-variant-numeric-prop">
     use std::fmt;
@@ -1665,7 +1662,7 @@ ${helpers.single_keyword("font-variant-position",
     #[derive(Debug, Clone, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum FigureValue {
-        Lining, 
+        Lining,
         Oldstyle,
     }
 

--- a/components/style/properties/shorthand/font.mako.rs
+++ b/components/style/properties/shorthand/font.mako.rs
@@ -7,9 +7,9 @@
 <%helpers:shorthand name="font"
                     sub_properties="font-style font-variant font-weight font-stretch
                                     font-size line-height font-family
-                                    font-size-adjust' if product == 'gecko' or data.testing else ''}
-                                    font-kerning' if product == 'gecko' or data.testing else ''}
-                                    font-variant-caps' if product == 'gecko' or data.testing else ''}
+                                    ${'font-size-adjust' if product == 'gecko' or data.testing else ''}
+                                    ${'font-kerning' if product == 'gecko' or data.testing else ''}
+                                    ${'font-variant-caps' if product == 'gecko' or data.testing else ''}
                                     ${'font-variant-position' if product == 'gecko' or data.testing else ''}
                                     ${'font-variant-alternates' if product == 'gecko' or data.testing else ''}
                                     ${'font-variant-east-asian' if product == 'gecko' or data.testing else ''}

--- a/components/style/properties/shorthand/font.mako.rs
+++ b/components/style/properties/shorthand/font.mako.rs
@@ -10,12 +10,16 @@
                                                 ${'font-kerning' if product == 'gecko' or data.testing else ''}
                                                 ${'font-variant-caps' if product == 'gecko' or data.testing else ''}
                                                 ${'font-variant-position' if product == 'gecko' or data.testing else ''}
+                                                ${'font-variant-alternates' if product == 'gecko' or data.testing else ''}
+                                                ${'font-variant-east-asian' if product == 'gecko' or data.testing else ''}
+                                                ${'font-variant-ligatures' if product == 'gecko' or data.testing else ''}
+                                                ${'font-variant-numeric' if product == 'gecko' or data.testing else ''}
                                                 ${'font-language-override' if data.testing else ''}"
                     spec="https://drafts.csswg.org/css-fonts-3/#propdef-font">
     use properties::longhands::{font_style, font_variant, font_weight, font_stretch};
     use properties::longhands::{font_size, line_height};
     % if product == "gecko" or data.testing:
-    use properties::longhands::{font_size_adjust, font_kerning, font_variant_caps, font_variant_position};
+    use properties::longhands::{font_size_adjust, font_kerning, font_variant_caps, font_variant_position, font_variant_alternates, font_variant_east_asian, font_variant_ligatures, font_variant_numeric};
     % endif
     % if data.testing:
     use properties::longhands::font_language_override;
@@ -84,7 +88,7 @@
             line_height: unwrap_or_initial!(line_height),
             font_family: family,
             % if product == "gecko" or data.testing:
-                % for name in "size_adjust kerning variant_caps variant_position".split():
+                % for name in "size_adjust kerning variant_caps variant_position variant_alternates variant_east_asian variant_ligatures variant_numeric".split():
                     font_${name}: font_${name}::get_initial_specified_value(),
                 % endfor
             % endif
@@ -99,7 +103,7 @@
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
 
     % if product == "gecko" or data.testing:
-        % for name in "size_adjust kerning variant_caps variant_position".split():
+        % for name in "size_adjust kerning variant_caps variant_position variant_alternates variant_east_asian variant_ligatures variant_numeric".split():
             if self.font_${name} != &font_${name}::get_initial_specified_value() {
                 return Ok(());
             }

--- a/components/style/properties/shorthand/font.mako.rs
+++ b/components/style/properties/shorthand/font.mako.rs
@@ -4,22 +4,25 @@
 
 <%namespace name="helpers" file="/helpers.mako.rs" />
 
-<%helpers:shorthand name="font" sub_properties="font-style font-variant font-weight font-stretch
-                                                font-size line-height font-family
-                                                ${'font-size-adjust' if product == 'gecko' or data.testing else ''}
-                                                ${'font-kerning' if product == 'gecko' or data.testing else ''}
-                                                ${'font-variant-caps' if product == 'gecko' or data.testing else ''}
-                                                ${'font-variant-position' if product == 'gecko' or data.testing else ''}
-                                                ${'font-variant-alternates' if product == 'gecko' or data.testing else ''}
-                                                ${'font-variant-east-asian' if product == 'gecko' or data.testing else ''}
-                                                ${'font-variant-ligatures' if product == 'gecko' or data.testing else ''}
-                                                ${'font-variant-numeric' if product == 'gecko' or data.testing else ''}
-                                                ${'font-language-override' if data.testing else ''}"
+<%helpers:shorthand name="font"
+                    sub_properties="font-style font-variant font-weight font-stretch
+                                    font-size line-height font-family
+                                    font-size-adjust' if product == 'gecko' or data.testing else ''}
+                                    font-kerning' if product == 'gecko' or data.testing else ''}
+                                    font-variant-caps' if product == 'gecko' or data.testing else ''}
+                                    ${'font-variant-position' if product == 'gecko' or data.testing else ''}
+                                    ${'font-variant-alternates' if product == 'gecko' or data.testing else ''}
+                                    ${'font-variant-east-asian' if product == 'gecko' or data.testing else ''}
+                                    ${'font-variant-ligatures' if product == 'gecko' or data.testing else ''}
+                                    ${'font-variant-numeric' if product == 'gecko' or data.testing else ''}
+                                    ${'font-language-override' if data.testing else ''}"
                     spec="https://drafts.csswg.org/css-fonts-3/#propdef-font">
     use properties::longhands::{font_style, font_variant, font_weight, font_stretch};
     use properties::longhands::{font_size, line_height};
     % if product == "gecko" or data.testing:
-    use properties::longhands::{font_size_adjust, font_kerning, font_variant_caps, font_variant_position, font_variant_alternates, font_variant_east_asian, font_variant_ligatures, font_variant_numeric};
+    use properties::longhands::{font_size_adjust, font_kerning, font_variant_caps, font_variant_position,
+                                font_variant_alternates, font_variant_east_asian, font_variant_ligatures,
+                                font_variant_numeric};
     % endif
     % if data.testing:
     use properties::longhands::font_language_override;

--- a/tests/unit/style/parsing/font.rs
+++ b/tests/unit/style/parsing/font.rs
@@ -122,3 +122,55 @@ fn font_language_override_should_fail_on_empty_str() {
 
     parse_longhand!(font_language_override, "");
 }
+
+#[test]
+fn font_variant_alternates_should_be_parsed_correctly() {
+    use style::properties::longhands::font_variant_alternates;
+
+    assert_roundtrip_with_context!(font_variant_alternates::parse, "normal");
+    assert_roundtrip_with_context!(font_variant_alternates::parse, "historical-forms");
+    assert_roundtrip_with_context!(font_variant_alternates::parse, "styleset(ident1, ident2)");
+    assert_roundtrip_with_context!(font_variant_alternates::parse, "character-variant(ident)");
+    assert_roundtrip_with_context!(font_variant_alternates::parse, "swash(ident)");
+    assert_roundtrip_with_context!(font_variant_alternates::parse, "ornaments(ident)");
+    assert_roundtrip_with_context!(font_variant_alternates::parse, "annotation(ident)");
+    assert_roundtrip_with_context!(font_variant_alternates::parse, "historical-forms styleset(ident1, ident2) annotation(ident)");
+}
+
+#[test]
+fn font_variant_east_asian_should_be_parsed_correctly() {
+    use style::properties::longhands::font_variant_east_asian;
+
+    assert_roundtrip_with_context!(font_variant_east_asian::parse, "normal");
+    assert_roundtrip_with_context!(font_variant_east_asian::parse, "ruby");
+    assert_roundtrip_with_context!(font_variant_east_asian::parse, "jis78");
+    assert_roundtrip_with_context!(font_variant_east_asian::parse, "traditional");
+    assert_roundtrip_with_context!(font_variant_east_asian::parse, "simplified");
+    assert_roundtrip_with_context!(font_variant_east_asian::parse, "full-width");
+    assert_roundtrip_with_context!(font_variant_east_asian::parse, "ruby jis78 full-width");
+}
+
+#[test]
+fn font_variant_ligatures_should_be_parsed_correctly() {
+    use style::properties::longhands::font_variant_ligatures;
+
+    assert_roundtrip_with_context!(font_variant_ligatures::parse, "none");
+    assert_roundtrip_with_context!(font_variant_ligatures::parse, "normal");
+    assert_roundtrip_with_context!(font_variant_ligatures::parse, "common-ligatures");
+    assert_roundtrip_with_context!(font_variant_ligatures::parse, "non-common-ligatures");
+    assert_roundtrip_with_context!(font_variant_ligatures::parse, "contextual");
+    assert_roundtrip_with_context!(font_variant_ligatures::parse, "non-contextual");
+    assert_roundtrip_with_context!(font_variant_ligatures::parse, "non-historical-ligatures contextual");
+}
+
+#[test]
+fn font_variant_numeric_should_be_parsed_correctly() {
+    use style::properties::longhands::font_variant_numeric;
+
+    assert_roundtrip_with_context!(font_variant_numeric::parse, "normal");
+    assert_roundtrip_with_context!(font_variant_numeric::parse, "ordinal");
+    assert_roundtrip_with_context!(font_variant_numeric::parse, "lining-nums");
+    assert_roundtrip_with_context!(font_variant_numeric::parse, "tabular-nums");
+    assert_roundtrip_with_context!(font_variant_numeric::parse, "diagonal-fractions");
+    assert_roundtrip_with_context!(font_variant_numeric::parse, "ordinal diagonal-fractions");
+}

--- a/tests/unit/style/parsing/font.rs
+++ b/tests/unit/style/parsing/font.rs
@@ -134,7 +134,7 @@ fn font_variant_alternates_should_be_parsed_correctly() {
     assert_roundtrip_with_context!(font_variant_alternates::parse, "swash(ident)");
     assert_roundtrip_with_context!(font_variant_alternates::parse, "ornaments(ident)");
     assert_roundtrip_with_context!(font_variant_alternates::parse, "annotation(ident)");
-    assert_roundtrip_with_context!(font_variant_alternates::parse, "historical-forms styleset(ident1, ident2) annotation(ident)");
+    assert_roundtrip_with_context!(font_variant_alternates::parse, "historical-forms styleset(ident1, ident2)");
 }
 
 #[test]

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -650,6 +650,10 @@ mod shorthand_serialization {
                               font-kerning: auto; \
                               font-variant-caps: normal; \
                               font-variant-position: normal; \
+                              font-variant-alternates: normal; \
+                              font-variant-east-asian: normal; \
+                              font-variant-ligatures: normal; \
+                              font-variant-numeric: normal; \
                               font-language-override: normal;";
 
             let block = parse_declaration_block(block_text);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implemented serialization and parsing for the font-variant-{alternates, east-asian, ligatures, numeric} properties. Also added the corresponding shorthands.

Currently `./mach test-tidy` fails on two lines, which are macros and I don't know how to fix those so I'll need some help there.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [X] These changes fix #15957 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16571)
<!-- Reviewable:end -->
