### PR TITLE
stylo: Bug 1369625 - Make stop-color, flood-color, lighting-color animatable.

### DIFF
--- a/components/style/properties/longhand/svg.mako.rs
+++ b/components/style/properties/longhand/svg.mako.rs
@@ -23,7 +23,7 @@ ${helpers.predefined_type(
     "stop-color", "RGBAColor",
     "RGBA::new(0, 0, 0, 255)",
     products="gecko",
-    animation_value_type="none",
+    animation_value_type="IntermediateRGBA",
     spec="https://www.w3.org/TR/SVGTiny12/painting.html#StopColorProperty")}
 
 ${helpers.predefined_type("stop-opacity", "Opacity", "1.0",
@@ -37,7 +37,7 @@ ${helpers.predefined_type(
     "flood-color", "RGBAColor",
     "RGBA::new(0, 0, 0, 255)",
     products="gecko",
-    animation_value_type="none",
+    animation_value_type="IntermediateRGBA",
     spec="https://www.w3.org/TR/SVG/filters.html#FloodColorProperty")}
 
 ${helpers.predefined_type("flood-opacity", "Opacity",
@@ -48,7 +48,7 @@ ${helpers.predefined_type(
     "lighting-color", "RGBAColor",
     "RGBA::new(255, 255, 255, 255)",
     products="gecko",
-    animation_value_type="none",
+    animation_value_type="IntermediateRGBA",
     spec="https://www.w3.org/TR/SVG/filters.html#LightingColorProperty")}
 
 // CSS Masking Module Level 1


### PR DESCRIPTION
This is an interdependent patch of Bug 1369625. We make stop-color, flood-color, and lighting-color animatable by using IntermediateRGBA as the animation value type, just like 'color'
attribute. On the Gecko-side, we enable/add the reftest of them and update WPT expectations for these properties.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1369625](https://bugzilla.mozilla.org/show_bug.cgi?id=1369625).
- [X] These changes do not require tests because we have tests already in Gekco.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17422)
<!-- Reviewable:end -->
