### PR TITLE
style: Reject non-positive resolution values in media queries.

### DIFF
--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -181,6 +181,10 @@ impl Resolution {
             _ => return Err(()),
         };
 
+        if value <= 0. {
+            return Err(())
+        }
+
         Ok(match_ignore_ascii_case! { &unit,
             "dpi" => Resolution::Dpi(value),
             "dppx" => Resolution::Dppx(value),


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1366961
See: https://github.com/w3c/csswg-drafts/issues/1454

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17006)
<!-- Reviewable:end -->
