### PR TITLE
[script/textinput] Fix warning: unreachable pattern

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -632,14 +632,6 @@ impl<T: ClipboardProvider> TextInput<T> {
                 self.insert_char(c);
                 KeyReaction::DispatchInput
             },
-            #[cfg(target_os = "macos")]
-            (None, Key::Home) => {
-                KeyReaction::RedrawSelection
-            },
-            #[cfg(target_os = "macos")]
-            (None, Key::End) => {
-                KeyReaction::RedrawSelection
-            },
             (None, Key::Delete) => {
                 self.delete_char(Direction::Forward);
                 KeyReaction::DispatchInput
@@ -694,12 +686,18 @@ impl<T: ClipboardProvider> TextInput<T> {
             },
             (None, Key::Enter) | (None, Key::KpEnter) => self.handle_return(),
             (None, Key::Home) => {
-                self.edit_point.index = 0;
+                #[cfg(not(target_os = "macos"))]
+                {
+                    self.edit_point.index = 0;
+                }
                 KeyReaction::RedrawSelection
             },
             (None, Key::End) => {
-                self.edit_point.index = self.current_line_length();
-                self.assert_ok_selection();
+                #[cfg(not(target_os = "macos"))]
+                {
+                    self.edit_point.index = self.current_line_length();
+                    self.assert_ok_selection();
+                }
                 KeyReaction::RedrawSelection
             },
             (None, Key::PageUp) => {


### PR DESCRIPTION
The `cfg` attribute in use resulted in two match arms for two cases on
`macos`. Since both arms had a main functionality in common, I merged
them and conditions the extra `macos` part.

```
warning: unreachable pattern
   -->
/Users/behnam/code/servo/servo/components/script/textinput.rs:696:13
    |
696 |             (None, Key::Home) => {
    |             ^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(unreachable_patterns)] on by default

warning: unreachable pattern
   -->
/Users/behnam/code/servo/servo/components/script/textinput.rs:700:13
    |
700 |             (None, Key::End) => {
    |             ^^^^^^^^^^^^^^^^
    |
    = note: #[warn(unreachable_patterns)] on by default
```

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable). [N/A]

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because fixes compile-time warnings.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17017)
<!-- Reviewable:end -->
