### PR TITLE
Load fonts only when needed

### DIFF
--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -179,7 +179,6 @@ impl FontCache {
                 }
                 Command::AddWebFont(family_name, sources, result) => {
                     self.unfetched_web_fonts.insert(family_name, (sources, result.clone()));
-                    result.send(()).unwrap();
                 }
                 Command::FetchWebFont(family_name, sources, result) => {
                     self.get_web_font_from_source(family_name, sources, result);

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -102,7 +102,6 @@ use std::mem as std_mem;
 use std::ops::{Deref, DerefMut};
 use std::process;
 use std::sync::{Arc, Mutex, MutexGuard};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::thread;
 use style::animation::Animation;
@@ -189,9 +188,6 @@ pub struct LayoutThread {
 
     /// Receives newly-discovered animations.
     new_animations_receiver: Receiver<Animation>,
-
-    /// The number of Web fonts that have been requested but not yet loaded.
-    outstanding_web_fonts: Arc<AtomicUsize>,
 
     /// The root of the flow tree.
     root_flow: RefCell<Option<FlowRef>>,
@@ -391,8 +387,7 @@ fn add_font_face_rules(stylesheet: &Stylesheet,
                        guard: &SharedRwLockReadGuard,
                        device: &Device,
                        font_cache_thread: &FontCacheThread,
-                       font_cache_sender: &IpcSender<()>,
-                       outstanding_web_fonts_counter: &Arc<AtomicUsize>) {
+                       font_cache_sender: &IpcSender<()>) {
     if opts::get().load_webfonts_synchronously {
         let (sender, receiver) = ipc::channel().unwrap();
         stylesheet.effective_font_face_rules(&device, guard, |rule| {
@@ -408,7 +403,6 @@ fn add_font_face_rules(stylesheet: &Stylesheet,
         stylesheet.effective_font_face_rules(&device, guard, |rule| {
             if let Some(font_face) = rule.font_face() {
                 let effective_sources = font_face.effective_sources();
-                outstanding_web_fonts_counter.fetch_add(1, Ordering::SeqCst);
                 font_cache_thread.add_web_font(font_face.family().clone(),
                                               effective_sources,
                                               (*font_cache_sender).clone());
@@ -459,7 +453,6 @@ impl LayoutThread {
             ROUTER.route_ipc_receiver_to_new_mpsc_receiver(ipc_font_cache_receiver);
 
         let stylist = Stylist::new(device, QuirksMode::NoQuirks);
-        let outstanding_web_fonts_counter = Arc::new(AtomicUsize::new(0));
         let ua_stylesheets = &*UA_STYLESHEETS;
         let guard = ua_stylesheets.shared_lock.read();
         for stylesheet in &ua_stylesheets.user_or_user_agent_stylesheets {
@@ -467,8 +460,7 @@ impl LayoutThread {
                                 &guard,
                                 stylist.device(),
                                 &font_cache_thread,
-                                &ipc_font_cache_sender,
-                                &outstanding_web_fonts_counter);
+                                &ipc_font_cache_sender);
         }
 
         LayoutThread {
@@ -493,7 +485,6 @@ impl LayoutThread {
             generation: Cell::new(0),
             new_animations_sender: new_animations_sender,
             new_animations_receiver: new_animations_receiver,
-            outstanding_web_fonts: outstanding_web_fonts_counter,
             root_flow: RefCell::new(None),
             document_shared_lock: None,
             running_animations: StyleArc::new(RwLock::new(FnvHashMap::default())),
@@ -633,7 +624,6 @@ impl LayoutThread {
             },
             Request::FromFontCache => {
                 let _rw_data = possibly_locked_rw_data.lock();
-                self.outstanding_web_fonts.fetch_sub(1, Ordering::SeqCst);
                 font_context::invalidate_font_caches();
                 self.script_chan.send(ConstellationControlMsg::WebFontLoaded(self.id)).unwrap();
                 true
@@ -687,8 +677,7 @@ impl LayoutThread {
             }
             Msg::GetWebFontLoadState(sender) => {
                 let _rw_data = possibly_locked_rw_data.lock();
-                let outstanding_web_fonts = self.outstanding_web_fonts.load(Ordering::SeqCst);
-                sender.send(outstanding_web_fonts != 0).unwrap();
+                sender.send(!self.font_cache_thread.is_web_font_loading_finished()).unwrap();
             },
             Msg::CreateLayoutThread(info) => {
                 self.create_layout_thread(info)
@@ -814,8 +803,7 @@ impl LayoutThread {
                                 &guard,
                                 self.stylist.device(),
                                 &self.font_cache_thread,
-                                &self.font_cache_sender,
-                                &self.outstanding_web_fonts);
+                                &self.font_cache_sender);
         }
 
         possibly_locked_rw_data.block(rw_data);

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -388,27 +388,14 @@ fn add_font_face_rules(stylesheet: &Stylesheet,
                        device: &Device,
                        font_cache_thread: &FontCacheThread,
                        font_cache_sender: &IpcSender<()>) {
-    if opts::get().load_webfonts_synchronously {
-        let (sender, receiver) = ipc::channel().unwrap();
-        stylesheet.effective_font_face_rules(&device, guard, |rule| {
-            if let Some(font_face) = rule.font_face() {
-                let effective_sources = font_face.effective_sources();
-                font_cache_thread.add_web_font(font_face.family().clone(),
-                                               effective_sources,
-                                               sender.clone());
-                receiver.recv().unwrap();
-            }
-        })
-    } else {
-        stylesheet.effective_font_face_rules(&device, guard, |rule| {
-            if let Some(font_face) = rule.font_face() {
-                let effective_sources = font_face.effective_sources();
-                font_cache_thread.add_web_font(font_face.family().clone(),
-                                              effective_sources,
-                                              (*font_cache_sender).clone());
-            }
-        })
-    }
+    stylesheet.effective_font_face_rules(&device, guard, |rule| {
+        if let Some(font_face) = rule.font_face() {
+            let effective_sources = font_face.effective_sources();
+            font_cache_thread.add_web_font(font_face.family().clone(),
+                                          effective_sources,
+                                          (*font_cache_sender).clone());
+        }
+    })
 }
 
 impl LayoutThread {

--- a/tests/unit/gfx/font_cache_thread.rs
+++ b/tests/unit/gfx/font_cache_thread.rs
@@ -4,8 +4,10 @@
 
 use cssparser::SourceLocation;
 use gfx::font_cache_thread::FontCacheThread;
+use gfx::font_template::FontTemplateDescriptor;
 use ipc_channel::ipc;
-use style::computed_values::font_family::FamilyName;
+use style::computed_values::{font_stretch, font_weight};
+use style::computed_values::font_family::{FamilyName, FontFamily};
 use style::font_face::{FontFaceRuleData, Source};
 
 #[test]
@@ -31,9 +33,18 @@ fn test_local_web_font() {
     };
 
     font_cache_thread.add_web_font(
-        family_name,
+        family_name.clone(),
         font_face_rule.font_face().unwrap().effective_sources(),
         out_chan);
+
+    let font_family = FontFamily::FamilyName(family_name);
+    let font_template_descriptor = FontTemplateDescriptor::new(font_weight::T::Weight400,
+                                                               font_stretch::T::normal,
+                                                               false);
+    let result = font_cache_thread.find_font_template(font_family.clone(), font_template_descriptor.clone());
+    if let Some(_) = result {
+        panic!("Should not have a value since we don't even load it yet.");
+    }
 
     assert_eq!(out_receiver.recv().unwrap(), ());
 }


### PR DESCRIPTION
I'm just unsure what to do about the synchronous font loading. It looks like synchronous font loading was just a [temporary patch](https://groups.google.com/d/msg/mozilla.dev.servo/q9QXq4974k0/5xlKe7N1BAAJ). Do you want to keep that features or can I completly remove it ? 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #8342 (github issue number if applicable).
- [x] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17545)
<!-- Reviewable:end -->
