### PR TITLE
stylo: Bug 1357357 - Make the parser of transition-property match the spec.

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -659,6 +659,7 @@ mod bindings {
             "StyleBasicShape",
             "StyleBasicShapeType",
             "StyleShapeSource",
+            "StyleTransition",
             "nsCSSFontFaceRule",
             "nsCSSKeyword",
             "nsCSSPropertyID",

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -520,7 +520,7 @@ pub trait TElement : Eq + PartialEq + Debug + Hash + Sized + Copy + Clone +
     /// Returns true if we need to update transitions for the specified property on this element.
     #[cfg(feature = "gecko")]
     fn needs_transitions_update_per_property(&self,
-                                             property: TransitionProperty,
+                                             property: &TransitionProperty,
                                              combined_duration: f32,
                                              before_change_style: &Arc<ComputedValues>,
                                              after_change_style: &Arc<ComputedValues>,

--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -39,6 +39,7 @@ use gecko_bindings::structs::SheetParsingMode;
 use gecko_bindings::structs::StyleBasicShape;
 use gecko_bindings::structs::StyleBasicShapeType;
 use gecko_bindings::structs::StyleShapeSource;
+use gecko_bindings::structs::StyleTransition;
 use gecko_bindings::structs::nsCSSFontFaceRule;
 use gecko_bindings::structs::nsCSSKeyword;
 use gecko_bindings::structs::nsCSSPropertyID;
@@ -691,6 +692,11 @@ extern "C" {
                                            *mut ::std::os::raw::c_void,
                                        aProperty: nsCSSPropertyID)
      -> RawServoAnimationValueBorrowedOrNull;
+}
+extern "C" {
+    pub fn Gecko_StyleTransition_SetUnsupportedProperty(aTransition:
+                                                            *mut StyleTransition,
+                                                        aAtom: *mut nsIAtom);
 }
 extern "C" {
     pub fn Gecko_Atomize(aString: *const ::std::os::raw::c_char, aLength: u32)

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -259,8 +259,8 @@ fn get_animated_properties(keyframes: &[Arc<Locked<Keyframe>>], guard: &SharedRw
 
             if let Some(property) = TransitionProperty::from_declaration(declaration) {
                 if !seen.has_transition_property_bit(&property) {
-                    ret.push(property);
                     seen.set_transition_property_bit(&property);
+                    ret.push(property);
                 }
             }
         }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -258,7 +258,7 @@ impl LonghandIdSet {
                     TransitionProperty::${prop.camel_case} => self.insert(LonghandId::${prop.camel_case}),
                 % endif
             % endfor
-            other => unreachable!("Tried to set TransitionProperty::{:?} in a PropertyBitfield", other),
+            ref other => unreachable!("Tried to set TransitionProperty::{:?} in a PropertyBitfield", other),
         }
     }
 
@@ -271,7 +271,7 @@ impl LonghandIdSet {
                     TransitionProperty::${prop.camel_case} => self.contains(LonghandId::${prop.camel_case}),
                 % endif
             % endfor
-            other => unreachable!("Tried to get TransitionProperty::{:?} in a PropertyBitfield", other),
+            ref other => unreachable!("Tried to get TransitionProperty::{:?} in a PropertyBitfield", other),
         }
     }
 }

--- a/components/style/properties/shorthand/box.mako.rs
+++ b/components/style/properties/shorthand/box.mako.rs
@@ -98,10 +98,12 @@ macro_rules! try_parse_one {
             loop {
                 parsed += 1;
 
-                try_parse_one!(input, property, transition_property);
                 try_parse_one!(context, input, duration, transition_duration);
                 try_parse_one!(context, input, timing_function, transition_timing_function);
                 try_parse_one!(context, input, delay, transition_delay);
+                // Must check 'transition-property' after 'transition-timing-function' since
+                // 'transition-property' accepts any keyword.
+                try_parse_one!(input, property, transition_property);
 
                 parsed -= 1;
                 break

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1985,7 +1985,7 @@ pub extern "C" fn Servo_GetComputedKeyframeValues(keyframes: RawGeckoKeyframeLis
                     // This is safe since we immediately write to the uninitialized values.
                     unsafe { animation_values.set_len((i + 1) as u32) };
                     seen.set_transition_property_bit(&anim.0);
-                    animation_values[i].mProperty = anim.0.into();
+                    animation_values[i].mProperty = (&anim.0).into();
                     // We only make sure we have enough space for this variable,
                     // but didn't construct a default value for StyleAnimationValue,
                     // so we should zero it to avoid getting undefined behaviors.
@@ -2056,7 +2056,7 @@ pub extern "C" fn Servo_StyleSet_FillKeyframesForName(raw_data: RawServoStyleSet
                 let block = style.to_declaration_block(property.clone().into());
                 unsafe {
                     (*keyframe).mPropertyValues.set_len((index + 1) as u32);
-                    (*keyframe).mPropertyValues[index].mProperty = property.clone().into();
+                    (*keyframe).mPropertyValues[index].mProperty = property.into();
                     // FIXME. Do not set computed values once we handles missing keyframes
                     // with additive composition.
                     (*keyframe).mPropertyValues[index].mServoDeclarationBlock.set_arc_leaky(
@@ -2087,7 +2087,7 @@ pub extern "C" fn Servo_StyleSet_FillKeyframesForName(raw_data: RawServoStyleSet
                         unsafe {
                             let property = TransitionProperty::from_declaration(declaration).unwrap();
                             (*keyframe).mPropertyValues.set_len((index + 1) as u32);
-                            (*keyframe).mPropertyValues[index].mProperty = property.into();
+                            (*keyframe).mPropertyValues[index].mProperty = (&property).into();
                             (*keyframe).mPropertyValues[index].mServoDeclarationBlock.set_arc_leaky(
                                 Arc::new(global_style_data.shared_lock.wrap(
                                   PropertyDeclarationBlock::with_one(

--- a/tests/wpt/metadata-css/css-transitions-1_dev/html/transition-property-002.htm.ini
+++ b/tests/wpt/metadata-css/css-transitions-1_dev/html/transition-property-002.htm.ini
@@ -6,15 +6,6 @@
   [parse 'all, none']
     expected: FAIL
 
-  [parse 'foobar']
-    expected: FAIL
-
-  [parse 'all, foobar']
-    expected: FAIL
-
-  [parse 'foobar, all']
-    expected: FAIL
-
   [parse 'initial']
     expected: FAIL
 


### PR DESCRIPTION
These are interdependent patches of Bug 1357357. We add one more arm, TransitionProperty::Unsupported, which stores the string of non-animatable, custom, or unrecognized property, so we can parse these kinds of properties and serialize them correctly. This is necessary because we need to start transitions even though some transition-properties are non-animatable, custom, or unrecognized.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1357357](https://bugzilla.mozilla.org/show_bug.cgi?id=1357357).
- [X] There are tests for these changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16614)
<!-- Reviewable:end -->
