### PR TITLE
return Option from GlobalScope::current

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -543,12 +543,16 @@ impl GlobalScope {
     ///
     /// ["current"]: https://html.spec.whatwg.org/multipage/#current
     #[allow(unsafe_code)]
-    pub fn current() -> Root<Self> {
+    pub fn current() -> Option<Root<Self>> {
         unsafe {
             let cx = Runtime::get();
             assert!(!cx.is_null());
             let global = CurrentGlobalOrNull(cx);
-            global_scope_from_global(global)
+            if global.is_null() {
+                None
+            } else {
+                Some(global_scope_from_global(global))
+            }
         }
     }
 

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -590,7 +590,7 @@ impl HTMLIFrameElementMethods for HTMLIFrameElement {
             Some(document) => document,
         };
         // Step 4.
-        let current = GlobalScope::current().as_window().Document();
+        let current = GlobalScope::current().expect("No current global object").as_window().Document();
         if !current.origin().same_origin_domain(document.origin()) {
             return None;
         }

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -241,7 +241,7 @@ impl PermissionAlgorithm for Permissions {
                 let state =
                     prompt_user(&format!("{} {} ?", REQUEST_DIALOG_MESSAGE, perm_name.clone()));
 
-                let globalscope = GlobalScope::current();
+                let globalscope = GlobalScope::current().expect("No current global object");
                 globalscope.as_window()
                            .permission_state_invocation_results()
                            .borrow_mut()
@@ -266,7 +266,7 @@ pub fn get_descriptor_permission_state(permission_name: PermissionName,
     // Step 1.
     let settings = match env_settings_obj {
         Some(env_settings_obj) => Root::from_ref(env_settings_obj),
-        None => GlobalScope::current(),
+        None => GlobalScope::current().expect("No current global object"),
     };
 
     // Step 2.

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -586,7 +586,7 @@ impl WindowMethods for Window {
         };
         // Step 6.
         let container_doc = document_from_node(container);
-        let current_doc = GlobalScope::current().as_window().Document();
+        let current_doc = GlobalScope::current().expect("No current global object").as_window().Document();
         if !current_doc.origin().same_origin_domain(container_doc.origin()) {
             return None;
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
handles the case where `GlobalScope::current` calls `CurrentGlobalOrNull` and the result is null

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17238

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because: no functionality change & ./mach build -d has no errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17472)
<!-- Reviewable:end -->
