### PR TITLE
Replace intrinsics::abort with process::abort

### DIFF
--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -4,7 +4,6 @@
 
 #![allow(non_camel_case_types)]
 #![feature(box_syntax)]
-#![feature(core_intrinsics)]
 #![feature(link_args)]
 
 #[macro_use]

--- a/ports/cef/stubs.rs
+++ b/ports/cef/stubs.rs
@@ -12,9 +12,7 @@ macro_rules! stub(
         #[allow(non_snake_case)]
         pub extern "C" fn $name() {
             println!("CEF stub function called: {}", stringify!($name));
-            unsafe {
-                ::std::intrinsics::abort()
-            }
+            ::std::process::abort()
         }
     )
 );

--- a/ports/servo/main.rs
+++ b/ports/servo/main.rs
@@ -15,7 +15,7 @@
 //!
 //! [glutin]: https://github.com/tomaka/glutin
 
-#![feature(start, core_intrinsics)]
+#![feature(start)]
 
 #[cfg(target_os = "android")]
 extern crate android_injected_glue;
@@ -58,7 +58,7 @@ pub mod platform {
 fn install_crash_handler() {
     use backtrace::Backtrace;
     use sig::ffi::Sig;
-    use std::intrinsics::abort;
+    use std::process::abort;
     use std::thread;
 
     fn handler(_sig: i32) {
@@ -67,9 +67,7 @@ fn install_crash_handler() {
             .map(|n| format!(" for thread \"{}\"", n))
             .unwrap_or("".to_owned());
         println!("Stack trace{}\n{:?}", name, Backtrace::new());
-        unsafe {
-            abort();
-        }
+        abort();
     }
 
     signal!(Sig::SEGV, handler); // handle segfaults


### PR DESCRIPTION
This removes some unsafe/unstable code and replaces it with a new safe/stable alternative.

Note that `process::abort` is not identical to `intrinsics::abort`, since it runs global cleanups to do things like flush stderr (though neither function performs stack unwinding).  I don't *think* the difference matters for our use cases.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they should not change functionality

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16680)
<!-- Reviewable:end -->
