### PR TITLE
stylo: -moz-image-region shouldn't parse unitless lengths in quirks mode

### DIFF
--- a/components/style/properties/longhand/effects.mako.rs
+++ b/components/style/properties/longhand/effects.mako.rs
@@ -83,6 +83,7 @@ ${helpers.predefined_type("clip",
                           "computed::ClipRectOrAuto::auto()",
                           animation_value_type="ComputedValue",
                           boxed="True",
+                          allow_quirks=True,
                           spec="https://drafts.fxtf.org/css-masking/#clip-property")}
 
 // FIXME: This prop should be animatable


### PR DESCRIPTION
For clip property, `ClipRectOrAuto` was parsing its lengths without units in quirks mode. But `-moz-image-region` property should reject unitless lengths according to gecko. This fixes a stylo test failure.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16856)
<!-- Reviewable:end -->
