### PR TITLE
stylo: Export RefPtr<ImageValue> to stylo.

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -777,11 +777,6 @@ mod bindings {
             "RawGeckoServoStyleRuleList",
         ];
         for &ty in structs_types.iter() {
-            // XXX cku: will be removed in Part 2.
-            if ty.starts_with("mozilla::css::ImageValue") {
-                builder = builder
-                    .raw_line("#[allow(unused_imports)]");
-            }
             builder = builder.hide_type(ty)
                 .raw_line(format!("use gecko_bindings::structs::{};", ty));
             // TODO this is hacky, figure out a better way to do it without

--- a/components/style/gecko_bindings/sugar/refptr.rs
+++ b/components/style/gecko_bindings/sugar/refptr.rs
@@ -280,3 +280,7 @@ impl_threadsafe_refcount!(::gecko_bindings::structs::mozilla::css::URLValue,
 impl_threadsafe_refcount!(::gecko_bindings::structs::mozilla::css::GridTemplateAreasValue,
                           Gecko_AddRefGridTemplateAreasValueArbitraryThread,
                           Gecko_ReleaseGridTemplateAreasValueArbitraryThread);
+impl_threadsafe_refcount!(::gecko_bindings::structs::ImageValue,
+                          Gecko_AddRefImageValueArbitraryThread,
+                          Gecko_ReleaseImageValueArbitraryThread);
+


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is the second patch in bug 1310885
"Bug 1310885 - Part 2. (stylo) Export RefPtr<ImageValue> from gecko to stylo."

Bugzilla link:
https://bugzilla.mozilla.org/show_bug.cgi?id=1310885
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16789)
<!-- Reviewable:end -->
