### PR TITLE
Bug 1270740 - remove requestAutocomplete reference

### DIFF
--- a/components/script/dom/webidls/HTMLFormElement.webidl
+++ b/components/script/dom/webidls/HTMLFormElement.webidl
@@ -24,6 +24,4 @@ interface HTMLFormElement : HTMLElement {
   void reset();
   //boolean checkValidity();
   //boolean reportValidity();
-
-  //void requestAutocomplete();
 };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I was in charge of removing the `requestAutocomplete` feature in [mozilla-central](https://bugzilla.mozilla.org/show_bug.cgi?id=1270740), and needed to remove a reference to that feature in the **servo** comments. The change, therefore, is really trivial.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] These changes do not require tests because I simply removed a comment

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16885)
<!-- Reviewable:end -->
