### PR TITLE
Replace remaining usage of deprecated Range::step_by

### DIFF
--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -8,7 +8,6 @@
 #![feature(conservative_impl_trait)]
 #![feature(nonzero)]
 #![feature(raw)]
-#![feature(step_by)]
 
 extern crate app_units;
 extern crate atomic_refcell;

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -1572,7 +1572,6 @@ pub mod tests {
     use builder::HAS_PSEUDO_BIT;
     use cssparser::{Parser as CssParser, ToCss, serialize_identifier, ParserInput};
     use parser;
-    use std::borrow::Cow;
     use std::collections::HashMap;
     use std::fmt;
     use super::*;


### PR DESCRIPTION
… which is being removed in rust-lang/rust#43012

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17605)
<!-- Reviewable:end -->
