### PR TITLE
Count number of braces on a line when checking spec links in test-tidy

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -3368,6 +3368,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         self.tex_parameter(target, name, TexParameterValue::Int(value))
     }
 
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
     fn CheckFramebufferStatus(&self, target: u32) -> u32 {
         // From the GLES 2.0.25 spec, 4.4 ("Framebuffer Objects"):
         //
@@ -3385,6 +3386,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         }
     }
 
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7
     fn RenderbufferStorage(&self, target: u32, internal_format: u32,
                            width: i32, height: i32) {
         // From the GLES 2.0.25 spec:
@@ -3423,6 +3425,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         // accessed.  See https://github.com/servo/servo/issues/13710
     }
 
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
     fn FramebufferRenderbuffer(&self, target: u32, attachment: u32,
                                renderbuffertarget: u32,
                                rb: Option<&WebGLRenderbuffer>) {
@@ -3436,6 +3439,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         };
     }
 
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
     fn FramebufferTexture2D(&self, target: u32, attachment: u32,
                             textarget: u32, texture: Option<&WebGLTexture>,
                             level: i32) {

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -828,8 +828,8 @@ def check_spec(file_name, lines):
     # Pattern representing a line with comment containing a spec link
     link_patt = re.compile("^\s*///? https://.+$")
 
-    # Pattern representing a line with comment
-    comment_patt = re.compile("^\s*///?.+$")
+    # Pattern representing a line with comment or attribute
+    comment_patt = re.compile("^\s*(///?.+|#\[.+\])$")
 
     brace_count = 0
     in_impl = False
@@ -851,12 +851,11 @@ def check_spec(file_name, lines):
                         # No more comments exist above, yield warning
                         yield (idx + 1, "method declared in webidl is missing a comment with a specification link")
                         break
-            if '{' in line and in_impl:
-                brace_count += 1
-            if '}' in line and in_impl:
-                if brace_count == 1:
+            if in_impl:
+                brace_count += line.count('{')
+                brace_count -= line.count('}')
+                if brace_count < 1:
                     break
-                brace_count -= 1
 
 
 def check_config_file(config_file, print_text=True):

--- a/python/tidy/servo_tidy_tests/speclink.rs
+++ b/python/tidy/servo_tidy_tests/speclink.rs
@@ -3,7 +3,30 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 impl SpecLinkMethods for SpecLink {
+    amacro!("Macros inside impls should trigger spec checks.")
+
+    // Method declarations should trigger spec checks.
     fn Test(&self) -> f32 {
+        amacro!("Macros inside function declarations should not trigger spec checks.");
+        if unsafe { false } {
+        }
+        amacro!("Even if there's weird brace counts.");
         0
     }
+
+    // A spec link.
+    // https://example.com/
+    fn Foo() {}
+
+    /// A spec link.
+    /// https://example.com/
+    fn Foo() {}
+
+    /// A spec link.
+    /// https://example.com/
+    /// Doc comments are OK
+    // Regular comments are OK
+    #[allow(attributes_too)]
+    fn Foo() {}
 }
+

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -155,6 +155,7 @@ class CheckTidiness(unittest.TestCase):
         tidy.SPEC_BASE_PATH = base_path
         errors = tidy.collect_errors_for_files(iterFile('speclink.rs'), [], [tidy.check_spec], print_text=False)
         self.assertEqual('method declared in webidl is missing a comment with a specification link', errors.next()[2])
+        self.assertEqual('method declared in webidl is missing a comment with a specification link', errors.next()[2])
         self.assertNoMoreErrors(errors)
 
     def test_script_thread(self):


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Allow more than one brace per line when checking spec links in test-tidy.

We had problems caused  by `if unsafe { ... } {`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes have tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17193)
<!-- Reviewable:end -->
