### PR TITLE
Correctly test CSSStyleRule.style.

### DIFF
--- a/tests/wpt/metadata/cssom/CSSStyleRule.html.ini
+++ b/tests/wpt/metadata/cssom/CSSStyleRule.html.ini
@@ -9,9 +9,9 @@
   [Values of CSSRule attributes]
     expected: FAIL
 
-  [Existence, writability and type of CSSStyleRule attributes]
+  [Values of CSSStyleRule attributes]
     expected: FAIL
 
-  [Values of CSSStyleRule attributes]
+  [Existence and type of CSSStyleRule attributes]
     expected: FAIL
 

--- a/tests/wpt/web-platform-tests/cssom/CSSStyleRule.html
+++ b/tests/wpt/web-platform-tests/cssom/CSSStyleRule.html
@@ -67,8 +67,24 @@
             assert_idl_attribute(rule, "selectorText");
             assert_equals(typeof rule.selectorText, "string");
             assert_idl_attribute(rule, "style");
-            assert_readonly(rule, "style");
-        }, "Existence, writability and type of CSSStyleRule attributes");
+        }, "Existence and type of CSSStyleRule attributes");
+
+        test(function() {
+            // CSSStyleRule.style has PutForwards=cssText and SameObject.
+            var initial = rule.style.cssText;
+            var style = rule.style;
+
+            rule.style = "";
+            assert_equals(rule.style.cssText, "");
+            assert_equals(rule.style, style);
+
+            rule.style = "margin: 42px;";
+            assert_equals(rule.style.margin, "42px");
+            assert_equals(rule.style, style);
+
+            rule.style = initial;
+            assert_equals(rule.style, style);
+        }, "Assigning to CSSStyleRule.style assigns to cssText; CSSStyleRule.style returns the same object");
 
         test(function() {
             assert_equals(rule.selectorText, "div");


### PR DESCRIPTION
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

- [X] These changes do not require tests

This is part of a series of PRs to fix https://github.com/servo/servo/issues/17182

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17260)
<!-- Reviewable:end -->