### PR TITLE
Make History attributes and methods throw

### DIFF
--- a/components/script/dom/webidls/History.webidl
+++ b/components/script/dom/webidls/History.webidl
@@ -7,12 +7,20 @@
 // https://html.spec.whatwg.org/multipage/#the-history-interface
 [Exposed=(Window,Worker)]
 interface History {
+  [Throws]
   readonly attribute unsigned long length;
+  // [Throws]
   // attribute ScrollRestoration scrollRestoration;
+  // [Throws]
   // readonly attribute any state;
-  [Throws] void go(optional long delta = 0);
+  [Throws]
+  void go(optional long delta = 0);
+  [Throws]
   void back();
+  [Throws]
   void forward();
+  // [Throws]
   // void pushState(any data, DOMString title, optional USVString? url = null);
+  // [Throws]
   // void replaceState(any data, DOMString title, optional USVString? url = null);
 };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
All History methods and attributes should throw a `SecurityError` if the document associated with the `History` object is not fully active.
https://html.spec.whatwg.org/multipage/browsers.html#history-3

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16697)
<!-- Reviewable:end -->
