### PR TITLE
Fix build_gecko.rs for cross-macOS builds.

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -133,7 +133,8 @@ mod bindings {
     }
 
     fn update_last_modified(file: &Path) {
-        let modified = get_modified_time(file).unwrap();
+        let modified = get_modified_time(file)
+            .expect("Couldn't get file modification time");
         let mut last_modified = LAST_MODIFIED.lock().unwrap();
         *last_modified = cmp::max(modified, *last_modified);
     }

--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -61,31 +61,44 @@ mod bindings {
         }
     }
 
+    fn read_config(path: &PathBuf) -> toml::Table {
+        println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
+        update_last_modified(&path);
+
+        let mut contents = String::new();
+        File::open(path).expect("Failed to open config file")
+            .read_to_string(&mut contents).expect("Failed to read config file");
+        let mut parser = toml::Parser::new(&contents);
+        if let Some(result) = parser.parse() {
+            result
+        } else {
+            use std::fmt::Write;
+            let mut reason = String::from("Failed to parse config file:");
+            for err in parser.errors.iter() {
+                let parsed = &contents[..err.lo];
+                write!(&mut reason, "\n* line {} column {}: {}",
+                       parsed.lines().count(),
+                       parsed.lines().last().map_or(0, |l| l.len()),
+                       err).unwrap();
+            }
+            panic!(reason)
+        }
+    }
+
     lazy_static! {
         static ref CONFIG: toml::Table = {
+            // Load Gecko's binding generator config from the source tree.
             let path = PathBuf::from(env::var("MOZ_SRC").unwrap())
                 .join("layout/style/ServoBindings.toml");
-            println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
-            update_last_modified(&path);
-
-            let mut contents = String::new();
-            File::open(path).expect("Failed to open config file")
-                .read_to_string(&mut contents).expect("Failed to read config file");
-            let mut parser = toml::Parser::new(&contents);
-            if let Some(result) = parser.parse() {
-                result
-            } else {
-                use std::fmt::Write;
-                let mut reason = String::from("Failed to parse config file:");
-                for err in parser.errors.iter() {
-                    let parsed = &contents[..err.lo];
-                    write!(&mut reason, "\n* line {} column {}: {}",
-                           parsed.lines().count(),
-                           parsed.lines().last().map_or(0, |l| l.len()),
-                           err).unwrap();
-                }
-                panic!(reason)
-            }
+            read_config(&path)
+        };
+        static ref BUILD_CONFIG: toml::Table = {
+            // Load build-specific config overrides.
+            // FIXME: We should merge with CONFIG above instead of
+            // forcing callers to do it.
+            let path = PathBuf::from(env::var("MOZ_TOPOBJDIR").unwrap())
+                .join("layout/style/bindgen.toml");
+            read_config(&path)
         };
         static ref TARGET_INFO: HashMap<String, String> = {
             const TARGET_PREFIX: &'static str = "CARGO_CFG_TARGET_";
@@ -212,6 +225,8 @@ mod bindings {
 
             let mut matched_os = false;
             let build_config = CONFIG["build"].as_table().expect("Malformed config file");
+            builder = add_clang_args(builder, build_config, &mut matched_os);
+            let build_config = BUILD_CONFIG["build"].as_table().expect("Malformed config file");
             builder = add_clang_args(builder, build_config, &mut matched_os);
             if !matched_os {
                 panic!("Unknown platform");


### PR DESCRIPTION
This was [reviewed](https://bugzilla.mozilla.org/show_bug.cgi?id=1368083) over on the gecko side, and is now ready to land. This adds an additional build-time `bindgen.toml` file whose compiler args are merged into the libclang invocation.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because I *think* this is gecko-only. We'll find out.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17638)
<!-- Reviewable:end -->
