### PR TITLE
Add an index.html page for geckolib docs

### DIFF
--- a/etc/ci/upload_docs.sh
+++ b/etc/ci/upload_docs.sh
@@ -16,10 +16,11 @@ cd "$(dirname ${0})/../.."
 
 ./mach doc
 # etc/doc.servo.org/index.html overwrites $(mach rust-root)/doc/index.html
-cp etc/doc.servo.org/* target/doc/
+# Use recursive copy here to avoid `cp` returning an error code
+# when it encounters directories.
+cp -r etc/doc.servo.org/* target/doc/
 
 ./mach cargo-geckolib doc
-mkdir target/doc/geckolib
 # Use recursive copy here to avoid `cp` returning an error code
 # when it encounters directories.
 cp -r target/geckolib/doc/* target/doc/geckolib/

--- a/etc/doc.servo.org/geckolib/index.html
+++ b/etc/doc.servo.org/geckolib/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<title>Geckolib, a subset of Servo’s style system for Stylo project.</title>
+<meta http-equiv=refresh content="0;url=geckoservo/index.html">
+
+Documentation for Geckolib, a subset of Servo’s style system for Stylo project.
+Start with <a href="geckoservo/index.html">the <code>geckoservo</code> crate</a>


### PR DESCRIPTION
We have successfully added docs for geckolib to `doc.servo.org` in #17243 but we still can't use http://doc.servo.org/geckolib to navigate to geckolib docs because of the lack of an index.html file.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because they are CI changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17272)
<!-- Reviewable:end -->
