### PR TITLE
Add get_zero_value for IntermediateSVGPaint.

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -2765,7 +2765,7 @@ impl Animatable for IntermediateRGBA {
 
     #[inline]
     fn get_zero_value(&self) -> Option<Self> {
-        Some(IntermediateRGBA::new(0., 0., 0., 1.))
+        Some(IntermediateRGBA::transparent())
     }
 
     #[inline]
@@ -2982,6 +2982,14 @@ impl Animatable for IntermediateSVGPaint {
         Ok(self.kind.compute_squared_distance(&other.kind)? +
             self.fallback.compute_squared_distance(&other.fallback)?)
     }
+
+    #[inline]
+    fn get_zero_value(&self) -> Option<Self> {
+        Some(IntermediateSVGPaint {
+            kind: option_try!(self.kind.get_zero_value()),
+            fallback: self.fallback.and_then(|v| v.get_zero_value()),
+        })
+    }
 }
 
 impl Animatable for IntermediateSVGPaintKind {
@@ -3010,6 +3018,18 @@ impl Animatable for IntermediateSVGPaintKind {
             (&SVGPaintKind::ContextFill, &SVGPaintKind::ContextFill) |
             (&SVGPaintKind::ContextStroke, &SVGPaintKind::ContextStroke)=> Ok(0.0),
             _ => Err(())
+        }
+    }
+
+    #[inline]
+    fn get_zero_value(&self) -> Option<Self> {
+        match self {
+            &SVGPaintKind::Color(ref color) => color.get_zero_value()
+                                                    .map(SVGPaintKind::Color),
+            &SVGPaintKind::None |
+            &SVGPaintKind::ContextFill |
+            &SVGPaintKind::ContextStroke =>  Some(self.clone()),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is a PR for https://bugzilla.mozilla.org/show_bug.cgi?id=1371199


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
There are tests for these changes, a test case will be landed in reftests in https://bugzilla.mozilla.org/show_bug.cgi?id=1371199

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17288)
<!-- Reviewable:end -->
