### PR TITLE
Remove unicode-bidi/with_serde feature from style deps

### DIFF
--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -67,7 +67,7 @@ style_derive = {path = "../style_derive"}
 style_traits = {path = "../style_traits"}
 servo_url = {path = "../url", optional = true}
 time = "0.1"
-unicode-bidi = {version = "0.3", features = ["with_serde"]}
+unicode-bidi = "0.3"
 unicode-segmentation = "1.0"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
It seems removing this feature from here would unbust stylo build on Gecko side, and style crate doesn't need it anyway, and for Servo, other crates would bring this feature back, so it shouldn't break Servo either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17118)
<!-- Reviewable:end -->
