### PR TITLE
Convert node serialization to a purely iterative algorithm.

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13737,6 +13737,12 @@
      {}
     ]
    ],
+   "mozilla/deep_serialization_succeeds.html": [
+    [
+     "/_mozilla/mozilla/deep_serialization_succeeds.html",
+     {}
+    ]
+   ],
    "mozilla/deterministic-raf.html": [
     [
      "/_mozilla/mozilla/deterministic-raf.html",
@@ -26885,6 +26891,10 @@
   "mozilla/css-paint-api/valid-image-before-load.html": [
    "67d8cdd3e3a1656ba315fcbf6dae7236680bac16",
    "reftest"
+  ],
+  "mozilla/deep_serialization_succeeds.html": [
+   "cb3d201d577c17d19babf1f6c04ba882fa42048e",
+   "testharness"
   ],
   "mozilla/details_ui_closed.html": [
    "2acbe3afbec267bad4dd986803e636740a707507",

--- a/tests/wpt/mozilla/tests/mozilla/deep_serialization_succeeds.html
+++ b/tests/wpt/mozilla/tests/mozilla/deep_serialization_succeeds.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Deep Serialization Test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+// The test here is that Servo doesn't crash.
+
+test(function() {
+  var first = document.createElement('div');
+  var last = first;
+  for (var i = 0; i < 3000; i++) {
+    var e = document.createElement('div');
+    last.appendChild(e);
+    last = e;
+  }
+  last.textContent = "abcdef";
+  var elem = first;
+  assert_regexp_match(elem.outerHTML, /abcdef/);
+}, "Test that deep trees can serialize without crashing.");
+</script>
+</body>
+</html>


### PR DESCRIPTION
We maintain a stack of open element nodes with their children count, popping from the top of the stack and closing when the count reaches zero.

Contrary to my comment in #16696, this is a purely iterative algorithm.  I just wasn't feeling sufficiently clever with respect to finding a relatively clean way until later.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #16696 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes.


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17520)
<!-- Reviewable:end -->
