### PR TITLE
Fix future illegal_floating_point_literal_pattern warnings.

### DIFF
--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -143,16 +143,19 @@ impl MarginCollapseInfo {
                 may_collapse_through = may_collapse_through &&
                     match fragment.style().content_block_size() {
                         LengthOrPercentageOrAuto::Auto => true,
-                        LengthOrPercentageOrAuto::Length(Au(0)) => true,
-                        LengthOrPercentageOrAuto::Percentage(0.) => true,
-                        LengthOrPercentageOrAuto::Percentage(_) if
-                            containing_block_size.is_none() => true,
-                        _ => false,
+                        LengthOrPercentageOrAuto::Length(Au(v)) => v == 0,
+                        LengthOrPercentageOrAuto::Percentage(v) => {
+                            v == 0. || containing_block_size.is_none()
+                        }
+                        LengthOrPercentageOrAuto::Calc(_) => false,
                     };
 
                 if may_collapse_through {
                     match fragment.style().min_block_size() {
-                        LengthOrPercentage::Length(Au(0)) | LengthOrPercentage::Percentage(0.) => {
+                        LengthOrPercentage::Length(Au(0)) => {
+                            FinalMarginState::MarginsCollapseThrough
+                        },
+                        LengthOrPercentage::Percentage(v) if v == 0. => {
                             FinalMarginState::MarginsCollapseThrough
                         },
                         _ => {

--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -375,7 +375,7 @@ impl ::std::ops::Deref for AttrValue {
 pub fn parse_nonzero_length(value: &str) -> LengthOrPercentageOrAuto {
     match parse_length(value) {
         LengthOrPercentageOrAuto::Length(x) if x == Au::zero() => LengthOrPercentageOrAuto::Auto,
-        LengthOrPercentageOrAuto::Percentage(0.) => LengthOrPercentageOrAuto::Auto,
+        LengthOrPercentageOrAuto::Percentage(x) if x == 0. => LengthOrPercentageOrAuto::Auto,
         x => x,
     }
 }

--- a/components/style/values/computed/length.rs
+++ b/components/style/values/computed/length.rs
@@ -221,8 +221,9 @@ impl LengthOrPercentage {
     pub fn is_definitely_zero(&self) -> bool {
         use self::LengthOrPercentage::*;
         match *self {
-            Length(Au(0)) | Percentage(0.0) => true,
-            Length(_) | Percentage(_) | Calc(_) => false
+            Length(Au(0)) => true,
+            Percentage(p) => p == 0.0,
+            Length(_) | Calc(_) => false
         }
     }
 
@@ -312,8 +313,9 @@ impl LengthOrPercentageOrAuto {
     pub fn is_definitely_zero(&self) -> bool {
         use self::LengthOrPercentageOrAuto::*;
         match *self {
-            Length(Au(0)) | Percentage(0.0) => true,
-            Length(_) | Percentage(_) | Calc(_) | Auto => false
+            Length(Au(0)) => true,
+            Percentage(p) => p == 0.0,
+            Length(_) | Calc(_) | Auto => false
         }
     }
 }

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -266,14 +266,13 @@ pub enum AbsoluteLength {
 impl AbsoluteLength {
     fn is_zero(&self) -> bool {
         match *self {
-            AbsoluteLength::Px(0.)
-            | AbsoluteLength::In(0.)
-            | AbsoluteLength::Cm(0.)
-            | AbsoluteLength::Mm(0.)
-            | AbsoluteLength::Q(0.)
-            | AbsoluteLength::Pt(0.)
-            | AbsoluteLength::Pc(0.) => true,
-            _ => false,
+            AbsoluteLength::Px(v)
+            | AbsoluteLength::In(v)
+            | AbsoluteLength::Cm(v)
+            | AbsoluteLength::Mm(v)
+            | AbsoluteLength::Q(v)
+            | AbsoluteLength::Pt(v)
+            | AbsoluteLength::Pc(v) => v == 0.,
         }
     }
 }


### PR DESCRIPTION
They make component/style fail to build, because of `#[deny(warnings)]`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16837)
<!-- Reviewable:end -->
