### PR TITLE
Fix setting img src before window.onload causing panic

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -493,6 +493,7 @@ impl HTMLImageElement {
         request.image = None;
         request.metadata = None;
         let document = document_from_node(self);
+        LoadBlocker::terminate(&mut request.blocker);
         request.blocker = Some(LoadBlocker::new(&*document, LoadType::Image(url.clone())));
     }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13193,6 +13193,12 @@
      {}
     ]
    ],
+   "mozilla/img_async_src_set_before_window_load.html": [
+    [
+     "/_mozilla/mozilla/img_async_src_set_before_window_load.html",
+     {}
+    ]
+   ],
    "mozilla/img_find_non_sibling_map.html": [
     [
      "/_mozilla/mozilla/img_find_non_sibling_map.html",
@@ -25860,6 +25866,10 @@
   ],
   "mozilla/iframe_replacement.html": [
    "3c4f36abed83367c851d943b1f25b8394de6fe75",
+   "testharness"
+  ],
+  "mozilla/img_async_src_set_before_window_load.html": [
+   "ef8a1a0623d6f6743bd27e47df4dd77535da0d3e",
    "testharness"
   ],
   "mozilla/img_find_non_sibling_map.html": [

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -25869,7 +25869,7 @@
    "testharness"
   ],
   "mozilla/img_async_src_set_before_window_load.html": [
-   "ef8a1a0623d6f6743bd27e47df4dd77535da0d3e",
+   "c7895fe3b7b7f11a4853760e386e12a08bb51b96",
    "testharness"
   ],
   "mozilla/img_find_non_sibling_map.html": [

--- a/tests/wpt/mozilla/tests/mozilla/img_async_src_set_before_window_load.html
+++ b/tests/wpt/mozilla/tests/mozilla/img_async_src_set_before_window_load.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<img id="image" src="#">
+<script>
+  async_test(function(t) {
+    image = document.getElementById('image');
+
+    setTimeout(t.step_func_done(function() {
+      image.src = 'test.png';
+    }), 0);
+  }, "Setting src attribute asynchronously on image before window.onload doesn't panic.");
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/img_async_src_set_before_window_load.html
+++ b/tests/wpt/mozilla/tests/mozilla/img_async_src_set_before_window_load.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
-<title></title>
+<title>Shouldn't panic when setting src attribute on img asynchronously before window.onload.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <img id="image" src="#">


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Setting an image source asynchronously (e.g. using `setTimeout` or in the callback of an `XMLHttpRequest`) before `window.onload` fired would cause a panic due to a preexisting load blocker not being terminated before assigning a new one.

This PR fixes that and adds a test for it.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #17319.

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17347)
<!-- Reviewable:end -->
