### PR TITLE
stylo: Parse eSafeAgentSheetFeatures as agent sheet

### DIFF
--- a/components/style/gecko_bindings/structs_debug.rs
+++ b/components/style/gecko_bindings/structs_debug.rs
@@ -5293,18 +5293,28 @@ pub mod root {
  * exposure on the public Web, but are very useful for expressing
  * user style overrides, such as @-moz-document rules.
  *
+ * XXX: eUserSheetFeatures was added in bug 1035091, but some patches in
+ * that bug never landed to use this enum value. Currently, all the features
+ * in user sheet are also available in author sheet.
+ *
  * Agent sheets have access to all author- and user-sheet features
  * plus more extensions that are necessary for internal use but,
  * again, not yet suitable for exposure on the public Web.  Some of
  * these are outright unsafe to expose; in particular, incorrect
  * styling of anonymous box pseudo-elements can violate layout
  * invariants.
+ *
+ * Agent sheets that do not use any unsafe rules could use
+ * eSafeAgentSheetFeatures when creating the sheet. This enum value allows
+ * Servo backend to recognize the sheets as the agent level, but Gecko
+ * backend will parse it under _author_ level.
  */
             #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
             pub enum SheetParsingMode {
                 eAuthorSheetFeatures = 0,
                 eUserSheetFeatures = 1,
                 eAgentSheetFeatures = 2,
+                eSafeAgentSheetFeatures = 3,
             }
             #[repr(C)]
             #[derive(Debug, Copy, Clone)]

--- a/components/style/gecko_bindings/structs_release.rs
+++ b/components/style/gecko_bindings/structs_release.rs
@@ -5222,18 +5222,28 @@ pub mod root {
  * exposure on the public Web, but are very useful for expressing
  * user style overrides, such as @-moz-document rules.
  *
+ * XXX: eUserSheetFeatures was added in bug 1035091, but some patches in
+ * that bug never landed to use this enum value. Currently, all the features
+ * in user sheet are also available in author sheet.
+ *
  * Agent sheets have access to all author- and user-sheet features
  * plus more extensions that are necessary for internal use but,
  * again, not yet suitable for exposure on the public Web.  Some of
  * these are outright unsafe to expose; in particular, incorrect
  * styling of anonymous box pseudo-elements can violate layout
  * invariants.
+ *
+ * Agent sheets that do not use any unsafe rules could use
+ * eSafeAgentSheetFeatures when creating the sheet. This enum value allows
+ * Servo backend to recognize the sheets as the agent level, but Gecko
+ * backend will parse it under _author_ level.
  */
             #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
             pub enum SheetParsingMode {
                 eAuthorSheetFeatures = 0,
                 eUserSheetFeatures = 1,
                 eAgentSheetFeatures = 2,
+                eSafeAgentSheetFeatures = 3,
             }
             #[repr(C)]
             #[derive(Debug, Copy, Clone)]

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -509,6 +509,7 @@ pub extern "C" fn Servo_StyleSheet_Empty(mode: SheetParsingMode) -> RawServoStyl
         SheetParsingMode::eAuthorSheetFeatures => Origin::Author,
         SheetParsingMode::eUserSheetFeatures => Origin::User,
         SheetParsingMode::eAgentSheetFeatures => Origin::UserAgent,
+        SheetParsingMode::eSafeAgentSheetFeatures => Origin::UserAgent,
     };
     let shared_lock = global_style_data.shared_lock.clone();
     Arc::new(Stylesheet::from_str(
@@ -533,6 +534,7 @@ pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(loader: *mut Loader,
         SheetParsingMode::eAuthorSheetFeatures => Origin::Author,
         SheetParsingMode::eUserSheetFeatures => Origin::User,
         SheetParsingMode::eAgentSheetFeatures => Origin::UserAgent,
+        SheetParsingMode::eSafeAgentSheetFeatures => Origin::UserAgent,
     };
 
     let url_data = unsafe { RefPtr::from_ptr_ref(&extra_data) };


### PR DESCRIPTION
This was reviewed in https://bugzilla.mozilla.org/show_bug.cgi?id=1321754

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16686)
<!-- Reviewable:end -->
