### PR TITLE
Check Gecko pref before parsing frames() timing function

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -804,6 +804,9 @@ extern "C" {
      -> f64;
 }
 extern "C" {
+    pub fn Gecko_IsFramesTimingEnabled() -> bool;
+}
+extern "C" {
     pub fn Gecko_AnimationGetBaseStyle(aBaseStyles:
                                            *mut ::std::os::raw::c_void,
                                        aProperty: nsCSSPropertyID)

--- a/components/style/values/specified/transform.rs
+++ b/components/style/values/specified/transform.rs
@@ -131,6 +131,17 @@ impl<S> OriginComponent<S> {
     }
 }
 
+#[cfg(feature = "gecko")]
+#[inline]
+fn allow_frames_timing() -> bool {
+    use gecko_bindings::bindings;
+    unsafe { bindings::Gecko_IsFramesTimingEnabled() }
+}
+
+#[cfg(feature = "servo")]
+#[inline]
+fn allow_frames_timing() -> bool { true }
+
 impl Parse for TimingFunction {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
         if let Ok(keyword) = input.try(TimingKeyword::parse) {
@@ -172,8 +183,12 @@ impl Parse for TimingFunction {
                     Ok(GenericTimingFunction::Steps(steps, position))
                 },
                 "frames" => {
-                    let frames = Integer::parse_with_minimum(context, i, 2)?;
-                    Ok(GenericTimingFunction::Frames(frames))
+                    if allow_frames_timing() {
+                        let frames = Integer::parse_with_minimum(context, i, 2)?;
+                        Ok(GenericTimingFunction::Frames(frames))
+                    } else {
+                        Err(())
+                    }
                 },
                 _ => Err(()),
             }).map_err(|()| StyleParseError::UnexpectedFunction(function).into())


### PR DESCRIPTION
These are the Servo-side changes for [Gecko bug 1379582](https://bugzilla.mozilla.org/show_bug.cgi?id=1379582).

They have been reviewed by @hiikezoe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17682)
<!-- Reviewable:end -->
