### PR TITLE
Using stack-allocated variable for font feature setting

### DIFF
--- a/components/style/values/generics/mod.rs
+++ b/components/style/values/generics/mod.rs
@@ -181,12 +181,12 @@ impl<T> OneOrMoreCommaSeparated for FontSettingTag<T> {}
 
 impl<T: ToCss> ToCss for FontSettingTag<T> {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-        use byteorder::{WriteBytesExt, BigEndian};
+        use byteorder::{BigEndian, ByteOrder};
         use cssparser::serialize_string;
         use std::str;
 
-        let mut raw: Vec<u8> = vec!();
-        raw.write_u32::<BigEndian>(self.tag).unwrap();
+        let mut raw = [0u8; 4];
+        BigEndian::write_u32(&mut raw, self.tag);
         serialize_string(str::from_utf8(&raw).unwrap_or_default(), dest)?;
 
         self.value.to_css(dest)
@@ -310,5 +310,3 @@ impl ToCss for FontSettingTagFloat {
         self.0.to_css(dest)
     }
 }
-
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Using stack-allocated small vector instead of the previous vector<u8>. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix   #16743 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this is an optimization

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16987)
<!-- Reviewable:end -->
