### PR TITLE
stylo: Fixup an embarrassing typo that has turned everything orange.

### DIFF
--- a/components/style/gecko/pseudo_element.rs
+++ b/components/style/gecko/pseudo_element.rs
@@ -55,7 +55,7 @@ impl PseudoElement {
     /// This is not the common thing, but there are some pseudos (namely:
     /// ::backdrop), that shouldn't inherit from the parent element.
     pub fn inherits_from_default_values(&self) -> bool {
-        !matches!(*self, PseudoElement::Backdrop)
+        matches!(*self, PseudoElement::Backdrop)
     }
 
     /// Gets the canonical index of this eagerly-cascaded pseudo-element.


### PR DESCRIPTION
I messed up when turning the conditions the other way around in #16981.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17005)
<!-- Reviewable:end -->
