### PR TITLE
Revert "Replace intrinsics::abort with process::abort"

### DIFF
--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -4,6 +4,7 @@
 
 #![allow(non_camel_case_types)]
 #![feature(box_syntax)]
+#![feature(core_intrinsics)]
 #![feature(link_args)]
 
 #[macro_use]

--- a/ports/cef/stubs.rs
+++ b/ports/cef/stubs.rs
@@ -12,7 +12,9 @@ macro_rules! stub(
         #[allow(non_snake_case)]
         pub extern "C" fn $name() {
             println!("CEF stub function called: {}", stringify!($name));
-            ::std::process::abort()
+            unsafe {
+                ::std::intrinsics::abort()
+            }
         }
     )
 );

--- a/ports/servo/main.rs
+++ b/ports/servo/main.rs
@@ -15,7 +15,7 @@
 //!
 //! [glutin]: https://github.com/tomaka/glutin
 
-#![feature(start)]
+#![feature(start, core_intrinsics)]
 
 #[cfg(target_os = "android")]
 extern crate android_injected_glue;
@@ -58,7 +58,7 @@ pub mod platform {
 fn install_crash_handler() {
     use backtrace::Backtrace;
     use sig::ffi::Sig;
-    use std::process::abort;
+    use std::intrinsics::abort;
     use std::thread;
 
     fn handler(_sig: i32) {
@@ -67,7 +67,9 @@ fn install_crash_handler() {
             .map(|n| format!(" for thread \"{}\"", n))
             .unwrap_or("".to_owned());
         println!("Stack trace{}\n{:?}", name, Backtrace::new());
-        abort();
+        unsafe {
+            abort();
+        }
     }
 
     signal!(Sig::SEGV, handler); // handle segfaults

--- a/ports/servo/main.rs
+++ b/ports/servo/main.rs
@@ -68,6 +68,8 @@ fn install_crash_handler() {
             .unwrap_or("".to_owned());
         println!("Stack trace{}\n{:?}", name, Backtrace::new());
         unsafe {
+            // N.B. Using process::abort() here causes the crash handler to be
+            //      triggered recursively.
             abort();
         }
     }


### PR DESCRIPTION
This reverts #16680. Calling `process::abort` from the crash handler causes the crash handler to be invoked again recursively.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #16898

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16899)
<!-- Reviewable:end -->
