### PR TITLE
Don't report the charade package as an error.

### DIFF
--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -2,4 +2,5 @@ platforms:
   pypi:
     charade:
       tests:
+        removed: skip
         unmaintained: skip


### PR DESCRIPTION
DependencyCI does not like that the charade package has been removed from PyPi. This is really not something we care about, though. It's an upstream part of html5lib which is used in the web-platform-tests, and I've filed https://github.com/w3c/web-platform-tests/issues/6269 about replacing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17393)
<!-- Reviewable:end -->
