### PR TITLE
Remove whitespace when serializing operators in attribute selectors

### DIFF
--- a/components/selectors/attr.rs
+++ b/components/selectors/attr.rs
@@ -79,12 +79,12 @@ pub enum AttrSelectorOperator {
 impl ToCss for AttrSelectorOperator {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         dest.write_str(match *self {
-            AttrSelectorOperator::Equal => " = ",
-            AttrSelectorOperator::Includes => " ~= ",
-            AttrSelectorOperator::DashMatch => " |= ",
-            AttrSelectorOperator::Prefix => " ^= ",
-            AttrSelectorOperator::Substring => " *= ",
-            AttrSelectorOperator::Suffix => " $= ",
+            AttrSelectorOperator::Equal => "=",
+            AttrSelectorOperator::Includes => "~=",
+            AttrSelectorOperator::DashMatch => "|=",
+            AttrSelectorOperator::Prefix => "^=",
+            AttrSelectorOperator::Substring => "*=",
+            AttrSelectorOperator::Suffix => "$=",
         })
     }
 }

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -2007,7 +2007,7 @@ pub mod tests {
                 ].into_boxed_slice())
             ), specificity(0, 0, 1))
         ))));
-        assert_eq!(parse("[attr |= \"foo\"]"), Ok(SelectorList::from_vec(vec!(
+        assert_eq!(parse("[attr|=\"foo\"]"), Ok(SelectorList::from_vec(vec!(
             Selector::from_vec(vec!(
                 Component::AttributeInNoNamespace {
                     local_name: DummyAtom::from("attr"),

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -2064,9 +2064,10 @@ pub mod tests {
             ), (1 << 20) + (1 << 10) + (0 << 0))
         ))));
         parser.default_ns = None;
+        
         assert!(parse(":not(#provel.old)").is_err());
         assert!(parse(":not(#provel > old)").is_err());
-        assert!(parse("table[rules]:not([rules = \"none\"]):not([rules = \"\"])").is_ok());
+        assert!(parse("table[rules]:not([rules=\"none\"]):not([rules=\"\"])").is_ok());
         assert_eq!(parse(":not(#provel)"), Ok(SelectorList::from_vec(vec!(
             Selector::from_vec(vec!(Component::Negation(vec!(
                     Component::ID(DummyAtom::from("provel")),

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -2064,7 +2064,6 @@ pub mod tests {
             ), (1 << 20) + (1 << 10) + (0 << 0))
         ))));
         parser.default_ns = None;
-        
         assert!(parse(":not(#provel.old)").is_err());
         assert!(parse(":not(#provel > old)").is_err());
         assert!(parse("table[rules]:not([rules=\"none\"]):not([rules=\"\"])").is_ok());

--- a/tests/unit/style/parsing/selectors.rs
+++ b/tests/unit/style/parsing/selectors.rs
@@ -23,5 +23,5 @@ fn test_selectors() {
     assert_roundtrip!(parse_selector, "div");
     assert_roundtrip!(parse_selector, "svg|circle");
     assert_roundtrip!(parse_selector, "p:before", "p::before");
-    assert_roundtrip!(parse_selector, "[border = \"0\"]:-servo-nonzero-border ~ ::-servo-details-summary");
+    assert_roundtrip!(parse_selector, "[border=\"0\"]:-servo-nonzero-border ~ ::-servo-details-summary");
 }

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -93,13 +93,13 @@ fn test_revalidation_selectors() {
         // Attribute selectors.
         "div[foo]",
         "div:not([foo])",
-        "div[foo = \"bar\"]",
-        "div[foo ~= \"bar\"]",
-        "div[foo |= \"bar\"]",
-        "div[foo ^= \"bar\"]",
-        "div[foo $= \"bar\"]",
-        "div[foo *= \"bar\"]",
-        "*|div[foo][bar = \"baz\"]",
+        "div[foo=\"bar\"]",
+        "div[foo~=\"bar\"]",
+        "div[foo|=\"bar\"]",
+        "div[foo^=\"bar\"]",
+        "div[foo$=\"bar\"]",
+        "div[foo*=\"bar\"]",
+        "*|div[foo][bar=\"baz\"]",
 
         // Non-state-based pseudo-classes.
         "div:empty",
@@ -138,13 +138,13 @@ fn test_revalidation_selectors() {
         // Attribute selectors.
         "div[foo]",
         "div:not([foo])",
-        "div[foo = \"bar\"]",
-        "div[foo ~= \"bar\"]",
-        "div[foo |= \"bar\"]",
-        "div[foo ^= \"bar\"]",
-        "div[foo $= \"bar\"]",
-        "div[foo *= \"bar\"]",
-        "*|div[foo][bar = \"baz\"]",
+        "div[foo=\"bar\"]",
+        "div[foo~=\"bar\"]",
+        "div[foo|=\"bar\"]",
+        "div[foo^=\"bar\"]",
+        "div[foo$=\"bar\"]",
+        "div[foo*=\"bar\"]",
+        "*|div[foo][bar=\"baz\"]",
 
         // Non-state-based pseudo-classes.
         "div:empty",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17181.

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17203)
<!-- Reviewable:end -->
