### PR TITLE
fix double borrowing of image request

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -524,22 +524,20 @@ impl HTMLImageElement {
                         }
                         self.image_request.set(ImageRequestPhase::Pending);
                         self.init_image_request(&mut pending_request, &url, &src);
-                        self.fetch_image(&url);
                     },
                     (_, State::Broken) | (_, State::Unavailable) => {
                         // Step 12.5
                         self.init_image_request(&mut current_request, &url, &src);
-                        self.fetch_image(&url);
                     },
                     (_, _) => {
                         // step 12.6
                         self.image_request.set(ImageRequestPhase::Pending);
                         self.init_image_request(&mut pending_request, &url, &src);
-                        self.fetch_image(&url);
                     },
                 }
             }
         }
+        self.fetch_image(&url);
     }
 
     /// Step 8-12 of html.spec.whatwg.org/multipage/#update-the-image-data


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

@jdm I couldn't reproduce the crashes, but looking at the code, I can tell that if we hit the cache inside `fetch_image`, we go straight to `process_image_response`, so we're still in the same scope as that where the borrowing occurs in `prepare_image_request`. When there is no cache hit, `process_image_response` is executed as part of a task...

This should fix the issue, while retaining the original logic. 

All tests in `the-img-element` are passing...

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #17109 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17120)
<!-- Reviewable:end -->
