### PR TITLE
[WIP] Finish implementation of HTML5 form validation.

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -7,6 +7,7 @@ use dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
 use dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::HTMLButtonElementBinding::HTMLButtonElementMethods;
+use dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementBinding::HTMLElementMethods;
 use dom::bindings::codegen::Bindings::HTMLFormControlsCollectionBinding::HTMLFormControlsCollectionMethods;
 use dom::bindings::codegen::Bindings::HTMLFormElementBinding;
 use dom::bindings::codegen::Bindings::HTMLFormElementBinding::HTMLFormElementMethods;
@@ -454,13 +455,18 @@ impl HTMLFormElement {
     /// Interactively validate the constraints of form elements
     /// https://html.spec.whatwg.org/multipage/#interactively-validate-the-constraints
     fn interactive_validation(&self) -> Result<(), ()> {
-        // Step 1-3
-        let _unhandled_invalid_controls = match self.static_validation() {
+        // Step 1-2
+        let unhandled_invalid_controls = match self.static_validation() {
             Ok(()) => return Ok(()),
             Err(err) => err
         };
-        // TODO: Report the problems with the constraints of at least one of
-        //       the elements given in unhandled invalid controls to the user
+        // Step 3
+        // TODO: Replace println! by something more visible to the user when a better reporting method
+        // becomes available.
+        let ref first_invalid_element = unhandled_invalid_controls[0].as_html_element();
+        println!("Validation error in element {}",
+                 first_invalid_element.upcast::<Element>().get_string_attribute(&local_name!("name")));
+        first_invalid_element.Focus();
         // Step 4
         Err(())
     }
@@ -755,6 +761,16 @@ impl FormSubmittableElement {
             FormSubmittableElement::TextAreaElement(Root::from_ref(&input))
         } else {
             unreachable!()
+        }
+    }
+
+    fn as_html_element(&self) -> &HTMLElement {
+        match *self {
+            FormSubmittableElement::ButtonElement(ref button) => button.upcast(),
+            FormSubmittableElement::InputElement(ref input) => input.upcast(),
+            FormSubmittableElement::ObjectElement(ref object) => object.upcast(),
+            FormSubmittableElement::SelectElement(ref select) => select.upcast(),
+            FormSubmittableElement::TextAreaElement(ref textarea) => textarea.upcast()
         }
     }
 }

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -70,56 +70,56 @@ impl ValidityState {
 impl ValidityStateMethods for ValidityState {
     // https://html.spec.whatwg.org/multipage/#dom-validitystate-valuemissing
     fn ValueMissing(&self) -> bool {
-        false
+        self.element.as_maybe_validatable().map_or(false, |e| e.validate(VALUE_MISSING))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-validitystate-typemismatch
     fn TypeMismatch(&self) -> bool {
-        false
+        self.element.as_maybe_validatable().map_or(false, |e| e.validate(TYPE_MISMATCH))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-validitystate-patternmismatch
     fn PatternMismatch(&self) -> bool {
-        false
+        self.element.as_maybe_validatable().map_or(false, |e| e.validate(PATTERN_MISMATCH))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-validitystate-toolong
     fn TooLong(&self) -> bool {
-        false
+        self.element.as_maybe_validatable().map_or(false, |e| e.validate(TOO_LONG))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-validitystate-tooshort
     fn TooShort(&self) -> bool {
-        false
+        self.element.as_maybe_validatable().map_or(false, |e| e.validate(TOO_SHORT))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-validitystate-rangeunderflow
     fn RangeUnderflow(&self) -> bool {
-        false
+        self.element.as_maybe_validatable().map_or(false, |e| e.validate(RANGE_UNDERFLOW))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-validitystate-rangeoverflow
     fn RangeOverflow(&self) -> bool {
-        false
+        self.element.as_maybe_validatable().map_or(false, |e| e.validate(RANGE_OVERFLOW))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-validitystate-stepmismatch
     fn StepMismatch(&self) -> bool {
-        false
+        self.element.as_maybe_validatable().map_or(false, |e| e.validate(STEP_MISMATCH))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-validitystate-badinput
     fn BadInput(&self) -> bool {
-        false
+        self.element.as_maybe_validatable().map_or(false, |e| e.validate(BAD_INPUT))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-validitystate-customerror
     fn CustomError(&self) -> bool {
-        false
+        self.element.as_maybe_validatable().map_or(false, |e| e.validate(CUSTOM_ERROR))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-validitystate-valid
     fn Valid(&self) -> bool {
-        false
+        !self.element.as_maybe_validatable().map_or(false, |e| e.validate(ValidationFlags::all()))
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is still work in progress, but comments would be highly appreciated.

Some questions:


1- The standard doesn't mention date and telephone validation (I checked which sections refer to the "type mismatch" validity state, and only URL and Email were there). That's why I left it out, but the last PR (#10843) had some validation for them. Should I bring it back?

2- In URL validation, I've checked whether there is either a '.' or a '/' (since for instance http://localhost is a valid URL). Is that fine?

3- For emails, I've only checked whether there is an '@' in the text. However, there's a suggested regex in the standard. Should we use it?

4- In the 'pattern mismatch' error, how do I use JavaScript's Regex engine? I'm guessing the `regex` crate might differ.

5- How do I handle 'multiple' inputs? Since there's only one value in an input element, I'm not sure how multiple inputs should be validated.

6- What does `/tests/html/form_html5_validations.html` actually test? Or is it simply a page for manual testing?

TODO:

- [ ] Check for missing validity flags in HTMLInputElement: range errors (underflow/overflow), step mismatch, bad input, custom error
- [ ] Implement HTMLSelectElement::validate
- [ ] Implement HTMLTextAreaElement::validate
- [ ] Implement the constraint validation API
- [ ] Write WPT tests
- [ ] Anything else?


---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #11444 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17657)
<!-- Reviewable:end -->
