### PR TITLE
Make no_viewport_percentage! use an absolute path for HasViewportPerc…

### DIFF
--- a/components/style/properties/longhand/color.mako.rs
+++ b/components/style/properties/longhand/color.mako.rs
@@ -14,7 +14,6 @@
     use cssparser::RGBA;
     use std::fmt;
     use style_traits::ToCss;
-    use values::HasViewportPercentage;
     use values::specified::{Color, CSSColor, CSSRGBA};
 
     impl ToComputedValue for SpecifiedValue {

--- a/components/style/values/mod.rs
+++ b/components/style/values/mod.rs
@@ -56,7 +56,7 @@ macro_rules! define_numbered_css_keyword_enum {
 /// for a given type that may never contain viewport units.
 macro_rules! no_viewport_percentage {
     ($name: ident) => {
-        impl HasViewportPercentage for $name {
+        impl $crate::values::HasViewportPercentage for $name {
             #[inline]
             fn has_viewport_percentage(&self) -> bool {
                 false

--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -12,7 +12,6 @@ use parser::{Parse, ParserContext};
 use std::ascii::AsciiExt;
 use std::fmt;
 use style_traits::ToCss;
-use values::HasViewportPercentage;
 
 bitflags! {
     /// Constants shared by multiple CSS Box Alignment properties

--- a/components/style/values/specified/basic_shape.rs
+++ b/components/style/values/specified/basic_shape.rs
@@ -14,7 +14,6 @@ use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::fmt;
 use style_traits::ToCss;
-use values::HasViewportPercentage;
 use values::computed::{ComputedValueAsSpecified, Context, ToComputedValue};
 use values::computed::basic_shape as computed_basic_shape;
 use values::generics::BorderRadiusSize;

--- a/components/style/values/specified/color.rs
+++ b/components/style/values/specified/color.rs
@@ -27,7 +27,6 @@ mod gecko {
     use properties::longhands::color::SystemColor;
     use std::fmt;
     use style_traits::ToCss;
-    use values::HasViewportPercentage;
 
     /// Color value including non-standard -moz prefixed values.
     #[derive(Clone, Copy, PartialEq, Debug)]

--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -671,7 +671,6 @@ impl SizeKeyword {
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct LayerImage(pub Option<Image>);
-use values::HasViewportPercentage;
 no_viewport_percentage!(LayerImage);
 
 impl ToCss for LayerImage {

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -52,7 +52,6 @@ pub mod position;
 pub mod url {
 use cssparser::Parser;
 use parser::{Parse, ParserContext};
-use values::HasViewportPercentage;
 use values::computed::ComputedValueAsSpecified;
 
 #[cfg(feature = "servo")]


### PR DESCRIPTION
…entage

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #16781 

<!-- Either: -->
- [X] These changes do not require tests because the compiler warnings should be enough

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16805)
<!-- Reviewable:end -->
