### PR TITLE
Move bindings tests out of the style crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2872,6 +2872,7 @@ dependencies = [
  "servo_atoms 0.0.1",
  "servo_config 0.0.1",
  "servo_url 0.0.1",
+ "size_of_test 0.0.1",
  "style 0.0.1",
  "style_traits 0.0.1",
 ]
@@ -2901,6 +2902,7 @@ dependencies = [
  "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.18.0",
+ "size_of_test 0.0.1",
  "style 0.0.1",
  "style_traits 0.0.1",
 ]

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 
 build = "build.rs"
 
+# https://github.com/rust-lang/cargo/issues/3544
+links = "for some reason the links key is required to pass data around between build scripts"
+
 [lib]
 name = "style"
 path = "lib.rs"

--- a/components/style/build.rs
+++ b/components/style/build.rs
@@ -83,6 +83,7 @@ fn generate_properties() {
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:out_dir={}", env::var("OUT_DIR").unwrap());
     generate_properties();
     build_gecko::generate();
 }

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -61,7 +61,7 @@ extern crate log;
 extern crate matches;
 #[cfg(feature = "gecko")]
 #[macro_use]
-extern crate nsstring_vendor as nsstring;
+pub extern crate nsstring_vendor as nsstring;
 #[cfg(feature = "gecko")] extern crate num_cpus;
 extern crate num_integer;
 extern crate num_traits;

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2802,30 +2802,6 @@ macro_rules! longhand_properties_idents {
     }
 }
 
-/// Testing function to check the size of a PropertyDeclaration. We implement
-/// this here so that the code can be used by both servo and stylo unit tests.
-/// This is important because structs can have different sizes in stylo and
-/// servo.
-#[cfg(feature = "testing")]
-pub fn test_size_of_property_declaration() {
-    use std::mem::size_of;
-
-    let old = 32;
-    let new = size_of::<PropertyDeclaration>();
-    if new < old {
-        panic!("Your changes have decreased the stack size of PropertyDeclaration enum from {} to {}. \
-                Good work! Please update the size in components/style/properties/properties.mako.rs.",
-                old, new)
-    } else if new > old {
-        panic!("Your changes have increased the stack size of PropertyDeclaration enum from {} to {}. \
-                These enum is present in large quantities in the style, and increasing the size \
-                may negatively affect style system performance. Please consider using `boxed=\"True\"` in \
-                the longhand If you feel that the increase is necessary, update to the new size in \
-                components/style/properties/properties.mako.rs.",
-                old, new)
-    }
-}
-
 /// Testing function to check the size of all SpecifiedValues.
 #[cfg(feature = "testing")]
 pub fn test_size_of_specified_values() {

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -299,13 +299,8 @@ class MachCommands(CommandBase):
         env["CARGO_TARGET_DIR"] = path.join(self.context.topdir, "target", "geckolib").encode("UTF-8")
 
         release = ["--release"] if release else []
-        ret = 0
         with cd(path.join("ports", "geckolib")):
-            ret = call(["cargo", "test", "-p", "stylo_tests", "--features", "testing"] + release, env=env)
-        if ret != 0:
-            return ret
-        with cd(path.join("ports", "geckolib")):
-            return call(["cargo", "test", "-p", "style"] + release, env=env)
+            return call(["cargo", "test", "-p", "stylo_tests", "--features", "testing"] + release, env=env)
 
     @Command('test-compiletest',
              description='Run compiletests',

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -24,6 +24,7 @@ rustc-serialize = "0.3"
 selectors = {path = "../../../components/selectors"}
 servo_atoms = {path = "../../../components/atoms"}
 servo_config = {path = "../../../components/config"}
+servo_url = {path = "../../../components/url"}
+size_of_test = {path = "../../../components/size_of_test"}
 style = {path = "../../../components/style"}
 style_traits = {path = "../../../components/style_traits"}
-servo_url = {path = "../../../components/url"}

--- a/tests/unit/style/lib.rs
+++ b/tests/unit/style/lib.rs
@@ -17,6 +17,7 @@ extern crate selectors;
 extern crate servo_atoms;
 extern crate servo_config;
 extern crate servo_url;
+#[macro_use] extern crate size_of_test;
 extern crate style;
 extern crate style_traits;
 extern crate test;

--- a/tests/unit/style/size_of.rs
+++ b/tests/unit/style/size_of.rs
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#[test]
-fn size_of_property_declaration() {
-    ::style::properties::test_size_of_property_declaration();
-}
+use style::properties;
+
+size_of_test!(test_size_of_property_declaration, properties::PropertyDeclaration, 32);
 
 #[test]
 fn size_of_specified_values() {

--- a/tests/unit/stylo/Cargo.toml
+++ b/tests/unit/stylo/Cargo.toml
@@ -19,9 +19,10 @@ atomic_refcell = "0.1"
 cssparser = "0.13.3"
 env_logger = "0.4"
 euclid = "0.11"
+geckoservo = {path = "../../../ports/geckolib"}
 libc = "0.2"
 log = {version = "0.3.5", features = ["release_max_level_info"]}
 selectors = {path = "../../../components/selectors", features = ["gecko_like_types"]}
+size_of_test = {path = "../../../components/size_of_test"}
 style_traits = {path = "../../../components/style_traits"}
-geckoservo = {path = "../../../ports/geckolib"}
 style = {path = "../../../components/style", features = ["gecko"]}

--- a/tests/unit/stylo/build.rs
+++ b/tests/unit/stylo/build.rs
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path;
 use std::process::Command;
 
 fn main() {
@@ -11,4 +15,13 @@ fn main() {
     println!("cargo:rerun-if-changed=../../../components/style/gecko_bindings/bindings.rs");
     assert!(Command::new("python").arg("./check_bindings.py")
                                   .spawn().unwrap().wait().unwrap().success());
+
+    // https://github.com/rust-lang/cargo/issues/3544
+    let style_out_dir = env::var_os("DEP_FOR SOME REASON THE LINKS KEY IS REQUIRED \
+                                     TO PASS DATA AROUND BETWEEN BUILD SCRIPTS_OUT_DIR").unwrap();
+    fs::File::create(path::PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("bindings.rs"))
+        .unwrap()
+        .write_all(format!("include!(concat!({:?}, \"/gecko/structs_debug.rs\"));",
+                           style_out_dir).as_bytes())
+        .unwrap();
 }

--- a/tests/unit/stylo/lib.rs
+++ b/tests/unit/stylo/lib.rs
@@ -8,6 +8,7 @@ extern crate env_logger;
 extern crate geckoservo;
 #[macro_use] extern crate log;
 extern crate selectors;
+#[macro_use] extern crate size_of_test;
 #[macro_use] extern crate style;
 extern crate style_traits;
 

--- a/tests/unit/stylo/lib.rs
+++ b/tests/unit/stylo/lib.rs
@@ -17,3 +17,9 @@ mod size_of;
 
 mod servo_function_signatures;
 
+use style::*;
+
+#[allow(dead_code, improper_ctypes)]
+mod bindings {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}

--- a/tests/unit/stylo/size_of.rs
+++ b/tests/unit/stylo/size_of.rs
@@ -19,10 +19,7 @@ fn size_of_selectors_dummy_types() {
     assert_eq!(align_of::<dummies::Atom>(), align_of::<style::Atom>());
 }
 
-#[test]
-fn size_of_property_declaration() {
-    ::style::properties::test_size_of_property_declaration();
-}
+size_of_test!(test_size_of_property_declaration, style::properties::PropertyDeclaration, 32);
 
 #[test]
 fn size_of_specified_values() {


### PR DESCRIPTION
This cuts in almost half the time to run:

```
touch components/style/lib.rs
./mach test-stylo
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16935)
<!-- Reviewable:end -->
