### PR TITLE
stylo: Bug 1375812 - Build an identity matrix for InterpolateMatrix.

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -1621,19 +1621,18 @@ fn build_identity_transform_list(list: &[TransformOperation]) -> Vec<TransformOp
                 result.push(TransformOperation::Rotate(0.0, 0.0, 1.0, Angle::zero()));
             }
             TransformOperation::Perspective(..) |
-            TransformOperation::AccumulateMatrix { .. } => {
+            TransformOperation::AccumulateMatrix { .. } |
+            TransformOperation::InterpolateMatrix { .. } => {
                 // Perspective: We convert a perspective function into an equivalent
                 //     ComputedMatrix, and then decompose/interpolate/recompose these matrices.
-                // AccumulateMatrix: We do interpolation on AccumulateMatrix by reading it as a
-                //     ComputedMatrix (with layout information), and then do matrix interpolation.
+                // AccumulateMatrix/InterpolateMatrix: We do interpolation on
+                //     AccumulateMatrix/InterpolateMatrix by reading it as a ComputedMatrix
+                //     (with layout information), and then do matrix interpolation.
                 //
                 // Therefore, we use an identity matrix to represent the identity transform list.
                 // http://dev.w3.org/csswg/css-transforms/#identity-transform-function
                 let identity = ComputedMatrix::identity();
                 result.push(TransformOperation::Matrix(identity));
-            }
-            TransformOperation::InterpolateMatrix { .. } => {
-                panic!("Building the identity matrix for InterpolateMatrix is not supported");
             }
         }
     }


### PR DESCRIPTION
We have to build an identity matrix while add_weighted() between InterpolateMatrix and none transform in some cases, e.g. trigger a transition from a mid-point of another transition to none.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1375812](https://bugzilla.mozilla.org/show_bug.cgi?id=1375812).
- [X] These changes do not require tests because we have tests in Gecko already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17553)
<!-- Reviewable:end -->
