### PR TITLE
stylo: Avoid FFI calls to get animation rules when known not-needed.

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -478,6 +478,10 @@ fn get_animation_rule(element: &GeckoElement,
                       cascade_level: CascadeLevel)
                       -> Option<Arc<Locked<PropertyDeclarationBlock>>> {
     use gecko_bindings::sugar::ownership::HasSimpleFFI;
+    if !self.may_have_animations() {
+        return None;
+    }
+
     // Also, we should try to reuse the PDB, to avoid creating extra rule nodes.
     let mut animation_values = AnimationValueMap::new();
     if unsafe { Gecko_GetAnimationRule(element.0,
@@ -614,6 +618,10 @@ impl<'le> TElement for GeckoElement<'le> {
     }
 
     fn get_animation_rules(&self) -> AnimationRules {
+        if !self.may_have_animations() {
+            return AnimationRules(None, None);
+        }
+
         AnimationRules(self.get_animation_rule(),
                        self.get_transition_rule())
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16964)
<!-- Reviewable:end -->
