### PR TITLE
Fix warning in a future compiler version.

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -1325,6 +1325,7 @@ ${helpers.single_keyword_system("font-kerning",
     }
 </%helpers:longhand>
 
+#[cfg(any(feature = "gecko", feature = "testing"))]
 macro_rules! exclusive_value {
     (($value:ident, $set:expr) => $ident:ident) => {
         if $value.intersects($set) {


### PR DESCRIPTION
(Do not upgrade yet because of https://github.com/rust-lang/rust/issues/42101)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16950)
<!-- Reviewable:end -->
