### PR TITLE
style: Don't use SmallVec::into_iter to move into another vector.

### DIFF
--- a/components/style/invalidation/element/invalidator.rs
+++ b/components/style/invalidation/element/invalidator.rs
@@ -492,7 +492,7 @@ impl<'a, 'b: 'a, E> TreeStyleInvalidator<'a, 'b, E>
             }
         }
 
-        sibling_invalidations.extend(new_sibling_invalidations.into_iter());
+        sibling_invalidations.extend(new_sibling_invalidations.drain());
         invalidated_self
     }
 


### PR DESCRIPTION
See bug 1374848 for why.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17443)
<!-- Reviewable:end -->
