### PR TITLE
stylo: disable @viewport

### DIFF
--- a/components/style/stylesheets.rs
+++ b/components/style/stylesheets.rs
@@ -1759,7 +1759,7 @@ fn is_viewport_enabled() -> bool {
 
 #[cfg(not(feature = "servo"))]
 fn is_viewport_enabled() -> bool {
-    true
+    false // Gecko doesn't support @viewport
 }
 
 impl<'a, 'b> AtRuleParser for NestedRuleParser<'a, 'b> {


### PR DESCRIPTION
Firefox doesn't support @viewport, we shouldn't either.


r=emilio https://bugzilla.mozilla.org/show_bug.cgi?id=1347410

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17153)
<!-- Reviewable:end -->
