### PR TITLE
Shim subprocess.DEVNULL for Python 2

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -490,13 +490,15 @@ class PackageCommands(CommandBase):
                     '--message=Version Bump: {}'.format(brew_version),
                 ])
 
-                token = os.environ['GITHUB_HOMEBREW_TOKEN']
-                call_git([
-                    'push',
-                    '-qf',
-                    'https://{}@github.com/servo/homebrew-servo.git'.format(token),
-                    'master',
-                ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                push_url = 'https://{}@github.com/servo/homebrew-servo.git'
+                # TODO(aneeshusa): Use subprocess.DEVNULL with Python 3.3+
+                with open(os.devnull, 'wb') as DEVNULL:
+                    call_git([
+                        'push',
+                        '-qf',
+                        push_url.format(os.environ['GITHUB_HOMEBREW_TOKEN']),
+                        'master',
+                    ], stdout=DEVNULL, stderr=DEVNULL)
 
         timestamp = datetime.utcnow().replace(microsecond=0)
         for package in PACKAGES[platform]:


### PR DESCRIPTION
This was introduced in Python 3.3, so provide our own version.

Requires careful review since this will leak secrets (!!!) if not done properly.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes help with #17045 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because must be tested manually

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17103)
<!-- Reviewable:end -->
