### PR TITLE
Avoid searching for old nightlies in missing dirs

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -323,6 +323,8 @@ class MachCommands(CommandBase):
         removing_anything = False
         for tool in ["rust", "cargo"]:
             base = path.join(self.context.sharedir, tool)
+            if not path.isdir(base):
+                continue
             for name in os.listdir(base):
                 # We append `-alt` if LLVM assertions aren't enabled,
                 # so use just the commit hash itself.


### PR DESCRIPTION
These directories may be missing (e.g. a first time build or due to Buildbot cleaning),
so don't try to look inside them for old nightlies if so.

I noticed this in http://build.servo.org/builders/arm32/builds/6815/steps/shell__1/logs/stdio.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16639)
<!-- Reviewable:end -->
