### PR TITLE
mathvariant attributes should affect computed font style and weight in stylo

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -2191,7 +2191,7 @@ ${helpers.single_keyword("-moz-math-display",
                          need_clone="True")}
 
 ${helpers.single_keyword("-moz-math-variant",
-                         """normal bold italic bold-italic script bold-script
+                         """none normal bold italic bold-italic script bold-script
                             fraktur double-struck bold-fraktur sans-serif
                             bold-sans-serif sans-serif-italic sans-serif-bold-italic
                             monospace initial tailed looped stretched""",
@@ -2200,6 +2200,7 @@ ${helpers.single_keyword("-moz-math-variant",
                          products="gecko",
                          spec="Internal (not web-exposed)",
                          animation_value_type="none",
+                         need_clone="True",
                          needs_conversion=True)}
 
 <%helpers:longhand name="-moz-script-min-size" products="gecko" animation_value_type="none"

--- a/components/style/style_adjuster.rs
+++ b/components/style/style_adjuster.rs
@@ -174,6 +174,22 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
         }
     }
 
+    /// When mathvariant is not "none", font-weight and font-style are
+    /// both forced to "normal".
+    #[cfg(feature = "gecko")]
+    fn adjust_for_mathvariant(&mut self) {
+        use properties::longhands::_moz_math_variant::computed_value::T as moz_math_variant;
+        use properties::longhands::font_style::computed_value::T as font_style;
+        use properties::longhands::font_weight::computed_value::T as font_weight;
+        if self.style.get_font().clone__moz_math_variant() != moz_math_variant::none {
+            let mut font_style = self.style.mutate_font();
+            // Sadly we don't have a nice name for the computed value
+            // of "font-weight: normal".
+            font_style.set_font_weight(font_weight::Weight400);
+            font_style.set_font_style(font_style::normal);
+        }
+    }
+
     /// This implements an out-of-date spec. The new spec moves the handling of
     /// this to layout, which Gecko implements but Servo doesn't.
     ///
@@ -299,6 +315,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
         {
             self.adjust_for_table_text_align();
             self.adjust_for_contain();
+            self.adjust_for_mathvariant();
         }
         #[cfg(feature = "servo")]
         {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://bugzilla.mozilla.org/show_bug.cgi?id=1367301

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this is stylo-only and Gecko tests it.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17026)
<!-- Reviewable:end -->
