### PR TITLE
Move Ctrl-F12 keybindings outside of libservo

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -11,7 +11,7 @@ use gfx_traits::Epoch;
 use gleam::gl;
 use image::{DynamicImage, ImageFormat, RgbImage};
 use ipc_channel::ipc::{self, IpcSharedMemory};
-use msg::constellation_msg::{Key, KeyModifiers, KeyState, CONTROL};
+use msg::constellation_msg::{Key, KeyModifiers, KeyState};
 use msg::constellation_msg::{PipelineId, PipelineIndex, PipelineNamespaceId, TraversalDirection};
 use net_traits::image::base::{Image, PixelFormat};
 use profile_traits::time::{self, ProfilerCategory, profile};
@@ -825,6 +825,11 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                     warn!("Sending reload to constellation failed ({}).", e);
                 }
             }
+
+            WindowEvent::ToggleWebRenderProfiler => {
+                let profiler_enabled = self.webrender.get_profiler_enabled();
+                self.set_webrender_profiler_enabled(!profiler_enabled);
+            }
         }
     }
 
@@ -1313,18 +1318,6 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                     key: Key,
                     state: KeyState,
                     modifiers: KeyModifiers) {
-        // Steal a few key events for webrender debug options.
-        if modifiers.contains(CONTROL) && state == KeyState::Pressed {
-            match key {
-                Key::F12 => {
-                    let profiler_enabled = self.webrender.get_profiler_enabled();
-                    self.webrender.set_profiler_enabled(!profiler_enabled);
-                    return;
-                }
-                _ => {}
-            }
-        }
-
         let msg = ConstellationMsg::KeyEvent(ch, key, state, modifiers);
         if let Err(e) = self.constellation_chan.send(msg) {
             warn!("Sending key event to constellation failed ({}).", e);

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -828,7 +828,8 @@ impl<Window: WindowMethods> IOCompositor<Window> {
 
             WindowEvent::ToggleWebRenderProfiler => {
                 let profiler_enabled = self.webrender.get_profiler_enabled();
-                self.set_webrender_profiler_enabled(!profiler_enabled);
+                self.webrender.set_profiler_enabled(!profiler_enabled);
+                self.webrender_api.generate_frame(None);
             }
         }
     }
@@ -1630,11 +1631,6 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         }
 
         self.shutdown_state != ShutdownState::FinishedShuttingDown
-    }
-
-    pub fn set_webrender_profiler_enabled(&mut self, enabled: bool) {
-        self.webrender.set_profiler_enabled(enabled);
-        self.webrender_api.generate_frame(None);
     }
 
     /// Repaints and recomposites synchronously. You must be careful when calling this, as if a

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -76,6 +76,8 @@ pub enum WindowEvent {
     KeyEvent(Option<char>, Key, KeyState, KeyModifiers),
     /// Sent when Ctr+R/Apple+R is called to reload the current page.
     Reload,
+    /// Toggles the Web renderer profiler on and off
+    ToggleWebRenderProfiler,
 }
 
 impl Debug for WindowEvent {
@@ -98,6 +100,7 @@ impl Debug for WindowEvent {
             WindowEvent::Navigation(..) => write!(f, "Navigation"),
             WindowEvent::Quit => write!(f, "Quit"),
             WindowEvent::Reload => write!(f, "Reload"),
+            WindowEvent::ToggleWebRenderProfiler => write!(f, "ToggleWebRenderProfiler"),
         }
     }
 }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -244,10 +244,6 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
         self.compositor.handle_events(events)
     }
 
-    pub fn set_webrender_profiler_enabled(&mut self, enabled: bool) {
-        self.compositor.set_webrender_profiler_enabled(enabled);
-    }
-
     pub fn repaint_synchronously(&mut self) {
         self.compositor.repaint_synchronously()
     }

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -1290,6 +1290,9 @@ impl WindowMethods for Window {
                     self.event_queue.borrow_mut().push(WindowEvent::Quit);
                 }
             }
+            (CONTROL, None, Key::F12) => {
+                self.event_queue.borrow_mut().push(WindowEvent::ToggleWebRenderProfiler);
+            }
 
             _ => {
                 self.platform_handle_key(key, mods);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Creates a new WindowEvent called ToggleProfiller, when this Event is queued the profiler is toggled. 
When Crtl + F12 are pressed the Event is queued.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17647 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17652)
<!-- Reviewable:end -->
