### PR TITLE
Add a fast path for eq_ignore_ascii_case

### DIFF
--- a/components/style/gecko_string_cache/mod.rs
+++ b/components/style/gecko_string_cache/mod.rs
@@ -239,6 +239,10 @@ impl Atom {
 
     /// Return whether two atoms are ASCII-case-insensitive matches
     pub fn eq_ignore_ascii_case(&self, other: &Self) -> bool {
+        if self == other {
+            return true;
+        }
+
         let a = self.as_slice();
         let b = other.as_slice();
         a.len() == b.len() && a.iter().zip(b).all(|(&a16, &b16)| {


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1363778#c6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17022)
<!-- Reviewable:end -->
