### PR TITLE
Improvements to gradients.

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -976,12 +976,23 @@ pub struct GradientBorder {
     pub outset: SideOffsets2D<f32>,
 }
 
+/// A border that is made of radial gradient
+#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+pub struct RadialGradientBorder {
+    /// The gradient info that this border uses, border-image-source.
+    pub gradient: RadialGradient,
+
+    /// Outsets for the border, as per border-image-outset.
+    pub outset: SideOffsets2D<f32>,
+}
+
 /// Specifies the type of border
 #[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
 pub enum BorderDetails {
     Normal(NormalBorder),
     Image(ImageBorder),
     Gradient(GradientBorder),
+    RadialGradient(RadialGradientBorder),
 }
 
 /// Paints a border.

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -650,8 +650,8 @@ fn convert_gradient_stops(gradient_items: &[GradientItem],
     }
 
     // Step 3: Evenly space stops without position.
-    // Note: Remove the + 1 if fix_gradient_stops is changed.
-    let mut stops = Vec::with_capacity(stop_items.len() + 1);
+    // Note: Remove the + 2 if fix_gradient_stops is changed.
+    let mut stops = Vec::with_capacity(stop_items.len() + 2);
     let mut stop_run = None;
     for (i, stop) in stop_items.iter().enumerate() {
         let offset = match stop.position {
@@ -698,7 +698,7 @@ fn convert_gradient_stops(gradient_items: &[GradientItem],
 }
 
 #[inline]
-/// Duplicate the last stop if its position is smaller 100%.
+/// Duplicate the first and last stops if necessary.
 ///
 /// Explanation by pyfisch:
 /// If the last stop is at the same position as the previous stop the
@@ -706,7 +706,17 @@ fn convert_gradient_stops(gradient_items: &[GradientItem],
 /// (I think so). The  implementations of Chrome and Firefox seem
 /// to have the same problem but work fine if the position of the last
 /// stop is smaller than 100%. (Otherwise they ignore the last stop.)
+///
+/// Similarly the first stop is duplicated if it is not placed
+/// at the start of the virtual gradient ray.
 fn fix_gradient_stops(stops: &mut Vec<GradientStop>) {
+    if stops.first().unwrap().offset > 0.0 {
+        let color = stops.first().unwrap().color;
+        stops.insert(0, GradientStop {
+            offset: 0.0,
+            color: color,
+        })
+    }
     if stops.last().unwrap().offset < 1.0 {
         let color = stops.last().unwrap().color;
         stops.push(GradientStop {

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -710,7 +710,7 @@ fn convert_circle_size_keyword(keyword: SizeKeyword,
                                center: &Point2D<Au>) -> Size2D<Au> {
     use style::values::computed::image::SizeKeyword::*;
     let radius = match keyword {
-        ClosestSide => {
+        ClosestSide | Contain => {
             let dist = get_distance_to_sides(size, center, ::std::cmp::min);
             ::std::cmp::min(dist.width, dist.height)
         }
@@ -719,12 +719,7 @@ fn convert_circle_size_keyword(keyword: SizeKeyword,
             ::std::cmp::max(dist.width, dist.height)
         }
         ClosestCorner => get_distance_to_corner(size, center, ::std::cmp::min),
-        FarthestCorner => get_distance_to_corner(size, center, ::std::cmp::max),
-        _ => {
-            // TODO(#16542)
-            println!("TODO: implement size keyword {:?} for circles", keyword);
-            Au::new(0)
-        }
+        FarthestCorner | Cover => get_distance_to_corner(size, center, ::std::cmp::max),
     };
     Size2D::new(radius, radius)
 }
@@ -736,15 +731,10 @@ fn convert_ellipse_size_keyword(keyword: SizeKeyword,
                                 center: &Point2D<Au>) -> Size2D<Au> {
     use style::values::computed::image::SizeKeyword::*;
     match keyword {
-        ClosestSide => get_distance_to_sides(size, center, ::std::cmp::min),
+        ClosestSide | Contain => get_distance_to_sides(size, center, ::std::cmp::min),
         FarthestSide => get_distance_to_sides(size, center, ::std::cmp::max),
         ClosestCorner => get_ellipse_radius(size, center, ::std::cmp::min),
-        FarthestCorner => get_ellipse_radius(size, center, ::std::cmp::max),
-        _ => {
-            // TODO(#16542)
-            println!("TODO: implement size keyword {:?} for ellipses", keyword);
-            Size2D::new(Au::new(0), Au::new(0))
-        }
+        FarthestCorner | Cover => get_ellipse_radius(size, center, ::std::cmp::max),
     }
 }
 

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1334,8 +1334,24 @@ impl FragmentDisplayListBuilding for Fragment {
                             }),
                         }));
                     }
-                    GradientKind::Radial(_, _) => {
-                        // TODO(#16638): Handle border-image with radial gradient.
+                    GradientKind::Radial(ref shape, ref center) => {
+                        let grad = self.convert_radial_gradient(&bounds,
+                                                                &gradient.items[..],
+                                                                shape,
+                                                                center,
+                                                                gradient.repeating,
+                                                                style);
+                        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
+                            base: base,
+                            border_widths: border.to_physical(style.writing_mode),
+                            details: BorderDetails::RadialGradient(
+                                display_list::RadialGradientBorder {
+                                    gradient: grad,
+
+                                    // TODO(gw): Support border-image-outset
+                                    outset: SideOffsets2D::zero(),
+                                }),
+                        }));
                     }
                 }
             }

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1167,9 +1167,8 @@ impl FragmentDisplayListBuilding for Fragment {
             EndingShape::Ellipse(LengthOrPercentageOrKeyword::Keyword(word))
                 => convert_ellipse_size_keyword(word, &bounds.size, &center),
         };
-        let length = Au::from_f32_px(radius.width.to_f32_px().hypot(radius.height.to_f32_px()));
 
-        let mut stops = convert_gradient_stops(stops, length, style);
+        let mut stops = convert_gradient_stops(stops, radius.width, style);
         if !repeating {
             fix_gradient_stops(&mut stops);
         }

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -352,14 +352,34 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                         }
                     }
                     BorderDetails::Gradient(ref gradient) => {
+                        let extend_mode = if gradient.gradient.repeating {
+                            ExtendMode::Repeat
+                        } else {
+                            ExtendMode::Clamp
+                        };
                         webrender_traits::BorderDetails::Gradient(webrender_traits::GradientBorder {
                             gradient: builder.create_gradient(
                                           gradient.gradient.start_point.to_pointf(),
                                           gradient.gradient.end_point.to_pointf(),
                                           gradient.gradient.stops.clone(),
-                                          ExtendMode::Clamp),
+                                          extend_mode),
                             outset: gradient.outset,
                         })
+                    }
+                    BorderDetails::RadialGradient(ref gradient) => {
+                        let extend_mode = if gradient.gradient.repeating {
+                            ExtendMode::Repeat
+                        } else {
+                            ExtendMode::Clamp
+                        };
+                       webrender_traits::BorderDetails::RadialGradient(webrender_traits::RadialGradientBorder {
+                           gradient: builder.create_radial_gradient(
+                               gradient.gradient.center.to_pointf(),
+                               gradient.gradient.radius.to_sizef(),
+                               gradient.gradient.stops.clone(),
+                               extend_mode),
+                           outset: gradient.outset,
+                       })
                     }
                 };
 


### PR DESCRIPTION
This is a collection of commits improving the rendering of linear and radial gradients by making them conform more closely to the spec.

All commits are are independent and should work without the others.

These commits address the following issues:
* a956e3fd529715cc0ac39b23910f19e092c7c5a9 resolves #3908 but contains also some other necessary changes to `convert_gradient_stops`. The updated function has a few more copys but should be more correct. Maybe @pcwalton wants to comment since he has originally written the code.
* b230be8aaf318fb754cf58e5cd243087df2f7e0f partially solves #16638. (Partially because `border-image-outset` is not implemented. This is an older issue for border gradients: #15894.

To quickly catch regressions and see changes to gradients I have created [a set of twelve manual testcases](https://pyfisch.org/stuff/testcases-gradients.html) and placed them in a single file. Attached are two files. One shows how the gradients were rendered before the PR the other one with the changes applied.

![testcases-old](https://cloud.githubusercontent.com/assets/2781017/25580052/b433278e-2e7d-11e7-9396-500fef12eee0.png)
![testcases-new](https://cloud.githubusercontent.com/assets/2781017/25580051/b43222c6-2e7d-11e7-99ab-c0a2709baf41.png)

r? @emilio
and maybe also @jdm?

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16666)
<!-- Reviewable:end -->
