### PR TITLE
Handle prefixed value of -moz-user-select properly

### DIFF
--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -60,7 +60,7 @@ class Keyword(object):
                  extra_gecko_values=None, extra_servo_values=None,
                  aliases=None,
                  extra_gecko_aliases=None, extra_servo_aliases=None,
-                 gecko_strip_moz_prefix=True,
+                 gecko_strip_moz_prefix=None,
                  gecko_inexhaustive=None):
         self.name = name
         self.values = values.split()
@@ -75,7 +75,8 @@ class Keyword(object):
         self.extra_gecko_aliases = parse_aliases(extra_gecko_aliases or "")
         self.extra_servo_aliases = parse_aliases(extra_servo_aliases or "")
         self.consts_map = {} if custom_consts is None else custom_consts
-        self.gecko_strip_moz_prefix = gecko_strip_moz_prefix
+        self.gecko_strip_moz_prefix = True \
+            if gecko_strip_moz_prefix is None else gecko_strip_moz_prefix
         self.gecko_inexhaustive = gecko_inexhaustive or (gecko_enum_prefix is None)
 
     def gecko_values(self):

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -701,7 +701,7 @@
             'gecko_constant_prefix', 'gecko_enum_prefix',
             'extra_gecko_values', 'extra_servo_values',
             'aliases', 'extra_gecko_aliases', 'extra_servo_aliases',
-            'custom_consts', 'gecko_inexhaustive',
+            'custom_consts', 'gecko_inexhaustive', 'gecko_strip_moz_prefix',
         ]}
     %>
 

--- a/components/style/properties/longhand/ui.mako.rs
+++ b/components/style/properties/longhand/ui.mako.rs
@@ -17,11 +17,13 @@ ${helpers.single_keyword("ime-mode", "auto normal active disabled inactive",
                          spec="https://drafts.csswg.org/css-ui/#input-method-editor")}
 
 ${helpers.single_keyword("-moz-user-select", "auto text none all element elements" +
-                            " toggle tri-state -moz-all -moz-none -moz-text",
+                            " toggle tri-state -moz-all -moz-text",
                          products="gecko",
                          alias="-webkit-user-select",
                          gecko_ffi_name="mUserSelect",
                          gecko_enum_prefix="StyleUserSelect",
+                         gecko_strip_moz_prefix=False,
+                         aliases="-moz-none=none",
                          animation_value_type="none",
                          spec="https://drafts.csswg.org/css-ui-4/#propdef-user-select")}
 

--- a/tests/unit/style/parsing/ui.rs
+++ b/tests/unit/style/parsing/ui.rs
@@ -20,8 +20,9 @@ fn test_moz_user_select() {
     assert_roundtrip_with_context!(_moz_user_select::parse, "toggle");
     assert_roundtrip_with_context!(_moz_user_select::parse, "tri-state");
     assert_roundtrip_with_context!(_moz_user_select::parse, "-moz-all");
-    assert_roundtrip_with_context!(_moz_user_select::parse, "-moz-none");
     assert_roundtrip_with_context!(_moz_user_select::parse, "-moz-text");
+    assert_eq!(parse(_moz_user_select::parse, "-moz-none"),
+               Ok(_moz_user_select::SpecifiedValue::none));
 
     assert!(parse(_moz_user_select::parse, "potato").is_err());
 }


### PR DESCRIPTION
This is supposed to fix [bug 1374996](https://bugzilla.mozilla.org/show_bug.cgi?id=1374996).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17568)
<!-- Reviewable:end -->
