### PR TITLE
Add an update_stylesheet method to StylesheetSet.

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1886,6 +1886,11 @@ extern "C" {
                                                  before_unique_id: u64);
 }
 extern "C" {
+    pub fn Servo_StyleSet_UpdateStyleSheet(set: RawServoStyleSetBorrowed,
+                                           sheet: RawServoStyleSheetBorrowed,
+                                           unique_id: u64);
+}
+extern "C" {
     pub fn Servo_StyleSet_FlushStyleSheets(set: RawServoStyleSetBorrowed,
                                            doc_elem:
                                                RawGeckoElementBorrowedOrNull);

--- a/components/style/stylesheet_set.rs
+++ b/components/style/stylesheet_set.rs
@@ -137,6 +137,23 @@ impl StylesheetSet {
             guard)
     }
 
+    /// Update the sheet that matches the unique_id.
+    pub fn update_stylesheet(
+        &mut self,
+        sheet: &Arc<Stylesheet>,
+        unique_id: u64)
+    {
+        // Since this function doesn't set self.dirty, or call
+        // self.invalidations.collect_invalidations_for, it should
+        // only be called in the case where sheet is a clone of
+        // the sheet it is updating.
+        debug!("StylesheetSet::update_stylesheet");
+        if let Some(entry) = self.entries.iter_mut().find(
+            |e| e.unique_id == unique_id) {
+            entry.sheet = sheet.clone();
+        }
+    }
+
     /// Remove a given stylesheet from the set.
     pub fn remove_stylesheet(&mut self, unique_id: u64) {
         debug!("StylesheetSet::remove_stylesheet");

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -910,6 +910,17 @@ pub extern "C" fn Servo_StyleSet_InsertStyleSheetBefore(raw_data: RawServoStyleS
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_StyleSet_UpdateStyleSheet(raw_data: RawServoStyleSetBorrowed,
+                                                  raw_sheet: RawServoStyleSheetBorrowed,
+                                                  unique_id: u64) {
+    let mut data = PerDocumentStyleData::from_ffi(raw_data).borrow_mut();
+    let sheet = HasArcFFI::as_arc(&raw_sheet);
+    data.stylesheets.update_stylesheet(
+        sheet,
+        unique_id);
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_StyleSet_RemoveStyleSheet(raw_data: RawServoStyleSetBorrowed,
                                                   unique_id: u64) {
     let mut data = PerDocumentStyleData::from_ffi(raw_data).borrow_mut();


### PR DESCRIPTION
MozReview-Commit-ID: KlRkApYL8wk

<!-- Please describe your changes on the following line: -->
Provides a method for just-cloned sheets to be swapped in to stylesheet_sets without changing the order or triggering restyle.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17436)
<!-- Reviewable:end -->
