### PR TITLE
Clear webrender image id when resizing a canvas.

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -547,6 +547,10 @@ impl<'a> CanvasPaintThread<'a> {
 
     fn recreate(&mut self, size: Size2D<i32>) {
         self.drawtarget = CanvasPaintThread::create(size);
+        // Webrender doesn't let images change size, so we clear the webrender image key.
+        if let Some(image_key) = self.image_key.take() {
+            self.webrender_api.delete_image(image_key);
+        }
     }
 
     fn send_pixels(&mut self, chan: IpcSender<Option<Vec<u8>>>) {

--- a/components/canvas/webgl_paint_thread.rs
+++ b/components/canvas/webgl_paint_thread.rs
@@ -291,13 +291,17 @@ impl WebGLPaintThread {
     #[allow(unsafe_code)]
     fn recreate(&mut self, size: Size2D<i32>) -> Result<(), &'static str> {
         match self.data {
-            WebGLPaintTaskData::Readback(ref mut context, _, _) => {
+            WebGLPaintTaskData::Readback(ref mut context, ref webrender_api, ref mut image_key) => {
                 if size.width > self.size.width ||
                    size.height > self.size.height {
                     self.size = try!(context.resize(size));
                 } else {
                     self.size = size;
                     context.gl().scissor(0, 0, size.width, size.height);
+                }
+                // Webrender doesn't let images change size, so we clear the webrender image key.
+                if let Some(image_key) = image_key.take() {
+                    webrender_api.delete_image(image_key);
                 }
             }
             WebGLPaintTaskData::WebRender(ref api, id) => {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6449,6 +6449,18 @@
      {}
     ]
    ],
+   "mozilla/canvas/set_dimensions.html": [
+    [
+     "/_mozilla/mozilla/canvas/set_dimensions.html",
+     [
+      [
+       "/_mozilla/mozilla/canvas/set_dimensions_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "mozilla/details_ui_closed.html": [
     [
      "/_mozilla/mozilla/details_ui_closed.html",
@@ -9566,6 +9578,11 @@
     ]
    ],
    "mozilla/bluetooth/bluetooth-helpers.js": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/canvas/set_dimensions_ref.html": [
     [
      {}
     ]
@@ -25492,6 +25509,14 @@
   "mozilla/canvas/fill_and_stroke_getters_setters.html": [
    "794dd75566d0e2086deb0dcfc727dfe1834ca17e",
    "testharness"
+  ],
+  "mozilla/canvas/set_dimensions.html": [
+   "db6e4fa9b3480609a9a3a582430c64fb49b2b047",
+   "reftest"
+  ],
+  "mozilla/canvas/set_dimensions_ref.html": [
+   "dd9ab8e1a360063d40e5155c1228e69154fa0966",
+   "support"
   ],
   "mozilla/caption.html": [
    "51ed2927d2f3910fb9c2dc4bb1ea4d41c261c8c1",

--- a/tests/wpt/mozilla/tests/mozilla/canvas/set_dimensions.html
+++ b/tests/wpt/mozilla/tests/mozilla/canvas/set_dimensions.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html class="reftest-wait">
+    <head>
+        <meta charset=utf-8>
+        <title>Resizing a canvas</title>
+        <link rel=match href=/_mozilla/mozilla/canvas/set_dimensions_ref.html>
+    </head>
+
+    <body>
+        <canvas width="50px" height="50px"></canvas>
+        <script>
+            var canvas = document.getElementsByTagName('canvas')[0];
+            var ctx = canvas.getContext('2d');
+            ctx.fillStyle = "red";
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            setTimeout(function() {
+                canvas.width = 100;
+                canvas.height = 100;
+                ctx.fillStyle = "green";
+                ctx.fillRect(0, 0, canvas.width, canvas.height);
+                document.documentElement.classList.remove("reftest-wait");
+            }, 0);
+        </script>
+    </body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/canvas/set_dimensions_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/canvas/set_dimensions_ref.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset=utf-8>
+        <title>Resizing a canvas reference</title>
+    </head>
+
+    <body>
+        <canvas width="100px" height="100px"></canvas>
+        <script>
+            var canvas = document.getElementsByTagName('canvas')[0];
+            var ctx = canvas.getContext('2d');
+            ctx.fillStyle = "green";
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Webrender isn't very happy if images change size, so clear the webrender image key when resizing a canvas.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17277
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17278)
<!-- Reviewable:end -->
