### PR TITLE
Stylo: Implement {specified|computed}::LayerImage.

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -921,13 +921,13 @@ fn static_assert() {
                                need_clone=True) %>
     % endfor
 
-    pub fn set_border_image_source(&mut self, v: longhands::border_image_source::computed_value::T) {
+    pub fn set_border_image_source(&mut self, image: longhands::border_image_source::computed_value::T) {
         unsafe {
             // Prevent leaking of the last elements we did set
             Gecko_SetNullImageValue(&mut self.gecko.mBorderImageSource);
         }
 
-        if let Some(image) = v.0 {
+        if let Some(image) = image.0 {
             self.gecko.mBorderImageSource.set(image, &mut false)
         }
     }
@@ -2756,18 +2756,9 @@ fn static_assert() {
 
         for (image, geckoimage) in images.0.into_iter().zip(self.gecko.${image_layers_field}
                                                                 .mLayers.iter_mut()) {
-            % if shorthand == "background":
-                if let Some(image) = image.0 {
-                    geckoimage.mImage.set(image, cacheable)
-                }
-            % else:
-                use properties::longhands::mask_image::single_value::computed_value::T;
-                match image {
-                    T::Image(image) => geckoimage.mImage.set(image, cacheable),
-                    _ => ()
-                }
-            % endif
-
+            if let Some(image) = image.0 {
+                geckoimage.mImage.set(image, cacheable)
+            }
         }
     }
 

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -309,7 +309,7 @@
                                                                                       computed,
                                                                                       inherited_style.get_font());
                                 % else:
-                                    % if property.has_uncacheable_values:
+                                    % if property.has_uncacheable_values == "True":
                                     context.mutate_style().mutate_${data.current_style_struct.name_lower}()
                                                           .set_${property.ident}(computed, cacheable ${maybe_wm});
                                     % else:

--- a/components/style/properties/longhand/background.mako.rs
+++ b/components/style/properties/longhand/background.mako.rs
@@ -12,82 +12,13 @@ ${helpers.predefined_type("background-color", "CSSColor",
     spec="https://drafts.csswg.org/css-backgrounds/#background-color",
     animation_value_type="IntermediateColor", complex_color=True)}
 
-<%helpers:vector_longhand name="background-image" animation_value_type="none"
-                          spec="https://drafts.csswg.org/css-backgrounds/#the-background-image"
-                          has_uncacheable_values="${product == 'gecko'}">
-    use std::fmt;
-    use style_traits::ToCss;
-    use values::HasViewportPercentage;
-    use values::specified::Image;
-
-    pub mod computed_value {
-        use values::computed;
-        #[derive(Debug, Clone, PartialEq)]
-        #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-        pub struct T(pub Option<computed::Image>);
-    }
-
-    impl ToCss for computed_value::T {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match self.0 {
-                None => dest.write_str("none"),
-                Some(ref image) => image.to_css(dest),
-            }
-        }
-    }
-
-    no_viewport_percentage!(SpecifiedValue);
-
-    #[derive(Debug, Clone, PartialEq)]
-    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    pub struct SpecifiedValue(pub Option<Image>);
-
-    impl ToCss for SpecifiedValue {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match *self {
-                SpecifiedValue(Some(ref image)) => image.to_css(dest),
-                SpecifiedValue(None) => dest.write_str("none"),
-            }
-        }
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        computed_value::T(None)
-    }
-    #[inline]
-    pub fn get_initial_specified_value() -> SpecifiedValue {
-        SpecifiedValue(None)
-    }
-    pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-        if input.try(|input| input.expect_ident_matching("none")).is_ok() {
-            Ok(SpecifiedValue(None))
-        } else {
-            Ok(SpecifiedValue(Some(try!(Image::parse(context, input)))))
-        }
-    }
-    impl ToComputedValue for SpecifiedValue {
-        type ComputedValue = computed_value::T;
-
-        #[inline]
-        fn to_computed_value(&self, context: &Context) -> computed_value::T {
-            match *self {
-                SpecifiedValue(None) => computed_value::T(None),
-                SpecifiedValue(Some(ref image)) =>
-                    computed_value::T(Some(image.to_computed_value(context))),
-            }
-        }
-
-        #[inline]
-        fn from_computed_value(computed: &computed_value::T) -> Self {
-            match *computed {
-                computed_value::T(None) => SpecifiedValue(None),
-                computed_value::T(Some(ref image)) =>
-                    SpecifiedValue(Some(ToComputedValue::from_computed_value(image))),
-            }
-        }
-    }
-</%helpers:vector_longhand>
+${helpers.predefined_type("background-image", "LayerImage",
+    initial_value="computed_value::T(None)",
+    initial_specified_value="SpecifiedValue(None)",
+    spec="https://drafts.csswg.org/css-backgrounds/#the-background-image",
+    vector="True",
+    animation_value_type="none",
+    has_uncacheable_values="True" if product == "gecko" else "False")}
 
 <%helpers:predefined_type name="background-position-x" type="position::HorizontalPosition"
                           initial_value="computed::position::HorizontalPosition::zero()"

--- a/components/style/properties/longhand/border.mako.rs
+++ b/components/style/properties/longhand/border.mako.rs
@@ -190,81 +190,14 @@ ${helpers.single_keyword("-moz-float-edge", "content-box margin-box",
                          spec="Nonstandard (https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-float-edge)",
                          animation_value_type="none")}
 
-<%helpers:longhand name="border-image-source" animation_value_type="none" boxed="True"
-                   spec="https://drafts.csswg.org/css-backgrounds/#border-image-source">
-    use std::fmt;
-    use style_traits::ToCss;
-    use values::HasViewportPercentage;
-    use values::specified::Image;
-
-    no_viewport_percentage!(SpecifiedValue);
-
-    pub mod computed_value {
-        use values::computed;
-        #[derive(Debug, Clone, PartialEq)]
-        #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-        pub struct T(pub Option<computed::Image>);
-    }
-
-    #[derive(Debug, Clone, PartialEq)]
-    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    pub struct SpecifiedValue(pub Option<Image>);
-
-    impl ToCss for computed_value::T {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match self.0 {
-                Some(ref image) => image.to_css(dest),
-                None => dest.write_str("none"),
-            }
-        }
-    }
-    impl ToCss for SpecifiedValue {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match self.0 {
-                Some(ref image) => image.to_css(dest),
-                None => dest.write_str("none"),
-            }
-        }
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        computed_value::T(None)
-    }
-
-    #[inline]
-    pub fn get_initial_specified_value() -> SpecifiedValue {
-        SpecifiedValue(None)
-    }
-
-    impl ToComputedValue for SpecifiedValue {
-        type ComputedValue = computed_value::T;
-
-        #[inline]
-        fn to_computed_value(&self, context: &Context) -> computed_value::T {
-            match self.0 {
-                Some(ref image) => computed_value::T(Some(image.to_computed_value(context))),
-                None => computed_value::T(None),
-            }
-        }
-        #[inline]
-        fn from_computed_value(computed: &computed_value::T) -> Self {
-            match computed.0 {
-                Some(ref image) =>
-                    SpecifiedValue(Some(ToComputedValue::from_computed_value(image))),
-                None => SpecifiedValue(None),
-            }
-        }
-    }
-
-    pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-        if input.try(|input| input.expect_ident_matching("none")).is_ok() {
-            return Ok(SpecifiedValue(None));
-        }
-
-        Ok(SpecifiedValue(Some(try!(Image::parse(context, input)))))
-    }
-</%helpers:longhand>
+${helpers.predefined_type("border-image-source", "LayerImage",
+    initial_value="computed_value::T(None)",
+    initial_specified_value="SpecifiedValue(None)",
+    spec="https://drafts.csswg.org/css-backgrounds/#the-background-image",
+    vector=False,
+    animation_value_type="none",
+    has_uncacheable_values=False,
+    boxed="True")}
 
 <%helpers:longhand name="border-image-outset" animation_value_type="none"
                    spec="https://drafts.csswg.org/css-backgrounds/#border-image-outset">

--- a/components/style/properties/longhand/svg.mako.rs
+++ b/components/style/properties/longhand/svg.mako.rs
@@ -190,98 +190,13 @@ ${helpers.single_keyword("mask-composite",
                          extra_prefixes="webkit",
                          animation_value_type="none",
                          spec="https://drafts.fxtf.org/css-masking/#propdef-mask-composite")}
-
-<%helpers:vector_longhand name="mask-image" products="gecko" animation_value_type="none" extra_prefixes="webkit"
-                          has_uncacheable_values="${product == 'gecko'}"
-                          flags="CREATES_STACKING_CONTEXT",
-                          spec="https://drafts.fxtf.org/css-masking/#propdef-mask-image">
-    use std::fmt;
-    use style_traits::ToCss;
-    use stylearc::Arc;
-    use values::specified::Image;
-    use values::specified::url::SpecifiedUrl;
-    use values::HasViewportPercentage;
-
-    pub mod computed_value {
-        use std::fmt;
-        use style_traits::ToCss;
-        use values::computed;
-        use values::specified::url::SpecifiedUrl;
-        #[derive(Debug, Clone, PartialEq)]
-        #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-        pub enum T {
-            Image(computed::Image),
-            None
-        }
-
-        impl ToCss for T {
-            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-                match *self {
-                    T::None => dest.write_str("none"),
-                    T::Image(ref image) => image.to_css(dest),
-                }
-            }
-        }
-    }
-
-    no_viewport_percentage!(SpecifiedValue);
-
-    #[derive(Debug, Clone, PartialEq)]
-    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    pub enum SpecifiedValue {
-        Image(Image),
-        None
-    }
-
-    impl ToCss for SpecifiedValue {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match *self {
-                SpecifiedValue::Image(ref image) => image.to_css(dest),
-                SpecifiedValue::None => dest.write_str("none"),
-            }
-        }
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        computed_value::T::None
-    }
-    #[inline]
-    pub fn get_initial_specified_value() -> SpecifiedValue {
-        SpecifiedValue::None
-    }
-    pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {
-        if input.try(|input| input.expect_ident_matching("none")).is_ok() {
-            Ok(SpecifiedValue::None)
-        } else {
-            let image = try!(Image::parse(context, input));
-            match image {
-                Image::Url(url_value) => {
-                    Ok(SpecifiedValue::Image(Image::Url(url_value)))
-                }
-                image => Ok(SpecifiedValue::Image(image))
-            }
-        }
-    }
-    impl ToComputedValue for SpecifiedValue {
-        type ComputedValue = computed_value::T;
-
-        #[inline]
-        fn to_computed_value(&self, context: &Context) -> computed_value::T {
-            match *self {
-                SpecifiedValue::None => computed_value::T::None,
-                SpecifiedValue::Image(ref image) =>
-                    computed_value::T::Image(image.to_computed_value(context)),
-            }
-        }
-
-        #[inline]
-        fn from_computed_value(computed: &computed_value::T) -> Self {
-            match *computed {
-                computed_value::T::None => SpecifiedValue::None,
-                computed_value::T::Image(ref image) =>
-                    SpecifiedValue::Image(ToComputedValue::from_computed_value(image)),
-            }
-        }
-    }
-</%helpers:vector_longhand>
+${helpers.predefined_type("mask-image", "LayerImage",
+    initial_value="computed_value::T(None)",
+    initial_specified_value="SpecifiedValue(None)",
+    spec="https://drafts.fxtf.org/css-masking/#propdef-mask-image",
+    vector=True,
+    products="gecko",
+    extra_prefixes="webkit",
+    animation_value_type="none",
+    flags="CREATES_STACKING_CONTEXT",
+    has_uncacheable_values="True" if product == "gecko" else "False")}

--- a/components/style/values/computed/image.rs
+++ b/components/style/values/computed/image.rs
@@ -677,3 +677,17 @@ impl AngleOrCorner {
         }
     }
 }
+
+/// Computed values for none | <image> | <mask-source>.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub struct LayerImage(pub Option<Image>);
+
+impl ToCss for LayerImage {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        match self.0 {
+            None => dest.write_str("none"),
+            Some(ref image) => image.to_css(dest),
+        }
+    }
+}

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -22,7 +22,7 @@ use super::specified::grid::{TrackBreadth as GenericTrackBreadth, TrackSize as G
 
 pub use app_units::Au;
 pub use cssparser::Color as CSSColor;
-pub use self::image::{AngleOrCorner, EndingShape as GradientShape, Gradient, GradientItem};
+pub use self::image::{AngleOrCorner, EndingShape as GradientShape, Gradient, GradientItem, LayerImage};
 pub use self::image::{GradientKind, Image, ImageRect, LengthOrKeyword, LengthOrPercentageOrKeyword};
 pub use super::{Auto, Either, None_};
 #[cfg(feature = "gecko")]

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -29,7 +29,7 @@ pub use self::align::{AlignItems, AlignJustifyContent, AlignJustifySelf, Justify
 pub use self::color::Color;
 pub use self::grid::{GridLine, TrackKeyword};
 pub use self::image::{AngleOrCorner, ColorStop, EndingShape as GradientEndingShape, Gradient};
-pub use self::image::{GradientItem, GradientKind, HorizontalDirection, Image, ImageRect};
+pub use self::image::{GradientItem, GradientKind, HorizontalDirection, Image, ImageRect, LayerImage};
 pub use self::image::{LengthOrKeyword, LengthOrPercentageOrKeyword, SizeKeyword, VerticalDirection};
 pub use self::length::AbsoluteLength;
 pub use self::length::{FontRelativeLength, ViewportPercentageLength, CharacterWidth, Length, CalcLengthOrPercentage};

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -827,8 +827,8 @@ mod shorthand_serialization {
             let mut properties = Vec::new();
 
             let image = single_vec_value_typedef!(image,
-                image::single_value::SpecifiedValue::Image(
-                    Image::Url(SpecifiedUrl::new_for_testing("http://servo/test.png"))));
+                image::single_value::SpecifiedValue(
+                    Some(Image::Url(SpecifiedUrl::new_for_testing("http://servo/test.png")))));
 
             let mode = single_vec_keyword_value!(mode, luminance);
 
@@ -882,8 +882,8 @@ mod shorthand_serialization {
             let mut properties = Vec::new();
 
             let image = single_vec_value_typedef!(image,
-                image::single_value::SpecifiedValue::Image(
-                    Image::Url(SpecifiedUrl::new_for_testing("http://servo/test.png"))));
+                image::single_value::SpecifiedValue(
+                    Some(Image::Url(SpecifiedUrl::new_for_testing("http://servo/test.png")))));
 
             let mode = single_vec_keyword_value!(mode, luminance);
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Bug 1359787 - Stylo: Unite the implementation of background-image/ mask-image and border-image-source in {background|svg|border}.mako.rs

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16707)
<!-- Reviewable:end -->
