### PR TITLE
style: Support a restyle hint that indicates all descendants must be recascaded.

### DIFF
--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -367,6 +367,11 @@ impl StoredRestyleHint {
         StoredRestyleHint(RestyleHint::subtree_and_later_siblings())
     }
 
+    /// Creates a restyle hint that indicates the element must be recascaded.
+    pub fn recascade_self() -> Self {
+        StoredRestyleHint(RestyleHint::recascade_self())
+    }
+
     /// Returns true if the hint indicates that our style may be invalidated.
     pub fn has_self_invalidations(&self) -> bool {
         self.0.affects_self()
@@ -402,6 +407,12 @@ impl StoredRestyleHint {
     pub fn has_animation_hint(&self) -> bool {
         self.0.has_animation_hint()
     }
+
+    /// Returns true if the hint indicates the current element must be
+    /// recascaded.
+    pub fn has_recascade_self(&self) -> bool {
+        self.0.has_recascade_self()
+    }
 }
 
 impl Default for StoredRestyleHint {
@@ -425,10 +436,6 @@ pub struct RestyleData {
     /// for this element, its children, and its descendants.
     pub hint: StoredRestyleHint,
 
-    /// Whether we need to recascade.
-    /// FIXME(bholley): This should eventually become more fine-grained.
-    pub recascade: bool,
-
     /// The restyle damage, indicating what kind of layout changes are required
     /// afte restyling.
     pub damage: RestyleDamage,
@@ -447,7 +454,7 @@ pub struct RestyleData {
 impl RestyleData {
     /// Returns true if this RestyleData might invalidate the current style.
     pub fn has_invalidations(&self) -> bool {
-        self.hint.has_self_invalidations() || self.recascade
+        self.hint.has_self_invalidations()
     }
 
     /// Returns true if this RestyleData might invalidate sibling styles.
@@ -598,12 +605,11 @@ impl ElementData {
             return RestyleKind::MatchAndCascade;
         }
 
-        if !hint.is_empty() {
+        if hint.has_replacements() {
             return RestyleKind::CascadeWithReplacements(hint.replacements);
         }
 
-        debug_assert!(restyle_data.recascade,
-                      "We definitely need to do something!");
+        debug_assert!(hint.has_recascade_self(), "We definitely need to do something!");
         return RestyleKind::CascadeOnly;
     }
 


### PR DESCRIPTION
This also moves the result of deciding whether to recascade from the RestyleData into the RestyleHint.

Reviewed in https://bugzilla.mozilla.org/show_bug.cgi?id=1367647.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17087)
<!-- Reviewable:end -->
