### PR TITLE
Bug 1360399: Don't deduplicate revalidation selectors. r=bholley

### DIFF
--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -476,12 +476,12 @@ pub enum Component<Impl: SelectorImpl> {
     //
     // CSS3 Negation only takes a simple simple selector, but we still need to
     // treat it as a compound selector because it might be a type selector which
-    // we represent as a namespace and and localname.
+    // we represent as a namespace and a localname.
     //
-    // Note: if/when we upgrade this to CSS4, which supports combinators, we need
-    // to think about how this should interact with visit_complex_selector, and
-    // what the consumers of those APIs should do about the presence of combinators
-    // in negation.
+    // Note: if/when we upgrade this to CSS4, which supports combinators, we
+    // need to think about how this should interact with visit_complex_selector,
+    // and what the consumers of those APIs should do about the presence of
+    // combinators in negation.
     Negation(Box<[Component<Impl>]>),
     FirstChild, LastChild, OnlyChild,
     Root,

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -199,6 +199,8 @@ fn element_matches_candidate<E: TElement>(element: &E,
     debug_assert!(data.has_current_styles());
     let current_styles = data.styles();
 
+    debug!("Sharing style between {:?} and {:?}", element, candidate_element);
+
     Ok(current_styles.primary.clone())
 }
 


### PR DESCRIPTION
It's unfortunate, but it's a correctness issue. I was looking at the
expectations update here:

 * https://hg.mozilla.org/integration/autoland/rev/659cddddd434

And investigating it I realised that it's wrong to coalesce selectors like that,
because we keep the bloom filter flags.

So in the test cases disabled, we have a selector that looks like this:

```
msub > :not(:first-child),
msup > :not(:first-child),
msubsup > :not(:first-child),
mmultiscripts > :not(:first-child) {
    -moz-script-level: +1;
    -moz-math-display: inline;
}
```

And an element that looks like this:

```
<msubsup><mi></mi><mi></mi></msubsup>
```

We're only inserting the first selector msub > :not(:first-child) into the set,
so when we're going to match the <mi> elements we fast-reject it in both cases
due to the bloom filter, so they share style.

I can't see an easy way to fix this keeping the deduplication. If we keep it, we
need to remove the bloom filter optimization, which means that we'd trash the
cache for every first-child in the document (the :not(:first-child) effectively
becomes a global rule).

MozReview-Commit-ID: 9VPkmdj9zDg
Signed-off-by: Emilio Cobos Álvarez <emilio@crisal.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16641)
<!-- Reviewable:end -->
