### PR TITLE
Fix cef to follow new Browser::new() interface

### DIFF
--- a/ports/cef/browser.rs
+++ b/ports/cef/browser.rs
@@ -9,7 +9,6 @@ use interfaces::{CefBrowser, CefBrowserHost, CefClient, CefFrame, CefRequestCont
 use interfaces::{cef_browser_t, cef_browser_host_t, cef_client_t, cef_frame_t};
 use interfaces::{cef_request_context_t};
 use servo::Browser;
-use servo::servo_config::prefs::PREFS;
 use servo::servo_url::ServoUrl;
 use types::{cef_browser_settings_t, cef_string_t, cef_window_info_t, cef_window_handle_t};
 use window;
@@ -124,7 +123,7 @@ pub struct ServoCefBrowser {
 }
 
 impl ServoCefBrowser {
-    pub fn new(window_info: &cef_window_info_t, client: CefClient) -> ServoCefBrowser {
+    pub fn new(window_info: &cef_window_info_t, client: CefClient, target_url: ServoUrl) -> ServoCefBrowser {
         let frame = ServoCefFrame::new().as_cef_interface();
         let host = ServoCefBrowserHost::new(client.clone()).as_cef_interface();
         let mut window_handle: cef_window_handle_t = get_null_window_handle();
@@ -132,9 +131,7 @@ impl ServoCefBrowser {
         let (glutin_window, servo_browser) = if window_info.windowless_rendering_enabled == 0 {
             let parent_window = glutin_app::WindowID::new(window_info.parent_window as *mut _);
             let glutin_window = glutin_app::create_window(Some(parent_window));
-            let home_url = ServoUrl::parse(PREFS.get("shell.homepage").as_string()
-                    .unwrap_or("about:blank")).unwrap();
-            let servo_browser = Browser::new(glutin_window.clone(), home_url);
+            let servo_browser = Browser::new(glutin_window.clone(), target_url);
             window_handle = glutin_window.platform_window().window as cef_window_handle_t;
             (Some(glutin_window), ServoBrowser::OnScreen(servo_browser))
         } else {
@@ -175,8 +172,7 @@ impl ServoCefBrowserExtensions for CefBrowser {
         if window_info.windowless_rendering_enabled != 0 {
             let window = window::Window::new(window_info.width, window_info.height);
             window.set_browser(self.clone());
-            let home_url = ServoUrl::parse(PREFS.get("shell.homepage").as_string()
-                    .unwrap_or("about:blank")).unwrap();
+            let home_url = ServoUrl::parse("about:blank").unwrap();
             let servo_browser = Browser::new(window.clone(), home_url);
             *self.downcast().servo_browser.borrow_mut() = ServoBrowser::OffScreen(servo_browser);
         }
@@ -274,11 +270,17 @@ fn browser_host_create(window_info: &cef_window_info_t,
                        url: *const cef_string_t,
                        callback_executed: bool)
                        -> CefBrowser {
-    let browser = ServoCefBrowser::new(window_info, client).as_cef_interface();
+    let url_string = if url != ptr::null() {
+        unsafe { String::from_utf16(CefWrap::to_rust(url)).ok() }
+    } else {
+        None
+    };
+    let target_url = url_string
+        .and_then(|val| ServoUrl::parse(&val).ok())
+        .or(ServoUrl::parse("about:blank").ok())
+        .unwrap();
+    let browser = ServoCefBrowser::new(window_info, client, target_url).as_cef_interface();
     browser.init(window_info);
-    if url != ptr::null() {
-       unsafe { browser.downcast().frame.set_url(CefWrap::to_rust(url)); }
-    }
     if callback_executed {
         browser_callback_after_created(browser.clone());
     }


### PR DESCRIPTION
Changes the call to `Browser::new()` in cef to contain the target_url.

cc @paulrouget 
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #17273.

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17548)
<!-- Reviewable:end -->
