### PR TITLE
Properly use big endianness to parse font feature tags

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -1815,10 +1815,10 @@ ${helpers.single_keyword_system("font-variant-position",
         impl ToCss for FeatureTagValue {
             fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
                 use std::str;
-                use byteorder::{WriteBytesExt, NativeEndian};
+                use byteorder::{WriteBytesExt, BigEndian};
 
                 let mut raw: Vec<u8> = vec!();
-                raw.write_u32::<NativeEndian>(self.tag).unwrap();
+                raw.write_u32::<BigEndian>(self.tag).unwrap();
                 let str_print = str::from_utf8(&raw).unwrap_or_default();
 
                 match self.value {
@@ -1836,7 +1836,7 @@ ${helpers.single_keyword_system("font-variant-position",
                 use std::io::Cursor;
                 use std::str;
                 use std::ops::Deref;
-                use byteorder::{ReadBytesExt, NativeEndian};
+                use byteorder::{ReadBytesExt, BigEndian};
 
                 let tag = try!(input.expect_string());
 
@@ -1848,7 +1848,7 @@ ${helpers.single_keyword_system("font-variant-position",
                 }
 
                 let mut raw = Cursor::new(tag.as_bytes());
-                let u_tag = raw.read_u32::<NativeEndian>().unwrap();
+                let u_tag = raw.read_u32::<BigEndian>().unwrap();
 
                 if let Ok(value) = input.try(|input| input.expect_integer()) {
                     // handle integer, throw if it is negative

--- a/tests/unit/style/parsing/font.rs
+++ b/tests/unit/style/parsing/font.rs
@@ -10,7 +10,7 @@ use style_traits::ToCss;
 
 #[test]
 fn font_feature_settings_should_parse_properly() {
-    use byteorder::{ReadBytesExt, NativeEndian};
+    use byteorder::{ReadBytesExt, BigEndian};
     use std::io::Cursor;
 
     let normal = parse_longhand!(font_feature_settings, "normal");
@@ -20,8 +20,8 @@ fn font_feature_settings_should_parse_properly() {
     let mut a_d_bytes = Cursor::new(b"abcd");
     let mut e_h_bytes = Cursor::new(b"efgh");
 
-    let abcd = a_d_bytes.read_u32::<NativeEndian>().unwrap();
-    let efgh = e_h_bytes.read_u32::<NativeEndian>().unwrap();
+    let abcd = a_d_bytes.read_u32::<BigEndian>().unwrap();
+    let efgh = e_h_bytes.read_u32::<BigEndian>().unwrap();
 
     let on = parse_longhand!(font_feature_settings, "\"abcd\" on");
     let on_computed = computed_value::T::Tag(vec![


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16742)
<!-- Reviewable:end -->
