### PR TITLE
WR update: preserve-3d support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "webvr_traits"
 version = "0.0.1"
 dependencies = [
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "rust-webvr 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "binary-space-partition"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -221,7 +221,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bluetooth_traits 0.0.1",
  "device 0.0.1 (git+https://github.com/servo/devices)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_config 0.0.1",
  "servo_rand 0.0.1",
  "tinyfiledialogs 2.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -232,7 +232,7 @@ dependencies = [
 name = "bluetooth_traits"
 version = "0.0.1"
 dependencies = [
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -302,12 +302,12 @@ dependencies = [
  "cssparser 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_config 0.0.1",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -318,10 +318,10 @@ dependencies = [
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -430,7 +430,7 @@ dependencies = [
  "gfx_traits 0.0.1",
  "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
@@ -441,8 +441,8 @@ dependencies = [
  "servo_url 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.36.0 (git+https://github.com/servo/webrender)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -460,7 +460,7 @@ dependencies = [
  "gaol 0.0.1 (git+https://github.com/servo/gaol)",
  "gfx 0.0.1",
  "gfx_traits 0.0.1",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "layout_traits 0.0.1",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -477,7 +477,7 @@ dependencies = [
  "servo_remutex 0.0.1",
  "servo_url 0.0.1",
  "style_traits 0.0.1",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
 ]
 
@@ -629,7 +629,7 @@ dependencies = [
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -647,7 +647,7 @@ dependencies = [
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -724,7 +724,7 @@ dependencies = [
  "servo_geometry 0.0.1",
  "servo_url 0.0.1",
  "style_traits 0.0.1",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
  "x11 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -924,10 +924,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gamma-lut"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -995,7 +995,7 @@ dependencies = [
  "harfbuzz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1016,7 +1016,7 @@ dependencies = [
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "truetype 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
  "xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1025,7 +1025,7 @@ name = "gfx_tests"
 version = "0.0.1"
 dependencies = [
  "gfx 0.0.1",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
 ]
 
@@ -1095,7 +1095,7 @@ dependencies = [
  "servo_url 0.0.1",
  "style_traits 0.0.1",
  "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "ipc-channel"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 1.0.0-alpha6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1372,7 +1372,7 @@ dependencies = [
  "gfx_traits 0.0.1",
  "heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -1396,7 +1396,7 @@ dependencies = [
  "style_traits 0.0.1",
  "unicode-bidi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -1416,7 +1416,7 @@ dependencies = [
  "gfx 0.0.1",
  "gfx_traits 0.0.1",
  "heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "layout 0.0.1",
  "layout_traits 0.0.1",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1436,7 +1436,7 @@ dependencies = [
  "servo_geometry 0.0.1",
  "servo_url 0.0.1",
  "style 0.0.1",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -1444,13 +1444,13 @@ name = "layout_traits"
 version = "0.0.1"
 dependencies = [
  "gfx 0.0.1",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
  "profile_traits 0.0.1",
  "script_traits 0.0.1",
  "servo_url 0.0.1",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -1520,7 +1520,7 @@ dependencies = [
  "gaol 0.0.1 (git+https://github.com/servo/gaol)",
  "gfx 0.0.1",
  "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "layout_thread 0.0.1",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -1537,8 +1537,8 @@ dependencies = [
  "style 0.0.1",
  "style_traits 0.0.1",
  "webdriver_server 0.0.1",
- "webrender 0.36.0 (git+https://github.com/servo/webrender)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
  "webvr 0.0.1",
  "webvr_traits 0.0.1",
 ]
@@ -1702,7 +1702,7 @@ dependencies = [
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -1723,7 +1723,7 @@ dependencies = [
  "hyper-openssl 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "immeta 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1746,7 +1746,7 @@ dependencies = [
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -1771,7 +1771,7 @@ dependencies = [
  "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-openssl 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net 0.0.1",
  "net_traits 0.0.1",
@@ -1794,7 +1794,7 @@ dependencies = [
  "hyper_serde 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "immeta 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -1805,7 +1805,7 @@ dependencies = [
  "servo_url 0.0.1",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -2056,10 +2056,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "plane-split"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "binary-space-partition 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "binary-space-partition 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2101,7 +2101,7 @@ name = "profile"
 version = "0.0.1"
 dependencies = [
  "heartbeats-simple 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "profile_traits 0.0.1",
@@ -2118,7 +2118,7 @@ dependencies = [
 name = "profile_tests"
 version = "0.0.1"
 dependencies = [
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "profile 0.0.1",
  "profile_traits 0.0.1",
 ]
@@ -2129,7 +2129,7 @@ version = "0.0.1"
 dependencies = [
  "energy-monitor 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "energymon 0.3.0 (git+https://github.com/energymon/energymon-rust.git)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2311,7 +2311,7 @@ dependencies = [
  "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "js 0.1.4 (git+https://github.com/servo/rust-mozjs)",
  "jstraceable_derive 0.0.1",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2352,7 +2352,7 @@ dependencies = [
  "unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
  "webvr 0.0.1",
  "webvr_traits 0.0.1",
  "xml5ever 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2371,7 +2371,7 @@ dependencies = [
  "heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -2382,7 +2382,7 @@ dependencies = [
  "selectors 0.18.0",
  "servo_url 0.0.1",
  "style 0.0.1",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -2414,7 +2414,7 @@ dependencies = [
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
@@ -2427,7 +2427,7 @@ dependencies = [
  "style_traits 0.0.1",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
 ]
 
@@ -3203,7 +3203,7 @@ dependencies = [
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
@@ -3219,8 +3219,8 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.36.0"
-source = "git+https://github.com/servo/webrender#005eb39d79afca7ea0dc140d5cf7b809be06589b"
+version = "0.38.0"
+source = "git+https://github.com/servo/webrender#de9ffef857421b811b267959bfc9dd4af4f3b3ec"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.0-alpha6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3233,23 +3233,23 @@ dependencies = [
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gamma-lut 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gamma-lut 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "plane-split 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plane-split 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.36.0"
-source = "git+https://github.com/servo/webrender#005eb39d79afca7ea0dc140d5cf7b809be06589b"
+version = "0.38.0"
+source = "git+https://github.com/servo/webrender#de9ffef857421b811b267959bfc9dd4af4f3b3ec"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.0-alpha6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3260,7 +3260,7 @@ dependencies = [
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3271,12 +3271,12 @@ dependencies = [
 name = "webvr"
 version = "0.0.1"
 dependencies = [
- "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "script_traits 0.0.1",
  "servo_config 0.0.1",
- "webrender_traits 0.36.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
 ]
 
@@ -3381,7 +3381,7 @@ dependencies = [
 "checksum backtrace 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f551bc2ddd53aea015d453ef0b635af89444afa5ed2405dd0b2062ad5d600d80"
 "checksum backtrace-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d192fd129132fbc97497c1f2ec2c2c5174e376b95f535199ef4fe0a293d33842"
 "checksum base64 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "979d348dc50dfcd050a87df408ec61f01a0a27ee9b4ebdc6085baba8275b2c7f"
-"checksum binary-space-partition 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "df65281d9b2b5c332f5bfbd9bb5e5f2e62f627c259cf9dc9cd10fecb758be33d"
+"checksum binary-space-partition 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88ceb0d16c4fd0e42876e298d7d3ce3780dd9ebdcbe4199816a32c77e08597ff"
 "checksum bincode 1.0.0-alpha6 (registry+https://github.com/rust-lang/crates.io-index)" = "fb0cdeac1c5d567fdb487ae5853c024e4acf1ea85ba6a6552fe084e0805fea5d"
 "checksum bindgen 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)" = "21a1de90068c1e58dd31b71daab70e1a1e54212b43cc6c4714e7c8acefb28992"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
@@ -3449,7 +3449,7 @@ dependencies = [
 "checksum freetype 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fde23272c687e4570aefec06cb71174ec0f5284b725deac4e77ba2665d635faf"
 "checksum futf 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "51f93f3de6ba1794dcd5810b3546d004600a59a98266487c8407bc4b24e398f3"
 "checksum futures 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "55f0008e13fc853f79ea8fc86e931486860d4c4c156cdffb59fa5f7fa833660a"
-"checksum gamma-lut 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8728df930776135895cbb25cbdd17791cde7d4285d53cf58fe6ee2e6412455"
+"checksum gamma-lut 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41f72af1e933f296b827361eb9e70d0267abf8ad0de9ec7fa667bbe67177b297"
 "checksum gaol 0.0.1 (git+https://github.com/servo/gaol)" = "<none>"
 "checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
@@ -3475,7 +3475,7 @@ dependencies = [
 "checksum inflate 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e7e0062d2dc2f17d2f13750d95316ae8a2ff909af0fda957084f5defd87c43bb"
 "checksum io-surface 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c35a3278fa52fb070fdc874dfd057163e6c21e0a9295f87f54daee9dd5530b43"
 "checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
-"checksum ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f1e8d7f511a1e2dae4e26efac30a85d2376b67d7c6f2c691ea95ebd850b017da"
+"checksum ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b7639999a1fb3f63da25d4bc1f6fe9acbdcd127ae8c81caba66e4faf7bb884f"
 "checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum jpeg-decoder 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "919d49b634cde303392353c5dd51153ec005a1a981c6f4b8277692a51e9d260d"
@@ -3537,7 +3537,7 @@ dependencies = [
 "checksum phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6b07ffcc532ccc85e3afc45865469bf5d9e4ef5bfcf9622e3cfe80c2d275ec03"
 "checksum phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "07e24b0ca9643bdecd0632f2b3da6b1b89bbb0030e0b992afc1113b23a7bc2f2"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
-"checksum plane-split 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a05e1e40e37630095627acfd2c7c6cf259e8b4f4ef4f01b2adf2a35331e45975"
+"checksum plane-split 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b3624c9e5e728dcc6347bde5762406b0f0707bea527d585e8f7b6ac44fdd33a"
 "checksum png 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3cb773e9a557edb568ce9935cf783e3cdcabe06a9449d41b3e5506d88e582c82"
 "checksum precomputed-hash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf1fc3616b3ef726a847f2cd2388c646ef6a1f1ba4835c2629004da48184150"
 "checksum procedural-masquerade 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f566249236c6ca4340f7ca78968271f0ed2b0f234007a61b66f9ecd0af09260"
@@ -3622,8 +3622,8 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"
 "checksum webdriver 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d548aabf87411b1b4ba91fd07eacd8b238135c7131a452b8a9f6386209167e18"
-"checksum webrender 0.36.0 (git+https://github.com/servo/webrender)" = "<none>"
-"checksum webrender_traits 0.36.0 (git+https://github.com/servo/webrender)" = "<none>"
+"checksum webrender 0.38.0 (git+https://github.com/servo/webrender)" = "<none>"
+"checksum webrender_traits 0.38.0 (git+https://github.com/servo/webrender)" = "<none>"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04614a58714f3fd4a8b1da4bcae9f031c532d35988c3d39627619248113f8be8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,13 +301,13 @@ dependencies = [
  "canvas_traits 0.0.1",
  "cssparser 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_config 0.0.1",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -321,7 +321,7 @@ dependencies = [
  "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -351,7 +351,7 @@ name = "cgl"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -428,7 +428,7 @@ version = "0.0.1"
 dependencies = [
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
- "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -441,8 +441,8 @@ dependencies = [
  "servo_url 0.0.1",
  "style_traits 0.0.1",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender 0.38.0 (git+https://github.com/servo/webrender)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender 0.39.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -477,7 +477,7 @@ dependencies = [
  "servo_remutex 0.0.1",
  "servo_url 0.0.1",
  "style_traits 0.0.1",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
 ]
 
@@ -711,7 +711,7 @@ dependencies = [
  "compositing 0.0.1",
  "devtools 0.0.1",
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin_app 0.0.1",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "libservo 0.0.1",
@@ -724,7 +724,7 @@ dependencies = [
  "servo_geometry 0.0.1",
  "servo_url 0.0.1",
  "style_traits 0.0.1",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
  "x11 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1016,7 +1016,7 @@ dependencies = [
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "truetype 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
  "xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "gleam"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1081,7 +1081,7 @@ dependencies = [
  "compositing 0.0.1",
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
@@ -1095,7 +1095,7 @@ dependencies = [
  "servo_url 0.0.1",
  "style_traits 0.0.1",
  "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1264,7 +1264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cgl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "leaky-cow 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1396,7 +1396,7 @@ dependencies = [
  "style_traits 0.0.1",
  "unicode-bidi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -1436,7 +1436,7 @@ dependencies = [
  "servo_geometry 0.0.1",
  "servo_url 0.0.1",
  "style 0.0.1",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -1450,7 +1450,7 @@ dependencies = [
  "profile_traits 0.0.1",
  "script_traits 0.0.1",
  "servo_url 0.0.1",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -1519,7 +1519,7 @@ dependencies = [
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gaol 0.0.1 (git+https://github.com/servo/gaol)",
  "gfx 0.0.1",
- "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "layout_thread 0.0.1",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1537,8 +1537,8 @@ dependencies = [
  "style 0.0.1",
  "style_traits 0.0.1",
  "webdriver_server 0.0.1",
- "webrender 0.38.0 (git+https://github.com/servo/webrender)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender 0.39.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
  "webvr 0.0.1",
  "webvr_traits 0.0.1",
 ]
@@ -1702,7 +1702,7 @@ dependencies = [
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -1746,7 +1746,7 @@ dependencies = [
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -1805,7 +1805,7 @@ dependencies = [
  "servo_url 0.0.1",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -1894,7 +1894,7 @@ dependencies = [
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2352,7 +2352,7 @@ dependencies = [
  "unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
  "webvr 0.0.1",
  "webvr_traits 0.0.1",
  "xml5ever 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2382,7 +2382,7 @@ dependencies = [
  "selectors 0.18.0",
  "servo_url 0.0.1",
  "style 0.0.1",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
@@ -2427,7 +2427,7 @@ dependencies = [
  "style_traits 0.0.1",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
 ]
 
@@ -2577,7 +2577,7 @@ dependencies = [
  "cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "expat-sys 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glx 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "io-surface 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3219,8 +3219,8 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.38.0"
-source = "git+https://github.com/servo/webrender#de9ffef857421b811b267959bfc9dd4af4f3b3ec"
+version = "0.39.0"
+source = "git+https://github.com/servo/webrender#d335555e69ff2d9743cde43a5eac4cc3872d17aa"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.0-alpha6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3234,7 +3234,7 @@ dependencies = [
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gamma-lut 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3243,13 +3243,13 @@ dependencies = [
  "rayon 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_profiler 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]
 name = "webrender_traits"
-version = "0.38.0"
-source = "git+https://github.com/servo/webrender#de9ffef857421b811b267959bfc9dd4af4f3b3ec"
+version = "0.39.0"
+source = "git+https://github.com/servo/webrender#d335555e69ff2d9743cde43a5eac4cc3872d17aa"
 dependencies = [
  "app_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.0-alpha6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3258,7 +3258,7 @@ dependencies = [
  "core-graphics 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwrote 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "offscreen_gl_context 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3276,7 +3276,7 @@ dependencies = [
  "msg 0.0.1",
  "script_traits 0.0.1",
  "servo_config 0.0.1",
- "webrender_traits 0.38.0 (git+https://github.com/servo/webrender)",
+ "webrender_traits 0.39.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
 ]
 
@@ -3456,7 +3456,7 @@ dependencies = [
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
 "checksum gif 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8a80d6fe9e52f637df9afd4779449a7be17c39cc9c35b01589bb833f956ba596"
 "checksum gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1d8edc81c5ae84605a62f5dac661a2313003b26d59839f81d47d46cf0f16a55"
-"checksum gleam 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "63ac332ee5656cd5e01facdeeef205952a403bafcb4268f79269b36627b490ee"
+"checksum gleam 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86944a6a4d7f54507f8ee930192d971f18a7b1da526ff529b7a0d4043935380"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glx 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b280007fa9c7442cfd1e0b1addb8d1a59240267110e8705f8f7e2c7bfb7e2f72"
 "checksum harfbuzz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6b76113246f5c089dcf272cf89c3f61168a4d77b50ec5b2c1fab8c628c9ea762"
@@ -3622,8 +3622,8 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"
 "checksum webdriver 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d548aabf87411b1b4ba91fd07eacd8b238135c7131a452b8a9f6386209167e18"
-"checksum webrender 0.38.0 (git+https://github.com/servo/webrender)" = "<none>"
-"checksum webrender_traits 0.38.0 (git+https://github.com/servo/webrender)" = "<none>"
+"checksum webrender 0.39.0 (git+https://github.com/servo/webrender)" = "<none>"
+"checksum webrender_traits 0.39.0 (git+https://github.com/servo/webrender)" = "<none>"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04614a58714f3fd4a8b1da4bcae9f031c532d35988c3d39627619248113f8be8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ opt-level = 3
 # crate, add that here. Use the form:
 #
 #     "<crate>:<version>" = { path = "/path/to/local/checkout" }
+#"https://github.com/servo/webrender#0.37.0" = { path = "/home/martin/work/mozilla/webrender-alt/webrender" }
+#"https://github.com/servo/webrender#webrender_traits:0.37.0" = { path = "/home/martin/work/mozilla/webrender-alt/webrender_traits" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,3 @@ opt-level = 3
 # crate, add that here. Use the form:
 #
 #     "<crate>:<version>" = { path = "/path/to/local/checkout" }
-#"https://github.com/servo/webrender#0.37.0" = { path = "/home/martin/work/mozilla/webrender-alt/webrender" }
-#"https://github.com/servo/webrender#webrender_traits:0.37.0" = { path = "/home/martin/work/mozilla/webrender-alt/webrender_traits" }
-

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -39,7 +39,7 @@ use style_traits::viewport::ViewportConstraints;
 use time::{precise_time_ns, precise_time_s};
 use touch::{TouchHandler, TouchAction};
 use webrender;
-use webrender_traits::{self, ClipId, LayoutPoint, ScrollEventPhase, ScrollLocation};
+use webrender_traits::{self, ClipId, LayoutPoint, ScrollEventPhase, ScrollLocation, ScrollClamping};
 use windowing::{self, MouseWindowEvent, WindowEvent, WindowMethods, WindowNavigateMsg};
 
 #[derive(Debug, PartialEq)]
@@ -777,7 +777,8 @@ impl<Window: WindowMethods> IOCompositor<Window> {
     }
 
     fn scroll_fragment_to_point(&mut self, id: ClipId, point: Point2D<f32>) {
-        self.webrender_api.scroll_node_with_id(LayoutPoint::from_untyped(&point), id);
+        self.webrender_api.scroll_node_with_id(LayoutPoint::from_untyped(&point), id,
+                                               ScrollClamping::ToContentBounds);
     }
 
     fn handle_window_message(&mut self, event: WindowEvent) {

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -48,6 +48,16 @@ pub struct DisplayList {
 }
 
 impl DisplayList {
+    /// Return the bounds of this display list based on the dimensions of the root
+    /// stacking context.
+    pub fn bounds(&self) -> Rect<Au> {
+        match self.list.get(0) {
+            Some(&DisplayItem::PushStackingContext(ref item)) => item.stacking_context.bounds,
+            Some(_) => unreachable!("Root element of display list not stacking context."),
+            None => Rect::zero(),
+        }
+    }
+
     // Returns the text index within a node for the point of interest.
     pub fn text_index(&self,
                       node: OpaqueNode,

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -30,11 +30,11 @@ use std::cmp::{self, Ordering};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
-use style::computed_values::{border_style, filter, image_rendering, mix_blend_mode};
+use style::computed_values::{border_style, filter, image_rendering};
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::ByteIndex;
-use webrender_traits::{self, ClipId, ColorF, GradientStop, ScrollPolicy, WebGLContextId};
+use webrender_traits::{self, ClipId, ColorF, GradientStop, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
 
 pub use style::dom::OpaqueNode;
 
@@ -375,10 +375,13 @@ pub struct StackingContext {
     pub filters: filter::T,
 
     /// The blend mode with which this stacking context blends with its backdrop.
-    pub blend_mode: mix_blend_mode::T,
+    pub mix_blend_mode: MixBlendMode,
 
     /// A transform to be applied to this stacking context.
     pub transform: Option<Matrix4D<f32>>,
+
+    /// The transform style of this stacking context.
+    pub transform_style: TransformStyle,
 
     /// The perspective matrix to be applied to children.
     pub perspective: Option<Matrix4D<f32>>,
@@ -399,8 +402,9 @@ impl StackingContext {
                overflow: &Rect<Au>,
                z_index: i32,
                filters: filter::T,
-               blend_mode: mix_blend_mode::T,
+               mix_blend_mode: MixBlendMode,
                transform: Option<Matrix4D<f32>>,
+               transform_style: TransformStyle,
                perspective: Option<Matrix4D<f32>>,
                scroll_policy: ScrollPolicy,
                parent_scroll_id: ClipId)
@@ -412,8 +416,9 @@ impl StackingContext {
             overflow: *overflow,
             z_index: z_index,
             filters: filters,
-            blend_mode: blend_mode,
+            mix_blend_mode: mix_blend_mode,
             transform: transform,
+            transform_style: transform_style,
             perspective: perspective,
             scroll_policy: scroll_policy,
             parent_scroll_id: parent_scroll_id,
@@ -428,8 +433,9 @@ impl StackingContext {
                              &Rect::zero(),
                              0,
                              filter::T::new(Vec::new()),
-                             mix_blend_mode::T::normal,
+                             MixBlendMode::Normal,
                              None,
+                             TransformStyle::Flat,
                              None,
                              ScrollPolicy::Scrollable,
                              pipeline_id.root_scroll_node())

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -66,7 +66,8 @@ use style::values::specified::{HorizontalDirection, VerticalDirection};
 use style_traits::CSSPixel;
 use style_traits::cursor::Cursor;
 use table_cell::CollapsedBordersForCell;
-use webrender_traits::{ColorF, ClipId, GradientStop, RepeatMode, ScrollPolicy};
+use webrender_helpers::{ToMixBlendMode, ToTransformStyle};
+use webrender_traits::{ColorF, ClipId, GradientStop, RepeatMode, ScrollPolicy, TransformStyle};
 
 trait ResolvePercentage {
     fn resolve(&self, length: u32) -> u32;
@@ -182,6 +183,9 @@ pub struct DisplayListBuildState<'a> {
     /// A stack of clips used to cull display list entries that are outside the
     /// rendered region, but only collected at containing block boundaries.
     pub containing_block_clip_stack: Vec<Rect<Au>>,
+
+    /// The current transform style of the stacking context.
+    current_transform_style: TransformStyle,
 }
 
 impl<'a> DisplayListBuildState<'a> {
@@ -199,6 +203,7 @@ impl<'a> DisplayListBuildState<'a> {
             iframe_sizes: Vec::new(),
             clip_stack: Vec::new(),
             containing_block_clip_stack: Vec::new(),
+            current_transform_style: TransformStyle::Flat,
         }
     }
 
@@ -210,6 +215,7 @@ impl<'a> DisplayListBuildState<'a> {
     fn add_stacking_context(&mut self,
                             parent_id: StackingContextId,
                             stacking_context: StackingContext) {
+        self.current_transform_style = stacking_context.transform_style;
         let info = self.stacking_context_info
                        .entry(parent_id)
                        .or_insert(StackingContextInfo::new());
@@ -1933,8 +1939,9 @@ impl FragmentDisplayListBuilding for Fragment {
                              &overflow,
                              self.effective_z_index(),
                              filters,
-                             self.style().get_effects().mix_blend_mode,
+                             self.style().get_effects().mix_blend_mode.to_mix_blend_mode(),
                              self.transform_matrix(&border_box),
+                             self.style().get_used_transform_style().to_transform_style(),
                              self.perspective_matrix(&border_box),
                              scroll_policy,
                              parent_scroll_id)
@@ -2139,6 +2146,7 @@ pub struct PreservedDisplayListState {
     containing_block_scroll_root_id: ClipId,
     clips_pushed: usize,
     containing_block_clips_pushed: usize,
+    transform_style: TransformStyle,
 }
 
 impl PreservedDisplayListState {
@@ -2149,6 +2157,7 @@ impl PreservedDisplayListState {
             containing_block_scroll_root_id: state.containing_block_scroll_root_id,
             clips_pushed: 0,
             containing_block_clips_pushed: 0,
+            transform_style: state.current_transform_style,
         }
     }
 
@@ -2169,6 +2178,8 @@ impl PreservedDisplayListState {
         let truncate_length = state.containing_block_clip_stack.len() -
                               self.containing_block_clips_pushed;
         state.containing_block_clip_stack.truncate(truncate_length);
+
+        state.current_transform_style = self.transform_style;
     }
 
     fn push_clip(&mut self,
@@ -2600,14 +2611,14 @@ impl InlineFlowDisplayListBuilding for InlineFlow {
                     fragment.stacking_context_id = fragment.stacking_context_id();
 
                     let current_stacking_context_id = state.current_stacking_context_id;
-                    let current_scroll_root_id = state.current_scroll_root_id;
+                    let stacking_context = fragment.create_stacking_context(fragment.stacking_context_id,
+                                                                            &self.base,
+                                                                            ScrollPolicy::Scrollable,
+                                                                            StackingContextCreationMode::Normal,
+                                                                            state.current_scroll_root_id);
+
                     state.add_stacking_context(current_stacking_context_id,
-                                               fragment.create_stacking_context(
-                                                   fragment.stacking_context_id,
-                                                   &self.base,
-                                                   ScrollPolicy::Scrollable,
-                                                   StackingContextCreationMode::Normal,
-                                                   current_scroll_root_id));
+                                               stacking_context);
                 }
                 _ => fragment.stacking_context_id = state.current_stacking_context_id,
             }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2466,7 +2466,10 @@ impl Fragment {
         if self.style().get_effects().mix_blend_mode != mix_blend_mode::T::normal {
             return true
         }
-        if self.style().get_box().transform.0.is_some() {
+
+        if self.style().get_box().transform.0.is_some() ||
+           self.style().get_box().transform_style == transform_style::T::preserve_3d ||
+           self.style().overrides_transform_style() {
             return true
         }
 
@@ -2479,13 +2482,6 @@ impl Fragment {
         // Fixed position blocks always create stacking contexts.
         if self.style.get_box().position == position::T::fixed {
             return true
-        }
-
-        match self.style().get_used_transform_style() {
-            transform_style::T::flat | transform_style::T::preserve_3d => {
-                return true
-            }
-            transform_style::T::auto => {}
         }
 
         match (self.style().get_box().position,

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -12,7 +12,7 @@ use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
 use gfx::display_list::{BorderDetails, BorderRadii, BoxShadowClipMode, ClippingRegion};
 use gfx::display_list::{DisplayItem, DisplayList, DisplayListTraversal, StackingContextType};
 use msg::constellation_msg::PipelineId;
-use style::computed_values::{image_rendering, mix_blend_mode};
+use style::computed_values::{image_rendering, mix_blend_mode, transform_style};
 use style::computed_values::filter::{self, Filter};
 use style::values::computed::BorderStyle;
 use webrender_traits::{self, DisplayListBuilder, ExtendMode};
@@ -146,12 +146,12 @@ impl ToBorderRadius for BorderRadii<Au> {
     }
 }
 
-trait ToBlendMode {
-    fn to_blend_mode(&self) -> webrender_traits::MixBlendMode;
+pub trait ToMixBlendMode {
+    fn to_mix_blend_mode(&self) -> webrender_traits::MixBlendMode;
 }
 
-impl ToBlendMode for mix_blend_mode::T {
-    fn to_blend_mode(&self) -> webrender_traits::MixBlendMode {
+impl ToMixBlendMode for mix_blend_mode::T {
+    fn to_mix_blend_mode(&self) -> webrender_traits::MixBlendMode {
         match *self {
             mix_blend_mode::T::normal => webrender_traits::MixBlendMode::Normal,
             mix_blend_mode::T::multiply => webrender_traits::MixBlendMode::Multiply,
@@ -208,6 +208,19 @@ impl ToFilterOps for filter::T {
             }
         }
         result
+    }
+}
+
+pub trait ToTransformStyle {
+    fn to_transform_style(&self) -> webrender_traits::TransformStyle;
+}
+
+impl ToTransformStyle for transform_style::T {
+    fn to_transform_style(&self) -> webrender_traits::TransformStyle {
+        match *self {
+            transform_style::T::auto | transform_style::T::flat => webrender_traits::TransformStyle::Flat,
+            transform_style::T::preserve_3d => webrender_traits::TransformStyle::Preserve3D,
+        }
     }
 }
 
@@ -465,9 +478,9 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                 builder.push_stacking_context(stacking_context.scroll_policy,
                                               stacking_context.bounds.to_rectf(),
                                               transform,
-                                              webrender_traits::TransformStyle::Flat,
+                                              stacking_context.transform_style,
                                               perspective,
-                                              stacking_context.blend_mode.to_blend_mode(),
+                                              stacking_context.mix_blend_mode,
                                               stacking_context.filters.to_filter_ops());
             }
             DisplayItem::PopStackingContext(_) => builder.pop_stacking_context(),

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -214,8 +214,10 @@ impl ToFilterOps for filter::T {
 impl WebRenderDisplayListConverter for DisplayList {
     fn convert_to_webrender(&self, pipeline_id: PipelineId) -> DisplayListBuilder {
         let traversal = DisplayListTraversal::new(self);
+
         let webrender_pipeline_id = pipeline_id.to_webrender();
-        let mut builder = DisplayListBuilder::new(webrender_pipeline_id);
+        let mut builder = DisplayListBuilder::new(webrender_pipeline_id,
+                                                  self.bounds().size.to_sizef());
 
         let mut current_scroll_root_id = ClipId::root_scroll_node(webrender_pipeline_id);
         builder.push_clip_id(current_scroll_root_id);

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1946,33 +1946,30 @@ impl ComputedValues {
         ))
     }
 
-    /// https://drafts.csswg.org/css-transforms/#grouping-property-values
-    pub fn get_used_transform_style(&self) -> computed_values::transform_style::T {
+    /// Return true if the effects force the transform style to be Flat
+    pub fn overrides_transform_style(&self) -> bool {
         use computed_values::mix_blend_mode;
-        use computed_values::transform_style;
 
         let effects = self.get_effects();
+        // TODO(gw): Add clip-path, isolation, mask-image, mask-border-source when supported.
+        effects.opacity < 1.0 ||
+           !effects.filter.is_empty() ||
+           !effects.clip.is_auto() ||
+           effects.mix_blend_mode != mix_blend_mode::T::normal
+    }
+
+    /// https://drafts.csswg.org/css-transforms/#grouping-property-values
+    pub fn get_used_transform_style(&self) -> computed_values::transform_style::T {
+        use computed_values::transform_style;
+
         let box_ = self.get_box();
 
-        // TODO(gw): Add clip-path, isolation, mask-image, mask-border-source when supported.
-        if effects.opacity < 1.0 ||
-           !effects.filter.is_empty() ||
-           !effects.clip.is_auto() {
-           effects.mix_blend_mode != mix_blend_mode::T::normal ||
-            return transform_style::T::flat;
+        if self.overrides_transform_style() {
+            transform_style::T::flat
+        } else {
+            // Return the computed value if not overridden by the above exceptions
+            box_.transform_style
         }
-
-        if box_.transform_style == transform_style::T::auto {
-            if box_.transform.0.is_some() {
-                return transform_style::T::flat;
-            }
-            if let Either::First(ref _length) = box_.perspective {
-                return transform_style::T::flat;
-            }
-        }
-
-        // Return the computed value if not overridden by the above exceptions
-        box_.transform_style
     }
 
     /// Whether given this transform value, the compositor would require a

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-transform-style.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/css-transform-3d-transform-style.htm.ini
@@ -1,3 +1,0 @@
-[css-transform-3d-transform-style.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-sorting-004.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-sorting-004.htm.ini
@@ -1,4 +1,4 @@
-[transform3d-sorting-006.htm]
+[transform3d-sorting-004.htm]
   type: reftest
   expected: FAIL
   bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1362543

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-sorting-005.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform3d-sorting-005.htm.ini
@@ -1,3 +1,0 @@
-[transform3d-sorting-005.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is WR update to https://github.com/servo/webrender/commit/d335555e69ff2d9743cde43a5eac4cc3872d17aa having new features:
  - limited "preserve-3d" support (https://github.com/servo/webrender/pull/1169, https://github.com/servo/webrender/pull/1208)
  - rayon thread pool (https://github.com/servo/webrender/pull/1202)
  - further border rendering improvements

Edit: the references to bincode serialization and border styles are removed from here, since they are already integrated into Servo.
Edit2: this is alternative/similar to  #16801, based on @mrobinson code (see first commit).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

Related to #9087
Note that I'm unlocking a few tests as well as changing some related to `preserve-3d`. The changes come from common sense and comparison to Chromium. I'm ready to discuss them on a individual basis.

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

There is still an investigation to do with regards to the differences of preserve3d logic between Blink and Gecko.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16775)
<!-- Reviewable:end -->
