### PR TITLE
Remove logic from webrender_helpers.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,7 +1000,6 @@ dependencies = [
  "gfx_traits 0.0.1",
  "harfbuzz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -19,7 +19,6 @@ fontsan = {git = "https://github.com/servo/fontsan"}
 gfx_traits = {path = "../gfx_traits"}
 harfbuzz-sys = "0.1"
 heapsize = "0.3.0"
-heapsize_derive = "0.1"
 ipc-channel = "0.7"
 lazy_static = "0.2"
 libc = "0.2"

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -34,8 +34,7 @@ use style::computed_values::{border_style, filter, image_rendering};
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::ByteIndex;
-use webrender_traits::{self, ClipId, ColorF, ExtendMode, GradientStop, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
-
+use webrender_traits::{self, BoxShadowClipMode, ClipId, ColorF, ExtendMode, GradientStop, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
 pub use style::dom::OpaqueNode;
 
 /// The factor that we multiply the blur radius by in order to inflate the boundaries of display
@@ -1189,19 +1188,6 @@ pub struct DefineClipItem {
 
     /// The scroll root that this item starts.
     pub scroll_root: ScrollRoot,
-}
-
-/// How a box shadow should be clipped.
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
-pub enum BoxShadowClipMode {
-    /// No special clipping should occur. This is used for (shadowed) text decorations.
-    None,
-    /// The area inside `box_bounds` should be clipped out. Corresponds to the normal CSS
-    /// `box-shadow`.
-    Outset,
-    /// The area outside `box_bounds` should be clipped out. Corresponds to the `inset` flag on CSS
-    /// `box-shadow`.
-    Inset,
 }
 
 impl DisplayItem {

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -30,12 +30,12 @@ use std::cmp::{self, Ordering};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
-use style::computed_values::{filter, image_rendering};
+use style::computed_values::image_rendering;
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::ByteIndex;
-use webrender_traits::{self, BorderStyle, BoxShadowClipMode, ClipId, ColorF, ExtendMode};
-use webrender_traits::{GradientStop, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
+use webrender_traits::{self, BorderStyle, BoxShadowClipMode, ClipId, ColorF};
+use webrender_traits::{ExtendMode, FilterOp, GradientStop, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
 pub use style::dom::OpaqueNode;
 
 /// The factor that we multiply the blur radius by in order to inflate the boundaries of display
@@ -421,7 +421,7 @@ pub struct StackingContext {
     pub z_index: i32,
 
     /// CSS filters to be applied to this stacking context (including opacity).
-    pub filters: filter::T,
+    pub filters: Vec<FilterOp>,
 
     /// The blend mode with which this stacking context blends with its backdrop.
     pub mix_blend_mode: MixBlendMode,
@@ -450,7 +450,7 @@ impl StackingContext {
                bounds: &Rect<Au>,
                overflow: &Rect<Au>,
                z_index: i32,
-               filters: filter::T,
+               filters: Vec<FilterOp>,
                mix_blend_mode: MixBlendMode,
                transform: Option<Matrix4D<f32>>,
                transform_style: TransformStyle,
@@ -481,7 +481,7 @@ impl StackingContext {
                              &Rect::zero(),
                              &Rect::zero(),
                              0,
-                             filter::T::new(Vec::new()),
+                             Vec::new(),
                              MixBlendMode::Normal,
                              None,
                              TransformStyle::Flat,

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -33,7 +33,7 @@ use std::sync::Arc;
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::ByteIndex;
-use webrender_traits::{self, BorderRadius, BoxShadowClipMode, ClipId};
+use webrender_traits::{self, BorderRadius, BorderWidths, BoxShadowClipMode, ClipId};
 use webrender_traits::{ColorF, ExtendMode, FilterOp, GradientStop};
 use webrender_traits::{ImageRendering, LayoutPoint, LayoutSize, MixBlendMode};
 use webrender_traits::{NormalBorder, ScrollPolicy, TransformStyle, WebGLContextId};
@@ -1049,7 +1049,7 @@ pub struct BorderDisplayItem {
     pub base: BaseDisplayItem,
 
     /// Border widths.
-    pub border_widths: SideOffsets2D<Au>,
+    pub border_widths: BorderWidths,
 
     /// Details for specific border type
     pub details: BorderDetails,
@@ -1186,15 +1186,15 @@ impl DisplayItem {
                 let interior_rect =
                     Rect::new(
                         Point2D::new(border.base.bounds.origin.x +
-                                     border.border_widths.left,
+                                     Au::from_f32_px(border.border_widths.left),
                                      border.base.bounds.origin.y +
-                                     border.border_widths.top),
+                                     Au::from_f32_px(border.border_widths.top)),
                         Size2D::new(border.base.bounds.size.width -
-                                    (border.border_widths.left +
-                                     border.border_widths.right),
+                                    (Au::from_f32_px(border.border_widths.left) +
+                                     Au::from_f32_px(border.border_widths.right)),
                                     border.base.bounds.size.height -
-                                    (border.border_widths.top +
-                                     border.border_widths.bottom)));
+                                    (Au::from_f32_px(border.border_widths.top) +
+                                     Au::from_f32_px(border.border_widths.bottom))));
                 if interior_rect.contains(&point) {
                     return None;
                 }

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -34,7 +34,7 @@ use style::computed_values::{border_style, filter, image_rendering};
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::ByteIndex;
-use webrender_traits::{self, ClipId, ColorF, GradientStop, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
+use webrender_traits::{self, ClipId, ColorF, ExtendMode, GradientStop, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
 
 pub use style::dom::OpaqueNode;
 
@@ -952,8 +952,8 @@ pub struct Gradient {
     /// A list of color stops.
     pub stops: Vec<GradientStop>,
 
-    /// True if gradient repeats infinitly.
-    pub repeating: bool,
+    /// Clamp or Repeat depending on the gradient.
+    pub extend_mode: ExtendMode,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -977,8 +977,8 @@ pub struct RadialGradient {
     /// A list of color stops.
     pub stops: Vec<GradientStop>,
 
-    /// True if gradient repeats infinitly.
-    pub repeating: bool,
+    /// Clamp or Repeat depending on the gradient.
+    pub extend_mode: ExtendMode,
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -42,7 +42,7 @@ pub use style::dom::OpaqueNode;
 /// items that involve a blur. This ensures that the display item boundaries include all the ink.
 pub static BLUR_INFLATION_FACTOR: i32 = 3;
 
-#[derive(HeapSizeOf, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct DisplayList {
     pub list: Vec<DisplayItem>,
 }
@@ -386,7 +386,7 @@ impl<'a> Iterator for DisplayListTraversal<'a> {
 /// Display list sections that make up a stacking context. Each section  here refers
 /// to the steps in CSS 2.1 Appendix E.
 ///
-#[derive(Clone, Copy, Debug, Deserialize, Eq, HeapSizeOf, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum DisplayListSection {
     BackgroundAndBorders,
     BlockBackgroundsAndBorders,
@@ -394,7 +394,7 @@ pub enum DisplayListSection {
     Outlines,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, HeapSizeOf, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum StackingContextType {
     Real,
     PseudoPositioned,
@@ -402,7 +402,7 @@ pub enum StackingContextType {
     PseudoScrollingArea,
 }
 
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 /// Represents one CSS stacking context, which may or may not have a hardware layer.
 pub struct StackingContext {
     /// The ID of this StackingContext for uniquely identifying it.
@@ -558,7 +558,7 @@ impl fmt::Debug for StackingContext {
 }
 
 /// Defines a stacking context.
-#[derive(Clone, Debug, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ScrollRoot {
     /// The WebRender clip id of this scroll root based on the source of this clip
     /// and information about the fragment.
@@ -585,7 +585,7 @@ impl ScrollRoot {
 
 
 /// One drawing command in the list.
-#[derive(Clone, Deserialize, HeapSizeOf, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum DisplayItem {
     SolidColor(Box<SolidColorDisplayItem>),
     Text(Box<TextDisplayItem>),
@@ -602,7 +602,7 @@ pub enum DisplayItem {
 }
 
 /// Information common to all display items.
-#[derive(Clone, Deserialize, HeapSizeOf, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct BaseDisplayItem {
     /// The boundaries of the display item, in layer coordinates.
     pub bounds: Rect<Au>,
@@ -668,7 +668,7 @@ impl BaseDisplayItem {
 /// A clipping region for a display item. Currently, this can describe rectangles, rounded
 /// rectangles (for `border-radius`), or arbitrary intersections of the two. Arbitrary transforms
 /// are not supported because those are handled by the higher-level `StackingContext` abstraction.
-#[derive(Clone, PartialEq, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Deserialize, Serialize)]
 pub struct ClippingRegion {
     /// The main rectangular region. This does not include any corners.
     pub main: Rect<Au>,
@@ -682,7 +682,7 @@ pub struct ClippingRegion {
 /// A complex clipping region. These don't as easily admit arbitrary intersection operations, so
 /// they're stored in a list over to the side. Currently a complex clipping region is just a
 /// rounded rectangle, but the CSS WGs will probably make us throw more stuff in here eventually.
-#[derive(Clone, PartialEq, Debug, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct ComplexClippingRegion {
     /// The boundaries of the rectangle.
     pub rect: Rect<Au>,
@@ -852,7 +852,7 @@ impl ComplexClippingRegion {
 /// Metadata attached to each display item. This is useful for performing auxiliary threads with
 /// the display list involving hit testing: finding the originating DOM node and determining the
 /// cursor to use when the element is hovered over.
-#[derive(Clone, Copy, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Copy, Deserialize, Serialize)]
 pub struct DisplayItemMetadata {
     /// The DOM node from which this display item originated.
     pub node: OpaqueNode,
@@ -862,7 +862,7 @@ pub struct DisplayItemMetadata {
 }
 
 /// Paints a solid color.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct SolidColorDisplayItem {
     /// Fields common to all display items.
     pub base: BaseDisplayItem,
@@ -872,13 +872,12 @@ pub struct SolidColorDisplayItem {
 }
 
 /// Paints text.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct TextDisplayItem {
     /// Fields common to all display items.
     pub base: BaseDisplayItem,
 
     /// The text run.
-    #[ignore_heap_size_of = "Because it is non-owning"]
     pub text_run: Arc<TextRun>,
 
     /// The range of text within the text run.
@@ -897,7 +896,7 @@ pub struct TextDisplayItem {
     pub blur_radius: Au,
 }
 
-#[derive(Clone, Eq, PartialEq, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub enum TextOrientation {
     Upright,
     SidewaysLeft,
@@ -905,13 +904,12 @@ pub enum TextOrientation {
 }
 
 /// Paints an image.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct ImageDisplayItem {
     pub base: BaseDisplayItem,
 
     pub webrender_image: WebRenderImageInfo,
 
-    #[ignore_heap_size_of = "Because it is non-owning"]
     pub image_data: Option<Arc<IpcSharedMemory>>,
 
     /// The dimensions to which the image display item should be stretched. If this is smaller than
@@ -928,7 +926,7 @@ pub struct ImageDisplayItem {
     pub image_rendering: image_rendering::T,
 }
 
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct WebGLDisplayItem {
     pub base: BaseDisplayItem,
     pub context_id: WebGLContextId,
@@ -936,14 +934,14 @@ pub struct WebGLDisplayItem {
 
 
 /// Paints an iframe.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct IframeDisplayItem {
     pub base: BaseDisplayItem,
     pub iframe: PipelineId,
 }
 
 /// Paints a gradient.
-#[derive(Clone, Deserialize, HeapSizeOf, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct Gradient {
     /// The start point of the gradient (computed during display list construction).
     pub start_point: Point2D<Au>,
@@ -958,7 +956,7 @@ pub struct Gradient {
     pub repeating: bool,
 }
 
-#[derive(Clone, Deserialize, HeapSizeOf, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct GradientDisplayItem {
     /// Fields common to all display item.
     pub base: BaseDisplayItem,
@@ -968,7 +966,7 @@ pub struct GradientDisplayItem {
 }
 
 /// Paints a radial gradient.
-#[derive(Clone, Deserialize, HeapSizeOf, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct RadialGradient {
     /// The center point of the gradient.
     pub center: Point2D<Au>,
@@ -983,7 +981,7 @@ pub struct RadialGradient {
     pub repeating: bool,
 }
 
-#[derive(Clone, Deserialize, HeapSizeOf, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct RadialGradientDisplayItem {
     /// Fields common to all display item.
     pub base: BaseDisplayItem,
@@ -993,7 +991,7 @@ pub struct RadialGradientDisplayItem {
 }
 
 /// A normal border, supporting CSS border styles.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct NormalBorder {
     /// Border colors.
     pub color: SideOffsets2D<ColorF>,
@@ -1008,7 +1006,7 @@ pub struct NormalBorder {
 }
 
 /// A border that is made of image segments.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct ImageBorder {
     /// The image this border uses, border-image-source.
     pub image: WebRenderImageInfo,
@@ -1030,7 +1028,7 @@ pub struct ImageBorder {
 }
 
 /// A border that is made of linear gradient
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct GradientBorder {
     /// The gradient info that this border uses, border-image-source.
     pub gradient: Gradient,
@@ -1040,7 +1038,7 @@ pub struct GradientBorder {
 }
 
 /// A border that is made of radial gradient
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct RadialGradientBorder {
     /// The gradient info that this border uses, border-image-source.
     pub gradient: RadialGradient,
@@ -1050,7 +1048,7 @@ pub struct RadialGradientBorder {
 }
 
 /// Specifies the type of border
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum BorderDetails {
     Normal(NormalBorder),
     Image(ImageBorder),
@@ -1059,7 +1057,7 @@ pub enum BorderDetails {
 }
 
 /// Paints a border.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct BorderDisplayItem {
     /// Fields common to all display items.
     pub base: BaseDisplayItem,
@@ -1074,7 +1072,7 @@ pub struct BorderDisplayItem {
 /// Information about the border radii.
 ///
 /// TODO(pcwalton): Elliptical radii.
-#[derive(Clone, PartialEq, Debug, Copy, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Debug, Copy, Deserialize, Serialize)]
 pub struct BorderRadii<T> {
     pub top_left: Size2D<T>,
     pub top_right: Size2D<T>,
@@ -1136,7 +1134,7 @@ impl<T> BorderRadii<T> where T: PartialEq + Zero + Clone {
 }
 
 /// Paints a box shadow per CSS-BACKGROUNDS.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct BoxShadowDisplayItem {
     /// Fields common to all display items.
     pub base: BaseDisplayItem,
@@ -1166,7 +1164,7 @@ pub struct BoxShadowDisplayItem {
 }
 
 /// Defines a stacking context.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct PushStackingContextItem {
     /// Fields common to all display items.
     pub base: BaseDisplayItem,
@@ -1175,7 +1173,7 @@ pub struct PushStackingContextItem {
 }
 
 /// Defines a stacking context.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct PopStackingContextItem {
     /// Fields common to all display items.
     pub base: BaseDisplayItem,
@@ -1184,7 +1182,7 @@ pub struct PopStackingContextItem {
 }
 
 /// Starts a group of items inside a particular scroll root.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct DefineClipItem {
     /// Fields common to all display items.
     pub base: BaseDisplayItem,
@@ -1194,7 +1192,7 @@ pub struct DefineClipItem {
 }
 
 /// How a box shadow should be clipped.
-#[derive(Clone, Copy, Debug, PartialEq, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
 pub enum BoxShadowClipMode {
     /// No special clipping should occur. This is used for (shadowed) text decorations.
     None,
@@ -1347,7 +1345,7 @@ impl fmt::Debug for DisplayItem {
     }
 }
 
-#[derive(Copy, Clone, HeapSizeOf, Deserialize, Serialize)]
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct WebRenderImageInfo {
     pub width: u32,
     pub height: u32,

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -594,7 +594,6 @@ pub enum DisplayItem {
     Border(Box<BorderDisplayItem>),
     Gradient(Box<GradientDisplayItem>),
     RadialGradient(Box<RadialGradientDisplayItem>),
-    Line(Box<LineDisplayItem>),
     BoxShadow(Box<BoxShadowDisplayItem>),
     Iframe(Box<IframeDisplayItem>),
     PushStackingContext(Box<PushStackingContextItem>),
@@ -1136,18 +1135,6 @@ impl<T> BorderRadii<T> where T: PartialEq + Zero + Clone {
     }
 }
 
-/// Paints a line segment.
-#[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
-pub struct LineDisplayItem {
-    pub base: BaseDisplayItem,
-
-    /// The line segment color.
-    pub color: ColorF,
-
-    /// The line segment style.
-    pub style: border_style::T
-}
-
 /// Paints a box shadow per CSS-BACKGROUNDS.
 #[derive(Clone, HeapSizeOf, Deserialize, Serialize)]
 pub struct BoxShadowDisplayItem {
@@ -1229,7 +1216,6 @@ impl DisplayItem {
             DisplayItem::Border(ref border) => &border.base,
             DisplayItem::Gradient(ref gradient) => &gradient.base,
             DisplayItem::RadialGradient(ref gradient) => &gradient.base,
-            DisplayItem::Line(ref line) => &line.base,
             DisplayItem::BoxShadow(ref box_shadow) => &box_shadow.base,
             DisplayItem::Iframe(ref iframe) => &iframe.base,
             DisplayItem::PushStackingContext(ref stacking_context) => &stacking_context.base,
@@ -1349,7 +1335,6 @@ impl fmt::Debug for DisplayItem {
                 DisplayItem::Border(_) => "Border".to_owned(),
                 DisplayItem::Gradient(_) => "Gradient".to_owned(),
                 DisplayItem::RadialGradient(_) => "RadialGradient".to_owned(),
-                DisplayItem::Line(_) => "Line".to_owned(),
                 DisplayItem::BoxShadow(_) => "BoxShadow".to_owned(),
                 DisplayItem::Iframe(_) => "Iframe".to_owned(),
                 DisplayItem::PushStackingContext(_) |

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -30,12 +30,11 @@ use std::cmp::{self, Ordering};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
-use style::computed_values::image_rendering;
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::ByteIndex;
-use webrender_traits::{self, BorderStyle, BoxShadowClipMode, ClipId, ColorF};
-use webrender_traits::{ExtendMode, FilterOp, GradientStop, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
+use webrender_traits::{self, BorderStyle, BoxShadowClipMode, ClipId, ColorF, ExtendMode, FilterOp};
+use webrender_traits::{GradientStop, ImageRendering, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
 pub use style::dom::OpaqueNode;
 
 /// The factor that we multiply the blur radius by in order to inflate the boundaries of display
@@ -923,7 +922,7 @@ pub struct ImageDisplayItem {
 
     /// The algorithm we should use to stretch the image. See `image_rendering` in CSS-IMAGES-3 §
     /// 5.3.
-    pub image_rendering: image_rendering::T,
+    pub image_rendering: ImageRendering,
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -33,8 +33,10 @@ use std::sync::Arc;
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::ByteIndex;
-use webrender_traits::{self, BorderRadius, BoxShadowClipMode, ClipId, ColorF, ExtendMode, FilterOp, GradientStop};
-use webrender_traits::{ImageRendering, MixBlendMode, NormalBorder, ScrollPolicy, TransformStyle, WebGLContextId};
+use webrender_traits::{self, BorderRadius, BoxShadowClipMode, ClipId};
+use webrender_traits::{ColorF, ExtendMode, FilterOp, GradientStop};
+use webrender_traits::{ImageRendering, LayoutPoint, LayoutSize, MixBlendMode};
+use webrender_traits::{NormalBorder, ScrollPolicy, TransformStyle, WebGLContextId};
 pub use style::dom::OpaqueNode;
 
 /// The factor that we multiply the blur radius by in order to inflate the boundaries of display
@@ -914,11 +916,11 @@ pub struct ImageDisplayItem {
     /// The dimensions to which the image display item should be stretched. If this is smaller than
     /// the bounds of this display item, then the image will be repeated in the appropriate
     /// direction to tile the entire bounds.
-    pub stretch_size: Size2D<Au>,
+    pub stretch_size: LayoutSize,
 
     /// The amount of space to add to the right and bottom part of each tile, when the image
     /// is tiled.
-    pub tile_spacing: Size2D<Au>,
+    pub tile_spacing: LayoutSize,
 
     /// The algorithm we should use to stretch the image. See `image_rendering` in CSS-IMAGES-3 §
     /// 5.3.
@@ -943,10 +945,10 @@ pub struct IframeDisplayItem {
 #[derive(Clone, Deserialize, Serialize)]
 pub struct Gradient {
     /// The start point of the gradient (computed during display list construction).
-    pub start_point: Point2D<Au>,
+    pub start_point: LayoutPoint,
 
     /// The end point of the gradient (computed during display list construction).
-    pub end_point: Point2D<Au>,
+    pub end_point: LayoutPoint,
 
     /// A list of color stops.
     pub stops: Vec<GradientStop>,
@@ -968,10 +970,10 @@ pub struct GradientDisplayItem {
 #[derive(Clone, Deserialize, Serialize)]
 pub struct RadialGradient {
     /// The center point of the gradient.
-    pub center: Point2D<Au>,
+    pub center: LayoutPoint,
 
     /// The radius of the gradient with an x and an y component.
-    pub radius: Size2D<Au>,
+    pub radius: LayoutSize,
 
     /// A list of color stops.
     pub stops: Vec<GradientStop>,
@@ -1063,7 +1065,7 @@ pub struct BoxShadowDisplayItem {
     pub box_bounds: Rect<Au>,
 
     /// The offset of this shadow from the box.
-    pub offset: Point2D<Au>,
+    pub offset: LayoutPoint,
 
     /// The color of this shadow.
     pub color: ColorF,

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -26,15 +26,15 @@ use msg::constellation_msg::PipelineId;
 use net_traits::image::base::{Image, PixelFormat};
 use range::Range;
 use servo_geometry::max_rect;
-use std::cmp::{self, Ordering};
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::ByteIndex;
-use webrender_traits::{self, BorderStyle, BoxShadowClipMode, ClipId, ColorF, ExtendMode, FilterOp};
-use webrender_traits::{GradientStop, ImageRendering, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
+use webrender_traits::{self, BorderRadius, BoxShadowClipMode, ClipId, ColorF, ExtendMode, FilterOp, GradientStop};
+use webrender_traits::{ImageRendering, MixBlendMode, NormalBorder, ScrollPolicy, TransformStyle, WebGLContextId};
 pub use style::dom::OpaqueNode;
 
 /// The factor that we multiply the blur radius by in order to inflate the boundaries of display
@@ -686,7 +686,7 @@ pub struct ComplexClippingRegion {
     /// The boundaries of the rectangle.
     pub rect: Rect<Au>,
     /// Border radii of this rectangle.
-    pub radii: BorderRadii<Au>,
+    pub radii: BorderRadius,
 }
 
 impl ClippingRegion {
@@ -770,7 +770,7 @@ impl ClippingRegion {
 
     /// Intersects this clipping region with the given rounded rectangle.
     #[inline]
-    pub fn intersect_with_rounded_rect(&mut self, rect: &Rect<Au>, radii: &BorderRadii<Au>) {
+    pub fn intersect_with_rounded_rect(&mut self, rect: &Rect<Au>, radii: &BorderRadius) {
         let new_complex_region = ComplexClippingRegion {
             rect: *rect,
             radii: *radii,
@@ -836,10 +836,10 @@ impl ComplexClippingRegion {
     // TODO(pcwalton): This could be more aggressive by considering points that touch the inside of
     // the border radius ellipse.
     fn completely_encloses(&self, other: &ComplexClippingRegion) -> bool {
-        let left = cmp::max(self.radii.top_left.width, self.radii.bottom_left.width);
-        let top = cmp::max(self.radii.top_left.height, self.radii.top_right.height);
-        let right = cmp::max(self.radii.top_right.width, self.radii.bottom_right.width);
-        let bottom = cmp::max(self.radii.bottom_left.height, self.radii.bottom_right.height);
+        let left = Au::from_f32_px(self.radii.top_left.width.max(self.radii.bottom_left.width));
+        let top = Au::from_f32_px(self.radii.top_left.height.max(self.radii.top_right.height));
+        let right = Au::from_f32_px(self.radii.top_right.width.max(self.radii.bottom_right.width));
+        let bottom = Au::from_f32_px(self.radii.bottom_left.height.max(self.radii.bottom_right.height));
         let interior = Rect::new(Point2D::new(self.rect.origin.x + left, self.rect.origin.y + top),
                                  Size2D::new(self.rect.size.width - left - right,
                                              self.rect.size.height - top - bottom));
@@ -989,21 +989,6 @@ pub struct RadialGradientDisplayItem {
     pub gradient: RadialGradient,
 }
 
-/// A normal border, supporting CSS border styles.
-#[derive(Clone, Deserialize, Serialize)]
-pub struct NormalBorder {
-    /// Border colors.
-    pub color: SideOffsets2D<ColorF>,
-
-    /// Border styles.
-    pub style: SideOffsets2D<BorderStyle>,
-
-    /// Border radii.
-    ///
-    /// TODO(pcwalton): Elliptical radii.
-    pub radius: BorderRadii<Au>,
-}
-
 /// A border that is made of image segments.
 #[derive(Clone, Deserialize, Serialize)]
 pub struct ImageBorder {
@@ -1068,70 +1053,6 @@ pub struct BorderDisplayItem {
     pub details: BorderDetails,
 }
 
-/// Information about the border radii.
-///
-/// TODO(pcwalton): Elliptical radii.
-#[derive(Clone, PartialEq, Debug, Copy, Deserialize, Serialize)]
-pub struct BorderRadii<T> {
-    pub top_left: Size2D<T>,
-    pub top_right: Size2D<T>,
-    pub bottom_right: Size2D<T>,
-    pub bottom_left: Size2D<T>,
-}
-
-impl<T> Default for BorderRadii<T> where T: Default, T: Clone {
-    fn default() -> Self {
-        let top_left = Size2D::new(Default::default(),
-                                   Default::default());
-        let top_right = Size2D::new(Default::default(),
-                                    Default::default());
-        let bottom_left = Size2D::new(Default::default(),
-                                      Default::default());
-        let bottom_right = Size2D::new(Default::default(),
-                                       Default::default());
-        BorderRadii { top_left: top_left,
-                      top_right: top_right,
-                      bottom_left: bottom_left,
-                      bottom_right: bottom_right }
-    }
-}
-
-impl BorderRadii<Au> {
-    // Scale the border radii by the specified factor
-    pub fn scale_by(&self, s: f32) -> BorderRadii<Au> {
-        BorderRadii { top_left: BorderRadii::scale_corner_by(self.top_left, s),
-                      top_right: BorderRadii::scale_corner_by(self.top_right, s),
-                      bottom_left: BorderRadii::scale_corner_by(self.bottom_left, s),
-                      bottom_right: BorderRadii::scale_corner_by(self.bottom_right, s) }
-    }
-
-    // Scale the border corner radius by the specified factor
-    pub fn scale_corner_by(corner: Size2D<Au>, s: f32) -> Size2D<Au> {
-        Size2D::new(corner.width.scale_by(s), corner.height.scale_by(s))
-    }
-}
-
-impl<T> BorderRadii<T> where T: PartialEq + Zero {
-    /// Returns true if all the radii are zero.
-    pub fn is_square(&self) -> bool {
-        let zero = Zero::zero();
-        self.top_left == zero && self.top_right == zero && self.bottom_right == zero &&
-            self.bottom_left == zero
-    }
-}
-
-impl<T> BorderRadii<T> where T: PartialEq + Zero + Clone {
-    /// Returns a set of border radii that all have the given value.
-    pub fn all_same(value: T) -> BorderRadii<T> {
-        BorderRadii {
-            top_left: Size2D::new(value.clone(), value.clone()),
-            top_right: Size2D::new(value.clone(), value.clone()),
-            bottom_right: Size2D::new(value.clone(), value.clone()),
-            bottom_left: Size2D::new(value.clone(), value.clone()),
-        }
-    }
-}
-
 /// Paints a box shadow per CSS-BACKGROUNDS.
 #[derive(Clone, Deserialize, Serialize)]
 pub struct BoxShadowDisplayItem {
@@ -1156,7 +1077,7 @@ pub struct BoxShadowDisplayItem {
     /// The border radius of this shadow.
     ///
     /// TODO(pcwalton): Elliptical radii; different radii for each corner.
-    pub border_radius: Au,
+    pub border_radius: f32,
 
     /// How we should clip the result.
     pub clip_mode: BoxShadowClipMode,

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -30,11 +30,12 @@ use std::cmp::{self, Ordering};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
-use style::computed_values::{border_style, filter, image_rendering};
+use style::computed_values::{filter, image_rendering, mix_blend_mode};
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::ByteIndex;
-use webrender_traits::{self, BoxShadowClipMode, ClipId, ColorF, ExtendMode, GradientStop, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
+use webrender_traits::{self, BorderStyle, BoxShadowClipMode, ClipId, ColorF, ExtendMode};
+use webrender_traits::{GradientStop, MixBlendMode, ScrollPolicy, TransformStyle, WebGLContextId};
 pub use style::dom::OpaqueNode;
 
 /// The factor that we multiply the blur radius by in order to inflate the boundaries of display
@@ -996,7 +997,7 @@ pub struct NormalBorder {
     pub color: SideOffsets2D<ColorF>,
 
     /// Border styles.
-    pub style: SideOffsets2D<border_style::T>,
+    pub style: SideOffsets2D<BorderStyle>,
 
     /// Border radii.
     ///

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -894,7 +894,7 @@ pub struct TextDisplayItem {
     pub orientation: TextOrientation,
 
     /// The blur radius for this text. If zero, this text is not blurred.
-    pub blur_radius: Au,
+    pub blur_radius: f32,
 }
 
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -1071,10 +1071,10 @@ pub struct BoxShadowDisplayItem {
     pub color: ColorF,
 
     /// The blur radius for this shadow.
-    pub blur_radius: Au,
+    pub blur_radius: f32,
 
     /// The spread radius of this shadow.
-    pub spread_radius: Au,
+    pub spread_radius: f32,
 
     /// The border radius of this shadow.
     ///

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -30,7 +30,7 @@ use std::cmp::{self, Ordering};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
-use style::computed_values::{filter, image_rendering, mix_blend_mode};
+use style::computed_values::{filter, image_rendering};
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::ByteIndex;

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -45,7 +45,6 @@ extern crate gfx_traits;
 extern crate harfbuzz_sys as harfbuzz;
 
 extern crate heapsize;
-#[macro_use] extern crate heapsize_derive;
 extern crate ipc_channel;
 #[macro_use]
 extern crate lazy_static;

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1103,8 +1103,8 @@ impl FragmentDisplayListBuilding for Fragment {
               base: base,
               webrender_image: webrender_image,
               image_data: None,
-              stretch_size: stretch_size,
-              tile_spacing: tile_spacing,
+              stretch_size: stretch_size.to_layout(),
+              tile_spacing: tile_spacing.to_layout(),
               image_rendering: style.get_inheritedbox().image_rendering.to_layout(),
             }));
 
@@ -1169,8 +1169,8 @@ impl FragmentDisplayListBuilding for Fragment {
         let center = Point2D::new(bounds.size.width / 2, bounds.size.height / 2);
 
         display_list::Gradient {
-            start_point: center - delta,
-            end_point: center + delta,
+            start_point: (center - delta).to_layout(),
+            end_point: (center + delta).to_layout(),
             stops: stops,
             extend_mode: to_extend_mode(repeating),
         }
@@ -1209,8 +1209,8 @@ impl FragmentDisplayListBuilding for Fragment {
         }
 
         display_list::RadialGradient {
-            center: center,
-            radius: radius,
+            center: center.to_layout(),
+            radius: radius.to_layout(),
             stops: stops,
             extend_mode: to_extend_mode(repeating),
         }
@@ -1292,7 +1292,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 base: base,
                 box_bounds: *absolute_bounds,
                 color: style.resolve_color(box_shadow.color).to_gfx_color(),
-                offset: Point2D::new(box_shadow.offset_x, box_shadow.offset_y),
+                offset: Point2D::new(box_shadow.offset_x, box_shadow.offset_y).to_layout(),
                 blur_radius: box_shadow.blur_radius,
                 spread_radius: box_shadow.spread_radius,
                 border_radius: model::specified_border_radius(style.get_border()
@@ -1826,8 +1826,8 @@ impl FragmentDisplayListBuilding for Fragment {
                         base: base,
                         webrender_image: WebRenderImageInfo::from_image(image),
                         image_data: Some(Arc::new(image.bytes.clone())),
-                        stretch_size: stacking_relative_content_box.size,
-                        tile_spacing: Size2D::zero(),
+                        stretch_size: stacking_relative_content_box.size.to_layout(),
+                        tile_spacing: Size2D::zero().to_layout(),
                         image_rendering: self.style.get_inheritedbox().image_rendering.to_layout(),
                     }));
                 }
@@ -1864,8 +1864,8 @@ impl FragmentDisplayListBuilding for Fragment {
                                 key: Some(canvas_data.image_key),
                             },
                             image_data: None,
-                            stretch_size: stacking_relative_content_box.size,
-                            tile_spacing: Size2D::zero(),
+                            stretch_size: stacking_relative_content_box.size.to_layout(),
+                            tile_spacing: Size2D::zero().to_layout(),
                             image_rendering: ImageRendering::Auto,
                         })
                     }
@@ -2068,7 +2068,7 @@ impl FragmentDisplayListBuilding for Fragment {
             base: base,
             box_bounds: stacking_relative_box,
             color: color.to_gfx_color(),
-            offset: Point2D::zero(),
+            offset: ::webrender_traits::LayoutPoint::zero(),
             blur_radius: blur_radius,
             spread_radius: Au(0),
             border_radius: 0f32,

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -26,8 +26,7 @@ use gfx::display_list::{BorderDisplayItem, ImageBorder, NormalBorder};
 use gfx::display_list::{BorderRadii, BoxShadowClipMode, BoxShadowDisplayItem, ClippingRegion};
 use gfx::display_list::{DisplayItem, DisplayItemMetadata, DisplayList, DisplayListSection};
 use gfx::display_list::{GradientDisplayItem, RadialGradientDisplayItem, IframeDisplayItem, ImageDisplayItem};
-use gfx::display_list::{LineDisplayItem, OpaqueNode};
-use gfx::display_list::{SolidColorDisplayItem, ScrollRoot, StackingContext, StackingContextType};
+use gfx::display_list::{OpaqueNode, SolidColorDisplayItem, ScrollRoot, StackingContext, StackingContextType};
 use gfx::display_list::{TextDisplayItem, TextOrientation, WebGLDisplayItem, WebRenderImageInfo};
 use gfx_traits::{combine_id_with_fragment_type, FragmentType, StackingContextId};
 use inline::{FIRST_FRAGMENT_OF_ELEMENT, InlineFlow, LAST_FRAGMENT_OF_ELEMENT};
@@ -1502,12 +1501,9 @@ impl FragmentDisplayListBuilding for Fragment {
                                                  state: &mut DisplayListBuildState,
                                                  style: &ServoComputedValues,
                                                  stacking_relative_border_box: &Rect<Au>,
-                                                 stacking_relative_content_box: &Rect<Au>,
-                                                 text_fragment: &ScannedTextFragmentInfo,
+                                                 _stacking_relative_content_box: &Rect<Au>,
+                                                 _text_fragment: &ScannedTextFragmentInfo,
                                                  clip: &Rect<Au>) {
-        // FIXME(pcwalton, #2795): Get the real container size.
-        let container_size = Size2D::zero();
-
         // Compute the text fragment bounds and draw a border surrounding them.
         let base = state.create_base_display_item(stacking_relative_border_box,
                                                   &ClippingRegion::from_rect(&clip),
@@ -1522,25 +1518,6 @@ impl FragmentDisplayListBuilding for Fragment {
                 style: SideOffsets2D::new_all_same(border_style::T::solid),
                 radius: Default::default(),
             }),
-        }));
-
-        // Draw a rectangle representing the baselines.
-        let mut baseline = LogicalRect::from_physical(self.style.writing_mode,
-                                                      *stacking_relative_content_box,
-                                                      container_size);
-        baseline.start.b = baseline.start.b + text_fragment.run.ascent();
-        baseline.size.block = Au(0);
-        let baseline = baseline.to_physical(self.style.writing_mode, container_size);
-
-        let base = state.create_base_display_item(&baseline,
-                                                  &ClippingRegion::from_rect(&clip),
-                                                  self.node,
-                                                  style.get_cursor(Cursor::Default),
-                                                  DisplayListSection::Content);
-        state.add_display_item(DisplayItem::Line(box LineDisplayItem {
-            base: base,
-            color: ColorF::rgb(0, 200, 0),
-            style: border_style::T::dashed,
         }));
     }
 

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1293,8 +1293,8 @@ impl FragmentDisplayListBuilding for Fragment {
                 box_bounds: *absolute_bounds,
                 color: style.resolve_color(box_shadow.color).to_gfx_color(),
                 offset: Point2D::new(box_shadow.offset_x, box_shadow.offset_y).to_layout(),
-                blur_radius: box_shadow.blur_radius,
-                spread_radius: box_shadow.spread_radius,
+                blur_radius: box_shadow.blur_radius.to_f32_px(),
+                spread_radius: box_shadow.spread_radius.to_f32_px(),
                 border_radius: model::specified_border_radius(style.get_border()
                                                                    .border_top_left_radius,
                                                               absolute_bounds.size).width,
@@ -1993,7 +1993,7 @@ impl FragmentDisplayListBuilding for Fragment {
             text_color: text_color.to_gfx_color(),
             orientation: orientation,
             baseline_origin: baseline_origin,
-            blur_radius: shadow_blur_radius,
+            blur_radius: shadow_blur_radius.to_f32_px(),
         }));
 
         // Create display items for text decorations.
@@ -2069,8 +2069,8 @@ impl FragmentDisplayListBuilding for Fragment {
             box_bounds: stacking_relative_box,
             color: color.to_gfx_color(),
             offset: ::webrender_traits::LayoutPoint::zero(),
-            blur_radius: blur_radius,
-            spread_radius: Au(0),
+            blur_radius: blur_radius.to_f32_px(),
+            spread_radius: 0f32,
             border_radius: 0f32,
             clip_mode: BoxShadowClipMode::None,
         }));

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -67,8 +67,10 @@ use style_traits::cursor::Cursor;
 use table_cell::CollapsedBordersForCell;
 use to_layout::ToLayout;
 use webrender_helpers::ToTransformStyle;
-use webrender_traits::{BorderRadius, BorderSide, BorderWidths, BorderStyle, BoxShadowClipMode, ColorF, ClipId, ExtendMode};
-use webrender_traits::{GradientStop, ImageRendering, LayerSize, NormalBorder, RepeatMode, ScrollPolicy, TransformStyle};
+use webrender_traits::{BorderRadius, BorderSide, BorderWidths, BorderStyle};
+use webrender_traits::{BoxShadowClipMode, ColorF, ClipId, ExtendMode};
+use webrender_traits::{GradientStop, ImageRendering, LayerSize, NormalBorder};
+use webrender_traits::{RepeatMode, ScrollPolicy, TransformStyle};
 
 trait ResolvePercentage {
     fn resolve(&self, length: u32) -> u32;

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1932,7 +1932,7 @@ impl FragmentDisplayListBuilding for Fragment {
                              &border_box,
                              &overflow,
                              self.effective_z_index(),
-                             filters,
+                             filters.to_layout(),
                              self.style().get_effects().mix_blend_mode.to_layout(),
                              self.transform_matrix(&border_box),
                              self.style().get_used_transform_style().to_transform_style(),

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -68,7 +68,7 @@ use style_traits::CSSPixel;
 use style_traits::cursor::Cursor;
 use table_cell::CollapsedBordersForCell;
 use webrender_helpers::{ToMixBlendMode, ToTransformStyle};
-use webrender_traits::{ColorF, ClipId, GradientStop, RepeatMode, ScrollPolicy, TransformStyle};
+use webrender_traits::{ColorF, ClipId, ExtendMode, GradientStop, RepeatMode, ScrollPolicy, TransformStyle};
 
 trait ResolvePercentage {
     fn resolve(&self, length: u32) -> u32;
@@ -1170,7 +1170,7 @@ impl FragmentDisplayListBuilding for Fragment {
             start_point: center - delta,
             end_point: center + delta,
             stops: stops,
-            repeating: repeating,
+            extend_mode: to_extend_mode(repeating),
         }
     }
 
@@ -1210,7 +1210,7 @@ impl FragmentDisplayListBuilding for Fragment {
             center: center,
             radius: radius,
             stops: stops,
-            repeating: repeating,
+            extend_mode: to_extend_mode(repeating),
         }
     }
 
@@ -2794,6 +2794,14 @@ fn position_to_offset(position: LengthOrPercentage, total_length: Au) -> f32 {
 fn shadow_bounds(content_rect: &Rect<Au>, blur_radius: Au, spread_radius: Au) -> Rect<Au> {
     let inflation = spread_radius + blur_radius * BLUR_INFLATION_FACTOR;
     content_rect.inflate(inflation, inflation)
+}
+
+fn to_extend_mode(repeating: bool) -> ExtendMode {
+    if !repeating {
+        ExtendMode::Clamp
+    } else {
+        ExtendMode::Repeat
+    }
 }
 
 /// Allows a CSS color to be converted into a graphics color.

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -22,8 +22,8 @@ use fragment::{CoordinateSystem, Fragment, ImageFragmentInfo, ScannedTextFragmen
 use fragment::{SpecificFragmentInfo, TruncatedFragmentInfo};
 use gfx::display_list;
 use gfx::display_list::{BLUR_INFLATION_FACTOR, BaseDisplayItem, BorderDetails};
-use gfx::display_list::{BorderDisplayItem, ImageBorder, NormalBorder};
-use gfx::display_list::{BorderRadii, BoxShadowDisplayItem, ClippingRegion};
+use gfx::display_list::{BorderDisplayItem, ImageBorder};
+use gfx::display_list::{BoxShadowDisplayItem, ClippingRegion};
 use gfx::display_list::{DisplayItem, DisplayItemMetadata, DisplayList, DisplayListSection};
 use gfx::display_list::{GradientDisplayItem, RadialGradientDisplayItem, IframeDisplayItem, ImageDisplayItem};
 use gfx::display_list::{OpaqueNode, SolidColorDisplayItem, ScrollRoot, StackingContext, StackingContextType};
@@ -41,9 +41,7 @@ use script_layout_interface::wrapper_traits::PseudoElementType;
 use servo_config::opts;
 use servo_geometry::max_rect;
 use servo_url::ServoUrl;
-use std::{cmp, f32};
 use std::collections::HashMap;
-use std::default::Default;
 use std::mem;
 use std::sync::Arc;
 use style::computed_values::{background_attachment, background_clip, background_origin};
@@ -69,8 +67,8 @@ use style_traits::cursor::Cursor;
 use table_cell::CollapsedBordersForCell;
 use to_layout::ToLayout;
 use webrender_helpers::ToTransformStyle;
-use webrender_traits::{BorderStyle, BoxShadowClipMode, ColorF, ClipId};
-use webrender_traits::{ExtendMode, GradientStop, ImageRendering, RepeatMode, ScrollPolicy, TransformStyle};
+use webrender_traits::{BorderRadius, BorderSide, BorderStyle, BoxShadowClipMode, ColorF, ClipId, ExtendMode};
+use webrender_traits::{GradientStop, ImageRendering, LayerSize, NormalBorder, RepeatMode, ScrollPolicy, TransformStyle};
 
 trait ResolvePercentage {
     fn resolve(&self, length: u32) -> u32;
@@ -539,16 +537,16 @@ pub trait FragmentDisplayListBuilding {
     fn fragment_type(&self) -> FragmentType;
 }
 
-fn handle_overlapping_radii(size: &Size2D<Au>, radii: &BorderRadii<Au>) -> BorderRadii<Au> {
+fn handle_overlapping_radii(size: &Size2D<Au>, mut radii: BorderRadius) -> BorderRadius {
     // No two corners' border radii may add up to more than the length of the edge
     // between them. To prevent that, all radii are scaled down uniformly.
-    fn scale_factor(radius_a: Au, radius_b: Au, edge_length: Au) -> f32 {
+    fn scale_factor(radius_a: f32, radius_b: f32, edge_length: Au) -> f32 {
         let required = radius_a + radius_b;
 
-        if required <= edge_length {
+        if required <= edge_length.to_f32_px() {
             1.0
         } else {
-            edge_length.to_f32_px() / required.to_f32_px()
+            edge_length.to_f32_px() / required
         }
     }
 
@@ -558,20 +556,22 @@ fn handle_overlapping_radii(size: &Size2D<Au>, radii: &BorderRadii<Au>) -> Borde
     let right_factor = scale_factor(radii.top_right.height, radii.bottom_right.height, size.height);
     let min_factor = top_factor.min(bottom_factor).min(left_factor).min(right_factor);
     if min_factor < 1.0 {
-        radii.scale_by(min_factor)
-    } else {
-        *radii
+        radii.top_left = radii.top_left * min_factor;
+        radii.top_right = radii.top_right * min_factor;
+        radii.bottom_left = radii.bottom_left * min_factor;
+        radii.bottom_right = radii.bottom_right * min_factor;
     }
+    radii
 }
 
 fn build_border_radius(abs_bounds: &Rect<Au>,
                        border_style: &style_structs::Border)
-                       -> BorderRadii<Au> {
+                       -> BorderRadius {
     // TODO(cgaebel): Support border radii even in the case of multiple border widths.
     // This is an extension of supporting elliptical radii. For now, all percentage
     // radii will be relative to the width.
 
-    handle_overlapping_radii(&abs_bounds.size, &BorderRadii {
+    handle_overlapping_radii(&abs_bounds.size, BorderRadius {
         top_left:     model::specified_border_radius(border_style.border_top_left_radius,
                                                      abs_bounds.size),
         top_right:    model::specified_border_radius(border_style.border_top_right_radius,
@@ -587,9 +587,9 @@ fn build_border_radius(abs_bounds: &Rect<Au>,
 /// for building the clip for the content inside the border.
 fn build_border_radius_for_inner_rect(outer_rect: &Rect<Au>,
                                       style: &ServoComputedValues)
-                                      -> BorderRadii<Au> {
+                                      -> BorderRadius {
     let mut radii = build_border_radius(&outer_rect, style.get_border());
-    if radii.is_square() {
+    if is_square_border(radii) {
         return radii;
     }
 
@@ -597,17 +597,17 @@ fn build_border_radius_for_inner_rect(outer_rect: &Rect<Au>,
     // border width), we need to adjust to border radius so that we are smaller
     // rectangle with the same border curve.
     let border_widths = style.logical_border_width().to_physical(style.writing_mode);
-    radii.top_left.width = cmp::max(Au(0), radii.top_left.width - border_widths.left);
-    radii.bottom_left.width = cmp::max(Au(0), radii.bottom_left.width - border_widths.left);
+    radii.top_left.width = 0f32.max(radii.top_left.width - border_widths.left.to_f32_px());
+    radii.bottom_left.width = 0f32.max(radii.bottom_left.width - border_widths.left.to_f32_px());
 
-    radii.top_right.width = cmp::max(Au(0), radii.top_right.width - border_widths.right);
-    radii.bottom_right.width = cmp::max(Au(0), radii.bottom_right.width - border_widths.right);
+    radii.top_right.width = 0f32.max(radii.top_right.width - border_widths.right.to_f32_px());
+    radii.bottom_right.width = 0f32.max(radii.bottom_right.width - border_widths.right.to_f32_px());
 
-    radii.top_left.height = cmp::max(Au(0), radii.top_left.height - border_widths.top);
-    radii.top_right.height = cmp::max(Au(0), radii.top_right.height - border_widths.top);
+    radii.top_left.height = 0f32.max(radii.top_left.height - border_widths.top.to_f32_px());
+    radii.top_right.height = 0f32.max(radii.top_right.height - border_widths.top.to_f32_px());
 
-    radii.bottom_left.height = cmp::max(Au(0), radii.bottom_left.height - border_widths.bottom);
-    radii.bottom_right.height = cmp::max(Au(0), radii.bottom_right.height - border_widths.bottom);
+    radii.bottom_left.height = 0f32.max(radii.bottom_left.height - border_widths.bottom.to_f32_px());
+    radii.bottom_right.height = 0f32.max(radii.bottom_right.height - border_widths.bottom.to_f32_px());
     radii
 }
 
@@ -819,7 +819,7 @@ impl FragmentDisplayListBuilding for Fragment {
         // Adjust the clipping region as necessary to account for `border-radius`.
         let border_radii = build_border_radius(absolute_bounds, style.get_border());
         let mut clip = ClippingRegion::max();
-        if !border_radii.is_square() {
+        if !is_square_border(border_radii) {
             clip.intersect_with_rounded_rect(absolute_bounds, &border_radii);
         };
         let background = style.get_background();
@@ -1128,9 +1128,9 @@ impl FragmentDisplayListBuilding for Fragment {
                             bounds.size.width.to_f32_px()).atan();
                 match (horizontal, vertical) {
                     (X::Right, Y::Bottom)
-                        => f32::consts::PI - atan,
+                        => ::std::f32::consts::PI - atan,
                     (X::Left, Y::Bottom)
-                        => f32::consts::PI + atan,
+                        => ::std::f32::consts::PI + atan,
                     (X::Right, Y::Top)
                         => atan,
                     (X::Left, Y::Top)
@@ -1371,11 +1371,22 @@ impl FragmentDisplayListBuilding for Fragment {
                     base: base,
                     border_widths: border.to_physical(style.writing_mode),
                     details: BorderDetails::Normal(NormalBorder {
-                        color: SideOffsets2D::new(colors.top.to_gfx_color(),
-                                                  colors.right.to_gfx_color(),
-                                                  colors.bottom.to_gfx_color(),
-                                                  colors.left.to_gfx_color()),
-                        style: border_style,
+                        left: BorderSide {
+                            color: colors.left.to_gfx_color(),
+                            style: border_style.left,
+                        },
+                        right: BorderSide {
+                            color: colors.right.to_gfx_color(),
+                            style: border_style.right,
+                        },
+                        top: BorderSide {
+                            color: colors.top.to_gfx_color(),
+                            style: border_style.top,
+                        },
+                        bottom: BorderSide {
+                            color: colors.bottom.to_gfx_color(),
+                            style: border_style.bottom,
+                        },
                         radius: build_border_radius(&bounds, border_style_struct),
                     }),
                 }));
@@ -1495,11 +1506,7 @@ impl FragmentDisplayListBuilding for Fragment {
         state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(width),
-            details: BorderDetails::Normal(NormalBorder {
-                color: SideOffsets2D::new_all_same(color),
-                style: SideOffsets2D::new_all_same(outline_style),
-                radius: Default::default(),
-            }),
+            details: make_simple_border(color, outline_style),
         }));
     }
 
@@ -1519,11 +1526,7 @@ impl FragmentDisplayListBuilding for Fragment {
         state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
-            details: BorderDetails::Normal(NormalBorder {
-                color: SideOffsets2D::new_all_same(ColorF::rgb(0, 0, 200)),
-                style: SideOffsets2D::new_all_same(BorderStyle::Solid),
-                radius: Default::default(),
-            }),
+            details: make_simple_border(ColorF::rgb(0, 0, 200), BorderStyle::Solid),
         }));
     }
 
@@ -1540,11 +1543,7 @@ impl FragmentDisplayListBuilding for Fragment {
         state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
-            details: BorderDetails::Normal(NormalBorder {
-                color: SideOffsets2D::new_all_same(ColorF::rgb(0, 0, 200)),
-                style: SideOffsets2D::new_all_same(BorderStyle::Solid),
-                radius: Default::default(),
-            }),
+            details: make_simple_border(ColorF::rgb(0, 0, 200), BorderStyle::Solid),
         }));
     }
 
@@ -2072,7 +2071,7 @@ impl FragmentDisplayListBuilding for Fragment {
             offset: Point2D::zero(),
             blur_radius: blur_radius,
             spread_radius: Au(0),
-            border_radius: Au(0),
+            border_radius: 0f32,
             clip_mode: BoxShadowClipMode::None,
         }));
     }
@@ -2390,7 +2389,7 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
 
         let border_radii = build_border_radius_for_inner_rect(&border_box,
                                                               &self.fragment.style);
-        if !border_radii.is_square() {
+        if !is_square_border(border_radii) {
             clip.intersect_with_rounded_rect(&clip_rect, &border_radii)
         }
 
@@ -2412,7 +2411,7 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
         let clip_rect = Rect::new(Point2D::zero(), content_box.size);
         let mut clip = ClippingRegion::from_rect(&clip_rect);
         let radii = build_border_radius_for_inner_rect(&border_box, &self.fragment.style);
-        if !radii.is_square() {
+        if !is_square_border(radii) {
             clip.intersect_with_rounded_rect(&clip_rect, &radii)
         }
 
@@ -2749,11 +2748,7 @@ impl BaseFlowDisplayListBuilding for BaseFlow {
         state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(2)),
-            details: BorderDetails::Normal(NormalBorder {
-                color: SideOffsets2D::new_all_same(color),
-                style: SideOffsets2D::new_all_same(BorderStyle::Solid),
-                radius: BorderRadii::all_same(Au(0)),
-            }),
+            details: make_simple_border(color, BorderStyle::Solid),
         }));
     }
 }
@@ -2808,6 +2803,25 @@ fn to_extend_mode(repeating: bool) -> ExtendMode {
     } else {
         ExtendMode::Repeat
     }
+}
+
+fn make_simple_border(color: ColorF, style: BorderStyle) -> BorderDetails {
+    let side = BorderSide { color, style };
+    BorderDetails::Normal(NormalBorder {
+        left: side,
+        right: side,
+        top: side,
+        bottom: side,
+        radius: BorderRadius::zero(),
+    })
+}
+
+fn is_square_border(border: BorderRadius) -> bool {
+    let zero = LayerSize::zero();
+    border.top_left == zero &&
+    border.top_right == zero &&
+    border.bottom_right == zero &&
+    border.bottom_left == zero
 }
 
 /// Allows a CSS color to be converted into a graphics color.

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -48,7 +48,7 @@ use std::mem;
 use std::sync::Arc;
 use style::computed_values::{background_attachment, background_clip, background_origin};
 use style::computed_values::{background_repeat, background_size, border_style, cursor};
-use style::computed_values::{image_rendering, overflow_x, pointer_events, position, visibility};
+use style::computed_values::{overflow_x, pointer_events, position, visibility};
 use style::computed_values::filter::Filter;
 use style::computed_values::text_shadow::TextShadow;
 use style::logical_geometry::{LogicalPoint, LogicalRect, LogicalSize, WritingMode};
@@ -70,7 +70,7 @@ use table_cell::CollapsedBordersForCell;
 use to_layout::ToLayout;
 use webrender_helpers::ToTransformStyle;
 use webrender_traits::{BorderStyle, BoxShadowClipMode, ColorF, ClipId};
-use webrender_traits::{ExtendMode, GradientStop, RepeatMode, ScrollPolicy, TransformStyle};
+use webrender_traits::{ExtendMode, GradientStop, ImageRendering, RepeatMode, ScrollPolicy, TransformStyle};
 
 trait ResolvePercentage {
     fn resolve(&self, length: u32) -> u32;
@@ -1105,7 +1105,7 @@ impl FragmentDisplayListBuilding for Fragment {
               image_data: None,
               stretch_size: stretch_size,
               tile_spacing: tile_spacing,
-              image_rendering: style.get_inheritedbox().image_rendering.clone(),
+              image_rendering: style.get_inheritedbox().image_rendering.to_layout(),
             }));
 
         }
@@ -1829,7 +1829,7 @@ impl FragmentDisplayListBuilding for Fragment {
                         image_data: Some(Arc::new(image.bytes.clone())),
                         stretch_size: stacking_relative_content_box.size,
                         tile_spacing: Size2D::zero(),
-                        image_rendering: self.style.get_inheritedbox().image_rendering.clone(),
+                        image_rendering: self.style.get_inheritedbox().image_rendering.to_layout(),
                     }));
                 }
             }
@@ -1867,7 +1867,7 @@ impl FragmentDisplayListBuilding for Fragment {
                             image_data: None,
                             stretch_size: stacking_relative_content_box.size,
                             tile_spacing: Size2D::zero(),
-                            image_rendering: image_rendering::T::auto,
+                            image_rendering: ImageRendering::Auto,
                         })
                     }
                     CanvasData::WebGL(context_id) => {

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -23,7 +23,7 @@ use fragment::{SpecificFragmentInfo, TruncatedFragmentInfo};
 use gfx::display_list;
 use gfx::display_list::{BLUR_INFLATION_FACTOR, BaseDisplayItem, BorderDetails};
 use gfx::display_list::{BorderDisplayItem, ImageBorder, NormalBorder};
-use gfx::display_list::{BorderRadii, BoxShadowClipMode, BoxShadowDisplayItem, ClippingRegion};
+use gfx::display_list::{BorderRadii, BoxShadowDisplayItem, ClippingRegion};
 use gfx::display_list::{DisplayItem, DisplayItemMetadata, DisplayList, DisplayListSection};
 use gfx::display_list::{GradientDisplayItem, RadialGradientDisplayItem, IframeDisplayItem, ImageDisplayItem};
 use gfx::display_list::{OpaqueNode, SolidColorDisplayItem, ScrollRoot, StackingContext, StackingContextType};
@@ -68,7 +68,7 @@ use style_traits::CSSPixel;
 use style_traits::cursor::Cursor;
 use table_cell::CollapsedBordersForCell;
 use webrender_helpers::{ToMixBlendMode, ToTransformStyle};
-use webrender_traits::{ColorF, ClipId, ExtendMode, GradientStop, RepeatMode, ScrollPolicy, TransformStyle};
+use webrender_traits::{BoxShadowClipMode, ColorF, ClipId, ExtendMode, GradientStop, RepeatMode, TransformStyle, ScrollPolicy};
 
 trait ResolvePercentage {
     fn resolve(&self, length: u32) -> u32;

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -68,7 +68,7 @@ use style_traits::CSSPixel;
 use style_traits::cursor::Cursor;
 use table_cell::CollapsedBordersForCell;
 use to_layout::ToLayout;
-use webrender_helpers::{ToMixBlendMode, ToTransformStyle};
+use webrender_helpers::ToTransformStyle;
 use webrender_traits::{BorderStyle, BoxShadowClipMode, ColorF, ClipId};
 use webrender_traits::{ExtendMode, GradientStop, RepeatMode, ScrollPolicy, TransformStyle};
 
@@ -1933,7 +1933,7 @@ impl FragmentDisplayListBuilding for Fragment {
                              &overflow,
                              self.effective_z_index(),
                              filters,
-                             self.style().get_effects().mix_blend_mode.to_mix_blend_mode(),
+                             self.style().get_effects().mix_blend_mode.to_layout(),
                              self.transform_matrix(&border_box),
                              self.style().get_used_transform_style().to_transform_style(),
                              self.perspective_matrix(&border_box),

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -67,7 +67,7 @@ use style_traits::cursor::Cursor;
 use table_cell::CollapsedBordersForCell;
 use to_layout::ToLayout;
 use webrender_helpers::ToTransformStyle;
-use webrender_traits::{BorderRadius, BorderSide, BorderStyle, BoxShadowClipMode, ColorF, ClipId, ExtendMode};
+use webrender_traits::{BorderRadius, BorderSide, BorderWidths, BorderStyle, BoxShadowClipMode, ColorF, ClipId, ExtendMode};
 use webrender_traits::{GradientStop, ImageRendering, LayerSize, NormalBorder, RepeatMode, ScrollPolicy, TransformStyle};
 
 trait ResolvePercentage {
@@ -1369,7 +1369,7 @@ impl FragmentDisplayListBuilding for Fragment {
             Either::First(_) => {
                 state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
                     base: base,
-                    border_widths: border.to_physical(style.writing_mode),
+                    border_widths: border.to_physical(style.writing_mode).to_layout(),
                     details: BorderDetails::Normal(NormalBorder {
                         left: BorderSide {
                             color: colors.left.to_gfx_color(),
@@ -1402,7 +1402,7 @@ impl FragmentDisplayListBuilding for Fragment {
 
                         state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
                             base: base,
-                            border_widths: border.to_physical(style.writing_mode),
+                            border_widths: border.to_physical(style.writing_mode).to_layout(),
                             details: BorderDetails::Gradient(display_list::GradientBorder {
                                 gradient: grad,
 
@@ -1420,7 +1420,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                                 style);
                         state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
                             base: base,
-                            border_widths: border.to_physical(style.writing_mode),
+                            border_widths: border.to_physical(style.writing_mode).to_layout(),
                             details: BorderDetails::RadialGradient(
                                 display_list::RadialGradientBorder {
                                     gradient: grad,
@@ -1449,7 +1449,7 @@ impl FragmentDisplayListBuilding for Fragment {
 
                         state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
                             base: base,
-                            border_widths: border.to_physical(style.writing_mode),
+                            border_widths: border.to_physical(style.writing_mode).to_layout(),
                             details: BorderDetails::Image(ImageBorder {
                                 image: webrender_image,
                                 fill: border_style_struct.border_image_slice.fill,
@@ -1505,7 +1505,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   DisplayListSection::Outlines);
         state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
-            border_widths: SideOffsets2D::new_all_same(width),
+            border_widths: make_simple_border_width(width.to_f32_px()),
             details: make_simple_border(color, outline_style),
         }));
     }
@@ -1525,7 +1525,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   DisplayListSection::Content);
         state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
-            border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
+            border_widths: make_simple_border_width(1.0),
             details: make_simple_border(ColorF::rgb(0, 0, 200), BorderStyle::Solid),
         }));
     }
@@ -1542,7 +1542,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   DisplayListSection::Content);
         state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
-            border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
+            border_widths: make_simple_border_width(1.0),
             details: make_simple_border(ColorF::rgb(0, 0, 200), BorderStyle::Solid),
         }));
     }
@@ -2747,7 +2747,7 @@ impl BaseFlowDisplayListBuilding for BaseFlow {
             DisplayListSection::Content);
         state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
             base: base,
-            border_widths: SideOffsets2D::new_all_same(Au::from_px(2)),
+            border_widths: make_simple_border_width(2.0),
             details: make_simple_border(color, BorderStyle::Solid),
         }));
     }
@@ -2814,6 +2814,15 @@ fn make_simple_border(color: ColorF, style: BorderStyle) -> BorderDetails {
         bottom: side,
         radius: BorderRadius::zero(),
     })
+}
+
+fn make_simple_border_width(width: f32) -> BorderWidths {
+    BorderWidths {
+        left: width,
+        top: width,
+        right: width,
+        bottom: width,
+    }
 }
 
 fn is_square_border(border: BorderRadius) -> bool {

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -86,6 +86,7 @@ mod table_row;
 mod table_rowgroup;
 mod table_wrapper;
 mod text;
+mod to_layout;
 pub mod traversal;
 pub mod webrender_helpers;
 pub mod wrapper;

--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -17,6 +17,7 @@ use style::properties::ServoComputedValues;
 use style::values::computed::{BorderRadiusSize, LengthOrPercentageOrAuto};
 use style::values::computed::{LengthOrPercentage, LengthOrPercentageOrNone};
 use style::values::generics;
+use webrender_traits::LayoutSize;
 
 /// A collapsible margin. See CSS 2.1 § 8.3.1.
 #[derive(Copy, Clone, Debug)]
@@ -474,12 +475,12 @@ pub fn style_length(style_length: LengthOrPercentageOrAuto,
 pub fn specified_border_radius(
     radius: BorderRadiusSize,
     containing_size: Size2D<Au>)
-    -> Size2D<Au>
+    -> LayoutSize
 {
     let generics::BorderRadiusSize(size) = radius;
-    let w = size.width.to_used_value(containing_size.width);
-    let h = size.height.to_used_value(containing_size.height);
-    Size2D::new(w, h)
+    let w = size.width.to_used_value(containing_size.width).to_f32_px();
+    let h = size.height.to_used_value(containing_size.height).to_f32_px();
+    LayoutSize::new(w, h)
 }
 
 #[inline]

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -409,8 +409,7 @@ impl CollapsedBordersForCell {
     pub fn adjust_border_colors_and_styles_for_painting(
             &self,
             border_colors: &mut SideOffsets2D<Color>,
-            border_styles: &mut SideOffsets2D<border_top_style::T>,
-            writing_mode: WritingMode) {
+            writing_mode: WritingMode) -> SideOffsets2D<border_top_style::T> {
         let logical_border_colors = LogicalMargin::new(writing_mode,
                                                        self.block_start_border.color,
                                                        self.inline_end_border.color,
@@ -423,6 +422,6 @@ impl CollapsedBordersForCell {
                                                        self.inline_end_border.style,
                                                        self.block_end_border.style,
                                                        self.inline_start_border.style);
-        *border_styles = logical_border_styles.to_physical(writing_mode);
+        return logical_border_styles.to_physical(writing_mode);
     }
 }

--- a/components/layout/to_layout.rs
+++ b/components/layout/to_layout.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use style::computed_values::{filter, mix_blend_mode};
+use style::computed_values::{filter, image_rendering, mix_blend_mode};
 use style::values::computed;
-use webrender_traits::{BorderStyle, FilterOp, MixBlendMode};
+use webrender_traits::{BorderStyle, FilterOp, ImageRendering, MixBlendMode};
 
 pub trait ToLayout {
     type Type;
@@ -75,5 +75,17 @@ impl ToLayout for filter::T {
             })
         }
         result
+    }
+}
+
+impl ToLayout for image_rendering::T {
+    type Type = ImageRendering;
+    fn to_layout(&self) -> ImageRendering {
+        use webrender_traits::ImageRendering::*;
+        match *self {
+            image_rendering::T::crisp_edges => CrispEdges,
+            image_rendering::T::auto => Auto,
+            image_rendering::T::pixelated => Pixelated,
+        }
     }
 }

--- a/components/layout/to_layout.rs
+++ b/components/layout/to_layout.rs
@@ -6,7 +6,8 @@ use app_units::Au;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
 use style::computed_values::{filter, image_rendering, mix_blend_mode};
 use style::values::computed;
-use webrender_traits::{BorderStyle, BorderWidths, FilterOp, ImageRendering, LayoutPoint, LayoutRect, LayoutSize, MixBlendMode};
+use webrender_traits::{BorderStyle, BorderWidths, FilterOp, ImageRendering};
+use webrender_traits::{LayoutPoint, LayoutRect, LayoutSize, MixBlendMode};
 
 pub trait ToLayout {
     type Type;

--- a/components/layout/to_layout.rs
+++ b/components/layout/to_layout.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use style::computed_values::mix_blend_mode;
 use style::values::computed;
-use webrender_traits::BorderStyle;
+use webrender_traits::{BorderStyle, MixBlendMode};
 
 pub trait ToLayout {
     type Type;
@@ -25,6 +26,31 @@ impl ToLayout for computed::BorderStyle {
             computed::BorderStyle::ridge => Ridge,
             computed::BorderStyle::inset => Inset,
             computed::BorderStyle::outset => Outset,
+        }
+    }
+}
+
+impl ToLayout for mix_blend_mode::T {
+    type Type = MixBlendMode;
+    fn to_layout(&self) -> MixBlendMode {
+        use webrender_traits::MixBlendMode::*;
+        match *self {
+            mix_blend_mode::T::normal => Normal,
+            mix_blend_mode::T::multiply => Multiply,
+            mix_blend_mode::T::screen => Screen,
+            mix_blend_mode::T::overlay => Overlay,
+            mix_blend_mode::T::darken => Darken,
+            mix_blend_mode::T::lighten => Lighten,
+            mix_blend_mode::T::color_dodge => ColorDodge,
+            mix_blend_mode::T::color_burn => ColorBurn,
+            mix_blend_mode::T::hard_light => HardLight,
+            mix_blend_mode::T::soft_light => SoftLight,
+            mix_blend_mode::T::difference => Difference,
+            mix_blend_mode::T::exclusion => Exclusion,
+            mix_blend_mode::T::hue => Hue,
+            mix_blend_mode::T::saturation => Saturation,
+            mix_blend_mode::T::color => Color,
+            mix_blend_mode::T::luminosity => Luminosity,
         }
     }
 }

--- a/components/layout/to_layout.rs
+++ b/components/layout/to_layout.rs
@@ -2,9 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use app_units::Au;
+use euclid::{Point2D, Rect, Size2D};
 use style::computed_values::{filter, image_rendering, mix_blend_mode};
 use style::values::computed;
-use webrender_traits::{BorderStyle, FilterOp, ImageRendering, MixBlendMode};
+use webrender_traits::{BorderStyle, FilterOp, ImageRendering, LayoutPoint, LayoutRect, LayoutSize, MixBlendMode};
 
 pub trait ToLayout {
     type Type;
@@ -87,5 +89,26 @@ impl ToLayout for image_rendering::T {
             image_rendering::T::auto => Auto,
             image_rendering::T::pixelated => Pixelated,
         }
+    }
+}
+
+impl ToLayout for Point2D<Au> {
+    type Type = LayoutPoint;
+    fn to_layout(&self) -> LayoutPoint {
+        LayoutPoint::new(self.x.to_f32_px(), self.y.to_f32_px())
+    }
+}
+
+impl ToLayout for Size2D<Au> {
+    type Type = LayoutSize;
+    fn to_layout(&self) -> LayoutSize {
+        LayoutSize::new(self.width.to_f32_px(), self.height.to_f32_px())
+    }
+}
+
+impl ToLayout for Rect<Au> {
+    type Type = LayoutRect;
+    fn to_layout(&self) -> LayoutRect {
+        LayoutRect::new(self.origin.to_layout(), self.size.to_layout())
     }
 }

--- a/components/layout/to_layout.rs
+++ b/components/layout/to_layout.rs
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use style::values::computed;
+use webrender_traits::BorderStyle;
+
+pub trait ToLayout {
+    type Type;
+    fn to_layout(&self) -> Self::Type;
+}
+
+impl ToLayout for computed::BorderStyle {
+    type Type = BorderStyle;
+    fn to_layout(&self) -> Self::Type {
+        use webrender_traits::BorderStyle::*;
+        match *self {
+            computed::BorderStyle::none => None,
+            computed::BorderStyle::solid => Solid,
+            computed::BorderStyle::double => Double,
+            computed::BorderStyle::dotted => Dotted,
+            computed::BorderStyle::dashed => Dashed,
+            computed::BorderStyle::hidden => Hidden,
+            computed::BorderStyle::groove => Groove,
+            computed::BorderStyle::ridge => Ridge,
+            computed::BorderStyle::inset => Inset,
+            computed::BorderStyle::outset => Outset,
+        }
+    }
+}

--- a/components/layout/to_layout.rs
+++ b/components/layout/to_layout.rs
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
-use euclid::{Point2D, Rect, Size2D};
+use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
 use style::computed_values::{filter, image_rendering, mix_blend_mode};
 use style::values::computed;
-use webrender_traits::{BorderStyle, FilterOp, ImageRendering, LayoutPoint, LayoutRect, LayoutSize, MixBlendMode};
+use webrender_traits::{BorderStyle, BorderWidths, FilterOp, ImageRendering, LayoutPoint, LayoutRect, LayoutSize, MixBlendMode};
 
 pub trait ToLayout {
     type Type;
@@ -110,5 +110,17 @@ impl ToLayout for Rect<Au> {
     type Type = LayoutRect;
     fn to_layout(&self) -> LayoutRect {
         LayoutRect::new(self.origin.to_layout(), self.size.to_layout())
+    }
+}
+
+impl ToLayout for SideOffsets2D<Au> {
+    type Type = BorderWidths;
+    fn to_layout(&self) -> BorderWidths {
+        BorderWidths {
+            left: self.left.to_f32_px(),
+            top: self.top.to_f32_px(),
+            right: self.right.to_f32_px(),
+            bottom: self.bottom.to_f32_px(),
+        }
     }
 }

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -440,9 +440,6 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                              rect.size,
                                              webrender_traits::LayoutSize::zero());
             }
-            DisplayItem::Line(..) => {
-                println!("TODO DisplayItem::Line");
-            }
             DisplayItem::BoxShadow(ref item) => {
                 let rect = item.base.bounds.to_rectf();
                 let box_bounds = item.box_bounds.to_rectf();

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -14,7 +14,6 @@ use gfx::display_list::{DisplayItem, DisplayList, DisplayListTraversal, Stacking
 use msg::constellation_msg::PipelineId;
 use style::computed_values::{image_rendering, mix_blend_mode, transform_style};
 use style::computed_values::filter::{self, Filter};
-use style::values::computed::BorderStyle;
 use webrender_traits::{self, DisplayListBuilder};
 use webrender_traits::{LayoutTransform, ClipId, ClipRegionToken};
 
@@ -26,27 +25,6 @@ trait WebRenderDisplayItemConverter {
     fn convert_to_webrender(&self,
                             builder: &mut DisplayListBuilder,
                             current_scroll_root_id: &mut ClipId);
-}
-
-trait ToBorderStyle {
-    fn to_border_style(&self) -> webrender_traits::BorderStyle;
-}
-
-impl ToBorderStyle for BorderStyle {
-    fn to_border_style(&self) -> webrender_traits::BorderStyle {
-        match *self {
-            BorderStyle::none => webrender_traits::BorderStyle::None,
-            BorderStyle::solid => webrender_traits::BorderStyle::Solid,
-            BorderStyle::double => webrender_traits::BorderStyle::Double,
-            BorderStyle::dotted => webrender_traits::BorderStyle::Dotted,
-            BorderStyle::dashed => webrender_traits::BorderStyle::Dashed,
-            BorderStyle::hidden => webrender_traits::BorderStyle::Hidden,
-            BorderStyle::groove => webrender_traits::BorderStyle::Groove,
-            BorderStyle::ridge => webrender_traits::BorderStyle::Ridge,
-            BorderStyle::inset => webrender_traits::BorderStyle::Inset,
-            BorderStyle::outset => webrender_traits::BorderStyle::Outset,
-        }
-    }
 }
 
 trait ToBorderWidths {
@@ -311,19 +289,19 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                     BorderDetails::Normal(ref border) => {
                         let left = webrender_traits::BorderSide {
                             color: border.color.left,
-                            style: border.style.left.to_border_style(),
+                            style: border.style.left,
                         };
                         let top = webrender_traits::BorderSide {
                             color: border.color.top,
-                            style: border.style.top.to_border_style(),
+                            style: border.style.top,
                         };
                         let right = webrender_traits::BorderSide {
                             color: border.color.right,
-                            style: border.style.right.to_border_style(),
+                            style: border.style.right,
                         };
                         let bottom = webrender_traits::BorderSide {
                             color: border.color.bottom,
-                            style: border.style.bottom.to_border_style(),
+                            style: border.style.bottom,
                         };
                         let radius = border.radius.to_border_radius();
                         webrender_traits::BorderDetails::Normal(webrender_traits::NormalBorder {

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -15,7 +15,7 @@ use msg::constellation_msg::PipelineId;
 use style::computed_values::{image_rendering, mix_blend_mode, transform_style};
 use style::computed_values::filter::{self, Filter};
 use style::values::computed::BorderStyle;
-use webrender_traits::{self, DisplayListBuilder, ExtendMode};
+use webrender_traits::{self, DisplayListBuilder};
 use webrender_traits::{LayoutTransform, ClipId, ClipRegionToken};
 
 pub trait WebRenderDisplayListConverter {
@@ -367,32 +367,22 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                         }
                     }
                     BorderDetails::Gradient(ref gradient) => {
-                        let extend_mode = if gradient.gradient.repeating {
-                            ExtendMode::Repeat
-                        } else {
-                            ExtendMode::Clamp
-                        };
                         webrender_traits::BorderDetails::Gradient(webrender_traits::GradientBorder {
                             gradient: builder.create_gradient(
                                           gradient.gradient.start_point.to_pointf(),
                                           gradient.gradient.end_point.to_pointf(),
                                           gradient.gradient.stops.clone(),
-                                          extend_mode),
+                                          gradient.gradient.extend_mode),
                             outset: gradient.outset,
                         })
                     }
                     BorderDetails::RadialGradient(ref gradient) => {
-                        let extend_mode = if gradient.gradient.repeating {
-                            ExtendMode::Repeat
-                        } else {
-                            ExtendMode::Clamp
-                        };
                        webrender_traits::BorderDetails::RadialGradient(webrender_traits::RadialGradientBorder {
                            gradient: builder.create_radial_gradient(
                                gradient.gradient.center.to_pointf(),
                                gradient.gradient.radius.to_sizef(),
                                gradient.gradient.stops.clone(),
-                               extend_mode),
+                               gradient.gradient.extend_mode),
                            outset: gradient.outset,
                        })
                     }
@@ -405,15 +395,10 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                 let start_point = item.gradient.start_point.to_pointf();
                 let end_point = item.gradient.end_point.to_pointf();
                 let clip = item.base.clip.push_clip_region(builder);
-                let extend_mode = if item.gradient.repeating {
-                    ExtendMode::Repeat
-                } else {
-                    ExtendMode::Clamp
-                };
                 let gradient = builder.create_gradient(start_point,
                                                        end_point,
                                                        item.gradient.stops.clone(),
-                                                       extend_mode);
+                                                       item.gradient.extend_mode);
                 builder.push_gradient(rect,
                                       clip,
                                       gradient,
@@ -425,15 +410,10 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                 let center = item.gradient.center.to_pointf();
                 let radius = item.gradient.radius.to_sizef();
                 let clip = item.base.clip.push_clip_region(builder);
-                let extend_mode = if item.gradient.repeating {
-                    ExtendMode::Repeat
-                } else {
-                    ExtendMode::Clamp
-                };
                 let gradient = builder.create_radial_gradient(center,
                                                               radius,
                                                               item.gradient.stops.clone(),
-                                                              extend_mode);
+                                                              item.gradient.extend_mode);
                 builder.push_radial_gradient(rect,
                                              clip,
                                              gradient,

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -9,7 +9,7 @@
 
 use app_units::Au;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
-use gfx::display_list::{BorderDetails, BorderRadii, BoxShadowClipMode, ClippingRegion};
+use gfx::display_list::{BorderDetails, BorderRadii, ClippingRegion};
 use gfx::display_list::{DisplayItem, DisplayList, DisplayListTraversal, StackingContextType};
 use msg::constellation_msg::PipelineId;
 use style::computed_values::{image_rendering, mix_blend_mode, transform_style};
@@ -60,20 +60,6 @@ impl ToBorderWidths for SideOffsets2D<Au> {
             top: self.top.to_f32_px(),
             right: self.right.to_f32_px(),
             bottom: self.bottom.to_f32_px(),
-        }
-    }
-}
-
-trait ToBoxShadowClipMode {
-    fn to_clip_mode(&self) -> webrender_traits::BoxShadowClipMode;
-}
-
-impl ToBoxShadowClipMode for BoxShadowClipMode {
-    fn to_clip_mode(&self) -> webrender_traits::BoxShadowClipMode {
-        match *self {
-            BoxShadowClipMode::None => webrender_traits::BoxShadowClipMode::None,
-            BoxShadowClipMode::Inset => webrender_traits::BoxShadowClipMode::Inset,
-            BoxShadowClipMode::Outset => webrender_traits::BoxShadowClipMode::Outset,
         }
     }
 }
@@ -432,7 +418,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                         item.blur_radius.to_f32_px(),
                                         item.spread_radius.to_f32_px(),
                                         item.border_radius.to_f32_px(),
-                                        item.clip_mode.to_clip_mode());
+                                        item.clip_mode);
             }
             DisplayItem::Iframe(ref item) => {
                 let rect = item.base.bounds.to_rectf();

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -146,7 +146,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                       item.text_run.font_key,
                                       item.text_color,
                                       item.text_run.actual_pt_size,
-                                      item.blur_radius.to_f32_px(),
+                                      item.blur_radius,
                                       None);
                 }
             }
@@ -258,8 +258,8 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                         box_bounds,
                                         item.offset,
                                         item.color,
-                                        item.blur_radius.to_f32_px(),
-                                        item.spread_radius.to_f32_px(),
+                                        item.blur_radius,
+                                        item.spread_radius,
                                         item.border_radius,
                                         item.clip_mode);
             }

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -12,7 +12,7 @@ use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
 use gfx::display_list::{BorderDetails, BorderRadii, ClippingRegion};
 use gfx::display_list::{DisplayItem, DisplayList, DisplayListTraversal, StackingContextType};
 use msg::constellation_msg::PipelineId;
-use style::computed_values::{image_rendering, transform_style};
+use style::computed_values::transform_style;
 use webrender_traits::{self, DisplayListBuilder};
 use webrender_traits::{LayoutTransform, ClipId, ClipRegionToken};
 
@@ -105,20 +105,6 @@ impl ToBorderRadius for BorderRadii<Au> {
             top_right: self.top_right.to_sizef(),
             bottom_left: self.bottom_left.to_sizef(),
             bottom_right: self.bottom_right.to_sizef(),
-        }
-    }
-}
-
-trait ToImageRendering {
-    fn to_image_rendering(&self) -> webrender_traits::ImageRendering;
-}
-
-impl ToImageRendering for image_rendering::T {
-    fn to_image_rendering(&self) -> webrender_traits::ImageRendering {
-        match *self {
-            image_rendering::T::crisp_edges => webrender_traits::ImageRendering::CrispEdges,
-            image_rendering::T::auto => webrender_traits::ImageRendering::Auto,
-            image_rendering::T::pixelated => webrender_traits::ImageRendering::Pixelated,
         }
     }
 }
@@ -219,7 +205,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                            clip,
                                            item.stretch_size.to_sizef(),
                                            item.tile_spacing.to_sizef(),
-                                           item.image_rendering.to_image_rendering(),
+                                           item.image_rendering,
                                            id);
                     }
                 }

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -9,7 +9,7 @@
 
 use app_units::Au;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
-use gfx::display_list::{BorderDetails, BorderRadii, ClippingRegion};
+use gfx::display_list::{BorderDetails, ClippingRegion};
 use gfx::display_list::{DisplayItem, DisplayList, DisplayListTraversal, StackingContextType};
 use msg::constellation_msg::PipelineId;
 use style::computed_values::transform_style;
@@ -87,25 +87,10 @@ impl ToClipRegion for ClippingRegion {
                                 self.complex.iter().map(|complex_clipping_region| {
                                     webrender_traits::ComplexClipRegion::new(
                                         complex_clipping_region.rect.to_rectf(),
-                                        complex_clipping_region.radii.to_border_radius(),
+                                        complex_clipping_region.radii,
                                      )
                                 }),
                                 None)
-    }
-}
-
-trait ToBorderRadius {
-    fn to_border_radius(&self) -> webrender_traits::BorderRadius;
-}
-
-impl ToBorderRadius for BorderRadii<Au> {
-    fn to_border_radius(&self) -> webrender_traits::BorderRadius {
-        webrender_traits::BorderRadius {
-            top_left: self.top_left.to_sizef(),
-            top_right: self.top_right.to_sizef(),
-            bottom_left: self.bottom_left.to_sizef(),
-            bottom_right: self.bottom_right.to_sizef(),
-        }
     }
 }
 
@@ -221,30 +206,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
 
                 let details = match item.details {
                     BorderDetails::Normal(ref border) => {
-                        let left = webrender_traits::BorderSide {
-                            color: border.color.left,
-                            style: border.style.left,
-                        };
-                        let top = webrender_traits::BorderSide {
-                            color: border.color.top,
-                            style: border.style.top,
-                        };
-                        let right = webrender_traits::BorderSide {
-                            color: border.color.right,
-                            style: border.style.right,
-                        };
-                        let bottom = webrender_traits::BorderSide {
-                            color: border.color.bottom,
-                            style: border.style.bottom,
-                        };
-                        let radius = border.radius.to_border_radius();
-                        webrender_traits::BorderDetails::Normal(webrender_traits::NormalBorder {
-                            left: left,
-                            top: top,
-                            right: right,
-                            bottom: bottom,
-                            radius: radius,
-                        })
+                        webrender_traits::BorderDetails::Normal(border.clone())
                     }
                     BorderDetails::Image(ref image) => {
                         match image.image.key {
@@ -329,7 +291,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                         item.color,
                                         item.blur_radius.to_f32_px(),
                                         item.spread_radius.to_f32_px(),
-                                        item.border_radius.to_f32_px(),
+                                        item.border_radius,
                                         item.clip_mode);
             }
             DisplayItem::Iframe(ref item) => {

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -8,7 +8,7 @@
 //           completely converting layout to directly generate WebRender display lists, for example.
 
 use app_units::Au;
-use euclid::{Point2D, Rect, SideOffsets2D};
+use euclid::{Point2D, Rect};
 use gfx::display_list::{BorderDetails, ClippingRegion};
 use gfx::display_list::{DisplayItem, DisplayList, DisplayListTraversal, StackingContextType};
 use msg::constellation_msg::PipelineId;
@@ -24,21 +24,6 @@ trait WebRenderDisplayItemConverter {
     fn convert_to_webrender(&self,
                             builder: &mut DisplayListBuilder,
                             current_scroll_root_id: &mut ClipId);
-}
-
-trait ToBorderWidths {
-    fn to_border_widths(&self) -> webrender_traits::BorderWidths;
-}
-
-impl ToBorderWidths for SideOffsets2D<Au> {
-    fn to_border_widths(&self) -> webrender_traits::BorderWidths {
-        webrender_traits::BorderWidths {
-            left: self.left.to_f32_px(),
-            top: self.top.to_f32_px(),
-            right: self.right.to_f32_px(),
-            bottom: self.bottom.to_f32_px(),
-        }
-    }
 }
 
 trait ToRectF {
@@ -185,7 +170,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
             }
             DisplayItem::Border(ref item) => {
                 let rect = item.base.bounds.to_rectf();
-                let widths = item.border_widths.to_border_widths();
+                let widths = item.border_widths;
                 let clip = item.base.clip.push_clip_region(builder);
 
                 let details = match item.details {

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -13,7 +13,6 @@ use gfx::display_list::{BorderDetails, BorderRadii, ClippingRegion};
 use gfx::display_list::{DisplayItem, DisplayList, DisplayListTraversal, StackingContextType};
 use msg::constellation_msg::PipelineId;
 use style::computed_values::{image_rendering, transform_style};
-use style::computed_values::filter::{self, Filter};
 use webrender_traits::{self, DisplayListBuilder};
 use webrender_traits::{LayoutTransform, ClipId, ClipRegionToken};
 
@@ -121,30 +120,6 @@ impl ToImageRendering for image_rendering::T {
             image_rendering::T::auto => webrender_traits::ImageRendering::Auto,
             image_rendering::T::pixelated => webrender_traits::ImageRendering::Pixelated,
         }
-    }
-}
-
-trait ToFilterOps {
-    fn to_filter_ops(&self) -> Vec<webrender_traits::FilterOp>;
-}
-
-impl ToFilterOps for filter::T {
-    fn to_filter_ops(&self) -> Vec<webrender_traits::FilterOp> {
-        let mut result = Vec::with_capacity(self.filters.len());
-        for filter in self.filters.iter() {
-            match *filter {
-                Filter::Blur(radius) => result.push(webrender_traits::FilterOp::Blur(radius)),
-                Filter::Brightness(amount) => result.push(webrender_traits::FilterOp::Brightness(amount)),
-                Filter::Contrast(amount) => result.push(webrender_traits::FilterOp::Contrast(amount)),
-                Filter::Grayscale(amount) => result.push(webrender_traits::FilterOp::Grayscale(amount)),
-                Filter::HueRotate(angle) => result.push(webrender_traits::FilterOp::HueRotate(angle.radians())),
-                Filter::Invert(amount) => result.push(webrender_traits::FilterOp::Invert(amount)),
-                Filter::Opacity(amount) => result.push(webrender_traits::FilterOp::Opacity(amount.into())),
-                Filter::Saturate(amount) => result.push(webrender_traits::FilterOp::Saturate(amount)),
-                Filter::Sepia(amount) => result.push(webrender_traits::FilterOp::Sepia(amount)),
-            }
-        }
-        result
     }
 }
 
@@ -394,7 +369,7 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                               stacking_context.transform_style,
                                               perspective,
                                               stacking_context.mix_blend_mode,
-                                              stacking_context.filters.to_filter_ops());
+                                              stacking_context.filters.clone());
             }
             DisplayItem::PopStackingContext(_) => builder.pop_stacking_context(),
             DisplayItem::DefineClip(ref item) => {

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -12,7 +12,7 @@ use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
 use gfx::display_list::{BorderDetails, BorderRadii, ClippingRegion};
 use gfx::display_list::{DisplayItem, DisplayList, DisplayListTraversal, StackingContextType};
 use msg::constellation_msg::PipelineId;
-use style::computed_values::{image_rendering, mix_blend_mode, transform_style};
+use style::computed_values::{image_rendering, transform_style};
 use style::computed_values::filter::{self, Filter};
 use webrender_traits::{self, DisplayListBuilder};
 use webrender_traits::{LayoutTransform, ClipId, ClipRegionToken};
@@ -106,33 +106,6 @@ impl ToBorderRadius for BorderRadii<Au> {
             top_right: self.top_right.to_sizef(),
             bottom_left: self.bottom_left.to_sizef(),
             bottom_right: self.bottom_right.to_sizef(),
-        }
-    }
-}
-
-pub trait ToMixBlendMode {
-    fn to_mix_blend_mode(&self) -> webrender_traits::MixBlendMode;
-}
-
-impl ToMixBlendMode for mix_blend_mode::T {
-    fn to_mix_blend_mode(&self) -> webrender_traits::MixBlendMode {
-        match *self {
-            mix_blend_mode::T::normal => webrender_traits::MixBlendMode::Normal,
-            mix_blend_mode::T::multiply => webrender_traits::MixBlendMode::Multiply,
-            mix_blend_mode::T::screen => webrender_traits::MixBlendMode::Screen,
-            mix_blend_mode::T::overlay => webrender_traits::MixBlendMode::Overlay,
-            mix_blend_mode::T::darken => webrender_traits::MixBlendMode::Darken,
-            mix_blend_mode::T::lighten => webrender_traits::MixBlendMode::Lighten,
-            mix_blend_mode::T::color_dodge => webrender_traits::MixBlendMode::ColorDodge,
-            mix_blend_mode::T::color_burn => webrender_traits::MixBlendMode::ColorBurn,
-            mix_blend_mode::T::hard_light => webrender_traits::MixBlendMode::HardLight,
-            mix_blend_mode::T::soft_light => webrender_traits::MixBlendMode::SoftLight,
-            mix_blend_mode::T::difference => webrender_traits::MixBlendMode::Difference,
-            mix_blend_mode::T::exclusion => webrender_traits::MixBlendMode::Exclusion,
-            mix_blend_mode::T::hue => webrender_traits::MixBlendMode::Hue,
-            mix_blend_mode::T::saturation => webrender_traits::MixBlendMode::Saturation,
-            mix_blend_mode::T::color => webrender_traits::MixBlendMode::Color,
-            mix_blend_mode::T::luminosity => webrender_traits::MixBlendMode::Luminosity,
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR is the first step in resolving the TODO at the top of the *webrender_helpers.rs* file.
> TODO(gw): This contains helper traits and implementations for converting Servo display lists
>           into WebRender display lists. In the future, this step should be completely removed.
>           This might be achieved by sharing types between WR and Servo display lists, or
>           completely converting layout to directly generate WebRender display lists, for example.

It moves logic outside of the helper file into the *display_list_builder.rs*. Where possible intermediate types are removed and webrender types are used. Inside display list types `LayoutPoint` and friends are used like in webrender. This PR will make it easier to completely remove intermediate display lists in servo.

There is a [FIXME](https://github.com/pyfisch/servo/blob/674efa355a8abd234677a8a689fcdc8511528153/components/layout/webrender_helpers.rs#L114) in *webrender_helpers.rs* depending on servo/webrender#1244.

The `derive(HeapSizeOf)` was removed from display list types because it is unused and made it impossible to use some webrender types inside of them since they do not implement it.

This is similar to #14546 by @pcwalton but does not completely replace old display lists yet.

If this changeset is too big it can also be merged in steps since all commits leave servo in a working condition.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors


<!-- Either: -->
- [X] These changes do not require tests because: *refactor*

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16838)
<!-- Reviewable:end -->
