### PR TITLE
Make stylo support moz-prefixed cursor values.

### DIFF
--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 doctest = false
 
 [features]
-gecko = ["nsstring_vendor", "rayon/unstable", "num_cpus"]
+gecko = ["nsstring_vendor", "rayon/unstable", "num_cpus", "style_traits/gecko"]
 use_bindgen = ["bindgen", "regex"]
 servo = ["serde/unstable", "serde", "serde_derive", "heapsize", "heapsize_derive",
          "style_traits/servo", "servo_atoms", "servo_config", "html5ever-atoms",

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3832,6 +3832,11 @@ clip-path
                 Cursor::AllScroll => structs::NS_STYLE_CURSOR_ALL_SCROLL,
                 Cursor::ZoomIn => structs::NS_STYLE_CURSOR_ZOOM_IN,
                 Cursor::ZoomOut => structs::NS_STYLE_CURSOR_ZOOM_OUT,
+                // note: the following properties are gecko-only.
+                Cursor::MozGrab => structs::NS_STYLE_CURSOR_GRAB,
+                Cursor::MozGrabbing => structs::NS_STYLE_CURSOR_GRABBING,
+                Cursor::MozZoomIn => structs::NS_STYLE_CURSOR_ZOOM_IN,
+                Cursor::MozZoomOut => structs::NS_STYLE_CURSOR_ZOOM_OUT,
             }
         } as u8;
 

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -12,6 +12,7 @@ path = "lib.rs"
 [features]
 servo = ["heapsize", "heapsize_derive", "serde", "serde_derive",
          "cssparser/heapsize", "cssparser/serde"]
+gecko = []
 
 [dependencies]
 app_units = "0.4"

--- a/components/style_traits/cursor.rs
+++ b/components/style_traits/cursor.rs
@@ -7,21 +7,30 @@
 use super::ToCss;
 
 macro_rules! define_cursor {
-    ($( $css: expr => $variant: ident = $value: expr, )+) => {
+    (
+        common properties = [
+            $( $c_css: expr => $c_variant: ident = $c_value: expr, )+
+        ]
+        gecko properties = [
+            $( $g_css: expr => $g_variant: ident = $g_value: expr, )+
+        ]
+    ) => {
         /// https://drafts.csswg.org/css-ui/#cursor
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
         #[cfg_attr(feature = "servo", derive(Deserialize, Serialize, HeapSizeOf))]
         #[repr(u8)]
         #[allow(missing_docs)]
         pub enum Cursor {
-            $( $variant = $value ),+
+            $( $c_variant = $c_value, )+
+            $( #[cfg(feature = "gecko")] $g_variant = $g_value, )+
         }
 
         impl Cursor {
             /// Given a CSS keyword, get the corresponding cursor enum.
             pub fn from_css_keyword(keyword: &str) -> Result<Cursor, ()> {
                 match_ignore_ascii_case! { &keyword,
-                    $( $css => Ok(Cursor::$variant), )+
+                    $( $c_css => Ok(Cursor::$c_variant), )+
+                    $( #[cfg(feature = "gecko")] $g_css => Ok(Cursor::$g_variant), )+
                     _ => Err(())
                 }
             }
@@ -30,7 +39,8 @@ macro_rules! define_cursor {
         impl ToCss for Cursor {
             fn to_css<W>(&self, dest: &mut W) -> ::std::fmt::Result where W: ::std::fmt::Write {
                 match *self {
-                    $( Cursor::$variant => dest.write_str($css) ),+
+                    $( Cursor::$c_variant => dest.write_str($c_css), )+
+                    $( #[cfg(feature = "gecko")] Cursor::$g_variant => dest.write_str($g_css), )+
                 }
             }
         }
@@ -39,39 +49,48 @@ macro_rules! define_cursor {
 
 
 define_cursor! {
-    "none" => None = 0,
-    "default" => Default = 1,
-    "pointer" => Pointer = 2,
-    "context-menu" => ContextMenu = 3,
-    "help" => Help = 4,
-    "progress" => Progress = 5,
-    "wait" => Wait = 6,
-    "cell" => Cell = 7,
-    "crosshair" => Crosshair = 8,
-    "text" => Text = 9,
-    "vertical-text" => VerticalText = 10,
-    "alias" => Alias = 11,
-    "copy" => Copy = 12,
-    "move" => Move = 13,
-    "no-drop" => NoDrop = 14,
-    "not-allowed" => NotAllowed = 15,
-    "grab" => Grab = 16,
-    "grabbing" => Grabbing = 17,
-    "e-resize" => EResize = 18,
-    "n-resize" => NResize = 19,
-    "ne-resize" => NeResize = 20,
-    "nw-resize" => NwResize = 21,
-    "s-resize" => SResize = 22,
-    "se-resize" => SeResize = 23,
-    "sw-resize" => SwResize = 24,
-    "w-resize" => WResize = 25,
-    "ew-resize" => EwResize = 26,
-    "ns-resize" => NsResize = 27,
-    "nesw-resize" => NeswResize = 28,
-    "nwse-resize" => NwseResize = 29,
-    "col-resize" => ColResize = 30,
-    "row-resize" => RowResize = 31,
-    "all-scroll" => AllScroll = 32,
-    "zoom-in" => ZoomIn = 33,
-    "zoom-out" => ZoomOut = 34,
+    common properties = [
+        "none" => None = 0,
+        "default" => Default = 1,
+        "pointer" => Pointer = 2,
+        "context-menu" => ContextMenu = 3,
+        "help" => Help = 4,
+        "progress" => Progress = 5,
+        "wait" => Wait = 6,
+        "cell" => Cell = 7,
+        "crosshair" => Crosshair = 8,
+        "text" => Text = 9,
+        "vertical-text" => VerticalText = 10,
+        "alias" => Alias = 11,
+        "copy" => Copy = 12,
+        "move" => Move = 13,
+        "no-drop" => NoDrop = 14,
+        "not-allowed" => NotAllowed = 15,
+        "grab" => Grab = 16,
+        "grabbing" => Grabbing = 17,
+        "e-resize" => EResize = 18,
+        "n-resize" => NResize = 19,
+        "ne-resize" => NeResize = 20,
+        "nw-resize" => NwResize = 21,
+        "s-resize" => SResize = 22,
+        "se-resize" => SeResize = 23,
+        "sw-resize" => SwResize = 24,
+        "w-resize" => WResize = 25,
+        "ew-resize" => EwResize = 26,
+        "ns-resize" => NsResize = 27,
+        "nesw-resize" => NeswResize = 28,
+        "nwse-resize" => NwseResize = 29,
+        "col-resize" => ColResize = 30,
+        "row-resize" => RowResize = 31,
+        "all-scroll" => AllScroll = 32,
+        "zoom-in" => ZoomIn = 33,
+        "zoom-out" => ZoomOut = 34,
+    ]
+    // gecko only properties
+    gecko properties = [
+        "-moz-grab" => MozGrab = 35,
+        "-moz-grabbing" => MozGrabbing = 36,
+        "-moz-zoom-in" => MozZoomIn = 37,
+        "-moz-zoom-out" => MozZoomOut = 38,
+    ]
 }


### PR DESCRIPTION

<!-- Please describe your changes on the following line: -->

This issue is reported at https://bugzilla.mozilla.org/show_bug.cgi?id=1356072.

We need to support the following moz-prefix properties in stylo:
- -moz-grab
- -moz-grabbing
- -moz-zoom-in
- -moz-zoom-out

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1356072](https://bugzilla.mozilla.org/show_bug.cgi?id=1356072).

<!-- Either: -->
- [X] These changes do not require tests because the tests already exist in Gecko.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16733)
<!-- Reviewable:end -->
