### PR TITLE
Fix variable serialization bug on shorthand alias properties

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1223,8 +1223,11 @@ impl ToCss for PropertyDeclaration {
             PropertyDeclaration::CSSWideKeyword(_, keyword) => keyword.to_css(dest),
             PropertyDeclaration::WithVariables(_, ref with_variables) => {
                 // https://drafts.csswg.org/css-variables/#variables-in-shorthands
-                if with_variables.from_shorthand.is_none() {
-                    dest.write_str(&*with_variables.css)?
+                match with_variables.from_shorthand {
+                    Some(shorthand) if shorthand.flags().contains(ALIAS_PROPERTY) =>
+                        dest.write_str(&*with_variables.css)?,
+                    None => dest.write_str(&*with_variables.css)?,
+                    _ => {},
                 }
                 Ok(())
             },
@@ -1302,7 +1305,12 @@ impl PropertyDeclaration {
                     if s == shorthand {
                         Some(&*with_variables.css)
                     } else { None }
-                } else { None }
+                } else {
+                    if shorthand.flags().contains(ALIAS_PROPERTY) {
+                        return Some(&*with_variables.css);
+                    }
+                    None
+                }
             },
             _ => None,
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
-moz-transform were having a problem with variable serialization. It wasn't printing transform's value and transform wasn't printing -moz-transform's if their value was a variable. This PR fixes that. 
Reduces stylo -moz-transform failures to 2: https://treeherder.mozilla.org/#/jobs?repo=try&revision=3fd3a57873e5e98dfcb173eef4b13822a66fdf6a

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16607)
<!-- Reviewable:end -->
