### PR TITLE
stylo: Bug 1360144 - make stroke-{*} animatable for stylo.

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3808,6 +3808,26 @@ clip-path
             bindings::Gecko_nsStyleSVG_CopyDashArray(&mut self.gecko, &other.gecko);
         }
     }
+
+    pub fn clone_stroke_dasharray(&self) -> longhands::stroke_dasharray::computed_value::T {
+        use smallvec::SmallVec;
+        use values::computed::LengthOrPercentage;
+
+        let mut vec = SmallVec::new();
+        for gecko in self.gecko.mStrokeDasharray.iter() {
+            match gecko.as_value() {
+                CoordDataValue::Factor(number) => vec.push(Either::First(number)),
+                CoordDataValue::Coord(coord) =>
+                    vec.push(Either::Second(LengthOrPercentage::Length(Au(coord)))),
+                CoordDataValue::Percent(p) =>
+                    vec.push(Either::Second(LengthOrPercentage::Percentage(p))),
+                CoordDataValue::Calc(calc) =>
+                    vec.push(Either::Second(LengthOrPercentage::Calc(calc.into()))),
+                _ => unreachable!(),
+            }
+        }
+        longhands::stroke_dasharray::computed_value::T(vec)
+    }
 </%self:impl_trait>
 
 <%self:impl_trait style_struct_name="Color"

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -621,6 +621,8 @@ pub trait Interpolate: Sized {
 /// https://drafts.csswg.org/css-transitions/#animtype-repeatable-list
 pub trait RepeatableListInterpolate: Interpolate {}
 
+impl RepeatableListInterpolate for Either<f32, LengthOrPercentage> {}
+
 impl<T: RepeatableListInterpolate> Interpolate for SmallVec<[T; 1]> {
     fn interpolate(&self, other: &Self, progress: f64) -> Result<Self, ()> {
         use num_integer::lcm;

--- a/components/style/properties/longhand/inherited_svg.mako.rs
+++ b/components/style/properties/longhand/inherited_svg.mako.rs
@@ -74,20 +74,20 @@ ${helpers.predefined_type(
     spec="https://www.w3.org/TR/SVG2/painting.html#StrokeWidth")}
 
 ${helpers.single_keyword("stroke-linecap", "butt round square",
-                         products="gecko", animation_value_type="none",
+                         products="gecko", animation_value_type="discrete",
                          spec="https://www.w3.org/TR/SVG11/painting.html#StrokeLinecapProperty")}
 
 ${helpers.single_keyword("stroke-linejoin", "miter round bevel",
-                         products="gecko", animation_value_type="none",
+                         products="gecko", animation_value_type="discrete",
                          spec="https://www.w3.org/TR/SVG11/painting.html#StrokeLinejoinProperty")}
 
 ${helpers.predefined_type("stroke-miterlimit", "Number", "4.0",
                           "parse_at_least_one", products="gecko",
-                          animation_value_type="none",
+                          animation_value_type="ComputedValue",
                           spec="https://www.w3.org/TR/SVG11/painting.html#StrokeMiterlimitProperty")}
 
 ${helpers.predefined_type("stroke-opacity", "Opacity", "1.0",
-                          products="gecko", animation_value_type="none",
+                          products="gecko", animation_value_type="ComputedValue",
                           spec="https://www.w3.org/TR/SVG11/painting.html#StrokeOpacityProperty")}
 
 ${helpers.predefined_type("stroke-dasharray",
@@ -95,9 +95,10 @@ ${helpers.predefined_type("stroke-dasharray",
                           "Either::First(0.0)",
                           "parse_non_negative",
                           vector="True",
+                          delegate_animate="True",
                           allow_empty="True",
                           products="gecko",
-                          animation_value_type="none",
+                          animation_value_type="ComputedValue",
                           space_separated_allowed="True",
                           spec="https://www.w3.org/TR/SVG2/painting.html#StrokeDashing")}
 


### PR DESCRIPTION
This part includes making stroke-linecap, stroke-linejoin, stroke-miterlimit,
stroke-opacity, and stroke-dasharray animatable.

For properties that already implemented Interpolate trait and clone() for
glue code, we can just make them animatable by replacing the animation_value_type
with proper type name. So, set animation_value_type to 'discrete' for
stroke-linecap and stroke-linejoin. Set animation_value_type to 'ComputedValue'
for stroke-miterlimit and stroke-opacity.

As to stroke-dasharray, we need to implement Interpolate trait and glue codes
for it.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16711)
<!-- Reviewable:end -->
