### PR TITLE
Introduce and start using the MallocSizeOf trait.

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -39,6 +39,7 @@ use gecko_bindings::structs::FontSizePrefs;
 use gecko_bindings::structs::GeckoFontMetrics;
 use gecko_bindings::structs::IterationCompositeOperation;
 use gecko_bindings::structs::Keyframe;
+use gecko_bindings::structs::MallocSizeOf;
 use gecko_bindings::structs::ServoBundledURI;
 use gecko_bindings::structs::ServoElementSnapshot;
 use gecko_bindings::structs::ServoElementSnapshotTable;
@@ -1764,6 +1765,11 @@ extern "C" {
 extern "C" {
     pub fn Servo_StyleSheet_Clone(sheet: RawServoStyleSheetBorrowed)
      -> RawServoStyleSheetStrong;
+}
+extern "C" {
+    pub fn Servo_StyleSheet_SizeOfIncludingThis(malloc_size_of: MallocSizeOf,
+                                                sheet: RawServoStyleSheetBorrowed)
+     -> usize;
 }
 extern "C" {
     pub fn Servo_StyleSet_Init(pres_context: RawGeckoPresContextOwned)

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::slice::Iter;
 use style_traits::ToCss;
 use stylesheets::{CssRuleType, Origin, UrlExtraData};
+use stylesheets::{MallocSizeOf, MallocSizeOfFn};
 use super::*;
 #[cfg(feature = "gecko")] use properties::animated_properties::AnimationValueMap;
 
@@ -46,6 +47,12 @@ pub enum Importance {
     Important,
 }
 
+impl MallocSizeOf for Importance {
+    fn malloc_size_of_children(&self, _malloc_size_of: MallocSizeOfFn) -> usize {
+        0
+    }
+}
+
 impl Importance {
     /// Return whether this is an important declaration.
     pub fn important(self) -> bool {
@@ -68,6 +75,12 @@ pub struct PropertyDeclarationBlock {
     important_count: usize,
 
     longhands: LonghandIdSet,
+}
+
+impl MallocSizeOf for PropertyDeclarationBlock {
+    fn malloc_size_of_children(&self, malloc_size_of: MallocSizeOfFn) -> usize {
+        self.declarations.malloc_size_of_children(malloc_size_of)
+    }
 }
 
 /// Iterator for PropertyDeclaration to be generated from PropertyDeclarationBlock.

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -35,7 +35,7 @@ use properties::animated_properties::TransitionProperty;
 #[cfg(feature = "servo")] use servo_config::prefs::PREFS;
 use shared_lock::StylesheetGuards;
 use style_traits::{HasViewportPercentage, ToCss};
-use stylesheets::{CssRuleType, Origin, UrlExtraData};
+use stylesheets::{CssRuleType, MallocSizeOf, MallocSizeOfFn, Origin, UrlExtraData};
 #[cfg(feature = "servo")] use values::Either;
 use values::computed;
 use cascade_info::CascadeInfo;
@@ -1170,6 +1170,14 @@ impl ToCss for PropertyDeclaration {
         }
     % endif
 </%def>
+
+impl MallocSizeOf for PropertyDeclaration {
+    fn malloc_size_of_children(&self, _malloc_size_of: MallocSizeOfFn) -> usize {
+        // The variants of PropertyDeclaration mostly (entirely?) contain
+        // scalars, so this is reasonable.
+        0
+    }
+}
 
 impl PropertyDeclaration {
     /// Given a property declaration, return the property declaration id.


### PR DESCRIPTION
MallocSizeOf is similar to the existing HeapSizeOf trait from the
heapsize crate. The only difference is that MallocSizeOf's
malloc_size_of_children() function takes an additional MallocSizeOfFn
argument, which is used to measure heap blocks. This extra argument
makes MallocSizeOf match how Gecko's memory measurements work, and is
required for Stylo to integrate with DMD.

The patch also introduces a second trait, MallocSizeOfWithGuard, which
is much the same as MallocSizeOf, but with a |guard| argument for the
global style lock.

Finally, the patch uses the new traits to measure a small amount of
Stylo's memory usage.




---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because code is only for Gecko integration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17044)
<!-- Reviewable:end -->
