### PR TITLE
Support for Android arm64 compilations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "blurdroid"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -657,7 +657,7 @@ name = "device"
 version = "0.0.1"
 source = "git+https://github.com/servo/devices#1bb5a200c7ae1f42ddf3c42b235b3db66226aabf"
 dependencies = [
- "blurdroid 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blurdroid 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "blurmock 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blurz 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1339,7 +1339,7 @@ dependencies = [
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3438,7 +3438,7 @@ dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3550,7 +3550,7 @@ dependencies = [
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitreader 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "80b13e2ab064ff3aa0bdbf1eff533f9822dc37899821f5f98c67f263eab51707"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-"checksum blurdroid 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9880ddea1a97824ae9fc176f718e2a029491cd7d10bac4061ba4063569f4bc64"
+"checksum blurdroid 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7daba519d29beebfc7d302795af88a16b43f431b9b268586926ac61cc655a68"
 "checksum blurmock 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "68dd72da3a3bb40f3d3bdd366c4cf8e2b1d208c366304f382c80cef8126ca8da"
 "checksum blurz 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e73bda0f4c71c63a047351070097f3f507e6718e86b9ee525173371ef7b94b73"
 "checksum brotli 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "951f20a2cc403194b2746d9ac6f796292e3c0344e983c72c7d6bd6cff6c3d102"
@@ -3665,7 +3665,7 @@ dependencies = [
 "checksum mime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9d69889cdc6336ed56b174514ce876c4c3dc564cc23dd872e7bca589bb2a36c8"
 "checksum mime_guess 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76da6df85047af8c0edfa53f48eb1073012ce1cc95c8fedc0a374f659a89dd65"
 "checksum miniz-sys 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "28eaee17666671fa872e567547e8428e83308ebe5808cdf6a0e28397dbe2c726"
-"checksum mio 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6d19442734abd7d780b981c590c325680d933e99795fe1f693f0686c9ed48022"
+"checksum mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9e965267d4d58496fc4f740e9861118367f13570cadf66316ed2c3f2f14d87c7"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mozjs_sys 0.0.0 (git+https://github.com/servo/mozjs)" = "<none>"
 "checksum mp3-metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2f61cf32f7fc3cec83a15a255ac60bceb6cac59a7ce190cb824ca25c0fce0feb"

--- a/ports/servo/build.rs
+++ b/ports/servo/build.rs
@@ -80,7 +80,7 @@ fn android_main() {
     }
 
     // compiling libandroid_native_app_glue.a
-    if Command::new(toolchain_path.join("bin").join("arm-linux-androideabi-ar"))
+    if Command::new(toolchain_path.join("bin").join(format!("{}-ar", toolchain)))
         .arg("rcs")
         .arg(directory.join("libandroid_native_app_glue.a"))
         .arg(directory.join("android_native_app_glue.o"))

--- a/ports/servo/fake-ld-arm.sh
+++ b/ports/servo/fake-ld-arm.sh
@@ -11,4 +11,4 @@ set -o pipefail
 source fake-ld.sh
 
 export _GCC_PARAMS="${@}"
-call_gcc "arch-arm" "arm-linux-androideabi-4.9" "android-18" "armeabi"
+call_gcc "arch-arm" "arm-linux-androideabi" "android-18" "armeabi"

--- a/ports/servo/fake-ld-arm64.sh
+++ b/ports/servo/fake-ld-arm64.sh
@@ -11,4 +11,4 @@ set -o pipefail
 source fake-ld.sh
 
 export _GCC_PARAMS="${@}"
-call_gcc "arch-arm64" "aarch64-linux-android-4.9" "android-21" "arm64-v8a"
+call_gcc "arch-arm64" "aarch64-linux-android" "android-21" "arm64-v8a"

--- a/ports/servo/fake-ld-armv7.sh
+++ b/ports/servo/fake-ld-armv7.sh
@@ -11,4 +11,4 @@ set -o pipefail
 source fake-ld.sh
 
 export _GCC_PARAMS="${@}"
-call_gcc "arch-arm" "arm-linux-androideabi-4.9" "android-18" "armeabi-v7a"
+call_gcc "arch-arm" "arm-linux-androideabi" "android-18" "armeabi-v7a"

--- a/ports/servo/fake-ld.sh
+++ b/ports/servo/fake-ld.sh
@@ -18,8 +18,8 @@ call_gcc()
   export ANDROID_SYSROOT="${ANDROID_NDK}/platforms/${_ANDROID_PLATFORM}/${_ANDROID_ARCH}"
   ANDROID_TOOLCHAIN=""
   for host in "linux-x86_64" "linux-x86" "darwin-x86_64" "darwin-x86"; do
-    if [[ -d "${ANDROID_NDK}/toolchains/${_ANDROID_EABI}/prebuilt/${host}/bin" ]]; then
-      ANDROID_TOOLCHAIN="${ANDROID_NDK}/toolchains/${_ANDROID_EABI}/prebuilt/${host}/bin"
+    if [[ -d "${ANDROID_NDK}/toolchains/${_ANDROID_EABI}-4.9/prebuilt/${host}/bin" ]]; then
+      ANDROID_TOOLCHAIN="${ANDROID_NDK}/toolchains/${_ANDROID_EABI}-4.9/prebuilt/${host}/bin"
       break
     fi
   done
@@ -32,7 +32,7 @@ call_gcc()
   echo "sysroot: ${ANDROID_SYSROOT}"
   echo "targetdir: ${ANDROID_CXX_LIBS}"
 
-  "${ANDROID_TOOLCHAIN}/arm-linux-androideabi-gcc" \
+  "${ANDROID_TOOLCHAIN}/${_ANDROID_EABI}-gcc" \
     --sysroot="${ANDROID_SYSROOT}" -L "${ANDROID_CXX_LIBS}" ${_GCC_PARAMS} -lc++ \
     -o "${TARGET_DIR}/libservo.so" -shared && touch "${TARGET_DIR}/servo"
 }

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -246,6 +246,10 @@ class MachCommands(CommandBase):
             env["RUSTFLAGS"] = "-C debug_assertions"
 
         if android:
+            android_platform = self.config["android"]["platform"]
+            android_toolchain = self.config["android"]["toolchain_name"]
+            android_arch = "arch-" + self.config["android"]["arch"]
+
             # Build OpenSSL for android
             env["OPENSSL_VERSION"] = "1.0.2k"
             make_cmd = ["make"]
@@ -258,6 +262,7 @@ class MachCommands(CommandBase):
             shutil.copy(path.join(self.android_support_dir(), "openssl.makefile"), openssl_dir)
             shutil.copy(path.join(self.android_support_dir(), "openssl.sh"), openssl_dir)
             env["ANDROID_NDK_ROOT"] = env["ANDROID_NDK"]
+            env["RUST_TARGET"] = target
             with cd(openssl_dir):
                 status = call(
                     make_cmd + ["-f", "openssl.makefile"],
@@ -282,10 +287,6 @@ class MachCommands(CommandBase):
             elif cpu_type in ["x86_64", "x86-64", "x64", "amd64"]:
                 host_suffix = "x86_64"
             host = os_type + "-" + host_suffix
-
-            android_platform = self.config["android"]["platform"]
-            android_toolchain = self.config["android"]["toolchain_name"]
-            android_arch = "arch-" + self.config["android"]["arch"]
 
             env['PATH'] = path.join(
                 env['ANDROID_NDK'], "toolchains", android_toolchain, "prebuilt", host, "bin"

--- a/support/android/openssl.sh
+++ b/support/android/openssl.sh
@@ -22,12 +22,48 @@ _ANDROID_NDK="android-ndk-r9"
 # list in $ANDROID_NDK_ROOT/toolchains. This value is always used.
 # _ANDROID_EABI="x86-4.6"
 # _ANDROID_EABI="arm-linux-androideabi-4.6"
-_ANDROID_EABI="arm-linux-androideabi-4.9"
 
 # Set _ANDROID_ARCH to the architecture you are building for.
 # This value is always used.
 # _ANDROID_ARCH=arch-x86
-_ANDROID_ARCH=arch-arm
+
+
+case $RUST_TARGET in
+    armv7*)
+      _ANDROID_TARGET="arm-linux-androideabi"
+      _ANDROID_ARCH=arch-arm
+      _OPENSSL_MACHINE="armv7"
+      _OPENSSL_ARCH="arm"
+      _OPENSSL_CONFIG="android-armv7"
+      ;;
+    arm*)
+      _ANDROID_TARGET=$RUST_TARGET
+      _ANDROID_ARCH=arch-arm
+      _OPENSSL_MACHINE="arm"
+      _OPENSSL_ARCH="arm"
+      _OPENSSL_CONFIG="android-armv7"
+      ;;
+    aarch64*)
+      _ANDROID_TARGET=$RUST_TARGET
+      _ANDROID_ARCH=arch-arm64
+      _OPENSSL_MACHINE="armv7"
+      _OPENSSL_ARCH="arm64"
+      _OPENSSL_CONFIG="linux-generic64 -DB_ENDIAN"
+      ;;
+    x86*)
+      _ANDROID_TARGET=$RUST_TARGET
+      _ANDROID_ARCH=arch-x86
+      _OPENSSL_MACHINE="x86"
+      _OPENSSL_ARCH="arm"
+      _OPENSSL_CONFIG="android-x86"
+      ;;
+    *)
+      echo "Error: Invalid TARGET platform: $RUST_TARGET"
+      ;;
+esac
+
+_ANDROID_EABI="$_ANDROID_TARGET-4.9"
+
 
 # Set _ANDROID_API to the API you want to use. You should set it
 # to one of: android-14, android-9, android-8, android-14, android-5
@@ -93,17 +129,7 @@ if [ -z "$ANDROID_TOOLCHAIN" ] || [ ! -d "$ANDROID_TOOLCHAIN" ]; then
   # exit 1
 fi
 
-case $_ANDROID_ARCH in
-    arch-arm)
-      ANDROID_TOOLS="arm-linux-androideabi-gcc arm-linux-androideabi-ranlib arm-linux-androideabi-ld"
-      ;;
-    arch-x86)
-      ANDROID_TOOLS="i686-linux-android-gcc i686-linux-android-ranlib i686-linux-android-ld"
-      ;;
-    *)
-      echo "ERROR ERROR ERROR"
-      ;;
-esac
+ANDROID_TOOLS="$_ANDROID_TARGET-gcc $_ANDROID_TARGET-ranlib $_ANDROID_TARGET-ld"
 
 for tool in $ANDROID_TOOLS
 do
@@ -141,24 +167,17 @@ fi
 #####################################################################
 
 # Most of these should be OK (MACHINE, SYSTEM, ARCH). RELEASE is ignored.
-export MACHINE=armv7
+export MACHINE=$_OPENSSL_MACHINE
 export RELEASE=2.6.37
 export SYSTEM=android
-export ARCH=arm
-export CROSS_COMPILE="arm-linux-androideabi-"
-
-if [ "$_ANDROID_ARCH" == "arch-x86" ]; then
-    export MACHINE=i686
-    export RELEASE=2.6.37
-    export SYSTEM=android
-    export ARCH=x86
-    export CROSS_COMPILE="i686-linux-android-"
-fi
+export ARCH=$_OPENSSL_ARCH
+export CROSS_COMPILE="$_ANDROID_TARGET-"
 
 # For the Android toolchain
 # https://android.googlesource.com/platform/ndk/+/ics-mr0/docs/STANDALONE-TOOLCHAIN.html
 export ANDROID_SYSROOT="$ANDROID_NDK_ROOT/platforms/$_ANDROID_API/$_ANDROID_ARCH"
 export SYSROOT="$ANDROID_SYSROOT"
+export CROSS_SYSROOT="$ANDROID_SYSROOT"
 export NDK_SYSROOT="$ANDROID_SYSROOT"
 export ANDROID_NDK_SYSROOT="$ANDROID_SYSROOT"
 export ANDROID_API="$_ANDROID_API"
@@ -167,6 +186,9 @@ export ANDROID_API="$_ANDROID_API"
 # export CROSS_COMPILE="arm-linux-androideabi-"
 export ANDROID_DEV="$ANDROID_NDK_ROOT/platforms/$_ANDROID_API/$_ANDROID_ARCH/usr"
 export HOSTCC=gcc
+
+# See https://github.com/cocochpie/android-openssl/blob/master/build-all-arch.sh
+xCFLAGS="-DSHARED_EXTENSION=.so -fPIC -DOPENSSL_PIC -DDSO_DLFCN -DHAVE_DLFCN_H -mandroid -I$ANDROID_DEV/include -B$ANDROID_DEV/lib -O3 -fomit-frame-pointer -Wall"
 
 VERBOSE=1
 if [ ! -z "$VERBOSE" ] && [ "$VERBOSE" != "0" ]; then
@@ -186,6 +208,6 @@ perl -pi -e 's/install: all install_docs install_sw/install: install_docs instal
 
 # The code being built isn't maintained by us, so we redirect stderr to stdout
 # so that the warnings don't clutter up buildbot
-./config shared -no-ssl2 -no-ssl3 -no-comp -no-hw -no-engine --openssldir=/usr/local/ssl/$ANDROID_API 2>&1
+./Configure shared -no-ssl2 -no-ssl3 -no-comp -no-hw -no-engine --openssldir=/usr/local/ssl/$ANDROID_API $_OPENSSL_CONFIG $xCFLAGS 2>&1
 make depend 2>&1
 make all 2>&1


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR is the final step to adds support for Android arm64 compilations. See https://github.com/servo/servo/issues/11921 for previous work.

Fixes in this PR:
- Fix js dependency compilation: https://github.com/servo/rust-mozjs/pull/360
- Fix skia dependency link error: https://github.com/servo/skia/pull/136
- Fix blurdroid dependency compilation: https://github.com/szeged/blurdroid/pull/4
- Fix mio and net2 dependency compilations: https://github.com/carllerche/mio/pull/599
- Fix gcc compiler name in the fake linker
- Compile OpenSSL for aarch64 (update to stable 1.1.0 was required for this)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17099)
<!-- Reviewable:end -->
