### PR TITLE
Added exception-handling to worker wpt tests.

### DIFF
--- a/tests/wpt/metadata/workers/Worker_ErrorEvent_error.htm.ini
+++ b/tests/wpt/metadata/workers/Worker_ErrorEvent_error.htm.ini
@@ -1,2 +1,0 @@
-[Worker_ErrorEvent_error.htm]
-  expected: ERROR

--- a/tests/wpt/metadata/workers/data-url.html.ini
+++ b/tests/wpt/metadata/workers/data-url.html.ini
@@ -1,6 +1,5 @@
 [data-url.html]
   type: testharness
-  expected: ERROR
   [worker has opaque origin]
     expected: FAIL
 

--- a/tests/wpt/web-platform-tests/workers/Worker_ErrorEvent_error.htm
+++ b/tests/wpt/web-platform-tests/workers/Worker_ErrorEvent_error.htm
@@ -4,6 +4,10 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
+// The worker events races with the window's load event; if the worker events
+// arrive first, the harness will detect the error event and fail the test.
+setup({ allow_uncaught_exception: true });
+
 var t1 = async_test("Error handler outside the worker should not see the error value");
 var t2 = async_test("Error handlers inside a worker should see the error value");
 

--- a/tests/wpt/web-platform-tests/workers/data-url.html
+++ b/tests/wpt/web-platform-tests/workers/data-url.html
@@ -25,7 +25,9 @@ function assert_worker_construction_fails(test_desc, mime_type, worker_code) {
     w.onmessage = t.step_func_done(function(e) {
       assert_unreached('Should not receive any message back.');
     });
-    w.onerror = t.step_func_done(function() {
+    w.onerror = t.step_func_done(function(e) {
+      // Stop the error from being propagated to the WPT test harness
+      e.preventDefault();
     });
   }, test_desc);
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Added exception-handling to worker wpt tests.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15668 and #17460 
- [X] These changes do not require tests because these are tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17475)
<!-- Reviewable:end -->
