### PR TITLE
Add pref to force WebGL context creation failure

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -51,6 +51,7 @@ use net_traits::image::base::PixelFormat;
 use net_traits::image_cache::ImageResponse;
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use script_traits::ScriptMsg as ConstellationMsg;
+use servo_config::prefs::PREFS;
 use std::cell::Cell;
 use std::collections::HashMap;
 use webrender_traits;
@@ -166,6 +167,10 @@ impl WebGLRenderingContext {
                      size: Size2D<i32>,
                      attrs: GLContextAttributes)
                      -> Result<WebGLRenderingContext, String> {
+        if let Some(true) = PREFS.get("webgl.testing.context_creation_error").as_boolean() {
+            return Err("WebGL context creation error forced by pref `webgl.testing.context_creation_error`".into());
+        }
+
         let (sender, receiver) = ipc::channel().unwrap();
         let constellation_chan = window.upcast::<GlobalScope>().constellation_chan();
         constellation_chan.send(ConstellationMsg::CreateWebGLPaintThread(size, attrs, sender))

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -66,5 +66,6 @@
   "shell.homepage": "https://servo.org",
   "shell.keep_screen_on.enabled": false,
   "shell.native-orientation": "both",
-  "shell.native-titlebar.enabled": true
+  "shell.native-titlebar.enabled": true,
+  "webgl.testing.context_creation_error": false
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -31668,7 +31668,7 @@
    "support"
   ],
   "mozilla/webgl/context_creation_error.html": [
-   "d6ffc0c4ea5671399d3c9b6440608b47c80699cf",
+   "583df4d3fb090862383338a50548b4afb333dd52",
    "testharness"
   ],
   "mozilla/webgl/draw_arrays_simple.html": [

--- a/tests/wpt/mozilla/meta/mozilla/webgl/context_creation_error.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/webgl/context_creation_error.html.ini
@@ -1,5 +1,3 @@
 [context_creation_error.html]
   type: reftest
-  [WebGLContextEvent "webglcontextcreationerror" event]
-    expected: FAIL
-
+  prefs: ["webgl.testing.context_creation_error:true"]

--- a/tests/wpt/mozilla/tests/mozilla/webgl/context_creation_error.html
+++ b/tests/wpt/mozilla/tests/mozilla/webgl/context_creation_error.html
@@ -14,9 +14,7 @@ async_test(function() {
                 "'statusMessage' should be a string, " + typeof(e.statusMessage) + " found");
   }), false);
 
-  // TODO: Create a dummy function to fail the webgl context forcefully from js tests.
-  // Now that antialias doesn't throw an error, there isn't a way to force context creation errors.
-  var gl = canvas.getContext('webgl', { antialiasing: true });
+  var gl = canvas.getContext('webgl');
 
   assert_false(!!gl, "WebGLContext creation succeeded, please update this test!");
 });


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Introduces the pref `webgl.testing.context_creation_error`, to force creation of a new WebGLRenderingContext to fail.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17038 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17189)
<!-- Reviewable:end -->
