### PR TITLE
Fix warn stable_features

### DIFF
--- a/ports/glutin/lib.rs
+++ b/ports/glutin/lib.rs
@@ -5,7 +5,6 @@
 //! A simple application that uses glutin to open a window for Servo to display in.
 
 #![feature(box_syntax)]
-#![feature(struct_field_attributes)]
 
 #[macro_use] extern crate bitflags;
 extern crate compositing;


### PR DESCRIPTION
struct_field_attributes has been stable since 1.20.0. Attribute no longer needed.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this fixes a compiler warning only by removing a feature flag

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17588)
<!-- Reviewable:end -->
