### PR TITLE
stylo: Implement custom property value getter

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -3083,3 +3083,21 @@ pub extern "C" fn Servo_StyleSet_HasStateDependency(raw_data: RawServoStyleSetBo
     let data = PerDocumentStyleData::from_ffi(raw_data).borrow();
     data.stylist.might_have_state_dependency(ElementState::from_bits_truncate(state))
 }
+
+#[no_mangle]
+pub extern "C" fn Servo_GetCustomProperty(computed_values: ServoComputedValuesBorrowed,
+                                          name: *const nsAString, value: *mut nsAString) -> bool {
+    let custom_properties = match ComputedValues::as_arc(&computed_values).custom_properties() {
+        Some(p) => p,
+        None => return false,
+    };
+
+    let name = unsafe { Atom::from((&*name)) };
+    let computed_value = match custom_properties.get(&name) {
+        Some(v) => v,
+        None => return false,
+    };
+
+    computed_value.to_css(unsafe { value.as_mut().unwrap() }).unwrap();
+    true
+}


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

https://bugzilla.mozilla.org/show_bug.cgi?id=1336891

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17470)
<!-- Reviewable:end -->
