### PR TITLE
style: Rewrite calc to be cleaner and support arbitrary expressions.

### DIFF
--- a/components/style/values/specified/calc.rs
+++ b/components/style/values/specified/calc.rs
@@ -1,0 +1,547 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! [Calc expressions][calc].
+//!
+//! [calc]: https://drafts.csswg.org/css-values/#calc-notation
+
+use app_units::Au;
+use cssparser::{Parser, Token};
+use parser::ParserContext;
+use std::ascii::AsciiExt;
+use std::fmt;
+use style_traits::ToCss;
+use values::{CSSInteger, CSSFloat, HasViewportPercentage};
+use values::specified::{Angle, Time};
+use values::specified::length::{FontRelativeLength, NoCalcLength, ViewportPercentageLength};
+
+/// A node inside a `Calc` expression's AST.
+#[derive(Clone, Debug)]
+pub enum CalcNode {
+    /// `<length>`
+    Length(NoCalcLength),
+    /// `<angle>`
+    Angle(Angle),
+    /// `<time>`
+    Time(Time),
+    /// `<percentage>`
+    Percentage(CSSFloat),
+    /// `<number>`
+    Number(CSSFloat),
+    /// An expression of the form `x + y`
+    Sum(Box<CalcNode>, Box<CalcNode>),
+    /// An expression of the form `x - y`
+    Sub(Box<CalcNode>, Box<CalcNode>),
+    /// An expression of the form `x * y`
+    Mul(Box<CalcNode>, Box<CalcNode>),
+    /// An expression of the form `x / y`
+    Div(Box<CalcNode>, Box<CalcNode>),
+}
+
+/// An expected unit we intend to parse within a `calc()` expression.
+///
+/// This is used as a hint for the parser to fast-reject invalid expressions.
+#[derive(Clone, Copy, PartialEq)]
+pub enum CalcUnit {
+    /// `<number>`
+    Number,
+    /// `<integer>`
+    Integer,
+    /// `<length>`
+    Length,
+    /// `<length> | <percentage>`
+    LengthOrPercentage,
+    /// `<angle>`
+    Angle,
+    /// `<time>`
+    Time,
+}
+
+/// A struct to hold a simplified `<length>` or `<percentage>` expression.
+#[derive(Clone, PartialEq, Copy, Debug, Default)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+#[allow(missing_docs)]
+pub struct CalcLengthOrPercentage {
+    pub absolute: Option<Au>,
+    pub vw: Option<CSSFloat>,
+    pub vh: Option<CSSFloat>,
+    pub vmin: Option<CSSFloat>,
+    pub vmax: Option<CSSFloat>,
+    pub em: Option<CSSFloat>,
+    pub ex: Option<CSSFloat>,
+    pub ch: Option<CSSFloat>,
+    pub rem: Option<CSSFloat>,
+    pub percentage: Option<CSSFloat>,
+    #[cfg(feature = "gecko")]
+    pub mozmm: Option<CSSFloat>,
+}
+
+impl HasViewportPercentage for CalcLengthOrPercentage {
+    fn has_viewport_percentage(&self) -> bool {
+        self.vw.is_some() || self.vh.is_some() ||
+        self.vmin.is_some() || self.vmax.is_some()
+    }
+}
+
+impl ToCss for CalcLengthOrPercentage {
+    #[allow(unused_assignments)]
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        let mut first_value = true;
+        macro_rules! first_value_check {
+            () => {
+                if !first_value {
+                    try!(dest.write_str(" + "));
+                } else {
+                    first_value = false;
+                }
+            };
+        }
+
+        macro_rules! serialize {
+            ( $( $val:ident ),* ) => {
+                $(
+                    if let Some(val) = self.$val {
+                        first_value_check!();
+                        try!(val.to_css(dest));
+                        try!(dest.write_str(stringify!($val)));
+                    }
+                )*
+            };
+        }
+
+        try!(dest.write_str("calc("));
+
+        serialize!(ch, em, ex, rem, vh, vmax, vmin, vw);
+
+        #[cfg(feature = "gecko")]
+        {
+            serialize!(mozmm);
+        }
+
+        if let Some(val) = self.absolute {
+            first_value_check!();
+            try!(val.to_css(dest));
+        }
+
+        if let Some(val) = self.percentage {
+            first_value_check!();
+            try!(write!(dest, "{}%", val * 100.));
+        }
+
+        write!(dest, ")")
+    }
+}
+
+impl CalcNode {
+    /// Tries to parse a single element in the expression, that is, a
+    /// `<length>`, `<angle>`, `<time>`, `<percentage>`, according to
+    /// `expected_unit`.
+    ///
+    /// May return a "complex" `CalcNode`, in the presence of a parenthesized
+    /// expression, for example.
+    fn parse_one(
+        context: &ParserContext,
+        input: &mut Parser,
+        expected_unit: CalcUnit)
+        -> Result<Self, ()>
+    {
+        match (try!(input.next()), expected_unit) {
+            (Token::Number(ref value), _) => Ok(CalcNode::Number(value.value)),
+            (Token::Dimension(ref value, ref unit), CalcUnit::Length) |
+            (Token::Dimension(ref value, ref unit), CalcUnit::LengthOrPercentage) => {
+                NoCalcLength::parse_dimension(context, value.value, unit)
+                    .map(CalcNode::Length)
+            }
+            (Token::Dimension(ref value, ref unit), CalcUnit::Angle) => {
+                Angle::parse_dimension(value.value,
+                                       unit,
+                                       /* from_calc = */ true)
+                    .map(CalcNode::Angle)
+            }
+            (Token::Dimension(ref value, ref unit), CalcUnit::Time) => {
+                Time::parse_dimension(value.value,
+                                      unit,
+                                      /* from_calc = */ true)
+                    .map(CalcNode::Time)
+            }
+            (Token::Percentage(ref value), CalcUnit::LengthOrPercentage) => {
+                Ok(CalcNode::Percentage(value.unit_value))
+            }
+            (Token::ParenthesisBlock, _) => {
+                input.parse_nested_block(|i| {
+                    CalcNode::parse(context, i, expected_unit)
+                })
+            }
+            (Token::Function(ref name), _) if name.eq_ignore_ascii_case("calc") => {
+                input.parse_nested_block(|i| {
+                    CalcNode::parse(context, i, expected_unit)
+                })
+            }
+            _ => Err(())
+        }
+    }
+
+    /// Parse a top-level `calc` expression, with all nested sub-expressions.
+    ///
+    /// This is in charge of parsing, for example, `2 + 3 * 100%`.
+    fn parse(
+        context: &ParserContext,
+        input: &mut Parser,
+        expected_unit: CalcUnit)
+        -> Result<Self, ()>
+    {
+        let mut root = Self::parse_product(context, input, expected_unit)?;
+
+        loop {
+            let position = input.position();
+            match input.next_including_whitespace() {
+                Ok(Token::WhiteSpace(_)) => {
+                    if input.is_exhausted() {
+                        break; // allow trailing whitespace
+                    }
+                    match input.next()? {
+                        Token::Delim('+') => {
+                            let rhs =
+                                Self::parse_product(context, input, expected_unit)?;
+                            let new_root =
+                                CalcNode::Sum(Box::new(root), Box::new(rhs));
+                            root = new_root;
+                        }
+                        Token::Delim('-') => {
+                            let rhs =
+                                Self::parse_product(context, input, expected_unit)?;
+                            let new_root =
+                                CalcNode::Sub(Box::new(root), Box::new(rhs));
+                            root = new_root;
+                        }
+                        _ => return Err(()),
+                    }
+                }
+                _ => {
+                    input.reset(position);
+                    break
+                }
+            }
+        }
+
+        Ok(root)
+    }
+
+    /// Parse a top-level `calc` expression, and all the products that may
+    /// follow, and stop as soon as a non-product expression is found.
+    ///
+    /// This should parse correctly:
+    ///
+    ///     * `2`
+    ///     * `2 * 2`
+    ///     * `2 * 2 + 2` (but will leave the `+ 2` unparsed).
+    ///
+    fn parse_product(
+        context: &ParserContext,
+        input: &mut Parser,
+        expected_unit: CalcUnit)
+        -> Result<Self, ()>
+    {
+        let mut root = Self::parse_one(context, input, expected_unit)?;
+
+        loop {
+            let position = input.position();
+            match input.next() {
+                Ok(Token::Delim('*')) => {
+                    let rhs = Self::parse_one(context, input, expected_unit)?;
+                    let new_root = CalcNode::Mul(Box::new(root), Box::new(rhs));
+                    root = new_root;
+                }
+                // TODO(emilio): Figure out why the `Integer` check.
+                Ok(Token::Delim('/')) if expected_unit != CalcUnit::Integer => {
+                    let rhs = Self::parse_one(context, input, expected_unit)?;
+                    let new_root = CalcNode::Div(Box::new(root), Box::new(rhs));
+                    root = new_root;
+                }
+                _ => {
+                    input.reset(position);
+                    break
+                }
+            }
+        }
+
+        Ok(root)
+    }
+
+    /// Tries to simplify this expression into a `<length>` or `<percentage`>
+    /// value.
+    fn to_length_or_percentage(&self) -> Result<CalcLengthOrPercentage, ()> {
+        let mut ret = CalcLengthOrPercentage::default();
+        self.add_length_or_percentage_to(&mut ret, 1.0)?;
+        Ok(ret)
+    }
+
+    /// Puts this `<length>` or `<percentage>` into `ret`, or error.
+    ///
+    /// `factor` is the sign or multiplicative factor to account for the sign
+    /// (this allows adding and substracting into the return value).
+    fn add_length_or_percentage_to(
+        &self,
+        ret: &mut CalcLengthOrPercentage,
+        factor: CSSFloat)
+        -> Result<(), ()>
+    {
+        match *self {
+            CalcNode::Percentage(pct) => {
+                ret.percentage = Some(ret.percentage.unwrap_or(0.) + pct * factor)
+            }
+            CalcNode::Length(ref l) => {
+                match *l {
+                    NoCalcLength::Absolute(abs) => {
+                        ret.absolute = Some(
+                            ret.absolute.unwrap_or(Au(0)) +
+                            Au::from(abs).scale_by(factor)
+                        );
+                    }
+                    NoCalcLength::FontRelative(rel) => {
+                        match rel {
+                            FontRelativeLength::Em(em) => {
+                                ret.em = Some(ret.em.unwrap_or(0.) + em * factor);
+                            }
+                            FontRelativeLength::Ex(ex) => {
+                                ret.ex = Some(ret.em.unwrap_or(0.) + ex * factor);
+                            }
+                            FontRelativeLength::Ch(ch) => {
+                                ret.ch = Some(ret.ch.unwrap_or(0.) + ch * factor);
+                            }
+                            FontRelativeLength::Rem(rem) => {
+                                ret.rem = Some(ret.rem.unwrap_or(0.) + rem * factor);
+                            }
+                        }
+                    }
+                    NoCalcLength::ViewportPercentage(rel) => {
+                        match rel {
+                            ViewportPercentageLength::Vh(vh) => {
+                                ret.vh = Some(ret.vh.unwrap_or(0.) + vh * factor)
+                            }
+                            ViewportPercentageLength::Vw(vw) => {
+                                ret.vw = Some(ret.vw.unwrap_or(0.) + vw * factor)
+                            }
+                            ViewportPercentageLength::Vmax(vmax) => {
+                                ret.vmax = Some(ret.vmax.unwrap_or(0.) + vmax * factor)
+                            }
+                            ViewportPercentageLength::Vmin(vmin) => {
+                                ret.vmin = Some(ret.vmin.unwrap_or(0.) + vmin * factor)
+                            }
+                        }
+                    }
+                    NoCalcLength::ServoCharacterWidth(..) => unreachable!(),
+                    #[cfg(feature = "gecko")]
+                    NoCalcLength::Physical(physical) => {
+                        ret.mozmm = Some(ret.mozmm.unwrap_or(0.) + physical.0 * factor);
+                    }
+                }
+            }
+            CalcNode::Sub(ref a, ref b) => {
+                a.add_length_or_percentage_to(ret, factor)?;
+                b.add_length_or_percentage_to(ret, factor * -1.0)?;
+            }
+            CalcNode::Sum(ref a, ref b) => {
+                a.add_length_or_percentage_to(ret, factor)?;
+                b.add_length_or_percentage_to(ret, factor)?;
+            }
+            CalcNode::Mul(ref a, ref b) => {
+                match b.to_number() {
+                    Ok(rhs) => {
+                        a.add_length_or_percentage_to(ret, factor * rhs)?;
+                    }
+                    Err(..) => {
+                        let lhs = a.to_number()?;
+                        b.add_length_or_percentage_to(ret, factor * lhs)?;
+                    }
+                }
+            }
+            CalcNode::Div(ref a, ref b) => {
+                let new_factor = b.to_number()?;
+                if new_factor == 0. {
+                    return Err(());
+                }
+                a.add_length_or_percentage_to(ret, factor / new_factor)?;
+            }
+            CalcNode::Angle(..) |
+            CalcNode::Time(..) |
+            CalcNode::Number(..) => return Err(()),
+        }
+
+        Ok(())
+    }
+
+    /// Tries to simplify this expression into a `<time>` value.
+    fn to_time(&self) -> Result<Time, ()> {
+        Ok(match *self {
+            CalcNode::Time(ref time) => time.clone(),
+            CalcNode::Sub(ref a, ref b) => {
+                let lhs = a.to_time()?;
+                let rhs = b.to_time()?;
+                Time::from_calc(lhs.seconds() - rhs.seconds())
+            }
+            CalcNode::Sum(ref a, ref b) => {
+                let lhs = a.to_time()?;
+                let rhs = b.to_time()?;
+                Time::from_calc(lhs.seconds() + rhs.seconds())
+            }
+            CalcNode::Mul(ref a, ref b) => {
+                match b.to_number() {
+                    Ok(rhs) => {
+                        let lhs = a.to_time()?;
+                        Time::from_calc(lhs.seconds() * rhs)
+                    }
+                    Err(()) => {
+                        let lhs = a.to_number()?;
+                        let rhs = b.to_time()?;
+                        Time::from_calc(lhs * rhs.seconds())
+                    }
+                }
+            }
+            CalcNode::Div(ref a, ref b) => {
+                let lhs = a.to_time()?;
+                let rhs = b.to_number()?;
+                if rhs == 0. {
+                    return Err(())
+                }
+                Time::from_calc(lhs.seconds() / rhs)
+            }
+            CalcNode::Number(..) |
+            CalcNode::Length(..) |
+            CalcNode::Percentage(..) |
+            CalcNode::Angle(..) => return Err(()),
+        })
+    }
+
+    /// Tries to simplify this expression into an `Angle` value.
+    fn to_angle(&self) -> Result<Angle, ()> {
+        Ok(match *self {
+            CalcNode::Angle(ref angle) => angle.clone(),
+            CalcNode::Sub(ref a, ref b) => {
+                let lhs = a.to_angle()?;
+                let rhs = b.to_angle()?;
+                Angle::from_calc(lhs.radians() - rhs.radians())
+            }
+            CalcNode::Sum(ref a, ref b) => {
+                let lhs = a.to_angle()?;
+                let rhs = b.to_angle()?;
+                Angle::from_calc(lhs.radians() + rhs.radians())
+            }
+            CalcNode::Mul(ref a, ref b) => {
+                match a.to_angle() {
+                    Ok(lhs) => {
+                        let rhs = b.to_number()?;
+                        Angle::from_calc(lhs.radians() * rhs)
+                    }
+                    Err(..) => {
+                        let lhs = a.to_number()?;
+                        let rhs = b.to_angle()?;
+                        Angle::from_calc(lhs * rhs.radians())
+                    }
+                }
+            }
+            CalcNode::Div(ref a, ref b) => {
+                let lhs = a.to_angle()?;
+                let rhs = b.to_number()?;
+                if rhs == 0. {
+                    return Err(())
+                }
+                Angle::from_calc(lhs.radians() / rhs)
+            }
+            CalcNode::Number(..) |
+            CalcNode::Length(..) |
+            CalcNode::Percentage(..) |
+            CalcNode::Time(..) => return Err(()),
+        })
+    }
+
+    /// Tries to simplify this expression into a `<number>` value.
+    fn to_number(&self) -> Result<CSSFloat, ()> {
+        Ok(match *self {
+            CalcNode::Number(n) => n,
+            CalcNode::Sum(ref a, ref b) => {
+                a.to_number()? + b.to_number()?
+            }
+            CalcNode::Sub(ref a, ref b) => {
+                a.to_number()? - b.to_number()?
+            }
+            CalcNode::Mul(ref a, ref b) => {
+                a.to_number()? * b.to_number()?
+            }
+            CalcNode::Div(ref a, ref b) => {
+                let lhs = a.to_number()?;
+                let rhs = b.to_number()?;
+                if rhs == 0. {
+                    return Err(())
+                }
+                lhs / rhs
+            }
+            CalcNode::Length(..) |
+            CalcNode::Percentage(..) |
+            CalcNode::Angle(..) |
+            CalcNode::Time(..) => return Err(()),
+        })
+    }
+
+    /// Convenience parsing function for integers.
+    pub fn parse_integer(
+        context: &ParserContext,
+        input: &mut Parser)
+        -> Result<CSSInteger, ()>
+    {
+        Self::parse(context, input, CalcUnit::Integer)?
+            .to_number()
+            .map(|n| n as CSSInteger)
+    }
+
+    /// Convenience parsing function for `<length> | <percentage>`.
+    pub fn parse_length_or_percentage(
+        context: &ParserContext,
+        input: &mut Parser)
+        -> Result<CalcLengthOrPercentage, ()>
+    {
+        Self::parse(context, input, CalcUnit::LengthOrPercentage)?
+            .to_length_or_percentage()
+    }
+
+    /// Convenience parsing function for `<length>`.
+    pub fn parse_length(
+        context: &ParserContext,
+        input: &mut Parser)
+        -> Result<CalcLengthOrPercentage, ()>
+    {
+        Self::parse(context, input, CalcUnit::Length)?
+            .to_length_or_percentage()
+    }
+
+    /// Convenience parsing function for `<number>`.
+    pub fn parse_number(
+        context: &ParserContext,
+        input: &mut Parser)
+        -> Result<CSSFloat, ()>
+    {
+        Self::parse(context, input, CalcUnit::Number)?
+            .to_number()
+    }
+
+    /// Convenience parsing function for `<angle>`.
+    pub fn parse_angle(
+        context: &ParserContext,
+        input: &mut Parser)
+        -> Result<Angle, ()>
+    {
+        Self::parse(context, input, CalcUnit::Angle)?
+            .to_angle()
+    }
+
+    /// Convenience parsing function for `<time>`.
+    pub fn parse_time(
+        context: &ParserContext,
+        input: &mut Parser)
+        -> Result<Time, ()>
+    {
+        Self::parse(context, input, CalcUnit::Time)?
+            .to_time()
+    }
+}

--- a/tests/unit/style/parsing/inherited_box.rs
+++ b/tests/unit/style/parsing/inherited_box.rs
@@ -14,14 +14,14 @@ fn image_orientation_longhand_should_parse_properly() {
     assert_eq!(from_image, SpecifiedValue { angle: None, flipped: false });
 
     let flip = parse_longhand!(image_orientation, "flip");
-    assert_eq!(flip, SpecifiedValue { angle: Some(Angle::from_degrees(0.0)), flipped: true });
+    assert_eq!(flip, SpecifiedValue { angle: Some(Angle::zero()), flipped: true });
 
     let zero = parse_longhand!(image_orientation, "0deg");
-    assert_eq!(zero, SpecifiedValue { angle: Some(Angle::from_degrees(0.0)), flipped: false });
+    assert_eq!(zero, SpecifiedValue { angle: Some(Angle::zero()), flipped: false });
 
     let negative_rad = parse_longhand!(image_orientation, "-1rad");
-    assert_eq!(negative_rad, SpecifiedValue { angle: Some(Angle::from_radians(-1.0)), flipped: false });
+    assert_eq!(negative_rad, SpecifiedValue { angle: Some(Angle::from_radians(-1.0, false)), flipped: false });
 
     let flip_with_180 = parse_longhand!(image_orientation, "180deg flip");
-    assert_eq!(flip_with_180, SpecifiedValue { angle: Some(Angle::from_degrees(180.0)), flipped: true });
+    assert_eq!(flip_with_180, SpecifiedValue { angle: Some(Angle::from_degrees(180.0, false)), flipped: true });
 }

--- a/tests/unit/style/parsing/length.rs
+++ b/tests/unit/style/parsing/length.rs
@@ -20,6 +20,7 @@ fn test_calc() {
     assert!(parse(Length::parse, "calc( 1px + 2px )").is_ok());
     assert!(parse(Length::parse, "calc(1px + 2px )").is_ok());
     assert!(parse(Length::parse, "calc( 1px + 2px)").is_ok());
+    assert!(parse(Length::parse, "calc( 1px + 2px / ( 1 + 2 - 1))").is_ok());
 }
 
 #[test]

--- a/tests/unit/style/parsing/value.rs
+++ b/tests/unit/style/parsing/value.rs
@@ -6,7 +6,6 @@ use app_units::Au;
 use parsing::parse;
 use style::values::HasViewportPercentage;
 use style::values::specified::{AbsoluteLength, NoCalcLength, ViewportPercentageLength};
-use style::values::specified::length::{CalcLengthOrPercentage, CalcUnit};
 
 #[test]
 fn length_has_viewport_percentage() {
@@ -14,22 +13,4 @@ fn length_has_viewport_percentage() {
     assert!(l.has_viewport_percentage());
     let l = NoCalcLength::Absolute(AbsoluteLength::Px(Au(100).to_f32_px()));
     assert!(!l.has_viewport_percentage());
-}
-
-#[test]
-fn calc_top_level_number_with_unit() {
-    fn parse_value(text: &str, unit: CalcUnit) -> Result<CalcLengthOrPercentage, ()> {
-        parse(|context, input| CalcLengthOrPercentage::parse(context, input, unit), text)
-    }
-    assert_eq!(parse_value("1", CalcUnit::Length), Err(()));
-    assert_eq!(parse_value("1", CalcUnit::LengthOrPercentage), Err(()));
-    assert_eq!(parse_value("1", CalcUnit::Angle), Err(()));
-    assert_eq!(parse_value("1", CalcUnit::Time), Err(()));
-    assert_eq!(parse_value("1px  + 1", CalcUnit::Length), Err(()));
-    assert_eq!(parse_value("1em  + 1", CalcUnit::Length), Err(()));
-    assert_eq!(parse_value("1px  + 1", CalcUnit::LengthOrPercentage), Err(()));
-    assert_eq!(parse_value("1%   + 1", CalcUnit::LengthOrPercentage), Err(()));
-    assert_eq!(parse_value("1rad + 1", CalcUnit::Angle), Err(()));
-    assert_eq!(parse_value("1deg + 1", CalcUnit::Angle), Err(()));
-    assert_eq!(parse_value("1s   + 1", CalcUnit::Time), Err(()));
 }

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -1043,19 +1043,19 @@ mod shorthand_serialization {
         #[test]
         fn transform_skew() {
             validate_serialization(
-                &SpecifiedOperation::Skew(Angle::from_degrees(42.3), None),
+                &SpecifiedOperation::Skew(Angle::from_degrees(42.3, false), None),
                 "skew(42.3deg)");
             validate_serialization(
-                &SpecifiedOperation::Skew(Angle::from_gradians(-50.0), Some(Angle::from_turns(0.73))),
+                &SpecifiedOperation::Skew(Angle::from_gradians(-50.0, false), Some(Angle::from_turns(0.73, false))),
                 "skew(-50grad, 0.73turn)");
             validate_serialization(
-                &SpecifiedOperation::SkewX(Angle::from_radians(0.31)), "skewX(0.31rad)");
+                &SpecifiedOperation::SkewX(Angle::from_radians(0.31, false)), "skewX(0.31rad)");
         }
 
         #[test]
         fn transform_rotate() {
             validate_serialization(
-                &SpecifiedOperation::Rotate(Angle::from_turns(35.0)),
+                &SpecifiedOperation::Rotate(Angle::from_turns(35.0, false)),
                 "rotate(35turn)"
             )
         }


### PR DESCRIPTION
This improves Servo's calc support compliant with[1], and makes it cleaner and
more straight-forward. (also fixes #15192)

[1]: https://github.com/w3c/csswg-drafts/issues/1241

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16728)
<!-- Reviewable:end -->
