### PR TITLE
deny_public_fields: display field identifier in help message

### DIFF
--- a/components/deny_public_fields/lib.rs
+++ b/components/deny_public_fields/lib.rs
@@ -17,7 +17,8 @@ fn expand_string(input: &str) -> String {
     let style = synstructure::BindStyle::Ref.into();
     synstructure::each_field(&type_, &style, |binding| {
         if binding.field.vis != syn::Visibility::Inherited {
-            panic!("Field {} should not be public", binding.ident);
+            panic!("Field `{}` should not be public",
+                   binding.field.ident.as_ref().unwrap_or(&binding.ident));
         }
         "".to_owned()
     });

--- a/tests/compiletest/plugin/compile-fail/privatize.rs
+++ b/tests/compiletest/plugin/compile-fail/privatize.rs
@@ -9,6 +9,7 @@ extern crate deny_public_fields;
 
 #[derive(DenyPublicFields)]
 //~^ ERROR proc-macro derive panicked
+//~| HELP Field `v1` should not be public
 struct Foo {
     pub v1: i32,
     v2: i32


### PR DESCRIPTION
Use a binding's field identifier to produce more descriptive output.
Fall back to a binding's identifier if a field identifier is not
available.

Additionally, make the privatize.rs compiletest more specific and
wrap the identifier in backticks to aid readability.

As an aside, should I send a PR to rename ```compile-fail/privatize.rs``` to ```compile-fail/deny_public_fields.rs``` as privatize isn't mentioned in the codebase any more?

```
$ find . -name "*privatize*"
./tests/compiletest/plugin/compile-fail/privatize.rs
```


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #17438 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17514)
<!-- Reviewable:end -->
