### PR TITLE
Reverse Number and LengthOrPercentage in LengthOrPercentageOrNumber

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3782,8 +3782,8 @@ clip-path
 
         for (mut gecko, servo) in self.gecko.mStrokeDasharray.iter_mut().zip(v.0.into_iter()) {
             match servo {
-                Either::First(lop) => gecko.set(lop),
-                Either::Second(number) => gecko.set_value(CoordDataValue::Factor(number)),
+                Either::First(number) => gecko.set_value(CoordDataValue::Factor(number)),
+                Either::Second(lop) => gecko.set(lop),
             }
         }
     }

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -1993,8 +1993,8 @@ ${helpers.predefined_type("scroll-snap-coordinate",
                                 m32: Number::from_computed_value(&computed.m32),
                                 m33: Number::from_computed_value(&computed.m33),
                                 m34: Number::from_computed_value(&computed.m34),
-                                m41: Either::First(LengthOrPercentage::from_computed_value(&computed.m41)),
-                                m42: Either::First(LengthOrPercentage::from_computed_value(&computed.m42)),
+                                m41: Either::Second(LengthOrPercentage::from_computed_value(&computed.m41)),
+                                m42: Either::Second(LengthOrPercentage::from_computed_value(&computed.m42)),
                                 m43: LengthOrNumber::from_computed_value(&Either::First(computed.m43)),
                                 m44: Number::from_computed_value(&computed.m44),
                             });
@@ -2041,8 +2041,8 @@ ${helpers.predefined_type("scroll-snap-coordinate",
     // LengthOrPercentage. Number maps into Length
     fn lopon_to_lop(value: &ComputedLoPoNumber) -> ComputedLoP {
         match *value {
-            Either::First(length_or_percentage) => length_or_percentage,
-            Either::Second(number) => ComputedLoP::Length(Au::from_f32_px(number)),
+            Either::First(number) => ComputedLoP::Length(Au::from_f32_px(number)),
+            Either::Second(length_or_percentage) => length_or_percentage,
         }
     }
 

--- a/components/style/properties/longhand/inherited_svg.mako.rs
+++ b/components/style/properties/longhand/inherited_svg.mako.rs
@@ -92,7 +92,7 @@ ${helpers.predefined_type("stroke-opacity", "Opacity", "1.0",
 
 ${helpers.predefined_type("stroke-dasharray",
                           "LengthOrPercentageOrNumber",
-                          "Either::Second(0.0)",
+                          "Either::First(0.0)",
                           "parse_non_negative",
                           vector="True",
                           allow_empty="True",

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -468,7 +468,7 @@ impl ToCss for SVGPaint {
 }
 
 /// <length> | <percentage> | <number>
-pub type LengthOrPercentageOrNumber = Either<LengthOrPercentage, Number>;
+pub type LengthOrPercentageOrNumber = Either<Number, LengthOrPercentage>;
 
 #[derive(Clone, PartialEq, Eq, Copy, Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -1191,7 +1191,7 @@ impl ToComputedValue for SVGPaintKind {
 }
 
 /// <length> | <percentage> | <number>
-pub type LengthOrPercentageOrNumber = Either<LengthOrPercentage, Number>;
+pub type LengthOrPercentageOrNumber = Either<Number, LengthOrPercentage>;
 
 impl LengthOrPercentageOrNumber {
     /// parse a <length-percentage> | <number> enforcing that the contents aren't negative
@@ -1199,10 +1199,10 @@ impl LengthOrPercentageOrNumber {
         // NB: Parse numbers before Lengths so we are consistent about how to
         // recognize and serialize "0".
         if let Ok(num) = input.try(|i| Number::parse_non_negative(context, i)) {
-            return Ok(Either::Second(num))
+            return Ok(Either::First(num))
         }
 
-        LengthOrPercentage::parse_non_negative(context, input).map(Either::First)
+        LengthOrPercentage::parse_non_negative(context, input).map(Either::Second)
     }
 }
 

--- a/tests/unit/style/parsing/length.rs
+++ b/tests/unit/style/parsing/length.rs
@@ -8,6 +8,8 @@ use parsing::parse;
 use style::context::QuirksMode;
 use style::parser::{LengthParsingMode, Parse, ParserContext};
 use style::stylesheets::{CssRuleType, Origin};
+use style::values::Either;
+use style::values::specified::{LengthOrPercentageOrNumber, Number};
 use style::values::specified::length::{AbsoluteLength, Length, NoCalcLength};
 use style_traits::ToCss;
 
@@ -45,4 +47,9 @@ fn test_length_parsing_modes() {
     let result = Length::parse(&context, &mut parser);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), Length::NoCalc(NoCalcLength::Absolute(AbsoluteLength::Px(1.))));
+}
+
+#[test]
+fn test_zero_percentage_length_or_number() {
+    assert_eq!(parse(LengthOrPercentageOrNumber::parse, "0"), Ok(Either::First(Number::new(0.))));
 }


### PR DESCRIPTION
"0" must be parsed as the number 0, not the unitless 0px length.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16646)
<!-- Reviewable:end -->
