### PR TITLE
Stylo: Bug 1350175 - Support getting line / column number of CSS rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,6 +1024,7 @@ dependencies = [
 name = "gfx_tests"
 version = "0.0.1"
 dependencies = [
+ "cssparser 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
  "ipc-channel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",

--- a/components/style/encoding_support.rs
+++ b/components/style/encoding_support.rs
@@ -88,6 +88,7 @@ impl Stylesheet {
                               &string,
                               url_data,
                               stylesheet_loader,
-                              error_reporter)
+                              error_reporter,
+                              0)
     }
 }

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -12,6 +12,7 @@
 use computed_values::{font_style, font_weight, font_stretch};
 use computed_values::font_family::FamilyName;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser};
+use cssparser::SourceLocation;
 #[cfg(feature = "gecko")] use gecko_bindings::structs::CSSFontFaceDescriptors;
 #[cfg(feature = "gecko")] use cssparser::UnicodeRange;
 use parser::{ParserContext, log_css_error, Parse};
@@ -74,8 +75,10 @@ impl ToCss for UrlSource {
 /// Parse the block inside a `@font-face` rule.
 ///
 /// Note that the prelude parsing code lives in the `stylesheets` module.
-pub fn parse_font_face_block(context: &ParserContext, input: &mut Parser) -> FontFaceRuleData {
+pub fn parse_font_face_block(context: &ParserContext, input: &mut Parser, location: SourceLocation)
+    -> FontFaceRuleData {
     let mut rule = FontFaceRuleData::empty();
+    rule.source_location = location;
     {
         let parser = FontFaceRuleParser {
             context: context,
@@ -186,6 +189,8 @@ macro_rules! font_face_descriptors_common {
                 #[$doc]
                 pub $ident: Option<$ty>,
             )*
+            /// Line and column of the @font-face rule source code.
+            pub source_location: SourceLocation,
         }
 
         impl FontFaceRuleData {
@@ -194,6 +199,10 @@ macro_rules! font_face_descriptors_common {
                     $(
                         $ident: None,
                     )*
+                    source_location: SourceLocation {
+                        line: 0,
+                        column: 0,
+                    },
                 }
             }
 

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1240,7 +1240,8 @@ extern "C" {
      -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    pub fn Gecko_CSSFontFaceRule_Create() -> *mut nsCSSFontFaceRule;
+    pub fn Gecko_CSSFontFaceRule_Create(line: u32, column: u32)
+     -> *mut nsCSSFontFaceRule;
 }
 extern "C" {
     pub fn Gecko_CSSFontFaceRule_GetCssText(rule: *const nsCSSFontFaceRule,
@@ -1603,7 +1604,8 @@ extern "C" {
                                           media_list:
                                               *const RawServoMediaList,
                                           extra_data:
-                                              *mut RawGeckoURLExtraData)
+                                              *mut RawGeckoURLExtraData,
+                                          line_number_offset: u32)
      -> RawServoStyleSheetStrong;
 }
 extern "C" {
@@ -1618,7 +1620,8 @@ extern "C" {
                                                *mut ServoStyleSheet,
                                            data: *const nsACString,
                                            extra_data:
-                                               *mut RawGeckoURLExtraData);
+                                                *mut RawGeckoURLExtraData,
+                                           line_number_offset: u32);
 }
 extern "C" {
     pub fn Servo_StyleSheet_HasRules(sheet: RawServoStyleSheetBorrowed)
@@ -1708,7 +1711,8 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_CssRules_GetStyleRuleAt(rules: ServoCssRulesBorrowed,
-                                         index: u32)
+                                         index: u32, line: *mut u32,
+                                         column: *mut u32)
      -> RawServoStyleRuleStrong;
 }
 extern "C" {
@@ -1721,7 +1725,8 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_CssRules_GetMediaRuleAt(rules: ServoCssRulesBorrowed,
-                                         index: u32)
+                                         index: u32, line: *mut u32,
+                                         column: *mut u32)
      -> RawServoMediaRuleStrong;
 }
 extern "C" {
@@ -1738,7 +1743,8 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_CssRules_GetNamespaceRuleAt(rules: ServoCssRulesBorrowed,
-                                             index: u32)
+                                             index: u32, line: *mut u32,
+                                             column: *mut u32)
      -> RawServoNamespaceRuleStrong;
 }
 extern "C" {
@@ -1751,7 +1757,9 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_CssRules_GetPageRuleAt(rules: ServoCssRulesBorrowed,
-                                        index: u32) -> RawServoPageRuleStrong;
+                                        index: u32, line: *mut u32,
+                                        column: *mut u32)
+     -> RawServoPageRuleStrong;
 }
 extern "C" {
     pub fn Servo_PageRule_Debug(rule: RawServoPageRuleBorrowed,
@@ -1763,7 +1771,8 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_CssRules_GetSupportsRuleAt(rules: ServoCssRulesBorrowed,
-                                            index: u32)
+                                            index: u32, line: *mut u32,
+                                            column: *mut u32)
      -> RawServoSupportsRuleStrong;
 }
 extern "C" {
@@ -1780,7 +1789,8 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_CssRules_GetDocumentRuleAt(rules: ServoCssRulesBorrowed,
-                                            index: u32)
+                                            index: u32, line: *mut u32,
+                                            column: *mut u32)
      -> RawServoDocumentRuleStrong;
 }
 extern "C" {

--- a/components/style/gecko/rules.rs
+++ b/components/style/gecko/rules.rs
@@ -117,7 +117,9 @@ impl ToNsCssValue for Vec<UnicodeRange> {
 impl From<FontFaceRuleData> for FontFaceRule {
     fn from(data: FontFaceRuleData) -> FontFaceRule {
         let mut result = unsafe {
-            UniqueRefPtr::from_addrefed(bindings::Gecko_CSSFontFaceRule_Create())
+            UniqueRefPtr::from_addrefed(bindings::Gecko_CSSFontFaceRule_Create(
+                data.source_location.line as u32, data.source_location.column as u32
+            ))
         };
         data.set_descriptors(&mut result.mDecl.mDescriptors);
         result.get()

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -552,7 +552,8 @@ pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(loader: *mut Loader,
                                                  data: *const nsACString,
                                                  mode: SheetParsingMode,
                                                  media_list: *const RawServoMediaList,
-                                                 extra_data: *mut URLExtraData)
+                                                 extra_data: *mut URLExtraData,
+                                                 line_number_offset: u32)
                                                  -> RawServoStyleSheetStrong {
     let global_style_data = &*GLOBAL_STYLE_DATA;
     let input = unsafe { data.as_ref().unwrap().as_str_unchecked() };
@@ -586,7 +587,8 @@ pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(loader: *mut Loader,
 
     Arc::new(Stylesheet::from_str(
         input, url_data.clone(), origin, media,
-        shared_lock, loader, &RustLogReporter, QuirksMode::NoQuirks, 0u64)
+        shared_lock, loader, &RustLogReporter,
+        QuirksMode::NoQuirks, line_number_offset as u64)
     ).into_strong()
 }
 
@@ -595,7 +597,8 @@ pub extern "C" fn Servo_StyleSheet_ClearAndUpdate(stylesheet: RawServoStyleSheet
                                                   loader: *mut Loader,
                                                   gecko_stylesheet: *mut ServoStyleSheet,
                                                   data: *const nsACString,
-                                                  extra_data: *mut URLExtraData)
+                                                  extra_data: *mut URLExtraData,
+                                                  line_number_offset: u32)
 {
     let input = unsafe { data.as_ref().unwrap().as_str_unchecked() };
     let url_data = unsafe { RefPtr::from_ptr_ref(&extra_data) };
@@ -613,8 +616,8 @@ pub extern "C" fn Servo_StyleSheet_ClearAndUpdate(stylesheet: RawServoStyleSheet
     };
 
     let sheet = Stylesheet::as_arc(&stylesheet);
-    Stylesheet::update_from_str(&sheet, input, url_data,
-                                loader, &RustLogReporter);
+    Stylesheet::update_from_str(&sheet, input, url_data, loader,
+                                &RustLogReporter, line_number_offset as u64);
 }
 
 #[no_mangle]
@@ -763,16 +766,24 @@ macro_rules! impl_basic_rule_funcs {
         to_css: $to_css:ident,
     } => {
         #[no_mangle]
-        pub extern "C" fn $getter(rules: ServoCssRulesBorrowed, index: u32) -> Strong<$raw_type> {
-            read_locked_arc(rules, |rules: &CssRules| {
-                match rules.0[index as usize] {
-                    CssRule::$name(ref rule) => rule.clone().into_strong(),
-                    _ => {
-                        unreachable!(concat!(stringify!($getter), "should only be called ",
-                                             "on a ", stringify!($name), " rule"));
-                    }
+        pub extern "C" fn $getter(rules: ServoCssRulesBorrowed, index: u32,
+                                  line: *mut u32, column: *mut u32)
+            -> Strong<$raw_type> {
+            let global_style_data = &*GLOBAL_STYLE_DATA;
+            let guard = global_style_data.shared_lock.read();
+            let rules = Locked::<CssRules>::as_arc(&rules).read_with(&guard);
+            match rules.0[index as usize] {
+                CssRule::$name(ref rule) => {
+                    let location = rule.read_with(&guard).source_location;
+                    *unsafe { line.as_mut().unwrap() } = location.line as u32;
+                    *unsafe { column.as_mut().unwrap() } = location.column as u32;
+                    rule.clone().into_strong()
+                },
+                _ => {
+                    unreachable!(concat!(stringify!($getter), "should only be called ",
+                                         "on a ", stringify!($name), " rule"));
                 }
-            })
+            }
         }
 
         #[no_mangle]
@@ -905,7 +916,7 @@ pub extern "C" fn Servo_NamespaceRule_GetURI(rule: RawServoNamespaceRuleBorrowed
 #[no_mangle]
 pub extern "C" fn Servo_PageRule_GetStyle(rule: RawServoPageRuleBorrowed) -> RawServoDeclarationBlockStrong {
     read_locked_arc(rule, |rule: &PageRule| {
-        rule.0.clone().into_strong()
+        rule.block.clone().into_strong()
     })
 }
 
@@ -914,7 +925,7 @@ pub extern "C" fn Servo_PageRule_SetStyle(rule: RawServoPageRuleBorrowed,
                                            declarations: RawServoDeclarationBlockBorrowed) {
     let declarations = Locked::<PropertyDeclarationBlock>::as_arc(&declarations);
     write_locked_arc(rule, |rule: &mut PageRule| {
-        rule.0 = declarations.clone();
+        rule.block = declarations.clone();
     })
 }
 

--- a/tests/unit/gfx/Cargo.toml
+++ b/tests/unit/gfx/Cargo.toml
@@ -10,6 +10,7 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
+cssparser = "0.13.3"
 gfx = {path = "../../../components/gfx"}
 ipc-channel = "0.7"
 style = {path = "../../../components/style"}

--- a/tests/unit/gfx/font_cache_thread.rs
+++ b/tests/unit/gfx/font_cache_thread.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use cssparser::SourceLocation;
 use gfx::font_cache_thread::FontCacheThread;
 use ipc_channel::ipc;
 use style::computed_values::font_family::FamilyName;
@@ -23,6 +24,10 @@ fn test_local_web_font() {
     let font_face_rule = FontFaceRuleData {
         family: Some(family_name.clone()),
         sources: Some(vec![Source::Local(variant_name)]),
+        source_location: SourceLocation {
+            line: 0,
+            column: 0,
+        },
     };
 
     font_cache_thread.add_web_font(

--- a/tests/unit/gfx/lib.rs
+++ b/tests/unit/gfx/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+extern crate cssparser;
 extern crate gfx;
 extern crate ipc_channel;
 extern crate style;

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cssparser::{self, Parser as CssParser, SourcePosition};
+use cssparser::{self, Parser as CssParser, SourcePosition, SourceLocation};
 use html5ever::{Namespace as NsAtom};
 use media_queries::CSSErrorReporterTest;
 use parking_lot::RwLock;
@@ -82,7 +82,11 @@ fn test_parse_stylesheet() {
         rules: CssRules::new(vec![
             CssRule::Namespace(Arc::new(stylesheet.shared_lock.wrap(NamespaceRule {
                 prefix: None,
-                url: NsAtom::from("http://www.w3.org/1999/xhtml")
+                url: NsAtom::from("http://www.w3.org/1999/xhtml"),
+                source_location: SourceLocation {
+                    line: 1,
+                    column: 19,
+                },
             }))),
             CssRule::Style(Arc::new(stylesheet.shared_lock.wrap(StyleRule {
                 selectors: SelectorList(vec![
@@ -116,6 +120,10 @@ fn test_parse_stylesheet() {
                      DeclaredValueOwned::CSSWideKeyword(CSSWideKeyword::Inherit)),
                      Importance::Important),
                 ]))),
+                source_location: SourceLocation {
+                    line: 3,
+                    column: 31,
+                },
             }))),
             CssRule::Style(Arc::new(stylesheet.shared_lock.wrap(StyleRule {
                 selectors: SelectorList(vec![
@@ -152,6 +160,10 @@ fn test_parse_stylesheet() {
                     (PropertyDeclaration::Display(longhands::display::SpecifiedValue::block),
                      Importance::Normal),
                 ]))),
+                source_location: SourceLocation {
+                    line: 11,
+                    column: 27,
+                },
             }))),
             CssRule::Style(Arc::new(stylesheet.shared_lock.wrap(StyleRule {
                 selectors: SelectorList(vec![
@@ -220,6 +232,10 @@ fn test_parse_stylesheet() {
                                                    ::get_initial_specified_value()])),
                      Importance::Normal),
                 ]))),
+                source_location: SourceLocation {
+                    line: 15,
+                    column: 20,
+                },
             }))),
             CssRule::Keyframes(Arc::new(stylesheet.shared_lock.wrap(KeyframesRule {
                 name: KeyframesName::Ident(CustomIdent("foo".into())),

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use cssparser::SourceLocation;
 use html5ever::LocalName;
 use selectors::parser::LocalName as LocalNameSelector;
 use selectors::parser::Selector;
@@ -32,6 +33,10 @@ fn get_mock_rules(css_selectors: &[&str]) -> (Vec<Vec<Rule>>, SharedRwLock) {
                     longhands::display::SpecifiedValue::block),
                 Importance::Normal
             ))),
+            source_location: SourceLocation {
+                line: 0,
+                column: 0,
+            },
         }));
 
         let guard = shared_lock.read();


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1350175

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16835)
<!-- Reviewable:end -->
