### PR TITLE
Fix calculation of base styles to drop animation rules

### DIFF
--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -369,7 +369,7 @@ impl RuleTree {
         let mut last = path;
         let mut children = vec![];
         for node in iter {
-            if node.cascade_level().is_animation() {
+            if !node.cascade_level().is_animation() {
                 children.push((node.get().source.clone().unwrap(), node.cascade_level()));
             }
             last = node;


### PR DESCRIPTION
It seems that changeset 97ce9ed5b08f7b1c7c6cd71a9499068b8bd2ae4e mistakenly changed the check that a cascade level to keep is *not* an animation level to a check that it *is* an animation level.

This patch has been reviewed by @hiikezoe in [Mozilla bug 1367960](https://bugzilla.mozilla.org/show_bug.cgi?id=1367960).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17050)
<!-- Reviewable:end -->
