### PR TITLE
Backed out changeset 90036d4d378e (bug 17564) because gecko-side patch caused bustage on Windows. r=backout on a CLOSED TREE

### DIFF
--- a/components/style/element_state.rs
+++ b/components/style/element_state.rs
@@ -138,16 +138,3 @@ bitflags! {
         const IN_AUTOFILL_PREVIEW_STATE = 1 << 51,
     }
 }
-
-bitflags! {
-    /// Event-based document states.
-    ///
-    /// NB: Is important for this to remain in sync with Gecko's
-    /// dom/base/nsIDocument.h.
-    pub flags DocumentState: u64 {
-        /// RTL locale: specific to the XUL localedir attribute
-        const NS_DOCUMENT_STATE_RTL_LOCALE = 1 << 0,
-        /// Window activation status
-        const NS_DOCUMENT_STATE_WINDOW_INACTIVE = 1 << 1,
-    }
-}

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -219,7 +219,6 @@ use gecko_bindings::structs::nsStyleTransformMatrix::MatrixTransformOperator;
 unsafe impl Send for nsStyleTransformMatrix::MatrixTransformOperator {}
 unsafe impl Sync for nsStyleTransformMatrix::MatrixTransformOperator {}
 use gecko_bindings::structs::RawGeckoGfxMatrix4x4;
-use gecko_bindings::structs::EventStates;
 pub type nsTArrayBorrowed_uintptr_t<'a> = &'a mut ::gecko_bindings::structs::nsTArray<usize>;
 pub type RawServoStyleSetOwned = ::gecko_bindings::sugar::ownership::Owned<RawServoStyleSet>;
 pub type RawServoStyleSetOwnedOrNull = ::gecko_bindings::sugar::ownership::OwnedOrNull<RawServoStyleSet>;
@@ -586,10 +585,6 @@ extern "C" {
 extern "C" {
     pub fn Gecko_GetDocumentLWTheme(aDocument: *const nsIDocument)
      -> nsIDocument_DocumentTheme;
-}
-extern "C" {
-    pub fn Gecko_GetDocumentState(aDocument: *const nsIDocument)
-     -> EventStates;
 }
 extern "C" {
     pub fn Gecko_AtomAttrValue(element: RawGeckoElementBorrowed,

--- a/components/style/gecko/non_ts_pseudo_class_list.rs
+++ b/components/style/gecko/non_ts_pseudo_class_list.rs
@@ -26,6 +26,8 @@
  *
  * Pending pseudo-classes:
  *
+ *  :-moz-window-inactive.
+ *
  *  :scope -> <style scoped>, pending discussion.
  *
  * This follows the order defined in layout/style/nsCSSPseudoClassList.h when
@@ -114,7 +116,6 @@ macro_rules! apply_non_ts_list {
                 ("-moz-lwtheme", MozLWTheme, mozLWTheme, _, _),
                 ("-moz-lwtheme-brighttext", MozLWThemeBrightText, mozLWThemeBrightText, _, _),
                 ("-moz-lwtheme-darktext", MozLWThemeDarkText, mozLWThemeDarkText, _, _),
-                ("-moz-window-inactive", MozWindowInactive, mozWindowInactive, _, _),
             ],
             string: [
                 ("-moz-system-metric", MozSystemMetric, mozSystemMetric, _, PSEUDO_CLASS_INTERNAL),

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -22,7 +22,7 @@ use context::{QuirksMode, SharedStyleContext, UpdateAnimationsTasks};
 use data::ElementData;
 use dom::{self, DescendantsBit, LayoutIterator, NodeInfo, TElement, TNode, UnsafeNode};
 use dom::{OpaqueNode, PresentationalHintsSynthesizer};
-use element_state::{ElementState, DocumentState, NS_DOCUMENT_STATE_WINDOW_INACTIVE};
+use element_state::ElementState;
 use error_reporting::create_error_reporter;
 use font_metrics::{FontMetrics, FontMetricsProvider, FontMetricsQueryResult};
 use gecko::data::PerDocumentStyleData;
@@ -31,7 +31,7 @@ use gecko::selector_parser::{SelectorImpl, NonTSPseudoClass, PseudoElement};
 use gecko::snapshot_helpers;
 use gecko_bindings::bindings;
 use gecko_bindings::bindings::{Gecko_ConstructStyleChildrenIterator, Gecko_DestroyStyleChildrenIterator};
-use gecko_bindings::bindings::{Gecko_ElementState, Gecko_GetDocumentLWTheme, Gecko_GetDocumentState};
+use gecko_bindings::bindings::{Gecko_ElementState, Gecko_GetDocumentLWTheme};
 use gecko_bindings::bindings::{Gecko_GetLastChild, Gecko_GetNextStyleChild};
 use gecko_bindings::bindings::{Gecko_IsRootElement, Gecko_MatchesElement, Gecko_Namespace};
 use gecko_bindings::bindings::{Gecko_SetNodeFlags, Gecko_UnsetNodeFlags};
@@ -650,14 +650,6 @@ impl<'le> GeckoElement<'le> {
             return self.0.mState.mStates;
         }
         unsafe { Gecko_ElementState(self.0) }
-    }
-
-    fn document_state(&self) -> DocumentState {
-        let node = self.as_node();
-        unsafe {
-            let states = Gecko_GetDocumentState(node.owner_doc());
-            DocumentState::from_bits_truncate(states.mStates)
-        }
     }
 
     #[inline]
@@ -1765,9 +1757,6 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
             }
             NonTSPseudoClass::MozLWThemeDarkText => {
                 self.get_document_theme() == DocumentTheme::Doc_Theme_Dark
-            }
-            NonTSPseudoClass::MozWindowInactive => {
-                self.document_state().contains(NS_DOCUMENT_STATE_WINDOW_INACTIVE)
             }
             NonTSPseudoClass::MozPlaceholder => false,
             NonTSPseudoClass::MozAny(ref sels) => {


### PR DESCRIPTION
Backed out changeset 90036d4d378e (bug 17564) because gecko-side patch caused bustage on Windows. r=backout on a CLOSED TREE

Backs out https://github.com/servo/servo/pull/17564

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17567)
<!-- Reviewable:end -->
