### PR TITLE
Don't process RestyleKind::MatchAndCascade during animation-only rest…

### DIFF
--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -509,6 +509,7 @@ pub struct ElementData {
 }
 
 /// The kind of restyle that a single element should do.
+#[derive(Debug)]
 pub enum RestyleKind {
     /// We need to run selector matching plus re-cascade, that is, a full
     /// restyle.
@@ -573,22 +574,38 @@ impl ElementData {
 
     /// Returns the kind of restyling that we're going to need to do on this
     /// element, based of the stored restyle hint.
-    pub fn restyle_kind(&self) -> RestyleKind {
+    pub fn restyle_kind(&self,
+                        shared_context: &SharedStyleContext)
+                        -> RestyleKind {
         debug_assert!(!self.has_styles() || self.has_invalidations(),
                       "Should've stopped earlier");
         if !self.has_styles() {
+            debug_assert!(!shared_context.traversal_flags.for_animation_only(),
+                          "Unstyled element shouldn't be traversed during \
+                           animation-only traversal");
             return RestyleKind::MatchAndCascade;
         }
 
         debug_assert!(self.restyle.is_some());
         let restyle_data = self.restyle.as_ref().unwrap();
-
         let hint = restyle_data.hint.0;
+
+        if shared_context.traversal_flags.for_animation_only() {
+            // return either CascadeWithReplacements or CascadeOnly in case of
+            // animation-only restyle.
+            if hint.has_animation_hint() {
+                return RestyleKind::CascadeWithReplacements(hint & RestyleHint::for_animations());
+            }
+            return RestyleKind::CascadeOnly;
+        }
+
         if hint.match_self() {
             return RestyleKind::MatchAndCascade;
         }
 
         if hint.has_replacements() {
+            debug_assert!(!hint.has_animation_hint(),
+                          "Animation only restyle hint should have already processed");
             return RestyleKind::CascadeWithReplacements(hint & RestyleHint::replacements());
         }
 

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -786,10 +786,15 @@ fn compute_style<E, D>(_traversal: &D,
     use sharing::StyleSharingResult::*;
 
     context.thread_local.statistics.elements_styled += 1;
-    let kind = data.restyle_kind();
+    let kind = data.restyle_kind(context.shared);
+
+    debug!("compute_style: {:?} (kind={:?})", element, kind);
 
     match kind {
         MatchAndCascade => {
+            debug_assert!(!context.shared.traversal_flags.for_animation_only(),
+                          "MatchAndCascade shouldn't be processed during \
+                           animation-only traversal");
             // Ensure the bloom filter is up to date.
             context.thread_local.bloom_filter
                    .insert_parents_recovering(element,


### PR DESCRIPTION
…yle.

<!-- Please describe your changes on the following line: -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1372335

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's for stylo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17305)
<!-- Reviewable:end -->
