### PR TITLE
explicitly specify bitness for x86 cross-compilation situations

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -153,6 +153,15 @@ mod bindings {
             }
             if cfg!(target_os = "linux") {
                 builder = builder.clang_arg("-DOS_LINUX=1");
+                // We may be cross-compiling with a clang that defaults to
+                // a different architecture, so we should explicitly specify
+                // the bitness being used here. Specifying --target instead
+                // leads to difficulties with LLVM search paths.
+                if cfg!(target_arch = "x86") {
+                    builder = builder.clang_arg("-m32")
+                } else if cfg!(target_arch = "x86_64") {
+                    builder = builder.clang_arg("-m64")
+                }
             } else if cfg!(target_os = "solaris") {
                 builder = builder.clang_arg("-DOS_SOLARIS=1");
             } else if cfg!(target_os = "dragonfly") {


### PR DESCRIPTION
Despite compiling for architecture X, the user may have specified a
clang that defaults to architecture Y.  We need to ensure that we invoke
clang with the correct architecture selection.  We do not use --target
to do this, however, because that runs into problems with LLVM's default
search paths.  For the x86 case, we can simply use -m$BITNESS to select
the correct architecture.

This is not at all a general solution, but it does unblock compiling Stylo for 32-bit Linux on Gecko's infra.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16843)
<!-- Reviewable:end -->
