### PR TITLE
Fix unsafe AtomicRefCell<T>  transmutes in Layout component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,7 +1403,9 @@ dependencies = [
 name = "layout_tests"
 version = "0.0.1"
 dependencies = [
+ "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "layout 0.0.1",
+ "script_layout_interface 0.0.1",
 ]
 
 [[package]]

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -93,6 +93,7 @@ pub mod wrapper;
 // For unit tests:
 pub use fragment::Fragment;
 pub use fragment::SpecificFragmentInfo;
+pub use self::data::PersistentLayoutData;
 
 /// Returns whether the two arguments point to the same value.
 ///

--- a/components/script_layout_interface/lib.rs
+++ b/components/script_layout_interface/lib.rs
@@ -50,6 +50,7 @@ use servo_url::ServoUrl;
 use std::sync::atomic::AtomicIsize;
 use style::data::ElementData;
 
+#[repr(C)]
 pub struct PartialPersistentLayoutData {
     /// Data that the style system associates with a node. When the
     /// style system is being used standalone, this is all that hangs
@@ -59,6 +60,9 @@ pub struct PartialPersistentLayoutData {
 
     /// Information needed during parallel traversals.
     pub parallel: DomParallelInfo,
+
+    // Required alignment for safe transmutes between PersistentLayoutData and PartialPersistentLayoutData.
+    _align: [u64; 0]
 }
 
 impl PartialPersistentLayoutData {
@@ -66,6 +70,7 @@ impl PartialPersistentLayoutData {
         PartialPersistentLayoutData {
             style_data: ElementData::new(None),
             parallel: DomParallelInfo::new(),
+            _align: [],
         }
     }
 }

--- a/tests/unit/layout/Cargo.toml
+++ b/tests/unit/layout/Cargo.toml
@@ -10,4 +10,6 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
+atomic_refcell = "0.1"
 layout = {path = "../../../components/layout"}
+script_layout_interface = {path = "../../../components/script_layout_interface"}

--- a/tests/unit/layout/align_of.rs
+++ b/tests/unit/layout/align_of.rs
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use atomic_refcell::AtomicRefCell;
+use layout::PersistentLayoutData;
+use script_layout_interface::PartialPersistentLayoutData;
+use std::mem::align_of;
+
+fn check_layout_alignment(expected: usize, current: usize) {
+    if current != expected {
+        panic!("Your changes have altered the mem alignment of the PartialPersistentLayoutData \
+                struct to {}, but it must match the {}-alignment of PersistentLayoutData struct. \
+                Please fix alignment in components/script_layout_interface/lib.rs",
+                current, expected);
+    }
+}
+
+#[test]
+fn test_persistent_layout_data_alignment() {
+    check_layout_alignment(align_of::<PersistentLayoutData>(),
+                           align_of::<PartialPersistentLayoutData>());
+
+    check_layout_alignment(align_of::<AtomicRefCell<PersistentLayoutData>>(),
+                           align_of::<AtomicRefCell<PartialPersistentLayoutData>>());
+}

--- a/tests/unit/layout/lib.rs
+++ b/tests/unit/layout/lib.rs
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+extern crate atomic_refcell;
 extern crate layout;
+extern crate script_layout_interface;
 
+#[cfg(test)] mod align_of;
 #[cfg(all(test, target_pointer_width = "64"))] mod size_of;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fixes unsafe transmute between `AtomicRefCell<PersistentLayoutData>` and `AtomicRefCell<PartialPersistentLayoutData>` which have different memory alignment in 32 bit archs leading to SEGV crashes. See https://github.com/servo/servo/issues/16817 and https://github.com/servo/servo/pull/16816

mem::align_of values in 32 bit archs (e.g. Android):
```
PersistentLayoutData 8
PersistentLayoutData 4
AtomicRefCell<PersistentLayoutData> 8
AtomicRefCell<PartialPersistentLayoutData> 4
```
mem::align_of values in 64 bit archs
```
PersistentLayoutData 8
PersistentLayoutData 8
AtomicRefCell<PersistentLayoutData> 8
AtomicRefCell<PartialPersistentLayoutData> 8
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #16817 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16833)
<!-- Reviewable:end -->
