### PR TITLE
Pass -vv through mach to cargo

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -167,6 +167,9 @@ class MachCommands(CommandBase):
     @CommandArgument('--verbose', '-v',
                      action='store_true',
                      help='Print verbose output')
+    @CommandArgument('--very-verbose', '-vv',
+                     action='store_true',
+                     help='Print very verbose output')
     @CommandArgument('params', nargs='...',
                      help="Command-line arguments to be passed through to Cargo")
     @CommandArgument('--with-debug-assertions',
@@ -174,8 +177,8 @@ class MachCommands(CommandBase):
                      action='store_true',
                      help='Enable debug assertions in release')
     def build(self, target=None, release=False, dev=False, jobs=None,
-              features=None, android=None, verbose=False, debug_mozjs=False, params=None,
-              with_debug_assertions=False):
+              features=None, android=None, verbose=False, very_verbose=False,
+              debug_mozjs=False, params=None, with_debug_assertions=False):
         if android is None:
             android = self.config["build"]["android"]
         features = features or self.servo_features()
@@ -221,6 +224,8 @@ class MachCommands(CommandBase):
             opts += ["-j", jobs]
         if verbose:
             opts += ["-v"]
+        if very_verbose:
+            opts += ["-vv"]
 
         if android:
             target = self.config["android"]["target"]


### PR DESCRIPTION
This change fixes the issue #17231 (passing `-vv` to `./mach build ...` only passes `-v` to `cargo`).

But this introduces another pontential issue, as you can now pass `-vv` and `-v` at the same time. But I do not expect this to be a real problem, especially since `cargo` doesn't care.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17231 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the changes are really simple.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17237)
<!-- Reviewable:end -->
