### PR TITLE
Fix color stop sorting in -webkit-gradient

### DIFF
--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -433,10 +433,7 @@ impl Gradient {
                     (&GenericGradientItem::ColorStop(ref a), &GenericGradientItem::ColorStop(ref b)) => {
                         match (&a.position, &b.position) {
                             (&Some(LengthOrPercentage::Percentage(a)), &Some(LengthOrPercentage::Percentage(b))) => {
-                                let ordering = a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal);
-                                if ordering != Ordering::Equal {
-                                    return ordering;
-                                }
+                                return a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal);
                             },
                             _ => {},
                         }


### PR DESCRIPTION
This was causing a reftest failure in gecko side(layout/reftests/webkit-gradient/webkit-gradient-linear-2.html). Basically, it was sorting exactly opposite if two color stops have the same percentage.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17587)
<!-- Reviewable:end -->
