### PR TITLE
Allow text to be in background shorthand

### DIFF
--- a/components/style/properties/shorthand/background.mako.rs
+++ b/components/style/properties/shorthand/background.mako.rs
@@ -72,13 +72,6 @@
                     if ${name}.is_none() {
                         if let Ok(value) = input.try(|input| background_${name}::single_value
                                                                                ::parse(context, input)) {
-                            % if name == "clip" and product == "gecko":
-                            // "text" value of background-clip should not be part of background
-                            // shorthand per current spec and impls.
-                            if value == background_clip::single_value::SpecifiedValue::text {
-                                return Err(());
-                            }
-                            % endif
                             ${name} = Some(value);
                             continue
                         }


### PR DESCRIPTION
Servo side change of [bug 1188074](https://bugzilla.mozilla.org/show_bug.cgi?id=1188074).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17035)
<!-- Reviewable:end -->
