### PR TITLE
Windows can run WPT

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -45,7 +45,8 @@ WEB_PLATFORM_TESTS_PATH = os.path.join("tests", "wpt", "web-platform-tests")
 SERVO_TESTS_PATH = os.path.join("tests", "wpt", "mozilla", "tests")
 
 TEST_SUITES = OrderedDict([
-    ("tidy", {"kwargs": {"all_files": False, "no_progress": False, "self_test": False},
+    ("tidy", {"kwargs": {"all_files": False, "no_progress": False, "self_test": False,
+                         "stylo": False},
               "include_arg": "include"}),
     ("wpt", {"kwargs": {"release": False},
              "paths": [path.abspath(WEB_PLATFORM_TESTS_PATH),
@@ -111,7 +112,8 @@ class MachCommands(CommandBase):
     def test(self, params, render_mode=DEFAULT_RENDER_MODE, release=False, tidy_all=False,
              no_progress=False, self_test=False, all_suites=False):
         suites = copy.deepcopy(TEST_SUITES)
-        suites["tidy"]["kwargs"] = {"all_files": tidy_all, "no_progress": no_progress, "self_test": self_test}
+        suites["tidy"]["kwargs"] = {"all_files": tidy_all, "no_progress": no_progress, "self_test": self_test,
+                                    "stylo": False}
         suites["wpt"]["kwargs"] = {"release": release}
         suites["css"]["kwargs"] = {"release": release}
         suites["unit"]["kwargs"] = {}

--- a/tests/wpt/grouping_formatter.py
+++ b/tests/wpt/grouping_formatter.py
@@ -7,6 +7,7 @@ import collections
 import os
 import sys
 import subprocess
+import platform
 
 DEFAULT_MOVE_UP_CODE = u"\x1b[A"
 DEFAULT_CLEAR_EOL_CODE = u"\x1b[K"
@@ -29,8 +30,12 @@ class GroupingFormatter(base.BaseFormatter):
 
         # TODO(mrobinson, 8313): We need to add support for Windows terminals here.
         if self.interactive:
-            self.line_width = int(subprocess.check_output(['stty', 'size']).split()[1])
             self.move_up, self.clear_eol = self.get_move_up_and_clear_eol_codes()
+            if platform.system() != "Windows":
+                self.line_width = int(subprocess.check_output(['stty', 'size']).split()[1])
+            else:
+                # Until we figure out proper Windows support, this makes things work well enough to run.
+                self.line_width = 80
 
         self.expected = {
             'OK': 0,

--- a/tests/wpt/harness/wptrunner/wptcommandline.py
+++ b/tests/wpt/harness/wptrunner/wptcommandline.py
@@ -256,8 +256,10 @@ def exe_path(name):
         return
 
     path = find_executable(name)
-    if os.access(path, os.X_OK):
+    if path and os.access(path, os.X_OK):
         return path
+    else:
+        return None
 
 
 def check_args(kwargs):


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR contains fixes that address the specific errors in #17392: WTP workarounds for Windows terminals (see #8313), modifications to `mach test --all` that allow `test_tidy` to be called properly, and modifications to the test harness for WPT that allow it to run when OpenSSL isn't found.  How to handle OpenSSL on Windows is probably a separate issue because it doesn't have a straightforward answer: we either need to provide specific instructions to users or bundle it in binary form ourselves.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #17392  (github issue number if applicable).

<!-- Either: -->
- [x] These changes do not require tests because they fix test running.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17419)
<!-- Reviewable:end -->
