### PR TITLE
style: Avoid overriding the root font size from a getDefaultComputedStyle call

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -341,7 +341,6 @@ trait PrivateMatchMethods: TElement {
         if self.is_native_anonymous() || cascade_target == CascadeTarget::EagerPseudo {
             cascade_flags.insert(PROHIBIT_DISPLAY_CONTENTS);
         } else if self.is_root() {
-            debug_assert!(self.owner_doc_matches_for_testing(shared_context.stylist.device()));
             cascade_flags.insert(IS_ROOT_ELEMENT);
         }
 
@@ -563,9 +562,14 @@ trait PrivateMatchMethods: TElement {
                 // If the root font-size changed since last time, and something
                 // in the document did use rem units, ensure we recascade the
                 // entire tree.
-                if old_values.map_or(false, |v| v.get_font().clone_font_size() != new_font_size) &&
-                   device.used_root_font_size() {
-                    child_cascade_requirement = ChildCascadeRequirement::MustCascadeDescendants;
+                if old_values.map_or(true, |v| v.get_font().clone_font_size() != new_font_size) {
+                    // FIXME(emilio): This can fire when called from a document
+                    // from the bfcache (bug 1376897).
+                    debug_assert!(self.owner_doc_matches_for_testing(device));
+                    device.set_root_font_size(new_font_size);
+                    if device.used_root_font_size() {
+                        child_cascade_requirement = ChildCascadeRequirement::MustCascadeDescendants;
+                    }
                 }
             }
         }

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -553,9 +553,12 @@ trait PrivateMatchMethods: TElement {
                                        None);
 
             // Handle root font-size changes.
-            if self.is_root() && !self.is_native_anonymous() {
-                // The new root font-size has already been updated on the Device
-                // in properties::apply_declarations.
+            //
+            // TODO(emilio): This should arguably be outside of the path for
+            // getComputedStyle/getDefaultComputedStyle, but it's unclear how to
+            // do it without duplicating a bunch of code.
+            if self.is_root() && !self.is_native_anonymous() &&
+                !context.shared.traversal_flags.for_default_styles() {
                 let device = context.shared.stylist.device();
                 let new_font_size = new_values.get_font().clone_font_size();
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2901,11 +2901,6 @@ pub fn apply_declarations<'a, F, I>(device: &Device,
                                                  error_reporter);
             % endif
             }
-
-            if context.is_root_element {
-                let s = context.style.get_font().clone_font_size();
-                context.device.set_root_font_size(s);
-            }
         % endif
     % endfor
 
@@ -2937,7 +2932,6 @@ pub fn apply_declarations<'a, F, I>(device: &Device,
 
     style.build()
 }
-
 
 /// See StyleAdjuster::adjust_for_border_width.
 pub fn adjust_border_width(style: &mut StyleBuilder) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17639)
<!-- Reviewable:end -->
