### PR TITLE
mach: Fail properly if we can't find the path for OSMesa or GLAPI.

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -189,12 +189,13 @@ def set_osmesa_env(bin_path, env):
         env["LD_LIBRARY_PATH"] = osmesa_path
         env["GALLIUM_DRIVER"] = "softpipe"
     elif is_macosx():
-        osmesa_path = path.join(find_dep_path_newest('osmesa-src', bin_path),
-                                "out", "src", "gallium", "targets", "osmesa", ".libs")
-        glapi_path = path.join(find_dep_path_newest('osmesa-src', bin_path),
-                               "out", "src", "mapi", "shared-glapi", ".libs")
-        if not (osmesa_path and glapi_path):
+        osmesa_dep_path = find_dep_path_newest('osmesa-src', bin_path)
+        if not osmesa_dep_path:
             return None
+        osmesa_path = path.join(osmesa_dep_path,
+                                "out", "src", "gallium", "targets", "osmesa", ".libs")
+        glapi_path = path.join(osmesa_dep_path,
+                               "out", "src", "mapi", "shared-glapi", ".libs")
         env["DYLD_LIBRARY_PATH"] = osmesa_path + ":" + glapi_path
         env["GALLIUM_DRIVER"] = "softpipe"
     return env


### PR DESCRIPTION
Currently we check `if not (osmesa_path and glapi_path)` after using
`path.join`. It seems we actually want to check whether
`find_dep_path_newest` returns something, because if calls to that
function fail, we'll instead get an error from `path.join` about
`NoneType` not having attribute `endswith` (it expects a string), which
preempts this check.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this is a change to `./mach` (are there tests for that?)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17483)
<!-- Reviewable:end -->
