### PR TITLE
Fix the situation when :any-link starts or stops matching to actually restyle correctly.

### DIFF
--- a/components/style/gecko/non_ts_pseudo_class_list.rs
+++ b/components/style/gecko/non_ts_pseudo_class_list.rs
@@ -38,7 +38,9 @@
  * possible.
  *
  * $gecko_type can be either "_" or an ident in Gecko's CSSPseudoClassType.
- * $state can be either "_" or an expression of type ElementState.
+ * $state can be either "_" or an expression of type ElementState.  If present,
+ *        the semantics are that the pseudo-class matches if any of the bits in
+ *        $state are set on the element.
  * $flags can be either "_" or an expression of type NonTSPseudoClassFlag,
  * see selector_parser.rs for more details.
  */

--- a/components/style/restyle_hints.rs
+++ b/components/style/restyle_hints.rs
@@ -343,7 +343,7 @@ impl<'a, E> Element for ElementWrapper<'a, E>
                                                           &mut |_, _| {})
         }
         match self.snapshot().and_then(|s| s.state()) {
-            Some(snapshot_state) => snapshot_state.contains(flag),
+            Some(snapshot_state) => snapshot_state.intersects(flag),
             None => {
                 self.element.match_non_ts_pseudo_class(pseudo_class,
                                                        relations,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://bugzilla.mozilla.org/show_bug.cgi?id=1364335

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16841)
<!-- Reviewable:end -->
