### PR TITLE
stylo: Propagate quirks mode information from Gecko to Servo

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -418,7 +418,7 @@ impl LayoutThread {
         let font_cache_receiver =
             ROUTER.route_ipc_receiver_to_new_mpsc_receiver(ipc_font_cache_receiver);
 
-        let stylist = Stylist::new(device);
+        let stylist = Stylist::new(device, QuirksMode::NoQuirks);
         let outstanding_web_fonts_counter = Arc::new(AtomicUsize::new(0));
         let ua_stylesheets = &*UA_STYLESHEETS;
         let guard = ua_stylesheets.shared_lock.read();

--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -689,6 +689,7 @@ mod bindings {
             "nsCursorImage",
             "nsFont",
             "nsIAtom",
+            "nsCompatibility",
             "nsMediaFeature",
             "nsRestyleHint",
             "nsStyleBackground",

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -53,6 +53,7 @@ use gecko_bindings::structs::nsChangeHint;
 use gecko_bindings::structs::nsCursorImage;
 use gecko_bindings::structs::nsFont;
 use gecko_bindings::structs::nsIAtom;
+use gecko_bindings::structs::nsCompatibility;
 use gecko_bindings::structs::nsMediaFeature;
 use gecko_bindings::structs::nsRestyleHint;
 use gecko_bindings::structs::nsStyleBackground;
@@ -1949,7 +1950,8 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_ParseStyleAttribute(data: *const nsACString,
-                                     extra_data: *mut RawGeckoURLExtraData)
+                                     extra_data: *mut RawGeckoURLExtraData,
+                                     quirks_mode: nsCompatibility)
      -> RawServoDeclarationBlockStrong;
 }
 extern "C" {

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -336,8 +336,9 @@ impl<'le> fmt::Debug for GeckoElement<'le> {
 impl<'le> GeckoElement<'le> {
     /// Parse the style attribute of an element.
     pub fn parse_style_attribute(value: &str,
-                                 url_data: &UrlExtraData) -> PropertyDeclarationBlock {
-        parse_style_attribute(value, url_data, &RustLogReporter, QuirksMode::NoQuirks)
+                                 url_data: &UrlExtraData,
+                                 quirks_mode: QuirksMode) -> PropertyDeclarationBlock {
+        parse_style_attribute(value, url_data, &RustLogReporter, quirks_mode)
     }
 
     fn flags(&self) -> u32 {

--- a/components/style/gecko_bindings/sugar/mod.rs
+++ b/components/style/gecko_bindings/sugar/mod.rs
@@ -5,6 +5,7 @@
 //! Rust sugar and convenience methods for Gecko types.
 
 mod ns_com_ptr;
+mod ns_compatibility;
 mod ns_css_shadow_array;
 pub mod ns_css_value;
 mod ns_style_auto_array;

--- a/components/style/gecko_bindings/sugar/ns_compatibility.rs
+++ b/components/style/gecko_bindings/sugar/ns_compatibility.rs
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Little helper for `nsCompatibility`.
+
+use context::QuirksMode;
+use gecko_bindings::structs::nsCompatibility;
+
+impl From<nsCompatibility> for QuirksMode {
+    fn from(mode: nsCompatibility) -> QuirksMode {
+        match mode {
+            nsCompatibility::eCompatibility_FullStandards => QuirksMode::NoQuirks,
+            nsCompatibility::eCompatibility_AlmostStandards => QuirksMode::LimitedQuirks,
+            nsCompatibility::eCompatibility_NavQuirks => QuirksMode::Quirks,
+        }
+    }
+}

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -189,16 +189,17 @@ impl<'a> ExtraStyleData<'a> {
 }
 
 impl Stylist {
-    /// Construct a new `Stylist`, using a given `Device`.  If more members are
-    /// added here, think about whether they should be reset in clear().
+    /// Construct a new `Stylist`, using given `Device` and `QuirksMode`.
+    /// If more members are added here, think about whether they should
+    /// be reset in clear().
     #[inline]
-    pub fn new(device: Device) -> Self {
+    pub fn new(device: Device, quirks_mode: QuirksMode) -> Self {
         let mut stylist = Stylist {
             viewport_constraints: None,
             device: Arc::new(device),
             is_device_dirty: true,
             is_cleared: true,
-            quirks_mode: QuirksMode::NoQuirks,
+            quirks_mode: quirks_mode,
 
             element_map: PerPseudoElementSelectorMap::new(),
             pseudos_map: Default::default(),
@@ -776,6 +777,11 @@ impl Stylist {
     /// a @viewport rule.
     pub fn viewport_constraints(&self) -> Option<&ViewportConstraints> {
         self.viewport_constraints.as_ref()
+    }
+
+    /// Returns the Quirks Mode of the document.
+    pub fn quirks_mode(&self) -> QuirksMode {
+        self.quirks_mode
     }
 
     /// Sets the quirks mode of the document.

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -65,6 +65,7 @@ use style::gecko_bindings::structs::RawGeckoPresContextOwned;
 use style::gecko_bindings::structs::ServoElementSnapshotTable;
 use style::gecko_bindings::structs::URLExtraData;
 use style::gecko_bindings::structs::nsCSSValueSharedList;
+use style::gecko_bindings::structs::nsCompatibility;
 use style::gecko_bindings::structs::nsresult;
 use style::gecko_bindings::sugar::ownership::{FFIArcHelpers, HasFFI, HasArcFFI, HasBoxFFI};
 use style::gecko_bindings::sugar::ownership::{HasSimpleFFI, Strong};
@@ -162,8 +163,7 @@ fn create_shared_context<'a>(global_style_data: &GlobalStyleData,
         guards: StylesheetGuards::same(guard),
         error_reporter: &DEFAULT_ERROR_REPORTER,
         timer: Timer::new(),
-        // FIXME Find the real QuirksMode information for this document
-        quirks_mode: QuirksMode::NoQuirks,
+        quirks_mode: per_doc_data.stylist.quirks_mode(),
         traversal_flags: traversal_flags,
         snapshot_map: snapshot_map,
     }
@@ -1192,13 +1192,14 @@ pub extern "C" fn Servo_ParseEasing(easing: *const nsAString,
 
 #[no_mangle]
 pub extern "C" fn Servo_ParseStyleAttribute(data: *const nsACString,
-                                            raw_extra_data: *mut URLExtraData)
+                                            raw_extra_data: *mut URLExtraData,
+                                            quirks_mode: nsCompatibility)
                                             -> RawServoDeclarationBlockStrong {
     let global_style_data = &*GLOBAL_STYLE_DATA;
     let value = unsafe { data.as_ref().unwrap().as_str_unchecked() };
     let url_data = unsafe { RefPtr::from_ptr_ref(&raw_extra_data) };
     Arc::new(global_style_data.shared_lock.wrap(
-        GeckoElement::parse_style_attribute(value, url_data))).into_strong()
+        GeckoElement::parse_style_attribute(value, url_data, quirks_mode.into()))).into_strong()
 }
 
 #[no_mangle]
@@ -2071,7 +2072,7 @@ pub extern "C" fn Servo_GetComputedKeyframeValues(keyframes: RawGeckoKeyframeLis
         font_metrics_provider: &metrics,
         cached_system_font: None,
         in_media_query: false,
-        quirks_mode: QuirksMode::NoQuirks,
+        quirks_mode: data.stylist.quirks_mode(),
     };
 
     for (index, keyframe) in keyframes.iter().enumerate() {


### PR DESCRIPTION
r=bholley in bugzilla

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1360488](https://bugzilla.mozilla.org/show_bug.cgi?id=1360488)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16819)
<!-- Reviewable:end -->
