### PR TITLE
Fix Stylist::lazily_compute_pseudo_element_style to return None when it should.

### DIFF
--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -534,6 +534,10 @@ impl Stylist {
                                           &mut declarations,
                                           &mut set_selector_flags);
 
+        if declarations.is_empty() {
+            return None
+        }
+
         let rule_node =
             self.rule_tree.insert_ordered_rules(
                 declarations.into_iter().map(|a| (a.source, a.level)));


### PR DESCRIPTION
We have a fast path to return None if we have no rules for the pseudo-element at
all, but we should also return None if we have no _matching_ rules for it for
the given originating element.  This is relied on by consumers like
Servo_ResolvePseudoStyle, which needs to be able to detect the "no styles for
this pseudo-element for this originating element case", to support probing for
whether work for a specific pseudo-element should be done at all.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16637)
<!-- Reviewable:end -->
