### PR TITLE
layout: Stop mutating the style data from layout.

### DIFF
--- a/components/script/layout_wrapper.rs
+++ b/components/script/layout_wrapper.rs
@@ -30,7 +30,7 @@
 
 #![allow(unsafe_code)]
 
-use atomic_refcell::AtomicRefCell;
+use atomic_refcell::{AtomicRef, AtomicRefCell};
 use dom::bindings::inheritance::{CharacterDataTypeId, ElementTypeId};
 use dom::bindings::inheritance::{HTMLElementTypeId, NodeTypeId};
 use dom::bindings::js::LayoutJS;
@@ -1092,8 +1092,10 @@ impl<'le> ThreadSafeLayoutElement for ServoThreadSafeLayoutElement<'le> {
         self.element.get_attr(namespace, name)
     }
 
-    fn get_style_data(&self) -> Option<&AtomicRefCell<ElementData>> {
+    fn style_data(&self) -> AtomicRef<ElementData> {
         self.element.get_data()
+            .expect("Unstyled layout node?")
+            .borrow()
     }
 }
 

--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -12,9 +12,7 @@ use restyle_hints::{HintComputationContext, RestyleReplacements, RestyleHint};
 use rule_tree::StrongRuleNode;
 use selector_parser::{EAGER_PSEUDO_COUNT, PseudoElement, RestyleDamage};
 use shared_lock::StylesheetGuards;
-#[cfg(feature = "servo")] use std::collections::HashMap;
 use std::fmt;
-#[cfg(feature = "servo")] use std::hash::BuildHasherDefault;
 use stylearc::Arc;
 use traversal::TraversalFlags;
 
@@ -145,14 +143,6 @@ impl EagerPseudoStyles {
     }
 }
 
-/// A cache of precomputed and lazy pseudo-elements, used by servo. This isn't
-/// a very efficient design, but is the result of servo having previously used
-/// the eager pseudo map (when it was a map) for this cache.
-#[cfg(feature = "servo")]
-type PseudoElementCache = HashMap<PseudoElement, ComputedStyle, BuildHasherDefault<::fnv::FnvHasher>>;
-#[cfg(feature = "gecko")]
-type PseudoElementCache = ();
-
 /// The styles associated with a node, including the styles for any
 /// pseudo-elements.
 #[derive(Clone, Debug)]
@@ -161,8 +151,6 @@ pub struct ElementStyles {
     pub primary: ComputedStyle,
     /// A list of the styles for the element's eagerly-cascaded pseudo-elements.
     pub pseudos: EagerPseudoStyles,
-    /// NB: This is an empty field for gecko.
-    pub cached_pseudos: PseudoElementCache,
 }
 
 impl ElementStyles {
@@ -171,7 +159,6 @@ impl ElementStyles {
         ElementStyles {
             primary: primary,
             pseudos: EagerPseudoStyles(None),
-            cached_pseudos: PseudoElementCache::default(),
         }
     }
 


### PR DESCRIPTION
This is part of #16982.

Right now we have some code that tries to cache stuff in the style data during
layout.

This code is extremely rarely executed, only for `<details>` and `<summary>`.

I think if we really really want to cache these, we should find a place in the
layout data for it.

For now, let's move it away (and all the other layout code) from mutating the
style data from layout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16985)
<!-- Reviewable:end -->
