### PR TITLE
Update mach bootstrap for changes to wpt harness path in gecko

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -14,11 +14,6 @@ SEARCH_PATHS = [
     os.path.join("python", "tidy"),
 ]
 
-WPT_SEARCH_PATHS = [
-    ".",
-    "harness",
-]
-
 # Individual files providing mach commands.
 MACH_MODULES = [
     os.path.join('python', 'servo', 'bootstrap_commands.py'),
@@ -106,11 +101,21 @@ def _get_virtualenv_script_dir():
     return "bin"
 
 
-def wpt_path(topdir, paths, is_firefox):
+def wpt_path(is_firefox, topdir, *paths):
     if is_firefox:
         rel = os.path.join("..", "testing", "web-platform")
     else:
         rel = os.path.join("tests", "wpt")
+
+    return os.path.join(topdir, rel, *paths)
+
+
+def wpt_harness_path(is_firefox, topdir, *paths):
+    wpt_root = wpt_path(is_firefox, topdir)
+    if is_firefox:
+        rel = os.path.join(wpt_root, "tests", "tools", "wptrunner")
+    else:
+        rel = os.path.join(wpt_root, "harness")
 
     return os.path.join(topdir, rel, *paths)
 
@@ -157,9 +162,9 @@ def _activate_virtualenv(topdir, is_firefox):
     # and it will check for conflicts.
     requirements_paths = [
         os.path.join("python", "requirements.txt"),
-        wpt_path(topdir, ("harness", "requirements.txt"), is_firefox),
-        wpt_path(topdir, ("harness", "requirements_firefox.txt"), is_firefox),
-        wpt_path(topdir, ("harness", "requirements_servo.txt"), is_firefox),
+        wpt_harness_path(is_firefox, topdir, "requirements.txt",),
+        wpt_harness_path(is_firefox, topdir, "requirements_firefox.txt"),
+        wpt_harness_path(is_firefox, topdir, "requirements_servo.txt"),
     ]
 
     if need_pip_upgrade:
@@ -257,8 +262,10 @@ def bootstrap(topdir):
         raise AttributeError(key)
 
     sys.path[0:0] = [os.path.join(topdir, path) for path in SEARCH_PATHS]
-    sys.path[0:0] = [wpt_path(topdir, (path,), is_firefox)
-                     for path in WPT_SEARCH_PATHS]
+
+    sys.path[0:0] = [wpt_path(is_firefox, topdir),
+                     wpt_harness_path(is_firefox, topdir)]
+
     import mach.main
     mach = mach.main.Mach(os.getcwd())
     mach.populate_context_handler = populate_context


### PR DESCRIPTION
Gecko is now using the wpt harness under the wpt tools directory
rather than a copy in an adjacent directory. Therefore the path to the
requirements files, and the required model paths, have changed.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it only affects the mach bootstrap script

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17163)
<!-- Reviewable:end -->
