### PR TITLE
Bug 1367615 - Stylo: implement inIDOMUtils.getSelectorCount and inIDO…

### DIFF
--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -167,6 +167,23 @@ impl<Impl: SelectorImpl> SelectorList<Impl> {
     pub fn from_vec(v: Vec<Selector<Impl>>) -> Self {
         SelectorList(v.into_iter().map(SelectorAndHashes::new).collect())
     }
+
+    pub fn to_css_from_index<W>(&self, from_index: usize, dest: &mut W)
+        -> fmt::Result where W: fmt::Write {
+        let mut iter = self.0.iter().skip(from_index);
+
+        let first = match iter.next() {
+            Some(f) => f,
+            None => return Ok(()),
+        };
+
+        first.selector.to_css(dest)?;
+        for selector_and_hashes in iter {
+            dest.write_str(", ")?;
+            selector_and_hashes.selector.to_css(dest)?;
+        }
+        Ok(())
+    }
 }
 
 /// Copied from Gecko, who copied it from WebKit. Note that increasing the
@@ -638,15 +655,7 @@ impl<Impl: SelectorImpl> Debug for LocalName<Impl> {
 
 impl<Impl: SelectorImpl> ToCss for SelectorList<Impl> {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-        let mut iter = self.0.iter();
-        let first = iter.next()
-            .expect("Empty SelectorList, should contain at least one selector");
-        first.selector.to_css(dest)?;
-        for selector_and_hashes in iter {
-            dest.write_str(", ")?;
-            selector_and_hashes.selector.to_css(dest)?;
-        }
-        Ok(())
+        self.to_css_from_index(/* from_index = */ 0, dest)
     }
 }
 

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -2051,6 +2051,16 @@ extern "C" {
                                            result: *mut nsAString);
 }
 extern "C" {
+    pub fn Servo_StyleRule_GetSelectorTextFromIndex(rule:
+                                                        RawServoStyleRuleBorrowed,
+                                                    index: u32,
+                                                    result: *mut nsAString);
+}
+extern "C" {
+    pub fn Servo_StyleRule_GetSelectorCount(rule: RawServoStyleRuleBorrowed,
+                                            count: *mut u32);
+}
+extern "C" {
     pub fn Servo_ImportRule_GetHref(rule: RawServoImportRuleBorrowed,
                                     result: *mut nsAString);
 }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1157,6 +1157,25 @@ pub extern "C" fn Servo_StyleRule_GetSelectorText(rule: RawServoStyleRuleBorrowe
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_StyleRule_GetSelectorTextFromIndex(rule: RawServoStyleRuleBorrowed,
+                                                           aSelectorIndex: u32,
+                                                           result: *mut nsAString) {
+    read_locked_arc(rule, |rule: &StyleRule| {
+        rule.selectors.to_css_from_index(
+            aSelectorIndex as usize,
+            unsafe { result.as_mut().unwrap() }
+        ).unwrap();
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_StyleRule_GetSelectorCount(rule: RawServoStyleRuleBorrowed, count: *mut u32) {
+    read_locked_arc(rule, |rule: &StyleRule| {
+        *unsafe { count.as_mut().unwrap() } = rule.selectors.0.len() as u32;
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_ImportRule_GetHref(rule: RawServoImportRuleBorrowed, result: *mut nsAString) {
     read_locked_arc(rule, |rule: &ImportRule| {
         write!(unsafe { &mut *result }, "{}", rule.url.as_str()).unwrap();


### PR DESCRIPTION
…MUtils.getSelectorTextFromIndex

https://bugzilla.mozilla.org/show_bug.cgi?id=1367615

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17210)
<!-- Reviewable:end -->
