### PR TITLE
Stylo: match both ::placehoder & ::moz-placeholder for placeholder ps…

### DIFF
--- a/components/style/gecko/pseudo_element.rs
+++ b/components/style/gecko/pseudo_element.rs
@@ -102,6 +102,15 @@ impl PseudoElement {
     pub fn is_precomputed(&self) -> bool {
         self.is_anon_box()
     }
+
+    /// Covert non-canonical pseudo-element to canonical one, and keep a
+    /// canonical one as it is.
+    pub fn canonical(&self) -> PseudoElement {
+        match *self {
+            PseudoElement::MozPlaceholder => PseudoElement::Placeholder,
+            _ => self.clone(),
+        }
+    }
 }
 
 impl ToCss for PseudoElement {

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1368,7 +1368,7 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
         // match the proper pseudo-element, given how we rulehash the stuff
         // based on the pseudo.
         match self.implemented_pseudo_element() {
-            Some(ref pseudo) => pseudo == pseudo_element,
+            Some(ref pseudo) => *pseudo == pseudo_element.canonical(),
             None => false,
         }
     }

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -684,6 +684,8 @@ pub trait MatchMethods : TElement {
     {
         let implemented_pseudo = self.implemented_pseudo_element();
         if let Some(ref pseudo) = implemented_pseudo {
+            // We don't expect to match against a non-canonical pseudo-element.
+            debug_assert_eq!(*pseudo, pseudo.canonical());
             if pseudo.is_eager() {
                 // If it's an eager element-backed pseudo, just grab the matched
                 // rules from the parent, and update animations.

--- a/components/style/servo/selector_parser.rs
+++ b/components/style/servo/selector_parser.rs
@@ -152,6 +152,12 @@ impl PseudoElement {
             PseudoElement::ServoInlineAbsolute => PseudoElementCascadeType::Precomputed,
         }
     }
+
+    /// Covert non-canonical pseudo-element to canonical one, and keep a
+    /// canonical one as it is.
+    pub fn canonical(&self) -> PseudoElement {
+        self.clone()
+    }
 }
 
 /// A non tree-structural pseudo-class.

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -477,7 +477,7 @@ impl Stylist {
     {
         let map = if let Some(pseudo) = selector.pseudo_element() {
             self.pseudos_map
-                .entry(pseudo.clone())
+                .entry(pseudo.canonical())
                 .or_insert_with(PerPseudoElementSelectorMap::new)
                 .borrow_for_origin(&stylesheet.origin)
         } else {
@@ -669,8 +669,9 @@ impl Stylist {
                                 -> Option<StrongRuleNode>
         where E: TElement
     {
+        let pseudo = pseudo.canonical();
         debug_assert!(pseudo.is_lazy());
-        if self.pseudos_map.get(pseudo).is_none() {
+        if self.pseudos_map.get(&pseudo).is_none() {
             return None
         }
 
@@ -702,7 +703,7 @@ impl Stylist {
         let mut matching_context =
             MatchingContext::new(MatchingMode::ForStatelessPseudoElement, None);
         self.push_applicable_declarations(element,
-                                          Some(pseudo),
+                                          Some(&pseudo),
                                           None,
                                           None,
                                           AnimationRules(None, None),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The first patch of "Bug 1348490 - stylo: need support for ::-moz-placeholder pseudo element"

Part 2 need to be landed immediately after Part 1 be merged into servo repo:
https://reviewboard.mozilla.org/r/141264/diff/9#index_header

Bugzilla link:
https://bugzilla.mozilla.org/show_bug.cgi?id=1348490
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17010)
<!-- Reviewable:end -->
