### PR TITLE
Handle PseudoElement cases in :active and :hover quirk

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1566,12 +1566,12 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
             }
             NonTSPseudoClass::MozPlaceholder => false,
             NonTSPseudoClass::MozAny(ref sels) => {
-                let old_value = context.within_functional_pseudo_class_argument;
-                context.within_functional_pseudo_class_argument = true;
+                let old_value = context.hover_active_quirk_disabled;
+                context.hover_active_quirk_disabled = true;
                 let result = sels.iter().any(|s| {
                     matches_complex_selector(s.iter(), self, context, flags_setter)
                 });
-                context.within_functional_pseudo_class_argument = old_value;
+                context.hover_active_quirk_disabled = old_value;
                 result
             }
             NonTSPseudoClass::Lang(ref lang_arg) => {


### PR DESCRIPTION
Reviewed by bholley in bugzilla bug.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1371963](https://bugzilla.mozilla.org/show_bug.cgi?id=1371963)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17296)
<!-- Reviewable:end -->
