### PR TITLE
stylo: make font-weight descriptor in @font-face preserve keyword values

### DIFF
--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -70,6 +70,66 @@ define_css_keyword_enum!(FontDisplay:
                          "optional" => Optional);
 add_impls_for_keyword_enum!(FontDisplay);
 
+/// A font-weight value for a @font-face rule.
+/// The font-weight CSS property specifies the weight or boldness of the font.
+#[cfg(feature = "gecko")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FontWeight {
+    /// Numeric font weights for fonts that provide more than just normal and bold.
+    Weight(font_weight::T),
+    /// Normal font weight. Same as 400.
+    Normal,
+    /// Bold font weight. Same as 700.
+    Bold,
+}
+
+#[cfg(feature = "gecko")]
+impl ToCss for FontWeight {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        match *self {
+            FontWeight::Normal => dest.write_str("normal"),
+            FontWeight::Bold => dest.write_str("bold"),
+            FontWeight::Weight(ref weight) => weight.to_css(dest),
+        }
+    }
+}
+
+#[cfg(feature = "gecko")]
+impl Parse for FontWeight {
+    fn parse<'i, 't>(_: &ParserContext, input: &mut Parser<'i, 't>)
+        -> Result<FontWeight, ParseError<'i>> {
+        let result = input.try(|input| {
+            let ident = input.expect_ident().map_err(|_| ())?;
+            match_ignore_ascii_case! { &ident,
+                "normal" => Ok(FontWeight::Normal),
+                "bold" => Ok(FontWeight::Bold),
+                _ => Err(())
+            }
+        });
+        result.or_else(|_| {
+            FontWeight::from_int(input.expect_integer()?)
+                .map_err(|()| StyleParseError::UnspecifiedError.into())
+        })
+    }
+}
+
+#[cfg(feature = "gecko")]
+impl FontWeight {
+    fn from_int(kw: i32) -> Result<Self, ()> {
+        match kw {
+            100 => Ok(FontWeight::Weight(font_weight::T::Weight100)),
+            200 => Ok(FontWeight::Weight(font_weight::T::Weight200)),
+            300 => Ok(FontWeight::Weight(font_weight::T::Weight300)),
+            400 => Ok(FontWeight::Weight(font_weight::T::Weight400)),
+            500 => Ok(FontWeight::Weight(font_weight::T::Weight500)),
+            600 => Ok(FontWeight::Weight(font_weight::T::Weight600)),
+            700 => Ok(FontWeight::Weight(font_weight::T::Weight700)),
+            800 => Ok(FontWeight::Weight(font_weight::T::Weight800)),
+            900 => Ok(FontWeight::Weight(font_weight::T::Weight900)),
+            _ => Err(())
+        }
+    }
+}
 /// Parse the block inside a `@font-face` rule.
 ///
 /// Note that the prelude parsing code lives in the `stylesheets` module.
@@ -329,7 +389,7 @@ font_face_descriptors! {
         "font-style" style / mStyle: font_style::T = font_style::T::normal,
 
         /// The weight of this font face
-        "font-weight" weight / mWeight: font_weight::T = font_weight::T::Weight400 /* normal */,
+        "font-weight" weight / mWeight: FontWeight = FontWeight::Normal,
 
         /// The stretch of this font face
         "font-stretch" stretch / mStretch: font_stretch::T = font_stretch::T::normal,

--- a/components/style/gecko/rules.rs
+++ b/components/style/gecko/rules.rs
@@ -9,7 +9,7 @@ use computed_values::{font_feature_settings, font_stretch, font_style, font_weig
 use computed_values::font_family::FamilyName;
 use counter_style;
 use cssparser::UnicodeRange;
-use font_face::{FontFaceRuleData, Source, FontDisplay};
+use font_face::{FontFaceRuleData, Source, FontDisplay, FontWeight};
 use gecko_bindings::bindings;
 use gecko_bindings::structs::{self, nsCSSFontFaceRule, nsCSSValue};
 use gecko_bindings::structs::{nsCSSCounterDesc, nsCSSCounterStyleRule};
@@ -31,6 +31,18 @@ impl ToNsCssValue for FamilyName {
 impl ToNsCssValue for font_weight::T {
     fn convert(self, nscssvalue: &mut nsCSSValue) {
         nscssvalue.set_integer(self as i32)
+    }
+}
+
+impl ToNsCssValue for FontWeight {
+    fn convert(self, nscssvalue: &mut nsCSSValue) {
+        match self {
+            FontWeight::Normal =>
+                nscssvalue.set_enum(structs::NS_STYLE_FONT_WEIGHT_NORMAL as i32),
+            FontWeight::Bold =>
+                nscssvalue.set_enum(structs::NS_STYLE_FONT_WEIGHT_BOLD as i32),
+            FontWeight::Weight(weight) => nscssvalue.set_integer(weight as i32),
+        }
     }
 }
 


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://bugzilla.mozilla.org/show_bug.cgi?id=1355368

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17343)
<!-- Reviewable:end -->
