### PR TITLE
Handling of invalid values in svg paint server

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -475,6 +475,7 @@ def set_gecko_property(ffi_name, expr):
     #[allow(non_snake_case)]
     pub fn clone_${ident}(&self) -> longhands::${ident}::computed_value::T {
         use values::generics::{SVGPaint, SVGPaintKind};
+        use values::specified::url::SpecifiedUrl;
         use self::structs::nsStyleSVGPaintType;
         use self::structs::nsStyleSVGFallbackType;
         let ref paint = ${get_gecko_property(gecko_ffi_name)};
@@ -488,8 +489,13 @@ def set_gecko_property(ffi_name, expr):
             nsStyleSVGPaintType::eStyleSVGPaintType_ContextFill => SVGPaintKind::ContextFill,
             nsStyleSVGPaintType::eStyleSVGPaintType_ContextStroke => SVGPaintKind::ContextStroke,
             nsStyleSVGPaintType::eStyleSVGPaintType_Server => {
-                // FIXME (bug 1353966) this should animate
-                SVGPaintKind::None
+                unsafe {
+                    SVGPaintKind::PaintServer(
+                        SpecifiedUrl::from_url_value_data(
+                            &(**paint.mPaint.mPaintServer.as_ref())._base
+                        ).unwrap()
+                    )
+                }
             }
             nsStyleSVGPaintType::eStyleSVGPaintType_Color => {
                 unsafe { SVGPaintKind::Color(convert_nscolor_to_rgba(*paint.mPaint.mColor.as_ref())) }

--- a/components/style/values/generics/mod.rs
+++ b/components/style/values/generics/mod.rs
@@ -323,13 +323,25 @@ impl<ColorType> SVGPaintKind<ColorType> {
     }
 }
 
+/// Parse SVGPaint's fallback.
+/// fallback is keyword(none) or Color.
+/// https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint
+fn parse_fallback<'i, 't, ColorType: Parse>(context: &ParserContext,
+                                            input: &mut Parser<'i, 't>)
+                                            -> Option<ColorType> {
+    if input.try(|i| i.expect_ident_matching("none")).is_ok() {
+        None
+    } else {
+        input.try(|i| ColorType::parse(context, i)).ok()
+    }
+}
+
 impl<ColorType: Parse> Parse for SVGPaint<ColorType> {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
         if let Ok(url) = input.try(|i| SpecifiedUrl::parse(context, i)) {
-            let fallback = input.try(|i| ColorType::parse(context, i));
             Ok(SVGPaint {
                 kind: SVGPaintKind::PaintServer(url),
-                fallback: fallback.ok(),
+                fallback: parse_fallback(context, input),
             })
         } else if let Ok(kind) = input.try(SVGPaintKind::parse_ident) {
             if let SVGPaintKind::None = kind {
@@ -338,10 +350,9 @@ impl<ColorType: Parse> Parse for SVGPaint<ColorType> {
                     fallback: None,
                 })
             } else {
-                let fallback = input.try(|i| ColorType::parse(context, i));
                 Ok(SVGPaint {
                     kind: kind,
-                    fallback: fallback.ok(),
+                    fallback: parse_fallback(context, input),
                 })
             }
         } else if let Ok(color) = input.try(|i| ColorType::parse(context, i)) {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is a PR for https://bugzilla.mozilla.org/show_bug.cgi?id=1374161


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
There are tests for these changes, a test case will be landed in reftests in https://bugzilla.mozilla.org/show_bug.cgi?id=1374161.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17288)
<!-- Reviewable:end -->
