### PR TITLE
style: Make restyle hints handle child combinators better than restyling the entire subtree

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -160,7 +160,9 @@ pub fn recalc_style_for_animations(context: &LayoutContext,
                                            animation,
                                            &mut fragment.style,
                                            &ServoMetricsProvider);
-                damage |= RestyleDamage::compute(&old_style, &fragment.style);
+                let difference =
+                    RestyleDamage::compute_style_difference(&old_style, &fragment.style);
+                damage |= difference.damage;
             }
         }
     });

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1100,7 +1100,7 @@ impl LayoutThread {
                         let el = node.as_element().unwrap();
                         if let Some(mut d) = element.mutate_data() {
                             if d.has_styles() {
-                                d.ensure_restyle().hint.insert(&StoredRestyleHint::subtree());
+                                d.ensure_restyle().hint.insert(StoredRestyleHint::subtree());
                             }
                         }
                         if let Some(p) = el.parent_element() {
@@ -1136,7 +1136,7 @@ impl LayoutThread {
         if needs_dirtying {
             if let Some(mut d) = element.mutate_data() {
                 if d.has_styles() {
-                    d.ensure_restyle().hint.insert(&StoredRestyleHint::subtree());
+                    d.ensure_restyle().hint.insert(StoredRestyleHint::subtree());
                 }
             }
         }
@@ -1184,7 +1184,7 @@ impl LayoutThread {
             let mut restyle_data = style_data.ensure_restyle();
 
             // Stash the data on the element for processing by the style system.
-            restyle_data.hint.insert(&restyle.hint.into());
+            restyle_data.hint.insert(restyle.hint.into());
             restyle_data.damage = restyle.damage;
             debug!("Noting restyle for {:?}: {:?}", el, restyle_data);
         }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -131,7 +131,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 use style::attr::AttrValue;
 use style::context::{QuirksMode, ReflowGoal};
-use style::restyle_hints::{RestyleHint, RESTYLE_SELF, RESTYLE_STYLE_ATTRIBUTE};
+use style::restyle_hints::{RestyleHint, RestyleReplacements, RESTYLE_STYLE_ATTRIBUTE};
 use style::selector_parser::{RestyleDamage, Snapshot};
 use style::shared_lock::SharedRwLock as StyleSharedRwLock;
 use style::str::{HTML_SPACE_CHARACTERS, split_html_space_chars, str_join};
@@ -2361,14 +2361,14 @@ impl Document {
             entry.snapshot = Some(Snapshot::new(el.html_element_in_html_document()));
         }
         if attr.local_name() == &local_name!("style") {
-            entry.hint |= RESTYLE_STYLE_ATTRIBUTE;
+            entry.hint.insert(RestyleHint::for_replacements(RESTYLE_STYLE_ATTRIBUTE));
         }
 
         // FIXME(emilio): This should become something like
         // element.is_attribute_mapped(attr.local_name()).
         if attr.local_name() == &local_name!("width") ||
            attr.local_name() == &local_name!("height") {
-            entry.hint |= RESTYLE_SELF;
+            entry.hint.insert(RestyleHint::for_self());
         }
 
         let mut snapshot = entry.snapshot.as_mut().unwrap();

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -102,7 +102,7 @@ use style::context::{QuirksMode, ReflowGoal};
 use style::element_state::*;
 use style::properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, parse_style_attribute};
 use style::properties::longhands::{self, background_image, border_spacing, font_family, font_size, overflow_x};
-use style::restyle_hints::RESTYLE_SELF;
+use style::restyle_hints::RestyleHint;
 use style::rule_tree::CascadeLevel;
 use style::selector_parser::{NonTSPseudoClass, PseudoElement, RestyleDamage, SelectorImpl, SelectorParser};
 use style::shared_lock::{SharedRwLock, Locked};
@@ -245,7 +245,7 @@ impl Element {
 
         // FIXME(bholley): I think we should probably only do this for
         // NodeStyleDamaged, but I'm preserving existing behavior.
-        restyle.hint |= RESTYLE_SELF;
+        restyle.hint.insert(RestyleHint::for_self());
 
         if damage == NodeDamage::OtherNodeDamage {
             restyle.damage = RestyleDamage::rebuild_and_reflow();

--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -10,7 +10,7 @@ use context::SharedStyleContext;
 use dom::TElement;
 use properties::ComputedValues;
 use properties::longhands::display::computed_value as display;
-use restyle_hints::{RESTYLE_DESCENDANTS, RESTYLE_LATER_SIBLINGS, RESTYLE_SELF, RestyleHint};
+use restyle_hints::{RestyleReplacements, RestyleHint};
 use rule_tree::StrongRuleNode;
 use selector_parser::{EAGER_PSEUDO_COUNT, PseudoElement, RestyleDamage};
 #[cfg(feature = "servo")] use std::collections::HashMap;
@@ -197,21 +197,18 @@ impl StoredRestyleHint {
         // In the middle of an animation only restyle, we don't need to
         // propagate any restyle hints, and we need to remove ourselves.
         if traversal_flags.for_animation_only() {
-            self.0.remove(RestyleHint::for_animations());
+            self.0.remove_animation_hints();
             return Self::empty();
         }
 
-        debug_assert!(!self.0.intersects(RestyleHint::for_animations()),
+        debug_assert!(!self.0.has_animation_hint(),
                       "There should not be any animation restyle hints \
                        during normal traversal");
 
         // Else we should clear ourselves, and return the propagated hint.
-        let hint = mem::replace(&mut self.0, RestyleHint::empty());
-        StoredRestyleHint(if hint.contains(RESTYLE_DESCENDANTS) {
-            RESTYLE_SELF | RESTYLE_DESCENDANTS
-        } else {
-            RestyleHint::empty()
-        })
+        let new_hint = mem::replace(&mut self.0, RestyleHint::empty())
+                       .propagate_for_non_animation_restyle();
+        StoredRestyleHint(new_hint)
     }
 
     /// Creates an empty `StoredRestyleHint`.
@@ -222,25 +219,25 @@ impl StoredRestyleHint {
     /// Creates a restyle hint that forces the whole subtree to be restyled,
     /// including the element.
     pub fn subtree() -> Self {
-        StoredRestyleHint(RESTYLE_SELF | RESTYLE_DESCENDANTS)
+        StoredRestyleHint(RestyleHint::subtree())
     }
 
     /// Creates a restyle hint that forces the element and all its later
     /// siblings to have their whole subtrees restyled, including the elements
     /// themselves.
     pub fn subtree_and_later_siblings() -> Self {
-        StoredRestyleHint(RESTYLE_SELF | RESTYLE_DESCENDANTS | RESTYLE_LATER_SIBLINGS)
+        StoredRestyleHint(RestyleHint::subtree_and_later_siblings())
     }
 
     /// Returns true if the hint indicates that our style may be invalidated.
     pub fn has_self_invalidations(&self) -> bool {
-        self.0.intersects(RestyleHint::for_self())
+        self.0.affects_self()
     }
 
     /// Returns true if the hint indicates that our sibling's style may be
     /// invalidated.
     pub fn has_sibling_invalidations(&self) -> bool {
-        self.0.intersects(RESTYLE_LATER_SIBLINGS)
+        self.0.affects_later_siblings()
     }
 
     /// Whether the restyle hint is empty (nothing requires to be restyled).
@@ -249,13 +246,18 @@ impl StoredRestyleHint {
     }
 
     /// Insert another restyle hint, effectively resulting in the union of both.
-    pub fn insert(&mut self, other: &Self) {
-        self.0 |= other.0
+    pub fn insert(&mut self, other: Self) {
+        self.0.insert(other.0)
+    }
+
+    /// Insert another restyle hint, effectively resulting in the union of both.
+    pub fn insert_from(&mut self, other: &Self) {
+        self.0.insert_from(&other.0)
     }
 
     /// Returns true if the hint has animation-only restyle.
     pub fn has_animation_hint(&self) -> bool {
-        self.0.intersects(RestyleHint::for_animations())
+        self.0.has_animation_hint()
     }
 }
 
@@ -355,7 +357,7 @@ pub enum RestyleKind {
     MatchAndCascade,
     /// We need to recascade with some replacement rule, such as the style
     /// attribute, or animation rules.
-    CascadeWithReplacements(RestyleHint),
+    CascadeWithReplacements(RestyleReplacements),
     /// We only need to recascade, for example, because only inherited
     /// properties in the parent changed.
     CascadeOnly,
@@ -380,7 +382,7 @@ impl ElementData {
                context.traversal_flags);
 
         let mut hint = match self.get_restyle() {
-            Some(r) => r.hint.0,
+            Some(r) => r.hint.0.clone(),
             None => RestyleHint::empty(),
         };
 
@@ -392,7 +394,7 @@ impl ElementData {
                 element.implemented_pseudo_element());
 
         if element.has_snapshot() && !element.handled_snapshot() {
-            hint |= context.stylist.compute_restyle_hint(&element, context.snapshot_map);
+            hint.insert(context.stylist.compute_restyle_hint(&element, context.snapshot_map));
             unsafe { element.set_handled_snapshot() }
             debug_assert!(element.handled_snapshot());
         }
@@ -401,8 +403,7 @@ impl ElementData {
 
         // If the hint includes a directive for later siblings, strip it out and
         // notify the caller to modify the base hint for future siblings.
-        let later_siblings = hint.contains(RESTYLE_LATER_SIBLINGS);
-        hint.remove(RESTYLE_LATER_SIBLINGS);
+        let later_siblings = hint.remove_later_siblings_hint();
 
         // Insert the hint, overriding the previous hint. This effectively takes
         // care of removing the later siblings restyle hint.
@@ -444,13 +445,13 @@ impl ElementData {
         debug_assert!(self.restyle.is_some());
         let restyle_data = self.restyle.as_ref().unwrap();
 
-        let hint = restyle_data.hint.0;
-        if hint.contains(RESTYLE_SELF) {
+        let hint = &restyle_data.hint.0;
+        if hint.match_self() {
             return RestyleKind::MatchAndCascade;
         }
 
         if !hint.is_empty() {
-            return RestyleKind::CascadeWithReplacements(hint);
+            return RestyleKind::CascadeWithReplacements(hint.replacements);
         }
 
         debug_assert!(restyle_data.recascade,

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -951,7 +951,8 @@ extern "C" {
 }
 extern "C" {
     pub fn Gecko_CalcStyleDifference(oldstyle: *mut nsStyleContext,
-                                     newstyle: ServoComputedValuesBorrowed)
+                                     newstyle: ServoComputedValuesBorrowed,
+                                     any_style_changed: *mut bool)
      -> nsChangeHint;
 }
 extern "C" {

--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -49,9 +49,11 @@ impl GeckoRestyleDamage {
                    new_style: &Arc<ComputedValues>) -> Self {
         // TODO(emilio): Const-ify this?
         let context = source as *const nsStyleContext as *mut nsStyleContext;
+        let mut any_style_changed: bool = false;
         let hint = unsafe {
             bindings::Gecko_CalcStyleDifference(context,
-                                                new_style.as_borrowed_opt().unwrap())
+                                                new_style.as_borrowed_opt().unwrap(),
+                                                &mut any_style_changed)
         };
         GeckoRestyleDamage(hint)
     }

--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -8,6 +8,7 @@ use gecko_bindings::bindings;
 use gecko_bindings::structs;
 use gecko_bindings::structs::{nsChangeHint, nsStyleContext};
 use gecko_bindings::sugar::ownership::FFIArcHelpers;
+use matching::{StyleChange, StyleDifference};
 use properties::ComputedValues;
 use std::ops::{BitAnd, BitOr, BitOrAssign, Not};
 use stylearc::Arc;
@@ -38,15 +39,17 @@ impl GeckoRestyleDamage {
         self.0 == nsChangeHint(0)
     }
 
-    /// Computes a change hint given an old style (in the form of a
-    /// `nsStyleContext`, and a new style (in the form of `ComputedValues`).
+    /// Computes the `StyleDifference` (including the appropriate change hint)
+    /// given an old style (in the form of a `nsStyleContext`, and a new style
+    /// (in the form of `ComputedValues`).
     ///
     /// Note that we could in theory just get two `ComputedValues` here and diff
     /// them, but Gecko has an interesting optimization when they mark accessed
     /// structs, so they effectively only diff structs that have ever been
     /// accessed from layout.
-    pub fn compute(source: &nsStyleContext,
-                   new_style: &Arc<ComputedValues>) -> Self {
+    pub fn compute_style_difference(source: &nsStyleContext,
+                                    new_style: &Arc<ComputedValues>)
+                                    -> StyleDifference {
         // TODO(emilio): Const-ify this?
         let context = source as *const nsStyleContext as *mut nsStyleContext;
         let mut any_style_changed: bool = false;
@@ -55,7 +58,8 @@ impl GeckoRestyleDamage {
                                                 new_style.as_borrowed_opt().unwrap(),
                                                 &mut any_style_changed)
         };
-        GeckoRestyleDamage(hint)
+        let change = if any_style_changed { StyleChange::Changed } else { StyleChange::Unchanged };
+        StyleDifference::new(GeckoRestyleDamage(hint), change)
     }
 
     /// Returns true if this restyle damage contains all the damage of |other|.

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -16,6 +16,7 @@ use context::{CurrentElementInfo, SelectorFlagsMap, SharedStyleContext, StyleCon
 use data::{ComputedStyle, ElementData, ElementStyles, RestyleData};
 use dom::{AnimationRules, SendElement, TElement, TNode};
 use font_metrics::FontMetricsProvider;
+use log::LogLevel::Trace;
 use properties::{CascadeFlags, ComputedValues, SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP, cascade};
 use properties::longhands::display::computed_value as display;
 use restyle_hints::{RESTYLE_CSS_ANIMATIONS, RESTYLE_CSS_TRANSITIONS, RestyleHint};
@@ -1090,6 +1091,15 @@ pub trait MatchMethods : TElement {
             compute_rule_node::<Self>(&stylist.rule_tree,
                                       &mut applicable_declarations,
                                       &context.shared.guards);
+
+        if log_enabled!(Trace) {
+            trace!("Matched rules:");
+            for rn in primary_rule_node.self_and_ancestors() {
+                if let Some(source) = rn.style_source() {
+                    trace!(" > {:?}", source);
+                }
+            }
+        }
 
         return data.set_primary_rules(primary_rule_node);
     }

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -51,6 +51,34 @@ fn relations_are_shareable(relations: &StyleRelations) -> bool {
                           AFFECTED_BY_PRESENTATIONAL_HINTS)
 }
 
+/// Represents the result of comparing an element's old and new style.
+pub struct StyleDifference {
+    /// The resulting damage.
+    pub damage: RestyleDamage,
+
+    /// Whether any styles changed.
+    pub change: StyleChange,
+}
+
+impl StyleDifference {
+    /// Creates a new `StyleDifference`.
+    pub fn new(damage: RestyleDamage, change: StyleChange) -> Self {
+        StyleDifference {
+            change: change,
+            damage: damage,
+        }
+    }
+}
+
+/// Represents whether or not the style of an element has changed.
+#[derive(Copy, Clone)]
+pub enum StyleChange {
+    /// The style hasn't changed.
+    Unchanged,
+    /// The style has changed.
+    Changed,
+}
+
 /// Information regarding a style sharing candidate.
 ///
 /// Note that this information is stored in TLS and cleared after the traversal,
@@ -375,8 +403,37 @@ pub enum StyleSharingResult {
     /// We didn't find anybody to share the style with.
     CannotShare,
     /// The node's style can be shared. The integer specifies the index in the
-    /// LRU cache that was hit and the damage that was done.
-    StyleWasShared(usize),
+    /// LRU cache that was hit and the damage that was done. The
+    /// `ChildCascadeRequirement` indicates whether style changes due to using
+    /// the shared style mean we need to recascade to children.
+    StyleWasShared(usize, ChildCascadeRequirement),
+}
+
+/// Whether or not newly computed values for an element need to be cascade
+/// to children.
+pub enum ChildCascadeRequirement {
+    /// Old and new computed values were the same, or we otherwise know that
+    /// we won't bother recomputing style for children, so we can skip cascading
+    /// the new values into child elements.
+    CanSkipCascade,
+    /// Old and new computed values were different, so we must cascade the
+    /// new values to children.
+    ///
+    /// FIXME(heycam) Although this is "must" cascade, in the future we should
+    /// track whether child elements rely specifically on inheriting particular
+    /// property values.  When we do that, we can treat `MustCascade` as "must
+    /// cascade unless we know that changes to these properties can be
+    /// ignored".
+    MustCascade,
+}
+
+impl From<StyleChange> for ChildCascadeRequirement {
+    fn from(change: StyleChange) -> ChildCascadeRequirement {
+        match change {
+            StyleChange::Unchanged => ChildCascadeRequirement::CanSkipCascade,
+            StyleChange::Changed => ChildCascadeRequirement::MustCascade,
+        }
+    }
 }
 
 trait PrivateMatchMethods: TElement {
@@ -536,7 +593,8 @@ trait PrivateMatchMethods: TElement {
     /// setting them on the ElementData.
     fn cascade_primary(&self,
                        context: &mut StyleContext<Self>,
-                       data: &mut ElementData) {
+                       data: &mut ElementData)
+                       -> ChildCascadeRequirement {
         // Collect some values.
         let (mut styles, restyle) = data.styles_and_restyle_mut();
         let mut primary_style = &mut styles.primary;
@@ -554,16 +612,19 @@ trait PrivateMatchMethods: TElement {
                                     primary_style);
         }
 
-        if let Some(old) = old_values {
+        let child_cascade_requirement =
             self.accumulate_damage(&context.shared,
-                                   restyle.unwrap(),
-                                   &old,
+                                   restyle,
+                                   old_values.as_ref().map(|v| v.as_ref()),
                                    &new_values,
                                    None);
-        }
 
         // Set the new computed values.
         primary_style.values = Some(new_values);
+
+        // Return whether the damage indicates we must cascade new inherited
+        // values into children.
+        child_cascade_requirement
     }
 
     fn cascade_eager_pseudo(&self,
@@ -578,16 +639,14 @@ trait PrivateMatchMethods: TElement {
         let new_values =
             self.cascade_internal(context, &styles.primary, Some(pseudo_style));
 
-        if let Some(old) = old_values {
-            // ::before and ::after are element-backed in Gecko, so they do
-            // the damage calculation for themselves.
-            if cfg!(feature = "servo") || !pseudo.is_before_or_after() {
-                self.accumulate_damage(&context.shared,
-                                       restyle.unwrap(),
-                                       &old,
-                                       &new_values,
-                                       Some(pseudo));
-            }
+        // ::before and ::after are element-backed in Gecko, so they do
+        // the damage calculation for themselves.
+        if cfg!(feature = "servo") || !pseudo.is_before_or_after() {
+            self.accumulate_damage(&context.shared,
+                                   restyle,
+                                   old_values.as_ref().map(|v| v.as_ref()),
+                                   &new_values,
+                                   Some(pseudo));
         }
 
         pseudo_style.values = Some(new_values)
@@ -742,54 +801,68 @@ trait PrivateMatchMethods: TElement {
         }
     }
 
-    /// Computes and applies non-redundant damage.
-    #[cfg(feature = "gecko")]
+    /// Computes and applies restyle damage.
     fn accumulate_damage(&self,
                          shared_context: &SharedStyleContext,
-                         restyle: &mut RestyleData,
-                         old_values: &ComputedValues,
+                         restyle: Option<&mut RestyleData>,
+                         old_values: Option<&ComputedValues>,
                          new_values: &Arc<ComputedValues>,
-                         pseudo: Option<&PseudoElement>) {
+                         pseudo: Option<&PseudoElement>)
+                         -> ChildCascadeRequirement {
+        if restyle.is_none() || old_values.is_none() {
+            return ChildCascadeRequirement::MustCascade;
+        }
+
+        self.accumulate_damage_for(shared_context, restyle.unwrap(),
+                                   old_values.unwrap(), new_values, pseudo)
+    }
+
+    /// Computes and applies non-redundant damage.
+    #[cfg(feature = "gecko")]
+    fn accumulate_damage_for(&self,
+                             shared_context: &SharedStyleContext,
+                             restyle: &mut RestyleData,
+                             old_values: &ComputedValues,
+                             new_values: &Arc<ComputedValues>,
+                             pseudo: Option<&PseudoElement>)
+                             -> ChildCascadeRequirement {
         // Don't accumulate damage if we're in a restyle for reconstruction.
         if shared_context.traversal_flags.for_reconstruct() {
-            return;
+            return ChildCascadeRequirement::MustCascade;
         }
 
         // If an ancestor is already getting reconstructed by Gecko's top-down
-        // frame constructor, no need to apply damage.
-        if restyle.damage_handled.contains(RestyleDamage::reconstruct()) {
-            restyle.damage = RestyleDamage::empty();
-            return;
-        }
-
-        // Add restyle damage, but only the bits that aren't redundant with respect
-        // to damage applied on our ancestors.
+        // frame constructor, no need to apply damage.  Similarly if we already
+        // have an explicitly stored ReconstructFrame hint.
         //
         // See https://bugzilla.mozilla.org/show_bug.cgi?id=1301258#c12
         // for followup work to make the optimization here more optimal by considering
         // each bit individually.
-        if !restyle.damage.contains(RestyleDamage::reconstruct()) {
-            let new_damage = self.compute_restyle_damage(&old_values,
-                                                         &new_values,
-                                                         pseudo);
-            if !restyle.damage_handled.contains(new_damage) {
-                restyle.damage |= new_damage;
-            }
+        let skip_applying_damage =
+            restyle.damage_handled.contains(RestyleDamage::reconstruct()) ||
+            restyle.damage.contains(RestyleDamage::reconstruct());
+
+        let difference = self.compute_style_difference(&old_values,
+                                                       &new_values,
+                                                       pseudo);
+        if !skip_applying_damage {
+            restyle.damage |= difference.damage;
         }
+        difference.change.into()
     }
 
     /// Computes and applies restyle damage unless we've already maxed it out.
     #[cfg(feature = "servo")]
-    fn accumulate_damage(&self,
-                         _shared_context: &SharedStyleContext,
-                         restyle: &mut RestyleData,
-                         old_values: &ComputedValues,
-                         new_values: &Arc<ComputedValues>,
-                         pseudo: Option<&PseudoElement>) {
-        if restyle.damage != RestyleDamage::rebuild_and_reflow() {
-            restyle.damage |=
-                self.compute_restyle_damage(&old_values, &new_values, pseudo);
-        }
+    fn accumulate_damage_for(&self,
+                             _shared_context: &SharedStyleContext,
+                             restyle: &mut RestyleData,
+                             old_values: &ComputedValues,
+                             new_values: &Arc<ComputedValues>,
+                             pseudo: Option<&PseudoElement>)
+                             -> ChildCascadeRequirement {
+        let difference = self.compute_style_difference(&old_values, &new_values, pseudo);
+        restyle.damage |= difference.damage;
+        difference.change.into()
     }
 
     #[cfg(feature = "servo")]
@@ -877,7 +950,7 @@ pub trait MatchMethods : TElement {
     fn match_and_cascade(&self,
                          context: &mut StyleContext<Self>,
                          data: &mut ElementData,
-                         sharing: StyleSharingBehavior)
+                         sharing: StyleSharingBehavior) -> ChildCascadeRequirement
     {
         // Perform selector matching for the primary style.
         let mut relations = StyleRelations::empty();
@@ -886,7 +959,7 @@ pub trait MatchMethods : TElement {
                                                     &mut relations);
 
         // Cascade properties and compute primary values.
-        self.cascade_primary(context, data);
+        let child_cascade_requirement = self.cascade_primary(context, data);
 
         // Match and cascade eager pseudo-elements.
         if !data.styles().is_display_none() {
@@ -920,15 +993,18 @@ pub trait MatchMethods : TElement {
                                        relations,
                                        revalidation_match_results);
         }
+
+        child_cascade_requirement
     }
 
     /// Performs the cascade, without matching.
     fn cascade_primary_and_pseudos(&self,
                                    context: &mut StyleContext<Self>,
-                                   mut data: &mut ElementData)
+                                   mut data: &mut ElementData) -> ChildCascadeRequirement
     {
-        self.cascade_primary(context, &mut data);
+        let child_cascade_requirement = self.cascade_primary(context, &mut data);
         self.cascade_pseudos(context, &mut data);
+        child_cascade_requirement
     }
 
     /// Runs selector matching to (re)compute the primary rule node for this element.
@@ -1281,11 +1357,12 @@ pub trait MatchMethods : TElement {
                     debug_assert_eq!(data.has_styles(), data.has_restyle());
                     let old_values = data.get_styles_mut()
                                          .and_then(|s| s.primary.values.take());
-                    if let Some(old) = old_values {
+                    let child_cascade_requirement =
                         self.accumulate_damage(&context.shared,
-                                               data.restyle_mut(), &old,
-                                               shared_style.values(), None);
-                    }
+                                               data.get_restyle_mut(),
+                                               old_values.as_ref().map(|v| v.as_ref()),
+                                               shared_style.values(),
+                                               None);
 
                     // We never put elements with pseudo style into the style
                     // sharing cache, so we can just mint an ElementStyles
@@ -1295,7 +1372,7 @@ pub trait MatchMethods : TElement {
                     let styles = ElementStyles::new(shared_style);
                     data.set_styles(styles);
 
-                    return StyleSharingResult::StyleWasShared(i)
+                    return StyleSharingResult::StyleWasShared(i, child_cascade_requirement)
                 }
                 Err(miss) => {
                     debug!("Cache miss: {:?}", miss);
@@ -1379,14 +1456,14 @@ pub trait MatchMethods : TElement {
     /// Given the old and new style of this element, and whether it's a
     /// pseudo-element, compute the restyle damage used to determine which
     /// kind of layout or painting operations we'll need.
-    fn compute_restyle_damage(&self,
-                              old_values: &ComputedValues,
-                              new_values: &Arc<ComputedValues>,
-                              pseudo: Option<&PseudoElement>)
-                              -> RestyleDamage
+    fn compute_style_difference(&self,
+                                old_values: &ComputedValues,
+                                new_values: &Arc<ComputedValues>,
+                                pseudo: Option<&PseudoElement>)
+                                -> StyleDifference
     {
         match self.existing_style_for_restyle_damage(old_values, pseudo) {
-            Some(ref source) => RestyleDamage::compute(source, new_values),
+            Some(ref source) => RestyleDamage::compute_style_difference(source, new_values),
             None => {
                 // If there's no style source, that likely means that Gecko
                 // couldn't find a style context. This happens with display:none
@@ -1395,16 +1472,19 @@ pub trait MatchMethods : TElement {
                 if new_values.get_box().clone_display() == display::T::none &&
                     old_values.get_box().clone_display() == display::T::none {
                     // The style remains display:none. No need for damage.
-                    RestyleDamage::empty()
+                    // (It doesn't matter what value we use for the StyleChange,
+                    // since we won't traverse into the display:none subtree
+                    // anyway.)
+                    StyleDifference::new(RestyleDamage::empty(), StyleChange::Unchanged)
                 } else {
                     // Something else. Be conservative for now.
-                    RestyleDamage::reconstruct()
+                    StyleDifference::new(RestyleDamage::reconstruct(), StyleChange::Changed)
                 }
             }
         }
     }
 
-    /// Cascade the eager pseudo-elements of this element.
+    /// Performs the cascade for the element's eager pseudos.
     fn cascade_pseudos(&self,
                        context: &mut StyleContext<Self>,
                        mut data: &mut ElementData)

--- a/components/style/restyle_hints.rs
+++ b/components/style/restyle_hints.rs
@@ -28,32 +28,38 @@ use std::cell::Cell;
 use std::clone::Clone;
 use stylist::SelectorMap;
 
+/// When the ElementState of an element (like IN_HOVER_STATE) changes,
+/// certain pseudo-classes (like :hover) may require us to restyle that
+/// element, its siblings, and/or its descendants. Similarly, when various
+/// attributes of an element change, we may also need to restyle things with
+/// id, class, and attribute selectors. Doing this conservatively is
+/// expensive, and so we use RestyleHints to short-circuit work we know is
+/// unnecessary.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RestyleHint {
+    /// Rerun selector matching on the element.
+    match_self: bool,
+
+    /// Rerun selector matching on all of the element's descendants.
+    match_descendants: bool,
+
+    /// Rerun selector matching on all later siblings of the element and all
+    /// of their descendants.
+    match_later_siblings: bool,
+
+    /// Levels of the cascade whose rule nodes should be recomputed and
+    /// replaced.
+    pub replacements: RestyleReplacements,
+}
+
 bitflags! {
-    /// When the ElementState of an element (like IN_HOVER_STATE) changes,
-    /// certain pseudo-classes (like :hover) may require us to restyle that
-    /// element, its siblings, and/or its descendants. Similarly, when various
-    /// attributes of an element change, we may also need to restyle things with
-    /// id, class, and attribute selectors. Doing this conservatively is
-    /// expensive, and so we use RestyleHints to short-circuit work we know is
-    /// unnecessary.
+    /// Cascade levels that can be updated for an element by simply replacing
+    /// their rule node.
     ///
     /// Note that the bit values here must be kept in sync with the Gecko
     /// nsRestyleHint values.  If you add more bits with matching values,
     /// please add assertions to assert_restyle_hints_match below.
-    pub flags RestyleHint: u32 {
-        /// Rerun selector matching on the element.
-        const RESTYLE_SELF = 0x01,
-
-        /// Rerun selector matching on all of the element's descendants.
-        ///
-        /// NB: In Gecko, we have RESTYLE_SUBTREE which is inclusive of self,
-        /// but heycam isn't aware of a good reason for that.
-        const RESTYLE_DESCENDANTS = 0x04,
-
-        /// Rerun selector matching on all later siblings of the element and all
-        /// of their descendants.
-        const RESTYLE_LATER_SIBLINGS = 0x08,
-
+    pub flags RestyleReplacements: u8 {
         /// Replace the style data coming from CSS transitions without updating
         /// any other style data. This hint is only processed in animation-only
         /// traversal which is prior to normal traversal.
@@ -76,7 +82,7 @@ bitflags! {
     }
 }
 
-/// Asserts that all RestyleHint flags have a matching nsRestyleHint value.
+/// Asserts that all RestyleReplacements have a matching nsRestyleHint value.
 #[cfg(feature = "gecko")]
 #[inline]
 pub fn assert_restyle_hints_match() {
@@ -85,24 +91,18 @@ pub fn assert_restyle_hints_match() {
     macro_rules! check_restyle_hints {
         ( $( $a:ident => $b:ident ),*, ) => {
             if cfg!(debug_assertions) {
-                let mut hints = RestyleHint::all();
+                let mut replacements = RestyleReplacements::all();
                 $(
                     assert_eq!(structs::$a.0 as usize, $b.bits() as usize, stringify!($b));
-                    hints.remove($b);
+                    replacements.remove($b);
                 )*
-                assert_eq!(hints, RestyleHint::empty(), "all RestyleHint bits should have an assertion");
+                assert_eq!(replacements, RestyleReplacements::empty(),
+                           "all RestyleReplacements bits should have an assertion");
             }
         }
     }
 
     check_restyle_hints! {
-        nsRestyleHint_eRestyle_Self => RESTYLE_SELF,
-        // Note that eRestyle_Subtree means "self and descendants", while
-        // RESTYLE_DESCENDANTS means descendants only.  The From impl
-        // below handles converting eRestyle_Subtree into
-        // (RESTYLE_SELF | RESTYLE_DESCENDANTS).
-        nsRestyleHint_eRestyle_Subtree => RESTYLE_DESCENDANTS,
-        nsRestyleHint_eRestyle_LaterSiblings => RESTYLE_LATER_SIBLINGS,
         nsRestyleHint_eRestyle_CSSTransitions => RESTYLE_CSS_TRANSITIONS,
         nsRestyleHint_eRestyle_CSSAnimations => RESTYLE_CSS_ANIMATIONS,
         nsRestyleHint_eRestyle_StyleAttribute => RESTYLE_STYLE_ATTRIBUTE,
@@ -111,14 +111,193 @@ pub fn assert_restyle_hints_match() {
 }
 
 impl RestyleHint {
-    /// The subset hints that affect the styling of a single element during the
-    /// traversal.
+    /// Creates a new, empty `RestyleHint`, which represents no restyling work
+    /// needs to be done.
     #[inline]
-    pub fn for_self() -> Self {
-        RESTYLE_SELF | RESTYLE_STYLE_ATTRIBUTE | Self::for_animations()
+    pub fn empty() -> Self {
+        RestyleHint {
+            match_self: false,
+            match_descendants: false,
+            match_later_siblings: false,
+            replacements: RestyleReplacements::empty(),
+        }
     }
 
-    /// The subset hints that are used for animation restyle.
+    /// Creates a new `RestyleHint` that indicates selector matching must be
+    /// re-run on the element.
+    #[inline]
+    pub fn for_self() -> Self {
+        RestyleHint {
+            match_self: true,
+            match_descendants: false,
+            match_later_siblings: false,
+            replacements: RestyleReplacements::empty(),
+        }
+    }
+
+    /// Creates a new `RestyleHint` that indicates selector matching must be
+    /// re-run on all of the element's descendants.
+    #[inline]
+    pub fn descendants() -> Self {
+        RestyleHint {
+            match_self: false,
+            match_descendants: true,
+            match_later_siblings: false,
+            replacements: RestyleReplacements::empty(),
+        }
+    }
+
+    /// Creates a new `RestyleHint` that indicates selector matching must be
+    /// re-run on all of the element's later siblings and their descendants.
+    #[inline]
+    pub fn later_siblings() -> Self {
+        RestyleHint {
+            match_self: false,
+            match_descendants: false,
+            match_later_siblings: true,
+            replacements: RestyleReplacements::empty(),
+        }
+    }
+
+    /// Creates a new `RestyleHint` that indicates selector matching must be
+    /// re-run on the element and all of its descendants.
+    #[inline]
+    pub fn subtree() -> Self {
+        RestyleHint {
+            match_self: true,
+            match_descendants: true,
+            match_later_siblings: false,
+            replacements: RestyleReplacements::empty(),
+        }
+    }
+
+    /// Creates a new `RestyleHint` that indicates selector matching must be
+    /// re-run on the element, its descendants, its later siblings, and
+    /// their descendants.
+    #[inline]
+    pub fn subtree_and_later_siblings() -> Self {
+        RestyleHint {
+            match_self: true,
+            match_descendants: true,
+            match_later_siblings: true,
+            replacements: RestyleReplacements::empty(),
+        }
+    }
+
+    /// Creates a new `RestyleHint` that indicates the specified rule node
+    /// replacements must be performed on the element.
+    #[inline]
+    pub fn for_replacements(replacements: RestyleReplacements) -> Self {
+        RestyleHint {
+            match_self: false,
+            match_descendants: false,
+            match_later_siblings: false,
+            replacements: replacements,
+        }
+    }
+
+    /// Returns whether this `RestyleHint` represents no needed restyle work.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        *self == RestyleHint::empty()
+    }
+
+    /// Returns whether this `RestyleHint` represents the maximum possible
+    /// restyle work, and thus any `insert()` calls will have no effect.
+    #[inline]
+    pub fn is_maximum(&self) -> bool {
+        self.match_self && self.match_descendants && self.match_later_siblings && self.replacements.is_all()
+    }
+
+    /// Returns whether the hint specifies that some work must be performed on
+    /// the current element.
+    #[inline]
+    pub fn affects_self(&self) -> bool {
+        self.match_self || !self.replacements.is_empty()
+    }
+
+    /// Returns whether the hint specifies that later siblings must be restyled.
+    #[inline]
+    pub fn affects_later_siblings(&self) -> bool {
+        self.match_later_siblings
+    }
+
+    /// Returns whether the hint specifies that an animation cascade level must
+    /// be replaced.
+    #[inline]
+    pub fn has_animation_hint(&self) -> bool {
+        self.replacements.intersects(RestyleReplacements::for_animations())
+    }
+
+    /// Returns whether the hint specifies some restyle work other than an
+    /// animation cascade level replacement.
+    #[inline]
+    pub fn has_non_animation_hint(&self) -> bool {
+        self.match_self || self.match_descendants || self.match_later_siblings ||
+            self.replacements.contains(RESTYLE_STYLE_ATTRIBUTE)
+    }
+
+    /// Returns whether the hint specifies that selector matching must be re-run
+    /// for the element.
+    #[inline]
+    pub fn match_self(&self) -> bool {
+        self.match_self
+    }
+
+    /// Returns a new `RestyleHint` appropriate for children of the current
+    /// element.
+    #[inline]
+    pub fn propagate_for_non_animation_restyle(&self) -> Self {
+        if self.match_descendants {
+            Self::subtree()
+        } else {
+            Self::empty()
+        }
+    }
+
+    /// Removes all of the animation-related hints.
+    #[inline]
+    pub fn remove_animation_hints(&mut self) {
+        self.replacements.remove(RestyleReplacements::for_animations());
+    }
+
+    /// Removes the later siblings hint, and returns whether it was present.
+    pub fn remove_later_siblings_hint(&mut self) -> bool {
+        let later_siblings = self.match_later_siblings;
+        self.match_later_siblings = false;
+        later_siblings
+    }
+
+    /// Unions the specified `RestyleHint` into this one.
+    #[inline]
+    pub fn insert_from(&mut self, other: &Self) {
+        self.match_self |= other.match_self;
+        self.match_descendants |= other.match_descendants;
+        self.match_later_siblings |= other.match_later_siblings;
+        self.replacements.insert(other.replacements);
+    }
+
+    /// Unions the specified `RestyleHint` into this one.
+    #[inline]
+    pub fn insert(&mut self, other: Self) {
+        // A later patch should make it worthwhile to have an insert() function
+        // that consumes its argument.
+        self.insert_from(&other)
+    }
+
+    /// Returns whether this `RestyleHint` represents at least as much restyle
+    /// work as the specified one.
+    #[inline]
+    pub fn contains(&mut self, other: &Self) -> bool {
+        !(other.match_self && !self.match_self) &&
+        !(other.match_descendants && !self.match_descendants) &&
+        !(other.match_later_siblings && !self.match_later_siblings) &&
+        self.replacements.contains(other.replacements)
+    }
+}
+
+impl RestyleReplacements {
+    /// The replacements for the animation cascade levels.
     #[inline]
     pub fn for_animations() -> Self {
         RESTYLE_SMIL | RESTYLE_CSS_ANIMATIONS | RESTYLE_CSS_TRANSITIONS
@@ -126,24 +305,26 @@ impl RestyleHint {
 }
 
 #[cfg(feature = "gecko")]
+impl From<nsRestyleHint> for RestyleReplacements {
+    fn from(raw: nsRestyleHint) -> Self {
+        Self::from_bits_truncate(raw.0 as u8)
+    }
+}
+
+#[cfg(feature = "gecko")]
 impl From<nsRestyleHint> for RestyleHint {
     fn from(raw: nsRestyleHint) -> Self {
-        let raw_bits: u32 = raw.0;
+        use gecko_bindings::structs::nsRestyleHint_eRestyle_LaterSiblings as eRestyle_LaterSiblings;
+        use gecko_bindings::structs::nsRestyleHint_eRestyle_Self as eRestyle_Self;
+        use gecko_bindings::structs::nsRestyleHint_eRestyle_SomeDescendants as eRestyle_SomeDescendants;
+        use gecko_bindings::structs::nsRestyleHint_eRestyle_Subtree as eRestyle_Subtree;
 
-        // FIXME(bholley): Finish aligning the binary representations here and
-        // then .expect() the result of the checked version.
-        if Self::from_bits(raw_bits).is_none() {
-            warn!("stylo: dropping unsupported restyle hint bits");
+        RestyleHint {
+            match_self: (raw.0 & (eRestyle_Self.0 | eRestyle_Subtree.0)) != 0,
+            match_descendants: (raw.0 & (eRestyle_Subtree.0 | eRestyle_SomeDescendants.0)) != 0,
+            match_later_siblings: (raw.0 & eRestyle_LaterSiblings.0) != 0,
+            replacements: raw.into(),
         }
-
-        let mut bits = Self::from_bits_truncate(raw_bits);
-
-        // eRestyle_Subtree converts to (RESTYLE_SELF | RESTYLE_DESCENDANTS).
-        if bits.contains(RESTYLE_DESCENDANTS) {
-            bits |= RESTYLE_SELF;
-        }
-
-        bits
     }
 }
 
@@ -437,15 +618,16 @@ fn is_attr_selector(sel: &Component<SelectorImpl>) -> bool {
 
 fn combinator_to_restyle_hint(combinator: Option<Combinator>) -> RestyleHint {
     match combinator {
-        None => RESTYLE_SELF,
+        None => RestyleHint::for_self(),
         Some(c) => match c {
-            // NB: RESTYLE_SELF is needed to handle properly eager pseudos,
-            // otherwise we may leave a stale style on the parent.
-            Combinator::PseudoElement => RESTYLE_SELF | RESTYLE_DESCENDANTS,
-            Combinator::Child => RESTYLE_DESCENDANTS,
-            Combinator::Descendant => RESTYLE_DESCENDANTS,
-            Combinator::NextSibling => RESTYLE_LATER_SIBLINGS,
-            Combinator::LaterSibling => RESTYLE_LATER_SIBLINGS,
+            // NB: RestyleHint::subtree() and not RestyleHint::descendants() is
+            // needed to handle properly eager pseudos, otherwise we may leave
+            // a stale style on the parent.
+            Combinator::PseudoElement => RestyleHint::subtree(),
+            Combinator::Child => RestyleHint::descendants(),
+            Combinator::Descendant => RestyleHint::descendants(),
+            Combinator::NextSibling => RestyleHint::later_siblings(),
+            Combinator::LaterSibling => RestyleHint::later_siblings(),
         }
     }
 }
@@ -700,12 +882,12 @@ impl DependencySet {
                 return true;
             }
 
-            if hint.contains(dep.hint) {
+            if hint.contains(&dep.hint) {
                 trace!(" > hint was already there");
                 return true;
             }
 
-            // We can ignore the selector flags, since they would have already
+            // We can ignore the selector replacements, since they would have already
             // been set during original matching for any element that might
             // change its matching behavior here.
             let matched_then =
@@ -717,10 +899,10 @@ impl DependencySet {
                                  &mut matching_context,
                                  &mut |_, _| {});
             if matched_then != matches_now {
-                hint.insert(dep.hint);
+                hint.insert_from(&dep.hint);
             }
 
-            !hint.is_all()
+            !hint.is_maximum()
         });
 
         debug!("Calculated restyle hint: {:?} for {:?}. (State={:?}, {} Deps)",

--- a/components/style/restyle_hints.rs
+++ b/components/style/restyle_hints.rs
@@ -37,11 +37,8 @@ use stylist::SelectorMap;
 /// unnecessary.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RestyleHint {
-    /// Rerun selector matching on the element.
-    match_self: bool,
-
-    /// Rerun selector matching on all of the element's descendants.
-    match_descendants: bool,
+    /// Depths at which selector matching must be re-run.
+    match_under_self: RestyleDepths,
 
     /// Rerun selector matching on all later siblings of the element and all
     /// of their descendants.
@@ -82,6 +79,75 @@ bitflags! {
     }
 }
 
+/// Eight bit wide bitfield representing depths of a DOM subtree's descendants,
+/// used to represent which elements must have selector matching re-run on them.
+///
+/// The least significant bit indicates that selector matching must be re-run
+/// for the element itself, the second least significant bit for the element's
+/// children, the third its grandchildren, and so on.  If the most significant
+/// bit it set, it indicates that that selector matching must be re-run for
+/// elements at that depth and all of their descendants.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct RestyleDepths(u8);
+
+impl RestyleDepths {
+    /// Returns a `RestyleDepths` representing no element depths.
+    fn empty() -> Self {
+        RestyleDepths(0)
+    }
+
+    /// Returns a `RestyleDepths` representing the current element depth.
+    fn for_self() -> Self {
+        RestyleDepths(0x01)
+    }
+
+    /// Returns a `RestyleDepths` representing the depths of all descendants of
+    /// the current element.
+    fn for_descendants() -> Self {
+        RestyleDepths(0xfe)
+    }
+
+    /// Returns a `RestyleDepths` representing the current element depth and the
+    /// depths of all the current element's descendants.
+    fn for_self_and_descendants() -> Self {
+        RestyleDepths(0xff)
+    }
+
+    /// Returns whether this `RestyleDepths` represents the current element
+    /// depth and the depths of all the current element's descendants.
+    fn is_self_and_descendants(&self) -> bool {
+        self.0 == 0xff
+    }
+
+    /// Returns whether this `RestyleDepths` includes any element depth.
+    fn is_any(&self) -> bool {
+        self.0 != 0
+    }
+
+    /// Returns whether this `RestyleDepths` includes the current element depth.
+    fn has_self(&self) -> bool {
+        (self.0 & 0x01) != 0
+    }
+
+    /// Returns a new `RestyleDepths` with all depth values represented by this
+    /// `RestyleDepths` reduced by one.
+    fn propagate(&self) -> Self {
+        RestyleDepths((self.0 >> 1) | (self.0 & 0x80))
+    }
+
+    /// Returns a new `RestyleDepths` that represents the union of the depths
+    /// from `self` and `other`.
+    fn insert(&mut self, other: RestyleDepths) {
+        self.0 |= other.0;
+    }
+
+    /// Returns whether this `RestyleDepths` includes all depths represented
+    /// by `other`.
+    fn contains(&self, other: RestyleDepths) -> bool {
+        (self.0 & other.0) == other.0
+    }
+}
+
 /// Asserts that all RestyleReplacements have a matching nsRestyleHint value.
 #[cfg(feature = "gecko")]
 #[inline]
@@ -116,8 +182,7 @@ impl RestyleHint {
     #[inline]
     pub fn empty() -> Self {
         RestyleHint {
-            match_self: false,
-            match_descendants: false,
+            match_under_self: RestyleDepths::empty(),
             match_later_siblings: false,
             replacements: RestyleReplacements::empty(),
         }
@@ -128,8 +193,7 @@ impl RestyleHint {
     #[inline]
     pub fn for_self() -> Self {
         RestyleHint {
-            match_self: true,
-            match_descendants: false,
+            match_under_self: RestyleDepths::for_self(),
             match_later_siblings: false,
             replacements: RestyleReplacements::empty(),
         }
@@ -140,8 +204,7 @@ impl RestyleHint {
     #[inline]
     pub fn descendants() -> Self {
         RestyleHint {
-            match_self: false,
-            match_descendants: true,
+            match_under_self: RestyleDepths::for_descendants(),
             match_later_siblings: false,
             replacements: RestyleReplacements::empty(),
         }
@@ -152,8 +215,7 @@ impl RestyleHint {
     #[inline]
     pub fn later_siblings() -> Self {
         RestyleHint {
-            match_self: false,
-            match_descendants: false,
+            match_under_self: RestyleDepths::empty(),
             match_later_siblings: true,
             replacements: RestyleReplacements::empty(),
         }
@@ -164,8 +226,7 @@ impl RestyleHint {
     #[inline]
     pub fn subtree() -> Self {
         RestyleHint {
-            match_self: true,
-            match_descendants: true,
+            match_under_self: RestyleDepths::for_self_and_descendants(),
             match_later_siblings: false,
             replacements: RestyleReplacements::empty(),
         }
@@ -177,8 +238,7 @@ impl RestyleHint {
     #[inline]
     pub fn subtree_and_later_siblings() -> Self {
         RestyleHint {
-            match_self: true,
-            match_descendants: true,
+            match_under_self: RestyleDepths::for_self_and_descendants(),
             match_later_siblings: true,
             replacements: RestyleReplacements::empty(),
         }
@@ -189,8 +249,7 @@ impl RestyleHint {
     #[inline]
     pub fn for_replacements(replacements: RestyleReplacements) -> Self {
         RestyleHint {
-            match_self: false,
-            match_descendants: false,
+            match_under_self: RestyleDepths::empty(),
             match_later_siblings: false,
             replacements: replacements,
         }
@@ -206,14 +265,16 @@ impl RestyleHint {
     /// restyle work, and thus any `insert()` calls will have no effect.
     #[inline]
     pub fn is_maximum(&self) -> bool {
-        self.match_self && self.match_descendants && self.match_later_siblings && self.replacements.is_all()
+        self.match_under_self.is_self_and_descendants() &&
+            self.match_later_siblings &&
+            self.replacements.is_all()
     }
 
     /// Returns whether the hint specifies that some work must be performed on
     /// the current element.
     #[inline]
     pub fn affects_self(&self) -> bool {
-        self.match_self || !self.replacements.is_empty()
+        self.match_self() || !self.replacements.is_empty()
     }
 
     /// Returns whether the hint specifies that later siblings must be restyled.
@@ -233,7 +294,7 @@ impl RestyleHint {
     /// animation cascade level replacement.
     #[inline]
     pub fn has_non_animation_hint(&self) -> bool {
-        self.match_self || self.match_descendants || self.match_later_siblings ||
+        self.match_under_self.is_any() || self.match_later_siblings ||
             self.replacements.contains(RESTYLE_STYLE_ATTRIBUTE)
     }
 
@@ -241,17 +302,17 @@ impl RestyleHint {
     /// for the element.
     #[inline]
     pub fn match_self(&self) -> bool {
-        self.match_self
+        self.match_under_self.has_self()
     }
 
     /// Returns a new `RestyleHint` appropriate for children of the current
     /// element.
     #[inline]
     pub fn propagate_for_non_animation_restyle(&self) -> Self {
-        if self.match_descendants {
-            Self::subtree()
-        } else {
-            Self::empty()
+        RestyleHint {
+            match_under_self: self.match_under_self.propagate(),
+            match_later_siblings: false,
+            replacements: RestyleReplacements::empty(),
         }
     }
 
@@ -271,8 +332,7 @@ impl RestyleHint {
     /// Unions the specified `RestyleHint` into this one.
     #[inline]
     pub fn insert_from(&mut self, other: &Self) {
-        self.match_self |= other.match_self;
-        self.match_descendants |= other.match_descendants;
+        self.match_under_self.insert(other.match_under_self);
         self.match_later_siblings |= other.match_later_siblings;
         self.replacements.insert(other.replacements);
     }
@@ -289,9 +349,8 @@ impl RestyleHint {
     /// work as the specified one.
     #[inline]
     pub fn contains(&mut self, other: &Self) -> bool {
-        !(other.match_self && !self.match_self) &&
-        !(other.match_descendants && !self.match_descendants) &&
-        !(other.match_later_siblings && !self.match_later_siblings) &&
+        self.match_under_self.contains(other.match_under_self) &&
+        (self.match_later_siblings & other.match_later_siblings) == other.match_later_siblings &&
         self.replacements.contains(other.replacements)
     }
 }
@@ -319,9 +378,16 @@ impl From<nsRestyleHint> for RestyleHint {
         use gecko_bindings::structs::nsRestyleHint_eRestyle_SomeDescendants as eRestyle_SomeDescendants;
         use gecko_bindings::structs::nsRestyleHint_eRestyle_Subtree as eRestyle_Subtree;
 
+        let mut match_under_self = RestyleDepths::empty();
+        if (raw.0 & (eRestyle_Self.0 | eRestyle_Subtree.0)) != 0 {
+            match_under_self.insert(RestyleDepths::for_self());
+        }
+        if (raw.0 & (eRestyle_Subtree.0 | eRestyle_SomeDescendants.0)) != 0 {
+            match_under_self.insert(RestyleDepths::for_descendants());
+        }
+
         RestyleHint {
-            match_self: (raw.0 & (eRestyle_Self.0 | eRestyle_Subtree.0)) != 0,
-            match_descendants: (raw.0 & (eRestyle_Subtree.0 | eRestyle_SomeDescendants.0)) != 0,
+            match_under_self: match_under_self,
             match_later_siblings: (raw.0 & eRestyle_LaterSiblings.0) != 0,
             replacements: raw.into(),
         }

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -9,6 +9,7 @@
 
 use computed_values::display;
 use heapsize::HeapSizeOf;
+use matching::{StyleChange, StyleDifference};
 use properties::ServoComputedValues;
 use std::fmt;
 
@@ -57,12 +58,14 @@ impl HeapSizeOf for ServoRestyleDamage {
 }
 
 impl ServoRestyleDamage {
-    /// Compute the appropriate restyle damage for a given style change between
-    /// `old` and `new`.
-    pub fn compute(old: &ServoComputedValues,
-                   new: &ServoComputedValues)
-                   -> ServoRestyleDamage {
-        compute_damage(old, new)
+    /// Compute the `StyleDifference` (including the appropriate restyle damage)
+    /// for a given style change between `old` and `new`.
+    pub fn compute_style_difference(old: &ServoComputedValues,
+                                    new: &ServoComputedValues)
+                                    -> StyleDifference {
+        let damage = compute_damage(old, new);
+        let change = if damage.is_empty() { StyleChange::Unchanged } else { StyleChange::Changed };
+        StyleDifference::new(damage, change)
     }
 
     /// Returns a bitmask that represents a flow that needs to be rebuilt and

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -9,7 +9,7 @@ use context::{SharedStyleContext, StyleContext, ThreadLocalStyleContext};
 use data::{ElementData, ElementStyles, StoredRestyleHint};
 use dom::{DirtyDescendants, NodeInfo, OpaqueNode, TElement, TNode};
 use matching::{ChildCascadeRequirement, MatchMethods, StyleSharingBehavior};
-use restyle_hints::{RESTYLE_DESCENDANTS, RESTYLE_SELF};
+use restyle_hints::RestyleHint;
 use selector_parser::RestyleDamage;
 #[cfg(feature = "servo")] use servo_config::opts;
 use std::borrow::BorrowMut;
@@ -232,7 +232,7 @@ pub trait DomTraversal<E: TElement> : Sync {
                 if let Some(next) = root.next_sibling_element() {
                     if let Some(mut next_data) = next.mutate_data() {
                         let hint = StoredRestyleHint::subtree_and_later_siblings();
-                        next_data.ensure_restyle().hint.insert(&hint);
+                        next_data.ensure_restyle().hint.insert(hint);
                     }
                 }
             }
@@ -748,9 +748,9 @@ fn compute_style<E, D>(_traversal: &D,
             // Perform the matching and cascading.
             element.match_and_cascade(context, &mut data, StyleSharingBehavior::Allow)
         }
-        CascadeWithReplacements(hint) => {
+        CascadeWithReplacements(flags) => {
             let _rule_nodes_changed =
-                element.replace_rules(hint, context, &mut data);
+                element.replace_rules(flags, context, &mut data);
             element.cascade_primary_and_pseudos(context, &mut data)
         }
         CascadeOnly => {
@@ -808,11 +808,11 @@ fn preprocess_children<E, D>(traversal: &D,
 
         // Propagate the parent and sibling restyle hint.
         if !propagated_hint.is_empty() {
-            restyle_data.hint.insert(&propagated_hint);
+            restyle_data.hint.insert_from(&propagated_hint);
         }
 
         if later_siblings {
-            propagated_hint.insert(&(RESTYLE_SELF | RESTYLE_DESCENDANTS).into());
+            propagated_hint.insert(RestyleHint::subtree().into());
         }
 
         // Store the damage already handled by ancestors.

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -8,7 +8,7 @@ use atomic_refcell::{AtomicRefCell, AtomicRefMut};
 use context::{SharedStyleContext, StyleContext, ThreadLocalStyleContext};
 use data::{ElementData, ElementStyles, StoredRestyleHint};
 use dom::{DirtyDescendants, NodeInfo, OpaqueNode, TElement, TNode};
-use matching::{MatchMethods, StyleSharingBehavior};
+use matching::{ChildCascadeRequirement, MatchMethods, StyleSharingBehavior};
 use restyle_hints::{RESTYLE_DESCENDANTS, RESTYLE_SELF};
 use selector_parser::RestyleDamage;
 #[cfg(feature = "servo")] use servo_config::opts;
@@ -611,7 +611,12 @@ pub fn recalc_style_at<E, D>(traversal: &D,
 
     // Compute style for this element if necessary.
     if compute_self {
-        compute_style(traversal, traversal_data, context, element, &mut data);
+        match compute_style(traversal, traversal_data, context, element, &mut data) {
+            ChildCascadeRequirement::MustCascade => {
+                inherited_style_changed = true;
+            }
+            ChildCascadeRequirement::CanSkipCascade => {}
+        };
 
         // If we're restyling this element to display:none, throw away all style
         // data in the subtree, notify the caller to early-return.
@@ -620,9 +625,6 @@ pub fn recalc_style_at<E, D>(traversal: &D,
                    element);
             clear_descendant_data(element, &|e| unsafe { D::clear_element_data(&e) });
         }
-
-        // FIXME(bholley): Compute this accurately from the call to CalcStyleDifference.
-        inherited_style_changed = true;
     }
 
     // Now that matching and cascading is done, clear the bits corresponding to
@@ -711,7 +713,7 @@ fn compute_style<E, D>(_traversal: &D,
                        traversal_data: &PerLevelTraversalData,
                        context: &mut StyleContext<E>,
                        element: E,
-                       mut data: &mut AtomicRefMut<ElementData>)
+                       mut data: &mut AtomicRefMut<ElementData>) -> ChildCascadeRequirement
     where E: TElement,
           D: DomTraversal<E>,
 {
@@ -727,10 +729,10 @@ fn compute_style<E, D>(_traversal: &D,
         let sharing_result = unsafe {
             element.share_style_if_possible(context, &mut data)
         };
-        if let StyleWasShared(index) = sharing_result {
+        if let StyleWasShared(index, had_damage) = sharing_result {
             context.thread_local.statistics.styles_shared += 1;
             context.thread_local.style_sharing_candidate_cache.touch(index);
-            return;
+            return had_damage;
         }
     }
 
@@ -744,17 +746,17 @@ fn compute_style<E, D>(_traversal: &D,
             context.thread_local.statistics.elements_matched += 1;
 
             // Perform the matching and cascading.
-            element.match_and_cascade(context, &mut data, StyleSharingBehavior::Allow);
+            element.match_and_cascade(context, &mut data, StyleSharingBehavior::Allow)
         }
         CascadeWithReplacements(hint) => {
             let _rule_nodes_changed =
                 element.replace_rules(hint, context, &mut data);
-            element.cascade_primary_and_pseudos(context, &mut data);
+            element.cascade_primary_and_pseudos(context, &mut data)
         }
         CascadeOnly => {
-            element.cascade_primary_and_pseudos(context, &mut data);
+            element.cascade_primary_and_pseudos(context, &mut data)
         }
-    };
+    }
 }
 
 fn preprocess_children<E, D>(traversal: &D,

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2064,16 +2064,16 @@ pub extern "C" fn Servo_NoteExplicitHints(element: RawGeckoElementBorrowed,
            element, restyle_hint, change_hint);
 
     let restyle_hint: RestyleHint = restyle_hint.into();
-    debug_assert!(RestyleHint::for_animations().contains(restyle_hint) ||
-                  !RestyleHint::for_animations().intersects(restyle_hint),
+    debug_assert!(!(restyle_hint.has_animation_hint() &&
+                    restyle_hint.has_non_animation_hint()),
                   "Animation restyle hints should not appear with non-animation restyle hints");
 
     let mut maybe_data = element.mutate_data();
     let maybe_restyle_data = maybe_data.as_mut().and_then(|d| unsafe {
-        maybe_restyle(d, element, restyle_hint.intersects(RestyleHint::for_animations()))
+        maybe_restyle(d, element, restyle_hint.has_animation_hint())
     });
     if let Some(restyle_data) = maybe_restyle_data {
-        restyle_data.hint.insert(&restyle_hint.into());
+        restyle_data.hint.insert(restyle_hint.into());
         restyle_data.damage |= damage;
     } else {
         debug!("(Element not styled, discarding hints)");

--- a/tests/unit/style/restyle_hints.rs
+++ b/tests/unit/style/restyle_hints.rs
@@ -6,7 +6,7 @@
 fn smoke_restyle_hints() {
     use cssparser::Parser;
     use selectors::parser::SelectorList;
-    use style::restyle_hints::{DependencySet, RESTYLE_LATER_SIBLINGS};
+    use style::restyle_hints::DependencySet;
     use style::selector_parser::SelectorParser;
     use style::stylesheets::{Origin, Namespaces};
     let namespaces = Namespaces::default();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR reworks `RestyleHint` so that it can store the depth of the tree whose elements we need to re-run selector matching on, when selectors with `>` child combinators are involved.  For example, with `div.x > span > em`, if we toggle the `x` attribute on a `div`, we'll re-run selector matching on grandchildren of the `div`, rather than (as we do currently) on every descendants of the `div`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16906)
<!-- Reviewable:end -->
