### PR TITLE
Not headless by default

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -485,7 +485,7 @@ pub fn default_opts() -> Opts {
         replace_surrogates: false,
         gc_profile: false,
         load_webfonts_synchronously: false,
-        headless: true,
+        headless: false,
         hard_fail: true,
         bubble_inline_sizes_separately: false,
         show_debug_fragment_borders: false,


### PR DESCRIPTION
Without this, initializing Servo without using the command line (when embedded) requires to explicitly set `opts.headless = false`, which is weird as it's the only option that needs to be changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16904)
<!-- Reviewable:end -->
