### PR TITLE
style: Add a StyleBuilder struct to avoid refcount and atomic CAS during the cascade.

### DIFF
--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -16,7 +16,7 @@ use gecko_bindings::structs::{nsMediaFeature_ValueType, nsMediaFeature_RangeType
 use gecko_bindings::structs::RawGeckoPresContextOwned;
 use media_queries::MediaType;
 use parser::ParserContext;
-use properties::ComputedValues;
+use properties::{ComputedValues, StyleBuilder};
 use std::fmt::{self, Write};
 use std::sync::Arc;
 use str::starts_with_ignore_ascii_case;
@@ -552,6 +552,7 @@ impl Expression {
 
         let default_values = device.default_computed_values();
 
+
         let provider = get_metrics_provider_for_product();
 
         // http://dev.w3.org/csswg/mediaqueries3/#units
@@ -561,10 +562,9 @@ impl Expression {
             device: device,
             inherited_style: default_values,
             layout_parent_style: default_values,
-            // This cloning business is kind of dumb.... It's because Context
-            // insists on having an actual ComputedValues inside itself.
-            style: default_values.clone(),
+            style: StyleBuilder::for_derived_style(default_values),
             font_metrics_provider: &provider,
+            cached_system_font: None,
             in_media_query: true,
             // TODO: pass the correct value here.
             quirks_mode: quirks_mode,

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -102,32 +102,13 @@ pub struct ComputedValues {
 }
 
 impl ComputedValues {
-    /// Inherits style from the parent element, accounting for the default
-    /// computed values that need to be provided as well.
-    pub fn inherit_from(parent: &Self, default: &Self) -> Self {
-        ComputedValues {
-            custom_properties: parent.custom_properties.clone(),
-            writing_mode: parent.writing_mode,
-            root_font_size: parent.root_font_size,
-            font_size_keyword: parent.font_size_keyword,
-            cached_system_font: None,
-            % for style_struct in data.style_structs:
-            % if style_struct.inherited:
-            ${style_struct.ident}: parent.${style_struct.ident}.clone(),
-            % else:
-            ${style_struct.ident}: default.${style_struct.ident}.clone(),
-            % endif
-            % endfor
-        }
-    }
-
     pub fn new(custom_properties: Option<Arc<ComputedValuesMap>>,
-           writing_mode: WritingMode,
-           root_font_size: Au,
-           font_size_keyword: Option<(longhands::font_size::KeywordSize, f32)>,
-            % for style_struct in data.style_structs:
-           ${style_struct.ident}: Arc<style_structs::${style_struct.name}>,
-            % endfor
+               writing_mode: WritingMode,
+               root_font_size: Au,
+               font_size_keyword: Option<(longhands::font_size::KeywordSize, f32)>,
+               % for style_struct in data.style_structs:
+               ${style_struct.ident}: Arc<style_structs::${style_struct.name}>,
+               % endfor
     ) -> Self {
         ComputedValues {
             custom_properties: custom_properties,
@@ -168,6 +149,11 @@ impl ComputedValues {
     pub fn get_${style_struct.name_lower}(&self) -> &style_structs::${style_struct.name} {
         &self.${style_struct.ident}
     }
+
+    pub fn ${style_struct.name_lower}_arc(&self) -> &Arc<style_structs::${style_struct.name}> {
+        &self.${style_struct.ident}
+    }
+
     #[inline]
     pub fn mutate_${style_struct.name_lower}(&mut self) -> &mut style_structs::${style_struct.name} {
         Arc::make_mut(&mut self.${style_struct.ident})
@@ -175,18 +161,12 @@ impl ComputedValues {
     % endfor
 
     pub fn custom_properties(&self) -> Option<Arc<ComputedValuesMap>> {
-        self.custom_properties.as_ref().map(|x| x.clone())
+        self.custom_properties.clone()
     }
 
     #[allow(non_snake_case)]
     pub fn has_moz_binding(&self) -> bool {
         !self.get_box().gecko.mBinding.mPtr.mRawPtr.is_null()
-    }
-
-    #[allow(non_snake_case)]
-    pub fn in_top_layer(&self) -> bool {
-        matches!(self.get_box().clone__moz_top_layer(),
-                 longhands::_moz_top_layer::SpecifiedValue::top)
     }
 
     // FIXME(bholley): Implement this properly.

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -476,7 +476,7 @@
                     SpecifiedValue::Keyword(v) => v,
                     SpecifiedValue::System(_) => {
                         % if product == "gecko":
-                            _cx.style.cached_system_font.as_ref().unwrap().${to_rust_ident(name)}
+                            _cx.cached_system_font.as_ref().unwrap().${to_rust_ident(name)}
                         % else:
                             unreachable!()
                         % endif

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -50,7 +50,7 @@
                 SpecifiedValue::Value(v) => v,
                 SpecifiedValue::System(_) => {
                     <%self:nongecko_unreachable>
-                        _context.style.cached_system_font.as_ref().unwrap().${name}
+                        _context.cached_system_font.as_ref().unwrap().${name}
                     </%self:nongecko_unreachable>
                 }
             }
@@ -270,7 +270,7 @@
                 SpecifiedValue::Values(ref v) => computed_value::T(v.clone()),
                 SpecifiedValue::System(_) => {
                     <%self:nongecko_unreachable>
-                        _cx.style.cached_system_font.as_ref().unwrap().font_family.clone()
+                        _cx.cached_system_font.as_ref().unwrap().font_family.clone()
                     </%self:nongecko_unreachable>
                 }
             }
@@ -532,7 +532,7 @@ ${helpers.single_keyword_system("font-variant-caps",
                 },
                 SpecifiedValue::System(_) => {
                     <%self:nongecko_unreachable>
-                        context.style.cached_system_font.as_ref().unwrap().font_weight.clone()
+                        context.cached_system_font.as_ref().unwrap().font_weight.clone()
                     </%self:nongecko_unreachable>
                 }
             }
@@ -809,7 +809,7 @@ ${helpers.single_keyword_system("font-variant-caps",
 
                 SpecifiedValue::System(_) => {
                     <%self:nongecko_unreachable>
-                        context.style.cached_system_font.as_ref().unwrap().font_size
+                        context.cached_system_font.as_ref().unwrap().font_size
                     </%self:nongecko_unreachable>
                 }
             }
@@ -982,7 +982,7 @@ ${helpers.single_keyword_system("font-variant-caps",
                 SpecifiedValue::Number(ref n) => computed_value::T::Number(n.to_computed_value(context)),
                 SpecifiedValue::System(_) => {
                     <%self:nongecko_unreachable>
-                        context.style.cached_system_font.as_ref().unwrap().font_size_adjust
+                        context.cached_system_font.as_ref().unwrap().font_size_adjust
                     </%self:nongecko_unreachable>
                 }
             }
@@ -1966,7 +1966,7 @@ ${helpers.single_keyword_system("font-variant-position",
                 }
                 SpecifiedValue::System(_) => {
                     <%self:nongecko_unreachable>
-                        _context.style.cached_system_font.as_ref().unwrap().font_language_override
+                        _context.cached_system_font.as_ref().unwrap().font_language_override
                     </%self:nongecko_unreachable>
                 }
             }
@@ -2365,11 +2365,11 @@ ${helpers.single_keyword("-moz-math-variant",
         /// Must be called before attempting to compute a system font
         /// specified value
         pub fn resolve_system_font(system: SystemFont, context: &mut Context) {
-            if context.style.cached_system_font.is_none() {
+            if context.cached_system_font.is_none() {
                 let computed = system.to_computed_value(context);
-                context.style.cached_system_font = Some(computed);
+                context.cached_system_font = Some(computed);
             }
-            debug_assert!(system == context.style.cached_system_font.as_ref().unwrap().system_font)
+            debug_assert!(system == context.cached_system_font.as_ref().unwrap().system_font)
         }
 
         #[derive(Clone, Debug)]

--- a/components/style/servo/media_queries.rs
+++ b/components/style/servo/media_queries.rs
@@ -11,7 +11,7 @@ use euclid::{Size2D, TypedSize2D};
 use font_metrics::ServoMetricsProvider;
 use media_queries::MediaType;
 use parser::ParserContext;
-use properties::ComputedValues;
+use properties::{ComputedValues, StyleBuilder};
 use std::fmt;
 use style_traits::{CSSPixel, ToCss};
 use style_traits::viewport::ViewportConstraints;
@@ -185,14 +185,13 @@ impl Range<specified::Length> {
             device: device,
             inherited_style: default_values,
             layout_parent_style: default_values,
-            // This cloning business is kind of dumb.... It's because Context
-            // insists on having an actual ComputedValues inside itself.
-            style: default_values.clone(),
+            style: StyleBuilder::for_derived_style(default_values),
             // Servo doesn't support font metrics
             // A real provider will be needed here once we do; since
             // ch units can exist in media queries.
             font_metrics_provider: &ServoMetricsProvider,
             in_media_query: true,
+            cached_system_font: None,
             quirks_mode: quirks_mode,
         };
 

--- a/components/style/style_adjuster.rs
+++ b/components/style/style_adjuster.rs
@@ -6,7 +6,7 @@
 //! for it to adhere to the CSS spec.
 
 use app_units::Au;
-use properties::{self, ComputedValues};
+use properties::{self, ComputedValues, StyleBuilder};
 use properties::longhands::display::computed_value::T as display;
 use properties::longhands::float::computed_value::T as float;
 use properties::longhands::overflow_x::computed_value::T as overflow;
@@ -14,14 +14,14 @@ use properties::longhands::position::computed_value::T as position;
 
 
 /// An unsized struct that implements all the adjustment methods.
-pub struct StyleAdjuster<'a> {
-    style: &'a mut ComputedValues,
+pub struct StyleAdjuster<'a, 'b: 'a> {
+    style: &'a mut StyleBuilder<'b>,
     is_root_element: bool,
 }
 
-impl<'a> StyleAdjuster<'a> {
+impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     /// Trivially constructs a new StyleAdjuster.
-    pub fn new(style: &'a mut ComputedValues, is_root_element: bool) -> Self {
+    pub fn new(style: &'a mut StyleBuilder<'b>, is_root_element: bool) -> Self {
         StyleAdjuster {
             style: style,
             is_root_element: is_root_element,
@@ -264,7 +264,7 @@ impl<'a> StyleAdjuster<'a> {
     ///
     /// When comparing to Gecko, this is similar to the work done by
     /// `nsStyleContext::ApplyStyleFixups`.
-    pub fn adjust(mut self,
+    pub fn adjust(&mut self,
                   layout_parent_style: &ComputedValues,
                   skip_root_and_element_display_fixup: bool) {
         self.adjust_for_top_layer();

--- a/components/style/viewport.rs
+++ b/components/style/viewport.rs
@@ -17,6 +17,7 @@ use euclid::size::TypedSize2D;
 use font_metrics::get_metrics_provider_for_product;
 use media_queries::Device;
 use parser::{Parse, ParserContext, log_css_error};
+use properties::StyleBuilder;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use std::ascii::AsciiExt;
 use std::borrow::Cow;
@@ -678,14 +679,17 @@ impl MaybeNew for ViewportConstraints {
 
         let provider = get_metrics_provider_for_product();
 
+        let default_values = device.default_computed_values();
+
         // TODO(emilio): Stop cloning `ComputedValues` around!
         let context = Context {
             is_root_element: false,
             device: device,
-            inherited_style: device.default_computed_values(),
-            layout_parent_style: device.default_computed_values(),
-            style: device.default_computed_values().clone(),
+            inherited_style: default_values,
+            layout_parent_style: default_values,
+            style: StyleBuilder::for_derived_style(default_values),
             font_metrics_provider: &provider,
+            cached_system_font: None,
             in_media_query: false,
             quirks_mode: quirks_mode,
         };

--- a/tests/unit/style/parsing/image.rs
+++ b/tests/unit/style/parsing/image.rs
@@ -8,7 +8,7 @@ use std::f32::consts::PI;
 use style::context::QuirksMode;
 use style::font_metrics::ServoMetricsProvider;
 use style::media_queries::{Device, MediaType};
-use style::properties::ComputedValues;
+use style::properties::{ComputedValues, StyleBuilder};
 use style::values::computed;
 use style::values::computed::{Angle, Context, ToComputedValue};
 use style::values::specified;
@@ -49,7 +49,8 @@ fn test_linear_gradient() {
         device: &device,
         inherited_style: initial_style,
         layout_parent_style: initial_style,
-        style: initial_style.clone(),
+        style: StyleBuilder::for_derived_style(&initial_style),
+        cached_system_font: None,
         font_metrics_provider: &ServoMetricsProvider,
         in_media_query: false,
         quirks_mode: QuirksMode::NoQuirks,


### PR DESCRIPTION
This should fix most of the complaints that caused
https://bugzilla.mozilla.org/show_bug.cgi?id=1360889 to be open, and also fix a
bunch of other FIXMEs across the style system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16663)
<!-- Reviewable:end -->
