### PR TITLE
style: Fix starts_with_ignore_ascii_case.

### DIFF
--- a/components/style/str.rs
+++ b/components/style/str.rs
@@ -149,5 +149,5 @@ pub fn str_join<I, T>(strs: I, join: &str) -> String
 /// Returns true if a given string has a given prefix with case-insensitive match.
 pub fn starts_with_ignore_ascii_case(string: &str, prefix: &str) -> bool {
     string.len() > prefix.len() &&
-      string[0..prefix.len()].eq_ignore_ascii_case(prefix)
+      string.as_bytes()[0..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
 }

--- a/components/style/str.rs
+++ b/components/style/str.rs
@@ -148,6 +148,6 @@ pub fn str_join<I, T>(strs: I, join: &str) -> String
 
 /// Returns true if a given string has a given prefix with case-insensitive match.
 pub fn starts_with_ignore_ascii_case(string: &str, prefix: &str) -> bool {
-    string.len() > prefix.len() &&
+    string.len() >= prefix.len() &&
       string.as_bytes()[0..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
 }

--- a/tests/unit/style/str.rs
+++ b/tests/unit/style/str.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use style::str::{split_html_space_chars, str_join};
+use style::str::{split_html_space_chars, str_join, starts_with_ignore_ascii_case};
 
 #[test]
 pub fn split_html_space_chars_whitespace() {
@@ -32,4 +32,9 @@ pub fn test_str_join_many() {
     let actual = str_join(&slice, "-");
     let expected = "-alpha--beta-gamma-";
     assert_eq!(actual, expected);
+}
+
+#[test]
+pub fn test_starts_with_ignore_ascii_case_char_boundary() {
+    assert!(!starts_with_ignore_ascii_case("aaaaa💩", "-webkit-"));
 }

--- a/tests/unit/style/str.rs
+++ b/tests/unit/style/str.rs
@@ -35,6 +35,12 @@ pub fn test_str_join_many() {
 }
 
 #[test]
+pub fn test_starts_with_ignore_ascii_case_basic() {
+    assert!(starts_with_ignore_ascii_case("-webkit-", "-webkit-"));
+    assert!(starts_with_ignore_ascii_case("-webkit-foo", "-webkit-"));
+}
+
+#[test]
 pub fn test_starts_with_ignore_ascii_case_char_boundary() {
     assert!(!starts_with_ignore_ascii_case("aaaaa💩", "-webkit-"));
 }


### PR DESCRIPTION
In particular, fix a panic when the input is not ASCII and we happen to index in
something that is not a char boundary.

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1379380

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17640)
<!-- Reviewable:end -->
