### PR TITLE
Stop using unstable slice_patterns feature

### DIFF
--- a/components/net_traits/image/base.rs
+++ b/components/net_traits/image/base.rs
@@ -108,10 +108,7 @@ pub fn detect_image_format(buffer: &[u8]) -> Result<ImageFormat, &str> {
 }
 
 fn is_gif(buffer: &[u8]) -> bool {
-    match buffer {
-        &[b'G', b'I', b'F', b'8', n, b'a', _..] if n == b'7' || n == b'9' => true,
-        _ => false,
-    }
+    buffer.starts_with(b"GIF87a") || buffer.starts_with(b"GIF89a")
 }
 
 fn is_jpeg(buffer: &[u8]) -> bool {

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![feature(box_syntax)]
-#![feature(slice_patterns)]
 #![feature(step_by)]
 
 #![deny(unsafe_code)]

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -223,9 +223,9 @@ impl ChildrenList {
                         // by ChildrenMutation::replace().
                         unreachable!()
                     },
-                    (_, &[node, ..], _) => node,
-                    (_, &[], Some(next)) => next,
-                    (Some(prev), &[], None) => {
+                    (_, added, _) if !added.is_empty() => added[0],
+                    (_, _, Some(next)) => next,
+                    (Some(prev), _, None) => {
                         list.last_index.set(index - 1u32);
                         prev
                     },

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -12,7 +12,6 @@
 #![feature(optin_builtin_traits)]
 #![feature(plugin)]
 #![feature(proc_macro)]
-#![feature(slice_patterns)]
 #![feature(stmt_expr_attributes)]
 #![feature(try_from)]
 #![feature(untagged_unions)]

--- a/components/script_plugins/lib.rs
+++ b/components/script_plugins/lib.rs
@@ -15,7 +15,7 @@
 
 
 #![deny(unsafe_code)]
-#![feature(box_syntax, plugin, plugin_registrar, rustc_private, slice_patterns)]
+#![feature(box_syntax, plugin, plugin_registrar, rustc_private)]
 
 #[macro_use]
 extern crate rustc;


### PR DESCRIPTION
cc #5286

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because no functionality changed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16681)
<!-- Reviewable:end -->
