### PR TITLE
Correct bloom hash bitpacking documentation

### DIFF
--- a/components/selectors/bloom.rs
+++ b/components/selectors/bloom.rs
@@ -7,7 +7,7 @@
 use fnv::FnvHasher;
 use std::hash::{Hash, Hasher};
 
-// The top 12 bits of the 32-bit hash value are not used by the bloom filter.
+// The top 8 bits of the 32-bit hash value are not used by the bloom filter.
 // Consumers may rely on this to pack hashes more efficiently.
 pub const BLOOM_HASH_MASK: u32 = 0x00ffffff;
 const KEY_SIZE: usize = 12;


### PR DESCRIPTION
The two 12 bit keys add to 24 bits, which leaves 8 bits free in each word. (And 8 * 3 = 24, to pack in the fourth hash.)

<!-- Please describe your changes on the following line: -->
I have never actually built servo, but I'm pretty sure that's not necessary for a 1 line comment-only change

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X ] These changes do not require tests because this is a comment only change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17487)
<!-- Reviewable:end -->
