### PR TITLE
stylo: Run the stylehseet invalidation pass also for stylesheet removals

### DIFF
--- a/components/style/stylesheet_set.rs
+++ b/components/style/stylesheet_set.rs
@@ -125,8 +125,8 @@ where
         stylist: &Stylist,
         sheet: S,
         before_sheet: S,
-        guard: &SharedRwLockReadGuard)
-    {
+        guard: &SharedRwLockReadGuard
+    ) {
         debug!("StylesheetSet::insert_stylesheet_before");
         self.remove_stylesheet_if_present(&sheet);
         let index = self.entries.iter().position(|entry| {
@@ -142,12 +142,20 @@ where
     }
 
     /// Remove a given stylesheet from the set.
-    pub fn remove_stylesheet(&mut self, sheet: S) {
+    pub fn remove_stylesheet(
+        &mut self,
+        stylist: &Stylist,
+        sheet: S,
+        guard: &SharedRwLockReadGuard,
+    ) {
         debug!("StylesheetSet::remove_stylesheet");
         self.remove_stylesheet_if_present(&sheet);
         self.dirty = true;
-        // FIXME(emilio): We can do better!
-        self.invalidations.invalidate_fully();
+        self.invalidations.collect_invalidations_for(
+            stylist,
+            &sheet,
+            guard
+        );
     }
 
     /// Notes that the author style has been disabled for this document.

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -877,7 +877,8 @@ pub extern "C" fn Servo_StyleSet_InsertStyleSheetBefore(
         &data.stylist,
         unsafe { GeckoStyleSheet::new(sheet) },
         unsafe { GeckoStyleSheet::new(before_sheet) },
-        &guard);
+        &guard,
+    );
     data.clear_stylist();
 }
 
@@ -886,8 +887,15 @@ pub extern "C" fn Servo_StyleSet_RemoveStyleSheet(
     raw_data: RawServoStyleSetBorrowed,
     sheet: *const ServoStyleSheet
 ) {
+    let global_style_data = &*GLOBAL_STYLE_DATA;
     let mut data = PerDocumentStyleData::from_ffi(raw_data).borrow_mut();
-    data.stylesheets.remove_stylesheet(unsafe { GeckoStyleSheet::new(sheet) });
+    let mut data = &mut *data;
+    let guard = global_style_data.shared_lock.read();
+    data.stylesheets.remove_stylesheet(
+        &data.stylist,
+        unsafe { GeckoStyleSheet::new(sheet) },
+        &guard,
+    );
     data.clear_stylist();
 }
 


### PR DESCRIPTION
People apparently do all sorts of silly stuff with stylesheets, see Google Inbox
in bug 1379203.

Bug: 1379433
Reviewed-By: heycam
MozReview-Commit-ID: 4x2d3glOFu8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17644)
<!-- Reviewable:end -->
