### PR TITLE
Apply border-radius to img, canvas, iframe

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -836,7 +836,7 @@ fn clip_for_border_radius(style: &ServoComputedValues,
     let mut adjusted_clip = ClippingRegion::max();
     if !border_radii.is_square() {
         adjusted_clip.intersect_with_rounded_rect(clip, &border_radii);
-    };
+    }
 
     adjusted_clip
 }

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -830,18 +830,25 @@ fn convert_ellipse_size_keyword(keyword: ShapeExtent,
     }
 }
 
+fn clip_for_border_radius(style: &ServoComputedValues,
+                          clip: &Rect<Au>) -> ClippingRegion {
+    let border_radii = build_border_radius(clip, style.get_border());
+    let mut adjusted_clip = ClippingRegion::max();
+    if !border_radii.is_square() {
+        adjusted_clip.intersect_with_rounded_rect(clip, &border_radii);
+    };
+
+    adjusted_clip
+}
+
 impl FragmentDisplayListBuilding for Fragment {
     fn build_display_list_for_background_if_applicable(&self,
                                                        state: &mut DisplayListBuildState,
                                                        style: &ServoComputedValues,
                                                        display_list_section: DisplayListSection,
                                                        absolute_bounds: &Rect<Au>) {
-        // Adjust the clipping region as necessary to account for `border-radius`.
-        let border_radii = build_border_radius(absolute_bounds, style.get_border());
-        let mut clip = ClippingRegion::max();
-        if !border_radii.is_square() {
-            clip.intersect_with_rounded_rect(absolute_bounds, &border_radii);
-        };
+        let clip = clip_for_border_radius(style, absolute_bounds);
+
         let background = style.get_background();
 
         // FIXME: This causes a lot of background colors to be displayed when they are clearly not
@@ -1834,6 +1841,8 @@ impl FragmentDisplayListBuilding for Fragment {
         let stacking_relative_content_box =
             self.stacking_relative_content_box(stacking_relative_border_box);
 
+        let clipping_region = clip_for_border_radius(&self.style, &stacking_relative_content_box);
+
         match self.specific {
             SpecificFragmentInfo::TruncatedFragment(box TruncatedFragmentInfo {
                 text_info: Some(ref text_fragment),
@@ -1892,7 +1901,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 if !stacking_relative_content_box.is_empty() {
                     let base = state.create_base_display_item(
                         &stacking_relative_content_box,
-                        &ClippingRegion::from_rect(clip),
+                        &clipping_region,
                         self.node,
                         self.style.get_cursor(Cursor::Default),
                         DisplayListSection::Content);
@@ -1913,7 +1922,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 if let Some(ref image) = image_fragment.image {
                     let base = state.create_base_display_item(
                         &stacking_relative_content_box,
-                        &ClippingRegion::from_rect(clip),
+                        &clipping_region,
                         self.node,
                         self.style.get_cursor(Cursor::Default),
                         DisplayListSection::Content);
@@ -1944,7 +1953,7 @@ impl FragmentDisplayListBuilding for Fragment {
 
                 let base = state.create_base_display_item(
                     &stacking_relative_content_box,
-                    &ClippingRegion::from_rect(clip),
+                    &clipping_region,
                     self.node,
                     self.style.get_cursor(Cursor::Default),
                     DisplayListSection::Content);

--- a/tests/wpt/web-platform-tests/css/css-backgrounds-3/image-with-border-radius.html
+++ b/tests/wpt/web-platform-tests/css/css-backgrounds-3/image-with-border-radius.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Image with border-radius</title>
+<link rel="match" href="reference/image-with-border-radius.ref.html">
+<link rel="help" href="http://www.w3.org/TR/css3-background/#the-border-radius">
+
+<style>
+    #image {
+        border-radius: 15px;
+    }
+</style>
+
+<img src="support/60x60-green.png" id="image"/>

--- a/tests/wpt/web-platform-tests/css/css-backgrounds-3/reference/image-with-border-radius.ref.html
+++ b/tests/wpt/web-platform-tests/css/css-backgrounds-3/reference/image-with-border-radius.ref.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+
+<style>
+    #green {
+        width: 60px;
+        height: 60px;
+        border-radius: 15px;
+    }
+</style>
+
+<div id="green"><div/>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Added some code that adjusts the clipping region of ```img```, ```canvas```, ```iframe``` elements for the ```border-radius``` property. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17510 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17589)
<!-- Reviewable:end -->
