### PR TITLE
Use boxed slice instead of vec for FuntionTimerCallback

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -177,6 +177,14 @@ unsafe impl<T: JSTraceable + ?Sized> JSTraceable for Box<T> {
     }
 }
 
+unsafe impl<T: JSTraceable> JSTraceable for [T] {
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        for e in self.iter() {
+            e.trace(trc);
+        }
+    }
+}
+
 unsafe impl<T: JSTraceable + Copy> JSTraceable for Cell<T> {
     unsafe fn trace(&self, trc: *mut JSTracer) {
         self.get().trace(trc)

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -350,7 +350,7 @@ pub enum TimerCallback {
 #[derive(JSTraceable, Clone)]
 enum InternalTimerCallback {
     StringTimerCallback(DOMString),
-    FunctionTimerCallback(Rc<Function>, Rc<Vec<Heap<JSVal>>>),
+    FunctionTimerCallback(Rc<Function>, Rc<Box<[Heap<JSVal>]>>),
 }
 
 impl HeapSizeOf for InternalTimerCallback {
@@ -392,7 +392,7 @@ impl JsTimers {
                 for (i, item) in arguments.iter().enumerate() {
                     args.get_mut(i).unwrap().set(item.get());
                 }
-                InternalTimerCallback::FunctionTimerCallback(function, Rc::new(args))
+                InternalTimerCallback::FunctionTimerCallback(function, Rc::new(args.into_boxed_slice()))
             }
         };
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Added `fn trace()` implementation for `Box<[T]>` type, and change FunctionTimerCallback to store boxed slices for heap values instead of Vector.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #17611

<!-- Either: -->
- [x] These changes do not require tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17672)
<!-- Reviewable:end -->
