### PR TITLE
Move impl's into macro for macro-generated keyword types

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -33,9 +33,9 @@ use std::fmt;
 use style_traits::ToCss;
 use super::ComputedValues;
 use values::CSSFloat;
-use values::{Auto, Either, Normal, generics};
+use values::{Auto, Either, generics};
 use values::computed::{Angle, LengthOrPercentageOrAuto, LengthOrPercentageOrNone};
-use values::computed::{BorderRadiusSize, ClipRect, LengthOrNone};
+use values::computed::{BorderRadiusSize, ClipRect};
 use values::computed::{CalcLengthOrPercentage, Context, LengthOrPercentage};
 use values::computed::{MaxLength, MinLength};
 use values::computed::position::{HorizontalPosition, VerticalPosition};
@@ -628,20 +628,6 @@ impl Interpolate for Au {
     }
 }
 
-impl Interpolate for Auto {
-    #[inline]
-    fn interpolate(&self, _other: &Self, _progress: f64) -> Result<Self, ()> {
-        Ok(Auto)
-    }
-}
-
-impl Interpolate for Normal {
-    #[inline]
-    fn interpolate(&self, _other: &Self, _progress: f64) -> Result<Self, ()> {
-        Ok(Normal)
-    }
-}
-
 impl <T> Interpolate for Option<T>
     where T: Interpolate,
 {
@@ -1107,16 +1093,6 @@ impl Interpolate for ClipRect {
 
 ${impl_interpolate_for_shadow('BoxShadow', 'CSSParserColor::RGBA(RGBA::transparent())',)}
 ${impl_interpolate_for_shadow('TextShadow', 'CSSParserColor::RGBA(RGBA::transparent())',)}
-
-impl Interpolate for LengthOrNone {
-    fn interpolate(&self, other: &Self, progress: f64) -> Result<Self, ()> {
-        match (*self, *other) {
-            (Either::First(ref length), Either::First(ref other)) =>
-                length.interpolate(&other, progress).map(Either::First),
-            _ => Err(()),
-        }
-    }
-}
 
 /// Check if it's possible to do a direct numerical interpolation
 /// between these two transform lists.
@@ -2242,20 +2218,6 @@ impl ComputeDistance for Au {
     }
 }
 
-impl ComputeDistance for Auto {
-    #[inline]
-    fn compute_distance(&self, _other: &Self) -> Result<f64, ()> {
-        Err(())
-    }
-}
-
-impl ComputeDistance for Normal {
-    #[inline]
-    fn compute_distance(&self, _other: &Self) -> Result<f64, ()> {
-        Err(())
-    }
-}
-
 impl <T> ComputeDistance for Option<T>
     where T: ComputeDistance,
 {
@@ -2523,18 +2485,6 @@ impl ComputeDistance for LengthOrPercentageOrNone {
                 this.compute_distance(other)
             },
             _ => Err(())
-        }
-    }
-}
-
-impl ComputeDistance for LengthOrNone {
-    #[inline]
-    fn compute_distance(&self, other: &Self) -> Result<f64, ()> {
-        match (*self, *other) {
-            (Either::First(ref length), Either::First(ref other)) => {
-                length.compute_distance(other)
-            },
-            _ => Err(()),
         }
     }
 }

--- a/components/style/values/mod.rs
+++ b/components/style/values/mod.rs
@@ -11,6 +11,7 @@
 use Atom;
 pub use cssparser::{RGBA, Token, Parser, serialize_identifier, serialize_string};
 use parser::{Parse, ParserContext};
+use properties::animated_properties::{ComputeDistance, Interpolate};
 use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::fmt::{self, Debug};
@@ -123,6 +124,20 @@ macro_rules! define_keyword_type {
         impl ::style_traits::ToCss for $name {
             fn to_css<W>(&self, dest: &mut W) -> ::std::fmt::Result where W: ::std::fmt::Write {
                 write!(dest, $css)
+            }
+        }
+
+        impl Interpolate for $name {
+            #[inline]
+            fn interpolate(&self, _other: &Self, _progress: f64) -> Result<Self, ()> {
+                Ok($name)
+            }
+        }
+
+        impl ComputeDistance for $name {
+            #[inline]
+            fn compute_distance(&self, _other: &Self) -> Result<f64, ()> {
+                Err(())
             }
         }
 


### PR DESCRIPTION
Three keyword types are created through a macro but have some of their
impl's handled elsewhere. Since all impl's are the same, this commit
moves them into the macro to have them auto generated, for more concise
code.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #16604 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this doesn't add any new features, just alters `impl` locations

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16623)
<!-- Reviewable:end -->
