### PR TITLE
Make canvas origin clean checks use origin of image response

### DIFF
--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -183,7 +183,7 @@ impl<'a> LayoutContext<'a> {
         }
 
         match self.get_or_request_image_or_meta(node, url.clone(), use_placeholder) {
-            Some(ImageOrMetadataAvailable::ImageAvailable(image)) => {
+            Some(ImageOrMetadataAvailable::ImageAvailable(image, _)) => {
                 let image_info = WebRenderImageInfo::from_image(&*image);
                 if image_info.key.is_none() {
                     Some(image_info)

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -378,7 +378,7 @@ impl ImageFragmentInfo {
         });
 
         let (image, metadata) = match image_or_metadata {
-            Some(ImageOrMetadataAvailable::ImageAvailable(i)) => {
+            Some(ImageOrMetadataAvailable::ImageAvailable(i, _)) => {
                 (Some(i.clone()), Some(ImageMetadata { height: i.height, width: i.width } ))
             }
             Some(ImageOrMetadataAvailable::MetadataAvailable(m)) => {

--- a/components/net_traits/image_cache.rs
+++ b/components/net_traits/image_cache.rs
@@ -25,7 +25,7 @@ pub enum CanRequestImages {
 /// Indicating either entire image or just metadata availability
 #[derive(Clone, Deserialize, Serialize, HeapSizeOf)]
 pub enum ImageOrMetadataAvailable {
-    ImageAvailable(Arc<Image>),
+    ImageAvailable(Arc<Image>, ServoUrl),
     MetadataAvailable(ImageMetadata),
 }
 
@@ -63,11 +63,11 @@ impl ImageResponder {
 #[derive(Clone, Deserialize, Serialize, HeapSizeOf)]
 pub enum ImageResponse {
     /// The requested image was loaded.
-    Loaded(Arc<Image>),
+    Loaded(Arc<Image>, ServoUrl),
     /// The request image metadata was loaded.
     MetadataLoaded(ImageMetadata),
     /// The requested image failed to load, so a placeholder was loaded instead.
-    PlaceholderLoaded(Arc<Image>),
+    PlaceholderLoaded(Arc<Image>, ServoUrl),
     /// Neither the requested image nor the placeholder could be loaded.
     None,
 }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -32,7 +32,7 @@ use dom::htmlcanvaselement::HTMLCanvasElement;
 use dom::htmlcanvaselement::utils as canvas_utils;
 use dom::htmlimageelement::HTMLImageElement;
 use dom::imagedata::ImageData;
-use dom::node::{Node, NodeDamage, window_from_node};
+use dom::node::{document_from_node, Node, NodeDamage, window_from_node};
 use dom_struct::dom_struct;
 use euclid::matrix2d::Matrix2D;
 use euclid::point::Point2D;
@@ -228,16 +228,11 @@ impl CanvasRenderingContext2D {
             }
             HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2D::CanvasRenderingContext2D(image) =>
                 image.origin_is_clean(),
-            HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2D::HTMLImageElement(image) =>
-                match image.get_url() {
-                    None => true,
-                    Some(url) => {
-                        // TODO(zbarsky): we should check the origin of the image against
-                        // the entry settings object, but for now check it against the canvas' doc.
-                        let node: &Node = &*self.canvas.upcast();
-                        url.origin() == node.owner_doc().url().origin()
-                    }
-                }
+            HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2D::HTMLImageElement(image) => {
+                let image_origin = image.get_origin().expect("Image's origin is missing");
+                let document = document_from_node(&*self.canvas);
+                document.url().clone().origin() == image_origin
+            }
         }
     }
 
@@ -429,8 +424,8 @@ impl CanvasRenderingContext2D {
         };
 
         let img = match self.request_image_from_cache(url) {
-            ImageResponse::Loaded(img) => img,
-            ImageResponse::PlaceholderLoaded(_) |
+            ImageResponse::Loaded(img, _) => img,
+            ImageResponse::PlaceholderLoaded(_, _) |
             ImageResponse::None |
             ImageResponse::MetadataLoaded(_) => {
                 return None;

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -371,8 +371,8 @@ pub mod utils {
                                                UsePlaceholder::No,
                                                CanRequestImages::No);
         match response {
-            Ok(ImageOrMetadataAvailable::ImageAvailable(image)) =>
-                ImageResponse::Loaded(image),
+            Ok(ImageOrMetadataAvailable::ImageAvailable(image, url)) =>
+                ImageResponse::Loaded(image, url),
             _ => ImageResponse::None,
         }
     }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -48,6 +48,7 @@ use network_listener::{NetworkListener, PreInvoke};
 use num_traits::ToPrimitive;
 use script_thread::Runnable;
 use servo_url::ServoUrl;
+use servo_url::origin::ImmutableOrigin;
 use std::cell::Cell;
 use std::default::Default;
 use std::i32;
@@ -73,6 +74,7 @@ struct ImageRequest {
     #[ignore_heap_size_of = "Arc"]
     image: Option<Arc<Image>>,
     metadata: Option<ImageMetadata>,
+    final_url: Option<ServoUrl>,
 }
 #[dom_struct]
 pub struct HTMLImageElement {
@@ -215,8 +217,8 @@ impl HTMLImageElement {
                                                UsePlaceholder::Yes,
                                                CanRequestImages::Yes);
         match response {
-            Ok(ImageOrMetadataAvailable::ImageAvailable(image)) => {
-                self.process_image_response(ImageResponse::Loaded(image));
+            Ok(ImageOrMetadataAvailable::ImageAvailable(image, url)) => {
+                self.process_image_response(ImageResponse::Loaded(image, url));
             }
 
             Ok(ImageOrMetadataAvailable::MetadataAvailable(m)) => {
@@ -273,7 +275,8 @@ impl HTMLImageElement {
 
     fn process_image_response(&self, image: ImageResponse) {
         let (image, metadata, trigger_image_load, trigger_image_error) = match image {
-            ImageResponse::Loaded(image) | ImageResponse::PlaceholderLoaded(image) => {
+            ImageResponse::Loaded(image, url) | ImageResponse::PlaceholderLoaded(image, url) => {
+                self.current_request.borrow_mut().final_url = Some(url);
                 (Some(image.clone()),
                  Some(ImageMetadata { height: image.height, width: image.width }),
                  true,
@@ -378,6 +381,7 @@ impl HTMLImageElement {
                 image: None,
                 metadata: None,
                 blocker: None,
+                final_url: None,
             }),
             pending_request: DOMRefCell::new(ImageRequest {
                 state: State::Unavailable,
@@ -386,6 +390,7 @@ impl HTMLImageElement {
                 image: None,
                 metadata: None,
                 blocker: None,
+                final_url: None,
             }),
             form_owner: Default::default(),
             generation: Default::default(),
@@ -441,6 +446,14 @@ impl HTMLImageElement {
 
         useMapElements.map(|mapElem| mapElem.get_area_elements())
     }
+
+    pub fn get_origin(&self) -> Option<ImmutableOrigin> {
+        match self.current_request.borrow_mut().final_url {
+            Some(ref url) => Some(url.origin()),
+            None => None
+        }
+    }
+
 }
 
 pub trait LayoutHTMLImageElementHelpers {

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -465,8 +465,8 @@ impl WebGLRenderingContext {
                 let window = window_from_node(&*self.canvas);
 
                 let img = match canvas_utils::request_image_from_cache(&window, img_url) {
-                    ImageResponse::Loaded(img) => img,
-                    ImageResponse::PlaceholderLoaded(_) | ImageResponse::None |
+                    ImageResponse::Loaded(img, _) => img,
+                    ImageResponse::PlaceholderLoaded(_, _) | ImageResponse::None |
                     ImageResponse::MetadataLoaded(_)
                         => return Err(()),
                 };

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -386,8 +386,8 @@ impl Window {
         }
         match response.response {
             ImageResponse::MetadataLoaded(_) => {}
-            ImageResponse::Loaded(_) |
-            ImageResponse::PlaceholderLoaded(_) |
+            ImageResponse::Loaded(_, _) |
+            ImageResponse::PlaceholderLoaded(_, _) |
             ImageResponse::None => { nodes.remove(); }
         }
         self.add_pending_reflow();

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.drawImage.canvas.redirect.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.drawImage.canvas.redirect.html.ini
@@ -1,5 +1,0 @@
-[security.drawImage.canvas.redirect.html]
-  type: testharness
-  [drawImage of unclean canvas makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.drawImage.image.redirect.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.drawImage.image.redirect.html.ini
@@ -1,5 +1,0 @@
-[security.drawImage.image.redirect.html]
-  type: testharness
-  [drawImage of different-origin image makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.fillStyle.redirect.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.fillStyle.redirect.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.canvas.fillStyle.redirect.html]
-  type: testharness
-  [Setting fillStyle to a pattern of an unclean canvas makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.strokeStyle.redirect.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.strokeStyle.redirect.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.canvas.strokeStyle.redirect.html]
-  type: testharness
-  [Setting strokeStyle to a pattern of an unclean canvas makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.timing.redirect.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.timing.redirect.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.canvas.timing.redirect.html]
-  type: testharness
-  [Pattern safety depends on whether the source was origin-clean, not on whether it still is clean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.create.redirect.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.create.redirect.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.create.redirect.html]
-  type: testharness
-  [Creating an unclean pattern does not make the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.cross.redirect.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.cross.redirect.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.cross.redirect.html]
-  type: testharness
-  [Using an unclean pattern makes the target canvas origin-unclean, not the pattern canvas]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.image.fillStyle.redirect.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.image.fillStyle.redirect.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.image.fillStyle.redirect.html]
-  type: testharness
-  [Setting fillStyle to a pattern of a different-origin image makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.image.strokeStyle.redirect.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.pattern.image.strokeStyle.redirect.html.ini
@@ -1,5 +1,0 @@
-[security.pattern.image.strokeStyle.redirect.html]
-  type: testharness
-  [Setting strokeStyle to a pattern of a different-origin image makes the canvas origin-unclean]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.reset.redirect.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-canvas-element/security.reset.redirect.html.ini
@@ -1,5 +1,0 @@
-[security.reset.redirect.html]
-  type: testharness
-  [Resetting the canvas state does not reset the origin-clean flag]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/adopted_node_is_same_origin_domain.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/adopted_node_is_same_origin_domain.html.ini
@@ -2,3 +2,4 @@
   type: testharness
   [Adopting a node should make it same-origin-domain.]
     expected: FAIL
+

--- a/tests/wpt/web-platform-tests/common/canvas-tests.js
+++ b/tests/wpt/web-platform-tests/common/canvas-tests.js
@@ -101,4 +101,5 @@ function addCrossOriginRedirectYellowImage()
     img.className = "resource";
     img.src = get_host_info().HTTP_ORIGIN + "/common/redirect.py?location=" +
         get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png";
+    document.body.appendChild(img);
 }


### PR DESCRIPTION
Adapted from #15887.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15409
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16913)
<!-- Reviewable:end -->
