### PR TITLE
Renamed constellation::Frame to constellation::BrowsingContext

### DIFF
--- a/components/constellation/browsingcontext.rs
+++ b/components/constellation/browsingcontext.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use euclid::size::TypedSize2D;
-use msg::constellation_msg::{FrameId, PipelineId};
+use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use pipeline::Pipeline;
 use script_traits::LoadData;
 use std::collections::HashMap;
@@ -12,17 +12,16 @@ use std::mem::replace;
 use std::time::Instant;
 use style_traits::CSSPixel;
 
-/// A frame in the frame tree.
-/// Each frame is the constellation's view of a browsing context.
+/// The constellation's view of a browsing context.
 /// Each browsing context has a session history, caused by
-/// navigation and traversing the history. Each frame has its
+/// navigation and traversing the history. Each browsing contest has its
 /// current entry, plus past and future entries. The past is sorted
 /// chronologically, the future is sorted reverse chronologically:
 /// in particular prev.pop() is the latest past entry, and
 /// next.pop() is the earliest future entry.
-pub struct Frame {
-    /// The frame id.
-    pub id: FrameId,
+pub struct BrowsingContext {
+    /// The browsing context id.
+    pub id: BrowsingContextId,
 
     /// The size of the frame.
     pub size: Option<TypedSize2D<f32, CSSPixel>>,
@@ -37,17 +36,17 @@ pub struct Frame {
     pub load_data: LoadData,
 
     /// The past session history, ordered chronologically.
-    pub prev: Vec<FrameState>,
+    pub prev: Vec<SessionHistoryEntry>,
 
     /// The future session history, ordered reverse chronologically.
-    pub next: Vec<FrameState>,
+    pub next: Vec<SessionHistoryEntry>,
 }
 
-impl Frame {
-    /// Create a new frame.
-    /// Note this just creates the frame, it doesn't add it to the frame tree.
-    pub fn new(id: FrameId, pipeline_id: PipelineId, load_data: LoadData) -> Frame {
-        Frame {
+impl BrowsingContext {
+    /// Create a new browsing context.
+    /// Note this just creates the browsing context, it doesn't add it to the constellation's set of browsing contexts.
+    pub fn new(id: BrowsingContextId, pipeline_id: PipelineId, load_data: LoadData) -> BrowsingContext {
+        BrowsingContext {
             id: id,
             size: None,
             pipeline_id: pipeline_id,
@@ -58,17 +57,17 @@ impl Frame {
         }
     }
 
-    /// Get the current frame state.
-    pub fn current(&self) -> FrameState {
-        FrameState {
+    /// Get the current session history entry.
+    pub fn current(&self) -> SessionHistoryEntry {
+        SessionHistoryEntry {
             instant: self.instant,
-            frame_id: self.id,
+            browsing_context_id: self.id,
             pipeline_id: Some(self.pipeline_id),
             load_data: self.load_data.clone(),
         }
     }
 
-    /// Set the current frame entry, and push the current frame entry into the past.
+    /// Set the current session history entry, and push the current frame entry into the past.
     pub fn load(&mut self, pipeline_id: PipelineId, load_data: LoadData) {
         let current = self.current();
         self.prev.push(current);
@@ -78,25 +77,27 @@ impl Frame {
     }
 
     /// Set the future to be empty.
-    pub fn remove_forward_entries(&mut self) -> Vec<FrameState> {
+    pub fn remove_forward_entries(&mut self) -> Vec<SessionHistoryEntry> {
         replace(&mut self.next, vec!())
     }
 
-    /// Update the current entry of the Frame from an entry that has been traversed to.
-    pub fn update_current(&mut self, pipeline_id: PipelineId, entry: FrameState) {
+    /// Update the current entry of the BrowsingContext from an entry that has been traversed to.
+    pub fn update_current(&mut self, pipeline_id: PipelineId, entry: SessionHistoryEntry) {
         self.pipeline_id = pipeline_id;
         self.instant = entry.instant;
         self.load_data = entry.load_data;
     }
 }
 
-/// An entry in a frame's session history.
+/// An entry in a browsing context's session history.
 /// Each entry stores the pipeline id for a document in the session history.
 ///
 /// When we operate on the joint session history, entries are sorted chronologically,
 /// so we timestamp the entries by when the entry was added to the session history.
+///
+/// https://html.spec.whatwg.org/multipage/#session-history-entry
 #[derive(Clone)]
-pub struct FrameState {
+pub struct SessionHistoryEntry {
     /// The timestamp for when the session history entry was created
     pub instant: Instant,
 
@@ -108,14 +109,14 @@ pub struct FrameState {
     pub load_data: LoadData,
 
     /// The frame that this session history entry is part of
-    pub frame_id: FrameId,
+    pub browsing_context_id: BrowsingContextId,
 }
 
-/// Represents a pending change in the frame tree, that will be applied
+/// Represents a pending change in a session history, that will be applied
 /// once the new pipeline has loaded and completed initial layout / paint.
-pub struct FrameChange {
-    /// The frame to change.
-    pub frame_id: FrameId,
+pub struct SessionHistoryChange {
+    /// The browsing context to change.
+    pub browsing_context_id: BrowsingContextId,
 
     /// The pipeline for the document being loaded.
     pub new_pipeline_id: PipelineId,
@@ -129,16 +130,15 @@ pub struct FrameChange {
     pub replace_instant: Option<Instant>,
 }
 
-/// An iterator over a frame tree, returning the fully active frames in
-/// depth-first order. Note that this iterator only returns the fully
-/// active frames, that is ones where every ancestor frame is
-/// in the currently active pipeline of its parent frame.
-pub struct FrameTreeIterator<'a> {
-    /// The frames still to iterate over.
-    pub stack: Vec<FrameId>,
+/// An iterator over browsing contexts, returning the descendant
+/// contexts whose active documents are fully active, in depth-first
+/// order.
+pub struct FullyActiveBrowsingContextsIterator<'a> {
+    /// The browsing contexts still to iterate over.
+    pub stack: Vec<BrowsingContextId>,
 
-    /// The set of all frames.
-    pub frames: &'a HashMap<FrameId, Frame>,
+    /// The set of all browsing contexts.
+    pub browsing_contexts: &'a HashMap<BrowsingContextId, BrowsingContext>,
 
     /// The set of all pipelines.  We use this to find the active
     /// children of a frame, which are the iframes in the currently
@@ -146,73 +146,73 @@ pub struct FrameTreeIterator<'a> {
     pub pipelines: &'a HashMap<PipelineId, Pipeline>,
 }
 
-impl<'a> Iterator for FrameTreeIterator<'a> {
-    type Item = &'a Frame;
-    fn next(&mut self) -> Option<&'a Frame> {
+impl<'a> Iterator for FullyActiveBrowsingContextsIterator<'a> {
+    type Item = &'a BrowsingContext;
+    fn next(&mut self) -> Option<&'a BrowsingContext> {
         loop {
-            let frame_id = match self.stack.pop() {
-                Some(frame_id) => frame_id,
+            let browsing_context_id = match self.stack.pop() {
+                Some(browsing_context_id) => browsing_context_id,
                 None => return None,
             };
-            let frame = match self.frames.get(&frame_id) {
-                Some(frame) => frame,
+            let browsing_context = match self.browsing_contexts.get(&browsing_context_id) {
+                Some(browsing_context) => browsing_context,
                 None => {
-                    warn!("Frame {:?} iterated after closure.", frame_id);
+                    warn!("BrowsingContext {:?} iterated after closure.", browsing_context_id);
                     continue;
                 },
             };
-            let pipeline = match self.pipelines.get(&frame.pipeline_id) {
+            let pipeline = match self.pipelines.get(&browsing_context.pipeline_id) {
                 Some(pipeline) => pipeline,
                 None => {
-                    warn!("Pipeline {:?} iterated after closure.", frame.pipeline_id);
+                    warn!("Pipeline {:?} iterated after closure.", browsing_context.pipeline_id);
                     continue;
                 },
             };
             self.stack.extend(pipeline.children.iter());
-            return Some(frame)
+            return Some(browsing_context)
         }
     }
 }
 
-/// An iterator over a frame tree, returning all frames in depth-first
-/// order. Note that this iterator returns all frames, not just the
-/// fully active ones.
-pub struct FullFrameTreeIterator<'a> {
-    /// The frames still to iterate over.
-    pub stack: Vec<FrameId>,
+/// An iterator over browsing contexts, returning all descendant
+/// contexts in depth-first order. Note that this iterator returns all
+/// contexts, not just the fully active ones.
+pub struct AllBrowsingContextsIterator<'a> {
+    /// The browsing contexts still to iterate over.
+    pub stack: Vec<BrowsingContextId>,
 
-    /// The set of all frames.
-    pub frames: &'a HashMap<FrameId, Frame>,
+    /// The set of all browsing contexts.
+    pub browsing_contexts: &'a HashMap<BrowsingContextId, BrowsingContext>,
 
     /// The set of all pipelines.  We use this to find the
-    /// children of a frame, which are the iframes in all documents
+    /// children of a browsing context, which are the iframes in all documents
     /// in the session history.
     pub pipelines: &'a HashMap<PipelineId, Pipeline>,
 }
 
-impl<'a> Iterator for FullFrameTreeIterator<'a> {
-    type Item = &'a Frame;
-    fn next(&mut self) -> Option<&'a Frame> {
+impl<'a> Iterator for AllBrowsingContextsIterator<'a> {
+    type Item = &'a BrowsingContext;
+    fn next(&mut self) -> Option<&'a BrowsingContext> {
         let pipelines = self.pipelines;
         loop {
-            let frame_id = match self.stack.pop() {
-                Some(frame_id) => frame_id,
+            let browsing_context_id = match self.stack.pop() {
+                Some(browsing_context_id) => browsing_context_id,
                 None => return None,
             };
-            let frame = match self.frames.get(&frame_id) {
-                Some(frame) => frame,
+            let browsing_context = match self.browsing_contexts.get(&browsing_context_id) {
+                Some(browsing_context) => browsing_context,
                 None => {
-                    warn!("Frame {:?} iterated after closure.", frame_id);
+                    warn!("BrowsingContext {:?} iterated after closure.", browsing_context_id);
                     continue;
                 },
             };
-            let child_frame_ids = frame.prev.iter().chain(frame.next.iter())
+            let child_browsing_context_ids = browsing_context.prev.iter().chain(browsing_context.next.iter())
                 .filter_map(|entry| entry.pipeline_id)
-                .chain(once(frame.pipeline_id))
+                .chain(once(browsing_context.pipeline_id))
                 .filter_map(|pipeline_id| pipelines.get(&pipeline_id))
                 .flat_map(|pipeline| pipeline.children.iter());
-            self.stack.extend(child_frame_ids);
-            return Some(frame)
+            self.stack.extend(child_browsing_context_ids);
+            return Some(browsing_context)
         }
     }
 }

--- a/components/constellation/lib.rs
+++ b/components/constellation/lib.rs
@@ -41,9 +41,9 @@ extern crate style_traits;
 extern crate webrender_traits;
 extern crate webvr_traits;
 
+mod browsingcontext;
 mod constellation;
 mod event_loop;
-mod frame;
 mod pipeline;
 #[cfg(not(target_os = "windows"))]
 mod sandboxing;

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -34,7 +34,7 @@ use inline::{FIRST_FRAGMENT_OF_ELEMENT, InlineFlow, LAST_FRAGMENT_OF_ELEMENT};
 use ipc_channel::ipc;
 use list_item::ListItemFlow;
 use model::{self, MaybeAuto, specified};
-use msg::constellation_msg::FrameId;
+use msg::constellation_msg::BrowsingContextId;
 use net_traits::image::base::PixelFormat;
 use net_traits::image_cache::UsePlaceholder;
 use range::Range;
@@ -175,7 +175,7 @@ pub struct DisplayListBuildState<'a> {
 
     /// Vector containing iframe sizes, used to inform the constellation about
     /// new iframe sizes
-    pub iframe_sizes: Vec<(FrameId, TypedSize2D<f32, CSSPixel>)>,
+    pub iframe_sizes: Vec<(BrowsingContextId, TypedSize2D<f32, CSSPixel>)>,
 
     /// A stack of clips used to cull display list entries that are outside the
     /// rendered region.
@@ -1823,7 +1823,7 @@ impl FragmentDisplayListBuilding for Fragment {
 
                     let size = Size2D::new(item.bounds().size.width.to_f32_px(),
                                            item.bounds().size.height.to_f32_px());
-                    state.iframe_sizes.push((fragment_info.frame_id, TypedSize2D::from_untyped(&size)));
+                    state.iframe_sizes.push((fragment_info.browsing_context_id, TypedSize2D::from_untyped(&size)));
 
                     state.add_display_item(item);
                 }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -26,7 +26,7 @@ use ipc_channel::ipc::IpcSender;
 use layout_debug;
 use model::{self, IntrinsicISizes, IntrinsicISizesContribution, MaybeAuto, SizeConstraint};
 use model::{style_length, ToGfxMatrix};
-use msg::constellation_msg::{FrameId, PipelineId};
+use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use net_traits::image::base::{Image, ImageMetadata};
 use net_traits::image_cache::{ImageOrMetadataAvailable, UsePlaceholder};
 use range::*;
@@ -472,7 +472,7 @@ impl ImageFragmentInfo {
 #[derive(Clone)]
 pub struct IframeFragmentInfo {
     /// The frame ID of this iframe.
-    pub frame_id: FrameId,
+    pub browsing_context_id: BrowsingContextId,
     /// The pipelineID of this iframe.
     pub pipeline_id: PipelineId,
 }
@@ -480,10 +480,10 @@ pub struct IframeFragmentInfo {
 impl IframeFragmentInfo {
     /// Creates the information specific to an iframe fragment.
     pub fn new<N: ThreadSafeLayoutNode>(node: &N) -> IframeFragmentInfo {
-        let frame_id = node.iframe_frame_id();
+        let browsing_context_id = node.iframe_browsing_context_id();
         let pipeline_id = node.iframe_pipeline_id();
         IframeFragmentInfo {
-            frame_id: frame_id,
+            browsing_context_id: browsing_context_id,
             pipeline_id: pipeline_id,
         }
     }

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -74,7 +74,7 @@ use layout::webrender_helpers::WebRenderDisplayListConverter;
 use layout::wrapper::LayoutNodeLayoutData;
 use layout::wrapper::drop_style_and_layout_data;
 use layout_traits::LayoutThreadFactory;
-use msg::constellation_msg::{FrameId, PipelineId};
+use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use net_traits::image_cache::{ImageCache, UsePlaceholder};
 use parking_lot::RwLock;
 use profile_traits::mem::{self, Report, ReportKind, ReportsChan};
@@ -244,7 +244,7 @@ impl LayoutThreadFactory for LayoutThread {
 
     /// Spawns a new layout thread.
     fn create(id: PipelineId,
-              top_level_frame_id: Option<FrameId>,
+              top_level_browsing_context_id: Option<BrowsingContextId>,
               url: ServoUrl,
               is_iframe: bool,
               chan: (Sender<Msg>, Receiver<Msg>),
@@ -261,8 +261,8 @@ impl LayoutThreadFactory for LayoutThread {
         thread::Builder::new().name(format!("LayoutThread {:?}", id)).spawn(move || {
             thread_state::initialize(thread_state::LAYOUT);
 
-            if let Some(top_level_frame_id) = top_level_frame_id {
-                FrameId::install(top_level_frame_id);
+            if let Some(top_level_browsing_context_id) = top_level_browsing_context_id {
+                BrowsingContextId::install(top_level_browsing_context_id);
             }
 
             { // Ensures layout thread is destroyed before we send shutdown message
@@ -730,7 +730,7 @@ impl LayoutThread {
 
     fn create_layout_thread(&self, info: NewLayoutThreadInfo) {
         LayoutThread::create(info.id,
-                             FrameId::installed(),
+                             BrowsingContextId::installed(),
                              info.url.clone(),
                              info.is_parent,
                              info.layout_pair,
@@ -928,7 +928,7 @@ impl LayoutThread {
                             // build_state.iframe_sizes is only used here, so its okay to replace
                             // it with an empty vector
                             let iframe_sizes = std::mem::replace(&mut build_state.iframe_sizes, vec![]);
-                            let msg = ConstellationMsg::FrameSizes(iframe_sizes);
+                            let msg = ConstellationMsg::IFrameSizes(iframe_sizes);
                             if let Err(e) = self.constellation_chan.send(msg) {
                                 warn!("Layout resize to constellation failed ({}).", e);
                             }

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -20,7 +20,7 @@ extern crate webrender_traits;
 
 use gfx::font_cache_thread::FontCacheThread;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
-use msg::constellation_msg::{FrameId, PipelineId};
+use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use net_traits::image_cache::ImageCache;
 use profile_traits::{mem, time};
 use script_traits::{ConstellationControlMsg, LayoutControlMsg};
@@ -34,7 +34,7 @@ use std::sync::mpsc::{Receiver, Sender};
 pub trait LayoutThreadFactory {
     type Message;
     fn create(id: PipelineId,
-              top_level_frame_id: Option<FrameId>,
+              top_level_browsing_context_id: Option<BrowsingContextId>,
               url: ServoUrl,
               is_iframe: bool,
               chan: (Sender<Self::Message>, Receiver<Self::Message>),

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -58,7 +58,7 @@ use js::glue::{CallObjectTracer, CallValueTracer};
 use js::jsapi::{GCTraceKindToAscii, Heap, JSObject, JSTracer, TraceKind};
 use js::jsval::JSVal;
 use js::rust::Runtime;
-use msg::constellation_msg::{FrameId, FrameType, PipelineId};
+use msg::constellation_msg::{BrowsingContextId, FrameType, PipelineId};
 use net_traits::{Metadata, NetworkError, ReferrerPolicy, ResourceThreads};
 use net_traits::filemanager_thread::RelativePos;
 use net_traits::image::base::{Image, ImageMetadata};
@@ -336,7 +336,7 @@ unsafe_no_jsmanaged_fields!(TrustedPromise);
 unsafe_no_jsmanaged_fields!(PropertyDeclarationBlock);
 // These three are interdependent, if you plan to put jsmanaged data
 // in one of these make sure it is propagated properly to containing structs
-unsafe_no_jsmanaged_fields!(DocumentActivity, FrameId, FrameType, WindowSizeData, WindowSizeType, PipelineId);
+unsafe_no_jsmanaged_fields!(DocumentActivity, BrowsingContextId, FrameType, WindowSizeData, WindowSizeType, PipelineId);
 unsafe_no_jsmanaged_fields!(TimerEventId, TimerSource);
 unsafe_no_jsmanaged_fields!(TimelineMarkerType);
 unsafe_no_jsmanaged_fields!(WorkerId);

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -27,7 +27,7 @@ use js::jsapi::{HandleValue, JS_SetInterruptCallback};
 use js::jsapi::{JSAutoCompartment, JSContext};
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
-use msg::constellation_msg::FrameId;
+use msg::constellation_msg::BrowsingContextId;
 use net_traits::{IpcSend, load_whole_resource};
 use net_traits::request::{CredentialsMode, Destination, RequestInit, Type as RequestType};
 use script_runtime::{CommonScriptMsg, ScriptChan, ScriptPort, StackRootTLS, get_reports, new_rt_and_cx};
@@ -159,13 +159,13 @@ impl DedicatedWorkerGlobalScope {
                             closing: Arc<AtomicBool>) {
         let serialized_worker_url = worker_url.to_string();
         let name = format!("WebWorker for {}", serialized_worker_url);
-        let top_level_frame_id = FrameId::installed();
+        let top_level_browsing_context_id = BrowsingContextId::installed();
 
         thread::Builder::new().name(name).spawn(move || {
             thread_state::initialize(thread_state::SCRIPT | thread_state::IN_WORKER);
 
-            if let Some(top_level_frame_id) = top_level_frame_id {
-                FrameId::install(top_level_frame_id);
+            if let Some(top_level_browsing_context_id) = top_level_browsing_context_id {
+                BrowsingContextId::install(top_level_browsing_context_id);
             }
 
             let roots = RootCollection::new();

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -184,7 +184,9 @@ impl DissimilarOriginWindowMethods for DissimilarOriginWindow {
 
 impl DissimilarOriginWindow {
     pub fn post_message(&self, origin: Option<ImmutableOrigin>, data: StructuredCloneData) {
-        let msg = ConstellationMsg::PostMessage(self.window_proxy.frame_id(), origin, data.move_to_arraybuffer());
+        let msg = ConstellationMsg::PostMessage(self.window_proxy.browsing_context_id(),
+                                                origin,
+                                                data.move_to_arraybuffer());
         let _ = self.upcast::<GlobalScope>().constellation_chan().send(msg);
     }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -100,7 +100,7 @@ use ipc_channel::ipc::{self, IpcSender};
 use js::jsapi::{JSContext, JSObject, JSRuntime};
 use js::jsapi::JS_GetRuntime;
 use msg::constellation_msg::{ALT, CONTROL, SHIFT, SUPER};
-use msg::constellation_msg::{FrameId, Key, KeyModifiers, KeyState};
+use msg::constellation_msg::{BrowsingContextId, Key, KeyModifiers, KeyState};
 use net_traits::{FetchResponseMsg, IpcSend, ReferrerPolicy};
 use net_traits::CookieSource::NonHTTP;
 use net_traits::CoreResourceMsg::{GetCookiesForUrl, SetCookiesForUrl};
@@ -1897,9 +1897,9 @@ impl Document {
     }
 
     /// Find an iframe element in the document.
-    pub fn find_iframe(&self, frame_id: FrameId) -> Option<Root<HTMLIFrameElement>> {
+    pub fn find_iframe(&self, browsing_context_id: BrowsingContextId) -> Option<Root<HTMLIFrameElement>> {
         self.iter_iframes()
-            .find(|node| node.frame_id() == frame_id)
+            .find(|node| node.browsing_context_id() == browsing_context_id)
     }
 
     pub fn get_dom_loading(&self) -> u64 {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -61,7 +61,7 @@ use heapsize::{HeapSizeOf, heap_size_of};
 use html5ever::{Prefix, Namespace, QualName};
 use js::jsapi::{JSContext, JSObject, JSRuntime};
 use libc::{self, c_void, uintptr_t};
-use msg::constellation_msg::{FrameId, PipelineId};
+use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use ref_slice::ref_slice;
 use script_layout_interface::{HTMLCanvasData, OpaqueStyleAndLayoutData, SVGSVGData};
 use script_layout_interface::{LayoutElementType, LayoutNodeType, TrustedNodeAddress};
@@ -968,7 +968,7 @@ pub trait LayoutNodeHelpers {
     fn image_url(&self) -> Option<ServoUrl>;
     fn canvas_data(&self) -> Option<HTMLCanvasData>;
     fn svg_data(&self) -> Option<SVGSVGData>;
-    fn iframe_frame_id(&self) -> FrameId;
+    fn iframe_browsing_context_id(&self) -> BrowsingContextId;
     fn iframe_pipeline_id(&self) -> PipelineId;
     fn opaque(&self) -> OpaqueNode;
 }
@@ -1119,10 +1119,10 @@ impl LayoutNodeHelpers for LayoutJS<Node> {
             .map(|svg| svg.data())
     }
 
-    fn iframe_frame_id(&self) -> FrameId {
+    fn iframe_browsing_context_id(&self) -> BrowsingContextId {
         let iframe_element = self.downcast::<HTMLIFrameElement>()
             .expect("not an iframe element!");
-        iframe_element.frame_id()
+        iframe_element.browsing_context_id()
     }
 
     fn iframe_pipeline_id(&self) -> PipelineId {

--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -44,7 +44,7 @@ use dom::node::{LayoutNodeHelpers, Node};
 use dom::text::Text;
 use gfx_traits::ByteIndex;
 use html5ever::{LocalName, Namespace};
-use msg::constellation_msg::{FrameId, PipelineId};
+use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use range::Range;
 use script_layout_interface::{HTMLCanvasData, LayoutNodeType, SVGSVGData, TrustedNodeAddress};
 use script_layout_interface::{OpaqueStyleAndLayoutData, PartialPersistentLayoutData};
@@ -908,9 +908,9 @@ impl<'ln> ThreadSafeLayoutNode for ServoThreadSafeLayoutNode<'ln> {
         this.svg_data()
     }
 
-    fn iframe_frame_id(&self) -> FrameId {
+    fn iframe_browsing_context_id(&self) -> BrowsingContextId {
         let this = unsafe { self.get_jsmanaged() };
-        this.iframe_frame_id()
+        this.iframe_browsing_context_id()
     }
 
     fn iframe_pipeline_id(&self) -> PipelineId {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -109,10 +109,10 @@ pub fn handle_execute_async_script(documents: &Documents,
     window.upcast::<GlobalScope>().evaluate_js_on_global_with_result(&eval, rval.handle_mut());
 }
 
-pub fn handle_get_frame_id(documents: &Documents,
-                           pipeline: PipelineId,
-                           webdriver_frame_id: WebDriverFrameId,
-                           reply: IpcSender<Result<Option<PipelineId>, ()>>) {
+pub fn handle_get_pipeline_id(documents: &Documents,
+                              pipeline: PipelineId,
+                              webdriver_frame_id: WebDriverFrameId,
+                              reply: IpcSender<Result<Option<PipelineId>, ()>>) {
     let result = match webdriver_frame_id {
         WebDriverFrameId::Short(_) => {
             // This isn't supported yet

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -11,7 +11,7 @@ use SVGSVGData;
 use atomic_refcell::AtomicRefCell;
 use gfx_traits::{ByteIndex, FragmentType, combine_id_with_fragment_type};
 use html5ever::{Namespace, LocalName};
-use msg::constellation_msg::{FrameId, PipelineId};
+use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use range::Range;
 use servo_url::ServoUrl;
 use std::fmt::Debug;
@@ -271,9 +271,9 @@ pub trait ThreadSafeLayoutNode: Clone + Copy + Debug + GetLayoutData + NodeInfo 
 
     fn svg_data(&self) -> Option<SVGSVGData>;
 
-    /// If this node is an iframe element, returns its frame ID. If this node is
+    /// If this node is an iframe element, returns its browsing context ID. If this node is
     /// not an iframe element, fails.
-    fn iframe_frame_id(&self) -> FrameId;
+    fn iframe_browsing_context_id(&self) -> BrowsingContextId;
 
     /// If this node is an iframe element, returns its pipeline ID. If this node is
     /// not an iframe element, fails.

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -17,7 +17,7 @@ use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
 use euclid::point::Point2D;
 use euclid::size::{Size2D, TypedSize2D};
 use ipc_channel::ipc::IpcSender;
-use msg::constellation_msg::{FrameId, FrameType, PipelineId, TraversalDirection};
+use msg::constellation_msg::{BrowsingContextId, FrameType, PipelineId, TraversalDirection};
 use msg::constellation_msg::{Key, KeyModifiers, KeyState};
 use net_traits::CoreResourceMsg;
 use net_traits::storage_thread::StorageType;
@@ -34,8 +34,8 @@ use webrender_traits::ClipId;
 pub enum LayoutMsg {
     /// Indicates whether this pipeline is currently running animations.
     ChangeRunningAnimationsState(PipelineId, AnimationState),
-    /// Inform the constellation of the size of the frame's viewport.
-    FrameSizes(Vec<(FrameId, TypedSize2D<f32, CSSPixel>)>),
+    /// Inform the constellation of the size of the iframe's viewport.
+    IFrameSizes(Vec<(BrowsingContextId, TypedSize2D<f32, CSSPixel>)>),
     /// Requests that the constellation inform the compositor of the a cursor change.
     SetCursor(Cursor),
     /// Notifies the constellation that the viewport has been constrained in some manner
@@ -87,7 +87,7 @@ pub enum ScriptMsg {
     /// Requests that the constellation retrieve the current contents of the clipboard
     GetClipboardContents(IpcSender<String>),
     /// Get the frame id for a given pipeline.
-    GetFrameId(PipelineId, IpcSender<Option<FrameId>>),
+    GetBrowsingContextId(PipelineId, IpcSender<Option<BrowsingContextId>>),
     /// Get the parent info for a given pipeline.
     GetParentInfo(PipelineId, IpcSender<Option<(PipelineId, FrameType)>>),
     /// <head> tag finished parsing
@@ -99,7 +99,7 @@ pub enum ScriptMsg {
     /// instead of adding a new entry.
     LoadUrl(PipelineId, LoadData, bool),
     /// Post a message to the currently active window of a given browsing context.
-    PostMessage(FrameId, Option<ImmutableOrigin>, Vec<u8>),
+    PostMessage(BrowsingContextId, Option<ImmutableOrigin>, Vec<u8>),
     /// Dispatch a mozbrowser event to the parent of this pipeline.
     /// The first PipelineId is for the parent, the second is for the originating pipeline.
     MozBrowserEvent(PipelineId, PipelineId, MozBrowserEvent),
@@ -113,7 +113,7 @@ pub enum ScriptMsg {
     NodeStatus(Option<String>),
     /// Notification that this iframe should be removed.
     /// Returns a list of pipelines which were closed.
-    RemoveIFrame(FrameId, IpcSender<Vec<PipelineId>>),
+    RemoveIFrame(BrowsingContextId, IpcSender<Vec<PipelineId>>),
     /// Change pipeline visibility
     SetVisible(PipelineId, bool),
     /// Notifies constellation that an iframe's visibility has been changed.
@@ -147,8 +147,8 @@ pub enum ScriptMsg {
     ResizeTo(Size2D<u32>),
     /// Script has handled a touch event, and either prevented or allowed default actions.
     TouchEventProcessed(EventResult),
-    /// A log entry, with the top-level frame id and thread name
-    LogEntry(Option<FrameId>, Option<String>, LogEntry),
+    /// A log entry, with the top-level browsing context id and thread name
+    LogEntry(Option<BrowsingContextId>, Option<String>, LogEntry),
     /// Notifies the constellation that this pipeline has exited.
     PipelineExited(PipelineId),
     /// Send messages from postMessage calls from serviceworker

--- a/components/script_traits/webdriver_msg.rs
+++ b/components/script_traits/webdriver_msg.rs
@@ -31,7 +31,7 @@ pub enum WebDriverScriptCommand {
     GetElementRect(String, IpcSender<Result<Rect<f64>, ()>>),
     GetElementTagName(String, IpcSender<Result<String, ()>>),
     GetElementText(String, IpcSender<Result<String, ()>>),
-    GetFrameId(WebDriverFrameId, IpcSender<Result<Option<PipelineId>, ()>>),
+    GetPipelineId(WebDriverFrameId, IpcSender<Result<Option<PipelineId>, ()>>),
     GetUrl(IpcSender<ServoUrl>),
     IsEnabled(String, IpcSender<Result<bool, ()>>),
     IsSelected(String, IpcSender<Result<bool, ()>>),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Now that script has `WindowProxy` rather than `BrowsingContext` objects, we can rename `Frame` in the constellation to `BrowsingContext`. In particular, this means that `FrameId`s are now `BrowsingContextid`s, which better captures their purpose (and they are used in a lot of places, not just the constellation).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because renaming

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16876)
<!-- Reviewable:end -->
