### PR TITLE
Bug 1364850: Move PseudoElement to be just another combinator in selectors. r=bholley

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -85,7 +85,7 @@ use net_traits::request::CorsSettings;
 use ref_filter_map::ref_filter_map;
 use script_layout_interface::message::ReflowQueryType;
 use script_thread::Runnable;
-use selectors::matching::{ElementSelectorFlags, MatchingContext, matches_selector_list};
+use selectors::matching::{ElementSelectorFlags, MatchingContext, MatchingMode, matches_selector_list};
 use selectors::matching::{HAS_EDGE_CHILD_SELECTOR, HAS_SLOW_SELECTOR, HAS_SLOW_SELECTOR_LATER_SIBLINGS};
 use selectors::parser::{AttrSelector, NamespaceConstraint};
 use servo_atoms::Atom;
@@ -103,7 +103,7 @@ use style::properties::{Importance, PropertyDeclaration, PropertyDeclarationBloc
 use style::properties::longhands::{self, background_image, border_spacing, font_family, font_size, overflow_x};
 use style::restyle_hints::RESTYLE_SELF;
 use style::rule_tree::CascadeLevel;
-use style::selector_parser::{NonTSPseudoClass, RestyleDamage, SelectorImpl, SelectorParser};
+use style::selector_parser::{NonTSPseudoClass, PseudoElement, RestyleDamage, SelectorImpl, SelectorParser};
 use style::shared_lock::{SharedRwLock, Locked};
 use style::sink::Push;
 use style::stylearc::Arc;
@@ -2046,7 +2046,8 @@ impl ElementMethods for Element {
         match SelectorParser::parse_author_origin_no_namespace(&selectors) {
             Err(()) => Err(Error::Syntax),
             Ok(selectors) => {
-                Ok(matches_selector_list(&selectors.0, &Root::from_ref(self), None))
+                let mut ctx = MatchingContext::new(MatchingMode::Normal, None);
+                Ok(matches_selector_list(&selectors.0, &Root::from_ref(self), &mut ctx))
             }
         }
     }
@@ -2064,8 +2065,8 @@ impl ElementMethods for Element {
                 let root = self.upcast::<Node>();
                 for element in root.inclusive_ancestors() {
                     if let Some(element) = Root::downcast::<Element>(element) {
-                        if matches_selector_list(&selectors.0, &element, None)
-                        {
+                        let mut ctx = MatchingContext::new(MatchingMode::Normal, None);
+                        if matches_selector_list(&selectors.0, &element, &mut ctx) {
                             return Ok(Some(element));
                         }
                     }
@@ -2373,6 +2374,15 @@ impl<'a> ::selectors::Element for Root<Element> {
     fn parent_element(&self) -> Option<Root<Element>> {
         self.upcast::<Node>().GetParentElement()
     }
+
+    fn match_pseudo_element(&self,
+                            _pseudo: &PseudoElement,
+                            _context: &mut MatchingContext)
+                            -> bool
+    {
+        false
+    }
+
 
     fn first_child_element(&self) -> Option<Root<Element>> {
         self.node.child_elements().next()

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -68,7 +68,7 @@ use script_layout_interface::{LayoutElementType, LayoutNodeType, TrustedNodeAddr
 use script_layout_interface::message::Msg;
 use script_traits::DocumentActivity;
 use script_traits::UntrustedNodeAddress;
-use selectors::matching::matches_selector_list;
+use selectors::matching::{matches_selector_list, MatchingContext, MatchingMode};
 use selectors::parser::SelectorList;
 use servo_url::ServoUrl;
 use std::borrow::ToOwned;
@@ -341,11 +341,14 @@ impl<'a> Iterator for QuerySelectorIterator {
 
     fn next(&mut self) -> Option<Root<Node>> {
         let selectors = &self.selectors.0;
+
         // TODO(cgaebel): Is it worth it to build a bloom filter here
         // (instead of passing `None`)? Probably.
+        let mut ctx = MatchingContext::new(MatchingMode::Normal, None);
+
         self.iterator.by_ref().filter_map(|node| {
             if let Some(element) = Root::downcast(node) {
-                if matches_selector_list(selectors, &element, None) {
+                if matches_selector_list(selectors, &element, &mut ctx) {
                     return Some(Root::upcast(element));
                 }
             }
@@ -707,8 +710,9 @@ impl Node {
             Err(()) => Err(Error::Syntax),
             // Step 3.
             Ok(selectors) => {
+                let mut ctx = MatchingContext::new(MatchingMode::Normal, None);
                 Ok(self.traverse_preorder().filter_map(Root::downcast).find(|element| {
-                    matches_selector_list(&selectors.0, element, None)
+                    matches_selector_list(&selectors.0, element, &mut ctx)
                 }))
             }
         }

--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -652,6 +652,14 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
         self.element.namespace()
     }
 
+    fn match_pseudo_element(&self,
+                            _pseudo: &PseudoElement,
+                            _context: &mut MatchingContext)
+                            -> bool
+    {
+        false
+    }
+
     fn match_non_ts_pseudo_class<F>(&self,
                                     pseudo_class: &NonTSPseudoClass,
                                     _: &mut MatchingContext,
@@ -1148,6 +1156,14 @@ impl<'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
     #[inline]
     fn get_namespace(&self) -> &Namespace {
         self.element.get_namespace()
+    }
+
+    fn match_pseudo_element(&self,
+                            _pseudo: &PseudoElement,
+                            _context: &mut MatchingContext)
+                            -> bool
+    {
+        false
     }
 
     fn match_non_ts_pseudo_class<F>(&self,

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -20,7 +20,6 @@ use style::context::SharedStyleContext;
 use style::data::ElementData;
 use style::dom::{LayoutIterator, NodeInfo, PresentationalHintsSynthesizer, TNode};
 use style::dom::OpaqueNode;
-use style::element_state::ElementState;
 use style::font_metrics::ServoMetricsProvider;
 use style::properties::{CascadeFlags, ServoComputedValues};
 use style::selector_parser::{PseudoElement, PseudoElementCascadeType, SelectorImpl};
@@ -435,7 +434,6 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
                                            &context.guards,
                                            unsafe { &self.unsafe_get() },
                                            &style_pseudo,
-                                           ElementState::empty(),
                                            data.styles().primary.values(),
                                            &ServoMetricsProvider);
                             data.styles_mut().cached_pseudos

--- a/components/selectors/gecko_like_types.rs
+++ b/components/selectors/gecko_like_types.rs
@@ -19,9 +19,6 @@ pub enum PseudoElement {
     B,
 }
 
-#[derive(Eq, PartialEq, Clone, Debug)]
-pub struct PseudoElementSelector(PseudoElement, u64);
-
 #[derive(Eq, PartialEq, Clone, Debug, Default)]
 pub struct Atom(usize);
 

--- a/components/selectors/size_of_tests.rs
+++ b/components/selectors/size_of_tests.rs
@@ -3,14 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use cssparser::ToCss;
+use gecko_like_types;
 use gecko_like_types::*;
+use parser;
 use parser::*;
 use precomputed_hash::PrecomputedHash;
 use std::fmt;
 use visitor::SelectorVisitor;
 
-size_of_test!(size_of_selector, Selector<Impl>, 72);
-size_of_test!(size_of_pseudo_element, PseudoElementSelector, 16);
+size_of_test!(size_of_selector, Selector<Impl>, 48);
+size_of_test!(size_of_pseudo_element, gecko_like_types::PseudoElement, 1);
 size_of_test!(size_of_selector_inner, SelectorInner<Impl>, 40);
 size_of_test!(size_of_complex_selector, ComplexSelector<Impl>, 24);
 
@@ -18,6 +20,9 @@ size_of_test!(size_of_component, Component<Impl>, 64);
 size_of_test!(size_of_attr_selector, AttrSelector<Impl>, 48);
 size_of_test!(size_of_pseudo_class, PseudoClass, 24);
 
+impl parser::PseudoElement for gecko_like_types::PseudoElement {
+    type Impl = Impl;
+}
 
 // Boilerplate
 
@@ -31,7 +36,7 @@ impl SelectorImpl for Impl {
     type BorrowedLocalName = Atom;
     type BorrowedNamespaceUrl = Atom;
     type NonTSPseudoClass = PseudoClass;
-    type PseudoElementSelector = PseudoElementSelector;
+    type PseudoElement = gecko_like_types::PseudoElement;
 }
 
 impl SelectorMethods for PseudoClass {
@@ -45,7 +50,7 @@ impl ToCss for PseudoClass {
     fn to_css<W>(&self, _: &mut W) -> fmt::Result where W: fmt::Write { unimplemented!() }
 }
 
-impl ToCss for PseudoElementSelector {
+impl ToCss for gecko_like_types::PseudoElement {
     fn to_css<W>(&self, _: &mut W) -> fmt::Result where W: fmt::Write { unimplemented!() }
 }
 

--- a/components/selectors/tree.rs
+++ b/components/selectors/tree.rs
@@ -123,6 +123,14 @@ impl<T> MatchAttr for T where T: MatchAttrGeneric, T::Impl: SelectorImpl<AttrVal
 pub trait Element: MatchAttr + Sized {
     fn parent_element(&self) -> Option<Self>;
 
+    /// The parent of a given pseudo-element, after matching a pseudo-element
+    /// selector.
+    ///
+    /// This is guaranteed to be called in a pseudo-element.
+    fn pseudo_element_originating_element(&self) -> Option<Self> {
+        self.parent_element()
+    }
+
     // Skips non-element nodes
     fn first_child_element(&self) -> Option<Self>;
 
@@ -144,6 +152,11 @@ pub trait Element: MatchAttr + Sized {
                                     context: &mut MatchingContext,
                                     flags_setter: &mut F) -> bool
         where F: FnMut(&Self, ElementSelectorFlags);
+
+    fn match_pseudo_element(&self,
+                            pe: &<Self::Impl as SelectorImpl>::PseudoElement,
+                            context: &mut MatchingContext)
+                            -> bool;
 
     fn get_id(&self) -> Option<<Self::Impl as SelectorImpl>::Identifier>;
     fn has_class(&self, name: &<Self::Impl as SelectorImpl>::ClassName) -> bool;

--- a/components/style/gecko/pseudo_element.rs
+++ b/components/style/gecko/pseudo_element.rs
@@ -10,11 +10,23 @@
 
 use cssparser::ToCss;
 use gecko_bindings::structs::{self, CSSPseudoElementType};
-use selector_parser::PseudoElementCascadeType;
+use selector_parser::{NonTSPseudoClass, PseudoElementCascadeType, SelectorImpl};
 use std::fmt;
 use string_cache::Atom;
 
 include!(concat!(env!("OUT_DIR"), "/gecko/pseudo_element_definition.rs"));
+
+impl ::selectors::parser::PseudoElement for PseudoElement {
+    type Impl = SelectorImpl;
+
+    fn supports_pseudo_class(&self, pseudo_class: &NonTSPseudoClass) -> bool {
+        if !self.supports_user_action_state() {
+            return false;
+        }
+
+        return pseudo_class.is_safe_user_action_state();
+    }
+}
 
 impl PseudoElement {
     /// Returns the kind of cascade type that a given pseudo is going to use.

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1068,7 +1068,6 @@ fn get_pseudo_style(guard: &SharedRwLockReadGuard,
             d.stylist.lazily_compute_pseudo_element_style(&guards,
                                                           &element,
                                                           &pseudo,
-                                                          ElementState::empty(),
                                                           base,
                                                           &metrics)
                      .map(|s| s.values().clone())

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -90,8 +90,8 @@ fn test_parse_stylesheet() {
             }))),
             CssRule::Style(Arc::new(stylesheet.shared_lock.wrap(StyleRule {
                 selectors: SelectorList(vec![
-                    Selector {
-                        inner: SelectorInner::from_vec(vec![
+                    Selector::new_for_unit_testing(
+                        SelectorInner::from_vec(vec![
                             Component::DefaultNamespace(NsAtom::from("http://www.w3.org/1999/xhtml")),
                             Component::LocalName(LocalName {
                                 name: local_name!("input"),
@@ -106,9 +106,8 @@ fn test_parse_stylesheet() {
                                 }),
                             }, "hidden".to_owned(), CaseSensitivity::CaseInsensitive)
                         ]),
-                        pseudo_element: None,
-                        specificity: (0 << 20) + (1 << 10) + (1 << 0),
-                    },
+                        (0 << 20) + (1 << 10) + (1 << 0)
+                    ),
                 ]),
                 block: Arc::new(stylesheet.shared_lock.wrap(block_from(vec![
                     (PropertyDeclaration::Display(longhands::display::SpecifiedValue::none),
@@ -124,28 +123,26 @@ fn test_parse_stylesheet() {
             }))),
             CssRule::Style(Arc::new(stylesheet.shared_lock.wrap(StyleRule {
                 selectors: SelectorList(vec![
-                    Selector {
-                        inner: SelectorInner::from_vec(vec![
+                    Selector::new_for_unit_testing(
+                        SelectorInner::from_vec(vec![
                             Component::DefaultNamespace(NsAtom::from("http://www.w3.org/1999/xhtml")),
                             Component::LocalName(LocalName {
                                 name: local_name!("html"),
                                 lower_name: local_name!("html"),
                             }),
                         ]),
-                        pseudo_element: None,
-                        specificity: (0 << 20) + (0 << 10) + (1 << 0),
-                    },
-                    Selector {
-                        inner: SelectorInner::from_vec(vec![
+                        (0 << 20) + (0 << 10) + (1 << 0)
+                    ),
+                    Selector::new_for_unit_testing(
+                        SelectorInner::from_vec(vec![
                             Component::DefaultNamespace(NsAtom::from("http://www.w3.org/1999/xhtml")),
                             Component::LocalName(LocalName {
                                 name: local_name!("body"),
                                 lower_name: local_name!("body"),
                             }),
                         ]),
-                        pseudo_element: None,
-                        specificity: (0 << 20) + (0 << 10) + (1 << 0),
-                    },
+                        (0 << 20) + (0 << 10) + (1 << 0)
+                    ),
                 ]),
                 block: Arc::new(stylesheet.shared_lock.wrap(block_from(vec![
                     (PropertyDeclaration::Display(longhands::display::SpecifiedValue::block),
@@ -158,17 +155,16 @@ fn test_parse_stylesheet() {
             }))),
             CssRule::Style(Arc::new(stylesheet.shared_lock.wrap(StyleRule {
                 selectors: SelectorList(vec![
-                    Selector {
-                        inner: SelectorInner::from_vec(vec![
+                    Selector::new_for_unit_testing(
+                        SelectorInner::from_vec(vec![
                             Component::DefaultNamespace(NsAtom::from("http://www.w3.org/1999/xhtml")),
                             Component::ID(Atom::from("d1")),
                             Component::Combinator(Combinator::Child),
                             Component::DefaultNamespace(NsAtom::from("http://www.w3.org/1999/xhtml")),
                             Component::Class(Atom::from("ok")),
                         ]),
-                        pseudo_element: None,
-                        specificity: (1 << 20) + (1 << 10) + (0 << 0),
-                    },
+                        (1 << 20) + (1 << 10) + (0 << 0)
+                    ),
                 ]),
                 block: Arc::new(stylesheet.shared_lock.wrap(block_from(vec![
                     (PropertyDeclaration::BackgroundColor(

--- a/tests/unit/stylo/size_of.rs
+++ b/tests/unit/stylo/size_of.rs
@@ -12,8 +12,8 @@ fn size_of_selectors_dummy_types() {
     assert_eq!(size_of::<dummies::PseudoClass>(), size_of::<real::NonTSPseudoClass>());
     assert_eq!(align_of::<dummies::PseudoClass>(), align_of::<real::NonTSPseudoClass>());
 
-    assert_eq!(size_of::<dummies::PseudoElementSelector>(), size_of::<real::PseudoElementSelector>());
-    assert_eq!(align_of::<dummies::PseudoElementSelector>(), align_of::<real::PseudoElementSelector>());
+    assert_eq!(size_of::<dummies::PseudoElement>(), size_of::<real::PseudoElement>());
+    assert_eq!(align_of::<dummies::PseudoElement>(), align_of::<real::PseudoElement>());
 
     assert_eq!(size_of::<dummies::Atom>(), size_of::<style::Atom>());
     assert_eq!(align_of::<dummies::Atom>(), align_of::<style::Atom>());


### PR DESCRIPTION
On top of https://github.com/servo/servo/pull/16890.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16900)
<!-- Reviewable:end -->
