### PR TITLE
stylo: Use bitfield accessors in string-cache.

### DIFF
--- a/components/style/gecko_string_cache/mod.rs
+++ b/components/style/gecko_string_cache/mod.rs
@@ -148,11 +148,8 @@ impl WeakAtom {
     /// Returns whether this atom is static.
     #[inline]
     pub fn is_static(&self) -> bool {
-        // FIXME(emilio): re-introduce bitfield accessors:
-        //
-        // https://github.com/servo/rust-bindgen/issues/519
         unsafe {
-            ((*self.as_ptr())._bitfield_1 & (0x80000000 as u32)) != 0
+            (*self.as_ptr()).mIsStatic() != 0
         }
     }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17270)
<!-- Reviewable:end -->
