### PR TITLE
stylo: Fix has_author_specified_rules() for rules in XBL stylesheets

### DIFF
--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -1112,8 +1112,7 @@ impl StrongRuleNode {
                     CascadeLevel::UANormal |
                     CascadeLevel::UAImportant |
                     CascadeLevel::UserNormal |
-                    CascadeLevel::UserImportant |
-                    CascadeLevel::XBL => {
+                    CascadeLevel::UserImportant  => {
                         for (id, declaration) in longhands {
                             if properties.contains(id) {
                                 // This property was set by a non-author rule.
@@ -1136,6 +1135,7 @@ impl StrongRuleNode {
                     }
                     // Author rules:
                     CascadeLevel::PresHints |
+                    CascadeLevel::XBL |
                     CascadeLevel::AuthorNormal |
                     CascadeLevel::StyleAttributeNormal |
                     CascadeLevel::SMILOverride |


### PR DESCRIPTION
This change is reviewed in https://bugzilla.mozilla.org/show_bug.cgi?id=1372062

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17426)
<!-- Reviewable:end -->
