### PR TITLE
Properly handle scroll offsets in hit testing

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -81,8 +81,8 @@ pub struct LayoutThreadData {
     /// A queued response for the offset parent/rect of a node.
     pub margin_style_response: MarginStyleResponse,
 
-    /// Scroll offsets of stacking contexts. This will only be populated if WebRender is in use.
-    pub stacking_context_scroll_offsets: ScrollOffsetMap,
+    /// Scroll offsets of scrolling regions.
+    pub scroll_offsets: ScrollOffsetMap,
 
     /// Index in a text fragment. We need this do determine the insertion point.
     pub text_index_response: TextIndexResponse,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1955,12 +1955,8 @@ impl Document {
     }
 
     pub fn nodes_from_point(&self, client_point: &Point2D<f32>) -> Vec<UntrustedNodeAddress> {
-        let page_point =
-            Point2D::new(client_point.x + self.window.PageXOffset() as f32,
-                         client_point.y + self.window.PageYOffset() as f32);
-
         if !self.window.reflow(ReflowGoal::ForScriptQuery,
-                               ReflowQueryType::NodesFromPoint(page_point, *client_point),
+                               ReflowQueryType::NodesFromPoint(*client_point),
                                ReflowReason::Query) {
             return vec!();
         };

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -12,8 +12,8 @@ use msg::constellation_msg::PipelineId;
 use net_traits::image_cache::ImageCache;
 use profile_traits::mem::ReportsChan;
 use rpc::LayoutRPC;
-use script_traits::{ConstellationControlMsg, LayoutControlMsg, UntrustedNodeAddress};
-use script_traits::{LayoutMsg as ConstellationMsg, StackingContextScrollState, WindowSizeData};
+use script_traits::{ConstellationControlMsg, LayoutControlMsg, LayoutMsg as ConstellationMsg};
+use script_traits::{ScrollState, UntrustedNodeAddress, WindowSizeData};
 use servo_url::ServoUrl;
 use std::sync::Arc;
 use std::sync::mpsc::{Receiver, Sender};
@@ -79,7 +79,11 @@ pub enum Msg {
     SetFinalUrl(ServoUrl),
 
     /// Tells layout about the new scrolling offsets of each scrollable stacking context.
-    SetStackingContextScrollStates(Vec<StackingContextScrollState>),
+    SetScrollStates(Vec<ScrollState>),
+
+    /// Tells layout about a single new scrolling offset from the script. The rest will
+    /// remain untouched and layout won't forward this back to script.
+    UpdateScrollStateFromScript(ScrollState),
 }
 
 
@@ -90,7 +94,7 @@ pub enum ReflowQueryType {
     ContentBoxQuery(TrustedNodeAddress),
     ContentBoxesQuery(TrustedNodeAddress),
     NodeOverflowQuery(TrustedNodeAddress),
-    HitTestQuery(Point2D<f32>, Point2D<f32>, bool),
+    HitTestQuery(Point2D<f32>, bool),
     NodeScrollRootIdQuery(TrustedNodeAddress),
     NodeGeometryQuery(TrustedNodeAddress),
     NodeScrollGeometryQuery(TrustedNodeAddress),
@@ -98,7 +102,7 @@ pub enum ReflowQueryType {
     OffsetParentQuery(TrustedNodeAddress),
     MarginStyleQuery(TrustedNodeAddress),
     TextIndexQuery(TrustedNodeAddress, i32, i32),
-    NodesFromPoint(Point2D<f32>, Point2D<f32>),
+    NodesFromPoint(Point2D<f32>),
 }
 
 /// Information needed for a reflow.

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -122,7 +122,7 @@ pub enum LayoutControlMsg {
     /// Asks layout to run another step in its animation.
     TickAnimations,
     /// Tells layout about the new scrolling offsets of each scrollable stacking context.
-    SetStackingContextScrollStates(Vec<StackingContextScrollState>),
+    SetScrollStates(Vec<ScrollState>),
     /// Requests the current load state of Web fonts. `true` is returned if fonts are still loading
     /// and `false` is returned if all fonts have loaded.
     GetWebFontLoadState(IpcSender<bool>),
@@ -673,7 +673,7 @@ pub enum AnimationTickType {
 
 /// The scroll state of a stacking context.
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
-pub struct StackingContextScrollState {
+pub struct ScrollState {
     /// The ID of the scroll root.
     pub scroll_root_id: ClipId,
     /// The scrolling offset of this stacking context.


### PR DESCRIPTION
Scroll roots are no longer nested containers holding items, so instead
we need to track the offsets of each, carefully handling fixed position
items and stacking contexts that create new reference frames.
Additionally, we remove the complexity of the pre-computed page scroll
offset, instead opting to send script scrolls to the layout task in
order to more quickly have a ScrollState there that matches the
script's idea of the scroll world.

Fixes #16405.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #16405.

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it is currently impossible to test interactive scrolling with Servo's test infrastructure. Existing tests verify the script part though.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16865)
<!-- Reviewable:end -->
