### PR TITLE
[wip] Introduce ViewGeometry

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -9,9 +9,7 @@ use compositor_thread::{InitialCompositorState, Msg, RenderListener};
 use delayed_composition::DelayedCompositionTimerProxy;
 use euclid::Point2D;
 use euclid::point::TypedPoint2D;
-use euclid::rect::TypedRect;
 use euclid::scale_factor::ScaleFactor;
-use euclid::size::TypedSize2D;
 use gfx_traits::Epoch;
 use gleam::gl;
 use image::{DynamicImage, ImageFormat, RgbImage};
@@ -40,7 +38,7 @@ use time::{precise_time_ns, precise_time_s};
 use touch::{TouchHandler, TouchAction};
 use webrender;
 use webrender_traits::{self, ClipId, LayoutPoint, ScrollEventPhase, ScrollLocation, ScrollClamping};
-use windowing::{self, MouseWindowEvent, WindowEvent, WindowMethods, WindowNavigateMsg};
+use windowing::{self, ViewGeometry, MouseWindowEvent, WindowEvent, WindowMethods, WindowNavigateMsg};
 
 #[derive(Debug, PartialEq)]
 enum UnableToComposite {
@@ -114,11 +112,7 @@ pub struct IOCompositor<Window: WindowMethods> {
     /// The scene scale, to allow for zooming and high-resolution painting.
     scale: ScaleFactor<f32, LayerPixel, DevicePixel>,
 
-    /// The size of the rendering area.
-    frame_size: TypedSize2D<u32, DevicePixel>,
-
-    /// The position and size of the window within the rendering area.
-    window_rect: TypedRect<u32, DevicePixel>,
+    geometry: ViewGeometry,
 
     /// "Mobile-style" zoom that does not reflow the page.
     viewport_zoom: PinchZoomFactor,
@@ -129,9 +123,6 @@ pub struct IOCompositor<Window: WindowMethods> {
 
     /// "Desktop-style" zoom that resizes the viewport to fit the window.
     page_zoom: ScaleFactor<f32, CSSPixel, DeviceIndependentPixel>,
-
-    /// The device pixel ratio for this window.
-    scale_factor: ScaleFactor<f32, DeviceIndependentPixel, DevicePixel>,
 
     channel_to_self: Box<CompositorProxy + Send>,
 
@@ -353,13 +344,13 @@ impl webrender_traits::RenderDispatcher for CompositorThreadDispatcher {
 impl<Window: WindowMethods> IOCompositor<Window> {
     fn new(window: Rc<Window>, state: InitialCompositorState)
            -> IOCompositor<Window> {
-        let frame_size = window.framebuffer_size();
-        let window_rect = window.window_rect();
-        let scale_factor = window.hidpi_factor();
+
         let composite_target = match opts::get().output_file {
             Some(_) => CompositeTarget::PngFile,
             None => CompositeTarget::Window
         };
+
+        let geometry = window.get_geometry();
 
         IOCompositor {
             gl: window.gl(),
@@ -367,10 +358,8 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             port: state.receiver,
             root_pipeline: None,
             pipeline_details: HashMap::new(),
-            frame_size: frame_size,
-            window_rect: window_rect,
+            geometry: geometry,
             scale: ScaleFactor::new(1.0),
-            scale_factor: scale_factor,
             channel_to_self: state.sender.clone_compositor_proxy(),
             delayed_composition_timer: DelayedCompositionTimerProxy::new(state.sender),
             composition_request: CompositionRequest::NoCompositingNecessary,
@@ -501,7 +490,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
 
             (Msg::GetClientWindow(send),
              ShutdownState::NotShuttingDown) => {
-                let rect = self.window.client_window();
+                let rect = self.geometry.window_rect;
                 if let Err(e) = send.send(rect) {
                     warn!("Sending response to get client window failed ({}).", e);
                 }
@@ -739,16 +728,24 @@ impl<Window: WindowMethods> IOCompositor<Window> {
     fn send_window_size(&self, size_type: WindowSizeType) {
         let dppx = self.page_zoom * self.hidpi_factor();
 
-        let window_rect = {
-            let offset = webrender_traits::DeviceUintPoint::new(self.window_rect.origin.x, self.window_rect.origin.y);
-            let size = webrender_traits::DeviceUintSize::new(self.window_rect.size.width, self.window_rect.size.height);
+        let viewport_rect = &self.geometry.viewport_rect;
+        let rendering_rect = &self.geometry.rendering_rect;
+
+        let wr_viewport_rect = {
+            let offset = webrender_traits::DeviceUintPoint::new(viewport_rect.origin.x, viewport_rect.origin.y);
+            let size = webrender_traits::DeviceUintSize::new(viewport_rect.size.width, viewport_rect.size.height);
             webrender_traits::DeviceUintRect::new(offset, size)
         };
 
-        let frame_size = webrender_traits::DeviceUintSize::new(self.frame_size.width, self.frame_size.height);
-        self.webrender_api.set_window_parameters(frame_size, window_rect);
+        let wr_rendering_rect = {
+            let offset = webrender_traits::DeviceUintPoint::new(rendering_rect.origin.x, rendering_rect.origin.y);
+            let size = webrender_traits::DeviceUintSize::new(rendering_rect.size.width, rendering_rect.size.height);
+            webrender_traits::DeviceUintRect::new(offset, size)
+        };
 
-        let initial_viewport = self.window_rect.size.to_f32() / dppx;
+        self.webrender_api.set_view_geometry(wr_rendering_rect, wr_viewport_rect);
+
+        let initial_viewport = viewport_rect.size.to_f32() / dppx;
 
         let data = WindowSizeData {
             device_pixel_ratio: dppx,
@@ -794,8 +791,8 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 self.initialize_compositing();
             }
 
-            WindowEvent::Resize(size) => {
-                self.on_resize_window_event(size);
+            WindowEvent::Resize => {
+                self.on_resize_window_event();
             }
 
             WindowEvent::LoadUrl(url_string) => {
@@ -875,28 +872,19 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         }
     }
 
-    fn on_resize_window_event(&mut self, new_size: TypedSize2D<u32, DevicePixel>) {
-        debug!("compositor resizing to {:?}", new_size.to_untyped());
+    fn on_resize_window_event(&mut self) {
+        let old_geometry = self.geometry;
 
-        // A size change could also mean a resolution change.
-        let new_scale_factor = self.window.hidpi_factor();
-        if self.scale_factor != new_scale_factor {
-            self.scale_factor = new_scale_factor;
+        self.geometry = self.window.get_geometry();
+
+        if self.geometry.hidpi_factor != old_geometry.hidpi_factor {
             self.update_zoom_transform();
         }
 
-        let new_window_rect = self.window.window_rect();
-        let new_frame_size = self.window.framebuffer_size();
-
-        if self.window_rect == new_window_rect &&
-           self.frame_size == new_frame_size {
-            return;
+        if self.geometry.rendering_rect != old_geometry.rendering_rect ||
+           self.geometry.viewport_rect != old_geometry.viewport_rect {
+            self.send_window_size(WindowSizeType::Resize);
         }
-
-        self.frame_size = new_size;
-        self.window_rect = new_window_rect;
-
-        self.send_window_size(WindowSizeType::Resize);
     }
 
     fn on_load_url_window_event(&mut self, url_string: String) {
@@ -1289,7 +1277,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             Some(device_pixels_per_px) => ScaleFactor::new(device_pixels_per_px),
             None => match opts::get().output_file {
                 Some(_) => ScaleFactor::new(1.0),
-                None => self.scale_factor
+                None => self.geometry.hidpi_factor,
             }
         }
     }
@@ -1489,7 +1477,8 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                                  target: CompositeTarget)
                                  -> Result<Option<Image>, UnableToComposite> {
         let (width, height) =
-            (self.frame_size.width as usize, self.frame_size.height as usize);
+            (self.geometry.rendering_rect.size.width as usize,
+             self.geometry.rendering_rect.size.height as usize);
         if !self.window.prepare_for_composite(width, height) {
             return Err(UnableToComposite::WindowUnprepared)
         }
@@ -1527,7 +1516,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             debug!("compositor: compositing");
 
             // Paint the scene.
-            let size = webrender_traits::DeviceUintSize::from_untyped(&self.frame_size.to_untyped());
+            let size = webrender_traits::DeviceUintSize::from_untyped(&self.geometry.rendering_rect.size.to_untyped());
             self.webrender.render(size);
         });
 

--- a/ports/cef/browser_host.rs
+++ b/ports/cef/browser_host.rs
@@ -7,13 +7,11 @@ use eutil::Downcast;
 use interfaces::{CefBrowser, CefBrowserHost, CefClient, cef_browser_t, cef_browser_host_t, cef_client_t};
 use types::cef_event_flags_t::{EVENTFLAG_ALT_DOWN, EVENTFLAG_CONTROL_DOWN, EVENTFLAG_SHIFT_DOWN};
 use types::cef_key_event_type_t::{KEYEVENT_CHAR, KEYEVENT_KEYDOWN, KEYEVENT_KEYUP, KEYEVENT_RAWKEYDOWN};
-use types::{cef_mouse_button_type_t, cef_mouse_event, cef_rect_t, cef_key_event, cef_window_handle_t};
+use types::{cef_mouse_button_type_t, cef_mouse_event, cef_key_event, cef_window_handle_t};
 use webrender_traits::ScrollLocation;
-use wrappers::CefWrap;
 
 use compositing::windowing::{WindowEvent, MouseWindowEvent};
 use euclid::point::TypedPoint2D;
-use euclid::size::TypedSize2D;
 use libc::{c_double, c_int};
 use msg::constellation_msg::{self, KeyModifiers, KeyState};
 use script_traits::{MouseButton, TouchEventType};
@@ -371,22 +369,7 @@ full_cef_class_impl! {
         }}
 
         fn was_resized(&this,) -> () {{
-            let mut rect = cef_rect_t::zero();
-            if cfg!(target_os="macos") {
-                if check_ptr_exist!(this.get_client(), get_render_handler) &&
-                   check_ptr_exist!(this.get_client().get_render_handler(), get_backing_rect) {
-                    this.get_client()
-                        .get_render_handler()
-                        .get_backing_rect(this.downcast().browser.borrow().clone().unwrap(), &mut rect);
-                }
-            } else if check_ptr_exist!(this.get_client(), get_render_handler) &&
-               check_ptr_exist!(this.get_client().get_render_handler(), get_view_rect) {
-                this.get_client()
-                    .get_render_handler()
-                    .get_view_rect(this.downcast().browser.borrow().clone().unwrap(), &mut rect);
-               }
-            let size = TypedSize2D::new(rect.width as u32, rect.height as u32);
-            this.downcast().send_window_event(WindowEvent::Resize(size));
+            this.downcast().send_window_event(WindowEvent::Resize);
         }}
 
         fn close_browser(&this, _force: c_int [c_int],) -> () {{

--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -18,7 +18,6 @@ extern crate gleam;
 extern crate glutin_app;
 extern crate script_traits;
 extern crate servo_config;
-extern crate servo_geometry;
 extern crate servo_url;
 extern crate style_traits;
 

--- a/ports/servo/main.rs
+++ b/ports/servo/main.rs
@@ -188,7 +188,7 @@ struct BrowserWrapper {
 impl app::NestedEventLoopListener for BrowserWrapper {
     fn handle_event_from_nested_event_loop(&mut self, event: WindowEvent) -> bool {
         let is_resize = match event {
-            WindowEvent::Resize(..) => true,
+            WindowEvent::Resize => true,
             _ => false,
         };
         if !self.browser.handle_events(vec![event]) {


### PR DESCRIPTION
This patch is mostly cosmetic. Only its WebRender counter part adds functionalities (position the viewport, see https://github.com/servo/servo/issues/16809 and https://github.com/servo/webrender/pull/1306).

From the embedder perspective, we want to make it a bit easier to configure the position/size/margins of the content. Between the 5 windowing callbacks, the resize events and the WebRender's window parameters, and with all the different naming conventions (frame, window, viewport), it's quite confusing.

This PR introduces a new struct (`ViewGeometry`) and makes sure both servo and WR use the same names (rendering_rect, viewport_rect).

I still need to write some tests, but I'd like to get early feedback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17091)
<!-- Reviewable:end -->
