### PR TITLE
Support for Android armv7 and aarch64 target triples

### DIFF
--- a/ports/servo/.cargo/config
+++ b/ports/servo/.cargo/config
@@ -1,6 +1,14 @@
 [target.arm-linux-androideabi]
-linker = "./fake-ld.sh"
+linker = "./fake-ld-arm.sh"
 ar = "arm-linux-androideabi-ar"
+
+[target.armv7-linux-androideabi]
+linker = "./fake-ld-armv7.sh"
+ar = "arm-linux-androideabi-ar"
+
+[target.aarch64-linux-android]
+linker = "./fake-ld-arm64.sh"
+ar = "aarch64-linux-android-ar"
 
 [target.arm-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"

--- a/ports/servo/fake-ld-arm.sh
+++ b/ports/servo/fake-ld-arm.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source fake-ld.sh
+
+export _GCC_PARAMS="${@}"
+call_gcc "arch-arm" "arm-linux-androideabi-4.9" "android-18" "armeabi"

--- a/ports/servo/fake-ld-arm64.sh
+++ b/ports/servo/fake-ld-arm64.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source fake-ld.sh
+
+export _GCC_PARAMS="${@}"
+call_gcc "arch-arm64" "aarch64-linux-android-4.9" "android-21" "arm64-v8a"

--- a/ports/servo/fake-ld-armv7.sh
+++ b/ports/servo/fake-ld-armv7.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source fake-ld.sh
+
+export _GCC_PARAMS="${@}"
+call_gcc "arch-arm" "arm-linux-androideabi-4.9" "android-18" "armeabi-v7a"

--- a/ports/servo/fake-ld.sh
+++ b/ports/servo/fake-ld.sh
@@ -8,26 +8,31 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-TARGET_DIR="${OUT_DIR}/../../.."
+call_gcc()
+{
+  TARGET_DIR="${OUT_DIR}/../../.."
 
-export _ANDROID_ARCH=arch-arm
-export ANDROID_SYSROOT="${ANDROID_NDK}/platforms/android-18/${_ANDROID_ARCH}"
-export _ANDROID_EABI=arm-linux-androideabi-4.9
-ANDROID_TOOLCHAIN=""
-for host in "linux-x86_64" "linux-x86" "darwin-x86_64" "darwin-x86"; do
-  if [[ -d "${ANDROID_NDK}/toolchains/${_ANDROID_EABI}/prebuilt/${host}/bin" ]]; then
-    ANDROID_TOOLCHAIN="${ANDROID_NDK}/toolchains/${_ANDROID_EABI}/prebuilt/${host}/bin"
-    break
-  fi
-done
+  export _ANDROID_ARCH=$1
+  export _ANDROID_EABI=$2
+  export _ANDROID_PLATFORM=$3
+  export ANDROID_SYSROOT="${ANDROID_NDK}/platforms/${_ANDROID_PLATFORM}/${_ANDROID_ARCH}"
+  ANDROID_TOOLCHAIN=""
+  for host in "linux-x86_64" "linux-x86" "darwin-x86_64" "darwin-x86"; do
+    if [[ -d "${ANDROID_NDK}/toolchains/${_ANDROID_EABI}/prebuilt/${host}/bin" ]]; then
+      ANDROID_TOOLCHAIN="${ANDROID_NDK}/toolchains/${_ANDROID_EABI}/prebuilt/${host}/bin"
+      break
+    fi
+  done
 
-ANDROID_CPU_ARCH_DIR=armeabi
-ANDROID_CXX_LIBS="${ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${ANDROID_CPU_ARCH_DIR}"
+  ANDROID_CPU_ARCH_DIR=$4
+  ANDROID_CXX_LIBS="${ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${ANDROID_CPU_ARCH_DIR}"
 
-echo "toolchain: ${ANDROID_TOOLCHAIN}"
-echo "libs dir: ${ANDROID_CXX_LIBS}"
-echo "sysroot: ${ANDROID_SYSROOT}"
+  echo "toolchain: ${ANDROID_TOOLCHAIN}"
+  echo "libs dir: ${ANDROID_CXX_LIBS}"
+  echo "sysroot: ${ANDROID_SYSROOT}"
+  echo "targetdir: ${ANDROID_CXX_LIBS}"
 
-"${ANDROID_TOOLCHAIN}/arm-linux-androideabi-gcc" \
-  --sysroot="${ANDROID_SYSROOT}" -L "${ANDROID_CXX_LIBS}" "${@}" -lc++ \
-  -o "${TARGET_DIR}/libservo.so" -shared && touch "${TARGET_DIR}/servo"
+  "${ANDROID_TOOLCHAIN}/arm-linux-androideabi-gcc" \
+    --sysroot="${ANDROID_SYSROOT}" -L "${ANDROID_CXX_LIBS}" ${_GCC_PARAMS} -lc++ \
+    -o "${TARGET_DIR}/libservo.so" -shared && touch "${TARGET_DIR}/servo"
+}

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -221,11 +221,14 @@ class MachCommands(CommandBase):
             opts += ["-j", jobs]
         if verbose:
             opts += ["-v"]
+
         if android:
             target = self.config["android"]["target"]
 
         if target:
             opts += ["--target", target]
+            if not android:
+                android = self.handle_android_target(target)
 
         self.ensure_bootstrapped(target=target)
 
@@ -277,10 +280,15 @@ class MachCommands(CommandBase):
             elif cpu_type in ["x86_64", "x86-64", "x64", "amd64"]:
                 host_suffix = "x86_64"
             host = os_type + "-" + host_suffix
+
+            android_platform = self.config["android"]["platform"]
+            android_toolchain = self.config["android"]["toolchain_name"]
+            android_arch = "arch-" + self.config["android"]["arch"]
+
             env['PATH'] = path.join(
-                env['ANDROID_NDK'], "toolchains", "arm-linux-androideabi-4.9", "prebuilt", host, "bin"
+                env['ANDROID_NDK'], "toolchains", android_toolchain, "prebuilt", host, "bin"
             ) + ':' + env['PATH']
-            env['ANDROID_SYSROOT'] = path.join(env['ANDROID_NDK'], "platforms", "android-18", "arch-arm")
+            env['ANDROID_SYSROOT'] = path.join(env['ANDROID_NDK'], "platforms", android_platform, android_arch)
             support_include = path.join(env['ANDROID_NDK'], "sources", "android", "support", "include")
             cxx_include = path.join(
                 env['ANDROID_NDK'], "sources", "cxx-stl", "llvm-libc++", "libcxx", "include")
@@ -294,6 +302,7 @@ class MachCommands(CommandBase):
                 "-I" + support_include,
                 "-I" + cxx_include,
                 "-I" + cxxabi_include])
+            env["NDK_ANDROID_VERSION"] = android_platform.replace("android-", "")
 
         cargo_binary = "cargo" + BIN_SUFFIX
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -277,8 +277,7 @@ class CommandBase(object):
         self.config["android"].setdefault("sdk", "")
         self.config["android"].setdefault("ndk", "")
         self.config["android"].setdefault("toolchain", "")
-        self.config["android"].setdefault("platform", "android-18")
-        self.config["android"].setdefault("target", "arm-linux-androideabi")
+        self.handle_android_target("arm-linux-androideabi")
 
         self.set_cargo_root()
         self.set_use_stable_rust(False)
@@ -538,7 +537,31 @@ class CommandBase(object):
         return path.join(self.context.topdir, "support", "android")
 
     def android_build_dir(self, dev):
-        return path.join(self.get_target_dir(), "arm-linux-androideabi", "debug" if dev else "release")
+        return path.join(self.get_target_dir(), self.config["android"]["target"], "debug" if dev else "release")
+
+    def handle_android_target(self, target):
+        if target == "arm-linux-androideabi":
+            self.config["android"]["platform"] = "android-18"
+            self.config["android"]["target"] = target
+            self.config["android"]["arch"] = "arm"
+            self.config["android"]["lib"] = "armeabi"
+            self.config["android"]["toolchain_name"] = target + "-4.9"
+            return True
+        elif target == "armv7-linux-androideabi":
+            self.config["android"]["platform"] = "android-18"
+            self.config["android"]["target"] = target
+            self.config["android"]["arch"] = "arm"
+            self.config["android"]["lib"] = "armeabi-v7a"
+            self.config["android"]["toolchain_name"] = "arm-linux-androideabi-4.9"
+            return True
+        elif target == "aarch64-linux-android":
+            self.config["android"]["platform"] = "android-21"
+            self.config["android"]["target"] = target
+            self.config["android"]["arch"] = "arm64"
+            self.config["android"]["lib"] = "arm64-v8a"
+            self.config["android"]["toolchain_name"] = target + "-4.9"
+            return True
+        return False
 
     def ensure_bootstrapped(self, target=None):
         if self.context.bootstrapped:

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -141,10 +141,20 @@ class PackageCommands(CommandBase):
         dir_to_root = self.get_top_dir()
         target_dir = path.dirname(binary_path)
         if android:
-            if dev:
-                task_name = "assembleArmDebug"
+            android_target = self.config["android"]["target"]
+            if "aarch64" in android_target:
+                build_type = "Arm64"
+            elif "armv7" in android_target:
+                build_type = "Armv7"
             else:
-                task_name = "assembleArmRelease"
+                build_type = "Arm"
+
+            if dev:
+                build_mode = "Debug"
+            else:
+                build_mode = "Release"
+
+            task_name = "assemble" + build_type + build_mode
             try:
                 with cd(path.join("support", "android", "apk")):
                     subprocess.check_call(["./gradlew", "--no-daemon", task_name], env=env)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Support for Android armv7 and aarch64 target triples in python build scripts (build + packaging)

`--android` build parameter works as always (arm-linux-androideabi still the default)
`./mach build --release --android`

New compilation modes for android
`./mach build --release --target=arm-linux-androideabi`
`./mach build --release --target=armv7-linux-androideabi`
`./mach build --release --target=aarch64-linux-android`

See https://github.com/servo/servo/issues/11921. When all crates are ready we'll switch default android compilations to` armv7-linux-androideabi` target triple.  

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16769)
<!-- Reviewable:end -->
