### PR TITLE
Stop parsing @supports rules before Delimiter::Bang

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2298,7 +2298,7 @@ pub extern "C" fn Servo_CSSSupports2(property: *const nsACString,
 pub extern "C" fn Servo_CSSSupports(cond: *const nsACString) -> bool {
     let condition = unsafe { cond.as_ref().unwrap().as_str_unchecked() };
     let mut input = Parser::new(&condition);
-    let cond = parse_condition_or_declaration(&mut input);
+    let cond = input.parse_entirely(|i| parse_condition_or_declaration(i));
     if let Ok(cond) = cond {
         let url_data = unsafe { dummy_url_data() };
         let reporter = RustLogReporter;


### PR DESCRIPTION
Fixes #15482

Shorthand parsing uses `parse_entirely`, so we have to ask it to stop before the `!important`.

An alternate fix is to not use `parse_entirely` there and ensuring that all callers of `PropertyDeclaration::parse_into()` check that the input is exhausted. Two of the three callers do that anyway because they check for `!important`.

We also weren't checking for the end of the parser for `CSS.supports()`.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17173)
<!-- Reviewable:end -->
