### PR TITLE
Fix markdown warning in parse_product doc comment

### DIFF
--- a/components/style/values/specified/calc.rs
+++ b/components/style/values/specified/calc.rs
@@ -233,9 +233,9 @@ impl CalcNode {
     ///
     /// This should parse correctly:
     ///
-    ///     * `2`
-    ///     * `2 * 2`
-    ///     * `2 * 2 + 2` (but will leave the `+ 2` unparsed).
+    /// * `2`
+    /// * `2 * 2`
+    /// * `2 * 2 + 2` (but will leave the `+ 2` unparsed).
     ///
     fn parse_product(
         context: &ParserContext,


### PR DESCRIPTION
---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because no code changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16886)
<!-- Reviewable:end -->
