### PR TITLE
Set flex-basis to 0% when omitted in flex shorthand.

### DIFF
--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -1099,9 +1099,14 @@
 
             /// Returns a value representing a `0` length.
             pub fn zero() -> Self {
-                use values::specified::length::{LengthOrPercentageOrAuto, NoCalcLength};
-                SpecifiedValue(MozLength::LengthOrPercentageOrAuto(
-                    LengthOrPercentageOrAuto::Length(NoCalcLength::zero())))
+                use values::specified::length::LengthOrPercentageOrAuto;
+                SpecifiedValue(MozLength::LengthOrPercentageOrAuto(LengthOrPercentageOrAuto::zero()))
+            }
+
+            /// Returns a value representing a `0%` length.
+            pub fn zero_percent() -> Self {
+                use values::specified::length::LengthOrPercentageOrAuto;
+                SpecifiedValue(MozLength::LengthOrPercentageOrAuto(LengthOrPercentageOrAuto::zero_percent()))
             }
         }
         % endif

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -92,7 +92,11 @@
         Ok(expanded! {
             flex_grow: grow.unwrap_or(Number::new(1.0)),
             flex_shrink: shrink.unwrap_or(Number::new(1.0)),
-            flex_basis: basis.unwrap_or(longhands::flex_basis::SpecifiedValue::zero()),
+            // Per spec, this should be SpecifiedValue::zero(), but all
+            // browsers currently agree on using `0%`. This is a spec
+            // change which hasn't been adopted by browsers:
+            // https://github.com/w3c/csswg-drafts/commit/2c446befdf0f686217905bdd7c92409f6bd3921b
+            flex_basis: basis.unwrap_or(longhands::flex_basis::SpecifiedValue::zero_percent()),
         })
     }
 

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -735,6 +735,12 @@ impl Percentage {
         Self::parse_with_clamping_mode(input, AllowedNumericType::NonNegative)
     }
 
+    /// 0%
+    #[inline]
+    pub fn zero() -> Self {
+        Percentage(0.)
+    }
+
     /// 100%
     #[inline]
     pub fn hundred() -> Self {
@@ -999,6 +1005,11 @@ impl LengthOrPercentageOrAuto {
     pub fn zero() -> Self {
         LengthOrPercentageOrAuto::Length(NoCalcLength::zero())
     }
+
+    /// Returns a value representing `0%`.
+    pub fn zero_percent() -> Self {
+        LengthOrPercentageOrAuto::Percentage(Percentage::zero())
+    }
 }
 
 impl Parse for LengthOrPercentageOrAuto {
@@ -1156,6 +1167,11 @@ impl LengthOrPercentageOrAutoOrContent {
     /// Returns a value representing a `0` length.
     pub fn zero() -> Self {
         LengthOrPercentageOrAutoOrContent::Length(NoCalcLength::zero())
+    }
+
+    /// Returns a value representing `0%`.
+    pub fn zero_percent() -> Self {
+        LengthOrPercentageOrAutoOrContent::Percentage(Percentage::zero())
     }
 }
 

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-shorthand-number.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_computedstyle_flex-shorthand-number.htm.ini
@@ -1,0 +1,5 @@
+[flexbox_computedstyle_flex-shorthand-number.htm]
+  type: testharness
+  [flexbox | computed style | flex: number]
+    expected: FAIL
+


### PR DESCRIPTION
This should fix [bug 1331530](https://bugzilla.mozilla.org/show_bug.cgi?id=1331530).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17073)
<!-- Reviewable:end -->
