### PR TITLE
style: Correctly handle Gecko prefixed text-align values in property glue.

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3249,13 +3249,12 @@ fn static_assert() {
                   skip_longhands="text-align text-emphasis-style text-shadow line-height letter-spacing word-spacing
                                   -webkit-text-stroke-width text-emphasis-position -moz-tab-size -moz-text-size-adjust">
 
-    <% text_align_keyword = Keyword("text-align", "start end left right center justify -moz-center -moz-left " +
-                                                  "-moz-right char") %>
+    <% text_align_keyword = Keyword("text-align",
+                                    "start end left right center justify -moz-center -moz-left -moz-right char",
+                                    gecko_strip_moz_prefix=False) %>
     <% text_align_reachable_keyword = Keyword("text-align", "start end left right center justify char") %>
     ${impl_keyword('text_align', 'mTextAlign', text_align_keyword, need_clone=False)}
-    // Stable rust errors on unreachable patterns, and there is overlap, so we run with the overlapping
-    // constants removed
-    ${impl_keyword_clone('text_align', 'mTextAlign', text_align_reachable_keyword)}
+    ${impl_keyword_clone('text_align', 'mTextAlign', text_align_keyword)}
 
     pub fn set_text_shadow(&mut self, v: longhands::text_shadow::computed_value::T) {
         self.gecko.mTextShadow.replace_with_new(v.0.len() as u32);


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1360991.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16669)
<!-- Reviewable:end -->
