### PR TITLE
Convert -webkit-linear-gradient coordinate system for Stylo

### DIFF
--- a/components/style/values/generics/image.rs
+++ b/components/style/values/generics/image.rs
@@ -35,7 +35,7 @@ pub enum Image<Gradient, ImageRect> {
 
 /// A CSS gradient.
 /// https://drafts.csswg.org/css-images/#gradients
-#[derive(Clone, Debug, HasViewportPercentage, PartialEq, ToComputedValue)]
+#[derive(Clone, Debug, HasViewportPercentage, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct Gradient<LineDirection, Length, LengthOrPercentage, Position, Color> {
     /// Gradients can be linear or radial.
@@ -59,7 +59,7 @@ pub enum CompatMode {
 }
 
 /// A gradient kind.
-#[derive(Clone, Copy, Debug, HasViewportPercentage, PartialEq, ToComputedValue)]
+#[derive(Clone, Copy, Debug, HasViewportPercentage, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum GradientKind<LineDirection, Length, LengthOrPercentage, Position> {
     /// A linear gradient.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This patch will fix the -webkit-linear-gradient direction issue in Stylo. I decided to NOT change the behavior of Servo, because according to the webcompat spec the webkit prefixed version should just be an alias of non-prefixed version. But we might want to remove support for old syntax like "-webkit-linear-gradient(top, ...)" (without "to"), because they are not in the spec anymore. 

The Gecko layout system use different coordinate systems for prefixed and non-prefixed version, so I did a conversion, but for Servo I keep the modern version only.

Since I believe we should not support old syntax in Servo, so I'm not going to put the test in Servo. I'll submit my test cases to the Gecko wpt test instead.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix [Bug 1372821](https://bugzilla.mozilla.org/show_bug.cgi?id=1372821)
<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because test will be submitted to the Gecko side

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17428)
<!-- Reviewable:end -->
