### PR TITLE
Fix typo and simplify for PresentationalHintsSynthesizer

### DIFF
--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -65,7 +65,7 @@ use style::computed_values::display;
 use style::context::{QuirksMode, SharedStyleContext};
 use style::data::ElementData;
 use style::dom::{DescendantsBit, DirtyDescendants, LayoutIterator, NodeInfo, OpaqueNode};
-use style::dom::{PresentationalHintsSynthetizer, TElement, TNode, UnsafeNode};
+use style::dom::{PresentationalHintsSynthesizer, TElement, TNode, UnsafeNode};
 use style::element_state::*;
 use style::font_metrics::ServoMetricsProvider;
 use style::properties::{ComputedValues, PropertyDeclarationBlock};
@@ -362,7 +362,7 @@ impl<'le> fmt::Debug for ServoLayoutElement<'le> {
     }
 }
 
-impl<'le> PresentationalHintsSynthetizer for ServoLayoutElement<'le> {
+impl<'le> PresentationalHintsSynthesizer for ServoLayoutElement<'le> {
     fn synthesize_presentational_hints_for_legacy_attributes<V>(&self, hints: &mut V)
         where V: Push<ApplicableDeclarationBlock>
     {
@@ -1162,7 +1162,7 @@ impl<'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
     }
 }
 
-impl<'le> PresentationalHintsSynthetizer for ServoThreadSafeLayoutElement<'le> {
+impl<'le> PresentationalHintsSynthesizer for ServoThreadSafeLayoutElement<'le> {
     fn synthesize_presentational_hints_for_legacy_attributes<V>(&self, _hints: &mut V)
         where V: Push<ApplicableDeclarationBlock> {}
 }

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 use style::computed_values::display;
 use style::context::SharedStyleContext;
 use style::data::ElementData;
-use style::dom::{LayoutIterator, NodeInfo, PresentationalHintsSynthetizer, TNode};
+use style::dom::{LayoutIterator, NodeInfo, PresentationalHintsSynthesizer, TNode};
 use style::dom::OpaqueNode;
 use style::font_metrics::ServoMetricsProvider;
 use style::properties::{CascadeFlags, ServoComputedValues};
@@ -306,7 +306,7 @@ pub trait DangerousThreadSafeLayoutNode: ThreadSafeLayoutNode {
 pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
                                    ::selectors::Element<Impl=SelectorImpl> +
                                    GetLayoutData +
-                                   PresentationalHintsSynthetizer {
+                                   PresentationalHintsSynthesizer {
     type ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<ConcreteThreadSafeLayoutElement = Self>;
 
     fn as_node(&self) -> Self::ConcreteThreadSafeLayoutNode;

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -267,7 +267,7 @@ pub unsafe fn raw_note_descendants<E, B>(element: E) -> bool
 }
 
 /// A trait used to synthesize presentational hints for HTML element attributes.
-pub trait PresentationalHintsSynthetizer {
+pub trait PresentationalHintsSynthesizer {
     /// Generate the proper applicable declarations due to presentational hints,
     /// and insert them into `hints`.
     fn synthesize_presentational_hints_for_legacy_attributes<V>(&self, hints: &mut V)
@@ -290,7 +290,7 @@ impl AnimationRules {
 
 /// The element trait, the main abstraction the style crate acts over.
 pub trait TElement : Eq + PartialEq + Debug + Hash + Sized + Copy + Clone +
-                     ElementExt + PresentationalHintsSynthetizer {
+                     ElementExt + PresentationalHintsSynthesizer {
     /// The concrete node type.
     type ConcreteNode: TNode<ConcreteElement = Self>;
 

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -19,7 +19,7 @@ use atomic_refcell::AtomicRefCell;
 use context::{QuirksMode, SharedStyleContext, UpdateAnimationsTasks};
 use data::ElementData;
 use dom::{self, AnimationRules, DescendantsBit, LayoutIterator, NodeInfo, TElement, TNode, UnsafeNode};
-use dom::{OpaqueNode, PresentationalHintsSynthetizer};
+use dom::{OpaqueNode, PresentationalHintsSynthesizer};
 use element_state::ElementState;
 use error_reporting::RustLogReporter;
 use font_metrics::{FontMetrics, FontMetricsProvider, FontMetricsQueryResult};
@@ -907,7 +907,7 @@ impl<'le> Hash for GeckoElement<'le> {
     }
 }
 
-impl<'le> PresentationalHintsSynthetizer for GeckoElement<'le> {
+impl<'le> PresentationalHintsSynthesizer for GeckoElement<'le> {
     fn synthesize_presentational_hints_for_legacy_attributes<V>(&self, hints: &mut V)
         where V: Push<ApplicableDeclarationBlock>,
     {

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -10,7 +10,7 @@ use {Atom, LocalName};
 use bit_vec::BitVec;
 use context::QuirksMode;
 use data::ComputedStyle;
-use dom::{AnimationRules, PresentationalHintsSynthetizer, TElement};
+use dom::{AnimationRules, PresentationalHintsSynthesizer, TElement};
 use error_reporting::RustLogReporter;
 use font_metrics::FontMetricsProvider;
 use keyframes::KeyframesAnimation;
@@ -490,7 +490,7 @@ impl Stylist {
                                                   -> Option<ComputedStyle>
         where E: TElement +
                  fmt::Debug +
-                 PresentationalHintsSynthetizer
+                 PresentationalHintsSynthesizer
     {
         let rule_node = match self.lazy_pseudo_rules(guards, element, pseudo) {
             Some(rule_node) => rule_node,
@@ -525,7 +525,7 @@ impl Stylist {
                                 element: &E,
                                 pseudo: &PseudoElement)
                                 -> Option<StrongRuleNode>
-        where E: TElement + fmt::Debug + PresentationalHintsSynthetizer
+        where E: TElement + fmt::Debug + PresentationalHintsSynthesizer
     {
         debug_assert!(pseudo.is_lazy());
         if self.pseudos_map.get(pseudo).is_none() {
@@ -688,7 +688,7 @@ impl Stylist {
                                         -> StyleRelations
         where E: TElement +
                  fmt::Debug +
-                 PresentationalHintsSynthetizer,
+                 PresentationalHintsSynthesizer,
               V: Push<ApplicableDeclarationBlock> + VecLike<ApplicableDeclarationBlock>,
               F: FnMut(&E, ElementSelectorFlags),
     {

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -10,7 +10,7 @@ use {Atom, LocalName};
 use bit_vec::BitVec;
 use context::QuirksMode;
 use data::ComputedStyle;
-use dom::{AnimationRules, PresentationalHintsSynthesizer, TElement};
+use dom::{AnimationRules, TElement};
 use error_reporting::RustLogReporter;
 use font_metrics::FontMetricsProvider;
 use keyframes::KeyframesAnimation;
@@ -35,7 +35,6 @@ use sink::Push;
 use smallvec::VecLike;
 use std::borrow::Borrow;
 use std::collections::HashMap;
-use std::fmt;
 use std::hash::Hash;
 #[cfg(feature = "servo")]
 use std::marker::PhantomData;
@@ -488,9 +487,7 @@ impl Stylist {
                                                   parent: &Arc<ComputedValues>,
                                                   font_metrics: &FontMetricsProvider)
                                                   -> Option<ComputedStyle>
-        where E: TElement +
-                 fmt::Debug +
-                 PresentationalHintsSynthesizer
+        where E: TElement,
     {
         let rule_node = match self.lazy_pseudo_rules(guards, element, pseudo) {
             Some(rule_node) => rule_node,
@@ -525,7 +522,7 @@ impl Stylist {
                                 element: &E,
                                 pseudo: &PseudoElement)
                                 -> Option<StrongRuleNode>
-        where E: TElement + fmt::Debug + PresentationalHintsSynthesizer
+        where E: TElement
     {
         debug_assert!(pseudo.is_lazy());
         if self.pseudos_map.get(pseudo).is_none() {
@@ -686,9 +683,7 @@ impl Stylist {
                                         applicable_declarations: &mut V,
                                         flags_setter: &mut F)
                                         -> StyleRelations
-        where E: TElement +
-                 fmt::Debug +
-                 PresentationalHintsSynthesizer,
+        where E: TElement,
               V: Push<ApplicableDeclarationBlock> + VecLike<ApplicableDeclarationBlock>,
               F: FnMut(&E, ElementSelectorFlags),
     {


### PR DESCRIPTION
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it only affects build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16785)
<!-- Reviewable:end -->
