### PR TITLE
Clean up Area::parse (#15834)

### DIFF
--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -24,6 +24,7 @@ use html5ever::{LocalName, Prefix};
 use net_traits::ReferrerPolicy;
 use std::default::Default;
 use std::f32;
+use std::str;
 use style::attr::AttrValue;
 
 #[derive(PartialEq)]
@@ -68,7 +69,6 @@ impl Area {
         //This vector will hold all parsed coordinates
         let mut number_list = Vec::new();
         let mut array = Vec::new();
-        let ar_ref = &mut array;
 
         // Step 5: walk till end of string
         while index < size {
@@ -89,24 +89,24 @@ impl Area {
 
                 match val {
                     b',' | b';' | b' ' | b'\t' | b'\n' | 0x0C | b'\r' => break,
-                    _ => (*ar_ref).push(val),
+                    _ => array.push(val),
                 }
 
                 index += 1;
             }
 
             // The input does not consist any valid charecters
-            if (*ar_ref).is_empty() {
+            if array.is_empty() {
                 break;
             }
 
             // Convert String to float
-            match String::from_utf8((*ar_ref).clone()).unwrap().parse::<f32>() {
-                Ok(v) => number_list.push(v),
-                Err(_) => number_list.push(0.0),
+            match str::from_utf8(&array).ok().and_then(|s| s.parse::<f32>().ok()) {
+                Some(v) => number_list.push(v),
+                None => number_list.push(0.0),
             };
 
-            (*ar_ref).clear();
+            array.clear();
 
             // For rectangle and circle, stop parsing once we have three
             // and four coordinates respectively


### PR DESCRIPTION
Replace mutable reference to array with direct use

Remove unnecessary clone

Replace call to unwrap()

<!-- Please describe your changes on the following line: -->
This PR refactors `Area::parse` in `component/script/dom/htmlareaelement.rs`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15834  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's good enough that it compiles

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17620)
<!-- Reviewable:end -->
