### PR TITLE
Clear animation-only dirty descendants bit on display:none descendants

### DIFF
--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -537,7 +537,10 @@ pub fn resolve_style<E, F, G, H>(context: &mut StyleContext<E>, element: E,
     if !in_doc || display_none_root.is_some() {
         let mut curr = element;
         loop {
-            unsafe { curr.unset_dirty_descendants(); }
+            unsafe {
+                curr.unset_dirty_descendants();
+                curr.unset_animation_only_dirty_descendants();
+            }
             if in_doc && curr == display_none_root.unwrap() {
                 break;
             }
@@ -789,5 +792,8 @@ pub fn clear_descendant_data<E: TElement, F: Fn(E)>(el: E, clear_data: &F) {
         }
     }
 
-    unsafe { el.unset_dirty_descendants(); }
+    unsafe {
+        el.unset_dirty_descendants();
+        el.unset_animation_only_dirty_descendants();
+    }
 }


### PR DESCRIPTION
PR for [Gecko bug 1359658](https://bugzilla.mozilla.org/show_bug.cgi?id=1359658)

When an element has a display:none ancestor we don't traverse it during
restyle. However, at the end of restyling we expect the tree to be free
of dirty bits. We currently take special care to clear the regular
(non-animation) dirty bit on nodes in display:none subtrees in order to
preserve this invariant. This patch applies the same handling to the
animation-only dirty descendants bit.

---
- [X] `./mach build -d` just keeps crashing because mozjs calls sed.exe in a way that breaks it
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes on the Gecko side

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16613)
<!-- Reviewable:end -->
