### PR TITLE
Serialize style attributes on demand…

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -70,3 +70,8 @@ gattserverdisconnected
 onchange
 
 reftest-wait
+
+icon
+apple-touch-icon
+stylesheet
+alternate

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1689,8 +1689,8 @@ impl<N> ObjectElement for N  where N: ThreadSafeLayoutNode {
     fn has_object_data(&self) -> bool {
         let elem = self.as_element().unwrap();
         let type_and_data = (
-            elem.get_attr(&ns!(), &local_name!("type")),
-            elem.get_attr(&ns!(), &local_name!("data")),
+            elem.get_attr_enum(&ns!(), &local_name!("type")),
+            elem.get_attr_enum(&ns!(), &local_name!("data")).map(|a| a.as_string()),
         );
         match type_and_data {
             (None, Some(uri)) => is_image_data(uri),
@@ -1700,9 +1700,10 @@ impl<N> ObjectElement for N  where N: ThreadSafeLayoutNode {
 
     fn object_data(&self) -> Option<ServoUrl> {
         let elem = self.as_element().unwrap();
+
         let type_and_data = (
-            elem.get_attr(&ns!(), &local_name!("type")),
-            elem.get_attr(&ns!(), &local_name!("data")),
+            elem.get_attr_enum(&ns!(), &local_name!("type")),
+            elem.get_attr_enum(&ns!(), &local_name!("data")).map(|a| a.as_string()),
         );
         match type_and_data {
             (None, Some(uri)) if is_image_data(uri) => ServoUrl::parse(uri).ok(),

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -628,8 +628,9 @@ impl TableColumnFragmentInfo {
     /// Create the information specific to an table column fragment.
     pub fn new<N: ThreadSafeLayoutNode>(node: &N) -> TableColumnFragmentInfo {
         let element = node.as_element().unwrap();
-        let span = element.get_attr(&ns!(), &local_name!("span"))
-                          .and_then(|string| string.parse().ok())
+        // FIXME(emilio): Parse this as AttrValue::UInt beforehand.
+        let span = element.get_attr_enum(&ns!(), &local_name!("span"))
+                          .and_then(|a| a.as_string().parse().ok())
                           .unwrap_or(0);
         TableColumnFragmentInfo {
             span: span,

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -57,12 +57,10 @@ impl CSSStyleOwner {
                 let document = document_from_node(&**el);
                 let shared_lock = document.style_shared_lock();
                 let mut attr = el.style_attribute().borrow_mut().take();
-                let result = if attr.is_some() {
-                    let lock = attr.as_ref().unwrap();
+                let result = if let Some(ref lock) = attr {
                     let mut guard = shared_lock.write();
                     let mut pdb = lock.write_with(&mut guard);
-                    let result = f(&mut pdb, &mut changed);
-                    result
+                    f(&mut pdb, &mut changed)
                 } else {
                     let mut pdb = PropertyDeclarationBlock::new();
                     let result = f(&mut pdb, &mut changed);
@@ -85,11 +83,7 @@ impl CSSStyleOwner {
                     //
                     // [1]: https://github.com/whatwg/html/issues/2306
                     if let Some(pdb) = attr {
-                        let guard = shared_lock.read();
-                        let serialization = pdb.read_with(&guard).to_css_string();
-                        el.set_attribute(&local_name!("style"),
-                                         AttrValue::Declaration(serialization,
-                                                                pdb));
+                        el.set_attribute(&local_name!("style"), AttrValue::Declaration(pdb));
                     }
                 } else {
                     // Remember to put it back.

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -715,7 +715,7 @@ impl Document {
         let check_anchor = |node: &HTMLAnchorElement| {
             let elem = node.upcast::<Element>();
             elem.get_attribute(&ns!(), &local_name!("name"))
-                .map_or(false, |attr| &**attr.value() == name)
+                .map_or(false, |attr| &**attr.value().as_atom() == name)
         };
         let doc_node = self.upcast::<Node>();
         doc_node.traverse_preorder()
@@ -3204,7 +3204,7 @@ impl DocumentMethods for Document {
                 return false;
             }
             element.get_attribute(&ns!(), &local_name!("name"))
-                   .map_or(false, |attr| &**attr.value() == &*name)
+                   .map_or(false, |attr| &*attr.value().as_atom() == &*name)
         })
     }
 

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -67,7 +67,7 @@ impl HTMLAnchorElement {
         let attribute = self.upcast::<Element>().get_attribute(&ns!(), &local_name!("href"));
         *self.url.borrow_mut() = attribute.and_then(|attribute| {
             let document = document_from_node(self);
-            document.base_url().join(&attribute.value()).ok()
+            document.base_url().join(attribute.value().as_string()).ok()
         });
     }
 
@@ -276,7 +276,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
                     // Step 3.
                     None => String::new(),
                     // Step 4.
-                    Some(attribute) => (**attribute.value()).to_owned(),
+                    Some(attribute) => attribute.value().as_string().to_owned(),
                 }
             },
             // Step 5.

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -46,7 +46,7 @@ impl HTMLBaseElement {
                      that have a base url.");
         let document = document_from_node(self);
         let base = document.fallback_base_url();
-        let parsed = base.join(&href.value());
+        let parsed = base.join(href.value().as_string());
         parsed.unwrap_or(base)
     }
 

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -167,15 +167,16 @@ impl VirtualMethods for HTMLBodyElement {
                     &local_name!("onoffline") | &local_name!("ononline") |
                     &local_name!("onpagehide") | &local_name!("onpageshow") |
                     &local_name!("onpopstate") | &local_name!("onstorage") |
-                    &local_name!("onresize") | &local_name!("onunload") | &local_name!("onerror")
-                      => {
-                          let evtarget = window.upcast::<EventTarget>(); // forwarded event
-                          let source_line = 1; //TODO(#9604) obtain current JS execution line
-                          evtarget.set_event_handler_uncompiled(window.get_url(),
-                                                                source_line,
-                                                                &name[2..],
-                                                                DOMString::from(attr.value().serialize()));
-                          false
+                    &local_name!("onresize") | &local_name!("onunload") | &local_name!("onerror") => {
+                        let evtarget = window.upcast::<EventTarget>(); // forwarded event
+                        let source_line = 1; //TODO(#9604) obtain current JS execution line
+                        evtarget.set_event_handler_uncompiled(
+                            window.get_url(),
+                            source_line,
+                            &name[2..],
+                            DOMString::from(attr.value().as_string())
+                        );
+                        false
                     }
                     _ => true, // HTMLElement::attribute_mutated will take care of this.
                 }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -174,7 +174,7 @@ impl VirtualMethods for HTMLBodyElement {
                           evtarget.set_event_handler_uncompiled(window.get_url(),
                                                                 source_line,
                                                                 &name[2..],
-                                                                DOMString::from((**attr.value()).to_owned()));
+                                                                DOMString::from(attr.value().serialize()));
                           false
                     }
                     _ => true, // HTMLElement::attribute_mutated will take care of this.

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -202,7 +202,8 @@ impl VirtualMethods for HTMLButtonElement {
             &local_name!("type") => {
                 match mutation {
                     AttributeMutation::Set(_) => {
-                        let value = match &**attr.value() {
+                        // FIXME(emilio): Match on Atoms instead.
+                        let value = match &**attr.value().as_atom() {
                             "reset" => ButtonType::Reset,
                             "button" => ButtonType::Button,
                             "menu" => ButtonType::Menu,

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -439,8 +439,10 @@ impl HTMLElement {
     pub fn get_custom_attr(&self, local_name: DOMString) -> Option<DOMString> {
         // FIXME(ajeffrey): Convert directly from DOMString to LocalName
         let local_name = LocalName::from(to_snake_case(local_name));
-        self.upcast::<Element>().get_attribute(&ns!(), &local_name).map(|attr| {
-            DOMString::from(attr.value().serialize()) // FIXME(ajeffrey): Convert directly from AttrValue to DOMString
+        let element = self.upcast::<Element>();
+        element.get_attribute(&ns!(), &local_name).map(|attr| {
+            // FIXME(ajeffrey): Convert directly from AttrValue to DOMString
+            DOMString::from(element.serialize_attr(&attr))
         })
     }
 
@@ -557,7 +559,7 @@ impl VirtualMethods for HTMLElement {
                                                       source_line,
                                                       &name[2..],
                                                       // FIXME(ajeffrey): Convert directly from AttrValue to DOMString
-                                                      DOMString::from(attr.value().serialize()));
+                                                      DOMString::from(attr.value().as_string()));
             },
             _ => {}
         }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -440,7 +440,7 @@ impl HTMLElement {
         // FIXME(ajeffrey): Convert directly from DOMString to LocalName
         let local_name = LocalName::from(to_snake_case(local_name));
         self.upcast::<Element>().get_attribute(&ns!(), &local_name).map(|attr| {
-            DOMString::from(&**attr.value()) // FIXME(ajeffrey): Convert directly from AttrValue to DOMString
+            DOMString::from(attr.value().serialize()) // FIXME(ajeffrey): Convert directly from AttrValue to DOMString
         })
     }
 
@@ -557,7 +557,7 @@ impl VirtualMethods for HTMLElement {
                                                       source_line,
                                                       &name[2..],
                                                       // FIXME(ajeffrey): Convert directly from AttrValue to DOMString
-                                                      DOMString::from(&**attr.value()));
+                                                      DOMString::from(attr.value().serialize()));
             },
             _ => {}
         }

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -57,7 +57,7 @@ impl HTMLHeadElement {
         for meta in candidates {
             if let Some(content) = meta.get_attribute(&ns!(), &local_name!("content")).r() {
                 let content = content.value();
-                let content_val = content.trim();
+                let content_val = content.as_string().trim();
                 if !content_val.is_empty() {
                     doc.set_referrer_policy(determine_policy_for_token(content_val));
                     return;

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -105,6 +105,7 @@ impl HTMLIFrameElement {
         let element = self.upcast::<Element>();
         element.get_attribute(&ns!(), &local_name!("src")).and_then(|src| {
             let url = src.value();
+            let url = url.as_string();
             if url.is_empty() {
                 None
             } else {

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -687,6 +687,7 @@ impl HTMLImageElement {
         };
 
         let value = usemap_attr.value();
+        let value = value.as_string();
 
         if value.len() == 0 || !value.is_char_boundary(1) {
             return None

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -217,7 +217,8 @@ impl LayoutHTMLInputElementHelpers for LayoutJS<HTMLInputElement> {
         unsafe fn get_raw_attr_value(input: LayoutJS<HTMLInputElement>, default: &str) -> String {
             let elem = input.upcast::<Element>();
             let value = (*elem.unsafe_get())
-                .get_attr_val_for_layout(&ns!(), &local_name!("value"))
+                .get_attr_for_layout(&ns!(), &local_name!("value"))
+                .map(|v| v.as_string())
                 .unwrap_or(default);
             String::from(value)
         }
@@ -992,7 +993,7 @@ impl VirtualMethods for HTMLInputElement {
                 self.update_placeholder_shown_state();
             },
             &local_name!("value") if !self.value_changed.get() => {
-                let value = mutation.new_value(attr).map(|value| (**value).to_owned());
+                let value = mutation.new_value(attr).map(|value| value.as_string().to_owned());
                 self.textinput.borrow_mut().set_content(
                     value.map_or(DOMString::new(), DOMString::from));
                 self.update_placeholder_shown_state();
@@ -1031,7 +1032,7 @@ impl VirtualMethods for HTMLInputElement {
                     placeholder.clear();
                     if let AttributeMutation::Set(_) = mutation {
                         placeholder.extend(
-                            attr.value().chars().filter(|&c| c != '\n' && c != '\r'));
+                            attr.value().as_string().chars().filter(|&c| c != '\n' && c != '\r'));
                     }
                 }
                 self.update_placeholder_shown_state();

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -21,7 +21,6 @@ use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix};
 use parking_lot::RwLock;
 use servo_config::prefs::PREFS;
-use std::ascii::AsciiExt;
 use std::sync::atomic::AtomicBool;
 use style::attr::AttrValue;
 use style::media_queries::MediaList;
@@ -77,7 +76,7 @@ impl HTMLMetaElement {
     fn process_attributes(&self) {
         let element = self.upcast::<Element>();
         if let Some(name) = element.get_attribute(&ns!(), &local_name!("name")).r() {
-            let name = name.value().to_ascii_lowercase();
+            let name = name.value().as_atom().to_ascii_lowercase();
             let name = name.trim_matches(HTML_SPACE_CHARACTERS);
 
             if name == "viewport" {
@@ -97,8 +96,9 @@ impl HTMLMetaElement {
         let element = self.upcast::<Element>();
         if let Some(content) = element.get_attribute(&ns!(), &local_name!("content")).r() {
             let content = content.value();
+            let content = content.as_string();
             if !content.is_empty() {
-                if let Some(translated_rule) = ViewportRule::from_meta(&**content) {
+                if let Some(translated_rule) = ViewportRule::from_meta(content) {
                     let document = self.upcast::<Node>().owner_doc();
                     let shared_lock = document.style_shared_lock();
                     let rule = CssRule::Viewport(Arc::new(shared_lock.wrap(translated_rule)));
@@ -125,7 +125,7 @@ impl HTMLMetaElement {
     fn process_referrer_attribute(&self) {
         let element = self.upcast::<Element>();
         if let Some(name) = element.get_attribute(&ns!(), &local_name!("name")).r() {
-            let name = name.value().to_ascii_lowercase();
+            let name = name.value().as_atom().to_ascii_lowercase();
             let name = name.trim_matches(HTML_SPACE_CHARACTERS);
 
             if name == "referrer" {

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -79,9 +79,13 @@ impl HTMLStyleElement {
         let doc = document_from_node(self);
 
         let mq_attribute = element.get_attribute(&ns!(), &local_name!("media"));
+        let attr_value;
         let mq_str = match mq_attribute {
-            Some(a) => String::from(&**a.value()),
-            None => String::new(),
+            Some(ref a) => {
+                attr_value = a.value();
+                attr_value.as_string()
+            }
+            None => "",
         };
 
         let data = node.GetTextContent().expect("Element.textContent must be a string");
@@ -92,7 +96,7 @@ impl HTMLStyleElement {
                                                       PARSING_MODE_DEFAULT,
                                                       doc.quirks_mode());
         let shared_lock = node.owner_doc().style_shared_lock().clone();
-        let mut input = ParserInput::new(&mq_str);
+        let mut input = ParserInput::new(mq_str);
         let mq = Arc::new(shared_lock.wrap(
                     parse_media_query_list(&context, &mut CssParser::new(&mut input))));
         let loader = StylesheetLoader::for_element(self.upcast());

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -330,7 +330,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                     let mut placeholder = self.placeholder.borrow_mut();
                     placeholder.clear();
                     if let AttributeMutation::Set(_) = mutation {
-                        placeholder.push_str(&attr.value());
+                        placeholder.push_str(attr.value().as_string());
                     }
                 }
                 self.update_placeholder_shown_state();

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2307,7 +2307,7 @@ impl NodeMethods for Node {
                 other_element.attrs().iter().any(|other_attr| {
                     *attr.namespace() == *other_attr.namespace() &&
                     attr.local_name() == other_attr.local_name() &&
-                    attr.value().serialize() == other_attr.value().serialize()
+                    element.serialize_attr(attr) == other_element.serialize_attr(other_attr)
                 })
             })
         }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2302,12 +2302,12 @@ impl NodeMethods for Node {
         fn is_equal_element_attrs(node: &Node, other: &Node) -> bool {
             let element = node.downcast::<Element>().unwrap();
             let other_element = other.downcast::<Element>().unwrap();
-            assert!(element.attrs().len() == other_element.attrs().len());
+            assert_eq!(element.attrs().len(), other_element.attrs().len());
             element.attrs().iter().all(|attr| {
                 other_element.attrs().iter().any(|other_attr| {
-                    (*attr.namespace() == *other_attr.namespace()) &&
-                    (attr.local_name() == other_attr.local_name()) &&
-                    (**attr.value() == **other_attr.value())
+                    *attr.namespace() == *other_attr.namespace() &&
+                    attr.local_name() == other_attr.local_name() &&
+                    attr.value().serialize() == other_attr.value().serialize()
                 })
             })
         }

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -128,11 +128,11 @@ impl<'a> Serialize for &'a Node {
                     let attrs = elem.attrs().iter().map(|attr| {
                         let qname = QualName::new(None, attr.namespace().clone(),
                                                   attr.local_name().clone());
-                        let value = attr.value().clone();
+                        let value = attr.value().serialize().clone();
                         (qname, value)
                     }).collect::<Vec<_>>();
                     let attr_refs = attrs.iter().map(|&(ref qname, ref value)| {
-                        let ar: AttrRef = (&qname, &**value);
+                        let ar: AttrRef = (&qname, &*value);
                         ar
                     });
                     serializer.start_elem(name.clone(), attr_refs)?;

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -128,7 +128,7 @@ impl<'a> Serialize for &'a Node {
                     let attrs = elem.attrs().iter().map(|attr| {
                         let qname = QualName::new(None, attr.namespace().clone(),
                                                   attr.local_name().clone());
-                        let value = attr.value().serialize().clone();
+                        let value = elem.serialize_attr(attr);
                         (qname, value)
                     }).collect::<Vec<_>>();
                     let attr_refs = attrs.iter().map(|&(ref qname, ref value)| {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -899,8 +899,8 @@ impl TreeSink for Sink {
     fn is_mathml_annotation_xml_integration_point(&self, handle: &JS<Node>) -> bool {
         let elem = handle.downcast::<Element>().unwrap();
         elem.get_attribute(&ns!(), &local_name!("encoding")).map_or(false, |attr| {
-            attr.value().eq_ignore_ascii_case("text/html")
-                || attr.value().eq_ignore_ascii_case("application/xhtml+xml")
+            attr.value().as_string().eq_ignore_ascii_case("text/html")
+                || attr.value().as_string().eq_ignore_ascii_case("application/xhtml+xml")
         })
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2101,13 +2101,15 @@ impl ScriptThread {
                                                 .inclusive_ancestors()
                                                 .filter_map(Root::downcast::<HTMLAnchorElement>)
                                                 .next() {
-                        let status = anchor.upcast::<Element>()
-                                           .get_attribute(&ns!(), &local_name!("href"))
-                                           .and_then(|href| {
-                                               let value = href.value();
-                                               let url = document.url();
-                                               url.join(&value).map(|url| url.to_string()).ok()
-                                           });
+                        let status =
+                            anchor.upcast::<Element>()
+                                .get_attribute(&ns!(), &local_name!("href"))
+                                .and_then(|href| {
+                                    let value = href.value();
+                                    let url = document.url();
+                                    url.join(value.as_string())
+                                        .map(|url| url.to_string()).ok()
+                                });
 
                         let event = ConstellationMsg::NodeStatus(status);
                         self.constellation_chan.send(event).unwrap();

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -334,9 +334,6 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
     unsafe fn unsafe_get(self) ->
         <<Self::ConcreteThreadSafeLayoutNode as ThreadSafeLayoutNode>::ConcreteNode as TNode>::ConcreteElement;
 
-    #[inline]
-    fn get_attr(&self, namespace: &Namespace, name: &LocalName) -> Option<&str>;
-
     fn get_attr_enum(&self, namespace: &Namespace, name: &LocalName) -> Option<&AttrValue>;
 
     fn style_data(&self) -> AtomicRef<ElementData>;
@@ -376,7 +373,7 @@ pub trait ThreadSafeLayoutElement: Clone + Copy + Sized + Debug +
     fn get_details_content_pseudo(&self) -> Option<Self> {
         if self.get_local_name() == &local_name!("details") &&
            self.get_namespace() == &ns!(html) {
-            let display = if self.get_attr(&ns!(), &local_name!("open")).is_some() {
+            let display = if self.get_attr_enum(&ns!(), &local_name!("open")).is_some() {
                 None // Specified by the stylesheet
             } else {
                 Some(display::T::none)

--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -283,6 +283,18 @@ impl AttrValue {
         }
     }
 
+    /// Assumes the `AttrValue` is a `String` and returns its value
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the `AttrValue` is not a `String`
+    pub fn as_string(&self) -> &str {
+        match *self {
+            AttrValue::String(ref s) => &s,
+            _ => panic!("String not found"),
+        }
+    }
+
     /// Assumes the `AttrValue` is a `Length` and returns its value
     ///
     /// ## Panics
@@ -355,15 +367,13 @@ impl AttrValue {
         // FIXME(SimonSapin) this can be more efficient by matching on `(self, selector)` variants
         // and doing Atom comparisons instead of string comparisons where possible,
         // with SelectorImpl::AttrValue changed to Atom.
-        selector.eval_str(self)
+        let serialization = self.serialize();
+        selector.eval_str(&serialization)
     }
-}
 
-impl ::std::ops::Deref for AttrValue {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        match *self {
+    /// Serializes this attribute value into its string form.
+    pub fn serialize(&self) -> String {
+        let slice: &str = match *self {
             AttrValue::String(ref value) |
                 AttrValue::TokenList(ref value, _) |
                 AttrValue::UInt(ref value, _) |
@@ -375,16 +385,9 @@ impl ::std::ops::Deref for AttrValue {
                 AttrValue::Declaration(ref value, _) |
                 AttrValue::Dimension(ref value, _) => &value,
             AttrValue::Atom(ref value) => &value,
-        }
-    }
-}
+        };
 
-impl PartialEq<Atom> for AttrValue {
-    fn eq(&self, other: &Atom) -> bool {
-        match *self {
-            AttrValue::Atom(ref value) => value == other,
-            _ => other == &**self,
-        }
+        slice.into()
     }
 }
 

--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -48,20 +48,7 @@ pub enum AttrValue {
     Dimension(String, LengthOrPercentageOrAuto),
     Url(String, Option<ServoUrl>),
 
-    /// Note that this variant is only used transitively as a fast path to set
-    /// the property declaration block relevant to the style of an element when
-    /// set from the inline declaration of that element (that is,
-    /// `element.style`).
-    ///
-    /// This can, as of this writing, only correspond to the value of the
-    /// `style` element, and is set from its relevant CSSInlineStyleDeclaration,
-    /// and then converted to a string in Element::attribute_mutated.
-    ///
-    /// Note that we don't necessarily need to do that (we could just clone the
-    /// declaration block), but that avoids keeping a refcounted
-    /// declarationblock for longer than needed.
-    Declaration(String,
-                #[cfg_attr(feature = "servo", ignore_heap_size_of = "Arc")]
+    Declaration(#[cfg_attr(feature = "servo", ignore_heap_size_of = "Arc")]
                 Arc<Locked<PropertyDeclarationBlock>>)
 }
 
@@ -366,7 +353,7 @@ impl AttrValue {
     pub fn eval_selector<F>(&self, selector: &AttrSelectorOperation<&String>,
                             serialize_declaration_block: &mut F)
                             -> bool
-                            where F: FnOnce(&Locked<PropertyDeclarationBlock>) -> String {
+                            where F: FnMut(&Locked<PropertyDeclarationBlock>) -> String {
         // FIXME(SimonSapin) this can be more efficient by matching on `(self, selector)` variants
         // and doing Atom comparisons instead of string comparisons where possible,
         // with SelectorImpl::AttrValue changed to Atom.
@@ -375,8 +362,8 @@ impl AttrValue {
     }
 
     /// Serializes this attribute value into its string form.
-    pub fn serialize<F>(&self, _serialize_declaration_block: &mut F) -> String
-    where F: FnOnce(&Locked<PropertyDeclarationBlock>) -> String {
+    pub fn serialize<F>(&self, serialize_declaration_block: &mut F) -> String
+    where F: FnMut(&Locked<PropertyDeclarationBlock>) -> String {
         match *self {
             AttrValue::String(ref value) |
                 AttrValue::TokenList(ref value, _) |
@@ -386,9 +373,9 @@ impl AttrValue {
                 AttrValue::Color(ref value, _) |
                 AttrValue::Int(ref value, _) |
                 AttrValue::Url(ref value, _) |
-                AttrValue::Declaration(ref value, _) |
                 AttrValue::Dimension(ref value, _) => value.clone(),
             AttrValue::Atom(ref value) => String::from(&**value),
+            AttrValue::Declaration(ref block) => serialize_declaration_block(block),
         }
     }
 }

--- a/components/style/gecko/snapshot.rs
+++ b/components/style/gecko/snapshot.rs
@@ -15,6 +15,7 @@ use gecko_bindings::structs::ServoElementSnapshotFlags as Flags;
 use gecko_bindings::structs::ServoElementSnapshotTable;
 use invalidation::element::element_wrapper::ElementSnapshot;
 use selectors::attr::{AttrSelectorOperation, AttrSelectorOperator, CaseSensitivity, NamespaceConstraint};
+use shared_lock::SharedRwLockReadGuard;
 use string_cache::{Atom, Namespace};
 
 /// A snapshot of a Gecko element.
@@ -85,7 +86,8 @@ impl GeckoElementSnapshot {
     pub fn attr_matches(&self,
                         ns: &NamespaceConstraint<&Namespace>,
                         local_name: &Atom,
-                        operation: &AttrSelectorOperation<&Atom>)
+                        operation: &AttrSelectorOperation<&Atom>,
+                        _: &SharedRwLockReadGuard)
                         -> bool {
         unsafe {
             match *operation {

--- a/components/style/invalidation/element/invalidator.rs
+++ b/components/style/invalidation/element/invalidator.rs
@@ -97,7 +97,7 @@ impl<'a, 'b: 'a, E> TreeStyleInvalidator<'a, 'b, E>
         let shared_context = self.shared_context;
 
         let wrapper =
-            ElementWrapper::new(self.element, shared_context.snapshot_map);
+            ElementWrapper::new(self.element, shared_context);
         let state_changes = wrapper.state_changes();
         let snapshot = wrapper.snapshot().expect("has_snapshot lied");
 

--- a/components/style/servo/selector_parser.rs
+++ b/components/style/servo/selector_parser.rs
@@ -626,7 +626,7 @@ impl ElementSnapshot for ServoElementSnapshot {
     fn lang_attr(&self) -> Option<SelectorAttrValue> {
         self.get_attr(&ns!(xml), &local_name!("lang"))
             .or_else(|| self.get_attr(&ns!(), &local_name!("lang")))
-            .map(|v| String::from(v as &str))
+            .map(|v| v.serialize())
     }
 }
 


### PR DESCRIPTION
… rather than every time that CSSOM `Element.style` is modified. Results are *not* cached in this PR. We could add APIs that work with `&mut AttrValue` rather than `&AttrValue` to add some caching.

CC #17399

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17476)
<!-- Reviewable:end -->
