### PR TITLE
Use struct rather than nsCSSValue::Array to store counter functions in Gecko

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -79,6 +79,9 @@ unsafe impl Sync for nsStyleContent {}
 use gecko_bindings::structs::nsStyleContentData;
 unsafe impl Send for nsStyleContentData {}
 unsafe impl Sync for nsStyleContentData {}
+use gecko_bindings::structs::nsStyleContentData_CounterFunction;
+unsafe impl Send for nsStyleContentData_CounterFunction {}
+unsafe impl Sync for nsStyleContentData_CounterFunction {}
 use gecko_bindings::structs::nsStyleContentType;
 unsafe impl Send for nsStyleContentType {}
 unsafe impl Sync for nsStyleContentType {}
@@ -918,8 +921,9 @@ extern "C" {
                                           aImageValue: *mut ImageValue);
 }
 extern "C" {
-    pub fn Gecko_SetContentDataArray(content_data: *mut nsStyleContentData,
-                                     type_: nsStyleContentType, len: u32);
+    pub fn Gecko_SetCounterFunction(content_data: *mut nsStyleContentData,
+                                    type_: nsStyleContentType)
+     -> *mut nsStyleContentData_CounterFunction;
 }
 extern "C" {
     pub fn Gecko_GetNodeFlags(node: RawGeckoNodeBorrowed) -> u32;

--- a/components/style/gecko/generated/structs_debug.rs
+++ b/components/style/gecko/generated/structs_debug.rs
@@ -31871,11 +31871,66 @@ pub mod root {
         pub mContent: root::nsStyleContentData__bindgen_ty_1,
     }
     #[repr(C)]
+    #[derive(Debug)]
+    pub struct nsStyleContentData_CounterFunction {
+        pub mIdent: ::nsstring::nsStringRepr,
+        pub mSeparator: ::nsstring::nsStringRepr,
+        pub mCounterStyle: root::mozilla::CounterStylePtr,
+        pub mCounterStyleName: root::nsCOMPtr<root::nsIAtom>,
+        pub mRefCnt: root::mozilla::ThreadSafeAutoRefCnt,
+    }
+    pub type nsStyleContentData_CounterFunction_HasThreadSafeRefCnt =
+        root::mozilla::TrueType;
+    #[test]
+    fn bindgen_test_layout_nsStyleContentData_CounterFunction() {
+        assert_eq!(::std::mem::size_of::<nsStyleContentData_CounterFunction>()
+                   , 56usize , concat ! (
+                   "Size of: " , stringify ! (
+                   nsStyleContentData_CounterFunction ) ));
+        assert_eq! (::std::mem::align_of::<nsStyleContentData_CounterFunction>()
+                    , 8usize , concat ! (
+                    "Alignment of " , stringify ! (
+                    nsStyleContentData_CounterFunction ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleContentData_CounterFunction )
+                    ) . mIdent as * const _ as usize } , 0usize , concat ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleContentData_CounterFunction ) , "::" , stringify !
+                    ( mIdent ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleContentData_CounterFunction )
+                    ) . mSeparator as * const _ as usize } , 16usize , concat
+                    ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleContentData_CounterFunction ) , "::" , stringify !
+                    ( mSeparator ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleContentData_CounterFunction )
+                    ) . mCounterStyle as * const _ as usize } , 32usize ,
+                    concat ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleContentData_CounterFunction ) , "::" , stringify !
+                    ( mCounterStyle ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleContentData_CounterFunction )
+                    ) . mCounterStyleName as * const _ as usize } , 40usize ,
+                    concat ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleContentData_CounterFunction ) , "::" , stringify !
+                    ( mCounterStyleName ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleContentData_CounterFunction )
+                    ) . mRefCnt as * const _ as usize } , 48usize , concat ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleContentData_CounterFunction ) , "::" , stringify !
+                    ( mRefCnt ) ));
+    }
+    #[repr(C)]
     #[derive(Debug, Copy)]
     pub struct nsStyleContentData__bindgen_ty_1 {
         pub mString: root::__BindgenUnionField<*mut u16>,
         pub mImage: root::__BindgenUnionField<*mut root::nsStyleImageRequest>,
-        pub mCounters: root::__BindgenUnionField<*mut root::nsCSSValue_Array>,
+        pub mCounters: root::__BindgenUnionField<*mut root::nsStyleContentData_CounterFunction>,
         pub bindgen_union_field: u64,
     }
     #[test]

--- a/components/style/gecko/generated/structs_release.rs
+++ b/components/style/gecko/generated/structs_release.rs
@@ -31361,11 +31361,66 @@ pub mod root {
         pub mContent: root::nsStyleContentData__bindgen_ty_1,
     }
     #[repr(C)]
+    #[derive(Debug)]
+    pub struct nsStyleContentData_CounterFunction {
+        pub mIdent: ::nsstring::nsStringRepr,
+        pub mSeparator: ::nsstring::nsStringRepr,
+        pub mCounterStyle: root::mozilla::CounterStylePtr,
+        pub mCounterStyleName: root::nsCOMPtr,
+        pub mRefCnt: root::mozilla::ThreadSafeAutoRefCnt,
+    }
+    pub type nsStyleContentData_CounterFunction_HasThreadSafeRefCnt =
+        root::mozilla::TrueType;
+    #[test]
+    fn bindgen_test_layout_nsStyleContentData_CounterFunction() {
+        assert_eq!(::std::mem::size_of::<nsStyleContentData_CounterFunction>()
+                   , 56usize , concat ! (
+                   "Size of: " , stringify ! (
+                   nsStyleContentData_CounterFunction ) ));
+        assert_eq! (::std::mem::align_of::<nsStyleContentData_CounterFunction>()
+                    , 8usize , concat ! (
+                    "Alignment of " , stringify ! (
+                    nsStyleContentData_CounterFunction ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleContentData_CounterFunction )
+                    ) . mIdent as * const _ as usize } , 0usize , concat ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleContentData_CounterFunction ) , "::" , stringify !
+                    ( mIdent ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleContentData_CounterFunction )
+                    ) . mSeparator as * const _ as usize } , 16usize , concat
+                    ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleContentData_CounterFunction ) , "::" , stringify !
+                    ( mSeparator ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleContentData_CounterFunction )
+                    ) . mCounterStyle as * const _ as usize } , 32usize ,
+                    concat ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleContentData_CounterFunction ) , "::" , stringify !
+                    ( mCounterStyle ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleContentData_CounterFunction )
+                    ) . mCounterStyleName as * const _ as usize } , 40usize ,
+                    concat ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleContentData_CounterFunction ) , "::" , stringify !
+                    ( mCounterStyleName ) ));
+        assert_eq! (unsafe {
+                    & ( * ( 0 as * const nsStyleContentData_CounterFunction )
+                    ) . mRefCnt as * const _ as usize } , 48usize , concat ! (
+                    "Alignment of field: " , stringify ! (
+                    nsStyleContentData_CounterFunction ) , "::" , stringify !
+                    ( mRefCnt ) ));
+    }
+    #[repr(C)]
     #[derive(Debug, Copy)]
     pub struct nsStyleContentData__bindgen_ty_1 {
         pub mString: root::__BindgenUnionField<*mut u16>,
         pub mImage: root::__BindgenUnionField<*mut root::nsStyleImageRequest>,
-        pub mCounters: root::__BindgenUnionField<*mut root::nsCSSValue_Array>,
+        pub mCounters: root::__BindgenUnionField<*mut root::nsStyleContentData_CounterFunction>,
         pub bindgen_union_field: u64,
     }
     #[test]

--- a/components/style/gecko_bindings/sugar/ns_com_ptr.rs
+++ b/components/style/gecko_bindings/sugar/ns_com_ptr.rs
@@ -13,6 +13,13 @@ impl<T> nsCOMPtr<T> {
     pub fn raw<U>(&self) -> *mut T {
         self.mRawPtr
     }
+
+    /// Set this pointer from an addrefed raw pointer.
+    /// It leaks the old pointer.
+    #[inline]
+    pub unsafe fn set_raw_from_addrefed<U>(&mut self, ptr: *mut T) {
+        self.mRawPtr = ptr;
+    }
 }
 
 #[cfg(not(feature = "gecko_debug"))]
@@ -21,5 +28,12 @@ impl nsCOMPtr {
     #[inline]
     pub fn raw<T>(&self) -> *mut T {
         self._base.mRawPtr as *mut _
+    }
+
+    /// Set this pointer from an addrefed raw pointer.
+    /// It leaks the old pointer.
+    #[inline]
+    pub unsafe fn set_raw_from_addrefed<T>(&mut self, ptr: *mut T) {
+        self._base.mRawPtr = ptr as *mut _;
     }
 }

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -4212,7 +4212,9 @@ clip-path
         use properties::longhands::content::computed_value::T;
         use properties::longhands::content::computed_value::ContentItem;
         use values::generics::CounterStyleOrNone;
-        use gecko_bindings::structs::nsCSSValue;
+        use gecko_bindings::structs::nsIAtom;
+        use gecko_bindings::structs::nsStyleContentData;
+        use gecko_bindings::structs::nsStyleContentType;
         use gecko_bindings::structs::nsStyleContentType::*;
         use gecko_bindings::bindings::Gecko_ClearAndResizeStyleContents;
 
@@ -4226,11 +4228,23 @@ clip-path
             ptr
         }
 
-        fn set_counter_style(style: CounterStyleOrNone, dest: &mut nsCSSValue) {
-            dest.set_atom_ident(match style {
+        fn set_counter_function(data: &mut nsStyleContentData,
+                                content_type: nsStyleContentType,
+                                name: &str, sep: &str, style: CounterStyleOrNone) {
+            debug_assert!(content_type == eStyleContentType_Counter ||
+                          content_type == eStyleContentType_Counters);
+            let counter_func = unsafe {
+                bindings::Gecko_SetCounterFunction(data, content_type).as_mut().unwrap()
+            };
+            counter_func.mIdent.assign_utf8(name);
+            if content_type == eStyleContentType_Counters {
+                counter_func.mSeparator.assign_utf8(sep);
+            }
+            let ptr = match style {
                 CounterStyleOrNone::None_ => atom!("none"),
                 CounterStyleOrNone::Name(name) => name.0,
-            });
+            }.into_addrefed();
+            unsafe { counter_func.mCounterStyleName.set_raw_from_addrefed::<nsIAtom>(ptr); }
         }
 
         match v {
@@ -4293,23 +4307,12 @@ clip-path
                         ContentItem::NoCloseQuote
                             => self.gecko.mContents[i].mType = eStyleContentType_NoCloseQuote,
                         ContentItem::Counter(name, style) => {
-                            unsafe {
-                                bindings::Gecko_SetContentDataArray(&mut self.gecko.mContents[i],
-                                                                    eStyleContentType_Counter, 2)
-                            }
-                            let mut array = unsafe { &mut **self.gecko.mContents[i].mContent.mCounters.as_mut() };
-                            array[0].set_string(&name);
-                            set_counter_style(style, &mut array[1]);
+                            set_counter_function(&mut self.gecko.mContents[i],
+                                                 eStyleContentType_Counter, &name, "", style);
                         }
                         ContentItem::Counters(name, sep, style) => {
-                            unsafe {
-                                bindings::Gecko_SetContentDataArray(&mut self.gecko.mContents[i],
-                                                                    eStyleContentType_Counters, 3)
-                            }
-                            let mut array = unsafe { &mut **self.gecko.mContents[i].mContent.mCounters.as_mut() };
-                            array[0].set_string(&name);
-                            array[1].set_string(&sep);
-                            set_counter_style(style, &mut array[2]);
+                            set_counter_function(&mut self.gecko.mContents[i],
+                                                 eStyleContentType_Counters, &name, &sep, style);
                         }
                         ContentItem::Url(ref url) => {
                             unsafe {


### PR DESCRIPTION
This is the Servo side change for [bug 1366735](https://bugzilla.mozilla.org/show_bug.cgi?id=1366735).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17016)
<!-- Reviewable:end -->
