### PR TITLE
style: Recascade the document when rem units are used and the root font-size changes.

### DIFF
--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -9,7 +9,7 @@ use context::SharedStyleContext;
 use dom::TElement;
 use properties::{AnimationRules, ComputedValues, PropertyDeclarationBlock};
 use properties::longhands::display::computed_value as display;
-use restyle_hints::{HintComputationContext, RestyleReplacements, RestyleHint};
+use restyle_hints::{CascadeHint, HintComputationContext, RestyleReplacements, RestyleHint};
 use rule_tree::StrongRuleNode;
 use selector_parser::{EAGER_PSEUDO_COUNT, PseudoElement, RestyleDamage};
 use selectors::matching::VisitedHandlingMode;
@@ -413,6 +413,11 @@ impl StoredRestyleHint {
     /// recascaded.
     pub fn has_recascade_self(&self) -> bool {
         self.0.has_recascade_self()
+    }
+
+    /// Insert the specified `CascadeHint`.
+    pub fn insert_cascade_hint(&mut self, cascade_hint: CascadeHint) {
+        self.0.insert_cascade_hint(cascade_hint);
     }
 }
 

--- a/components/style/restyle_hints.rs
+++ b/components/style/restyle_hints.rs
@@ -446,6 +446,12 @@ impl RestyleHint {
         self.insert_from(&other)
     }
 
+    /// Inserts the specified `CascadeHint`.
+    #[inline]
+    pub fn insert_cascade_hint(&mut self, cascade_hint: CascadeHint) {
+        self.recascade.insert(cascade_hint);
+    }
+
     /// Returns whether this `RestyleHint` represents at least as much restyle
     /// work as the specified one.
     #[inline]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Reviewed in https://bugzilla.mozilla.org/show_bug.cgi?id=1367592.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17151)
<!-- Reviewable:end -->
