### PR TITLE
Background shorthand parsing issues

### DIFF
--- a/components/style/properties/shorthand/background.mako.rs
+++ b/components/style/properties/shorthand/background.mako.rs
@@ -39,17 +39,20 @@
             let mut background_${name} = background_${name}::SpecifiedValue(Vec::new());
         % endfor
         try!(input.parse_comma_separated(|input| {
+            // background-color can only be in the last element, so if it
+            // is parsed anywhere before, the value is invalid.
+            if background_color.is_some() {
+                return Err(());
+            }
+
             % for name in "image position repeat size attachment origin clip".split():
                 let mut ${name} = None;
             % endfor
             loop {
-                if let Ok(value) = input.try(|i| CSSColor::parse(context, i)) {
-                    if background_color.is_none() {
+                if background_color.is_none() {
+                    if let Ok(value) = input.try(|i| CSSColor::parse(context, i)) {
                         background_color = Some(value);
                         continue
-                    } else {
-                        // color can only be the last element
-                        return Err(())
                     }
                 }
                 if position.is_none() {

--- a/components/style/properties/shorthand/background.mako.rs
+++ b/components/style/properties/shorthand/background.mako.rs
@@ -69,6 +69,13 @@
                     if ${name}.is_none() {
                         if let Ok(value) = input.try(|input| background_${name}::single_value
                                                                                ::parse(context, input)) {
+                            % if name == "clip" and product == "gecko":
+                            // "text" value of background-clip should not be part of background
+                            // shorthand per current spec and impls.
+                            if value == background_clip::single_value::SpecifiedValue::text {
+                                return Err(());
+                            }
+                            % endif
                             ${name} = Some(value);
                             continue
                         }


### PR DESCRIPTION
Two issues around background shorthand:
1. color should be only allowed in the last element of background shorthand
2. text should not be allowed in background shorthand

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17019)
<!-- Reviewable:end -->
