### PR TITLE
Clean up HTMLImageElement::handle_event

### DIFF
--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -167,7 +167,7 @@ impl Area {
         }
     }
 
-    pub fn hit_test(&self, p: Point2D<f32>) -> bool {
+    pub fn hit_test(&self, p: &Point2D<f32>) -> bool {
         match *self {
             Area::Circle { left, top, radius } => {
                 (p.x - left) * (p.x - left) +

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -954,39 +954,37 @@ impl VirtualMethods for HTMLImageElement {
     }
 
     fn handle_event(&self, event: &Event) {
-       if event.type_() == atom!("click") {
-           let area_elements = self.areas();
-           let elements = if let Some(x) = area_elements {
-               x
-           } else {
+        if event.type_() != atom!("click") {
+            return
+        }
+
+       let area_elements = self.areas();
+       let elements = match area_elements {
+           Some(x) => x,
+           None => return,
+       };
+
+       // Fetch click coordinates
+       let mouse_event = match event.downcast::<MouseEvent>() {
+           Some(x) => x,
+           None => return,
+       };
+
+       let point = Point2D::new(mouse_event.ClientX().to_f32().unwrap(),
+                                mouse_event.ClientY().to_f32().unwrap());
+       let bcr = self.upcast::<Element>().GetBoundingClientRect();
+       let bcr_p = Point2D::new(bcr.X() as f32, bcr.Y() as f32);
+
+       // Walk HTMLAreaElements
+       for element in elements {
+           let shape = element.get_shape_from_coords();
+           let shp = match shape {
+               Some(x) => x.absolute_coords(bcr_p),
+               None => return,
+           };
+           if shp.hit_test(&point) {
+               element.activation_behavior(event, self.upcast());
                return
-           };
-
-           // Fetch click coordinates
-           let mouse_event = if let Some(x) = event.downcast::<MouseEvent>() {
-               x
-           } else {
-               return;
-           };
-
-           let point = Point2D::new(mouse_event.ClientX().to_f32().unwrap(),
-                                    mouse_event.ClientY().to_f32().unwrap());
-
-           // Walk HTMLAreaElements
-           for element in elements {
-               let shape = element.get_shape_from_coords();
-               let p = Point2D::new(self.upcast::<Element>().GetBoundingClientRect().X() as f32,
-                                    self.upcast::<Element>().GetBoundingClientRect().Y() as f32);
-
-               let shp = if let Some(x) = shape {
-                   x.absolute_coords(p)
-               } else {
-                   return
-               };
-               if shp.hit_test(point) {
-                   element.activation_behavior(event, self.upcast());
-                   return
-               }
            }
        }
     }

--- a/tests/unit/script/htmlareaelement.rs
+++ b/tests/unit/script/htmlareaelement.rs
@@ -100,23 +100,23 @@ fn polygon_eight_points_invalid_input() {
 #[test]
 fn test_hit_test_circle() {
    let circ1 = Area::Circle { left: 20.0, top: 10.0, radius: 5.0 };
-   assert!(!circ1.hit_test(Point2D::new(10.0, 20.0)));
+   assert!(!circ1.hit_test(&Point2D::new(10.0, 20.0)));
    let circ2 = Area::Circle { left: 10.0, top: 10.0, radius: 5.0 };
-   assert!(circ2.hit_test(Point2D::new(10.0, 12.0)));
+   assert!(circ2.hit_test(&Point2D::new(10.0, 12.0)));
 }
 
 #[test]
 fn test_hit_test_rectangle() {
    let rect1 = Area::Rectangle { top_left: (1.0, 7.0), bottom_right: (15.0, 10.0) };
-   assert!(!rect1.hit_test(Point2D::new(10.0, 5.0)));
+   assert!(!rect1.hit_test(&Point2D::new(10.0, 5.0)));
    let rect2 = Area::Rectangle { top_left: (8.0, 10.0), bottom_right: (20.0, 12.0) };
-   assert!(rect2.hit_test(Point2D::new(10.0, 12.0)));
+   assert!(rect2.hit_test(&Point2D::new(10.0, 12.0)));
 }
 
 #[test]
 fn test_hit_test_polygon() {
    let poly1 = Area::Polygon { points: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0] };
-   assert!(!poly1.hit_test(Point2D::new(10.0, 5.0)));
+   assert!(!poly1.hit_test(&Point2D::new(10.0, 5.0)));
    let poly2 = Area::Polygon { points: vec![7.0, 7.5, 8.2, 9.0, 11.0, 12.0] };
-   assert!(!poly2.hit_test(Point2D::new(10.0, 5.0)));
+   assert!(!poly2.hit_test(&Point2D::new(10.0, 5.0)));
 }


### PR DESCRIPTION
Reflects desired changes in #15832 

<!-- Please describe your changes on the following line: -->
Cleans up `HTMLImageElement::handle_event` located in `components/script/dom/htmlimageelement.rs`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15832 

- [X] These changes do not require tests because this change maintains the same logic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17632)
<!-- Reviewable:end -->
