### PR TITLE
Fix fixed table layout column width distribution

### DIFF
--- a/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-001.htm.ini
@@ -1,3 +1,0 @@
-[float-applies-to-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-001a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-001a.htm.ini
@@ -1,3 +1,0 @@
-[float-applies-to-001a.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-002.htm.ini
@@ -1,3 +1,0 @@
-[float-applies-to-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-004.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-004.htm.ini
@@ -1,3 +1,0 @@
-[float-applies-to-004.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-004a.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-004a.htm.ini
@@ -1,3 +1,0 @@
-[float-applies-to-004a.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-005.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-005.htm.ini
@@ -1,3 +1,0 @@
-[float-applies-to-005.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-006.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/float-applies-to-006.htm.ini
@@ -1,3 +1,0 @@
-[float-applies-to-006.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/floats-149.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/floats-149.htm.ini
@@ -1,3 +1,3 @@
-[float-applies-to-003.htm]
+[floats-149.htm]
   type: reftest
   expected: FAIL


### PR DESCRIPTION
Fixes #16324.

Replaces the incorrect [CSS3 "distributing excess width to columns" algorithm](https://drafts.csswg.org/css-tables-3/#distributing-width-to-columns) and implements the simpler [CSS2 fixed table layout algorithm](https://drafts.csswg.org/css2/tables.html#fixed-table-layout).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16588)
<!-- Reviewable:end -->
