### PR TITLE
Guard inheriting font-size with what we actually need.

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2535,13 +2535,16 @@ pub fn apply_declarations<'a, F, I>(device: &Device,
                                                  &mut cacheable,
                                                  &mut cascade_info,
                                                  error_reporter);
-            } else {
-                // Font size must be explicitly inherited to handle keyword
-                // sizes and scriptlevel
+            % if product == "gecko":
+            // Font size must be explicitly inherited to handle lang changes and
+            // scriptlevel changes.
+            } else if seen.contains(LonghandId::XLang) ||
+                      seen.contains(LonghandId::MozScriptLevel) ||
+                      font_family.is_some() {
                 let discriminant = LonghandId::FontSize as usize;
                 let size = PropertyDeclaration::CSSWideKeyword(
-                    LonghandId::FontSize, CSSWideKeyword::Inherit
-                );
+                    LonghandId::FontSize, CSSWideKeyword::Inherit);
+
                 (CASCADE_PROPERTY[discriminant])(&size,
                                                  inherited_style,
                                                  default_style,
@@ -2549,6 +2552,7 @@ pub fn apply_declarations<'a, F, I>(device: &Device,
                                                  &mut cacheable,
                                                  &mut cascade_info,
                                                  error_reporter);
+            % endif
             }
         % endif
     % endfor


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1361126

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16682)
<!-- Reviewable:end -->
