### PR TITLE
selectors: Avoid looking at MatchingMode if the selector isn't the topmost.

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1777,12 +1777,11 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
             }
             NonTSPseudoClass::MozPlaceholder => false,
             NonTSPseudoClass::MozAny(ref sels) => {
-                let old_value = context.hover_active_quirk_disabled;
-                context.hover_active_quirk_disabled = true;
+                context.nesting_level += 1;
                 let result = sels.iter().any(|s| {
                     matches_complex_selector(s.iter(), self, context, flags_setter)
                 });
-                context.hover_active_quirk_disabled = old_value;
+                context.nesting_level -= 1;
                 result
             }
             NonTSPseudoClass::Lang(ref lang_arg) => {


### PR DESCRIPTION
Also, switch the hover quirk to the same mechanism.

Bug: 1379696
Reviewed-By: bholley
MozReview-Commit-ID: KrmNqNyASf6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17658)
<!-- Reviewable:end -->
