### PR TITLE
stylo: Continue to propagate quirks mode information to Servo

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1623,7 +1623,8 @@ extern "C" {
                                               *const RawServoMediaList,
                                           extra_data:
                                               *mut RawGeckoURLExtraData,
-                                          line_number_offset: u32)
+                                          line_number_offset: u32,
+                                          quirks_mode: nsCompatibility)
      -> RawServoStyleSheetStrong;
 }
 extern "C" {
@@ -1876,7 +1877,8 @@ extern "C" {
     pub fn Servo_ParseProperty(property: nsCSSPropertyID,
                                value: *const nsACString,
                                data: *mut RawGeckoURLExtraData,
-                               parsing_mode: ParsingMode)
+                               parsing_mode: ParsingMode,
+                               quirks_mode: nsCompatibility)
      -> RawServoDeclarationBlockStrong;
 }
 extern "C" {
@@ -2046,7 +2048,8 @@ extern "C" {
                                               value: *const nsACString,
                                               is_important: bool,
                                               data: *mut RawGeckoURLExtraData,
-                                              parsing_mode: ParsingMode)
+                                              parsing_mode: ParsingMode,
+                                              quirks_mode: nsCompatibility)
      -> bool;
 }
 extern "C" {
@@ -2057,7 +2060,9 @@ extern "C" {
                                                   is_important: bool,
                                                   data:
                                                       *mut RawGeckoURLExtraData,
-                                                  parsing_mode: ParsingMode)
+                                                  parsing_mode: ParsingMode,
+                                                  quirks_mode:
+                                                      nsCompatibility)
      -> bool;
 }
 extern "C" {

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -572,7 +572,8 @@ pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(loader: *mut Loader,
                                                  mode: SheetParsingMode,
                                                  media_list: *const RawServoMediaList,
                                                  extra_data: *mut URLExtraData,
-                                                 line_number_offset: u32)
+                                                 line_number_offset: u32,
+                                                 quirks_mode: nsCompatibility)
                                                  -> RawServoStyleSheetStrong {
     let global_style_data = &*GLOBAL_STYLE_DATA;
     let input = unsafe { data.as_ref().unwrap().as_str_unchecked() };
@@ -607,7 +608,7 @@ pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(loader: *mut Loader,
     Arc::new(Stylesheet::from_str(
         input, url_data.clone(), origin, media,
         shared_lock, loader, &RustLogReporter,
-        QuirksMode::NoQuirks, line_number_offset as u64)
+        quirks_mode.into(), line_number_offset as u64)
     ).into_strong()
 }
 
@@ -1166,9 +1167,9 @@ pub extern "C" fn Servo_StyleSet_Drop(data: RawServoStyleSetOwned) {
 fn parse_property(property_id: PropertyId,
                   value: *const nsACString,
                   data: *mut URLExtraData,
-                  parsing_mode: structs::ParsingMode) -> Result<ParsedDeclaration, ()> {
+                  parsing_mode: structs::ParsingMode,
+                  quirks_mode: QuirksMode) -> Result<ParsedDeclaration, ()> {
     use style::parser::ParsingMode;
-
     let value = unsafe { value.as_ref().unwrap().as_str_unchecked() };
     let url_data = unsafe { RefPtr::from_ptr_ref(&data) };
     let parsing_mode = ParsingMode::from_bits_truncate(parsing_mode);
@@ -1178,17 +1179,18 @@ fn parse_property(property_id: PropertyId,
                           url_data,
                           &RustLogReporter,
                           parsing_mode,
-                          QuirksMode::NoQuirks)
+                          quirks_mode)
 }
 
 #[no_mangle]
 pub extern "C" fn Servo_ParseProperty(property: nsCSSPropertyID, value: *const nsACString,
                                       data: *mut URLExtraData,
-                                      parsing_mode: structs::ParsingMode)
+                                      parsing_mode: structs::ParsingMode,
+                                      quirks_mode: nsCompatibility)
                                       -> RawServoDeclarationBlockStrong {
     let id = get_property_id_from_nscsspropertyid!(property,
                                                    RawServoDeclarationBlockStrong::null());
-    match parse_property(id, value, data, parsing_mode) {
+    match parse_property(id, value, data, parsing_mode, quirks_mode.into()) {
         Ok(parsed) => {
             let global_style_data = &*GLOBAL_STYLE_DATA;
             let mut block = PropertyDeclarationBlock::new();
@@ -1347,8 +1349,9 @@ pub extern "C" fn Servo_DeclarationBlock_GetPropertyIsImportant(declarations: Ra
 
 fn set_property(declarations: RawServoDeclarationBlockBorrowed, property_id: PropertyId,
                 value: *const nsACString, is_important: bool, data: *mut URLExtraData,
-                parsing_mode: structs::ParsingMode) -> bool {
-    match parse_property(property_id, value, data, parsing_mode) {
+                parsing_mode: structs::ParsingMode,
+                quirks_mode: QuirksMode) -> bool {
+    match parse_property(property_id, value, data, parsing_mode, quirks_mode) {
         Ok(parsed) => {
             let importance = if is_important { Importance::Important } else { Importance::Normal };
             write_locked_arc(declarations, |decls: &mut PropertyDeclarationBlock| {
@@ -1363,18 +1366,20 @@ fn set_property(declarations: RawServoDeclarationBlockBorrowed, property_id: Pro
 pub extern "C" fn Servo_DeclarationBlock_SetProperty(declarations: RawServoDeclarationBlockBorrowed,
                                                      property: *const nsACString, value: *const nsACString,
                                                      is_important: bool, data: *mut URLExtraData,
-                                                     parsing_mode: structs::ParsingMode) -> bool {
+                                                     parsing_mode: structs::ParsingMode,
+                                                     quirks_mode: nsCompatibility) -> bool {
     set_property(declarations, get_property_id_from_property!(property, false),
-                 value, is_important, data, parsing_mode)
+                 value, is_important, data, parsing_mode, quirks_mode.into())
 }
 
 #[no_mangle]
 pub extern "C" fn Servo_DeclarationBlock_SetPropertyById(declarations: RawServoDeclarationBlockBorrowed,
                                                          property: nsCSSPropertyID, value: *const nsACString,
                                                          is_important: bool, data: *mut URLExtraData,
-                                                         parsing_mode: structs::ParsingMode) -> bool {
+                                                         parsing_mode: structs::ParsingMode,
+                                                         quirks_mode: nsCompatibility) -> bool {
     set_property(declarations, get_property_id_from_nscsspropertyid!(property, false),
-                 value, is_important, data, parsing_mode)
+                 value, is_important, data, parsing_mode, quirks_mode.into())
 }
 
 fn remove_property(declarations: RawServoDeclarationBlockBorrowed, property_id: PropertyId) {
@@ -1416,7 +1421,7 @@ pub extern "C" fn Servo_MediaList_Matches(list: RawServoMediaListBorrowed,
                                           -> bool {
     let per_doc_data = PerDocumentStyleData::from_ffi(raw_data).borrow();
     read_locked_arc(list, |list: &MediaList| {
-        list.evaluate(&per_doc_data.stylist.device, QuirksMode::NoQuirks)
+        list.evaluate(&per_doc_data.stylist.device, per_doc_data.stylist.quirks_mode())
     })
 }
 
@@ -1870,10 +1875,15 @@ pub extern "C" fn Servo_DeclarationBlock_SetTextDecorationColorOverride(declarat
 }
 
 #[no_mangle]
-pub extern "C" fn Servo_CSSSupports2(property: *const nsACString, value: *const nsACString) -> bool {
+pub extern "C" fn Servo_CSSSupports2(property: *const nsACString,
+                                     value: *const nsACString) -> bool {
     let id = get_property_id_from_property!(property, false);
 
-    parse_property(id, value, unsafe { DUMMY_URL_DATA }, structs::ParsingMode_Default).is_ok()
+    parse_property(id,
+                   value,
+                   unsafe { DUMMY_URL_DATA },
+                   structs::ParsingMode_Default,
+                   QuirksMode::NoQuirks).is_ok()
 }
 
 #[no_mangle]
@@ -2182,7 +2192,7 @@ pub extern "C" fn Servo_AnimationValue_Compute(declarations: RawServoDeclaration
         font_metrics_provider: &metrics,
         cached_system_font: None,
         in_media_query: false,
-        quirks_mode: QuirksMode::NoQuirks,
+        quirks_mode: data.stylist.quirks_mode(),
     };
 
     let global_style_data = &*GLOBAL_STYLE_DATA;


### PR DESCRIPTION
r=bholley in bugzilla

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1364746](https://bugzilla.mozilla.org/show_bug.cgi?id=1364746)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16882)
<!-- Reviewable:end -->
