### PR TITLE
Store font-weight as integer directly

### DIFF
--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -46,7 +46,7 @@ impl FontTemplateDescriptor {
             // A value higher than all weights.
             return 1000
         }
-        ((self.weight as i16) - (other.weight as i16)).abs() as u32
+        ((self.weight.0 as i16) - (other.weight.0 as i16)).abs() as u32
     }
 }
 

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -217,17 +217,7 @@ impl FontHandleMethods for FontHandle {
         } else {
             4.0 + normalized * 5.0  // [4.0, 9.0]
         }; // [1.0, 9.0], centered on 4.0
-        match normalized.round() as u32 {
-            1 => font_weight::T::Weight100,
-            2 => font_weight::T::Weight200,
-            3 => font_weight::T::Weight300,
-            4 => font_weight::T::Weight400,
-            5 => font_weight::T::Weight500,
-            6 => font_weight::T::Weight600,
-            7 => font_weight::T::Weight700,
-            8 => font_weight::T::Weight800,
-            _ => font_weight::T::Weight900,
-        }
+        font_weight::T::from_int(normalized.round() as i32 * 100).unwrap()
     }
 
     fn stretchiness(&self) -> font_stretch::T {

--- a/components/gfx/platform/windows/font.rs
+++ b/components/gfx/platform/windows/font.rs
@@ -155,18 +155,8 @@ impl FontInfo {
             },
         };
 
-        let weight = match min(9, max(1, weight_val / 100)) {
-            1 => font_weight::T::Weight100,
-            2 => font_weight::T::Weight200,
-            3 => font_weight::T::Weight300,
-            4 => font_weight::T::Weight400,
-            5 => font_weight::T::Weight500,
-            6 => font_weight::T::Weight600,
-            7 => font_weight::T::Weight700,
-            8 => font_weight::T::Weight800,
-            9 => font_weight::T::Weight900,
-            _ => return Err(()),
-        };
+        let weight = font_weight::T::
+            from_int(min(9, max(1, weight_val as i32 / 100)) * 100).unwrap();
 
         let stretch = match min(9, max(1, width_val)) {
             1 => font_stretch::T::ultra_condensed,
@@ -198,21 +188,21 @@ impl FontInfo {
 
     fn new_from_font(font: &Font) -> Result<FontInfo, ()> {
         let style = font.style();
-        let weight = match font.weight() {
-            FontWeight::Thin => font_weight::T::Weight100,
-            FontWeight::ExtraLight => font_weight::T::Weight200,
-            FontWeight::Light => font_weight::T::Weight300,
+        let weight = font_weight::T(match font.weight() {
+            FontWeight::Thin => 100,
+            FontWeight::ExtraLight => 200,
+            FontWeight::Light => 300,
             // slightly grayer gray
-            FontWeight::SemiLight => font_weight::T::Weight300,
-            FontWeight::Regular => font_weight::T::Weight400,
-            FontWeight::Medium => font_weight::T::Weight500,
-            FontWeight::SemiBold => font_weight::T::Weight600,
-            FontWeight::Bold => font_weight::T::Weight700,
-            FontWeight::ExtraBold => font_weight::T::Weight800,
-            FontWeight::Black => font_weight::T::Weight900,
+            FontWeight::SemiLight => 300,
+            FontWeight::Regular => 400,
+            FontWeight::Medium => 500,
+            FontWeight::SemiBold => 600,
+            FontWeight::Bold => 700,
+            FontWeight::ExtraBold => 800,
+            FontWeight::Black => 900,
             // slightly blacker black
-            FontWeight::ExtraBlack => font_weight::T::Weight900,
-        };
+            FontWeight::ExtraBlack => 900,
+        });
         let stretch = match font.stretch() {
             FontStretch::Undefined => font_stretch::T::normal,
             FontStretch::UltraCondensed => font_stretch::T::ultra_condensed,

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -109,29 +109,13 @@ impl Parse for FontWeight {
             }
         });
         result.or_else(|_| {
-            FontWeight::from_int(input.expect_integer()?)
+            font_weight::T::from_int(input.expect_integer()?)
+                .map(FontWeight::Weight)
                 .map_err(|()| StyleParseError::UnspecifiedError.into())
         })
     }
 }
 
-#[cfg(feature = "gecko")]
-impl FontWeight {
-    fn from_int(kw: i32) -> Result<Self, ()> {
-        match kw {
-            100 => Ok(FontWeight::Weight(font_weight::T::Weight100)),
-            200 => Ok(FontWeight::Weight(font_weight::T::Weight200)),
-            300 => Ok(FontWeight::Weight(font_weight::T::Weight300)),
-            400 => Ok(FontWeight::Weight(font_weight::T::Weight400)),
-            500 => Ok(FontWeight::Weight(font_weight::T::Weight500)),
-            600 => Ok(FontWeight::Weight(font_weight::T::Weight600)),
-            700 => Ok(FontWeight::Weight(font_weight::T::Weight700)),
-            800 => Ok(FontWeight::Weight(font_weight::T::Weight800)),
-            900 => Ok(FontWeight::Weight(font_weight::T::Weight900)),
-            _ => Err(())
-        }
-    }
-}
 /// Parse the block inside a `@font-face` rule.
 ///
 /// Note that the prelude parsing code lives in the `stylesheets` module.

--- a/components/style/gecko/rules.rs
+++ b/components/style/gecko/rules.rs
@@ -31,7 +31,7 @@ impl ToNsCssValue for FamilyName {
 
 impl ToNsCssValue for font_weight::T {
     fn convert(self, nscssvalue: &mut nsCSSValue) {
-        nscssvalue.set_integer(self as i32)
+        nscssvalue.set_integer(self.0 as i32)
     }
 }
 
@@ -42,7 +42,7 @@ impl ToNsCssValue for FontWeight {
                 nscssvalue.set_enum(structs::NS_STYLE_FONT_WEIGHT_NORMAL as i32),
             FontWeight::Bold =>
                 nscssvalue.set_enum(structs::NS_STYLE_FONT_WEIGHT_BOLD as i32),
-            FontWeight::Weight(weight) => nscssvalue.set_integer(weight as i32),
+            FontWeight::Weight(weight) => nscssvalue.set_integer(weight.0 as i32),
         }
     }
 }

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1893,7 +1893,7 @@ fn static_assert() {
     }
 
     pub fn set_font_weight(&mut self, v: longhands::font_weight::computed_value::T) {
-        self.gecko.mFont.weight = v as u16;
+        self.gecko.mFont.weight = v.0;
     }
     ${impl_simple_copy('font_weight', 'mFont.weight')}
 

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -1407,38 +1407,21 @@ impl Animatable for MaxLength {
 impl Animatable for FontWeight {
     #[inline]
     fn add_weighted(&self, other: &Self, self_portion: f64, other_portion: f64) -> Result<Self, ()> {
-        let a = (*self as u32) as f64;
-        let b = (*other as u32) as f64;
+        let a = self.0 as f64;
+        let b = other.0 as f64;
         const NORMAL: f64 = 400.;
         let weight = (a - NORMAL) * self_portion + (b - NORMAL) * other_portion + NORMAL;
-        Ok(if weight < 150. {
-            FontWeight::Weight100
-        } else if weight < 250. {
-            FontWeight::Weight200
-        } else if weight < 350. {
-            FontWeight::Weight300
-        } else if weight < 450. {
-            FontWeight::Weight400
-        } else if weight < 550. {
-            FontWeight::Weight500
-        } else if weight < 650. {
-            FontWeight::Weight600
-        } else if weight < 750. {
-            FontWeight::Weight700
-        } else if weight < 850. {
-            FontWeight::Weight800
-        } else {
-            FontWeight::Weight900
-        })
+        let weight = (weight.min(100.).max(900.) / 100.).round() * 100.;
+        Ok(FontWeight(weight as u16))
     }
 
     #[inline]
-    fn get_zero_value(&self) -> Result<Self, ()> { Ok(FontWeight::Weight400) }
+    fn get_zero_value(&self) -> Result<Self, ()> { Ok(FontWeight::normal()) }
 
     #[inline]
     fn compute_distance(&self, other: &Self) -> Result<f64, ()> {
-        let a = (*self as u32) as f64;
-        let b = (*other as u32) as f64;
+        let a = self.0 as f64;
+        let b = other.0 as f64;
         a.compute_distance(&b)
     }
 }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1673,7 +1673,7 @@ pub mod style_structs {
                     // Corresponds to the fields in
                     // `gfx::font_template::FontTemplateDescriptor`.
                     let mut hasher: FnvHasher = Default::default();
-                    hasher.write_u16(self.font_weight as u16);
+                    hasher.write_u16(self.font_weight.0);
                     self.font_stretch.hash(&mut hasher);
                     self.font_family.hash(&mut hasher);
                     self.hash = hasher.finish()

--- a/components/style/style_adjuster.rs
+++ b/components/style/style_adjuster.rs
@@ -184,7 +184,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
             let mut font_style = self.style.mutate_font();
             // Sadly we don't have a nice name for the computed value
             // of "font-weight: normal".
-            font_style.set_font_weight(font_weight::Weight400);
+            font_style.set_font_weight(font_weight::normal());
             font_style.set_font_style(font_style::normal);
         }
     }


### PR DESCRIPTION
It doesn't make much sense to store `font-weight` as separate enums, especially given that we would need to support (somehow) arbitrary font weight value when we implement CSS Fonts Level 4.

This PR refactors the `font-weight` a bit to make it store as `u16` directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17430)
<!-- Reviewable:end -->
