### PR TITLE
make gl context current on browser initialization

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -126,6 +126,8 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
         // Global configuration options, parsed from the command line.
         let opts = opts::get();
 
+        // Make sure the gl context is made current.
+        window.prepare_for_composite(0, 0);
 
         // Get both endpoints of a special channel for communication between
         // the client window and the compositor. This channel is unique because


### PR DESCRIPTION
As explained in servo/webrender#1233, it's necessary to make the current gl context current when the browser is initialized, otherwise the wrong gl context might be used if another window is created before the initialization.

/cc @glennw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16903)
<!-- Reviewable:end -->
