### PR TITLE
Rename PushScrollRoot and remove PopScrollRoot

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -86,7 +86,7 @@ impl DisplayList {
                                              scroll_offsets,
                                              result);
                 }
-                &DisplayItem::PushScrollRoot(ref item) => {
+                &DisplayItem::DefineClip(ref item) => {
                     let mut point = *translated_point;
                     DisplayList::scroll_root(&item.scroll_root,
                                              &mut point,
@@ -149,7 +149,7 @@ impl DisplayList {
                                            scroll_offsets,
                                            result);
                 }
-                &DisplayItem::PushScrollRoot(ref item) => {
+                &DisplayItem::DefineClip(ref item) => {
                     let mut point = *translated_point;
                     DisplayList::scroll_root(&item.scroll_root,
                                              &mut point,
@@ -160,7 +160,7 @@ impl DisplayList {
                                            scroll_offsets,
                                            result);
                 }
-                &DisplayItem::PopStackingContext(_) | &DisplayItem::PopScrollRoot(_) => return,
+                &DisplayItem::PopStackingContext(_) => return,
                 _ => {
                     if let Some(meta) = item.hit_test(*translated_point) {
                         result.push(meta);
@@ -510,8 +510,8 @@ pub struct ScrollRoot {
 }
 
 impl ScrollRoot {
-    pub fn to_push(&self, pipeline_id: PipelineId) -> DisplayItem {
-        DisplayItem::PushScrollRoot(box PushScrollRootItem {
+    pub fn to_define_item(&self, pipeline_id: PipelineId) -> DisplayItem {
+        DisplayItem::DefineClip(box DefineClipItem {
             base: BaseDisplayItem::empty(pipeline_id),
             scroll_root: self.clone(),
         })
@@ -534,8 +534,7 @@ pub enum DisplayItem {
     Iframe(Box<IframeDisplayItem>),
     PushStackingContext(Box<PushStackingContextItem>),
     PopStackingContext(Box<PopStackingContextItem>),
-    PushScrollRoot(Box<PushScrollRootItem>),
-    PopScrollRoot(Box<BaseDisplayItem>),
+    DefineClip(Box<DefineClipItem>),
 }
 
 /// Information common to all display items.
@@ -1123,7 +1122,7 @@ pub struct PopStackingContextItem {
 
 /// Starts a group of items inside a particular scroll root.
 #[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
-pub struct PushScrollRootItem {
+pub struct DefineClipItem {
     /// Fields common to all display items.
     pub base: BaseDisplayItem,
 
@@ -1159,8 +1158,7 @@ impl DisplayItem {
             DisplayItem::Iframe(ref iframe) => &iframe.base,
             DisplayItem::PushStackingContext(ref stacking_context) => &stacking_context.base,
             DisplayItem::PopStackingContext(ref item) => &item.base,
-            DisplayItem::PushScrollRoot(ref item) => &item.base,
-            DisplayItem::PopScrollRoot(ref base) => &base,
+            DisplayItem::DefineClip(ref item) => &item.base,
         }
     }
 
@@ -1246,12 +1244,8 @@ impl fmt::Debug for DisplayItem {
             return write!(f, "PopStackingContext({:?}", item.stacking_context_id);
         }
 
-        if let DisplayItem::PushScrollRoot(ref item) = *self {
-            return write!(f, "PushScrollRoot({:?}", item.scroll_root);
-        }
-
-        if let DisplayItem::PopScrollRoot(_) = *self {
-            return write!(f, "PopScrollRoot");
+        if let DisplayItem::DefineClip(ref item) = *self {
+            return write!(f, "DefineClip({:?}", item.scroll_root);
         }
 
         write!(f, "{} @ {:?} {:?}",
@@ -1277,8 +1271,7 @@ impl fmt::Debug for DisplayItem {
                 DisplayItem::Iframe(_) => "Iframe".to_owned(),
                 DisplayItem::PushStackingContext(_) |
                 DisplayItem::PopStackingContext(_) |
-                DisplayItem::PushScrollRoot(_) |
-                DisplayItem::PopScrollRoot(_) => "".to_owned(),
+                DisplayItem::DefineClip(_) => "".to_owned(),
             },
             self.bounds(),
             self.base().clip

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -289,12 +289,12 @@ impl<'a> DisplayListBuildState<'a> {
 
         let pipeline_id = self.layout_context.id;
         if stacking_context.context_type != StackingContextType::Real {
-            list.extend(info.scroll_roots.into_iter().map(|root| root.to_push(pipeline_id)));
+            list.extend(info.scroll_roots.into_iter().map(|root| root.to_define_item(pipeline_id)));
             self.to_display_list_for_items(list, child_items, info.children);
         } else {
             let (push_item, pop_item) = stacking_context.to_display_list_items(pipeline_id);
             list.push(push_item);
-            list.extend(info.scroll_roots.into_iter().map(|root| root.to_push(pipeline_id)));
+            list.extend(info.scroll_roots.into_iter().map(|root| root.to_define_item(pipeline_id)));
             self.to_display_list_for_items(list, child_items, info.children);
             list.push(pop_item);
         }

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -449,7 +449,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                               stacking_context.filters.to_filter_ops());
             }
             DisplayItem::PopStackingContext(_) => builder.pop_stacking_context(),
-            DisplayItem::PushScrollRoot(ref item) => {
+            DisplayItem::DefineClip(ref item) => {
                 builder.push_clip_id(item.scroll_root.parent_id);
 
                 let our_id = item.scroll_root.id;
@@ -460,7 +460,6 @@ impl WebRenderDisplayItemConverter for DisplayItem {
 
                 builder.pop_clip_id();
             }
-            DisplayItem::PopScrollRoot(_) => {} //builder.pop_scroll_layer(),
         }
     }
 }


### PR DESCRIPTION
PopScrollRoot was unused and PushScrollRoot no longer pushes a scroll
root, but defines a new one.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16735)
<!-- Reviewable:end -->
