### PR TITLE
Allow -moz-stack-sizing to work in a single direction only.

### DIFF
--- a/components/style/gecko/generated/structs_debug.rs
+++ b/components/style/gecko/generated/structs_debug.rs
@@ -185,9 +185,6 @@ pub mod root {
     pub const NS_FONT_SUB_SUPER_LARGE_SIZE: f64 = 45.;
     pub const NS_FONT_VARIANT_NORMAL: ::std::os::raw::c_uint = 0;
     pub const NS_FONT_VARIANT_SMALL_CAPS: ::std::os::raw::c_uint = 1;
-    pub const NS_STYLE_STACK_SIZING_IGNORE: ::std::os::raw::c_uint = 0;
-    pub const NS_STYLE_STACK_SIZING_STRETCH_TO_FIT: ::std::os::raw::c_uint =
-        1;
     pub const NS_STYLE_AZIMUTH_LEFT_SIDE: ::std::os::raw::c_uint = 0;
     pub const NS_STYLE_AZIMUTH_FAR_LEFT: ::std::os::raw::c_uint = 1;
     pub const NS_STYLE_AZIMUTH_LEFT: ::std::os::raw::c_uint = 2;
@@ -6090,6 +6087,14 @@ pub mod root {
             URL = 1,
             Shape = 2,
             Box = 3,
+        }
+        #[repr(u8)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+        pub enum StyleStackSizing {
+            Ignore = 0,
+            StretchToFit = 1,
+            IgnoreHorizontal = 2,
+            IgnoreVertical = 3,
         }
         #[repr(u8)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -30011,7 +30016,7 @@ pub mod root {
         pub mBoxDirection: root::mozilla::StyleBoxDirection,
         pub mBoxOrient: root::mozilla::StyleBoxOrient,
         pub mBoxPack: root::mozilla::StyleBoxPack,
-        pub mStretchStack: bool,
+        pub mStackSizing: root::mozilla::StyleStackSizing,
     }
     #[test]
     fn bindgen_test_layout_nsStyleXUL() {
@@ -30050,10 +30055,10 @@ pub mod root {
                     "Alignment of field: " , stringify ! ( nsStyleXUL ) , "::"
                     , stringify ! ( mBoxPack ) ));
         assert_eq! (unsafe {
-                    & ( * ( 0 as * const nsStyleXUL ) ) . mStretchStack as *
+                    & ( * ( 0 as * const nsStyleXUL ) ) . mStackSizing as *
                     const _ as usize } , 12usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleXUL ) , "::"
-                    , stringify ! ( mStretchStack ) ));
+                    , stringify ! ( mStackSizing ) ));
     }
     #[repr(C)]
     #[derive(Debug)]

--- a/components/style/gecko/generated/structs_release.rs
+++ b/components/style/gecko/generated/structs_release.rs
@@ -185,9 +185,6 @@ pub mod root {
     pub const NS_FONT_SUB_SUPER_LARGE_SIZE: f64 = 45.;
     pub const NS_FONT_VARIANT_NORMAL: ::std::os::raw::c_uint = 0;
     pub const NS_FONT_VARIANT_SMALL_CAPS: ::std::os::raw::c_uint = 1;
-    pub const NS_STYLE_STACK_SIZING_IGNORE: ::std::os::raw::c_uint = 0;
-    pub const NS_STYLE_STACK_SIZING_STRETCH_TO_FIT: ::std::os::raw::c_uint =
-        1;
     pub const NS_STYLE_AZIMUTH_LEFT_SIDE: ::std::os::raw::c_uint = 0;
     pub const NS_STYLE_AZIMUTH_FAR_LEFT: ::std::os::raw::c_uint = 1;
     pub const NS_STYLE_AZIMUTH_LEFT: ::std::os::raw::c_uint = 2;
@@ -5959,6 +5956,14 @@ pub mod root {
             URL = 1,
             Shape = 2,
             Box = 3,
+        }
+        #[repr(u8)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+        pub enum StyleStackSizing {
+            Ignore = 0,
+            StretchToFit = 1,
+            IgnoreHorizontal = 2,
+            IgnoreVertical = 3,
         }
         #[repr(u8)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -29501,7 +29506,7 @@ pub mod root {
         pub mBoxDirection: root::mozilla::StyleBoxDirection,
         pub mBoxOrient: root::mozilla::StyleBoxOrient,
         pub mBoxPack: root::mozilla::StyleBoxPack,
-        pub mStretchStack: bool,
+        pub mStackSizing: root::mozilla::StyleStackSizing,
     }
     #[test]
     fn bindgen_test_layout_nsStyleXUL() {
@@ -29540,10 +29545,10 @@ pub mod root {
                     "Alignment of field: " , stringify ! ( nsStyleXUL ) , "::"
                     , stringify ! ( mBoxPack ) ));
         assert_eq! (unsafe {
-                    & ( * ( 0 as * const nsStyleXUL ) ) . mStretchStack as *
+                    & ( * ( 0 as * const nsStyleXUL ) ) . mStackSizing as *
                     const _ as usize } , 12usize , concat ! (
                     "Alignment of field: " , stringify ! ( nsStyleXUL ) , "::"
-                    , stringify ! ( mStretchStack ) ));
+                    , stringify ! ( mStackSizing ) ));
     }
     #[repr(C)]
     #[derive(Debug)]

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -4199,16 +4199,7 @@ clip-path
 </%self:impl_trait>
 
 <%self:impl_trait style_struct_name="XUL"
-                  skip_longhands="-moz-stack-sizing -moz-box-ordinal-group">
-
-    #[allow(non_snake_case)]
-    pub fn set__moz_stack_sizing(&mut self, v: longhands::_moz_stack_sizing::computed_value::T) {
-        use properties::longhands::_moz_stack_sizing::computed_value::T;
-        self.gecko.mStretchStack = v == T::stretch_to_fit;
-    }
-
-    ${impl_simple_copy('_moz_stack_sizing', 'mStretchStack')}
-
+                  skip_longhands="-moz-box-ordinal-group">
     #[allow(non_snake_case)]
     pub fn set__moz_box_ordinal_group(&mut self, v: i32) {
         self.gecko.mBoxOrdinal = v as u32;

--- a/components/style/properties/longhand/xul.mako.rs
+++ b/components/style/properties/longhand/xul.mako.rs
@@ -44,9 +44,9 @@ ${helpers.single_keyword("-moz-box-pack", "start center end justify",
                          alias="-webkit-box-pack",
                          spec="Nonstandard (https://developer.mozilla.org/en-US/docs/Web/CSS/box-pack)")}
 
-${helpers.single_keyword("-moz-stack-sizing", "stretch-to-fit ignore",
-                         products="gecko", gecko_ffi_name="mStretchStack",
-                         gecko_constant_prefix="NS_STYLE_STACK_SIZING",
+${helpers.single_keyword("-moz-stack-sizing", "stretch-to-fit ignore ignore-horizontal ignore-vertical",
+                         products="gecko", gecko_ffi_name="mStackSizing",
+                         gecko_enum_prefix="StyleStackSizing",
                          animation_value_type="none",
                          spec="Nonstandard (https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-stack-sizing)")}
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1364115
https://reviewboard.mozilla.org/r/138434/

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because these properties are not implemented

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16892)
<!-- Reviewable:end -->
