### PR TITLE
Add rudimentary .taskcluster.yml

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,0 +1,34 @@
+version: 0
+metadata:
+  name: servo
+  description: >-
+    A modern, high-performance browser engine designed for both application
+    and embedded use.
+  owner: '{{ event.head.user.email }}'
+  source: '{{ event.head.repo.url }}'
+tasks:
+  - provisionerId: '{{ taskcluster.docker.provisionerId }}'
+    workerType: '{{ taskcluster.docker.workerType }}'
+    extra:
+      github:
+        events: []
+    payload:
+      maxRunTime: 3600
+      image: servobrowser/servo-linux-dev
+      command:
+        - /bin/bash
+        - '--login'
+        - '-c'
+        - '-x'
+        - >-
+          git clone {{event.head.repo.url}} servo &&
+          cd servo &&
+          git config advice.detachedHead false &&
+          git checkout {{event.head.sha}} &&
+          etc/ci/taskcluster-test.sh
+    metadata:
+      name: linux-tests
+      description: Run Linux tests.
+      owner: '{{ event.head.user.email }}'
+      source: '{{ event.head.repo.url }}'
+

--- a/etc/ci/taskcluster-test.sh
+++ b/etc/ci/taskcluster-test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Update this from the linux-dev builder in etc/ci/buildbot_steps.yml
+./mach test-tidy --no-progress --all
+./mach test-tidy --no-progress --self-test
+env CC=gcc-5 CXX=g++-5 ./mach build --dev
+env ./mach test-unit
+env ./mach package --dev
+env ./mach build-cef
+env ./mach build --dev --no-default-features --features default-except-unstable
+./mach build-geckolib
+./mach test-stylo
+bash ./etc/ci/lockfile_changed.sh
+bash ./etc/ci/manifest_changed.sh
+bash ./etc/ci/check_no_panic.sh


### PR DESCRIPTION
Template mostly from https://tools.taskcluster.net/quickstart/. Steps from the
linux-dev builder in etc/ci/buildbot_steps.yml, but with the real parts
commented out for speed during the testing process.

r? @aneeshusa 

I got the first-draft image built and pushed to docker hub at https://hub.docker.com/r/servobrowser/servo-linux-dev which is what this is set to pull from. 

cc @gregarndt @imbstack

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17580)
<!-- Reviewable:end -->
