### PR TITLE
Add default value to layout.threads in prefs.rs (fix #15638)

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -3,10 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use basedir::default_config_dir;
+use num_cpus;
 use opts;
 use resource_files::resources_dir_path;
 use rustc_serialize::json::{Json, ToJson};
 use std::borrow::ToOwned;
+use std::cmp::max;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write, stderr};
@@ -15,8 +17,11 @@ use std::sync::{Arc, RwLock};
 
 lazy_static! {
     pub static ref PREFS: Preferences = {
-        let prefs = read_prefs().ok().unwrap_or_else(HashMap::new);
-        Preferences(Arc::new(RwLock::new(prefs)))
+        let defaults = default_prefs();
+        if let Ok(prefs) = read_prefs() {
+            defaults.extend(prefs);
+        }
+        defaults
     };
 }
 
@@ -142,6 +147,13 @@ impl ToJson for Pref {
     fn to_json(&self) -> Json {
         self.value().to_json()
     }
+}
+
+pub fn default_prefs() -> Preferences {
+    let prefs = Preferences(Arc::new(RwLock::new(HashMap::new())));
+    prefs.set("layout.threads", PrefValue::Number(
+        max(num_cpus::get() * 3 / 4, 1) as f64));
+    prefs
 }
 
 pub fn read_prefs_from_file<T>(mut file: T)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Add default value to layout.threads in prefs.rs

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15638  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16818)
<!-- Reviewable:end -->
