### PR TITLE
Implement webkit prefixed values for display property

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -19,9 +19,10 @@
         values = """inline block inline-block
             table inline-table table-row-group table-header-group table-footer-group
             table-row table-column-group table-column table-cell table-caption
-            list-item flex inline-flex
-            none
+            list-item none
         """.split()
+        webkit_prefixed_values = "flex inline-flex".split()
+        values += webkit_prefixed_values
         if product == "gecko":
             values += """grid inline-grid ruby ruby-base ruby-base-container
                 ruby-text ruby-text-container contents flow-root -webkit-box
@@ -118,6 +119,11 @@
         try_match_ident_ignore_ascii_case! { input.expect_ident()?,
             % for value in values:
                 "${value}" => {
+                    Ok(computed_value::T::${to_rust_ident(value)})
+                },
+            % endfor
+            % for value in webkit_prefixed_values:
+                "-webkit-${value}" => {
                     Ok(computed_value::T::${to_rust_ident(value)})
                 },
             % endfor


### PR DESCRIPTION
Added -webkit-{flex,inline-flex} values as flex, inline-flex. I didn't do this gecko only since that doesn't require anything in layout side.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15400 (github issue number if applicable).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17455)
<!-- Reviewable:end -->
