### PR TITLE
Fix stylo's text-overflow handling to match gecko.

### DIFF
--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -710,7 +710,7 @@ impl LineBreaker {
         let available_inline_size = self.pending_line.green_zone.inline -
             self.pending_line.bounds.size.inline - indentation;
 
-        let ellipsis = match (&fragment.style().get_text().text_overflow.first,
+        let ellipsis = match (&fragment.style().get_text().text_overflow.second,
             fragment.style().get_box().overflow_x) {
             (&longhands::text_overflow::Side::Clip, _) | (_, overflow_x::T::visible) => None,
             (&longhands::text_overflow::Side::Ellipsis, _) => {

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3769,7 +3769,7 @@ fn static_assert() {
     }
     pub fn set_text_overflow(&mut self, v: longhands::text_overflow::computed_value::T) {
         use gecko_bindings::structs::nsStyleTextOverflowSide;
-        use properties::longhands::text_overflow::{SpecifiedValue, Side};
+        use properties::longhands::text_overflow::Side;
 
         fn set(side: &mut nsStyleTextOverflowSide, value: &Side) {
             let ty = match *value {
@@ -3784,13 +3784,10 @@ fn static_assert() {
         }
 
         self.clear_overflow_sides_if_string();
-        self.gecko.mTextOverflow.mLogicalDirections = v.second.is_none();
+        self.gecko.mTextOverflow.mLogicalDirections = v.sides_are_logical;
 
-        let SpecifiedValue { ref first, ref second } = v;
-        let second = second.as_ref().unwrap_or(&first);
-
-        set(&mut self.gecko.mTextOverflow.mLeft, first);
-        set(&mut self.gecko.mTextOverflow.mRight, second);
+        set(&mut self.gecko.mTextOverflow.mLeft, &v.first);
+        set(&mut self.gecko.mTextOverflow.mRight, &v.second);
     }
 
     pub fn copy_text_overflow_from(&mut self, other: &Self) {

--- a/components/style/properties/longhand/text.mako.rs
+++ b/components/style/properties/longhand/text.mako.rs
@@ -16,10 +16,8 @@
                    spec="https://drafts.csswg.org/css-ui/#propdef-text-overflow">
     use std::fmt;
     use style_traits::ToCss;
-    use values::computed::ComputedValueAsSpecified;
     use cssparser;
 
-    impl ComputedValueAsSpecified for SpecifiedValue {}
     no_viewport_percentage!(SpecifiedValue);
 
     #[derive(PartialEq, Eq, Clone, Debug)]
@@ -38,14 +36,73 @@
     }
 
     pub mod computed_value {
-        pub type T = super::SpecifiedValue;
+        pub use super::Side;
+
+        #[derive(Debug, Clone, PartialEq)]
+        #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+        pub struct T {
+            // When the specified value only has one side, that's the "second"
+            // side, and the sides are logical, so "second" means "end".  The
+            // start side is Clip in that case.
+            //
+            // When the specified value has two sides, those are our "first"
+            // and "second" sides, and they are physical sides ("left" and
+            // "right").
+            pub first: Side,
+            pub second: Side,
+            pub sides_are_logical: bool
+        }
+    }
+
+    impl ToCss for computed_value::T {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            if self.sides_are_logical {
+                assert!(self.first == Side::Clip);
+                try!(self.second.to_css(dest));
+            } else {
+                try!(self.first.to_css(dest));
+                try!(dest.write_str(" "));
+                try!(self.second.to_css(dest));
+            }
+            Ok(())
+        }
+    }
+
+    impl ToComputedValue for SpecifiedValue {
+        type ComputedValue = computed_value::T;
+
+        #[inline]
+        fn to_computed_value(&self, _context: &Context) -> Self::ComputedValue {
+            if let Some(ref second) = self.second {
+                Self::ComputedValue { first: self.first.clone(),
+                                      second: second.clone(),
+                                      sides_are_logical: false }
+            } else {
+                Self::ComputedValue { first: Side::Clip,
+                                      second: self.first.clone(),
+                                      sides_are_logical: true }
+            }
+        }
+
+        #[inline]
+        fn from_computed_value(computed: &Self::ComputedValue) -> Self {
+            if computed.sides_are_logical {
+                assert!(computed.first == Side::Clip);
+                SpecifiedValue { first: computed.second.clone(),
+                                 second: None }
+            } else {
+                SpecifiedValue { first: computed.first.clone(),
+                                 second: Some(computed.second.clone()) }
+            }
+        }
     }
 
     #[inline]
     pub fn get_initial_value() -> computed_value::T {
-        SpecifiedValue {
+        computed_value::T {
             first: Side::Clip,
-            second: None
+            second: Side::Clip,
+            sides_are_logical: true,
         }
     }
     pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<SpecifiedValue, ()> {


### PR DESCRIPTION
A single value sets the text-overflow on the _end_ of the text, not both start and end.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/16999)
<!-- Reviewable:end -->
