### PR TITLE
style: Have OneOrMoreSeparated replace OneOrMoreCommaSeparated.

### DIFF
--- a/components/style/counter_style/mod.rs
+++ b/components/style/counter_style/mod.rs
@@ -19,7 +19,7 @@ use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::fmt;
 use std::ops::Range;
-use style_traits::{ToCss, OneOrMoreCommaSeparated, ParseError, StyleParseError};
+use style_traits::{ToCss, OneOrMoreSeparated, CommaSeparator, ParseError, StyleParseError};
 use values::CustomIdent;
 
 /// Parse the prelude of an @counter-style rule
@@ -552,7 +552,9 @@ pub struct AdditiveTuple {
     pub symbol: Symbol,
 }
 
-impl OneOrMoreCommaSeparated for AdditiveTuple {}
+impl OneOrMoreSeparated for AdditiveTuple {
+    type S = CommaSeparator;
+}
 
 impl Parse for AdditiveTuple {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -20,7 +20,7 @@ use parser::{ParserContext, log_css_error, Parse};
 use selectors::parser::SelectorParseError;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt;
-use style_traits::{ToCss, OneOrMoreCommaSeparated, ParseError, StyleParseError};
+use style_traits::{ToCss, OneOrMoreSeparated, CommaSeparator, ParseError, StyleParseError};
 use values::specified::url::SpecifiedUrl;
 
 /// A source for a font-face rule.
@@ -34,7 +34,9 @@ pub enum Source {
     Local(FamilyName),
 }
 
-impl OneOrMoreCommaSeparated for Source {}
+impl OneOrMoreSeparated for Source {
+    type S = CommaSeparator;
+}
 
 /// A `UrlSource` represents a font-face source that has been specified with a
 /// `url()` function.

--- a/components/style/parser.rs
+++ b/components/style/parser.rs
@@ -7,7 +7,7 @@
 use context::QuirksMode;
 use cssparser::{Parser, SourcePosition, UnicodeRange};
 use error_reporting::{ParseErrorReporter, ContextualParseError};
-use style_traits::{OneOrMoreCommaSeparated, ParseError, ParsingMode};
+use style_traits::{OneOrMoreSeparated, IsCommaSeparator, ParseError, ParsingMode};
 #[cfg(feature = "gecko")]
 use style_traits::{PARSING_MODE_DEFAULT, PARSING_MODE_ALLOW_UNITLESS_LENGTH, PARSING_MODE_ALLOW_ALL_NUMERIC_VALUES};
 use stylesheets::{CssRuleType, Origin, UrlExtraData, Namespaces};
@@ -161,7 +161,9 @@ pub trait Parse : Sized {
                      -> Result<Self, ParseError<'i>>;
 }
 
-impl<T> Parse for Vec<T> where T: Parse + OneOrMoreCommaSeparated {
+impl<T> Parse for Vec<T> where T: Parse + OneOrMoreSeparated,
+                               <T as OneOrMoreSeparated>::S: IsCommaSeparator
+{
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                      -> Result<Self, ParseError<'i>> {
         input.parse_comma_separated(|input| T::parse(context, input))

--- a/components/style/values/generics/mod.rs
+++ b/components/style/values/generics/mod.rs
@@ -9,7 +9,7 @@ use counter_style::{Symbols, parse_counter_style_name};
 use cssparser::Parser;
 use parser::{Parse, ParserContext};
 use std::fmt;
-use style_traits::{OneOrMoreCommaSeparated, ToCss, ParseError, StyleParseError};
+use style_traits::{OneOrMoreSeparated, CommaSeparator, ToCss, ParseError, StyleParseError};
 use super::CustomIdent;
 use values::specified::url::SpecifiedUrl;
 
@@ -123,7 +123,9 @@ pub struct FontSettingTag<T> {
     pub value: T,
 }
 
-impl<T> OneOrMoreCommaSeparated for FontSettingTag<T> {}
+impl<T> OneOrMoreSeparated for FontSettingTag<T> {
+    type S = CommaSeparator;
+}
 
 impl<T: ToCss> ToCss for FontSettingTag<T> {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {

--- a/components/style_traits/lib.rs
+++ b/components/style_traits/lib.rs
@@ -71,7 +71,7 @@ pub mod values;
 #[macro_use]
 pub mod viewport;
 
-pub use values::{ToCss, OneOrMoreCommaSeparated};
+pub use values::{ToCss, OneOrMoreSeparated, CommaSeparator, SpaceSeparator, IsCommaSeparator};
 pub use viewport::HasViewportPercentage;
 
 /// The error type for all CSS parsing routines.


### PR DESCRIPTION
**NOTE** The alternative for me is just to duplicate the ToCss code, which is not bad and is less code changed! Don't know what others would think, though. Looking for feedback!

A future patch series has some values that should be separated by spaces. This
allows us to re-use the code for serialization, but the types do get a little
clunky. The separator is now indicated with an associated type.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they shoudl be tested by existing serialization code

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17414)
<!-- Reviewable:end -->
