### PR TITLE
stylo: Bug 1355345 - Support font-display descriptor in @font-face rule

### DIFF
--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -82,18 +82,7 @@ define_css_keyword_enum!(FontDisplay:
                          "fallback" => Fallback,
                          "optional" => Optional);
 
-impl Parse for FontDisplay {
-    fn parse(_: &ParserContext, input: &mut Parser) -> Result<FontDisplay, ()> {
-        Ok(match_ignore_ascii_case! { &*input.expect_ident()?,
-            "auto" => FontDisplay::Auto,
-            "block" => FontDisplay::Block,
-            "swap" => FontDisplay::Swap,
-            "fallback" => FontDisplay::Fallback,
-            "optional" => FontDisplay::Optional,
-            _ => return Err(())
-        })
-    }
-}
+add_parse_impl_for_keyword_enum!(FontDisplay);
 
 /// Parse the block inside a `@font-face` rule.
 ///

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -72,6 +72,29 @@ impl ToCss for UrlSource {
     }
 }
 
+/// A font-display value for a @font-face rule.
+/// The font-display descriptor determines how a font face is displayed based
+/// on whether and when it is downloaded and ready to use.
+define_css_keyword_enum!(FontDisplay:
+                         "auto" => Auto,
+                         "block" => Block,
+                         "swap" => Swap,
+                         "fallback" => Fallback,
+                         "optional" => Optional);
+
+impl Parse for FontDisplay {
+    fn parse(_: &ParserContext, input: &mut Parser) -> Result<FontDisplay, ()> {
+        Ok(match_ignore_ascii_case! { &*input.expect_ident()?,
+            "auto" => FontDisplay::Auto,
+            "block" => FontDisplay::Block,
+            "swap" => FontDisplay::Swap,
+            "fallback" => FontDisplay::Fallback,
+            "optional" => FontDisplay::Optional,
+            _ => return Err(())
+        })
+    }
+}
+
 /// Parse the block inside a `@font-face` rule.
 ///
 /// Note that the prelude parsing code lives in the `stylesheets` module.
@@ -332,12 +355,15 @@ font_face_descriptors! {
         /// The stretch of this font face
         "font-stretch" stretch / mStretch: font_stretch::T = font_stretch::T::normal,
 
+        /// The display of this font face
+        "font-display" display / mDisplay: FontDisplay = FontDisplay::Auto,
+
         /// The ranges of code points outside of which this font face should not be used.
         "unicode-range" unicode_range / mUnicodeRange: Vec<UnicodeRange> = vec![
             UnicodeRange { start: 0, end: 0x10FFFF }
         ],
 
-        // FIXME: add font-feature-settings, font-language-override, and font-display
+        // FIXME: add font-feature-settings and font-language-override
     ]
 }
 

--- a/components/style/gecko/rules.rs
+++ b/components/style/gecko/rules.rs
@@ -8,7 +8,7 @@ use computed_values::{font_style, font_weight, font_stretch};
 use computed_values::font_family::FamilyName;
 use counter_style;
 use cssparser::UnicodeRange;
-use font_face::{FontFaceRuleData, Source};
+use font_face::{FontFaceRuleData, Source, FontDisplay};
 use gecko_bindings::bindings;
 use gecko_bindings::structs::{self, nsCSSFontFaceRule, nsCSSValue};
 use gecko_bindings::structs::{nsCSSCounterDesc, nsCSSCounterStyleRule};
@@ -112,6 +112,18 @@ impl ToNsCssValue for Vec<UnicodeRange> {
             target[0].set_integer(range.start as i32);
             target[1].set_integer(range.end as i32);
         }
+    }
+}
+
+impl ToNsCssValue for FontDisplay {
+    fn convert(self, nscssvalue: &mut nsCSSValue) {
+        nscssvalue.set_enum(match self {
+            FontDisplay::Auto => structs::NS_FONT_DISPLAY_AUTO,
+            FontDisplay::Block => structs::NS_FONT_DISPLAY_BLOCK,
+            FontDisplay::Swap => structs::NS_FONT_DISPLAY_SWAP,
+            FontDisplay::Fallback => structs::NS_FONT_DISPLAY_FALLBACK,
+            FontDisplay::Optional => structs::NS_FONT_DISPLAY_OPTIONAL,
+        } as i32)
     }
 }
 

--- a/components/style/values/mod.rs
+++ b/components/style/values/mod.rs
@@ -68,19 +68,9 @@ macro_rules! no_viewport_percentage {
 /// A macro for implementing `ComputedValueAsSpecified`, `Parse`
 /// and `HasViewportPercentage` traits for the enums defined
 /// using `define_css_keyword_enum` macro.
-///
-/// NOTE: We should either move `Parse` trait to `style_traits`
-/// or `define_css_keyword_enum` macro to this crate, but that
-/// may involve significant cleanup in both the crates.
 macro_rules! add_impls_for_keyword_enum {
     ($name:ident) => {
-        impl Parse for $name {
-            #[inline]
-            fn parse(_context: &ParserContext, input: &mut ::cssparser::Parser) -> Result<Self, ()> {
-                $name::parse(input)
-            }
-        }
-
+        add_parse_impl_for_keyword_enum!($name);
         impl ComputedValueAsSpecified for $name {}
         no_viewport_percentage!($name);
     };

--- a/components/style_traits/values.rs
+++ b/components/style_traits/values.rs
@@ -173,6 +173,18 @@ macro_rules! __define_css_keyword_enum__actual {
     }
 }
 
+#[macro_export]
+macro_rules! add_parse_impl_for_keyword_enum {
+    ($name:ident) => {
+        impl Parse for $name {
+            #[inline]
+            fn parse(_context: &ParserContext, input: &mut ::cssparser::Parser) -> Result<Self, ()> {
+                $name::parse(input)
+            }
+        }
+    };
+}
+
 /// Helper types for the handling of specified values.
 pub mod specified {
     use app_units::Au;


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

https://bugzilla.mozilla.org/show_bug.cgi?id=1355345

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16928)
<!-- Reviewable:end -->
