### PR TITLE
Avoid panic when reloading a page with mouse event handlers

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1652,6 +1652,13 @@ impl ScriptThread {
             let load = self.incomplete_loads.borrow_mut().remove(idx);
             load.layout_chan.clone()
         } else if let Some(document) = self.documents.borrow_mut().remove(id) {
+            // We don't want to dispatch `mouseout` event pointing to non-existing element
+            if let Some(target) = self.topmost_mouse_over_target.get() {
+                if target.upcast::<Node>().owner_doc() == document {
+                    self.topmost_mouse_over_target.set(None);
+                }
+            }
+
             let window = document.window();
             if discard_bc == DiscardBrowsingContext::Yes {
                 window.window_proxy().discard_browsing_context();


### PR DESCRIPTION
This PR fixes issue #16057, by nullifying `topmost_mouse_over_target` inside of the `handle_exit_pipeline_msg` method, in case owner document is the same as the pipeline document that is being destroyed.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

Testing was done manually, by running `./mach run (-r|-d) "http://localhost:8000/minimal.html" `, where `minimal.html` contains `<div onmouseover="location.reload()" onmouseout="this.clientLeft">hi there</div>`.

r?@jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17323)
<!-- Reviewable:end -->
