### PR TITLE
style: Correctly serialize CSS Custom Property names.

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1169,7 +1169,7 @@ pub extern "C" fn Servo_DeclarationBlock_GetNthProperty(declarations: RawServoDe
     read_locked_arc(declarations, |decls: &PropertyDeclarationBlock| {
         if let Some(&(ref decl, _)) = decls.declarations().get(index as usize) {
             let result = unsafe { result.as_mut().unwrap() };
-            decl.id().to_css(result).unwrap();
+            result.assign_utf8(&decl.id().name());
             true
         } else {
             false


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1361303, and reviewed by Xidorn over there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16691)
<!-- Reviewable:end -->
