### PR TITLE
Move LRUCache to ArrayDeque crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,6 +2879,7 @@ name = "style"
 version = "0.0.1"
 dependencies = [
  "app_units 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arraydeque 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bindgen 0.25.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3499,6 +3509,7 @@ dependencies = [
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum app_units 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c89beb28482985f88b312de4021d748f45b3eecec6cc8dbaf0c2b3c3d1ce6da5"
+"checksum arraydeque 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "96e774cadb24c2245225280c6799793f9802b918a58a79615e9490607489a717"
 "checksum arrayvec 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "699e63a93b79d717e8c3b5eb1b28b7780d0d6d9e59a72eb769291c83b0c8dc67"
 "checksum aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfdf7355d9db158df68f976ed030ab0f6578af811f5a7bb6dcf221ec24e0e0"
 "checksum atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb2dcb6e6d35f20276943cc04bb98e538b348d525a04ac79c10021561d202f21"

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -32,6 +32,7 @@ gecko_debug = ["nsstring_vendor/gecko_debug"]
 [dependencies]
 app_units = "0.4.1"
 arrayvec = "0.3.20"
+arraydeque = "0.2.3"
 atomic_refcell = "0.1"
 bitflags = "0.7"
 bit-vec = "0.4.3"

--- a/components/style/cache.rs
+++ b/components/style/cache.rs
@@ -6,29 +6,28 @@
 
 #![deny(missing_docs)]
 
-use std::collections::VecDeque;
-use std::collections::vec_deque;
+extern crate arraydeque;
+use self::arraydeque::Array;
+use self::arraydeque::ArrayDeque;
 
 /// A LRU cache used to store a set of at most `n` elements at the same time.
 ///
 /// The most-recently-used entry is at index zero.
-pub struct LRUCache<K> {
-    entries: VecDeque<K>,
-    cache_size: usize,
+pub struct LRUCache <K: Array>{
+    entries: ArrayDeque<K>,
 }
 
 /// A iterator over the items of the LRU cache.
-pub type LRUCacheIterator<'a, K> = vec_deque::Iter<'a, K>;
+pub type LRUCacheIterator<'a, K> = arraydeque::Iter<'a, K>;
 
 /// A iterator over the mutable items of the LRU cache.
-pub type LRUCacheMutIterator<'a, K> = vec_deque::IterMut<'a, K>;
+pub type LRUCacheMutIterator<'a, K> = arraydeque::IterMut<'a, K>;
 
-impl<K: PartialEq> LRUCache<K> {
+impl<K: Array> LRUCache<K> {
     /// Create a new LRU cache with `size` elements at most.
-    pub fn new(size: usize) -> Self {
+    pub fn new() -> Self {
         LRUCache {
-          entries: VecDeque::with_capacity(size),
-          cache_size: size,
+          entries: ArrayDeque::new(),
         }
     }
 
@@ -49,22 +48,22 @@ impl<K: PartialEq> LRUCache<K> {
 
     /// Iterate over the contents of this cache, from more to less recently
     /// used.
-    pub fn iter(&self) -> vec_deque::Iter<K> {
+    pub fn iter(&self) -> arraydeque::Iter<K::Item> {
         self.entries.iter()
     }
 
     /// Iterate mutably over the contents of this cache.
-    pub fn iter_mut(&mut self) -> vec_deque::IterMut<K> {
+    pub fn iter_mut(&mut self) -> arraydeque::IterMut<K::Item> {
         self.entries.iter_mut()
     }
 
     /// Insert a given key in the cache.
-    pub fn insert(&mut self, key: K) {
-        if self.entries.len() == self.cache_size {
+    pub fn insert(&mut self, key: K::Item) {
+        if self.entries.len() == self.entries.capacity() {
             self.entries.pop_back();
         }
         self.entries.push_front(key);
-        debug_assert!(self.entries.len() <= self.cache_size);
+        debug_assert!(self.entries.len() <= self.entries.capacity());
     }
 
     /// Evict all elements from the cache.

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -349,7 +349,7 @@ pub struct SelectorFlagsMap<E: TElement> {
     map: FnvHashMap<SendElement<E>, ElementSelectorFlags>,
     /// An LRU cache to avoid hashmap lookups, which can be slow if the map
     /// gets big.
-    cache: LRUCache<(SendElement<E>, ElementSelectorFlags)>,
+    cache: LRUCache<[(SendElement<E>, ElementSelectorFlags); 4 + 1]>,
 }
 
 #[cfg(debug_assertions)]
@@ -364,7 +364,7 @@ impl<E: TElement> SelectorFlagsMap<E> {
     pub fn new() -> Self {
         SelectorFlagsMap {
             map: FnvHashMap::default(),
-            cache: LRUCache::new(4),
+            cache: LRUCache::new(),
         }
     }
 

--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -309,14 +309,14 @@ pub enum StyleSharingResult {
 /// Note that this cache is flushed every time we steal work from the queue, so
 /// storing nodes here temporarily is safe.
 pub struct StyleSharingCandidateCache<E: TElement> {
-    cache: LRUCache<StyleSharingCandidate<E>>,
+    cache: LRUCache<[StyleSharingCandidate<E>; STYLE_SHARING_CANDIDATE_CACHE_SIZE + 1]>,
 }
 
 impl<E: TElement> StyleSharingCandidateCache<E> {
     /// Create a new style sharing candidate cache.
     pub fn new() -> Self {
         StyleSharingCandidateCache {
-            cache: LRUCache::new(STYLE_SHARING_CANDIDATE_CACHE_SIZE),
+            cache: LRUCache::new(),
         }
     }
 


### PR DESCRIPTION
We move LRUCache from using VecDeque to ArrayDeque to avoid using heap allocations.

This relies on the fix in goandylok/arraydeque#4.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17054 (github issue number if applicable).


<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the use cases are the same, only minimal implementation changes have been made

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
---

I additionally ran test-unit, because I'm paranoid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17142)
<!-- Reviewable:end -->
