### PR TITLE
Bug 1366144: Correctly diff ::before and ::after pseudo-element styles if there's no generated content. r=heycam

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -160,7 +160,9 @@ pub fn recalc_style_for_animations(context: &LayoutContext,
                                            animation,
                                            &mut fragment.style,
                                            &ServoMetricsProvider);
-                damage |= RestyleDamage::compute(&old_style, &fragment.style);
+                let difference =
+                    RestyleDamage::compute_style_difference(&old_style, &fragment.style);
+                damage |= difference.damage;
             }
         }
     });

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1100,7 +1100,7 @@ impl LayoutThread {
                         let el = node.as_element().unwrap();
                         if let Some(mut d) = element.mutate_data() {
                             if d.has_styles() {
-                                d.ensure_restyle().hint.insert(&StoredRestyleHint::subtree());
+                                d.ensure_restyle().hint.insert(StoredRestyleHint::subtree());
                             }
                         }
                         if let Some(p) = el.parent_element() {
@@ -1136,7 +1136,7 @@ impl LayoutThread {
         if needs_dirtying {
             if let Some(mut d) = element.mutate_data() {
                 if d.has_styles() {
-                    d.ensure_restyle().hint.insert(&StoredRestyleHint::subtree());
+                    d.ensure_restyle().hint.insert(StoredRestyleHint::subtree());
                 }
             }
         }
@@ -1184,7 +1184,7 @@ impl LayoutThread {
             let mut restyle_data = style_data.ensure_restyle();
 
             // Stash the data on the element for processing by the style system.
-            restyle_data.hint.insert(&restyle.hint.into());
+            restyle_data.hint.insert(restyle.hint.into());
             restyle_data.damage = restyle.damage;
             debug!("Noting restyle for {:?}: {:?}", el, restyle_data);
         }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -131,7 +131,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 use style::attr::AttrValue;
 use style::context::{QuirksMode, ReflowGoal};
-use style::restyle_hints::{RestyleHint, RESTYLE_SELF, RESTYLE_STYLE_ATTRIBUTE};
+use style::restyle_hints::{RestyleHint, RestyleReplacements, RESTYLE_STYLE_ATTRIBUTE};
 use style::selector_parser::{RestyleDamage, Snapshot};
 use style::shared_lock::SharedRwLock as StyleSharedRwLock;
 use style::str::{HTML_SPACE_CHARACTERS, split_html_space_chars, str_join};
@@ -2361,14 +2361,14 @@ impl Document {
             entry.snapshot = Some(Snapshot::new(el.html_element_in_html_document()));
         }
         if attr.local_name() == &local_name!("style") {
-            entry.hint |= RESTYLE_STYLE_ATTRIBUTE;
+            entry.hint.insert(RestyleHint::for_replacements(RESTYLE_STYLE_ATTRIBUTE));
         }
 
         // FIXME(emilio): This should become something like
         // element.is_attribute_mapped(attr.local_name()).
         if attr.local_name() == &local_name!("width") ||
            attr.local_name() == &local_name!("height") {
-            entry.hint |= RESTYLE_SELF;
+            entry.hint.insert(RestyleHint::for_self());
         }
 
         let mut snapshot = entry.snapshot.as_mut().unwrap();

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -102,7 +102,7 @@ use style::context::{QuirksMode, ReflowGoal};
 use style::element_state::*;
 use style::properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, parse_style_attribute};
 use style::properties::longhands::{self, background_image, border_spacing, font_family, font_size, overflow_x};
-use style::restyle_hints::RESTYLE_SELF;
+use style::restyle_hints::RestyleHint;
 use style::rule_tree::CascadeLevel;
 use style::selector_parser::{NonTSPseudoClass, PseudoElement, RestyleDamage, SelectorImpl, SelectorParser};
 use style::shared_lock::{SharedRwLock, Locked};
@@ -245,7 +245,7 @@ impl Element {
 
         // FIXME(bholley): I think we should probably only do this for
         // NodeStyleDamaged, but I'm preserving existing behavior.
-        restyle.hint |= RESTYLE_SELF;
+        restyle.hint.insert(RestyleHint::for_self());
 
         if damage == NodeDamage::OtherNodeDamage {
             restyle.damage = RestyleDamage::rebuild_and_reflow();

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -961,7 +961,8 @@ extern "C" {
 }
 extern "C" {
     pub fn Gecko_CalcStyleDifference(oldstyle: *mut nsStyleContext,
-                                     newstyle: ServoComputedValuesBorrowed)
+                                     newstyle: ServoComputedValuesBorrowed,
+                                     any_style_changed: *mut bool)
      -> nsChangeHint;
 }
 extern "C" {

--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -49,9 +49,11 @@ impl GeckoRestyleDamage {
                    new_style: &Arc<ComputedValues>) -> Self {
         // TODO(emilio): Const-ify this?
         let context = source as *const nsStyleContext as *mut nsStyleContext;
+        let mut any_style_changed: bool = false;
         let hint = unsafe {
             bindings::Gecko_CalcStyleDifference(context,
-                                                new_style.as_borrowed_opt().unwrap())
+                                                new_style.as_borrowed_opt().unwrap(),
+                                                &mut any_style_changed)
         };
         GeckoRestyleDamage(hint)
     }

--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -8,6 +8,7 @@ use gecko_bindings::bindings;
 use gecko_bindings::structs;
 use gecko_bindings::structs::{nsChangeHint, nsStyleContext};
 use gecko_bindings::sugar::ownership::FFIArcHelpers;
+use matching::{StyleChange, StyleDifference};
 use properties::ComputedValues;
 use std::ops::{BitAnd, BitOr, BitOrAssign, Not};
 use stylearc::Arc;
@@ -38,15 +39,17 @@ impl GeckoRestyleDamage {
         self.0 == nsChangeHint(0)
     }
 
-    /// Computes a change hint given an old style (in the form of a
-    /// `nsStyleContext`, and a new style (in the form of `ComputedValues`).
+    /// Computes the `StyleDifference` (including the appropriate change hint)
+    /// given an old style (in the form of a `nsStyleContext`, and a new style
+    /// (in the form of `ComputedValues`).
     ///
     /// Note that we could in theory just get two `ComputedValues` here and diff
     /// them, but Gecko has an interesting optimization when they mark accessed
     /// structs, so they effectively only diff structs that have ever been
     /// accessed from layout.
-    pub fn compute(source: &nsStyleContext,
-                   new_style: &Arc<ComputedValues>) -> Self {
+    pub fn compute_style_difference(source: &nsStyleContext,
+                                    new_style: &Arc<ComputedValues>)
+                                    -> StyleDifference {
         // TODO(emilio): Const-ify this?
         let context = source as *const nsStyleContext as *mut nsStyleContext;
         let mut any_style_changed: bool = false;
@@ -55,7 +58,8 @@ impl GeckoRestyleDamage {
                                                 new_style.as_borrowed_opt().unwrap(),
                                                 &mut any_style_changed)
         };
-        GeckoRestyleDamage(hint)
+        let change = if any_style_changed { StyleChange::Changed } else { StyleChange::Unchanged };
+        StyleDifference::new(GeckoRestyleDamage(hint), change)
     }
 
     /// Returns true if this restyle damage contains all the damage of |other|.

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -19,7 +19,7 @@ use font_metrics::FontMetricsProvider;
 use log::LogLevel::Trace;
 use properties::{CascadeFlags, ComputedValues, SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP, cascade};
 use properties::longhands::display::computed_value as display;
-use restyle_hints::{RESTYLE_CSS_ANIMATIONS, RESTYLE_CSS_TRANSITIONS, RestyleHint};
+use restyle_hints::{RESTYLE_CSS_ANIMATIONS, RESTYLE_CSS_TRANSITIONS, RestyleReplacements};
 use restyle_hints::{RESTYLE_STYLE_ATTRIBUTE, RESTYLE_SMIL};
 use rule_tree::{CascadeLevel, RuleTree, StrongRuleNode};
 use selector_parser::{PseudoElement, RestyleDamage, SelectorImpl};
@@ -1327,7 +1327,7 @@ pub trait MatchMethods : TElement {
     /// the rule tree. Returns RulesChanged which indicates whether the rule nodes changed
     /// and whether the important rules changed.
     fn replace_rules(&self,
-                     hint: RestyleHint,
+                     replacements: RestyleReplacements,
                      context: &StyleContext<Self>,
                      data: &mut AtomicRefMut<ElementData>)
                      -> RulesChanged {
@@ -1359,10 +1359,10 @@ pub trait MatchMethods : TElement {
             //
             // Non-animation restyle hints will be processed in a subsequent
             // normal traversal.
-            if hint.intersects(RestyleHint::for_animations()) {
+            if replacements.intersects(RestyleReplacements::for_animations()) {
                 debug_assert!(context.shared.traversal_flags.for_animation_only());
 
-                if hint.contains(RESTYLE_SMIL) {
+                if replacements.contains(RESTYLE_SMIL) {
                     replace_rule_node(CascadeLevel::SMILOverride,
                                       self.get_smil_override(),
                                       primary_rules);
@@ -1378,16 +1378,16 @@ pub trait MatchMethods : TElement {
 
                 // Apply Transition rules and Animation rules if the corresponding restyle hint
                 // is contained.
-                if hint.contains(RESTYLE_CSS_TRANSITIONS) {
+                if replacements.contains(RESTYLE_CSS_TRANSITIONS) {
                     replace_rule_node_for_animation(CascadeLevel::Transitions,
                                                     primary_rules);
                 }
 
-                if hint.contains(RESTYLE_CSS_ANIMATIONS) {
+                if replacements.contains(RESTYLE_CSS_ANIMATIONS) {
                     replace_rule_node_for_animation(CascadeLevel::Animations,
                                                     primary_rules);
                 }
-            } else if hint.contains(RESTYLE_STYLE_ATTRIBUTE) {
+            } else if replacements.contains(RESTYLE_STYLE_ATTRIBUTE) {
                 let style_attribute = self.style_attribute();
                 replace_rule_node(CascadeLevel::StyleAttributeNormal,
                                   style_attribute,

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -141,6 +141,13 @@ impl ComputedValues {
         self.get_box().clone_display() == longhands::display::computed_value::T::contents
     }
 
+    /// Returns true if the value of the `content` property would make a
+    /// pseudo-element not rendered.
+    #[inline]
+    pub fn ineffective_content_property(&self) -> bool {
+        self.get_counters().ineffective_content_property()
+    }
+
     % for style_struct in data.style_structs:
     #[inline]
     pub fn clone_${style_struct.name_lower}(&self) -> Arc<style_structs::${style_struct.name}> {
@@ -4204,6 +4211,10 @@ clip-path
 
 <%self:impl_trait style_struct_name="Counters"
                   skip_longhands="content counter-increment counter-reset">
+    pub fn ineffective_content_property(&self) -> bool {
+        self.gecko.mContents.is_empty()
+    }
+
     pub fn set_content(&mut self, v: longhands::content::computed_value::T) {
         use properties::longhands::content::computed_value::T;
         use properties::longhands::content::computed_value::ContentItem;

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1813,6 +1813,19 @@ impl ComputedValues {
     /// Since this isn't supported in Servo, this is always false for Servo.
     pub fn is_display_contents(&self) -> bool { false }
 
+    #[inline]
+    /// Returns whether the "content" property for the given style is completely
+    /// ineffective, and would yield an empty `::before` or `::after`
+    /// pseudo-element.
+    pub fn ineffective_content_property(&self) -> bool {
+        use properties::longhands::content::computed_value::T;
+        match self.get_counters().content {
+            T::normal |
+            T::none => true,
+            T::Content(ref items) => items.is_empty(),
+        }
+    }
+
     /// Whether the current style is multicolumn.
     #[inline]
     pub fn is_multicol(&self) -> bool {

--- a/components/style/restyle_hints.rs
+++ b/components/style/restyle_hints.rs
@@ -28,32 +28,38 @@ use std::cell::Cell;
 use std::clone::Clone;
 use stylist::SelectorMap;
 
+/// When the ElementState of an element (like IN_HOVER_STATE) changes,
+/// certain pseudo-classes (like :hover) may require us to restyle that
+/// element, its siblings, and/or its descendants. Similarly, when various
+/// attributes of an element change, we may also need to restyle things with
+/// id, class, and attribute selectors. Doing this conservatively is
+/// expensive, and so we use RestyleHints to short-circuit work we know is
+/// unnecessary.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RestyleHint {
+    /// Rerun selector matching on the element.
+    match_self: bool,
+
+    /// Rerun selector matching on all of the element's descendants.
+    match_descendants: bool,
+
+    /// Rerun selector matching on all later siblings of the element and all
+    /// of their descendants.
+    match_later_siblings: bool,
+
+    /// Levels of the cascade whose rule nodes should be recomputed and
+    /// replaced.
+    pub replacements: RestyleReplacements,
+}
+
 bitflags! {
-    /// When the ElementState of an element (like IN_HOVER_STATE) changes,
-    /// certain pseudo-classes (like :hover) may require us to restyle that
-    /// element, its siblings, and/or its descendants. Similarly, when various
-    /// attributes of an element change, we may also need to restyle things with
-    /// id, class, and attribute selectors. Doing this conservatively is
-    /// expensive, and so we use RestyleHints to short-circuit work we know is
-    /// unnecessary.
+    /// Cascade levels that can be updated for an element by simply replacing
+    /// their rule node.
     ///
     /// Note that the bit values here must be kept in sync with the Gecko
     /// nsRestyleHint values.  If you add more bits with matching values,
     /// please add assertions to assert_restyle_hints_match below.
-    pub flags RestyleHint: u32 {
-        /// Rerun selector matching on the element.
-        const RESTYLE_SELF = 0x01,
-
-        /// Rerun selector matching on all of the element's descendants.
-        ///
-        /// NB: In Gecko, we have RESTYLE_SUBTREE which is inclusive of self,
-        /// but heycam isn't aware of a good reason for that.
-        const RESTYLE_DESCENDANTS = 0x04,
-
-        /// Rerun selector matching on all later siblings of the element and all
-        /// of their descendants.
-        const RESTYLE_LATER_SIBLINGS = 0x08,
-
+    pub flags RestyleReplacements: u8 {
         /// Replace the style data coming from CSS transitions without updating
         /// any other style data. This hint is only processed in animation-only
         /// traversal which is prior to normal traversal.
@@ -76,7 +82,7 @@ bitflags! {
     }
 }
 
-/// Asserts that all RestyleHint flags have a matching nsRestyleHint value.
+/// Asserts that all RestyleReplacements have a matching nsRestyleHint value.
 #[cfg(feature = "gecko")]
 #[inline]
 pub fn assert_restyle_hints_match() {
@@ -85,24 +91,18 @@ pub fn assert_restyle_hints_match() {
     macro_rules! check_restyle_hints {
         ( $( $a:ident => $b:ident ),*, ) => {
             if cfg!(debug_assertions) {
-                let mut hints = RestyleHint::all();
+                let mut replacements = RestyleReplacements::all();
                 $(
                     assert_eq!(structs::$a.0 as usize, $b.bits() as usize, stringify!($b));
-                    hints.remove($b);
+                    replacements.remove($b);
                 )*
-                assert_eq!(hints, RestyleHint::empty(), "all RestyleHint bits should have an assertion");
+                assert_eq!(replacements, RestyleReplacements::empty(),
+                           "all RestyleReplacements bits should have an assertion");
             }
         }
     }
 
     check_restyle_hints! {
-        nsRestyleHint_eRestyle_Self => RESTYLE_SELF,
-        // Note that eRestyle_Subtree means "self and descendants", while
-        // RESTYLE_DESCENDANTS means descendants only.  The From impl
-        // below handles converting eRestyle_Subtree into
-        // (RESTYLE_SELF | RESTYLE_DESCENDANTS).
-        nsRestyleHint_eRestyle_Subtree => RESTYLE_DESCENDANTS,
-        nsRestyleHint_eRestyle_LaterSiblings => RESTYLE_LATER_SIBLINGS,
         nsRestyleHint_eRestyle_CSSTransitions => RESTYLE_CSS_TRANSITIONS,
         nsRestyleHint_eRestyle_CSSAnimations => RESTYLE_CSS_ANIMATIONS,
         nsRestyleHint_eRestyle_StyleAttribute => RESTYLE_STYLE_ATTRIBUTE,
@@ -111,14 +111,193 @@ pub fn assert_restyle_hints_match() {
 }
 
 impl RestyleHint {
-    /// The subset hints that affect the styling of a single element during the
-    /// traversal.
+    /// Creates a new, empty `RestyleHint`, which represents no restyling work
+    /// needs to be done.
     #[inline]
-    pub fn for_self() -> Self {
-        RESTYLE_SELF | RESTYLE_STYLE_ATTRIBUTE | Self::for_animations()
+    pub fn empty() -> Self {
+        RestyleHint {
+            match_self: false,
+            match_descendants: false,
+            match_later_siblings: false,
+            replacements: RestyleReplacements::empty(),
+        }
     }
 
-    /// The subset hints that are used for animation restyle.
+    /// Creates a new `RestyleHint` that indicates selector matching must be
+    /// re-run on the element.
+    #[inline]
+    pub fn for_self() -> Self {
+        RestyleHint {
+            match_self: true,
+            match_descendants: false,
+            match_later_siblings: false,
+            replacements: RestyleReplacements::empty(),
+        }
+    }
+
+    /// Creates a new `RestyleHint` that indicates selector matching must be
+    /// re-run on all of the element's descendants.
+    #[inline]
+    pub fn descendants() -> Self {
+        RestyleHint {
+            match_self: false,
+            match_descendants: true,
+            match_later_siblings: false,
+            replacements: RestyleReplacements::empty(),
+        }
+    }
+
+    /// Creates a new `RestyleHint` that indicates selector matching must be
+    /// re-run on all of the element's later siblings and their descendants.
+    #[inline]
+    pub fn later_siblings() -> Self {
+        RestyleHint {
+            match_self: false,
+            match_descendants: false,
+            match_later_siblings: true,
+            replacements: RestyleReplacements::empty(),
+        }
+    }
+
+    /// Creates a new `RestyleHint` that indicates selector matching must be
+    /// re-run on the element and all of its descendants.
+    #[inline]
+    pub fn subtree() -> Self {
+        RestyleHint {
+            match_self: true,
+            match_descendants: true,
+            match_later_siblings: false,
+            replacements: RestyleReplacements::empty(),
+        }
+    }
+
+    /// Creates a new `RestyleHint` that indicates selector matching must be
+    /// re-run on the element, its descendants, its later siblings, and
+    /// their descendants.
+    #[inline]
+    pub fn subtree_and_later_siblings() -> Self {
+        RestyleHint {
+            match_self: true,
+            match_descendants: true,
+            match_later_siblings: true,
+            replacements: RestyleReplacements::empty(),
+        }
+    }
+
+    /// Creates a new `RestyleHint` that indicates the specified rule node
+    /// replacements must be performed on the element.
+    #[inline]
+    pub fn for_replacements(replacements: RestyleReplacements) -> Self {
+        RestyleHint {
+            match_self: false,
+            match_descendants: false,
+            match_later_siblings: false,
+            replacements: replacements,
+        }
+    }
+
+    /// Returns whether this `RestyleHint` represents no needed restyle work.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        *self == RestyleHint::empty()
+    }
+
+    /// Returns whether this `RestyleHint` represents the maximum possible
+    /// restyle work, and thus any `insert()` calls will have no effect.
+    #[inline]
+    pub fn is_maximum(&self) -> bool {
+        self.match_self && self.match_descendants && self.match_later_siblings && self.replacements.is_all()
+    }
+
+    /// Returns whether the hint specifies that some work must be performed on
+    /// the current element.
+    #[inline]
+    pub fn affects_self(&self) -> bool {
+        self.match_self || !self.replacements.is_empty()
+    }
+
+    /// Returns whether the hint specifies that later siblings must be restyled.
+    #[inline]
+    pub fn affects_later_siblings(&self) -> bool {
+        self.match_later_siblings
+    }
+
+    /// Returns whether the hint specifies that an animation cascade level must
+    /// be replaced.
+    #[inline]
+    pub fn has_animation_hint(&self) -> bool {
+        self.replacements.intersects(RestyleReplacements::for_animations())
+    }
+
+    /// Returns whether the hint specifies some restyle work other than an
+    /// animation cascade level replacement.
+    #[inline]
+    pub fn has_non_animation_hint(&self) -> bool {
+        self.match_self || self.match_descendants || self.match_later_siblings ||
+            self.replacements.contains(RESTYLE_STYLE_ATTRIBUTE)
+    }
+
+    /// Returns whether the hint specifies that selector matching must be re-run
+    /// for the element.
+    #[inline]
+    pub fn match_self(&self) -> bool {
+        self.match_self
+    }
+
+    /// Returns a new `RestyleHint` appropriate for children of the current
+    /// element.
+    #[inline]
+    pub fn propagate_for_non_animation_restyle(&self) -> Self {
+        if self.match_descendants {
+            Self::subtree()
+        } else {
+            Self::empty()
+        }
+    }
+
+    /// Removes all of the animation-related hints.
+    #[inline]
+    pub fn remove_animation_hints(&mut self) {
+        self.replacements.remove(RestyleReplacements::for_animations());
+    }
+
+    /// Removes the later siblings hint, and returns whether it was present.
+    pub fn remove_later_siblings_hint(&mut self) -> bool {
+        let later_siblings = self.match_later_siblings;
+        self.match_later_siblings = false;
+        later_siblings
+    }
+
+    /// Unions the specified `RestyleHint` into this one.
+    #[inline]
+    pub fn insert_from(&mut self, other: &Self) {
+        self.match_self |= other.match_self;
+        self.match_descendants |= other.match_descendants;
+        self.match_later_siblings |= other.match_later_siblings;
+        self.replacements.insert(other.replacements);
+    }
+
+    /// Unions the specified `RestyleHint` into this one.
+    #[inline]
+    pub fn insert(&mut self, other: Self) {
+        // A later patch should make it worthwhile to have an insert() function
+        // that consumes its argument.
+        self.insert_from(&other)
+    }
+
+    /// Returns whether this `RestyleHint` represents at least as much restyle
+    /// work as the specified one.
+    #[inline]
+    pub fn contains(&mut self, other: &Self) -> bool {
+        !(other.match_self && !self.match_self) &&
+        !(other.match_descendants && !self.match_descendants) &&
+        !(other.match_later_siblings && !self.match_later_siblings) &&
+        self.replacements.contains(other.replacements)
+    }
+}
+
+impl RestyleReplacements {
+    /// The replacements for the animation cascade levels.
     #[inline]
     pub fn for_animations() -> Self {
         RESTYLE_SMIL | RESTYLE_CSS_ANIMATIONS | RESTYLE_CSS_TRANSITIONS
@@ -126,24 +305,26 @@ impl RestyleHint {
 }
 
 #[cfg(feature = "gecko")]
+impl From<nsRestyleHint> for RestyleReplacements {
+    fn from(raw: nsRestyleHint) -> Self {
+        Self::from_bits_truncate(raw.0 as u8)
+    }
+}
+
+#[cfg(feature = "gecko")]
 impl From<nsRestyleHint> for RestyleHint {
     fn from(raw: nsRestyleHint) -> Self {
-        let raw_bits: u32 = raw.0;
+        use gecko_bindings::structs::nsRestyleHint_eRestyle_LaterSiblings as eRestyle_LaterSiblings;
+        use gecko_bindings::structs::nsRestyleHint_eRestyle_Self as eRestyle_Self;
+        use gecko_bindings::structs::nsRestyleHint_eRestyle_SomeDescendants as eRestyle_SomeDescendants;
+        use gecko_bindings::structs::nsRestyleHint_eRestyle_Subtree as eRestyle_Subtree;
 
-        // FIXME(bholley): Finish aligning the binary representations here and
-        // then .expect() the result of the checked version.
-        if Self::from_bits(raw_bits).is_none() {
-            warn!("stylo: dropping unsupported restyle hint bits");
+        RestyleHint {
+            match_self: (raw.0 & (eRestyle_Self.0 | eRestyle_Subtree.0)) != 0,
+            match_descendants: (raw.0 & (eRestyle_Subtree.0 | eRestyle_SomeDescendants.0)) != 0,
+            match_later_siblings: (raw.0 & eRestyle_LaterSiblings.0) != 0,
+            replacements: raw.into(),
         }
-
-        let mut bits = Self::from_bits_truncate(raw_bits);
-
-        // eRestyle_Subtree converts to (RESTYLE_SELF | RESTYLE_DESCENDANTS).
-        if bits.contains(RESTYLE_DESCENDANTS) {
-            bits |= RESTYLE_SELF;
-        }
-
-        bits
     }
 }
 
@@ -437,15 +618,16 @@ fn is_attr_selector(sel: &Component<SelectorImpl>) -> bool {
 
 fn combinator_to_restyle_hint(combinator: Option<Combinator>) -> RestyleHint {
     match combinator {
-        None => RESTYLE_SELF,
+        None => RestyleHint::for_self(),
         Some(c) => match c {
-            // NB: RESTYLE_SELF is needed to handle properly eager pseudos,
-            // otherwise we may leave a stale style on the parent.
-            Combinator::PseudoElement => RESTYLE_SELF | RESTYLE_DESCENDANTS,
-            Combinator::Child => RESTYLE_DESCENDANTS,
-            Combinator::Descendant => RESTYLE_DESCENDANTS,
-            Combinator::NextSibling => RESTYLE_LATER_SIBLINGS,
-            Combinator::LaterSibling => RESTYLE_LATER_SIBLINGS,
+            // NB: RestyleHint::subtree() and not RestyleHint::descendants() is
+            // needed to handle properly eager pseudos, otherwise we may leave
+            // a stale style on the parent.
+            Combinator::PseudoElement => RestyleHint::subtree(),
+            Combinator::Child => RestyleHint::descendants(),
+            Combinator::Descendant => RestyleHint::descendants(),
+            Combinator::NextSibling => RestyleHint::later_siblings(),
+            Combinator::LaterSibling => RestyleHint::later_siblings(),
         }
     }
 }
@@ -700,12 +882,12 @@ impl DependencySet {
                 return true;
             }
 
-            if hint.contains(dep.hint) {
+            if hint.contains(&dep.hint) {
                 trace!(" > hint was already there");
                 return true;
             }
 
-            // We can ignore the selector flags, since they would have already
+            // We can ignore the selector replacements, since they would have already
             // been set during original matching for any element that might
             // change its matching behavior here.
             let matched_then =
@@ -717,10 +899,10 @@ impl DependencySet {
                                  &mut matching_context,
                                  &mut |_, _| {});
             if matched_then != matches_now {
-                hint.insert(dep.hint);
+                hint.insert_from(&dep.hint);
             }
 
-            !hint.is_all()
+            !hint.is_maximum()
         });
 
         debug!("Calculated restyle hint: {:?} for {:?}. (State={:?}, {} Deps)",

--- a/components/style/restyle_hints.rs
+++ b/components/style/restyle_hints.rs
@@ -37,11 +37,8 @@ use stylist::SelectorMap;
 /// unnecessary.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RestyleHint {
-    /// Rerun selector matching on the element.
-    match_self: bool,
-
-    /// Rerun selector matching on all of the element's descendants.
-    match_descendants: bool,
+    /// Depths at which selector matching must be re-run.
+    match_under_self: RestyleDepths,
 
     /// Rerun selector matching on all later siblings of the element and all
     /// of their descendants.
@@ -82,6 +79,75 @@ bitflags! {
     }
 }
 
+/// Eight bit wide bitfield representing depths of a DOM subtree's descendants,
+/// used to represent which elements must have selector matching re-run on them.
+///
+/// The least significant bit indicates that selector matching must be re-run
+/// for the element itself, the second least significant bit for the element's
+/// children, the third its grandchildren, and so on.  If the most significant
+/// bit it set, it indicates that that selector matching must be re-run for
+/// elements at that depth and all of their descendants.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct RestyleDepths(u8);
+
+impl RestyleDepths {
+    /// Returns a `RestyleDepths` representing no element depths.
+    fn empty() -> Self {
+        RestyleDepths(0)
+    }
+
+    /// Returns a `RestyleDepths` representing the current element depth.
+    fn for_self() -> Self {
+        RestyleDepths(0x01)
+    }
+
+    /// Returns a `RestyleDepths` representing the depths of all descendants of
+    /// the current element.
+    fn for_descendants() -> Self {
+        RestyleDepths(0xfe)
+    }
+
+    /// Returns a `RestyleDepths` representing the current element depth and the
+    /// depths of all the current element's descendants.
+    fn for_self_and_descendants() -> Self {
+        RestyleDepths(0xff)
+    }
+
+    /// Returns whether this `RestyleDepths` represents the current element
+    /// depth and the depths of all the current element's descendants.
+    fn is_self_and_descendants(&self) -> bool {
+        self.0 == 0xff
+    }
+
+    /// Returns whether this `RestyleDepths` includes any element depth.
+    fn is_any(&self) -> bool {
+        self.0 != 0
+    }
+
+    /// Returns whether this `RestyleDepths` includes the current element depth.
+    fn has_self(&self) -> bool {
+        (self.0 & 0x01) != 0
+    }
+
+    /// Returns a new `RestyleDepths` with all depth values represented by this
+    /// `RestyleDepths` reduced by one.
+    fn propagate(&self) -> Self {
+        RestyleDepths((self.0 >> 1) | (self.0 & 0x80))
+    }
+
+    /// Returns a new `RestyleDepths` that represents the union of the depths
+    /// from `self` and `other`.
+    fn insert(&mut self, other: RestyleDepths) {
+        self.0 |= other.0;
+    }
+
+    /// Returns whether this `RestyleDepths` includes all depths represented
+    /// by `other`.
+    fn contains(&self, other: RestyleDepths) -> bool {
+        (self.0 & other.0) == other.0
+    }
+}
+
 /// Asserts that all RestyleReplacements have a matching nsRestyleHint value.
 #[cfg(feature = "gecko")]
 #[inline]
@@ -116,8 +182,7 @@ impl RestyleHint {
     #[inline]
     pub fn empty() -> Self {
         RestyleHint {
-            match_self: false,
-            match_descendants: false,
+            match_under_self: RestyleDepths::empty(),
             match_later_siblings: false,
             replacements: RestyleReplacements::empty(),
         }
@@ -128,8 +193,7 @@ impl RestyleHint {
     #[inline]
     pub fn for_self() -> Self {
         RestyleHint {
-            match_self: true,
-            match_descendants: false,
+            match_under_self: RestyleDepths::for_self(),
             match_later_siblings: false,
             replacements: RestyleReplacements::empty(),
         }
@@ -140,8 +204,7 @@ impl RestyleHint {
     #[inline]
     pub fn descendants() -> Self {
         RestyleHint {
-            match_self: false,
-            match_descendants: true,
+            match_under_self: RestyleDepths::for_descendants(),
             match_later_siblings: false,
             replacements: RestyleReplacements::empty(),
         }
@@ -152,8 +215,7 @@ impl RestyleHint {
     #[inline]
     pub fn later_siblings() -> Self {
         RestyleHint {
-            match_self: false,
-            match_descendants: false,
+            match_under_self: RestyleDepths::empty(),
             match_later_siblings: true,
             replacements: RestyleReplacements::empty(),
         }
@@ -164,8 +226,7 @@ impl RestyleHint {
     #[inline]
     pub fn subtree() -> Self {
         RestyleHint {
-            match_self: true,
-            match_descendants: true,
+            match_under_self: RestyleDepths::for_self_and_descendants(),
             match_later_siblings: false,
             replacements: RestyleReplacements::empty(),
         }
@@ -177,8 +238,7 @@ impl RestyleHint {
     #[inline]
     pub fn subtree_and_later_siblings() -> Self {
         RestyleHint {
-            match_self: true,
-            match_descendants: true,
+            match_under_self: RestyleDepths::for_self_and_descendants(),
             match_later_siblings: true,
             replacements: RestyleReplacements::empty(),
         }
@@ -189,8 +249,7 @@ impl RestyleHint {
     #[inline]
     pub fn for_replacements(replacements: RestyleReplacements) -> Self {
         RestyleHint {
-            match_self: false,
-            match_descendants: false,
+            match_under_self: RestyleDepths::empty(),
             match_later_siblings: false,
             replacements: replacements,
         }
@@ -206,14 +265,16 @@ impl RestyleHint {
     /// restyle work, and thus any `insert()` calls will have no effect.
     #[inline]
     pub fn is_maximum(&self) -> bool {
-        self.match_self && self.match_descendants && self.match_later_siblings && self.replacements.is_all()
+        self.match_under_self.is_self_and_descendants() &&
+            self.match_later_siblings &&
+            self.replacements.is_all()
     }
 
     /// Returns whether the hint specifies that some work must be performed on
     /// the current element.
     #[inline]
     pub fn affects_self(&self) -> bool {
-        self.match_self || !self.replacements.is_empty()
+        self.match_self() || !self.replacements.is_empty()
     }
 
     /// Returns whether the hint specifies that later siblings must be restyled.
@@ -233,7 +294,7 @@ impl RestyleHint {
     /// animation cascade level replacement.
     #[inline]
     pub fn has_non_animation_hint(&self) -> bool {
-        self.match_self || self.match_descendants || self.match_later_siblings ||
+        self.match_under_self.is_any() || self.match_later_siblings ||
             self.replacements.contains(RESTYLE_STYLE_ATTRIBUTE)
     }
 
@@ -241,17 +302,17 @@ impl RestyleHint {
     /// for the element.
     #[inline]
     pub fn match_self(&self) -> bool {
-        self.match_self
+        self.match_under_self.has_self()
     }
 
     /// Returns a new `RestyleHint` appropriate for children of the current
     /// element.
     #[inline]
     pub fn propagate_for_non_animation_restyle(&self) -> Self {
-        if self.match_descendants {
-            Self::subtree()
-        } else {
-            Self::empty()
+        RestyleHint {
+            match_under_self: self.match_under_self.propagate(),
+            match_later_siblings: false,
+            replacements: RestyleReplacements::empty(),
         }
     }
 
@@ -271,8 +332,7 @@ impl RestyleHint {
     /// Unions the specified `RestyleHint` into this one.
     #[inline]
     pub fn insert_from(&mut self, other: &Self) {
-        self.match_self |= other.match_self;
-        self.match_descendants |= other.match_descendants;
+        self.match_under_self.insert(other.match_under_self);
         self.match_later_siblings |= other.match_later_siblings;
         self.replacements.insert(other.replacements);
     }
@@ -289,9 +349,8 @@ impl RestyleHint {
     /// work as the specified one.
     #[inline]
     pub fn contains(&mut self, other: &Self) -> bool {
-        !(other.match_self && !self.match_self) &&
-        !(other.match_descendants && !self.match_descendants) &&
-        !(other.match_later_siblings && !self.match_later_siblings) &&
+        self.match_under_self.contains(other.match_under_self) &&
+        (self.match_later_siblings & other.match_later_siblings) == other.match_later_siblings &&
         self.replacements.contains(other.replacements)
     }
 }
@@ -319,9 +378,16 @@ impl From<nsRestyleHint> for RestyleHint {
         use gecko_bindings::structs::nsRestyleHint_eRestyle_SomeDescendants as eRestyle_SomeDescendants;
         use gecko_bindings::structs::nsRestyleHint_eRestyle_Subtree as eRestyle_Subtree;
 
+        let mut match_under_self = RestyleDepths::empty();
+        if (raw.0 & (eRestyle_Self.0 | eRestyle_Subtree.0)) != 0 {
+            match_under_self.insert(RestyleDepths::for_self());
+        }
+        if (raw.0 & (eRestyle_Subtree.0 | eRestyle_SomeDescendants.0)) != 0 {
+            match_under_self.insert(RestyleDepths::for_descendants());
+        }
+
         RestyleHint {
-            match_self: (raw.0 & (eRestyle_Self.0 | eRestyle_Subtree.0)) != 0,
-            match_descendants: (raw.0 & (eRestyle_Subtree.0 | eRestyle_SomeDescendants.0)) != 0,
+            match_under_self: match_under_self,
             match_later_siblings: (raw.0 & eRestyle_LaterSiblings.0) != 0,
             replacements: raw.into(),
         }

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -9,6 +9,7 @@
 
 use computed_values::display;
 use heapsize::HeapSizeOf;
+use matching::{StyleChange, StyleDifference};
 use properties::ServoComputedValues;
 use std::fmt;
 
@@ -57,12 +58,14 @@ impl HeapSizeOf for ServoRestyleDamage {
 }
 
 impl ServoRestyleDamage {
-    /// Compute the appropriate restyle damage for a given style change between
-    /// `old` and `new`.
-    pub fn compute(old: &ServoComputedValues,
-                   new: &ServoComputedValues)
-                   -> ServoRestyleDamage {
-        compute_damage(old, new)
+    /// Compute the `StyleDifference` (including the appropriate restyle damage)
+    /// for a given style change between `old` and `new`.
+    pub fn compute_style_difference(old: &ServoComputedValues,
+                                    new: &ServoComputedValues)
+                                    -> StyleDifference {
+        let damage = compute_damage(old, new);
+        let change = if damage.is_empty() { StyleChange::Unchanged } else { StyleChange::Changed };
+        StyleDifference::new(damage, change)
     }
 
     /// Returns a bitmask that represents a flow that needs to be rebuilt and

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -9,7 +9,7 @@ use context::{SharedStyleContext, StyleContext, ThreadLocalStyleContext};
 use data::{ElementData, ElementStyles, StoredRestyleHint};
 use dom::{DirtyDescendants, NodeInfo, OpaqueNode, TElement, TNode};
 use matching::{ChildCascadeRequirement, MatchMethods, StyleSharingBehavior};
-use restyle_hints::{RESTYLE_DESCENDANTS, RESTYLE_SELF};
+use restyle_hints::RestyleHint;
 use selector_parser::RestyleDamage;
 #[cfg(feature = "servo")] use servo_config::opts;
 use std::borrow::BorrowMut;
@@ -232,7 +232,7 @@ pub trait DomTraversal<E: TElement> : Sync {
                 if let Some(next) = root.next_sibling_element() {
                     if let Some(mut next_data) = next.mutate_data() {
                         let hint = StoredRestyleHint::subtree_and_later_siblings();
-                        next_data.ensure_restyle().hint.insert(&hint);
+                        next_data.ensure_restyle().hint.insert(hint);
                     }
                 }
             }
@@ -819,11 +819,11 @@ fn preprocess_children<E, D>(traversal: &D,
 
         // Propagate the parent and sibling restyle hint.
         if !propagated_hint.is_empty() {
-            restyle_data.hint.insert(&propagated_hint);
+            restyle_data.hint.insert_from(&propagated_hint);
         }
 
         if later_siblings {
-            propagated_hint.insert(&(RESTYLE_SELF | RESTYLE_DESCENDANTS).into());
+            propagated_hint.insert(RestyleHint::subtree().into());
         }
 
         // Store the damage already handled by ancestors.

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -8,7 +8,7 @@ use atomic_refcell::{AtomicRefCell, AtomicRefMut};
 use context::{SharedStyleContext, StyleContext, ThreadLocalStyleContext};
 use data::{ElementData, ElementStyles, StoredRestyleHint};
 use dom::{DirtyDescendants, NodeInfo, OpaqueNode, TElement, TNode};
-use matching::{MatchMethods, StyleSharingBehavior};
+use matching::{ChildCascadeRequirement, MatchMethods, StyleSharingBehavior};
 use restyle_hints::{RESTYLE_DESCENDANTS, RESTYLE_SELF};
 use selector_parser::RestyleDamage;
 #[cfg(feature = "servo")] use servo_config::opts;
@@ -611,7 +611,12 @@ pub fn recalc_style_at<E, D>(traversal: &D,
 
     // Compute style for this element if necessary.
     if compute_self {
-        compute_style(traversal, traversal_data, context, element, &mut data);
+        match compute_style(traversal, traversal_data, context, element, &mut data) {
+            ChildCascadeRequirement::MustCascade => {
+                inherited_style_changed = true;
+            }
+            ChildCascadeRequirement::CanSkipCascade => {}
+        };
 
         // If we're restyling this element to display:none, throw away all style
         // data in the subtree, notify the caller to early-return.
@@ -620,9 +625,6 @@ pub fn recalc_style_at<E, D>(traversal: &D,
                    element);
             clear_descendant_data(element, &|e| unsafe { D::clear_element_data(&e) });
         }
-
-        // FIXME(bholley): Compute this accurately from the call to CalcStyleDifference.
-        inherited_style_changed = true;
     }
 
     // Now that matching and cascading is done, clear the bits corresponding to
@@ -711,7 +713,7 @@ fn compute_style<E, D>(_traversal: &D,
                        traversal_data: &PerLevelTraversalData,
                        context: &mut StyleContext<E>,
                        element: E,
-                       mut data: &mut AtomicRefMut<ElementData>)
+                       mut data: &mut AtomicRefMut<ElementData>) -> ChildCascadeRequirement
     where E: TElement,
           D: DomTraversal<E>,
 {
@@ -727,10 +729,10 @@ fn compute_style<E, D>(_traversal: &D,
         let sharing_result = unsafe {
             element.share_style_if_possible(context, &mut data)
         };
-        if let StyleWasShared(index) = sharing_result {
+        if let StyleWasShared(index, had_damage) = sharing_result {
             context.thread_local.statistics.styles_shared += 1;
             context.thread_local.style_sharing_candidate_cache.touch(index);
-            return;
+            return had_damage;
         }
     }
 
@@ -744,17 +746,28 @@ fn compute_style<E, D>(_traversal: &D,
             context.thread_local.statistics.elements_matched += 1;
 
             // Perform the matching and cascading.
-            element.match_and_cascade(context, &mut data, StyleSharingBehavior::Allow);
+            element.match_and_cascade(
+                context,
+                &mut data,
+                StyleSharingBehavior::Allow
+            )
         }
-        CascadeWithReplacements(hint) => {
-            let rules_changed = element.replace_rules(hint, context, &mut data);
-            element.cascade_primary_and_pseudos(context, &mut data,
-                                                rules_changed.important_rules_changed());
+        CascadeWithReplacements(flags) => {
+            let rules_changed = element.replace_rules(flags, context, &mut data);
+            element.cascade_primary_and_pseudos(
+                context,
+                &mut data,
+                rules_changed.important_rules_changed()
+            )
         }
         CascadeOnly => {
-            element.cascade_primary_and_pseudos(context, &mut data, false);
+            element.cascade_primary_and_pseudos(
+                context,
+                &mut data,
+                /* important_rules_changed = */ false
+            )
         }
-    };
+    }
 }
 
 fn preprocess_children<E, D>(traversal: &D,

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2116,16 +2116,16 @@ pub extern "C" fn Servo_NoteExplicitHints(element: RawGeckoElementBorrowed,
            element, restyle_hint, change_hint);
 
     let restyle_hint: RestyleHint = restyle_hint.into();
-    debug_assert!(RestyleHint::for_animations().contains(restyle_hint) ||
-                  !RestyleHint::for_animations().intersects(restyle_hint),
+    debug_assert!(!(restyle_hint.has_animation_hint() &&
+                    restyle_hint.has_non_animation_hint()),
                   "Animation restyle hints should not appear with non-animation restyle hints");
 
     let mut maybe_data = element.mutate_data();
     let maybe_restyle_data = maybe_data.as_mut().and_then(|d| unsafe {
-        maybe_restyle(d, element, restyle_hint.intersects(RestyleHint::for_animations()))
+        maybe_restyle(d, element, restyle_hint.has_animation_hint())
     });
     if let Some(restyle_data) = maybe_restyle_data {
-        restyle_data.hint.insert(&restyle_hint.into());
+        restyle_data.hint.insert(restyle_hint.into());
         restyle_data.damage |= damage;
     } else {
         debug!("(Element not styled, discarding hints)");

--- a/tests/unit/style/restyle_hints.rs
+++ b/tests/unit/style/restyle_hints.rs
@@ -6,7 +6,7 @@
 fn smoke_restyle_hints() {
     use cssparser::Parser;
     use selectors::parser::SelectorList;
-    use style::restyle_hints::{DependencySet, RESTYLE_LATER_SIBLINGS};
+    use style::restyle_hints::DependencySet;
     use style::selector_parser::SelectorParser;
     use style::stylesheets::{Origin, Namespaces};
     let namespaces = Namespaces::default();

--- a/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-table-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/border-collapse-dynamic-table-002.htm.ini
@@ -1,0 +1,3 @@
+[border-collapse-dynamic-table-002.htm]
+  type: reftest
+  expected: FAIL


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16967)
<!-- Reviewable:end -->
