### PR TITLE
Increase the size of the style sharing cache to 31.

### DIFF
--- a/components/style/parallel.rs
+++ b/components/style/parallel.rs
@@ -37,9 +37,11 @@ use traversal::{DomTraversal, PerLevelTraversalData, PreTraverseToken};
 ///
 /// Larger values will increase style sharing cache hits and general DOM locality
 /// at the expense of decreased opportunities for parallelism. The style sharing
-/// cache can hold 8 entries, but not all styles are shareable, so we set this
-/// value to 16. These values have not been measured and could potentially be
-/// tuned.
+/// cache can hold 31 entries, but not all styles are shareable, so we set this
+/// value to 16. The size of the cache has been measured to provide pretty good
+/// sharing on a few pages, but could probably use more measurement and tuning.
+/// The work unit size is a bit of a guess at the moment; again could use
+/// measurement and tuning.
 pub const WORK_UNIT_MAX: usize = 16;
 
 /// Verify that the style sharing cache size doesn't change. If it does, we should
@@ -48,7 +50,7 @@ pub const WORK_UNIT_MAX: usize = 16;
 /// have surprising effects on the parallelism characteristics of the style system.
 #[allow(dead_code)]
 fn static_assert() {
-    unsafe { mem::transmute::<_, [u32; STYLE_SHARING_CANDIDATE_CACHE_SIZE]>([1; 8]); }
+    unsafe { mem::transmute::<_, [u32; STYLE_SHARING_CANDIDATE_CACHE_SIZE]>([1; 31]); }
 }
 
 /// A list of node pointers.

--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -84,8 +84,10 @@ use stylist::{ApplicableDeclarationBlock, Stylist};
 mod checks;
 
 /// The amount of nodes that the style sharing candidate cache should hold at
-/// most.
-pub const STYLE_SHARING_CANDIDATE_CACHE_SIZE: usize = 8;
+/// most.  We'd somewhat like 32, but ArrayDeque only implements certain backing
+/// store sizes.  A cache size of 32 would mean a backing store of 33, but
+/// that's not an implemented size: we can do 32 or 40.
+pub const STYLE_SHARING_CANDIDATE_CACHE_SIZE: usize = 31;
 
 /// Controls whether the style sharing cache is used.
 #[derive(Clone, Copy, PartialEq)]


### PR DESCRIPTION
Still a lot of guesswork here, but this does seem to get us better sharing.  See
https://bugzilla.mozilla.org/show_bug.cgi?id=1369621 for some data.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://bugzilla.mozilla.org/show_bug.cgi?id=1369621

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17198)
<!-- Reviewable:end -->
