### PR TITLE
Have unsafe_no_jsmanaged_fields! macro take a type as argument rather than an ident.

### DIFF
--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -303,7 +303,7 @@ macro_rules! make_nonzero_dimension_setter(
 /// For use on non-jsmanaged types
 /// Use #[derive(JSTraceable)] on JS managed types
 macro_rules! unsafe_no_jsmanaged_fields(
-    ($($ty:ident),+) => (
+    ($($ty:ty),+) => (
         $(
             #[allow(unsafe_code)]
             unsafe impl $crate::dom::bindings::trace::JSTraceable for $ty {


### PR DESCRIPTION
We only write unsafe_no_jsmanaged_fields!(SomeType), and the
documentation says it is to be used for types.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it should be checked at compile time

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17535)
<!-- Reviewable:end -->
