### PR TITLE
remove the ability to request for the title

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -463,7 +463,6 @@ impl<Window: WindowMethods> IOCompositor<Window> {
              ShutdownState::NotShuttingDown) => {
                 self.set_frame_tree(&frame_tree);
                 self.send_viewport_rects();
-                self.title_for_main_frame();
             }
 
             (Msg::ScrollFragmentPoint(scroll_root_id, point, _),
@@ -1669,17 +1668,6 @@ impl<Window: WindowMethods> IOCompositor<Window> {
     pub fn pinch_zoom_level(&self) -> f32 {
         // TODO(gw): Access via WR.
         1.0
-    }
-
-    pub fn title_for_main_frame(&self) {
-        let root_pipeline_id = match self.root_pipeline {
-            None => return,
-            Some(ref root_pipeline) => root_pipeline.id,
-        };
-        let msg = ConstellationMsg::GetPipelineTitle(root_pipeline_id);
-        if let Err(e) = self.constellation_chan.send(msg) {
-            warn!("Failed to send pipeline title ({}).", e);
-        }
     }
 }
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -919,10 +919,6 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                     .map(|pipeline| pipeline.top_level_browsing_context_id);
                 let _ = resp_chan.send(focus_browsing_context);
             }
-            FromCompositorMsg::GetPipelineTitle(pipeline_id) => {
-                debug!("constellation got get-pipeline-title message");
-                self.handle_get_pipeline_title_msg(pipeline_id);
-            }
             FromCompositorMsg::KeyEvent(ch, key, state, modifiers) => {
                 debug!("constellation got key event message");
                 self.handle_key_msg(ch, key, state, modifiers);
@@ -1910,16 +1906,6 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
         let result = match self.pipelines.get(&pipeline_id) {
             None => return warn!("Pipeline {} got reload event after closure.", pipeline_id),
             Some(pipeline) => pipeline.event_loop.send(msg),
-        };
-        if let Err(e) = result {
-            self.handle_send_error(pipeline_id, e);
-        }
-    }
-
-    fn handle_get_pipeline_title_msg(&mut self, pipeline_id: PipelineId) {
-        let result = match self.pipelines.get(&pipeline_id) {
-            None => return self.compositor_proxy.send(ToCompositorMsg::ChangePageTitle(pipeline_id, None)),
-            Some(pipeline) => pipeline.event_loop.send(ConstellationControlMsg::GetTitle(pipeline_id)),
         };
         if let Err(e) = result {
             self.handle_send_error(pipeline_id, e);

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -747,9 +747,6 @@ pub enum ConstellationMsg {
     /// Request that the constellation send the current focused top-level browsing context id,
     /// over a provided channel.
     GetFocusTopLevelBrowsingContext(IpcSender<Option<TopLevelBrowsingContextId>>),
-    /// Requests that the constellation inform the compositor of the title of the pipeline
-    /// immediately.
-    GetPipelineTitle(PipelineId),
     /// Request to load the initial page.
     InitLoadUrl(ServoUrl),
     /// Query the constellation to see if the current compositor output is stable

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -256,10 +256,6 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
         self.compositor.pinch_zoom_level()
     }
 
-    pub fn request_title_for_main_frame(&self) {
-        self.compositor.title_for_main_frame()
-    }
-
     pub fn setup_logging(&self) {
         let constellation_chan = self.constellation_chan.clone();
         log::set_logger(|max_log_level| {

--- a/ports/cef/browser.rs
+++ b/ports/cef/browser.rs
@@ -41,14 +41,6 @@ impl ServoBrowser {
         }
     }
 
-    pub fn request_title_for_main_frame(&self) {
-        match *self {
-            ServoBrowser::OnScreen(ref browser) => browser.request_title_for_main_frame(),
-            ServoBrowser::OffScreen(ref browser) => browser.request_title_for_main_frame(),
-            ServoBrowser::Invalid => {}
-        }
-    }
-
     pub fn pinch_zoom_level(&self) -> f32 {
         match *self {
             ServoBrowser::OnScreen(ref browser) => browser.pinch_zoom_level(),
@@ -163,7 +155,6 @@ impl ServoCefBrowser {
 pub trait ServoCefBrowserExtensions {
     fn init(&self, window_info: &cef_window_info_t);
     fn send_window_event(&self, event: WindowEvent);
-    fn request_title_for_main_frame(&self);
     fn pinch_zoom_level(&self) -> f32;
 }
 
@@ -198,10 +189,6 @@ impl ServoCefBrowserExtensions for CefBrowser {
             // we just queue up that event instead of immediately processing it.
             browser.message_queue.borrow_mut().push(event);
         }
-    }
-
-    fn request_title_for_main_frame(&self) {
-        self.downcast().servo_browser.borrow().request_title_for_main_frame()
     }
 
     fn pinch_zoom_level(&self) -> f32 {

--- a/ports/cef/frame.rs
+++ b/ports/cef/frame.rs
@@ -11,8 +11,8 @@ use compositing::windowing::WindowEvent;
 use std::cell::RefCell;
 
 pub struct ServoCefFrame {
-    pub title_visitor: RefCell<Option<CefStringVisitor>>,
     pub url: RefCell<String>,
+    pub title: RefCell<Vec<u16>>,
 
     /// A reference to the browser.
     pub browser: RefCell<Option<CefBrowser>>,
@@ -21,8 +21,8 @@ pub struct ServoCefFrame {
 impl ServoCefFrame {
     pub fn new() -> ServoCefFrame {
         ServoCefFrame {
-            title_visitor: RefCell::new(None),
             url: RefCell::new(String::new()),
+            title: RefCell::new(vec![]),
             browser: RefCell::new(None),
         }
     }
@@ -44,25 +44,20 @@ full_cef_class_impl! {
         }}
         fn get_text(&this, visitor: *mut cef_string_visitor_t [CefStringVisitor],) -> () {{
             let this = this.downcast();
-            *this.title_visitor.borrow_mut() = Some(visitor);
-            this.browser.borrow().as_ref().unwrap().request_title_for_main_frame();
+            let str = &*this.title.borrow();
+            visitor.visit(str)
         }}
     }
 }
 
 pub trait ServoCefFrameExtensions {
     fn set_browser(&self, browser: CefBrowser);
-    fn set_url(&self, url: &[u16]);
     fn load(&self);
 }
 
 impl ServoCefFrameExtensions for CefFrame {
     fn set_browser(&self, browser: CefBrowser) {
         *self.downcast().browser.borrow_mut() = Some(browser)
-    }
-    fn set_url(&self, url: &[u16]) {
-        let frame = self.downcast();
-        *frame.url.borrow_mut() = String::from_utf16(url).unwrap();
     }
     fn load(&self) {
         let event = WindowEvent::LoadUrl(self.downcast().url.borrow().clone());

--- a/ports/cef/window.rs
+++ b/ports/cef/window.rs
@@ -433,7 +433,6 @@ impl WindowMethods for Window {
         };
         let frame = browser.get_main_frame();
         let frame = frame.downcast();
-        let mut title_visitor = frame.title_visitor.borrow_mut();
         let str = match string {
             Some(s) => s.encode_utf16().collect(),
             None => vec![]
@@ -444,9 +443,7 @@ impl WindowMethods for Window {
             browser.get_host().get_client().get_display_handler().on_title_change((*browser).clone(), str.as_slice());
         }
 
-        if let Some(ref mut visitor) = *title_visitor {
-            visitor.visit(&str);
-        }
+        *frame.title.borrow_mut() = str;
     }
 
     fn history_changed(&self, history: Vec<LoadData>, current: usize) {


### PR DESCRIPTION
If we offer the ability to request info like these, we need to expose a lot of other getters, like url, loading state, favicon, …

It's up to the embedder to keep track of the state of a browser. So let's keep that consistent.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17686)
<!-- Reviewable:end -->
