### PR TITLE
Remove IndexSizeError in CanvasRenderingContext2D::drawImage

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -350,7 +350,7 @@ impl CanvasRenderingContext2D {
                                                                      dh);
 
         if !is_rect_valid(source_rect) || !is_rect_valid(dest_rect) {
-            return Err(Error::IndexSize);
+            return Ok(());
         }
 
         let smoothing_enabled = self.state.borrow().image_smoothing_enabled;
@@ -407,7 +407,7 @@ impl CanvasRenderingContext2D {
                                                                      dh);
 
         if !is_rect_valid(source_rect) || !is_rect_valid(dest_rect) {
-            return Err(Error::IndexSize);
+            return Ok(());
         }
 
         let smoothing_enabled = self.state.borrow().image_smoothing_enabled;

--- a/tests/wpt/metadata/2dcontext/conformance-requirements/2d.voidreturn.html.ini
+++ b/tests/wpt/metadata/2dcontext/conformance-requirements/2d.voidreturn.html.ini
@@ -1,6 +1,0 @@
-[2d.voidreturn.html]
-  type: testharness
-  bug: https://github.com/servo/servo/issues/10600
-  [void methods return undefined]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.zerosource.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.zerosource.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.zerosource.html]
-  type: testharness
-  [drawImage with zero-sized source rectangle draws nothing without exception]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The current spec don't expect the IndexSizeError if the rectangle is empty.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #10600 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16658)
<!-- Reviewable:end -->
