### PR TITLE
Fix dynamic updates when :dir matching changes in stylo.

### DIFF
--- a/components/style/element_state.rs
+++ b/components/style/element_state.rs
@@ -115,6 +115,11 @@ bitflags! {
         const IN_HANDLER_VULNERABLE_NO_UPDATE_STATE = 1 << 42,
         /// https://drafts.csswg.org/selectors-4/#the-focus-within-pseudo
         const IN_FOCUS_WITHIN_STATE = 1 << 43,
+        /// :dir matching; the states are used for dynamic change detection.
+        /// State that elements that match :dir(ltr) are in.
+        const IN_LTR_STATE = 1 << 44,
+        /// State that elements that match :dir(rtl) are in.
+        const IN_RTL_STATE = 1 << 45,
         /// Non-standard & undocumented.
         const IN_AUTOFILL_STATE = 1 << 50,
         /// Non-standard & undocumented.


### PR DESCRIPTION
This is the servo part of https://bugzilla.mozilla.org/show_bug.cgi?id=1364280

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://bugzilla.mozilla.org/show_bug.cgi?id=1364280
<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because Gecko has lots of tests for this and this is Gecko-only.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16873)
<!-- Reviewable:end -->
