### PR TITLE
Don't accept an extra token at the end of transform property

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -956,7 +956,7 @@ ${helpers.predefined_type("scroll-snap-coordinate",
 
         let mut result = Vec::new();
         loop {
-            let name = match input.expect_function() {
+            let name = match input.try(|i| i.expect_function()) {
                 Ok(name) => name,
                 Err(_) => break,
             };

--- a/tests/unit/style/parsing/box_.rs
+++ b/tests/unit/style/parsing/box_.rs
@@ -31,3 +31,10 @@ fn test_transform_translate() {
     assert!(parse(transform::parse, "translate(2px foo)").is_err());
     assert!(parse(transform::parse, "perspective(-10px)").is_err());
 }
+
+#[test]
+fn test_unexhausted_transform() {
+    use style::properties::longhands::transform;
+    assert_parser_exhausted!(transform::parse, "rotate(70deg)foo", false);
+    assert_parser_exhausted!(transform::parse, "rotate(70deg) foo", false);
+}


### PR DESCRIPTION
The lack of `input.try` usage makes transform property to accept values like `rotate(70deg)foo`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17218)
<!-- Reviewable:end -->
