### PR TITLE
Implement drawing an image from a CSS style value into a canvas

### DIFF
--- a/components/script/dom/cssstylevalue.rs
+++ b/components/script/dom/cssstylevalue.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use cssparser::Parser;
+use cssparser::ParserInput;
 use dom::bindings::codegen::Bindings::CSSStyleValueBinding::CSSStyleValueMethods;
 use dom::bindings::codegen::Bindings::CSSStyleValueBinding::Wrap;
 use dom::bindings::js::Root;
@@ -10,6 +12,7 @@ use dom::bindings::reflector::reflect_dom_object;
 use dom::bindings::str::DOMString;
 use dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
+use servo_url::ServoUrl;
 
 #[dom_struct]
 pub struct CSSStyleValue {
@@ -42,5 +45,18 @@ impl CSSStyleValueMethods for CSSStyleValue {
     // check-tidy: no specs after this line
     fn CssText(&self) -> DOMString {
         self.Stringifier()
+    }
+}
+
+impl CSSStyleValue {
+    /// Parse the value as a `url()`.
+    /// TODO: This should really always be an absolute URL, but we currently
+    /// return relative URLs for computed values, so we pass in a base.
+    /// https://github.com/servo/servo/issues/17625
+    pub fn get_url(&self, base_url: ServoUrl) -> Option<ServoUrl> {
+        let mut input = ParserInput::new(&*self.value);
+        let mut parser = Parser::new(&mut input);
+        parser.expect_url().ok()
+            .and_then(|string| base_url.join(&*string).ok())
     }
 }

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -11,7 +11,7 @@ use dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasLin
 use dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasRenderingContext2DMethods;
 use dom::bindings::codegen::Bindings::PaintRenderingContext2DBinding;
 use dom::bindings::codegen::Bindings::PaintRenderingContext2DBinding::PaintRenderingContext2DMethods;
-use dom::bindings::codegen::UnionTypes::HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2D;
+use dom::bindings::codegen::UnionTypes::HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2DOrCSSStyleValue;
 use dom::bindings::codegen::UnionTypes::StringOrCanvasGradientOrCanvasPattern;
 use dom::bindings::error::ErrorResult;
 use dom::bindings::error::Fallible;
@@ -24,11 +24,13 @@ use dom::canvasgradient::CanvasGradient;
 use dom::canvaspattern::CanvasPattern;
 use dom::canvasrenderingcontext2d::CanvasRenderingContext2D;
 use dom::paintworkletglobalscope::PaintWorkletGlobalScope;
+use dom::workletglobalscope::WorkletGlobalScope;
 use dom_struct::dom_struct;
 use euclid::ScaleFactor;
 use euclid::Size2D;
 use euclid::TypedSize2D;
 use ipc_channel::ipc::IpcSender;
+use servo_url::ServoUrl;
 use std::cell::Cell;
 use style_traits::CSSPixel;
 use style_traits::DevicePixel;
@@ -42,8 +44,10 @@ pub struct PaintRenderingContext2D {
 impl PaintRenderingContext2D {
     fn new_inherited(global: &PaintWorkletGlobalScope) -> PaintRenderingContext2D {
         let size = Size2D::zero();
+        let image_cache = global.image_cache();
+        let base_url = global.upcast::<WorkletGlobalScope>().base_url();
         PaintRenderingContext2D {
-            context: CanvasRenderingContext2D::new_inherited(global.upcast(), None, size),
+            context: CanvasRenderingContext2D::new_inherited(global.upcast(), None, image_cache, base_url, size),
             device_pixel_ratio: Cell::new(ScaleFactor::new(1.0)),
         }
     }
@@ -57,6 +61,10 @@ impl PaintRenderingContext2D {
     pub fn send_data(&self, sender: IpcSender<CanvasData>) {
         let msg = CanvasMsg::FromLayout(FromLayoutMsg::SendData(sender));
         let _ = self.context.ipc_renderer().send(msg);
+    }
+
+    pub fn take_missing_image_urls(&self) -> Vec<ServoUrl> {
+        self.context.take_missing_image_urls()
     }
 
     pub fn set_bitmap_dimensions(&self,
@@ -187,7 +195,7 @@ impl PaintRenderingContext2DMethods for PaintRenderingContext2D {
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
     fn DrawImage(&self,
-                 image: HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2D,
+                 image: HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2DOrCSSStyleValue,
                  dx: f64,
                  dy: f64)
                  -> ErrorResult {
@@ -196,7 +204,7 @@ impl PaintRenderingContext2DMethods for PaintRenderingContext2D {
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
     fn DrawImage_(&self,
-                  image: HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2D,
+                  image: HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2DOrCSSStyleValue,
                   dx: f64,
                   dy: f64,
                   dw: f64,
@@ -207,7 +215,7 @@ impl PaintRenderingContext2DMethods for PaintRenderingContext2D {
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
     fn DrawImage__(&self,
-                   image: HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2D,
+                   image: HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2DOrCSSStyleValue,
                    sx: f64,
                    sy: f64,
                    sw: f64,
@@ -309,7 +317,7 @@ impl PaintRenderingContext2DMethods for PaintRenderingContext2D {
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createpattern
     fn CreatePattern(&self,
-                     image: HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2D,
+                     image: HTMLImageElementOrHTMLCanvasElementOrCanvasRenderingContext2DOrCSSStyleValue,
                      repetition: DOMString)
                      -> Fallible<Root<CanvasPattern>> {
         self.context.CreatePattern(image, repetition)

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use canvas_traits::CanvasData;
-use canvas_traits::CanvasImageData;
 use dom::bindings::callback::CallbackContainer;
 use dom::bindings::cell::DOMRefCell;
 use dom::bindings::codegen::Bindings::PaintWorkletGlobalScopeBinding;
@@ -28,8 +27,7 @@ use dom::workletglobalscope::WorkletTask;
 use dom_struct::dom_struct;
 use euclid::ScaleFactor;
 use euclid::TypedSize2D;
-use ipc_channel::ipc::IpcSender;
-use ipc_channel::ipc::IpcSharedMemory;
+use ipc_channel::ipc;
 use js::jsapi::Call;
 use js::jsapi::Construct1;
 use js::jsapi::HandleValue;
@@ -45,10 +43,10 @@ use js::jsval::ObjectValue;
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use msg::constellation_msg::PipelineId;
-use net_traits::image::base::Image;
 use net_traits::image::base::PixelFormat;
 use net_traits::image_cache::ImageCache;
 use script_layout_interface::message::Msg;
+use script_traits::DrawAPaintImageResult;
 use script_traits::Painter;
 use servo_atoms::Atom;
 use servo_url::ServoUrl;
@@ -59,6 +57,8 @@ use std::ptr::null_mut;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::mpsc;
+use std::sync::mpsc::Sender;
 use style_traits::CSSPixel;
 use style_traits::DevicePixel;
 
@@ -67,7 +67,7 @@ use style_traits::DevicePixel;
 pub struct PaintWorkletGlobalScope {
     /// The worklet global for this object
     worklet_global: WorkletGlobalScope,
-    /// The image cache (used for generating invalid images).
+    /// The image cache
     #[ignore_heap_size_of = "Arc"]
     image_cache: Arc<ImageCache>,
     /// https://drafts.css-houdini.org/css-paint-api/#paint-definitions
@@ -94,11 +94,16 @@ impl PaintWorkletGlobalScope {
         unsafe { PaintWorkletGlobalScopeBinding::Wrap(runtime.cx(), global) }
     }
 
+    pub fn image_cache(&self) -> Arc<ImageCache> {
+        self.image_cache.clone()
+    }
+
     pub fn perform_a_worklet_task(&self, task: PaintWorkletTask) {
         match task {
-            PaintWorkletTask::DrawAPaintImage(name, size, device_pixel_ratio, properties, sender) => {
+            PaintWorkletTask::DrawAPaintImage(name, size_in_px, device_pixel_ratio, properties, sender) => {
                 let properties = StylePropertyMapReadOnly::from_iter(self.upcast(), properties);
-                self.draw_a_paint_image(name, size, device_pixel_ratio, &*properties, sender);
+                let result = self.draw_a_paint_image(name, size_in_px, device_pixel_ratio, &*properties);
+                let _ = sender.send(result);
             }
         }
     }
@@ -108,11 +113,11 @@ impl PaintWorkletGlobalScope {
                           name: Atom,
                           size_in_px: TypedSize2D<f32, CSSPixel>,
                           device_pixel_ratio: ScaleFactor<f32, CSSPixel, DevicePixel>,
-                          properties: &StylePropertyMapReadOnly,
-                          sender: IpcSender<CanvasData>)
+                          properties: &StylePropertyMapReadOnly)
+                          -> DrawAPaintImageResult
     {
         // TODO: document paint definitions.
-        self.invoke_a_paint_callback(name, size_in_px, device_pixel_ratio, properties, sender);
+        self.invoke_a_paint_callback(name, size_in_px, device_pixel_ratio, properties)
     }
 
     /// https://drafts.css-houdini.org/css-paint-api/#invoke-a-paint-callback
@@ -121,8 +126,8 @@ impl PaintWorkletGlobalScope {
                                name: Atom,
                                size_in_px: TypedSize2D<f32, CSSPixel>,
                                device_pixel_ratio: ScaleFactor<f32, CSSPixel, DevicePixel>,
-                               properties: &StylePropertyMapReadOnly,
-                               sender: IpcSender<CanvasData>)
+                               properties: &StylePropertyMapReadOnly)
+                               -> DrawAPaintImageResult
     {
         let size_in_dpx = size_in_px * device_pixel_ratio;
         let size_in_dpx = TypedSize2D::new(size_in_dpx.width.abs() as u32, size_in_dpx.height.abs() as u32);
@@ -140,13 +145,13 @@ impl PaintWorkletGlobalScope {
             None => {
                 // Step 2.2.
                 warn!("Drawing un-registered paint definition {}.", name);
-                return self.send_invalid_image(size_in_dpx, sender);
+                return self.invalid_image(size_in_dpx, vec![]);
             }
             Some(definition) => {
                 // Step 5.1
                 if !definition.constructor_valid_flag.get() {
                     debug!("Drawing invalid paint definition {}.", name);
-                    return self.send_invalid_image(size_in_dpx, sender);
+                    return self.invalid_image(size_in_dpx, vec![]);
                 }
                 class_constructor.set(definition.class_constructor.get());
                 paint_function.set(definition.paint_function.get());
@@ -174,7 +179,7 @@ impl PaintWorkletGlobalScope {
                     self.paint_definitions.borrow_mut().get_mut(&name)
                         .expect("Vanishing paint definition.")
                         .constructor_valid_flag.set(false);
-                    return self.send_invalid_image(size_in_dpx, sender);
+                    return self.invalid_image(size_in_dpx, vec![]);
                 }
                 // Step 5.4
                 entry.insert(Box::new(Heap::default())).set(paint_instance.get());
@@ -202,39 +207,42 @@ impl PaintWorkletGlobalScope {
 
         rooted!(in(cx) let mut result = UndefinedValue());
         unsafe { Call(cx, paint_instance.handle(), paint_function.handle(), &args, result.handle_mut()); }
+        let missing_image_urls = rendering_context.take_missing_image_urls();
 
         // Step 13.
         if unsafe { JS_IsExceptionPending(cx) } {
             debug!("Paint function threw an exception {}.", name);
             unsafe { JS_ClearPendingException(cx); }
-            return self.send_invalid_image(size_in_dpx, sender);
+            return self.invalid_image(size_in_dpx, missing_image_urls);
         }
 
+        let (sender, receiver) = ipc::channel().expect("IPC channel creation.");
         rendering_context.send_data(sender);
+        let image_key = match receiver.recv() {
+            Ok(CanvasData::Image(data)) => Some(data.image_key),
+            _ => None,
+        };
+
+        DrawAPaintImageResult {
+            width: size_in_dpx.width,
+            height: size_in_dpx.height,
+            format: PixelFormat::BGRA8,
+            image_key: image_key,
+            missing_image_urls: missing_image_urls,
+        }
     }
 
-    fn send_invalid_image(&self,
-                          size: TypedSize2D<u32, DevicePixel>,
-                          sender: IpcSender<CanvasData>)
-    {
-        debug!("Sending an invalid image.");
-        let width = size.width as u32;
-        let height = size.height as u32;
-        let len = (width as usize) * (height as usize) * 4;
-        let pixel = [0x00, 0x00, 0x00, 0x00];
-        let bytes: Vec<u8> = pixel.iter().cloned().cycle().take(len).collect();
-        let mut image = Image {
-            width: width,
-            height: height,
+    // https://drafts.csswg.org/css-images-4/#invalid-image
+    fn invalid_image(&self, size: TypedSize2D<u32, DevicePixel>, missing_image_urls: Vec<ServoUrl>)
+                     -> DrawAPaintImageResult {
+        debug!("Returning an invalid image.");
+        DrawAPaintImageResult {
+            width: size.width as u32,
+            height: size.height as u32,
             format: PixelFormat::BGRA8,
-            bytes: IpcSharedMemory::from_bytes(&*bytes),
-            id: None,
-        };
-        self.image_cache.set_webrender_image_key(&mut image);
-        let image_key = image.id.expect("Image cache should set image key.");
-        let image_data = CanvasImageData { image_key: image_key };
-        let canvas_data = CanvasData::Image(image_data);
-        let _ = sender.send(canvas_data);
+            image_key: None,
+            missing_image_urls: missing_image_urls,
+        }
     }
 
     fn painter(&self, name: Atom) -> Arc<Painter> {
@@ -244,13 +252,15 @@ impl PaintWorkletGlobalScope {
             fn draw_a_paint_image(&self,
                                   size: TypedSize2D<f32, CSSPixel>,
                                   device_pixel_ratio: ScaleFactor<f32, CSSPixel, DevicePixel>,
-                                  properties: Vec<(Atom, String)>,
-                                  sender: IpcSender<CanvasData>)
+                                  properties: Vec<(Atom, String)>)
+                                  -> DrawAPaintImageResult
             {
                 let name = self.0.clone();
+                let (sender, receiver) = mpsc::channel();
                 let task = PaintWorkletTask::DrawAPaintImage(name, size, device_pixel_ratio, properties, sender);
                 self.1.lock().expect("Locking a painter.")
                     .schedule_a_worklet_task(WorkletTask::Paint(task));
+                receiver.recv().expect("Worklet thread died?")
             }
         }
         Arc::new(WorkletPainter(name, Mutex::new(self.worklet_global.executor())))
@@ -346,7 +356,7 @@ pub enum PaintWorkletTask {
                     TypedSize2D<f32, CSSPixel>,
                     ScaleFactor<f32, CSSPixel, DevicePixel>,
                     Vec<(Atom, String)>,
-                    IpcSender<CanvasData>)
+                    Sender<DrawAPaintImageResult>)
 }
 
 /// A paint definition

--- a/components/script/dom/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script/dom/webidls/CanvasRenderingContext2D.webidl
@@ -8,8 +8,11 @@ enum CanvasFillRule { "nonzero", "evenodd" };
 typedef (HTMLImageElement or
          /* HTMLVideoElement or */
          HTMLCanvasElement or
-         CanvasRenderingContext2D /* or
-         ImageBitmap */) CanvasImageSource;
+         CanvasRenderingContext2D or
+         /* ImageBitmap or */
+         // This should probably be a CSSImageValue
+         // https://github.com/w3c/css-houdini-drafts/issues/416
+         CSSStyleValue) CanvasImageSource;
 
 //[Constructor(optional unsigned long width, unsigned long height)]
 interface CanvasRenderingContext2D {

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -39,7 +39,6 @@ mod script_msg;
 pub mod webdriver_msg;
 
 use bluetooth_traits::BluetoothRequest;
-use canvas_traits::CanvasData;
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
 use euclid::{Size2D, Length, Point2D, Vector2D, Rect, ScaleFactor, TypedSize2D};
 use gfx_traits::Epoch;
@@ -52,6 +51,7 @@ use msg::constellation_msg::{BrowsingContextId, TopLevelBrowsingContextId, Frame
 use msg::constellation_msg::{PipelineId, PipelineNamespaceId, TraversalDirection};
 use net_traits::{FetchResponseMsg, ReferrerPolicy, ResourceThreads};
 use net_traits::image::base::Image;
+use net_traits::image::base::PixelFormat;
 use net_traits::image_cache::ImageCache;
 use net_traits::response::HttpsState;
 use net_traits::storage_thread::StorageType;
@@ -69,6 +69,7 @@ use style_traits::CSSPixel;
 use style_traits::DevicePixel;
 use webdriver_msg::{LoadStatus, WebDriverScriptCommand};
 use webrender_api::ClipId;
+use webrender_api::ImageKey;
 use webvr_traits::{WebVREvent, WebVRMsg};
 
 pub use script_msg::{LayoutMsg, ScriptMsg, EventResult, LogEntry};
@@ -823,7 +824,22 @@ pub trait Painter: Sync + Send {
     fn draw_a_paint_image(&self,
                           size: TypedSize2D<f32, CSSPixel>,
                           zoom: ScaleFactor<f32, CSSPixel, DevicePixel>,
-                          properties: Vec<(Atom, String)>,
-                          sender: IpcSender<CanvasData>);
+                          properties: Vec<(Atom, String)>)
+                          -> DrawAPaintImageResult;
 }
 
+/// The result of executing paint code: the image together with any image URLs that need to be loaded.
+/// TODO: this should return a WR display list. https://github.com/servo/servo/issues/17497
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct DrawAPaintImageResult {
+    /// The image height
+    pub width: u32,
+    /// The image width
+    pub height: u32,
+    /// The image format
+    pub format: PixelFormat,
+    /// The image drawn, or None if an invalid paint image was drawn
+    pub image_key: Option<ImageKey>,
+    /// Drawing the image might have requested loading some image URLs.
+    pub missing_image_urls: Vec<ServoUrl>,
+}

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/paint2d-image.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/paint2d-image.html.ini
@@ -1,4 +1,0 @@
-[paint2d-image.html]
-  type: reftest
-  expected: FAIL
-  bug: https://github.com/servo/servo/issues/17432


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Implemented drawing a CSS style value into a canvas, which is needed for the Houdini CSS Paint API.

This PR is dependent on #17364.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17432.
- [X] These changes do not require tests because the existing CSS paint API wpt test cases test this behaviour.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17634)
<!-- Reviewable:end -->
