### PR TITLE
Reduce the size of ApplicableDeclarationBlock.

### DIFF
--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -1524,9 +1524,9 @@ impl Rule {
                                            -> ApplicableDeclarationBlock {
         ApplicableDeclarationBlock {
             source: StyleSource::Style(self.style_rule.clone()),
-            level: level,
             source_order: self.source_order,
             specificity: self.specificity(),
+            level: level,
         }
     }
 
@@ -1557,12 +1557,12 @@ pub struct ApplicableDeclarationBlock {
     /// The style source, either a style rule, or a property declaration block.
     #[cfg_attr(feature = "servo", ignore_heap_size_of = "Arc")]
     pub source: StyleSource,
-    /// The cascade level this applicable declaration block is in.
-    pub level: CascadeLevel,
     /// The source order of this block.
     pub source_order: usize,
     /// The specificity of the selector this block is represented by.
     pub specificity: u32,
+    /// The cascade level this applicable declaration block is in.
+    pub level: CascadeLevel,
 }
 
 impl ApplicableDeclarationBlock {
@@ -1574,9 +1574,9 @@ impl ApplicableDeclarationBlock {
                              -> Self {
         ApplicableDeclarationBlock {
             source: StyleSource::Declarations(declarations),
-            level: level,
             source_order: 0,
             specificity: 0,
+            level: level,
         }
     }
 }

--- a/tests/unit/stylo/size_of.rs
+++ b/tests/unit/stylo/size_of.rs
@@ -10,6 +10,7 @@ use style::data::{ComputedStyle, ElementData, ElementStyles};
 use style::gecko::selector_parser as real;
 use style::properties::ComputedValues;
 use style::rule_tree::StrongRuleNode;
+use style::stylist::ApplicableDeclarationBlock;
 
 #[test]
 fn size_of_selectors_dummy_types() {
@@ -35,6 +36,8 @@ size_of_test!(test_size_of_element_styles, ElementStyles, 48);
 size_of_test!(test_size_of_element_data, ElementData, 56);
 
 size_of_test!(test_size_of_property_declaration, style::properties::PropertyDeclaration, 32);
+
+size_of_test!(test_size_of_application_declaration_block, ApplicableDeclarationBlock, 32);
 
 // This is huge, but we allocate it on the stack and then never move it,
 // we only pass `&mut SourcePropertyDeclaration` references around.


### PR DESCRIPTION
The level is a u8, so on 64-bit it packs nicely after the u32 specificity.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://bugzilla.mozilla.org/show_bug.cgi?id=1371297

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17242)
<!-- Reviewable:end -->
