### PR TITLE
stylo: Bug 1346052 - Add Servo_AnimationValue_Compute.

### DIFF
--- a/components/style/gecko_bindings/bindings.rs
+++ b/components/style/gecko_bindings/bindings.rs
@@ -1075,10 +1075,6 @@ extern "C" {
      -> nscoord;
 }
 extern "C" {
-    pub fn Gecko_GetAppUnitsPerPhysicalInch(pres_context: RawGeckoPresContextBorrowed)
-     -> i32;
-}
-extern "C" {
     pub fn Gecko_CSSValue_GetKeyword(aCSSValue: nsCSSValueBorrowed)
      -> nsCSSKeyword;
 }
@@ -1171,6 +1167,11 @@ extern "C" {
                                 is_vertical: bool, font: *const nsStyleFont,
                                 font_size: nscoord, use_user_font_set: bool)
      -> GeckoFontMetrics;
+}
+extern "C" {
+    pub fn Gecko_GetAppUnitsPerPhysicalInch(pres_context:
+                                                RawGeckoPresContextBorrowed)
+     -> i32;
 }
 extern "C" {
     pub fn Gecko_GetMediaFeatures() -> *const nsMediaFeature;
@@ -1854,6 +1855,15 @@ extern "C" {
     pub fn Servo_AnimationValue_Uncompute(value:
                                               RawServoAnimationValueBorrowed)
      -> RawServoDeclarationBlockStrong;
+}
+extern "C" {
+    pub fn Servo_AnimationValue_Compute(declarations:
+                                            RawServoDeclarationBlockBorrowed,
+                                        style: ServoComputedValuesBorrowed,
+                                        parent_style:
+                                            ServoComputedValuesBorrowedOrNull,
+                                        raw_data: RawServoStyleSetBorrowed)
+     -> RawServoAnimationValueStrong;
 }
 extern "C" {
     pub fn Servo_ParseStyleAttribute(data: *const nsACString,


### PR DESCRIPTION
This is an interdependent patch of Bug 1346052. We need this FFI to compute the AnimationValue from a property id and a string, so nsDOMWindowUtils::ComputeAnimationDistance() can use this FFI to get the AnimationValue.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1346052](https://bugzilla.mozilla.org/show_bug.cgi?id=1346052).
- [X] These changes do not require tests because we have some tests for this in Gecko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16704)
<!-- Reviewable:end -->
