### PR TITLE
Fix incremental layout bugs for absolute and cleared elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,7 +1415,7 @@ version = "0.0.1"
 dependencies = [
  "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
  "euclid 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 [dependencies]
 app_units = "0.5"
 atomic_refcell = "0.1"
-bitflags = "0.7"
+bitflags = "0.8"
 canvas_traits = {path = "../canvas_traits"}
 euclid = "0.15"
 fnv = "1.0"

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -202,7 +202,7 @@ fn compute_damage(old: &ServoComputedValues, new: &ServoComputedValues) -> Servo
     add_if_not_equal!(old, new, damage,
                       [REPAINT, REPOSITION, STORE_OVERFLOW, BUBBLE_ISIZES, REFLOW_OUT_OF_FLOW,
                        REFLOW, RECONSTRUCT_FLOW], [
-        get_box.float, get_box.display, get_box.position, get_counters.content,
+        get_box.clear, get_box.float, get_box.display, get_box.position, get_counters.content,
         get_counters.counter_reset, get_counters.counter_increment,
         get_inheritedbox._servo_under_display_none,
         get_list.quotes, get_list.list_style_type,

--- a/tests/wpt/metadata-css/css21_dev/html4/dynamic-top-change-001.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/dynamic-top-change-001.htm.ini
@@ -1,3 +1,0 @@
-[dynamic-top-change-001.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2435,6 +2435,18 @@
      {}
     ]
    ],
+   "css/incremental_position.html": [
+    [
+     "/_mozilla/css/incremental_position.html",
+     [
+      [
+       "/_mozilla/css/incremental_position_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/incremental_text_color_a.html": [
     [
      "/_mozilla/css/incremental_text_color_a.html",
@@ -7907,6 +7919,11 @@
     ]
    ],
    "css/incremental_letter_spacing_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "css/incremental_position_ref.html": [
     [
      {}
     ]
@@ -22806,6 +22823,14 @@
   ],
   "css/incremental_letter_spacing_ref.html": [
    "3235e9662e37dc723364a1dd39e07157868dd290",
+   "support"
+  ],
+  "css/incremental_position.html": [
+   "849f3f5ae1df8ecf3bcf3f1723b5a755afeb3316",
+   "reftest"
+  ],
+  "css/incremental_position_ref.html": [
+   "67ab51b29fb015b82bf98942e2e886b3de5ea2cd",
    "support"
   ],
   "css/incremental_text_color_a.html": [

--- a/tests/wpt/mozilla/tests/css/incremental_position.html
+++ b/tests/wpt/mozilla/tests/css/incremental_position.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html class="reftest-wait">
+  <head>
+    <meta charset="utf-8">
+    <title>Incremental absolute position test</title>
+    <link rel="match" href="incremental_position_ref.html">
+    <style>
+      #rect {
+        position: absolute;
+        border: 1px solid red;
+        width: 40px;
+        height: 40px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="rect"></div>
+    <script>
+      window.onload = function() {
+        document.body.offsetWidth; // force layout
+        var e = document.getElementById("rect");
+        e.style.left = "100px";
+        document.documentElement.classList.remove('reftest-wait');
+      };
+    </script>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/incremental_position_ref.html
+++ b/tests/wpt/mozilla/tests/css/incremental_position_ref.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Incremental absolute position reference</title>
+    <style>
+      #rect {
+        position: absolute;
+        border: 1px solid red;
+        width: 40px;
+        height: 40px;
+        left: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="rect"></div>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #17307.  <del>There were two underlying bugs:</del>

* <del>Nodes were not marked dirty when their style attribute changed.</del>

* BaseFlow flags set during flow construction could get out of sync with the element's style if repair_style was called.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #17307
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17581)
<!-- Reviewable:end -->
