### PR TITLE
Serialize font longhands to -moz-use-system-font when using system font like what Gecko does

### DIFF
--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -493,8 +493,6 @@
     %>
     <%call expr="longhand(name, keyword=Keyword(name, values, **keyword_kwargs), **kwargs)">
         use properties::longhands::system_font::SystemFont;
-        use std::fmt;
-        use style_traits::ToCss;
         no_viewport_percentage!(SpecifiedValue);
 
         pub mod computed_value {
@@ -517,19 +515,10 @@
             ${gecko_keyword_conversion(keyword, keyword.values_for(product), type="T", cast_to="i32")}
         }
 
-        #[derive(Debug, Clone, PartialEq, Eq, Copy)]
+        #[derive(Debug, Clone, PartialEq, Eq, Copy, ToCss)]
         pub enum SpecifiedValue {
             Keyword(computed_value::T),
             System(SystemFont),
-        }
-
-        impl ToCss for SpecifiedValue {
-            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-                match *self {
-                    SpecifiedValue::Keyword(k) => k.to_css(dest),
-                    SpecifiedValue::System(_) => Ok(())
-                }
-            }
         }
 
         pub fn parse<'i, 't>(_: &ParserContext, input: &mut Parser<'i, 't>) -> Result<SpecifiedValue, ParseError<'i>> {

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -35,16 +35,6 @@ macro_rules! impl_gecko_keyword_conversions {
 // Define ToComputedValue, ToCss, and other boilerplate for a specified value
 // which is of the form `enum SpecifiedValue {Value(..), System(SystemFont)}`
 <%def name="simple_system_boilerplate(name)">
-    impl ToCss for SpecifiedValue {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match *self {
-                SpecifiedValue::Value(ref v) => v.to_css(dest),
-                SpecifiedValue::System(_) => Ok(())
-            }
-        }
-    }
-
-
     impl SpecifiedValue {
         pub fn system_font(f: SystemFont) -> Self {
             SpecifiedValue::System(f)
@@ -366,7 +356,7 @@ macro_rules! impl_gecko_keyword_conversions {
                     }
                     Ok(())
                 }
-                _ => Ok(())
+                SpecifiedValue::System(sys) => sys.to_css(dest),
             }
         }
     }
@@ -434,7 +424,7 @@ ${helpers.single_keyword_system("font-variant-caps",
                 SpecifiedValue::Bolder => dest.write_str("bolder"),
                 SpecifiedValue::Lighter => dest.write_str("lighter"),
                 SpecifiedValue::Weight(weight) => weight.to_css(dest),
-                SpecifiedValue::System(_) => Ok(())
+                SpecifiedValue::System(sys) => sys.to_css(dest),
             }
         }
     }
@@ -602,7 +592,7 @@ ${helpers.single_keyword_system("font-variant-caps",
                 SpecifiedValue::Keyword(kw, _) => kw.to_css(dest),
                 SpecifiedValue::Smaller => dest.write_str("smaller"),
                 SpecifiedValue::Larger => dest.write_str("larger"),
-                SpecifiedValue::System(_) => Ok(()),
+                SpecifiedValue::System(sys) => sys.to_css(dest),
             }
         }
     }
@@ -1033,7 +1023,7 @@ ${helpers.single_keyword_system("font-variant-caps",
             match *self {
                 SpecifiedValue::None => dest.write_str("none"),
                 SpecifiedValue::Number(number) => number.to_css(dest),
-                SpecifiedValue::System(_) => Ok(()),
+                SpecifiedValue::System(sys) => sys.to_css(dest),
             }
         }
     }
@@ -1272,7 +1262,7 @@ ${helpers.single_keyword_system("font-kerning",
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub struct VariantAlternatesList(pub Box<[VariantAlternates]>);
 
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq, ToCss)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum SpecifiedValue {
         Value(VariantAlternatesList),
@@ -1481,7 +1471,7 @@ macro_rules! exclusive_value {
     }
 
 
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq, ToCss)]
     pub enum SpecifiedValue {
         Value(VariantEastAsian),
         System(SystemFont)
@@ -1626,7 +1616,7 @@ macro_rules! exclusive_value {
     }
 
 
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq, ToCss)]
     pub enum SpecifiedValue {
         Value(VariantLigatures),
         System(SystemFont)
@@ -1785,7 +1775,7 @@ macro_rules! exclusive_value {
 
 
 
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq, ToCss)]
     pub enum SpecifiedValue {
         Value(VariantNumeric),
         System(SystemFont)
@@ -1920,11 +1910,9 @@ ${helpers.single_keyword_system("font-variant-position",
                    extra_prefixes="moz" boxed="True"
                    spec="https://drafts.csswg.org/css-fonts/#propdef-font-feature-settings">
     use properties::longhands::system_font::SystemFont;
-    use std::fmt;
-    use style_traits::ToCss;
     use values::generics::FontSettings;
 
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq, ToCss)]
     pub enum SpecifiedValue {
         Value(computed_value::T),
         System(SystemFont)
@@ -2012,7 +2000,7 @@ https://drafts.csswg.org/css-fonts-4/#low-level-font-variation-settings-control-
             match *self {
                 SpecifiedValue::Normal => dest.write_str("normal"),
                 SpecifiedValue::Override(ref lang) => lang.to_css(dest),
-                SpecifiedValue::System(_) => Ok(())
+                SpecifiedValue::System(sys) => sys.to_css(dest),
             }
         }
     }
@@ -2380,8 +2368,9 @@ ${helpers.single_keyword("-moz-math-variant",
         //! whenever a font longhand on the same element needs the system font.
 
         use app_units::Au;
-        use cssparser::Parser;
+        use cssparser::{Parser, ToCss};
         use properties::longhands;
+        use std::fmt;
         use std::hash::{Hash, Hasher};
         use style_traits::ParseError;
         use values::computed::{ToComputedValue, Context};
@@ -2513,6 +2502,14 @@ ${helpers.single_keyword("-moz-math-variant",
                 }
             }
         }
+
+        impl ToCss for SystemFont {
+            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+                // We may want to do something better in the future, see
+                // w3c/csswg-drafts#1586.
+                dest.write_str("-moz-use-system-font")
+            }
+        }
     }
 % else:
     pub mod system_font {
@@ -2522,7 +2519,7 @@ ${helpers.single_keyword("-moz-math-variant",
         // a lot of code with `if product == gecko` conditionals, we have a
         // dummy system font module that does nothing
 
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, ToCss)]
         #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
         /// void enum for system font, can never exist
         pub enum SystemFont {}


### PR DESCRIPTION
This is the Servo side change of [bug 1364289](https://bugzilla.mozilla.org/show_bug.cgi?id=1364289).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17660)
<!-- Reviewable:end -->
