### PR TITLE
Multiple gecko backouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Linux Build Status](https://img.shields.io/travis/servo/servo/master.svg?label=Linux%20build)](https://travis-ci.org/servo/servo)  [![Windows Build Status](https://img.shields.io/appveyor/ci/servo/servo/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/servo/servo/branch/master)  [![Changelog #228](https://img.shields.io/badge/changelog-%23228-9E978E.svg)](https://changelog.com/podcast/228)
 
-Servo is a web browser engine written in the
+Servo is a prototype web browser engine written in the
 [Rust](https://github.com/rust-lang/rust) language. It is currently developed on
 64bit OS X, 64bit Linux, and Android.
 


### PR DESCRIPTION
@bors-servo r+ force treeclosed=9001

Backed out changeset f5041651b877 (bug 17452) as requested by glob. r=backout

Backs out https://github.com/servo/servo/pull/17452

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17473)
<!-- Reviewable:end -->

---

Backed out changeset de9bb450199d  on request from glob

Backs out https://github.com/servo/servo/pull/17452