### PR TITLE
Define Gecko CounterStyle and FontFaceRule clone functions

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1421,6 +1421,10 @@ extern "C" {
      -> *mut nsCSSFontFaceRule;
 }
 extern "C" {
+    pub fn Gecko_CSSFontFaceRule_Clone(rule: *const nsCSSFontFaceRule)
+     -> *mut nsCSSFontFaceRule;
+}
+extern "C" {
     pub fn Gecko_CSSFontFaceRule_GetCssText(rule: *const nsCSSFontFaceRule,
                                             result: *mut nsAString);
 }
@@ -1432,6 +1436,10 @@ extern "C" {
 }
 extern "C" {
     pub fn Gecko_CSSCounterStyle_Create(name: *mut nsIAtom)
+     -> *mut nsCSSCounterStyleRule;
+}
+extern "C" {
+    pub fn Gecko_CSSCounterStyle_Clone(rule: *const nsCSSCounterStyleRule)
      -> *mut nsCSSCounterStyleRule;
 }
 extern "C" {

--- a/components/style/gecko/rules.rs
+++ b/components/style/gecko/rules.rs
@@ -150,6 +150,18 @@ impl ToNsCssValue for FontDisplay {
     }
 }
 
+impl FontFaceRule {
+    /// Ask Gecko to deep clone the nsCSSFontFaceRule, and then construct
+    /// a FontFaceRule object from it.
+    pub fn deep_clone_from_gecko(&self) -> FontFaceRule {
+        let result = unsafe {
+            UniqueRefPtr::from_addrefed(
+                bindings::Gecko_CSSFontFaceRule_Clone(self.get()))
+        };
+        result.get()
+    }
+}
+
 impl From<FontFaceRuleData> for FontFaceRule {
     fn from(data: FontFaceRuleData) -> FontFaceRule {
         let mut result = unsafe {
@@ -175,6 +187,18 @@ impl ToCssWithGuard for FontFaceRule {
 
 /// A @counter-style rule
 pub type CounterStyleRule = RefPtr<nsCSSCounterStyleRule>;
+
+impl CounterStyleRule {
+    /// Ask Gecko to deep clone the nsCSSCounterStyleRule, and then construct
+    /// a CounterStyleRule object from it.
+    pub fn deep_clone_from_gecko(&self) -> CounterStyleRule {
+        let result = unsafe {
+            UniqueRefPtr::from_addrefed(
+                bindings::Gecko_CSSCounterStyle_Clone(self.get()))
+        };
+        result.get()
+    }
+}
 
 impl From<counter_style::CounterStyleRuleData> for CounterStyleRule {
     fn from(data: counter_style::CounterStyleRuleData) -> CounterStyleRule {

--- a/components/style/stylesheets/counter_style_rule.rs
+++ b/components/style/stylesheets/counter_style_rule.rs
@@ -10,3 +10,15 @@
 pub use counter_style::CounterStyleRuleData as CounterStyleRule;
 #[cfg(feature = "gecko")]
 pub use gecko::rules::CounterStyleRule;
+
+impl CounterStyleRule {
+    #[cfg(feature = "servo")]
+    pub fn clone_conditionally_gecko_or_servo(&self) -> CounterStyleRule {
+        self.clone()
+    }
+
+    #[cfg(feature = "gecko")]
+    pub fn clone_conditionally_gecko_or_servo(&self) -> CounterStyleRule {
+        self.deep_clone_from_gecko()
+    }
+}

--- a/components/style/stylesheets/font_face_rule.rs
+++ b/components/style/stylesheets/font_face_rule.rs
@@ -10,3 +10,15 @@
 pub use font_face::FontFaceRuleData as FontFaceRule;
 #[cfg(feature = "gecko")]
 pub use gecko::rules::FontFaceRule;
+
+impl FontFaceRule {
+    #[cfg(feature = "servo")]
+    pub fn clone_conditionally_gecko_or_servo(&self) -> FontFaceRule {
+        self.clone()
+    }
+
+    #[cfg(feature = "gecko")]
+    pub fn clone_conditionally_gecko_or_servo(&self) -> FontFaceRule {
+        self.deep_clone_from_gecko()
+    }
+}

--- a/components/style/stylesheets/mod.rs
+++ b/components/style/stylesheets/mod.rs
@@ -289,11 +289,13 @@ impl DeepCloneWithLock for CssRule {
             },
             CssRule::FontFace(ref arc) => {
                 let rule = arc.read_with(guard);
-                CssRule::FontFace(Arc::new(lock.wrap(rule.clone())))
+                CssRule::FontFace(Arc::new(lock.wrap(
+                    rule.clone_conditionally_gecko_or_servo())))
             },
             CssRule::CounterStyle(ref arc) => {
                 let rule = arc.read_with(guard);
-                CssRule::CounterStyle(Arc::new(lock.wrap(rule.clone())))
+                CssRule::CounterStyle(Arc::new(lock.wrap(
+                    rule.clone_conditionally_gecko_or_servo())))
             },
             CssRule::Viewport(ref arc) => {
                 let rule = arc.read_with(guard);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Defines and calls Gecko CounterStyle and FontFaceRule clone functions, protected by cfg directives to only apply in gecko builds.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17236)
<!-- Reviewable:end -->
