### PR TITLE
use DisplayListBuilder::with_capacity

### DIFF
--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -223,8 +223,9 @@ impl WebRenderDisplayListConverter for DisplayList {
     fn convert_to_webrender(&self, pipeline_id: PipelineId) -> DisplayListBuilder {
         let traversal = DisplayListTraversal::new(self);
         let webrender_pipeline_id = pipeline_id.to_webrender();
-        let mut builder = DisplayListBuilder::new(webrender_pipeline_id,
-                                                  self.bounds().size.to_sizef());
+        let mut builder = DisplayListBuilder::with_capacity(webrender_pipeline_id,
+                                                            self.bounds().size.to_sizef(),
+                                                            1024 * 1024); // 1 MB of space
 
         let mut current_scroll_root_id = ClipId::root_scroll_node(webrender_pipeline_id);
         builder.push_clip_id(current_scroll_root_id);


### PR DESCRIPTION
DO NOT MERGE until https://github.com/servo/webrender/pull/1399 has landed in Servo.

Previously webrender was reserving 1MB of space for each display list (empirically pages weighed between 100k and 10MB when I implemented this). This was problematic for gecko because they used webrender differently. This just brings Servo back to where it was.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17406)
<!-- Reviewable:end -->
