### PR TITLE
Fix overflow in ::nth-child()

### DIFF
--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -407,7 +407,7 @@ fn matches_generic_nth_child<E, F>(element: &E,
         HAS_SLOW_SELECTOR_LATER_SIBLINGS
     });
 
-    let mut index = 1;
+    let mut index: i32 = 1;
     let mut next_sibling = if is_from_end {
         element.next_sibling_element()
     } else {
@@ -435,11 +435,13 @@ fn matches_generic_nth_child<E, F>(element: &E,
         };
     }
 
-    if a == 0 {
-        b == index
-    } else {
-        (index - b) / a >= 0 &&
-        (index - b) % a == 0
+    // Is there a non-negative integer n such that An+B=index?
+    match index.checked_sub(b) {
+        None => false,
+        Some(an) => match an.checked_div(a) {
+            Some(n) => n >= 0 && a * n == an,
+            None /* a == 0 */ => an == 0,
+        },
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is a PR of https://bugzilla.mozilla.org/show_bug.cgi?id=1358754

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
<!-- Either: -->
- [X] We have a test case in mozilla-central.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16615)
<!-- Reviewable:end -->
