### PR TITLE
Make shadow values share more code

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -51,7 +51,6 @@ use style::computed_values::{background_attachment, background_clip, background_
 use style::computed_values::{background_repeat, border_style, cursor};
 use style::computed_values::{image_rendering, overflow_x, pointer_events, position, visibility};
 use style::computed_values::filter::Filter;
-use style::computed_values::text_shadow::TextShadow;
 use style::logical_geometry::{LogicalPoint, LogicalRect, LogicalSize, WritingMode};
 use style::properties::{self, ServoComputedValues};
 use style::properties::longhands::border_image_repeat::computed_value::RepeatKeyword;
@@ -59,7 +58,7 @@ use style::properties::style_structs;
 use style::servo::restyle_damage::REPAINT;
 use style::values::{Either, RGBA};
 use style::values::computed::{Gradient, GradientItem, LengthOrPercentage};
-use style::values::computed::{LengthOrPercentageOrAuto, NumberOrPercentage, Position};
+use style::values::computed::{LengthOrPercentageOrAuto, NumberOrPercentage, Position, Shadow};
 use style::values::computed::image::{EndingShape, LineDirection};
 use style::values::generics::background::BackgroundSize;
 use style::values::generics::image::{Circle, Ellipse, EndingShape as GenericEndingShape};
@@ -504,7 +503,7 @@ pub trait FragmentDisplayListBuilding {
                                             state: &mut DisplayListBuildState,
                                             text_fragment: &ScannedTextFragmentInfo,
                                             stacking_relative_content_box: &Rect<Au>,
-                                            text_shadow: Option<&TextShadow>,
+                                            text_shadow: Option<&Shadow>,
                                             clip: &Rect<Au>);
 
     /// Creates the display item for a text decoration: underline, overline, or line-through.
@@ -1949,7 +1948,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                             state: &mut DisplayListBuildState,
                                             text_fragment: &ScannedTextFragmentInfo,
                                             stacking_relative_content_box: &Rect<Au>,
-                                            text_shadow: Option<&TextShadow>,
+                                            text_shadow: Option<&Shadow>,
                                             clip: &Rect<Au>) {
         // TODO(emilio): Allow changing more properties by ::selection
         let text_color = if let Some(shadow) = text_shadow {

--- a/components/style/gecko_bindings/sugar/mod.rs
+++ b/components/style/gecko_bindings/sugar/mod.rs
@@ -7,6 +7,7 @@
 mod ns_com_ptr;
 mod ns_compatibility;
 mod ns_css_shadow_array;
+mod ns_css_shadow_item;
 pub mod ns_css_value;
 mod ns_style_auto_array;
 pub mod ns_style_coord;

--- a/components/style/gecko_bindings/sugar/ns_css_shadow_item.rs
+++ b/components/style/gecko_bindings/sugar/ns_css_shadow_item.rs
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Rust helpers for Gecko's `nsCSSShadowItem`.
+
+use app_units::Au;
+use cssparser::Color;
+use gecko::values::{convert_rgba_to_nscolor, convert_nscolor_to_rgba};
+use gecko_bindings::structs::nsCSSShadowItem;
+use values::computed::Shadow;
+
+impl nsCSSShadowItem {
+    /// Set this item to the given shadow value.
+    pub fn set_from_shadow(&mut self, other: Shadow) {
+        self.mXOffset = other.offset_x.0;
+        self.mYOffset = other.offset_y.0;
+        self.mRadius = other.blur_radius.0;
+        self.mSpread = other.spread_radius.0;
+        self.mInset = other.inset;
+        self.mColor = match other.color {
+            Color::RGBA(rgba) => {
+                self.mHasColor = true;
+                convert_rgba_to_nscolor(&rgba)
+            },
+            // TODO handle currentColor
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=760345
+            Color::CurrentColor => 0,
+        }
+    }
+
+    /// Generate shadow value from this shadow item.
+    pub fn to_shadow(&self) -> Shadow {
+        Shadow {
+            offset_x: Au(self.mXOffset),
+            offset_y: Au(self.mYOffset),
+            blur_radius: Au(self.mRadius),
+            spread_radius: Au(self.mSpread),
+            inset: self.mInset,
+            color: Color::RGBA(convert_nscolor_to_rgba(self.mColor)),
+        }
+    }
+}

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3314,27 +3314,9 @@ fn static_assert() {
               I::IntoIter: ExactSizeIterator
     {
         let v = v.into_iter();
-
         self.gecko.mBoxShadow.replace_with_new(v.len() as u32);
-
         for (servo, gecko_shadow) in v.zip(self.gecko.mBoxShadow.iter_mut()) {
-
-            gecko_shadow.mXOffset = servo.offset_x.0;
-            gecko_shadow.mYOffset = servo.offset_y.0;
-            gecko_shadow.mRadius = servo.blur_radius.0;
-            gecko_shadow.mSpread = servo.spread_radius.0;
-            gecko_shadow.mSpread = servo.spread_radius.0;
-            gecko_shadow.mInset = servo.inset;
-            gecko_shadow.mColor = match servo.color {
-                Color::RGBA(rgba) => {
-                    gecko_shadow.mHasColor = true;
-                    convert_rgba_to_nscolor(&rgba)
-                },
-                // TODO handle currentColor
-                // https://bugzilla.mozilla.org/show_bug.cgi?id=760345
-                Color::CurrentColor => 0,
-            }
-
+            gecko_shadow.set_from_shadow(servo);
         }
     }
 
@@ -3343,16 +3325,7 @@ fn static_assert() {
     }
 
     pub fn clone_box_shadow(&self) -> longhands::box_shadow::computed_value::T {
-        let buf = self.gecko.mBoxShadow.iter().map(|shadow| {
-            Shadow {
-                offset_x: Au(shadow.mXOffset),
-                offset_y: Au(shadow.mYOffset),
-                blur_radius: Au(shadow.mRadius),
-                spread_radius: Au(shadow.mSpread),
-                inset: shadow.mInset,
-                color: Color::RGBA(convert_nscolor_to_rgba(shadow.mColor)),
-            }
-        }).collect();
+        let buf = self.gecko.mBoxShadow.iter().map(|v| v.to_shadow()).collect();
         longhands::box_shadow::computed_value::T(buf)
     }
 
@@ -3524,21 +3497,7 @@ fn static_assert() {
                     }
 
                     let mut gecko_shadow = init_shadow(gecko_filter);
-                    gecko_shadow.mArray[0].mXOffset = shadow.offset_x.0;
-                    gecko_shadow.mArray[0].mYOffset = shadow.offset_y.0;
-                    gecko_shadow.mArray[0].mRadius = shadow.blur_radius.0;
-                    // mSpread is not supported in the spec, so we leave it as 0
-                    gecko_shadow.mArray[0].mInset = false; // Not supported in spec level 1
-
-                    gecko_shadow.mArray[0].mColor = match shadow.color {
-                        Color::RGBA(rgba) => {
-                            gecko_shadow.mArray[0].mHasColor = true;
-                            convert_rgba_to_nscolor(&rgba)
-                        },
-                        // TODO handle currentColor
-                        // https://bugzilla.mozilla.org/show_bug.cgi?id=760345
-                        Color::CurrentColor => 0,
-                    };
+                    gecko_shadow.mArray[0].set_from_shadow(shadow);
                 }
                 Url(ref url) => {
                     unsafe {
@@ -3622,24 +3581,9 @@ fn static_assert() {
               I::IntoIter: ExactSizeIterator
     {
         let v = v.into_iter();
-
         self.gecko.mTextShadow.replace_with_new(v.len() as u32);
-
         for (servo, gecko_shadow) in v.zip(self.gecko.mTextShadow.iter_mut()) {
-            gecko_shadow.mXOffset = servo.offset_x.0;
-            gecko_shadow.mYOffset = servo.offset_y.0;
-            gecko_shadow.mRadius = servo.blur_radius.0;
-            gecko_shadow.mHasColor = false;
-            gecko_shadow.mColor = match servo.color {
-                Color::RGBA(rgba) => {
-                    gecko_shadow.mHasColor = true;
-                    convert_rgba_to_nscolor(&rgba)
-                },
-                // TODO handle currentColor
-                // https://bugzilla.mozilla.org/show_bug.cgi?id=760345
-                Color::CurrentColor => 0,
-            }
-
+            gecko_shadow.set_from_shadow(servo);
         }
     }
 
@@ -3648,16 +3592,7 @@ fn static_assert() {
     }
 
     pub fn clone_text_shadow(&self) -> longhands::text_shadow::computed_value::T {
-        let buf = self.gecko.mTextShadow.iter().map(|shadow| {
-            Shadow {
-                offset_x: Au(shadow.mXOffset),
-                offset_y: Au(shadow.mYOffset),
-                blur_radius: Au(shadow.mRadius),
-                spread_radius: Au(0),
-                color: Color::RGBA(convert_nscolor_to_rgba(shadow.mColor)),
-                inset: false,
-            }
-        }).collect();
+        let buf = self.gecko.mTextShadow.iter().map(|v| v.to_shadow()).collect();
         longhands::text_shadow::computed_value::T(buf)
     }
 

--- a/components/style/properties/longhand/effects.mako.rs
+++ b/components/style/properties/longhand/effects.mako.rs
@@ -15,7 +15,7 @@ ${helpers.predefined_type("opacity",
                           spec="https://drafts.csswg.org/css-color/#opacity")}
 
 <%helpers:vector_longhand name="box-shadow" allow_empty="True"
-                          animation_value_type="IntermediateBoxShadowList"
+                          animation_value_type="IntermediateShadowList"
                           extra_prefixes="webkit"
                           ignored_when_colors_disabled="True"
                           spec="https://drafts.csswg.org/css-backgrounds/#box-shadow">

--- a/components/style/properties/longhand/effects.mako.rs
+++ b/components/style/properties/longhand/effects.mako.rs
@@ -210,15 +210,9 @@ ${helpers.predefined_type("clip",
                 computed_value::Filter::Sepia(value) => try!(write!(dest, "sepia({})", value)),
                 % if product == "gecko":
                 computed_value::Filter::DropShadow(shadow) => {
-                    try!(dest.write_str("drop-shadow("));
-                    try!(shadow.offset_x.to_css(dest));
-                    try!(dest.write_str(" "));
-                    try!(shadow.offset_y.to_css(dest));
-                    try!(dest.write_str(" "));
-                    try!(shadow.blur_radius.to_css(dest));
-                    try!(dest.write_str(" "));
-                    try!(shadow.color.to_css(dest));
-                    try!(dest.write_str(")"));
+                    dest.write_str("drop-shadow(")?;
+                    shadow.to_css(dest)?;
+                    dest.write_str(")")?;
                 }
                 computed_value::Filter::Url(ref url) => {
                     url.to_css(dest)?;
@@ -251,17 +245,9 @@ ${helpers.predefined_type("clip",
                 SpecifiedFilter::Sepia(value) => try!(write!(dest, "sepia({})", value)),
                 % if product == "gecko":
                 SpecifiedFilter::DropShadow(ref shadow) => {
-                    try!(dest.write_str("drop-shadow("));
-                    try!(shadow.offset_x.to_css(dest));
-                    try!(dest.write_str(" "));
-                    try!(shadow.offset_y.to_css(dest));
-                    try!(dest.write_str(" "));
-                    try!(shadow.blur_radius.to_css(dest));
-                    if let Some(ref color) = shadow.color {
-                        try!(dest.write_str(" "));
-                        try!(color.to_css(dest));
-                    }
-                    try!(dest.write_str(")"));
+                    dest.write_str("drop-shadow(")?;
+                    shadow.to_css(dest)?;
+                    dest.write_str(")")?;
                 }
                 SpecifiedFilter::Url(ref url) => {
                     url.to_css(dest)?;

--- a/components/style/properties/longhand/effects.mako.rs
+++ b/components/style/properties/longhand/effects.mako.rs
@@ -19,54 +19,12 @@ ${helpers.predefined_type("opacity",
                           extra_prefixes="webkit"
                           ignored_when_colors_disabled="True"
                           spec="https://drafts.csswg.org/css-backgrounds/#box-shadow">
-    use std::fmt;
-    use style_traits::ToCss;
-
     pub type SpecifiedValue = specified::Shadow;
-
-    impl ToCss for SpecifiedValue {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            if self.inset {
-                try!(dest.write_str("inset "));
-            }
-            try!(self.offset_x.to_css(dest));
-            try!(dest.write_str(" "));
-            try!(self.offset_y.to_css(dest));
-            try!(dest.write_str(" "));
-            try!(self.blur_radius.to_css(dest));
-            try!(dest.write_str(" "));
-            try!(self.spread_radius.to_css(dest));
-
-            if let Some(ref color) = self.color {
-                try!(dest.write_str(" "));
-                try!(color.to_css(dest));
-            }
-            Ok(())
-        }
-    }
 
     pub mod computed_value {
         use values::computed::Shadow;
 
         pub type T = Shadow;
-    }
-
-    impl ToCss for computed_value::T {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            if self.inset {
-                try!(dest.write_str("inset "));
-            }
-            try!(self.blur_radius.to_css(dest));
-            try!(dest.write_str(" "));
-            try!(self.spread_radius.to_css(dest));
-            try!(dest.write_str(" "));
-            try!(self.offset_x.to_css(dest));
-            try!(dest.write_str(" "));
-            try!(self.offset_y.to_css(dest));
-            try!(dest.write_str(" "));
-            try!(self.color.to_css(dest));
-            Ok(())
-        }
     }
 
     pub fn parse(context: &ParserContext, input: &mut Parser) -> Result<specified::Shadow, ()> {

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -9,6 +9,7 @@ use context::QuirksMode;
 use euclid::size::Size2D;
 use font_metrics::FontMetricsProvider;
 use media_queries::Device;
+use num_traits::Zero;
 #[cfg(feature = "gecko")]
 use properties;
 use properties::{ComputedValues, StyleBuilder};
@@ -494,8 +495,10 @@ impl ToCss for Shadow {
         dest.write_str(" ")?;
         self.blur_radius.to_css(dest)?;
         dest.write_str(" ")?;
-        self.spread_radius.to_css(dest)?;
-        dest.write_str(" ")?;
+        if self.spread_radius != Au::zero() {
+            self.spread_radius.to_css(dest)?;
+            dest.write_str(" ")?;
+        }
         self.color.to_css(dest)?;
         Ok(())
     }

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -488,13 +488,13 @@ impl ToCss for Shadow {
         if self.inset {
             dest.write_str("inset ")?;
         }
-        self.blur_radius.to_css(dest)?;
-        dest.write_str(" ")?;
-        self.spread_radius.to_css(dest)?;
-        dest.write_str(" ")?;
         self.offset_x.to_css(dest)?;
         dest.write_str(" ")?;
         self.offset_y.to_css(dest)?;
+        dest.write_str(" ")?;
+        self.blur_radius.to_css(dest)?;
+        dest.write_str(" ")?;
+        self.spread_radius.to_css(dest)?;
         dest.write_str(" ")?;
         self.color.to_css(dest)?;
         Ok(())

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -483,6 +483,24 @@ pub struct Shadow {
     pub inset: bool,
 }
 
+impl ToCss for Shadow {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        if self.inset {
+            dest.write_str("inset ")?;
+        }
+        self.blur_radius.to_css(dest)?;
+        dest.write_str(" ")?;
+        self.spread_radius.to_css(dest)?;
+        dest.write_str(" ")?;
+        self.offset_x.to_css(dest)?;
+        dest.write_str(" ")?;
+        self.offset_y.to_css(dest)?;
+        dest.write_str(" ")?;
+        self.color.to_css(dest)?;
+        Ok(())
+    }
+}
+
 /// A `<number>` value.
 pub type Number = CSSFloat;
 

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -878,6 +878,27 @@ impl ToComputedValue for Shadow {
     }
 }
 
+impl ToCss for Shadow {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        if self.inset {
+            dest.write_str("inset ")?;
+        }
+        self.offset_x.to_css(dest)?;
+        dest.write_str(" ")?;
+        self.offset_y.to_css(dest)?;
+        dest.write_str(" ")?;
+        self.blur_radius.to_css(dest)?;
+        dest.write_str(" ")?;
+        self.spread_radius.to_css(dest)?;
+
+        if let Some(ref color) = self.color {
+            dest.write_str(" ")?;
+            color.to_css(dest)?;
+        }
+        Ok(())
+    }
+}
+
 impl Shadow {
     // disable_spread_and_inset is for filter: drop-shadow(...)
     #[allow(missing_docs)]

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -888,9 +888,10 @@ impl ToCss for Shadow {
         self.offset_y.to_css(dest)?;
         dest.write_str(" ")?;
         self.blur_radius.to_css(dest)?;
-        dest.write_str(" ")?;
-        self.spread_radius.to_css(dest)?;
-
+        if self.spread_radius != Length::zero() {
+            dest.write_str(" ")?;
+            self.spread_radius.to_css(dest)?;
+        }
         if let Some(ref color) = self.color {
             dest.write_str(" ")?;
             color.to_css(dest)?;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Make `text-shadow` reuse `Shadow` type directly.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because refactor

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17199)
<!-- Reviewable:end -->
