### PR TITLE
Fix containing block size for absolute root element

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -657,7 +657,7 @@ impl BlockFlow {
     pub fn containing_block_size(&self, viewport_size: &Size2D<Au>, descendant: OpaqueFlow)
                                  -> LogicalSize<Au> {
         debug_assert!(self.base.flags.contains(IS_ABSOLUTELY_POSITIONED));
-        if self.is_fixed() {
+        if self.is_fixed() || self.is_root() {
             // Initial containing block is the CB for the root
             LogicalSize::from_physical(self.base.writing_mode, *viewport_size)
         } else {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -3731,6 +3731,18 @@
      {}
     ]
    ],
+   "css/min_width_percent_root_a.html": [
+    [
+     "/_mozilla/css/min_width_percent_root_a.html",
+     [
+      [
+       "/_mozilla/css/min_width_percent_root_b.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/min_width_simple_a.html": [
     [
      "/_mozilla/css/min_width_simple_a.html",
@@ -8355,6 +8367,11 @@
     ]
    ],
    "css/min_width_float_simple_b.html": [
+    [
+     {}
+    ]
+   ],
+   "css/min_width_percent_root_b.html": [
     [
      {}
     ]
@@ -22620,6 +22637,14 @@
   ],
   "css/min_width_float_simple_b.html": [
    "e8ee634ab6350ad4c870cb1d0ce4f1a88b285581",
+   "support"
+  ],
+  "css/min_width_percent_root_a.html": [
+   "e8c23bc78daed932d5b513b972582e21711ea06a",
+   "reftest"
+  ],
+  "css/min_width_percent_root_b.html": [
+   "4c5b54f6b4e1bb77a15fdf7d99f9be3a47df7e8b",
    "support"
   ],
   "css/min_width_simple_a.html": [

--- a/tests/wpt/mozilla/tests/css/min_width_percent_root_a.html
+++ b/tests/wpt/mozilla/tests/css/min_width_percent_root_a.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <link rel="match" href="min_width_percent_root_b.html">
+    <title>absolute root element with percentage min-width</title>
+    <style>
+      html {
+        position: absolute;
+        min-width: 100%;
+        border: 2px solid red;
+      }
+    </style>
+  </head>
+  <body></body>
+</html>

--- a/tests/wpt/mozilla/tests/css/min_width_percent_root_b.html
+++ b/tests/wpt/mozilla/tests/css/min_width_percent_root_b.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>absolute root element with percentage min-width reference</title>
+    <style>
+      html {
+        min-width: 100%;
+        border: 2px solid red;
+      }
+    </style>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
The root element doesn't have a containing block, so use the viewport size instead of `self.base.absolute_cb`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #16248 (github issue number if applicable).
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16881)
<!-- Reviewable:end -->
