### PR TITLE
style: Avoid quadratic time serialization of a declaration block.

### DIFF
--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -590,7 +590,7 @@ impl ToCss for PropertyDeclarationBlock {
         // Step 1 -> dest = result list
 
         // Step 2
-        let mut already_serialized = Vec::new();
+        let mut already_serialized = PropertyDeclarationIdSet::new();
 
         // Step 3
         for &(ref declaration, importance) in &*self.declarations {
@@ -598,7 +598,7 @@ impl ToCss for PropertyDeclarationBlock {
             let property = declaration.id();
 
             // Step 3.2
-            if already_serialized.contains(&property) {
+            if already_serialized.contains(property) {
                 continue;
             }
 
@@ -606,8 +606,10 @@ impl ToCss for PropertyDeclarationBlock {
             let shorthands = declaration.shorthands();
             if !shorthands.is_empty() {
                 // Step 3.3.1
+                //
+                // FIXME(emilio): All this looks terribly inefficient...
                 let mut longhands = self.declarations.iter()
-                    .filter(|d| !already_serialized.contains(&d.0.id()))
+                    .filter(|d| !already_serialized.contains(d.0.id()))
                     .collect::<Vec<_>>();
 
                 // Step 3.3.2
@@ -642,10 +644,10 @@ impl ToCss for PropertyDeclarationBlock {
                         }
                         // Substep 1:
                         //
-                         // Assuming that the PropertyDeclarationBlock contains no
-                         // duplicate entries, if the current_longhands length is
-                         // equal to the properties length, it means that the
-                         // properties that map to shorthand are present in longhands
+                        // Assuming that the PropertyDeclarationBlock contains no
+                        // duplicate entries, if the current_longhands length is
+                        // equal to the properties length, it means that the
+                        // properties that map to shorthand are present in longhands
                         if current_longhands.len() != properties.len() {
                             continue;
                         }
@@ -725,7 +727,7 @@ impl ToCss for PropertyDeclarationBlock {
 
                     for current_longhand in &current_longhands {
                         // Substep 9
-                        already_serialized.push(current_longhand.id());
+                        already_serialized.insert(current_longhand.id());
                         let index_to_remove = longhands.iter().position(|l| l.0 == **current_longhand);
                         if let Some(index) = index_to_remove {
                             // Substep 10
@@ -736,7 +738,7 @@ impl ToCss for PropertyDeclarationBlock {
             }
 
             // Step 3.3.4
-            if already_serialized.contains(&property) {
+            if already_serialized.contains(property) {
                 continue;
             }
 
@@ -756,7 +758,7 @@ impl ToCss for PropertyDeclarationBlock {
                 &mut is_first_serialization)?;
 
             // Step 3.3.8
-            already_serialized.push(property);
+            already_serialized.insert(property);
         }
 
         // Step 4

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -14,6 +14,7 @@ use parser::{ParserContext, log_css_error};
 use properties::animated_properties::AnimationValue;
 use selectors::parser::SelectorParseError;
 use shared_lock::Locked;
+use smallvec::SmallVec;
 use std::fmt;
 use std::slice::Iter;
 use style_traits::{PARSING_MODE_DEFAULT, ToCss, ParseError, ParsingMode, StyleParseError};
@@ -605,24 +606,31 @@ impl ToCss for PropertyDeclarationBlock {
             // Step 3.3
             let shorthands = declaration.shorthands();
             if !shorthands.is_empty() {
-                // Step 3.3.1
-                //
-                // FIXME(emilio): All this looks terribly inefficient...
-                let mut longhands = self.declarations.iter()
-                    .filter(|d| !already_serialized.contains(d.0.id()))
-                    .collect::<Vec<_>>();
+                // Step 3.3.1 is done by checking already_serialized while
+                // iterating below.
 
                 // Step 3.3.2
                 for &shorthand in shorthands {
                     let properties = shorthand.longhands();
 
                     // Substep 2 & 3
-                    let mut current_longhands = Vec::new();
+                    let mut current_longhands = SmallVec::<[_; 10]>::new();
                     let mut important_count = 0;
                     let mut found_system = None;
 
-                    if shorthand == ShorthandId::Font && longhands.iter().any(|&&(ref l, _)| l.get_system().is_some()) {
-                        for &&(ref longhand, longhand_importance) in longhands.iter() {
+                    let is_system_font =
+                        shorthand == ShorthandId::Font &&
+                        self.declarations.iter().any(|&(ref l, _)| {
+                            !already_serialized.contains(l.id()) &&
+                            l.get_system().is_some()
+                        });
+
+                    if is_system_font {
+                        for &(ref longhand, longhand_importance) in &self.declarations {
+                            if already_serialized.contains(longhand.id()) {
+                                continue;
+                            }
+
                             if longhand.get_system().is_some() || longhand.is_default_line_height() {
                                 current_longhands.push(longhand);
                                 if found_system.is_none() {
@@ -634,7 +642,11 @@ impl ToCss for PropertyDeclarationBlock {
                             }
                         }
                     } else {
-                        for &&(ref longhand, longhand_importance) in longhands.iter() {
+                        for &(ref longhand, longhand_importance) in &self.declarations {
+                            if already_serialized.contains(longhand.id()) {
+                                continue;
+                            }
+
                             if longhand.id().is_longhand_of(shorthand) {
                                 current_longhands.push(longhand);
                                 if longhand_importance.important() {
@@ -728,11 +740,6 @@ impl ToCss for PropertyDeclarationBlock {
                     for current_longhand in &current_longhands {
                         // Substep 9
                         already_serialized.insert(current_longhand.id());
-                        let index_to_remove = longhands.iter().position(|l| l.0 == **current_longhand);
-                        if let Some(index) = index_to_remove {
-                            // Substep 10
-                            longhands.remove(index);
-                        }
                     }
                 }
             }


### PR DESCRIPTION
At least when the longhands aren't custom properties.

We should also look into not serializing the style attribute eagerly when it's
not needed... But a lot of code currently rely on attribute values being
dereferenciables to &str, so that's harder to fix.

We should really look into all those vectors around too, but that's probably
less urgent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17315)
<!-- Reviewable:end -->
