### PR TITLE
Pass some 48-bytes closures by references instead of by value.

### DIFF
--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -333,7 +333,7 @@
                     let quirks_mode = context.quirks_mode;
                     ::properties::substitute_variables_${property.ident}(
                         &declared_value, &custom_props,
-                    |value| {
+                    &mut |value| {
                         if let Some(ref mut cascade_info) = *cascade_info {
                             cascade_info.on_cascade_property(&declaration,
                                                              &value);

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -582,7 +582,7 @@ impl AnimationValue {
                             &variables.url_data,
                             variables.from_shorthand,
                             &custom_props,
-                            |v| {
+                            &mut |v| {
                                 let declaration = match *v {
                                     DeclaredValue::Value(value) => {
                                         PropertyDeclaration::${prop.camel_case}(value.clone())

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -373,13 +373,13 @@ impl PropertyDeclarationIdSet {
                 value: &DeclaredValue<longhands::${property.ident}::SpecifiedValue>,
             % endif
             custom_properties: &Option<Arc<::custom_properties::ComputedValuesMap>>,
-            f: F,
+            f: &mut F,
             error_reporter: &ParseErrorReporter,
             quirks_mode: QuirksMode)
             % if property.boxed:
-                where F: FnOnce(&DeclaredValue<Box<longhands::${property.ident}::SpecifiedValue>>)
+                where F: FnMut(&DeclaredValue<Box<longhands::${property.ident}::SpecifiedValue>>)
             % else:
-                where F: FnOnce(&DeclaredValue<longhands::${property.ident}::SpecifiedValue>)
+                where F: FnMut(&DeclaredValue<longhands::${property.ident}::SpecifiedValue>)
             % endif
         {
             if let DeclaredValue::WithVariables(ref with_variables) = *value {
@@ -404,13 +404,13 @@ impl PropertyDeclarationIdSet {
                 url_data: &UrlExtraData,
                 from_shorthand: Option<ShorthandId>,
                 custom_properties: &Option<Arc<::custom_properties::ComputedValuesMap>>,
-                f: F,
+                f: &mut F,
                 error_reporter: &ParseErrorReporter,
                 quirks_mode: QuirksMode)
                 % if property.boxed:
-                    where F: FnOnce(&DeclaredValue<Box<longhands::${property.ident}::SpecifiedValue>>)
+                    where F: FnMut(&DeclaredValue<Box<longhands::${property.ident}::SpecifiedValue>>)
                 % else:
-                    where F: FnOnce(&DeclaredValue<longhands::${property.ident}::SpecifiedValue>)
+                    where F: FnMut(&DeclaredValue<longhands::${property.ident}::SpecifiedValue>)
                 % endif
         {
             f(&


### PR DESCRIPTION
This reduced the generated code size by 74 KB: https://bugzilla.mozilla.org/show_bug.cgi?id=1375222#c4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17477)
<!-- Reviewable:end -->
