### PR TITLE
Treat application/xml like text/xml in ParserContext::process_response

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -648,13 +648,14 @@ impl FetchResponseListener for ParserContext {
                     parser.parse_sync();
                 }
             },
-            Some(ContentType(Mime(TopLevel::Text, SubLevel::Xml, _))) => {}, // Handle text/xml
+            // Handle xml (text/xml, application/xml, application/xhtml+xml)
+            Some(ContentType(Mime(ref toplevel @ _, ref sublevel @ _, _)))
+            if (
+                ((toplevel == &TopLevel::Application) && (sublevel.as_str() == "xhtml+xml")) ||
+                ((toplevel == &TopLevel::Application) && (sublevel == &SubLevel::Xml)) ||
+                ((toplevel == &TopLevel::Text) && (sublevel == &SubLevel::Xml))
+            ) => {},
             Some(ContentType(Mime(toplevel, sublevel, _))) => {
-                if toplevel.as_str() == "application" && sublevel.as_str() == "xhtml+xml" {
-                    // Handle xhtml (application/xhtml+xml).
-                    return;
-                }
-
                 // Show warning page for unknown mime types.
                 let page = format!("<html><body><p>Unknown content type ({}/{}).</p></body></html>",
                                    toplevel.as_str(),

--- a/tests/wpt/metadata/dom/nodes/Document-contentType/contentType/contenttype_html.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-contentType/contentType/contenttype_html.html.ini
@@ -1,0 +1,6 @@
+[contenttype_html.html]
+  type: testharness
+  expected: TIMEOUT
+  [HTM document.contentType === 'text/html']
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/dom/nodes/Document-contentType/contentType/contenttype_png.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-contentType/contentType/contenttype_png.html.ini
@@ -1,0 +1,6 @@
+[contenttype_png.html]
+  type: testharness
+  expected: TIMEOUT
+  [PNG document.contentType === 'image/png']
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/dom/nodes/Document-contentType/contentType/contenttype_txt.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-contentType/contentType/contenttype_txt.html.ini
@@ -1,0 +1,6 @@
+[contenttype_txt.html]
+  type: testharness
+  expected: TIMEOUT
+  [TXT document.contentType === 'text/plain']
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/dom/nodes/Document-createElement.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-createElement.html.ini
@@ -1,5 +1,6 @@
 [Document-createElement.html]
   type: testharness
+  expected: TIMEOUT
   [createElement(undefined) in XML document]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/nodes/Document-createElementNS.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-createElementNS.html.ini
@@ -1,5 +1,6 @@
 [Document-createElementNS.html]
   type: testharness
+  expected: TIMEOUT
   [createElementNS test in XML document: null,null,null]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/nodes/Element-childElementCount-dynamic-add.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-childElementCount-dynamic-add.html.ini
@@ -1,0 +1,3 @@
+[Element-childElementCount-dynamic-add.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-childElementCount-dynamic-remove.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-childElementCount-dynamic-remove.html.ini
@@ -1,0 +1,3 @@
+[Element-childElementCount-dynamic-remove.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-childElementCount-xhtml.xhtml.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-childElementCount-xhtml.xhtml.ini
@@ -1,0 +1,3 @@
+[Element-childElementCount-xhtml.xhtml]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-childElementCount.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-childElementCount.html.ini
@@ -1,0 +1,3 @@
+[Element-childElementCount.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-firstElementChild-namespace-xhtml.xhtml.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-firstElementChild-namespace-xhtml.xhtml.ini
@@ -1,0 +1,3 @@
+[Element-firstElementChild-namespace-xhtml.xhtml]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-firstElementChild-xhtml.xhtml.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-firstElementChild-xhtml.xhtml.ini
@@ -1,0 +1,3 @@
+[Element-firstElementChild-xhtml.xhtml]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-firstElementChild.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-firstElementChild.html.ini
@@ -1,0 +1,3 @@
+[Element-firstElementChild.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-lastElementChild-xhtml.xhtml.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-lastElementChild-xhtml.xhtml.ini
@@ -1,0 +1,3 @@
+[Element-lastElementChild-xhtml.xhtml]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-lastElementChild.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-lastElementChild.html.ini
@@ -1,0 +1,3 @@
+[Element-lastElementChild.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-matches.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-matches.html.ini
@@ -1,5 +1,6 @@
 [Element-matches.html]
   type: testharness
+  expected: TIMEOUT
   [In-document Element.matches: Universal selector, matching all children of the specified reference element (with refNode Element): >*]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/nodes/Element-nextElementSibling-xhtml.xhtml.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-nextElementSibling-xhtml.xhtml.ini
@@ -1,0 +1,3 @@
+[Element-nextElementSibling-xhtml.xhtml]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-nextElementSibling.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-nextElementSibling.html.ini
@@ -1,0 +1,3 @@
+[Element-nextElementSibling.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-previousElementSibling-xhtml.xhtml.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-previousElementSibling-xhtml.xhtml.ini
@@ -1,0 +1,3 @@
+[Element-previousElementSibling-xhtml.xhtml]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-previousElementSibling.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-previousElementSibling.html.ini
@@ -1,0 +1,3 @@
+[Element-previousElementSibling.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-siblingElement-null-xhtml.xhtml.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-siblingElement-null-xhtml.xhtml.ini
@@ -1,0 +1,3 @@
+[Element-siblingElement-null-xhtml.xhtml]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-siblingElement-null.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-siblingElement-null.html.ini
@@ -1,0 +1,3 @@
+[Element-siblingElement-null.html]
+  type: testharness
+  expected: TIMEOUT

--- a/tests/wpt/metadata/dom/nodes/Element-webkitMatchesSelector.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Element-webkitMatchesSelector.html.ini
@@ -1,5 +1,6 @@
 [Element-webkitMatchesSelector.html]
   type: testharness
+  expected: TIMEOUT
   [In-document Element.webkitMatchesSelector: Descendant combinator '>>', matching element that is a descendant of an element with id (with no refNodes): #descendant>>div]
     expected: FAIL
 
@@ -74,4 +75,7 @@
 
   [In-document Element.webkitMatchesSelector: Descendant combinator, '>>', matching element with class that is a descendant of an element with class (1) (with no refNodes): .descendant-div1>>.descendant-div3]
     expected: FAIL
+
+  [Selectors-API Level 2 Test Suite: HTML with Selectors Level 3]
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/dom/nodes/Node-isEqualNode-xhtml.xhtml.ini
+++ b/tests/wpt/metadata/dom/nodes/Node-isEqualNode-xhtml.xhtml.ini
@@ -1,5 +1,6 @@
 [Node-isEqualNode-xhtml.xhtml]
   type: testharness
+  expected: TIMEOUT
   [isEqualNode should return true when only the internal subsets of DocumentTypes differ.]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/nodes/ParentNode-querySelector-All-xht.xht.ini
+++ b/tests/wpt/metadata/dom/nodes/ParentNode-querySelector-All-xht.xht.ini
@@ -1,5 +1,6 @@
 [ParentNode-querySelector-All-xht.xht]
   type: testharness
+  expected: TIMEOUT
   [Document.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
     expected: FAIL
 
@@ -251,4 +252,7 @@
 
   [In-document Element.querySelector: Descendant combinator '>>', not matching element with id that is not a descendant of an element with id: #descendant-div1>>#descendant-div4]
     expected: FAIL
+
+  [Selectors-API Test Suite: XHTML]
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/dom/nodes/ParentNode-querySelector-All.html.ini
+++ b/tests/wpt/metadata/dom/nodes/ParentNode-querySelector-All.html.ini
@@ -1,5 +1,6 @@
 [ParentNode-querySelector-All.html]
   type: testharness
+  expected: TIMEOUT
   [Document.querySelectorAll: :first-line pseudo-element (one-colon syntax) selector, not matching any elements: #pseudo-element:first-line]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/nodes/getElementsByClassName-30.htm.ini
+++ b/tests/wpt/metadata/dom/nodes/getElementsByClassName-30.htm.ini
@@ -1,0 +1,3 @@
+[getElementsByClassName-30.htm]
+  type: testharness
+  expected: TIMEOUT


### PR DESCRIPTION
- components/script/dom/servoparser/mod.rs: merged existing xml-related branches into one and added application/xml as a supported type in that branch.
- tests updated to expect the new result

Fixes #15850 

---
- [X] `./mach build` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes modify expected results in test files via the automated: `./mach test-wpt tests/wpt/web-platform-tests/dom/nodes --log-raw /tmp/servo && ./mach update-wpt /tmp/servo`
- [ ] The tests run consistently

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17474)
<!-- Reviewable:end -->
