### PR TITLE
stylo: Implement font-language-override descriptor for @font-face rule

### DIFF
--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -17,6 +17,8 @@ use error_reporting::ContextualParseError;
 #[cfg(feature = "gecko")] use gecko_bindings::structs::CSSFontFaceDescriptors;
 #[cfg(feature = "gecko")] use cssparser::UnicodeRange;
 use parser::{ParserContext, log_css_error, Parse};
+#[cfg(feature = "gecko")]
+use properties::longhands::font_language_override;
 use selectors::parser::SelectorParseError;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt;
@@ -407,7 +409,10 @@ font_face_descriptors! {
             font_feature_settings::T::Normal
         },
 
-        // FIXME: add font-language-override.
+        /// The language override of this font face.
+        "font-language-override" language_override / mFontLanguageOverride: font_language_override::SpecifiedValue = {
+            font_language_override::SpecifiedValue::Normal
+        },
     ]
 }
 

--- a/components/style/gecko/rules.rs
+++ b/components/style/gecko/rules.rs
@@ -15,6 +15,7 @@ use gecko_bindings::structs::{self, nsCSSFontFaceRule, nsCSSValue};
 use gecko_bindings::structs::{nsCSSCounterDesc, nsCSSCounterStyleRule};
 use gecko_bindings::sugar::ns_css_value::ToNsCssValue;
 use gecko_bindings::sugar::refptr::{RefPtr, UniqueRefPtr};
+use properties::longhands::font_language_override;
 use shared_lock::{ToCssWithGuard, SharedRwLockReadGuard};
 use std::{fmt, str};
 use values::generics::FontSettings;
@@ -63,6 +64,17 @@ impl ToNsCssValue for font_feature_settings::T {
                     (feature, index)
                 }))
             }
+        }
+    }
+}
+
+impl ToNsCssValue for font_language_override::SpecifiedValue {
+    fn convert(self, nscssvalue: &mut nsCSSValue) {
+        match self {
+            font_language_override::SpecifiedValue::Normal => nscssvalue.set_normal(),
+            font_language_override::SpecifiedValue::Override(ref lang) => nscssvalue.set_string(&*lang),
+            // This path is unreachable because the descriptor is only specified by the user.
+            font_language_override::SpecifiedValue::System(_) => unreachable!(),
         }
     }
 }

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -2012,7 +2012,7 @@ https://drafts.csswg.org/css-fonts-4/#low-level-font-variation-settings-control-
         // OpenType "language system" tag, so we should be able to compute
         // it and store it as a 32-bit integer
         // (see http://www.microsoft.com/typography/otspec/languagetags.htm).
-        #[derive(PartialEq, Clone, Copy, Debug)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
         #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
         pub struct T(pub u32);
     }
@@ -2079,6 +2079,14 @@ https://drafts.csswg.org/css-fonts-4/#low-level-font-variation-settings-control-
             input.expect_string().map(|cow| {
                 SpecifiedValue::Override(cow.into_owned())
             }).map_err(|e| e.into())
+        }
+    }
+
+    /// Used in @font-face.
+    impl Parse for SpecifiedValue {
+        fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
+                         -> Result<Self, ParseError<'i>> {
+            parse(context, input)
         }
     }
 


### PR DESCRIPTION
Generally  we use computed values for `@font-face` rule descriptors but that descriptor is a bit different than the others in gecko side. It accepts strings instead of unsigned integer(which is computed value of this property). So we had to use SpecifiedValue for that in here.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1355364](https://bugzilla.mozilla.org/show_bug.cgi?id=1355364)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17517)
<!-- Reviewable:end -->
