### PR TITLE
Clear canvas thread state on recreation.

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -544,6 +544,8 @@ impl<'a> CanvasPaintThread<'a> {
 
     fn recreate(&mut self, size: Size2D<i32>) {
         self.drawtarget = CanvasPaintThread::create(size);
+        self.state = CanvasPaintState::new(self.state.draw_options.antialias == AntialiasMode::Default);
+        self.saved_states.clear();
         // Webrender doesn't let images change size, so we clear the webrender image key.
         if let Some(image_key) = self.image_key.take() {
             self.webrender_api.delete_image(image_key);

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/paint2d-composite.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/paint2d-composite.html.ini
@@ -1,4 +1,0 @@
-[paint2d-composite.html]
-  type: reftest
-  expected: FAIL
-  bug: https://github.com/servo/servo/issues/17533

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/paint2d-shadows.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/paint2d-shadows.html.ini
@@ -1,4 +1,0 @@
-[paint2d-shadows.html]
-  type: reftest
-  expected: FAIL
-  bug: https://github.com/servo/servo/issues/17533


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The canvas rendering context is cleared when it is recreated, but not the matching state in the canvas paint thread.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17533 
- [X] These changes do not require tests because the css-paint-api tests test for this already.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17609)
<!-- Reviewable:end -->
