### PR TITLE
Support currentColor for fill and stroke.

### DIFF
--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -1177,7 +1177,11 @@ impl ToComputedValue for SVGPaintKind {
             SVGPaintKind::ContextStroke => super::computed::SVGPaintKind::ContextStroke,
             SVGPaintKind::ContextFill => super::computed::SVGPaintKind::ContextFill,
             SVGPaintKind::Color(ref color) => {
-                super::computed::SVGPaintKind::Color(color.to_computed_value(context))
+                let color = match color.parsed {
+                    Color::CurrentColor => cssparser::Color::RGBA(context.style().get_color().clone_color()),
+                    _ => color.to_computed_value(context),
+                };
+                super::computed::SVGPaintKind::Color(color)
             }
             SVGPaintKind::PaintServer(ref server) => {
                 super::computed::SVGPaintKind::PaintServer(server.to_computed_value(context))


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is a PR for https://bugzilla.mozilla.org/show_bug.cgi?id=1368376

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's for stylo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17089)
<!-- Reviewable:end -->
