### PR TITLE
Fix unsafe casting between PersistentLayoutData and PartialPersistentLayoutData

### DIFF
--- a/components/layout/data.rs
+++ b/components/layout/data.rs
@@ -6,6 +6,7 @@ use construct::ConstructionResult;
 use script_layout_interface::PartialPersistentLayoutData;
 
 /// Data that layout associates with a node.
+#[repr(C)]
 pub struct PersistentLayoutData {
     /// Data accessed by script_layout_interface. This must be first to allow
     /// casting between PersistentLayoutData and PartialPersistentLayoutData.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

PersistentLayoutData and PartialPersistentLayoutData castings in Layout component assume that they have the same base raw address. This is unsafe because field order is not guaranteed by default, and it's causing some SEGV crashes on Android indeed (https://github.com/servo/servo/issues/16647)

Add a C representation to guarantee the order of the fields and the safe casting.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #16647 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16816)
<!-- Reviewable:end -->
