### PR TITLE
Expose -moz-context-properties on stylo

### DIFF
--- a/components/style/properties/longhand/inherited_svg.mako.rs
+++ b/components/style/properties/longhand/inherited_svg.mako.rs
@@ -268,7 +268,6 @@ ${helpers.predefined_type("marker-end", "UrlOrNone", "Either::Second(None_)",
                    animation_value_type="none"
                    products="gecko"
                    spec="Nonstandard (Internal-only)"
-                   internal="True"
                    allow_empty="True">
     use values::CustomIdent;
     use values::computed::ComputedValueAsSpecified;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Gecko already exposed `-moz-context-properties` behind pref `svg.context-properties.content.enabled`. I think we should do the same thing on stylo and make the reftests of `context-fill` and `context-stroke` pass.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix [Bug 1370797](https://bugzilla.mozilla.org/show_bug.cgi?id=1370797)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the tests are in gecko.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17424)
<!-- Reviewable:end -->
