### PR TITLE
Check ElementHasAnimations flag in rust side.

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -406,6 +406,12 @@ impl<'le> GeckoElement<'le> {
             },
         }
     }
+
+    fn may_have_animations(&self) -> bool {
+        use gecko_bindings::structs::nsINode_BooleanFlag;
+        self.as_node().bool_flags() &
+            (1u32 << nsINode_BooleanFlag::ElementHasAnimations as u32) != 0
+    }
 }
 
 /// Converts flags from the layout used by rust-selectors to the layout used
@@ -738,15 +744,15 @@ impl<'le> TElement for GeckoElement<'le> {
     }
 
     fn has_animations(&self) -> bool {
-        unsafe { Gecko_ElementHasAnimations(self.0) }
+        self.may_have_animations() && unsafe { Gecko_ElementHasAnimations(self.0) }
     }
 
     fn has_css_animations(&self) -> bool {
-        unsafe { Gecko_ElementHasCSSAnimations(self.0) }
+        self.may_have_animations() && unsafe { Gecko_ElementHasCSSAnimations(self.0) }
     }
 
     fn has_css_transitions(&self) -> bool {
-        unsafe { Gecko_ElementHasCSSTransitions(self.0) }
+        self.may_have_animations() && unsafe { Gecko_ElementHasCSSTransitions(self.0) }
     }
 
     fn get_css_transitions_info(&self)


### PR DESCRIPTION
We can bail out earlier before calling an FFI function.
This is a PR for https://bugzilla.mozilla.org/show_bug.cgi?id=1364264 .

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's for stylo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16826)
<!-- Reviewable:end -->
