### PR TITLE
register stylo threads with the gecko profiler

### DIFF
--- a/components/style/gecko/global_style_data.rs
+++ b/components/style/gecko/global_style_data.rs
@@ -5,11 +5,13 @@
 //! Global style data
 
 use context::StyleSystemOptions;
+use gecko_bindings::bindings::{Gecko_RegisterProfilerThread, Gecko_UnregisterProfilerThread};
 use num_cpus;
 use rayon;
 use shared_lock::SharedRwLock;
 use std::cmp;
 use std::env;
+use std::ffi::CString;
 
 /// Global style data
 pub struct GlobalStyleData {
@@ -26,6 +28,25 @@ pub struct GlobalStyleData {
     pub options: StyleSystemOptions,
 }
 
+fn thread_name(index: usize) -> String {
+    format!("StyleThread#{}", index)
+}
+
+fn thread_startup(index: usize) {
+    let name = thread_name(index);
+    let name = CString::new(name).unwrap();
+    unsafe {
+        // Gecko_RegisterProfilerThread copies the passed name here.
+        Gecko_RegisterProfilerThread(name.as_ptr());
+    }
+}
+
+fn thread_shutdown(_: usize) {
+    unsafe {
+        Gecko_UnregisterProfilerThread();
+    }
+}
+
 lazy_static! {
     /// Global style data
     pub static ref GLOBAL_STYLE_DATA: GlobalStyleData = {
@@ -39,8 +60,11 @@ lazy_static! {
         let pool = if num_threads <= 1 {
             None
         } else {
-            let configuration =
-                rayon::Configuration::new().num_threads(num_threads);
+            let configuration = rayon::Configuration::new()
+                .num_threads(num_threads)
+                .thread_name(thread_name)
+                .start_handler(thread_startup)
+                .exit_handler(thread_shutdown);
             let pool = rayon::ThreadPool::new(configuration).ok();
             pool
         };


### PR DESCRIPTION
Now that we require rayon 0.7, we can register start and stop handlers
that take care of dealing with the Gecko profiler for rayon threads in
the style thread pool.

Manually verified that adding "StyleThread" to the list of threads tracked by the Gecko profiler addon caused lots of threads to show up in a profile, and all the stack unwinding goodness seems to work!

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16786)
<!-- Reviewable:end -->
