### PR TITLE
Remove cssparser dependency from msg.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,7 +1740,6 @@ name = "msg"
 version = "0.0.1"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/msg/Cargo.toml
+++ b/components/msg/Cargo.toml
@@ -11,7 +11,6 @@ path = "lib.rs"
 
 [dependencies]
 bitflags = "0.7"
-cssparser = "0.13.3"
 heapsize = "0.4"
 heapsize_derive = "0.1"
 serde = "0.9"


### PR DESCRIPTION
This applies the change from #17111 once more since it was reverted by an incorrect rebase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17255)
<!-- Reviewable:end -->
