### PR TITLE
style: Make checks for attribute/state dependencies take stylist dirty state into account.

### DIFF
--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -546,10 +546,26 @@ impl Stylist {
     pub fn might_have_attribute_dependency(&self,
                                            local_name: &LocalName)
                                            -> bool {
-        if *local_name == local_name!("style") {
+        if self.is_cleared || self.is_device_dirty {
+            // We can't tell what attributes are in our style rules until
+            // we rebuild.
+            true
+        } else if *local_name == local_name!("style") {
             self.style_attribute_dependency
         } else {
             self.attribute_dependencies.might_contain_hash(local_name.get_hash())
+        }
+    }
+
+    /// Returns whether the given ElementState bit might be relied upon by a
+    /// selector of some rule in the stylist.
+    pub fn might_have_state_dependency(&self, state: ElementState) -> bool {
+        if self.is_cleared || self.is_device_dirty {
+            // If self.is_cleared is true, we can't tell what states our style
+            // rules rely on until we rebuild.
+            true
+        } else {
+            self.state_dependencies.intersects(state)
         }
     }
 

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -3066,5 +3066,5 @@ pub extern "C" fn Servo_StyleSet_MightHaveAttributeDependency(raw_data: RawServo
 pub extern "C" fn Servo_StyleSet_HasStateDependency(raw_data: RawServoStyleSetBorrowed,
                                                     state: u64) -> bool {
     let data = PerDocumentStyleData::from_ffi(raw_data).borrow();
-    data.stylist.has_state_dependency(ElementState::from_bits_truncate(state))
+    data.stylist.might_have_state_dependency(ElementState::from_bits_truncate(state))
 }


### PR DESCRIPTION
This is a follow-up Servo-side change for https://bugzilla.mozilla.org/show_bug.cgi?id=1352306
which caused some test failures on landing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17397)
<!-- Reviewable:end -->
