### PR TITLE
Make armv7-linux-androideabi default target on Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-egl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-freetype-sys 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "servo-skia 0.30000004.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo-skia 0.30000004.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "servo-skia"
-version = "0.30000004.1"
+version = "0.30000004.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cgl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3630,7 +3630,7 @@ dependencies = [
 "checksum servo-fontconfig-sys 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6be80777ee6edecbbbf8774c76e19dddfe336256c57a4ded06d6ad3df7be358e"
 "checksum servo-freetype-sys 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9232032c2e85118c0282c6562c84cab12316e655491ba0a5d1905b2320060d1b"
 "checksum servo-glutin 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8398095f9b3dc3c6d706d395e192624be1f1bcc6f366b009fe17a20cb5dd3d72"
-"checksum servo-skia 0.30000004.1 (registry+https://github.com/rust-lang/crates.io-index)" = "22ba980da523e91b9d2f7da9fb35f721138a1e604b8d8191e56f403e4760a9e4"
+"checksum servo-skia 0.30000004.3 (registry+https://github.com/rust-lang/crates.io-index)" = "109e567850bad212ee98ed9651e256de862bd9764476f2b16355af5f6ef59cfe"
 "checksum servo-websocket 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8a1ff13c5d852c2793805226e688044309f2c1d8f063784805a13e99cb75b611"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum shared_library 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fb04126b6fcfd2710fb5b6d18f4207b6c535f2850a7e1a43bcd526d44f30a79a"

--- a/etc/ci/check_dynamic_symbols.py
+++ b/etc/ci/check_dynamic_symbols.py
@@ -23,7 +23,7 @@ objdump_output = subprocess.check_output([
         os.environ['ANDROID_NDK'], 'toolchains', 'arm-linux-androideabi-4.9',
         'prebuilt', 'linux-x86_64', 'bin', 'arm-linux-androideabi-objdump'),
     '-T',
-    'target/arm-linux-androideabi/debug/libservo.so']
+    'target/armv7-linux-androideabi/debug/libservo.so']
 ).split(b'\n')
 
 for line in objdump_output:

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -277,7 +277,8 @@ class CommandBase(object):
         self.config["android"].setdefault("sdk", "")
         self.config["android"].setdefault("ndk", "")
         self.config["android"].setdefault("toolchain", "")
-        self.handle_android_target("arm-linux-androideabi")
+        # Set default android target
+        self.handle_android_target("armv7-linux-androideabi")
 
         self.set_cargo_root()
         self.set_use_stable_rust(False)

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -175,10 +175,18 @@ class PackageCommands(CommandBase):
                      default=None,
                      action='store_true',
                      help='Package Android')
-    def package(self, release=False, dev=False, android=None, debug=False, debugger=None):
+    @CommandArgument('--target', '-t',
+                     default=None,
+                     help='Package for given target platform')
+    def package(self, release=False, dev=False, android=None, debug=False, debugger=None, target=None):
         env = self.build_env()
         if android is None:
             android = self.config["build"]["android"]
+        if target and android:
+            print("Please specify either --target or --android.")
+            sys.exit(1)
+        if not android:
+            android = self.handle_android_target(target)
         binary_path = self.get_binary_path(release, dev, android=android)
         dir_to_root = self.get_top_dir()
         target_dir = path.dirname(binary_path)
@@ -384,7 +392,15 @@ class PackageCommands(CommandBase):
     @CommandArgument('--android',
                      action='store_true',
                      help='Install on Android')
-    def install(self, release=False, dev=False, android=False):
+    @CommandArgument('--target', '-t',
+                     default=None,
+                     help='Install the given target platform')
+    def install(self, release=False, dev=False, android=False, target=None):
+        if target and android:
+            print("Please specify either --target or --android.")
+            sys.exit(1)
+        if not android:
+            android = self.handle_android_target(target)
         try:
             binary_path = self.get_binary_path(release, dev, android=android)
         except BuildNotFound:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

See https://github.com/servo/servo/issues/11921

After fixing problematic dependencies this is the last step to support armv7-linux-androideabi target on Android:

- Updates skia dependency to fix a linker error. See https://github.com/servo/skia/pull/136
- Fixes specifying android targets on `./mach package` and `./mach install` steps:
  -`./mach package --release --target=arm-linux-androideabi`
  -`./mach package --release --target=armv7-linux-androideabi`
  -`./mach package --release --target=aarch64-linux-android`
- Make `armv7-linux-androideabi`default when `--android` param is used in build, package or install commands

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #11921 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17008)
<!-- Reviewable:end -->
