### PR TITLE
Fix the serialization of image-orientation property

### DIFF
--- a/components/style/properties/longhand/inherited_box.mako.rs
+++ b/components/style/properties/longhand/inherited_box.mako.rs
@@ -87,13 +87,13 @@ ${helpers.single_keyword("image-rendering",
             if let Some(angle) = self.angle {
                 try!(angle.to_css(dest));
                 if self.flipped {
-                    dest.write_str(" flipped")
+                    dest.write_str(" flip")
                 } else {
                     Ok(())
                 }
             } else {
                 if self.flipped {
-                    dest.write_str("flipped")
+                    dest.write_str("flip")
                 } else {
                     dest.write_str("from-image")
                 }


### PR DESCRIPTION
Gecko bug: [Bug 1363295](https://bugzilla.mozilla.org/show_bug.cgi?id=1363295)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16782)
<!-- Reviewable:end -->
