### PR TITLE
Add cli options to write profiler output to InfluxDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,6 +1310,15 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "influent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hyper 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "io-surface"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,6 +2173,7 @@ name = "profile"
 version = "0.0.1"
 dependencies = [
  "heartbeats-simple 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "influent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3637,6 +3647,7 @@ dependencies = [
 "checksum image 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d95816db758249fe16f23a4e23f1a3a817fe11892dbfd1c5836f625324702158"
 "checksum immeta 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0b9260463a221bfe3f02100c56e2d14c050d5ffe7e44a43d0a1b2b1f2b523502"
 "checksum inflate 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e7e0062d2dc2f17d2f13750d95316ae8a2ff909af0fda957084f5defd87c43bb"
+"checksum influent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a22b311b83431be3ab9af96ca9ea41554bb4a8551ea871ae44c3ce0c57e55f2c"
 "checksum io-surface 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c35a3278fa52fb070fdc874dfd057163e6c21e0a9295f87f54daee9dd5530b43"
 "checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
 "checksum ipc-channel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a38ad662f104525ac57012e0b79aad07507e3fc11e3bae668bf416264e760ebb"

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -11,6 +11,7 @@ path = "lib.rs"
 
 [dependencies]
 profile_traits = {path = "../profile_traits"}
+influent = "0.4"
 ipc-channel = "0.8"
 heartbeats-simple = "0.4"
 log = "0.3.5"

--- a/components/profile/lib.rs
+++ b/components/profile/lib.rs
@@ -11,6 +11,7 @@
 #[cfg(not(target_os = "windows"))]
 extern crate alloc_jemalloc;
 extern crate heartbeats_simple;
+extern crate influent;
 extern crate ipc_channel;
 #[cfg(not(target_os = "windows"))]
 extern crate libc;


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

This patch adds the command line options and associated code to write the output of running the profiler to an InfluxDB instance, so we can create graphs like [1] with Grafana.

This is part of the work required to record and watch PWM results during CI to catch performance regressions.

[1] https://screenshots.firefox.com/j6sSZrN7pTuPK2kX/localhost

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17536)
<!-- Reviewable:end -->
