### PR TITLE
stylo: Add auto-filled line names to mRepeatAutoLineNameListBefore array

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1405,9 +1405,14 @@ fn static_assert() {
                         &mut ${self_grid}.mRepeatAutoLineNameListAfter, 0);
                 }
             },
-            GridTemplateComponent::Subgrid(list) => {
+            GridTemplateComponent::Subgrid(mut list) => {
                 ${self_grid}.set_mIsSubgrid(true);
-                let num_values = cmp::min(list.names.len(), max_lines + 1);
+                let names_length = match list.fill_idx {
+                    Some(_) => list.names.len() - 1,
+                    None => list.names.len(),
+                };
+                let num_values = cmp::min(names_length, max_lines + 1);
+
                 unsafe {
                     bindings::Gecko_SetStyleGridTemplateArrayLengths(&mut ${self_grid}, 0);
                     bindings::Gecko_SetGridTemplateLineNamesLength(&mut ${self_grid}, num_values as u32);
@@ -1420,6 +1425,8 @@ fn static_assert() {
                 if let Some(idx) = list.fill_idx {
                     ${self_grid}.set_mIsAutoFill(true);
                     ${self_grid}.mRepeatAutoIndex = idx as i16;
+                    set_line_names(&list.names.swap_remove(idx as usize),
+                                   &mut ${self_grid}.mRepeatAutoLineNameListBefore);
                 }
 
                 for (servo_names, gecko_names) in list.names.iter().zip(${self_grid}.mLineNameLists.iter_mut()) {

--- a/components/style/values/generics/grid.rs
+++ b/components/style/values/generics/grid.rs
@@ -621,10 +621,10 @@ impl Parse for LineNameList {
                                   .take(num.value() as usize * names_list.len())),
                     RepeatCount::AutoFill if fill_idx.is_none() => {
                         // `repeat(autof-fill, ..)` should have just one line name.
-                        if names_list.len() > 1 {
+                        if names_list.len() != 1 {
                             return Err(StyleParseError::UnspecifiedError.into());
                         }
-                        let names = names_list.pop().expect("expected one name list for auto-fill");
+                        let names = names_list.pop().unwrap();
 
                         line_names.push(names);
                         fill_idx = Some(line_names.len() as u32 - 1);


### PR DESCRIPTION
Line names with `repeat(auto-fill, ...)` were not being added to mRepeatAutoLineNameListBefore. They were being added into mLineNameLists instead.
Basically, `subgrid repeat(auto-fill, [abc]) [y z]` was becoming  `subgrid repeat(auto-fill, []) [abc] [y z]` in computed value.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17616)
<!-- Reviewable:end -->
