### PR TITLE
Fixed typo in components/constellation/browsingcontext.rs

### DIFF
--- a/components/constellation/browsingcontext.rs
+++ b/components/constellation/browsingcontext.rs
@@ -14,7 +14,7 @@ use style_traits::CSSPixel;
 
 /// The constellation's view of a browsing context.
 /// Each browsing context has a session history, caused by
-/// navigation and traversing the history. Each browsing contest has its
+/// navigation and traversing the history. Each browsing context has its
 /// current entry, plus past and future entries. The past is sorted
 /// chronologically, the future is sorted reverse chronologically:
 /// in particular prev.pop() is the latest past entry, and


### PR DESCRIPTION
Changed a typo in a comment:
"Each browsing contest..." into "Each browsing context..."

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17048
- [X] These changes do not require tests because its a typo fix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17049)
<!-- Reviewable:end -->
