### PR TITLE
Servo changes for bug 1347409

### DIFF
--- a/components/style/gecko_bindings/structs_debug.rs
+++ b/components/style/gecko_bindings/structs_debug.rs
@@ -26200,7 +26200,7 @@ pub mod root {
                     "Alignment of field: " , stringify ! ( nsStyleColumn ) ,
                     "::" , stringify ! ( mTwipsPerPixel ) ));
     }
-    #[repr(u32)]
+    #[repr(u8)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub enum nsStyleSVGPaintType {
         eStyleSVGPaintType_None = 1,
@@ -26209,11 +26209,19 @@ pub mod root {
         eStyleSVGPaintType_ContextFill = 4,
         eStyleSVGPaintType_ContextStroke = 5,
     }
+    #[repr(u8)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    pub enum nsStyleSVGFallbackType {
+        eStyleSVGFallbackType_NotSet = 0,
+        eStyleSVGFallbackType_None = 1,
+        eStyleSVGFallbackType_Color = 2,
+    }
     #[repr(C)]
     #[derive(Debug)]
     pub struct nsStyleSVGPaint {
         pub mPaint: root::nsStyleSVGPaint__bindgen_ty_1,
         pub mType: root::nsStyleSVGPaintType,
+        pub mFallbackType: root::nsStyleSVGFallbackType,
         pub mFallbackColor: root::nscolor,
     }
     #[repr(C)]
@@ -26266,6 +26274,11 @@ pub mod root {
                     const _ as usize } , 8usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGPaint ) ,
                     "::" , stringify ! ( mType ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleSVGPaint ) ) . mFallbackType
+                    as * const _ as usize } , 9usize , concat ! (
+                    "Alignment of field: " , stringify ! ( nsStyleSVGPaint ) ,
+                    "::" , stringify ! ( mFallbackType ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGPaint ) ) . mFallbackColor
                     as * const _ as usize } , 12usize , concat ! (

--- a/components/style/gecko_bindings/structs_release.rs
+++ b/components/style/gecko_bindings/structs_release.rs
@@ -25541,7 +25541,7 @@ pub mod root {
                     "Alignment of field: " , stringify ! ( nsStyleColumn ) ,
                     "::" , stringify ! ( mTwipsPerPixel ) ));
     }
-    #[repr(u32)]
+    #[repr(u8)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     pub enum nsStyleSVGPaintType {
         eStyleSVGPaintType_None = 1,
@@ -25550,11 +25550,19 @@ pub mod root {
         eStyleSVGPaintType_ContextFill = 4,
         eStyleSVGPaintType_ContextStroke = 5,
     }
+    #[repr(u8)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    pub enum nsStyleSVGFallbackType {
+        eStyleSVGFallbackType_NotSet = 0,
+        eStyleSVGFallbackType_None = 1,
+        eStyleSVGFallbackType_Color = 2,
+    }
     #[repr(C)]
     #[derive(Debug)]
     pub struct nsStyleSVGPaint {
         pub mPaint: root::nsStyleSVGPaint__bindgen_ty_1,
         pub mType: root::nsStyleSVGPaintType,
+        pub mFallbackType: root::nsStyleSVGFallbackType,
         pub mFallbackColor: root::nscolor,
     }
     #[repr(C)]
@@ -25607,6 +25615,11 @@ pub mod root {
                     const _ as usize } , 8usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleSVGPaint ) ,
                     "::" , stringify ! ( mType ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleSVGPaint ) ) . mFallbackType
+                    as * const _ as usize } , 9usize , concat ! (
+                    "Alignment of field: " , stringify ! ( nsStyleSVGPaint ) ,
+                    "::" , stringify ! ( mFallbackType ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const nsStyleSVGPaint ) ) . mFallbackColor
                     as * const _ as usize } , 12usize , concat ! (

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -415,6 +415,7 @@ fn color_to_nscolor_zero_currentcolor(color: Color) -> structs::nscolor {
     pub fn set_${ident}(&mut self, mut v: longhands::${ident}::computed_value::T) {
         use values::computed::SVGPaintKind;
         use self::structs::nsStyleSVGPaintType;
+        use self::structs::nsStyleSVGFallbackType;
 
         let ref mut paint = ${get_gecko_property(gecko_ffi_name)};
         unsafe {
@@ -443,6 +444,7 @@ fn color_to_nscolor_zero_currentcolor(color: Color) -> structs::nscolor {
         }
 
         if let Some(fallback) = fallback {
+            paint.mFallbackType = nsStyleSVGFallbackType::eStyleSVGFallbackType_Color;
             paint.mFallbackColor = color_to_nscolor_zero_currentcolor(fallback);
         }
     }


### PR DESCRIPTION
bug 1347409 is introducing a fallback type for SVG paint servers so that we can distinguish between url(something) and url(something) none and serialise those cases correctly. When we get a url(something) color we need to set the mFallbackType to eStyleSVGFallbackType_Color.

This change has already been reviewed in https://bugzilla.mozilla.org/show_bug.cgi?id=1347409

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they are covered by tests that will land in gecko as part of the rest of the patch there.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16665)
<!-- Reviewable:end -->
