### PR TITLE
Skip licensing check for CSSWG test package

### DIFF
--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -3,3 +3,6 @@ platforms:
     charade:
       tests:
         unmaintained: skip
+    Template-Python:
+      tests:
+        unlicensed: skip


### PR DESCRIPTION
I'm attempting to make the dependencyci check green again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17117)
<!-- Reviewable:end -->
