### PR TITLE
Avoid panic when postMessage targets closed window.

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2000,7 +2000,8 @@ impl Runnable for PostMessageHandler {
 impl Window {
     pub fn post_message(&self, origin: Option<ImmutableOrigin>, data: StructuredCloneData) {
         let runnable = PostMessageHandler::new(self, origin, data);
-        let msg = CommonScriptMsg::RunnableMsg(ScriptThreadEventCategory::DomEvent, box runnable);
+        let runnable = self.get_runnable_wrapper().wrap_runnable(box runnable);
+        let msg = CommonScriptMsg::RunnableMsg(ScriptThreadEventCategory::DomEvent, runnable);
         // TODO(#12718): Use the "posted message task source".
         let _ = self.script_chan.send(msg);
     }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13929,6 +13929,12 @@
      {}
     ]
    ],
+   "mozilla/postmessage_closed.html": [
+    [
+     "/_mozilla/mozilla/postmessage_closed.html",
+     {}
+    ]
+   ],
    "mozilla/preferences.html": [
     [
      "/_mozilla/mozilla/preferences.html",
@@ -26768,6 +26774,10 @@
   ],
   "mozilla/parentnodes.html": [
    "47c91f505cb8120a7f4b310b260f13408f06b8fc",
+   "testharness"
+  ],
+  "mozilla/postmessage_closed.html": [
+   "70fc1b9dad5f611285f8f4ed04454800283e223c",
    "testharness"
   ],
   "mozilla/preferences.html": [

--- a/tests/wpt/mozilla/tests/mozilla/postmessage_closed.html
+++ b/tests/wpt/mozilla/tests/mozilla/postmessage_closed.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Window.postMessage does not panic when a window is closed before the message is received</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe></iframe>
+<script>
+  async_test(function(t) {
+    var i = document.querySelector('iframe');
+    i.contentWindow.postMessage('hi', '*');
+    i.remove();
+    t.step_timeout(function() { t.done() }, 0);
+  });
+</script>


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17664
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17665)
<!-- Reviewable:end -->
