### PR TITLE
windows: fix line height handling

### DIFF
--- a/components/gfx/platform/windows/font.rs
+++ b/components/gfx/platform/windows/font.rs
@@ -372,7 +372,7 @@ impl FontHandleMethods for FontHandle {
             descent:          au_from_du_s(dm.descent as i32),
             max_advance:      au_from_pt(0.0), // FIXME
             average_advance:  au_from_pt(0.0), // FIXME
-            line_gap:         au_from_du((dm.ascent + dm.descent + dm.lineGap as u16) as i32),
+            line_gap:         au_from_du_s((dm.ascent + dm.descent + dm.lineGap as u16) as i32),
         };
         debug!("Font metrics (@{} pt): {:?}", self.em_size * 12., metrics);
         metrics


### PR DESCRIPTION
hi there!

on windows, this change properly scales a font's line height by its size.

previously, line height was not scaled to the font's size at all, which meant line heights become worse and worse the further you scaled away from the font's design size (in either direction, larger or smaller).

this change makes the `line_gap` ratio and size scale with the font size. i've hand checked that the new computed `line_gap` matches the effective heights in chrome and firefox when `line-height = normal` for a bunch of system fonts. (servo's rendering quality on windows is a different story, though).

![demonstration](https://user-images.githubusercontent.com/975570/27185401-8e27023a-5228-11e7-8475-9e4223730d25.png)

i believe this also solves #16476.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17340)
<!-- Reviewable:end -->
