### PR TITLE
remove various things now that Rust 1.17 is required

### DIFF
--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1854,7 +1854,7 @@ impl Fragment {
         match (&mut self.specific, &next_fragment.specific) {
             (&mut SpecificFragmentInfo::ScannedText(ref mut this_info),
              &SpecificFragmentInfo::ScannedText(ref other_info)) => {
-                debug_assert!(::arc_ptr_eq(&this_info.run, &other_info.run));
+                debug_assert!(Arc::ptr_eq(&this_info.run, &other_info.run));
                 this_info.range_end_including_stripped_whitespace =
                     other_info.range_end_including_stripped_whitespace;
                 if other_info.requires_line_break_afterward_if_wrapping_on_newlines() {

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -401,7 +401,7 @@ impl LineBreaker {
                     result.border_padding.inline_end == Au(0) &&
                     candidate.border_padding.inline_start == Au(0) &&
                     result_info.selected() == candidate_info.selected() &&
-                    ::arc_ptr_eq(&result_info.run, &candidate_info.run) &&
+                    Arc::ptr_eq(&result_info.run, &candidate_info.run) &&
                         inline_contexts_are_equal(&result.inline_context,
                                                   &candidate.inline_context)
                 }

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -92,14 +92,6 @@ pub use fragment::Fragment;
 pub use fragment::SpecificFragmentInfo;
 pub use self::data::LayoutData;
 
-/// Returns whether the two arguments point to the same value.
-///
-/// FIXME: Remove this and use Arc::ptr_eq once we require Rust 1.17
-#[inline]
-pub fn arc_ptr_eq<T: 'static>(a: &::std::sync::Arc<T>, b: &::std::sync::Arc<T>) -> bool {
-    ::style::ptr_eq::<T>(&**a, &**b)
-}
-
 // We can't use stylearc for everything in layout, because the Flow stuff uses
 // weak references.
 use style::stylearc::Arc as StyleArc;

--- a/components/servo_arc/lib.rs
+++ b/components/servo_arc/lib.rs
@@ -39,6 +39,7 @@ use std::hash::{Hash, Hasher};
 use std::iter::{ExactSizeIterator, Iterator};
 use std::mem;
 use std::ops::{Deref, DerefMut};
+use std::process;
 use std::ptr;
 use std::slice;
 use std::sync::atomic;
@@ -247,13 +248,7 @@ impl<T: ?Sized> Clone for Arc<T> {
         // We abort because such a program is incredibly degenerate, and we
         // don't care to support it.
         if old_size > MAX_REFCOUNT {
-            // Note: std::process::abort is stable in 1.17, which we don't yet
-            // require for Gecko. Panic is good enough in practice here (it will
-            // trigger an abort at least in Gecko, and this case is degenerate
-            // enough that Servo shouldn't have code that triggers it).
-            //
-            // We should fix this when we require 1.17.
-            panic!();
+            process::abort();
         }
 
         Arc { p: NonZeroPtrMut::new(self.ptr()) }

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -186,14 +186,6 @@ macro_rules! reexport_computed_values {
 }
 longhand_properties_idents!(reexport_computed_values);
 
-/// Pointer equality
-///
-/// FIXME: Remove this and use std::ptr::eq once we require Rust 1.17
-#[inline]
-pub fn ptr_eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
-    a == b
-}
-
 /// Serializes as CSS a comma-separated list of any `T` that supports being
 /// serialized as CSS.
 pub fn serialize_comma_separated_list<W, T>(dest: &mut W,

--- a/components/style/shared_lock.rs
+++ b/components/style/shared_lock.rs
@@ -10,6 +10,8 @@ use atomic_refcell::{AtomicRefCell, AtomicRef, AtomicRefMut};
 use parking_lot::RwLock;
 use std::cell::UnsafeCell;
 use std::fmt;
+#[cfg(feature = "gecko")]
+use std::ptr;
 use stylearc::Arc;
 
 /// A shared read/write lock that can protect multiple objects.
@@ -154,7 +156,7 @@ impl<T> Locked<T> {
 
     #[cfg(feature = "gecko")]
     fn same_lock_as(&self, derefed_guard: &SomethingZeroSizedButTyped) -> bool {
-        ::ptr_eq(self.shared_lock.cell.as_ptr(), derefed_guard)
+        ptr::eq(self.shared_lock.cell.as_ptr(), derefed_guard)
     }
 
     /// Access the data for reading.


### PR DESCRIPTION
std::ptr::eq and Arc::ptr_eq are now usuable, and we can replace a
panic!() with abort().

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they are trivial replacements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17493)
<!-- Reviewable:end -->
