### PR TITLE
stylo: Fix a serialization bug for string pseudos.

### DIFF
--- a/components/style/gecko/selector_parser.rs
+++ b/components/style/gecko/selector_parser.rs
@@ -235,8 +235,12 @@ impl ToCss for NonTSPseudoClass {
                     $(NonTSPseudoClass::$s_name(ref s) => {
                         write!(dest, ":{}(", $s_css)?;
                         {
+                            // FIXME(emilio): Avoid the extra allocation!
                             let mut css = CssStringWriter::new(dest);
-                            css.write_str(&String::from_utf16(&s).unwrap())?;
+
+                            // Discount the null char in the end from the
+                            // string.
+                            css.write_str(&String::from_utf16(&s[..s.len() - 1]).unwrap())?;
                         }
                         return dest.write_str(")")
                     }, )*


### PR DESCRIPTION
The string is null-terminated, so we need to avoid passing that last null
character.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16595)
<!-- Reviewable:end -->
