### PR TITLE
Fix Rust compiler download error on Android

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -27,7 +27,7 @@ from mach.decorators import (
 )
 
 import servo.bootstrap as bootstrap
-from servo.command_base import CommandBase, BIN_SUFFIX, cd
+from servo.command_base import CommandBase, BIN_SUFFIX, cd, has_rustc_alt_build
 from servo.util import delete, download_bytes, download_file, extract, host_triple
 
 
@@ -67,6 +67,9 @@ class MachCommands(CommandBase):
                      action='store_true',
                      help='Use stable rustc version')
     def bootstrap_rustc(self, force=False, target=[], stable=False):
+        # Set default value for llvm-assertions when target platform is specified
+        if "SERVO_RUSTC_LLVM_ASSERTIONS" not in os.environ and target:
+            self.config["build"]["llvm-assertions"] = not has_rustc_alt_build(target)
         self.set_use_stable_rust(stable)
         version = self.rust_version()
         rust_path = self.rust_path()

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -201,6 +201,14 @@ def set_osmesa_env(bin_path, env):
     return env
 
 
+def has_rustc_alt_build(platform_or_triple):
+    platforms_with_rustc_alt_builds = ["unknown-linux-gnu", "apple-darwin", "pc-windows-msvc"]
+    for platform in platforms_with_rustc_alt_builds:
+        if platform in platform_or_triple:
+            return True
+    return False
+
+
 class BuildNotFound(Exception):
     def __init__(self, message):
         self.message = message
@@ -261,9 +269,8 @@ class CommandBase(object):
         self.config["tools"].setdefault("rustc-with-gold", get_env_bool("SERVO_RUSTC_WITH_GOLD", True))
 
         # https://github.com/rust-lang/rust/pull/39754
-        platforms_with_rustc_alt_builds = ["unknown-linux-gnu", "apple-darwin", "pc-windows-msvc"]
         llvm_assertions_default = ("SERVO_RUSTC_LLVM_ASSERTIONS" in os.environ
-                                   or host_platform() not in platforms_with_rustc_alt_builds)
+                                   or not has_rustc_alt_build(host_platform()))
 
         self.config.setdefault("build", {})
         self.config["build"].setdefault("android", False)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

After https://github.com/servo/servo/commit/6b523302e1159a4b89223d2e47f053e67240cf35 landed Android builds fail when downloading Rustc Compiler:
```
Downloading Host rust library for target armv7-linux-androideabi...
Download failed (404): Not Found - https://s3.amazonaws.com/rust-lang-ci/rustc-builds-alt/3bfc18a9619a5151ff4f11618db9cd882996ba6f/rust-std-nightly-armv7-linux-androideabi.tar.gz
```
I asked in rust-infra and they said that `alt` builds aren't compiled yet for all platforms (e.g. Android)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [x] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17604)
<!-- Reviewable:end -->
