### PR TITLE
Implemented paint worklets invoking worklet scripts.

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1172,6 +1172,7 @@ impl FragmentDisplayListBuilding for Fragment {
         };
 
         // TODO: add a one-place cache to avoid drawing the paint image every time.
+        // https://github.com/servo/servo/issues/17369
         debug!("Drawing a paint image {}({},{}).", name, size.width.to_px(), size.height.to_px());
         let mut image = match executor.draw_a_paint_image(name, size) {
             Ok(image) => image,

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -391,6 +391,8 @@ pub mod node;
 pub mod nodeiterator;
 pub mod nodelist;
 pub mod pagetransitionevent;
+pub mod paintrenderingcontext2d;
+pub mod paintsize;
 pub mod paintworkletglobalscope;
 pub mod performance;
 pub mod performancetiming;

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::codegen::Bindings::PaintRenderingContext2DBinding;
+use dom::bindings::js::Root;
+use dom::bindings::reflector::Reflector;
+use dom::bindings::reflector::reflect_dom_object;
+use dom::paintworkletglobalscope::PaintWorkletGlobalScope;
+use dom_struct::dom_struct;
+
+#[dom_struct]
+pub struct PaintRenderingContext2D {
+    reflector: Reflector,
+}
+
+impl PaintRenderingContext2D {
+    fn new_inherited() -> PaintRenderingContext2D {
+        PaintRenderingContext2D {
+            reflector: Reflector::new(),
+        }
+    }
+
+    pub fn new(global: &PaintWorkletGlobalScope) -> Root<PaintRenderingContext2D> {
+        reflect_dom_object(box PaintRenderingContext2D::new_inherited(),
+                           global,
+                           PaintRenderingContext2DBinding::Wrap)
+    }
+}

--- a/components/script/dom/paintsize.rs
+++ b/components/script/dom/paintsize.rs
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use app_units::Au;
+use dom::bindings::codegen::Bindings::PaintSizeBinding;
+use dom::bindings::codegen::Bindings::PaintSizeBinding::PaintSizeMethods;
+use dom::bindings::js::Root;
+use dom::bindings::num::Finite;
+use dom::bindings::reflector::Reflector;
+use dom::bindings::reflector::reflect_dom_object;
+use dom::paintworkletglobalscope::PaintWorkletGlobalScope;
+use dom_struct::dom_struct;
+use euclid::Size2D;
+
+#[dom_struct]
+pub struct PaintSize {
+    reflector: Reflector,
+    width: Finite<f64>,
+    height: Finite<f64>,
+}
+
+impl PaintSize {
+    fn new_inherited(size: Size2D<Au>) -> PaintSize {
+        PaintSize {
+            reflector: Reflector::new(),
+            width: Finite::wrap(size.width.to_px().abs() as f64),
+            height: Finite::wrap(size.height.to_px().abs() as f64),
+        }
+    }
+
+    pub fn new(global: &PaintWorkletGlobalScope, size: Size2D<Au>) -> Root<PaintSize> {
+        reflect_dom_object(box PaintSize::new_inherited(size), global, PaintSizeBinding::Wrap)
+    }
+}
+
+impl PaintSizeMethods for PaintSize {
+    /// https://drafts.css-houdini.org/css-paint-api/#paintsize
+    fn Width(&self) -> Finite<f64> {
+        self.width
+    }
+
+    /// https://drafts.css-houdini.org/css-paint-api/#paintsize
+    fn Height(&self) -> Finite<f64> {
+        self.height
+    }
+}

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -3,17 +3,39 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use app_units::Au;
+use dom::bindings::callback::CallbackContainer;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::PaintWorkletGlobalScopeBinding;
 use dom::bindings::codegen::Bindings::PaintWorkletGlobalScopeBinding::PaintWorkletGlobalScopeMethods;
 use dom::bindings::codegen::Bindings::VoidFunctionBinding::VoidFunction;
+use dom::bindings::conversions::StringificationBehavior;
+use dom::bindings::conversions::get_property;
+use dom::bindings::conversions::get_property_jsval;
+use dom::bindings::error::Error;
+use dom::bindings::error::Fallible;
 use dom::bindings::js::Root;
+use dom::bindings::reflector::DomObject;
 use dom::bindings::str::DOMString;
+use dom::paintrenderingcontext2d::PaintRenderingContext2D;
+use dom::paintsize::PaintSize;
 use dom::workletglobalscope::WorkletGlobalScope;
 use dom::workletglobalscope::WorkletGlobalScopeInit;
 use dom_struct::dom_struct;
 use euclid::Size2D;
 use ipc_channel::ipc::IpcSharedMemory;
+use js::jsapi::Call;
+use js::jsapi::Construct1;
+use js::jsapi::HandleValue;
+use js::jsapi::HandleValueArray;
+use js::jsapi::Heap;
+use js::jsapi::IsCallable;
+use js::jsapi::IsConstructor;
+use js::jsapi::JSAutoCompartment;
+use js::jsapi::JS_ClearPendingException;
+use js::jsapi::JS_IsExceptionPending;
+use js::jsval::JSVal;
+use js::jsval::ObjectValue;
+use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use msg::constellation_msg::PipelineId;
 use net_traits::image::base::Image;
@@ -21,14 +43,22 @@ use net_traits::image::base::PixelFormat;
 use script_traits::PaintWorkletError;
 use servo_atoms::Atom;
 use servo_url::ServoUrl;
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::ptr::null_mut;
 use std::rc::Rc;
 use std::sync::mpsc::Sender;
 
-#[dom_struct]
 /// https://drafts.css-houdini.org/css-paint-api/#paintworkletglobalscope
+#[dom_struct]
 pub struct PaintWorkletGlobalScope {
     /// The worklet global for this object
     worklet_global: WorkletGlobalScope,
+    /// https://drafts.css-houdini.org/css-paint-api/#paint-definitions
+    paint_definitions: DOMRefCell<HashMap<Atom, Box<PaintDefinition>>>,
+    /// https://drafts.css-houdini.org/css-paint-api/#paint-class-instances
+    paint_class_instances: DOMRefCell<HashMap<Atom, Box<Heap<JSVal>>>>,
     /// A buffer to draw into
     buffer: DOMRefCell<Vec<u8>>,
 }
@@ -43,6 +73,8 @@ impl PaintWorkletGlobalScope {
         debug!("Creating paint worklet global scope for pipeline {}.", pipeline_id);
         let global = box PaintWorkletGlobalScope {
             worklet_global: WorkletGlobalScope::new_inherited(pipeline_id, base_url, init),
+            paint_definitions: Default::default(),
+            paint_class_instances: Default::default(),
             buffer: Default::default(),
         };
         unsafe { PaintWorkletGlobalScopeBinding::Wrap(runtime.cx(), global) }
@@ -54,44 +86,246 @@ impl PaintWorkletGlobalScope {
         }
     }
 
+    /// https://drafts.css-houdini.org/css-paint-api/#draw-a-paint-image
     fn draw_a_paint_image(&self,
                           name: Atom,
-                          concrete_object_size: Size2D<Au>,
-                          sender: Sender<Result<Image, PaintWorkletError>>) {
-        let width = concrete_object_size.width.to_px().abs() as u32;
-        let height = concrete_object_size.height.to_px().abs() as u32;
+                          size: Size2D<Au>,
+                          sender: Sender<Result<Image, PaintWorkletError>>)
+    {
+        // TODO: document paint definitions.
+        self.invoke_a_paint_callback(name, size, sender);
+    }
+
+    /// https://drafts.css-houdini.org/css-paint-api/#invoke-a-paint-callback
+    #[allow(unsafe_code)]
+    fn invoke_a_paint_callback(&self,
+                               name: Atom,
+                               size: Size2D<Au>,
+                               sender: Sender<Result<Image, PaintWorkletError>>)
+    {
+        let width = size.width.to_px().abs() as u32;
+        let height = size.height.to_px().abs() as u32;
+        debug!("Invoking a paint callback {}({},{}).", name, width, height);
+
+        let cx = self.worklet_global.get_cx();
+        let _ac = JSAutoCompartment::new(cx, self.worklet_global.reflector().get_jsobject().get());
+
+        // TODO: Steps 1-2.1.
+        // Step 2.2-5.1.
+        rooted!(in(cx) let mut class_constructor = UndefinedValue());
+        rooted!(in(cx) let mut paint_function = UndefinedValue());
+        match self.paint_definitions.borrow().get(&name) {
+            None => {
+                // Step 2.2.
+                warn!("Drawing un-registered paint definition {}.", name);
+                let image = self.placeholder_image(width, height, [0x00, 0x00, 0xFF, 0xFF]);
+                let _ = sender.send(Ok(image));
+                return;
+            }
+            Some(definition) => {
+                // Step 5.1
+                if !definition.constructor_valid_flag.get() {
+                    debug!("Drawing invalid paint definition {}.", name);
+                    let image = self.placeholder_image(width, height, [0x00, 0x00, 0xFF, 0xFF]);
+                    let _ = sender.send(Ok(image));
+                    return;
+                }
+                class_constructor.set(definition.class_constructor.get());
+                paint_function.set(definition.paint_function.get());
+            }
+        };
+
+        // Steps 5.2-5.4
+        // TODO: the spec requires calling the constructor now, but we might want to
+        // prepopulate the paint instance in `RegisterPaint`, to avoid calling it in
+        // the primary worklet thread.
+        // https://github.com/servo/servo/issues/17377
+        rooted!(in(cx) let mut paint_instance = UndefinedValue());
+        match self.paint_class_instances.borrow_mut().entry(name.clone()) {
+            Entry::Occupied(entry) => paint_instance.set(entry.get().get()),
+            Entry::Vacant(entry) => {
+                // Step 5.2-5.3
+                let args = HandleValueArray::new();
+                rooted!(in(cx) let mut result = null_mut());
+                unsafe { Construct1(cx, class_constructor.handle(), &args, result.handle_mut()); }
+                paint_instance.set(ObjectValue(result.get()));
+                if unsafe { JS_IsExceptionPending(cx) } {
+                    debug!("Paint constructor threw an exception {}.", name);
+                    unsafe { JS_ClearPendingException(cx); }
+                    self.paint_definitions.borrow_mut().get_mut(&name)
+                        .expect("Vanishing paint definition.")
+                        .constructor_valid_flag.set(false);
+                    let image = self.placeholder_image(width, height, [0x00, 0x00, 0xFF, 0xFF]);
+                    let _ = sender.send(Ok(image));
+                    return;
+                }
+                // Step 5.4
+                entry.insert(Box::new(Heap::default())).set(paint_instance.get());
+            }
+        };
+
+        // TODO: Steps 6-7
+        // Step 8
+        let rendering_context = PaintRenderingContext2D::new(self);
+
+        // Step 9
+        let paint_size = PaintSize::new(self, size);
+
+        // TODO: Step 10
+        // Steps 11-12
+        debug!("Invoking paint function {}.", name);
+        let args_slice = [
+            ObjectValue(rendering_context.reflector().get_jsobject().get()),
+            ObjectValue(paint_size.reflector().get_jsobject().get()),
+        ];
+        let args = unsafe { HandleValueArray::from_rooted_slice(&args_slice) };
+        rooted!(in(cx) let mut result = UndefinedValue());
+        unsafe { Call(cx, paint_instance.handle(), paint_function.handle(), &args, result.handle_mut()); }
+
+        // Step 13.
+        if unsafe { JS_IsExceptionPending(cx) } {
+            debug!("Paint function threw an exception {}.", name);
+            unsafe { JS_ClearPendingException(cx); }
+            let image = self.placeholder_image(width, height, [0x00, 0x00, 0xFF, 0xFF]);
+            let _ = sender.send(Ok(image));
+            return;
+        }
+
+        // For now, we just build a dummy image.
+        let image = self.placeholder_image(width, height, [0xFF, 0x00, 0x00, 0xFF]);
+        let _ = sender.send(Ok(image));
+    }
+
+    fn placeholder_image(&self, width: u32, height: u32, pixel: [u8; 4]) -> Image {
         let area = (width as usize) * (height as usize);
         let old_buffer_size = self.buffer.borrow().len();
         let new_buffer_size = area * 4;
-        debug!("Drawing a paint image {}({},{}).", name, width, height);
-        // TODO: call into script to create the image.
-        // For now, we just build a dummy.
         if new_buffer_size > old_buffer_size {
-            let pixel = [0xFF, 0x00, 0x00, 0xFF];
             self.buffer.borrow_mut().extend(pixel.iter().cycle().take(new_buffer_size - old_buffer_size));
         } else {
             self.buffer.borrow_mut().truncate(new_buffer_size);
         }
-        let image = Image {
+        Image {
             width: width,
             height: height,
             format: PixelFormat::BGRA8,
             bytes: IpcSharedMemory::from_bytes(&*self.buffer.borrow()),
             id: None,
-        };
-        let _ = sender.send(Ok(image));
+        }
     }
 }
 
 impl PaintWorkletGlobalScopeMethods for PaintWorkletGlobalScope {
+    #[allow(unsafe_code)]
     /// https://drafts.css-houdini.org/css-paint-api/#dom-paintworkletglobalscope-registerpaint
-    fn RegisterPaint(&self, name: DOMString, _paintCtor: Rc<VoidFunction>) {
+    fn RegisterPaint(&self, name: DOMString, paint_ctor: Rc<VoidFunction>) -> Fallible<()> {
+        let name = Atom::from(name);
+        let cx = self.worklet_global.get_cx();
+        rooted!(in(cx) let paint_obj = paint_ctor.callback_holder().get());
+        rooted!(in(cx) let paint_val = ObjectValue(paint_obj.get()));
+
         debug!("Registering paint image name {}.", name);
-        // TODO
+
+        // Step 1.
+        if name.is_empty() {
+            return Err(Error::Type(String::from("Empty paint name."))) ;
+        }
+
+        // Step 2-3.
+        if self.paint_definitions.borrow().contains_key(&name) {
+            return Err(Error::InvalidModification);
+        }
+
+        // Step 4-6.
+        debug!("Getting input properties.");
+        let input_properties: Vec<DOMString> =
+            unsafe { get_property(cx, paint_obj.handle(), "inputProperties", StringificationBehavior::Default) }?
+            .unwrap_or_default();
+        debug!("Got {:?}.", input_properties);
+
+        // Step 7-9.
+        debug!("Getting input arguments.");
+        let input_arguments: Vec<DOMString> =
+            unsafe { get_property(cx, paint_obj.handle(), "inputArguments", StringificationBehavior::Default) }?
+            .unwrap_or_default();
+        debug!("Got {:?}.", input_arguments);
+
+        // TODO: Steps 10-11.
+
+        // Steps 12-13.
+        debug!("Getting alpha.");
+        let alpha: bool =
+            unsafe { get_property(cx, paint_obj.handle(), "alpha", ()) }?
+            .unwrap_or(true);
+        debug!("Got {:?}.", alpha);
+
+        // Step 14
+        if unsafe { !IsConstructor(paint_obj.get()) } {
+            return Err(Error::Type(String::from("Not a constructor.")));
+        }
+
+        // Steps 15-16
+        rooted!(in(cx) let mut prototype = UndefinedValue());
+        unsafe { get_property_jsval(cx, paint_obj.handle(), "prototype", prototype.handle_mut())?; }
+        if !prototype.is_object() {
+            return Err(Error::Type(String::from("Prototype is not an object.")));
+        }
+        rooted!(in(cx) let prototype = prototype.to_object());
+
+        // Steps 17-18
+        rooted!(in(cx) let mut paint_function = UndefinedValue());
+        unsafe { get_property_jsval(cx, prototype.handle(), "paint", paint_function.handle_mut())?; }
+        if !paint_function.is_object() || unsafe { !IsCallable(paint_function.to_object()) } {
+            return Err(Error::Type(String::from("Paint function is not callable.")));
+        }
+
+        // Steps 19-20.
+        debug!("Registering definition {}.", name);
+        self.paint_definitions.borrow_mut()
+            .insert(name,
+                    PaintDefinition::new(paint_val.handle(), paint_function.handle(), input_properties, alpha));
+
+        // TODO: Step 21.
+
+        Ok(())
     }
 }
 
 /// Tasks which can be peformed by a paint worklet
 pub enum PaintWorkletTask {
     DrawAPaintImage(Atom, Size2D<Au>, Sender<Result<Image, PaintWorkletError>>)
+}
+
+/// A paint definition
+/// https://drafts.css-houdini.org/css-paint-api/#paint-definition
+/// This type is dangerous, because it contains uboxed `Heap<JSVal>` values,
+/// which can't be moved.
+#[derive(JSTraceable, HeapSizeOf)]
+#[must_root]
+struct PaintDefinition {
+    class_constructor: Heap<JSVal>,
+    paint_function: Heap<JSVal>,
+    constructor_valid_flag: Cell<bool>,
+    input_properties: Vec<DOMString>,
+    context_alpha_flag: bool,
+}
+
+impl PaintDefinition {
+    fn new(class_constructor: HandleValue,
+           paint_function: HandleValue,
+           input_properties: Vec<DOMString>,
+           alpha: bool)
+           -> Box<PaintDefinition>
+    {
+        let result = Box::new(PaintDefinition {
+            class_constructor: Heap::default(),
+            paint_function: Heap::default(),
+            constructor_valid_flag: Cell::new(true),
+            input_properties: input_properties,
+            context_alpha_flag: alpha,
+        });
+        result.class_constructor.set(class_constructor.get());
+        result.paint_function.set(paint_function.get());
+        result
+    }
 }

--- a/components/script/dom/webidls/PaintRenderingContext2D.webidl
+++ b/components/script/dom/webidls/PaintRenderingContext2D.webidl
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// https://drafts.css-houdini.org/css-paint-api/#paintrenderingcontext2d
+[Exposed=PaintWorklet]
+interface PaintRenderingContext2D {
+};
+// PaintRenderingContext2D implements CanvasState;
+// PaintRenderingContext2D implements CanvasTransform;
+// PaintRenderingContext2D implements CanvasCompositing;
+// PaintRenderingContext2D implements CanvasImageSmoothing;
+// PaintRenderingContext2D implements CanvasFillStrokeStyles;
+// PaintRenderingContext2D implements CanvasShadowStyles;
+// PaintRenderingContext2D implements CanvasRect;
+// PaintRenderingContext2D implements CanvasDrawPath;
+// PaintRenderingContext2D implements CanvasDrawImage;
+// PaintRenderingContext2D implements CanvasPathDrawingStyles;
+// PaintRenderingContext2D implements CanvasPath;

--- a/components/script/dom/webidls/PaintSize.webidl
+++ b/components/script/dom/webidls/PaintSize.webidl
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// https://drafts.css-houdini.org/css-paint-api/#paintsize
+[Exposed=PaintWorklet]
+interface PaintSize {
+    readonly attribute double width;
+    readonly attribute double height;
+};

--- a/components/script/dom/webidls/PaintWorkletGlobalScope.webidl
+++ b/components/script/dom/webidls/PaintWorkletGlobalScope.webidl
@@ -5,5 +5,5 @@
 // https://drafts.css-houdini.org/css-paint-api/#paintworkletglobalscope
 [Global=(Worklet,PaintWorklet), Exposed=PaintWorklet]
 interface PaintWorkletGlobalScope : WorkletGlobalScope {
-    void registerPaint(DOMString name, VoidFunction paintCtor);
+    [Throws] void registerPaint(DOMString name, VoidFunction paintCtor);
 };

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -595,6 +595,9 @@ impl WorkletThread {
         // Step 4.
         // NOTE: the spec parses and executes the script in separate steps,
         // but our JS API doesn't separate these, so we do the steps out of order.
+        // Also, the spec currently doesn't allow exceptions to be propagated
+        // to the main script thread.
+        // https://github.com/w3c/css-houdini-drafts/issues/407
         let ok = script.map(|script| global_scope.evaluate_js(&*script)).unwrap_or(false);
 
         if !ok {

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -13,6 +13,7 @@ use dom::testworkletglobalscope::TestWorkletTask;
 use dom_struct::dom_struct;
 use ipc_channel::ipc;
 use ipc_channel::ipc::IpcSender;
+use js::jsapi::JSContext;
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use microtask::Microtask;
@@ -59,6 +60,11 @@ impl WorkletGlobalScope {
             base_url: base_url,
             microtask_queue: MicrotaskQueue::default(),
         }
+    }
+
+    /// Get the JS context.
+    pub fn get_cx(&self) -> *mut JSContext {
+        self.globalscope.get_cx()
     }
 
     /// Evaluate a JS script in this global.

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11271,6 +11271,41 @@
      {}
     ]
    ],
+   "mozilla/worklets/test_paint_worklet_alpha_throws.js": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/worklets/test_paint_worklet_arguments_throws.js": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/worklets/test_paint_worklet_empty_name.js": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/worklets/test_paint_worklet_no_paint.js": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/worklets/test_paint_worklet_not_constructor.js": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/worklets/test_paint_worklet_paint_not_callable.js": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/worklets/test_paint_worklet_properties_throws.js": [
+    [
+     {}
+    ]
+   ],
    "mozilla/worklets/test_paint_worklet_ref.html": [
     [
      {}
@@ -20159,6 +20194,12 @@
    "mozilla/windowproxy.html": [
     [
      "/_mozilla/mozilla/windowproxy.html",
+     {}
+    ]
+   ],
+   "mozilla/worklets/test_paint_worklet_loading.html": [
+    [
+     "/_mozilla/mozilla/worklets/test_paint_worklet_loading.html",
      {}
     ]
    ],
@@ -31905,6 +31946,38 @@
   ],
   "mozilla/worklets/test_paint_worklet.js": [
    "e714db50da9e5cb18c652629fcc1b5ccc453564d",
+   "support"
+  ],
+  "mozilla/worklets/test_paint_worklet_alpha_throws.js": [
+   "fe7df9db6799494f4d24f5ad00349f3aeebb2c23",
+   "support"
+  ],
+  "mozilla/worklets/test_paint_worklet_arguments_throws.js": [
+   "64ef8ea909c96c23932f77dd9ef793f85cfbb38d",
+   "support"
+  ],
+  "mozilla/worklets/test_paint_worklet_empty_name.js": [
+   "589e2a4061e51122750afe2d72f8f609ffb9b216",
+   "support"
+  ],
+  "mozilla/worklets/test_paint_worklet_loading.html": [
+   "20fef90b09fdf8dfb5e7461a01c8bd0f7e5d31af",
+   "testharness"
+  ],
+  "mozilla/worklets/test_paint_worklet_no_paint.js": [
+   "ad637c4f670a8be2814ff21dbc916157293892e5",
+   "support"
+  ],
+  "mozilla/worklets/test_paint_worklet_not_constructor.js": [
+   "70e69524890892e855155fc762a46c8cebaa1fbe",
+   "support"
+  ],
+  "mozilla/worklets/test_paint_worklet_paint_not_callable.js": [
+   "51f1b485d5c505c918edec8a146d54d9e0cf60d9",
+   "support"
+  ],
+  "mozilla/worklets/test_paint_worklet_properties_throws.js": [
+   "50fd53b8f561edda7c6bc8a0e9ac7207bdf22d8b",
    "support"
   ],
   "mozilla/worklets/test_paint_worklet_ref.html": [

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_alpha_throws.js
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_alpha_throws.js
@@ -1,0 +1,4 @@
+registerPaint("alphaThrows", class {
+    static get alpha() { throw new TypeError(); }
+    paint(ctx, size) { }
+});

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_arguments_throws.js
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_arguments_throws.js
@@ -1,0 +1,4 @@
+registerPaint("argumentsThrows", class {
+    static get inputArguments() { throw new TypeError(); }
+    paint(ctx, size) { }
+});

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_empty_name.js
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_empty_name.js
@@ -1,0 +1,6 @@
+registerPaint("", class {
+    paint(ctx, size) {
+        ctx.fillStyle = 'green';
+        ctx.fillRect(0, 0, size.width, size.height);
+    }
+});

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_loading.html
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_loading.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test paint worklet loading</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script>
+var host_info = get_host_info();
+
+promise_test(function() {
+  return paintWorklet.addModule("test_paint_worklet.js");
+}, "Loading a paint worklet.");
+
+promise_test(function(t) {
+   var path = new URL("test_paint_worklet.js", document.location).pathname;
+   var url = new URL(path, host_info.HTTP_REMOTE_ORIGIN);
+   return promise_rejects(t, "AbortError", paintWorklet.addModule(url));
+}, "Loading a cross-origin paint worklet.");
+
+promise_test(function(t) {
+   return promise_rejects(t, "AbortError", paintWorklet.addModule("nonexistent_worklet.js"));
+}, "Loading a nonexistent paint worklet.");
+
+promise_test(function(t) {
+   return promise_rejects(t, "AbortError", paintWorklet.addModule("syntax_error.js"));
+}, "Loading a syntactically incorrect paint worklet.");
+
+promise_test(function(t) {
+   return promise_rejects(t, "AbortError", paintWorklet.addModule("throw_exception.js"));
+}, "Loading an exception-throwing paint worklet.");
+
+promise_test(function(t) {
+   return promise_rejects(t, "AbortError", paintWorklet.addModule("test_paint_worklet.js"));
+}, "Loading a paint worklet again.");
+
+promise_test(function(t) {
+   return promise_rejects(t, "AbortError", paintWorklet.addModule("test_paint_worklet_empty_name.js"));
+}, "Loading a paint worklet with an empty name.");
+
+promise_test(function(t) {
+   return promise_rejects(t, "AbortError", paintWorklet.addModule("test_paint_worklet_properties_throws.js"));
+}, "Loading a paint worklet whose inputProperties throws an exception.");
+
+promise_test(function(t) {
+   return promise_rejects(t, "AbortError", paintWorklet.addModule("test_paint_worklet_arguments_throws.js"));
+}, "Loading a paint worklet whose inputArguments throws an exception.");
+
+promise_test(function(t) {
+   return promise_rejects(t, "AbortError", paintWorklet.addModule("test_paint_worklet_alpha_throws.js"));
+}, "Loading a paint worklet whose alpha throws an exception.");
+
+promise_test(function(t) {
+   return promise_rejects(t, "AbortError", paintWorklet.addModule("test_paint_worklet_not_constructor.js"));
+}, "Loading a paint worklet which isn't a constructor function.");
+
+promise_test(function(t) {
+   return promise_rejects(t, "AbortError", paintWorklet.addModule("test_paint_worklet_no_paint.js"));
+}, "Loading a paint worklet with no paint.");
+
+promise_test(function(t) {
+   return promise_rejects(t, "AbortError", paintWorklet.addModule("test_paint_worklet_paint_not_callable.js"));
+}, "Loading a paint worklet with a paint that is not callable.");
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_no_paint.js
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_no_paint.js
@@ -1,0 +1,2 @@
+registerPaint("noPaint", class {
+});

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_not_constructor.js
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_not_constructor.js
@@ -1,0 +1,3 @@
+registerPaint("notAConstructr", function() { return {
+    "prototype": { "paint": function() {} }
+}; });

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_paint_not_callable.js
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_paint_not_callable.js
@@ -1,0 +1,3 @@
+registerPaint("paintNotCallable", class {
+    get paint() { return 0; }
+});

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_properties_throws.js
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_properties_throws.js
@@ -1,0 +1,4 @@
+registerPaint("propertiesThrows", class {
+    static get inputProperties() { throw new TypeError(); }
+    paint(ctx, size) { }
+});


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Implemented the "invoke a paint callback" functionality of paint worklets (https://drafts.css-houdini.org/css-paint-api/#invoke-a-paint-callback).

This PR does not implement the 2D rendering context, and just generates a placeholder image.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because we can't write reftests until we have 2D rendering contexts implemented.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17239)
<!-- Reviewable:end -->
