### PR TITLE
Fix various build warnings

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1850,6 +1850,7 @@ class CGImports(CGWrapper):
                 'unused_imports',
                 'unused_variables',
                 'unused_assignments',
+                'unused_mut',
             ]
 
         def componentTypes(type):

--- a/components/script/dom/dissimilaroriginlocation.rs
+++ b/components/script/dom/dissimilaroriginlocation.rs
@@ -45,6 +45,7 @@ impl DissimilarOriginLocation {
                            DissimilarOriginLocationBinding::Wrap)
     }
 
+    #[allow(dead_code)]
     pub fn origin(&self) -> &MutableOrigin {
         self.window.origin()
     }

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -65,6 +65,7 @@ impl DissimilarOriginWindow {
         unsafe { DissimilarOriginWindowBinding::Wrap(cx, win) }
     }
 
+    #[allow(dead_code)]
     pub fn origin(&self) -> &MutableOrigin {
         self.globalscope.origin()
     }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -61,6 +61,7 @@ impl Location {
         self.window.load_url(self.get_url(), true, true, None);
     }
 
+    #[allow(dead_code)]
     pub fn origin(&self) -> &MutableOrigin {
         self.window.origin()
     }

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -693,6 +693,7 @@ impl Window {
         G_NESTED_EVENT_LOOP_LISTENER = None
     }
 
+    #[cfg(target_os = "windows")]
     fn char_to_script_key(c: char) -> Option<constellation_msg::Key> {
         match c {
             ' ' => Some(Key::Space),

--- a/ports/servo/main.rs
+++ b/ports/servo/main.rs
@@ -33,6 +33,7 @@ extern crate sig;
 use backtrace::Backtrace;
 use servo::Browser;
 use servo::compositing::windowing::WindowEvent;
+#[cfg(target_os = "android")]
 use servo::config;
 use servo::config::opts::{self, ArgumentParsingResult};
 use servo::config::servo_version;


### PR DESCRIPTION
This removes six separate warnings when building servo. One of
the warnings was an unused mut, and the other were various dead code
warnings

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #16584 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they address warnings from the build process

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16598)
<!-- Reviewable:end -->
