### PR TITLE
provide more information when bindgen fails

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -250,7 +250,14 @@ mod bindings {
                 return;
             }
         }
-        let mut result = builder.generate().expect("Unable to generate bindings").to_string();
+        let command_line_opts = builder.command_line_flags();
+        let result = builder.generate();
+        let mut result = match result {
+            Ok(bindings) => bindings.to_string(),
+            Err(_) => {
+                panic!("Failed to generate bindings, flags: {:?}", command_line_opts);
+            },
+        };
         for fixup in fixups.iter() {
             result = Regex::new(&format!(r"\b{}\b", fixup.pat)).unwrap().replace_all(&result, fixup.rep.as_str())
                 .into_owned().into();


### PR DESCRIPTION
Providing the flags we passed into clang can be informative for double-checking that we set everything up correctly.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16880)
<!-- Reviewable:end -->
