### PR TITLE
Commiting a trivial README.md change for the Firefox sheriffs to backout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Linux Build Status](https://img.shields.io/travis/servo/servo/master.svg?label=Linux%20build)](https://travis-ci.org/servo/servo)  [![Windows Build Status](https://img.shields.io/appveyor/ci/servo/servo/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/servo/servo/branch/master)  [![Changelog #228](https://img.shields.io/badge/changelog-%23228-9E978E.svg)](https://changelog.com/podcast/228)
 
-Servo is a prototype web browser engine written in the
+Servo is a web browser engine written in the
 [Rust](https://github.com/rust-lang/rust) language. It is currently developed on
 64bit OS X, 64bit Linux, and Android.
 


### PR DESCRIPTION
This change is intended to be used to test the backout scripts from the Firefox side. See the following mail thread for more details:
https://groups.google.com/forum/#!topic/mozilla.dev.servo/j4C7U_H_T2A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17452)
<!-- Reviewable:end -->
