### PR TITLE
Support nested requestAnimationFrame in the presence of reftest-wait

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1491,19 +1491,15 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         };
 
         if wait_for_stable_image {
-            match self.is_ready_to_paint_image_output() {
-                Ok(()) => {
-                    // The current image is ready to output. However, if there are animations active,
-                    // tick those instead and continue waiting for the image output to be stable AND
-                    // all active animations to complete.
-                    if self.animations_active() {
-                        self.process_animations();
-                        return Err(UnableToComposite::NotReadyToPaintImage(NotReadyToPaint::AnimationsActive));
-                    }
-                }
-                Err(result) => {
-                    return Err(UnableToComposite::NotReadyToPaintImage(result))
-                }
+            // The current image may be ready to output. However, if there are animations active,
+            // tick those instead and continue waiting for the image output to be stable AND
+            // all active animations to complete.
+            if self.animations_active() {
+                self.process_animations();
+                return Err(UnableToComposite::NotReadyToPaintImage(NotReadyToPaint::AnimationsActive));
+            }
+            if let Err(result) = self.is_ready_to_paint_image_output() {
+                return Err(UnableToComposite::NotReadyToPaintImage(result))
             }
         }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6533,6 +6533,18 @@
      {}
     ]
    ],
+   "mozilla/request_animation_frame_reftest_wait.html": [
+    [
+     "/_mozilla/mozilla/request_animation_frame_reftest_wait.html",
+     [
+      [
+       "/_mozilla/mozilla/request_animation_frame_reftest_wait_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "mozilla/restyle-out-of-document.html": [
     [
      "/_mozilla/mozilla/restyle-out-of-document.html",
@@ -11033,6 +11045,11 @@
     ]
    ],
    "mozilla/reparse_style_elements_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/request_animation_frame_reftest_wait_ref.html": [
     [
      {}
     ]
@@ -31444,6 +31461,14 @@
   ],
   "mozilla/reparse_style_elements_ref.html": [
    "df273cf90396cc2d3d3159ce72176122ab9518e5",
+   "support"
+  ],
+  "mozilla/request_animation_frame_reftest_wait.html": [
+   "9c5ce337c92c9954475309f3865a9b47b59fbe4d",
+   "reftest"
+  ],
+  "mozilla/request_animation_frame_reftest_wait_ref.html": [
+   "585548dfc915e3d53690e68ef07098044df39f1f",
    "support"
   ],
   "mozilla/resources/background-green.css": [

--- a/tests/wpt/mozilla/tests/mozilla/request_animation_frame_reftest_wait.html
+++ b/tests/wpt/mozilla/tests/mozilla/request_animation_frame_reftest_wait.html
@@ -1,0 +1,12 @@
+<html class="reftest-wait">
+  <title>Mix requestAnimationFrame with reftest-wait</title>
+  <link rel=match href=/_mozilla/mozilla/request_animation_frame_reftest_wait_ref.html>
+  <script>
+    // A regression test for https://github.com/servo/servo/issues/17408
+    requestAnimationFrame(function() {
+      requestAnimationFrame(function() {
+        document.documentElement.classList.remove("reftest-wait");
+      });
+    });
+ </script>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/request_animation_frame_reftest_wait_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/request_animation_frame_reftest_wait_ref.html
@@ -1,0 +1,3 @@
+<html>
+  <title>Mix requestAnimationFrame with reftest-wait</title>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Currently, nested rAF callbacks don't get called in the presence of reftest-wait. This PR fixes that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17408
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17410)
<!-- Reviewable:end -->
