### PR TITLE
Don’t log CSS parsing errors in user-agent stylesheets

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -110,7 +110,7 @@ use style::context::{QuirksMode, ReflowGoal, SharedStyleContext};
 use style::context::{StyleSystemOptions, ThreadLocalStyleContextCreationInfo};
 use style::data::StoredRestyleHint;
 use style::dom::{ShowSubtree, ShowSubtreeDataAndPrimaryValues, TElement, TNode};
-use style::error_reporting::RustLogReporter;
+use style::error_reporting::{NullReporter, RustLogReporter};
 use style::logical_geometry::LogicalPoint;
 use style::media_queries::{Device, MediaList, MediaType};
 use style::servo::restyle_damage::{REFLOW, REFLOW_OUT_OF_FLOW, REPAINT, REPOSITION, STORE_OVERFLOW};
@@ -1587,7 +1587,7 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
             MediaList::empty(),
             shared_lock.clone(),
             None,
-            &RustLogReporter))
+            &NullReporter))
     }
 
     let shared_lock = SharedRwLock::new();

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -110,7 +110,7 @@ use style::context::{QuirksMode, ReflowGoal, SharedStyleContext};
 use style::context::{StyleSystemOptions, ThreadLocalStyleContextCreationInfo};
 use style::data::StoredRestyleHint;
 use style::dom::{ShowSubtree, ShowSubtreeDataAndPrimaryValues, TElement, TNode};
-use style::error_reporting::StdoutErrorReporter;
+use style::error_reporting::RustLogReporter;
 use style::logical_geometry::LogicalPoint;
 use style::media_queries::{Device, MediaList, MediaType};
 use style::servo::restyle_damage::{REFLOW, REFLOW_OUT_OF_FLOW, REPAINT, REPOSITION, STORE_OVERFLOW};
@@ -1587,7 +1587,7 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
             MediaList::empty(),
             shared_lock.clone(),
             None,
-            &StdoutErrorReporter))
+            &RustLogReporter))
     }
 
     let shared_lock = SharedRwLock::new();
@@ -1600,7 +1600,7 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
     for &(ref contents, ref url) in &opts::get().user_stylesheets {
         user_or_user_agent_stylesheets.push(Stylesheet::from_bytes(
             &contents, url.clone(), None, None, Origin::User, MediaList::empty(),
-            shared_lock.clone(), None, &StdoutErrorReporter));
+            shared_lock.clone(), None, &RustLogReporter));
     }
 
     let quirks_mode_stylesheet = try!(parse_ua_stylesheet(&shared_lock, "quirks-mode.css"));

--- a/components/style/error_reporting.rs
+++ b/components/style/error_reporting.rs
@@ -42,3 +42,17 @@ impl ParseErrorReporter for StdoutErrorReporter {
         }
     }
 }
+
+/// Error reporter which silently forgets errors
+pub struct NullReporter;
+
+impl ParseErrorReporter for NullReporter {
+    fn report_error(&self,
+            _: &mut Parser,
+            _: SourcePosition,
+            _: &str,
+            _: &UrlExtraData,
+            _: u64) {
+        // do nothing
+    }
+}

--- a/components/style/error_reporting.rs
+++ b/components/style/error_reporting.rs
@@ -24,11 +24,15 @@ pub trait ParseErrorReporter : Sync + Send {
                     line_number_offset: u64);
 }
 
-/// An error reporter that reports the errors to the `info` log channel.
+/// An error reporter that uses [the `log` crate](https://github.com/rust-lang-nursery/log)
+/// at `info` level.
 ///
-/// TODO(emilio): The name of this reporter is a lie, and should be renamed!
-pub struct StdoutErrorReporter;
-impl ParseErrorReporter for StdoutErrorReporter {
+/// This logging is silent by default, and can be enabled with a `RUST_LOG=style=info`
+/// environment variable.
+/// (See [`env_logger`](https://rust-lang-nursery.github.io/log/env_logger/).)
+pub struct RustLogReporter;
+
+impl ParseErrorReporter for RustLogReporter {
     fn report_error(&self,
                     input: &mut Parser,
                     position: SourcePosition,

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -21,7 +21,7 @@ use data::ElementData;
 use dom::{self, AnimationRules, DescendantsBit, LayoutIterator, NodeInfo, TElement, TNode, UnsafeNode};
 use dom::{OpaqueNode, PresentationalHintsSynthetizer};
 use element_state::ElementState;
-use error_reporting::StdoutErrorReporter;
+use error_reporting::RustLogReporter;
 use font_metrics::{FontMetricsProvider, FontMetricsQueryResult};
 use gecko::global_style_data::GLOBAL_STYLE_DATA;
 use gecko::selector_parser::{SelectorImpl, NonTSPseudoClass, PseudoElement};
@@ -324,7 +324,7 @@ impl<'le> GeckoElement<'le> {
     /// Parse the style attribute of an element.
     pub fn parse_style_attribute(value: &str,
                                  url_data: &UrlExtraData) -> PropertyDeclarationBlock {
-        parse_style_attribute(value, url_data, &StdoutErrorReporter)
+        parse_style_attribute(value, url_data, &RustLogReporter)
     }
 
     fn flags(&self) -> u32 {

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -8,6 +8,7 @@
 
 use cssparser::{AtRuleParser, Parser, QualifiedRuleParser, RuleListParser};
 use cssparser::{DeclarationListParser, DeclarationParser, parse_one_rule};
+use error_reporting::NullReporter;
 use parser::{LengthParsingMode, ParserContext, log_css_error};
 use properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, PropertyId};
 use properties::{PropertyDeclarationId, LonghandId, ParsedDeclaration};
@@ -18,7 +19,7 @@ use shared_lock::{SharedRwLock, SharedRwLockReadGuard, Locked, ToCssWithGuard};
 use std::fmt;
 use std::sync::Arc;
 use style_traits::ToCss;
-use stylesheets::{CssRuleType, MemoryHoleReporter, Stylesheet, VendorPrefix};
+use stylesheets::{CssRuleType, Stylesheet, VendorPrefix};
 
 /// A number from 0 to 1, indicating the percentage of the animation when this
 /// keyframe should run.
@@ -125,7 +126,7 @@ impl Keyframe {
     /// Parse a CSS keyframe.
     pub fn parse(css: &str, parent_stylesheet: &Stylesheet)
                  -> Result<Arc<Locked<Self>>, ()> {
-        let error_reporter = MemoryHoleReporter;
+        let error_reporter = NullReporter;
         let context = ParserContext::new(parent_stylesheet.origin,
                                          &parent_stylesheet.url_data,
                                          &error_reporter,

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -413,7 +413,7 @@ impl AnimationValue {
     /// Construct an AnimationValue from a property declaration
     pub fn from_declaration(decl: &PropertyDeclaration, context: &mut Context,
                             initial: &ComputedValues) -> Option<Self> {
-        use error_reporting::StdoutErrorReporter;
+        use error_reporting::RustLogReporter;
         use properties::LonghandId;
         use properties::DeclaredValue;
 
@@ -467,7 +467,7 @@ impl AnimationValue {
             },
             PropertyDeclaration::WithVariables(id, ref variables) => {
                 let custom_props = context.style().custom_properties();
-                let reporter = StdoutErrorReporter;
+                let reporter = RustLogReporter;
                 match id {
                     % for prop in data.longhands:
                     % if prop.animatable:

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -8,7 +8,7 @@
 
 use {Atom, Prefix, Namespace};
 use cssparser::{AtRuleParser, Parser, QualifiedRuleParser};
-use cssparser::{AtRuleType, RuleListParser, SourcePosition, Token, parse_one_rule};
+use cssparser::{AtRuleType, RuleListParser, Token, parse_one_rule};
 use cssparser::ToCss as ParserToCss;
 use error_reporting::{ParseErrorReporter, NullReporter};
 #[cfg(feature = "servo")]

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -10,7 +10,7 @@ use {Atom, Prefix, Namespace};
 use cssparser::{AtRuleParser, Parser, QualifiedRuleParser};
 use cssparser::{AtRuleType, RuleListParser, SourcePosition, Token, parse_one_rule};
 use cssparser::ToCss as ParserToCss;
-use error_reporting::ParseErrorReporter;
+use error_reporting::{ParseErrorReporter, NullReporter};
 #[cfg(feature = "servo")]
 use font_face::FontFaceRuleData;
 use font_face::parse_font_face_block;
@@ -321,20 +321,6 @@ pub enum CssRuleType {
     Viewport            = 15,
 }
 
-/// Error reporter which silently forgets errors
-pub struct MemoryHoleReporter;
-
-impl ParseErrorReporter for MemoryHoleReporter {
-    fn report_error(&self,
-            _: &mut Parser,
-            _: SourcePosition,
-            _: &str,
-            _: &UrlExtraData,
-            _: u64) {
-        // do nothing
-    }
-}
-
 #[allow(missing_docs)]
 pub enum SingleRuleParseError {
     Syntax,
@@ -418,7 +404,7 @@ impl CssRule {
                  state: Option<State>,
                  loader: Option<&StylesheetLoader>)
                  -> Result<(Self, State), SingleRuleParseError> {
-        let error_reporter = MemoryHoleReporter;
+        let error_reporter = NullReporter;
         let mut namespaces = parent_stylesheet.namespaces.write();
         let context = ParserContext::new(parent_stylesheet.origin,
                                          &parent_stylesheet.url_data,

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -10,7 +10,7 @@ use {Atom, LocalName};
 use bit_vec::BitVec;
 use data::ComputedStyle;
 use dom::{AnimationRules, PresentationalHintsSynthetizer, TElement};
-use error_reporting::StdoutErrorReporter;
+use error_reporting::RustLogReporter;
 use font_metrics::FontMetricsProvider;
 use keyframes::KeyframesAnimation;
 use media_queries::Device;
@@ -415,7 +415,7 @@ impl Stylist {
                                 parent.map(|p| &**p),
                                 parent.map(|p| &**p),
                                 None,
-                                &StdoutErrorReporter,
+                                &RustLogReporter,
                                 font_metrics,
                                 cascade_flags);
         ComputedStyle::new(rule_node, Arc::new(computed))
@@ -533,7 +533,7 @@ impl Stylist {
                                 Some(&**parent),
                                 Some(&**parent),
                                 None,
-                                &StdoutErrorReporter,
+                                &RustLogReporter,
                                 font_metrics,
                                 CascadeFlags::empty());
 
@@ -863,7 +863,7 @@ impl Stylist {
                                      Some(parent_style),
                                      Some(parent_style),
                                      None,
-                                     &StdoutErrorReporter,
+                                     &RustLogReporter,
                                      &metrics,
                                      CascadeFlags::empty()))
     }


### PR DESCRIPTION
This used to make `RUST_LOG=style` basically useless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16585)
<!-- Reviewable:end -->
