### PR TITLE
Implement access to CSSKeyframesRule and CSSKeyframeRule for stylo

### DIFF
--- a/components/style/gecko/arc_types.rs
+++ b/components/style/gecko/arc_types.rs
@@ -8,20 +8,23 @@
 
 #![allow(non_snake_case, missing_docs)]
 
-use gecko_bindings::bindings::{RawServoMediaList, RawServoMediaRule, RawServoNamespaceRule, RawServoPageRule};
+use gecko_bindings::bindings::{RawServoKeyframe, RawServoKeyframesRule};
+use gecko_bindings::bindings::{RawServoMediaList, RawServoMediaRule};
+use gecko_bindings::bindings::{RawServoNamespaceRule, RawServoPageRule};
 use gecko_bindings::bindings::{RawServoRuleNode, RawServoRuleNodeStrong, RawServoDocumentRule};
 use gecko_bindings::bindings::{RawServoStyleSheet, RawServoImportRule, RawServoSupportsRule};
 use gecko_bindings::bindings::{ServoComputedValues, ServoCssRules};
 use gecko_bindings::structs::{RawServoDeclarationBlock, RawServoStyleRule};
 use gecko_bindings::structs::RawServoAnimationValue;
 use gecko_bindings::sugar::ownership::{HasArcFFI, HasFFI};
+use keyframes::Keyframe;
 use media_queries::MediaList;
 use properties::{ComputedValues, PropertyDeclarationBlock};
 use properties::animated_properties::AnimationValue;
 use rule_tree::StrongRuleNode;
 use shared_lock::Locked;
 use std::{mem, ptr};
-use stylesheets::{CssRules, Stylesheet, StyleRule, ImportRule, MediaRule};
+use stylesheets::{CssRules, Stylesheet, StyleRule, ImportRule, KeyframesRule, MediaRule};
 use stylesheets::{NamespaceRule, PageRule, SupportsRule, DocumentRule};
 
 macro_rules! impl_arc_ffi {
@@ -63,6 +66,12 @@ impl_arc_ffi!(Locked<ImportRule> => RawServoImportRule
 
 impl_arc_ffi!(AnimationValue => RawServoAnimationValue
               [Servo_AnimationValue_AddRef, Servo_AnimationValue_Release]);
+
+impl_arc_ffi!(Locked<Keyframe> => RawServoKeyframe
+              [Servo_Keyframe_AddRef, Servo_Keyframe_Release]);
+
+impl_arc_ffi!(Locked<KeyframesRule> => RawServoKeyframesRule
+              [Servo_KeyframesRule_AddRef, Servo_KeyframesRule_Release]);
 
 impl_arc_ffi!(Locked<MediaList> => RawServoMediaList
               [Servo_MediaList_AddRef, Servo_MediaList_Release]);

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -229,6 +229,16 @@ pub struct RawServoImportRule(RawServoImportRuleVoid);
 pub type RawServoAnimationValueStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoAnimationValue>;
 pub type RawServoAnimationValueBorrowed<'a> = &'a RawServoAnimationValue;
 pub type RawServoAnimationValueBorrowedOrNull<'a> = Option<&'a RawServoAnimationValue>;
+pub type RawServoKeyframeStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoKeyframe>;
+pub type RawServoKeyframeBorrowed<'a> = &'a RawServoKeyframe;
+pub type RawServoKeyframeBorrowedOrNull<'a> = Option<&'a RawServoKeyframe>;
+enum RawServoKeyframeVoid { }
+pub struct RawServoKeyframe(RawServoKeyframeVoid);
+pub type RawServoKeyframesRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoKeyframesRule>;
+pub type RawServoKeyframesRuleBorrowed<'a> = &'a RawServoKeyframesRule;
+pub type RawServoKeyframesRuleBorrowedOrNull<'a> = Option<&'a RawServoKeyframesRule>;
+enum RawServoKeyframesRuleVoid { }
+pub struct RawServoKeyframesRule(RawServoKeyframesRuleVoid);
 pub type RawServoMediaListStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoMediaList>;
 pub type RawServoMediaListBorrowed<'a> = &'a RawServoMediaList;
 pub type RawServoMediaListBorrowedOrNull<'a> = Option<&'a RawServoMediaList>;
@@ -394,6 +404,18 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_AnimationValue_Release(ptr: RawServoAnimationValueBorrowed);
+}
+extern "C" {
+    pub fn Servo_Keyframe_AddRef(ptr: RawServoKeyframeBorrowed);
+}
+extern "C" {
+    pub fn Servo_Keyframe_Release(ptr: RawServoKeyframeBorrowed);
+}
+extern "C" {
+    pub fn Servo_KeyframesRule_AddRef(ptr: RawServoKeyframesRuleBorrowed);
+}
+extern "C" {
+    pub fn Servo_KeyframesRule_Release(ptr: RawServoKeyframesRuleBorrowed);
 }
 extern "C" {
     pub fn Servo_MediaList_AddRef(ptr: RawServoMediaListBorrowed);
@@ -1805,6 +1827,28 @@ extern "C" {
                                       result: *mut nsAString);
 }
 extern "C" {
+    pub fn Servo_Keyframe_Debug(rule: RawServoKeyframeBorrowed,
+                                result: *mut nsACString);
+}
+extern "C" {
+    pub fn Servo_Keyframe_GetCssText(rule: RawServoKeyframeBorrowed,
+                                     result: *mut nsAString);
+}
+extern "C" {
+    pub fn Servo_CssRules_GetKeyframesRuleAt(rules: ServoCssRulesBorrowed,
+                                             index: u32, line: *mut u32,
+                                             column: *mut u32)
+     -> RawServoKeyframesRuleStrong;
+}
+extern "C" {
+    pub fn Servo_KeyframesRule_Debug(rule: RawServoKeyframesRuleBorrowed,
+                                     result: *mut nsACString);
+}
+extern "C" {
+    pub fn Servo_KeyframesRule_GetCssText(rule: RawServoKeyframesRuleBorrowed,
+                                          result: *mut nsAString);
+}
+extern "C" {
     pub fn Servo_CssRules_GetMediaRuleAt(rules: ServoCssRulesBorrowed,
                                          index: u32, line: *mut u32,
                                          column: *mut u32)
@@ -1908,6 +1952,54 @@ extern "C" {
 extern "C" {
     pub fn Servo_StyleRule_GetSelectorText(rule: RawServoStyleRuleBorrowed,
                                            result: *mut nsAString);
+}
+extern "C" {
+    pub fn Servo_Keyframe_GetKeyText(keyframe: RawServoKeyframeBorrowed,
+                                     result: *mut nsAString);
+}
+extern "C" {
+    pub fn Servo_Keyframe_SetKeyText(keyframe: RawServoKeyframeBorrowed,
+                                     text: *const nsACString) -> bool;
+}
+extern "C" {
+    pub fn Servo_Keyframe_GetStyle(keyframe: RawServoKeyframeBorrowed)
+     -> RawServoDeclarationBlockStrong;
+}
+extern "C" {
+    pub fn Servo_Keyframe_SetStyle(keyframe: RawServoKeyframeBorrowed,
+                                   declarations:
+                                       RawServoDeclarationBlockBorrowed);
+}
+extern "C" {
+    pub fn Servo_KeyframesRule_GetName(rule: RawServoKeyframesRuleBorrowed)
+     -> *mut nsIAtom;
+}
+extern "C" {
+    pub fn Servo_KeyframesRule_SetName(rule: RawServoKeyframesRuleBorrowed,
+                                       name: *mut nsIAtom);
+}
+extern "C" {
+    pub fn Servo_KeyframesRule_GetCount(rule: RawServoKeyframesRuleBorrowed)
+     -> u32;
+}
+extern "C" {
+    pub fn Servo_KeyframesRule_GetKeyframe(rule:
+                                               RawServoKeyframesRuleBorrowed,
+                                           index: u32)
+     -> RawServoKeyframeStrong;
+}
+extern "C" {
+    pub fn Servo_KeyframesRule_FindRule(rule: RawServoKeyframesRuleBorrowed,
+                                        key: *const nsACString) -> u32;
+}
+extern "C" {
+    pub fn Servo_KeyframesRule_AppendRule(rule: RawServoKeyframesRuleBorrowed,
+                                          sheet: RawServoStyleSheetBorrowed,
+                                          css: *const nsACString) -> bool;
+}
+extern "C" {
+    pub fn Servo_KeyframesRule_DeleteRule(rule: RawServoKeyframesRuleBorrowed,
+                                          index: u32);
 }
 extern "C" {
     pub fn Servo_MediaRule_GetMedia(rule: RawServoMediaRuleBorrowed)

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -71,7 +71,7 @@ impl KeyframePercentage {
 
 /// A keyframes selector is a list of percentages or from/to symbols, which are
 /// converted at parse time to percentages.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct KeyframeSelector(Vec<KeyframePercentage>);
 
 impl ToCss for KeyframeSelector {

--- a/components/style/keyframes.rs
+++ b/components/style/keyframes.rs
@@ -73,6 +73,19 @@ impl KeyframePercentage {
 /// converted at parse time to percentages.
 #[derive(Debug, PartialEq)]
 pub struct KeyframeSelector(Vec<KeyframePercentage>);
+
+impl ToCss for KeyframeSelector {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        let mut iter = self.0.iter();
+        iter.next().unwrap().to_css(dest)?;
+        for percentage in iter {
+            write!(dest, ", ")?;
+            percentage.to_css(dest)?;
+        }
+        Ok(())
+    }
+}
+
 impl KeyframeSelector {
     /// Return the list of percentages this selector contains.
     #[inline]
@@ -108,19 +121,13 @@ pub struct Keyframe {
 impl ToCssWithGuard for Keyframe {
     fn to_css<W>(&self, guard: &SharedRwLockReadGuard, dest: &mut W) -> fmt::Result
     where W: fmt::Write {
-        let mut iter = self.selector.percentages().iter();
-        try!(iter.next().unwrap().to_css(dest));
-        for percentage in iter {
-            try!(write!(dest, ", "));
-            try!(percentage.to_css(dest));
-        }
+        self.selector.to_css(dest)?;
         try!(dest.write_str(" { "));
         try!(self.block.read_with(guard).to_css(dest));
         try!(dest.write_str(" }"));
         Ok(())
     }
 }
-
 
 impl Keyframe {
     /// Parse a CSS keyframe.

--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -575,18 +575,14 @@ impl ToCssWithGuard for KeyframesRule {
     where W: fmt::Write {
         try!(dest.write_str("@keyframes "));
         try!(self.name.to_css(dest));
-        try!(dest.write_str(" { "));
+        try!(dest.write_str(" {"));
         let iter = self.keyframes.iter();
-        let mut first = true;
         for lock in iter {
-            if !first {
-                try!(dest.write_str(" "));
-            }
-            first = false;
+            try!(dest.write_str("\n"));
             let keyframe = lock.read_with(&guard);
             try!(keyframe.to_css(guard, dest));
         }
-        dest.write_str(" }")
+        dest.write_str("\n}")
     }
 }
 

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -246,6 +246,10 @@ fn test_parse_stylesheet() {
                     })),
                 ],
                 vendor_prefix: None,
+                source_location: SourceLocation {
+                    line: 16,
+                    column: 19,
+                },
             })))
 
         ], &stylesheet.shared_lock),


### PR DESCRIPTION
This is the Servo side change for [bug 1345697](https://bugzilla.mozilla.org/show_bug.cgi?id=1345697).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16944)
<!-- Reviewable:end -->
