### PR TITLE
scroll_offset_query returns inner scrolls

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1462,8 +1462,7 @@ impl Window {
                 None => break,
             }
         }
-        let vp_origin = self.current_viewport.get().origin;
-        Vector2D::new(vp_origin.x.to_f32_px(), vp_origin.y.to_f32_px())
+        Vector2D::new(0.0, 0.0)
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scroll


### PR DESCRIPTION
Before this change scroll_offset_query returned the
next scroll offset in the parents of the node.
If there was no scroll offset it returned the window
scroll offset.
Now if no scrolls are present a zero scroll is returned
ignoring window scrolling.
This solves a bug for element.scrollLeft/Top returning wrong
values.

closes #17342

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17346)
<!-- Reviewable:end -->
