### PR TITLE
stylo: Fix grid-template serialization in grid shorthand

### DIFF
--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -495,11 +495,9 @@
         })
     }
 
-    /// Returns true if every sub property value of `grid` shorthand is initial.
     impl<'a> LonghandsToSerialize<'a> {
-        fn is_initial(&self) -> bool {
-            *self.grid_template_rows == GridTemplateComponent::None &&
-            *self.grid_template_columns == GridTemplateComponent::None &&
+        /// Returns true if other sub properties except template-{rows,columns} are initial.
+        fn is_grid_template(&self) -> bool {
             *self.grid_template_areas == Either::Second(None_) &&
             *self.grid_auto_rows == TrackSize::default() &&
             *self.grid_auto_columns == TrackSize::default() &&
@@ -512,7 +510,7 @@
             if *self.grid_template_areas != Either::Second(None_) ||
                (*self.grid_template_rows != GridTemplateComponent::None &&
                    *self.grid_template_columns != GridTemplateComponent::None) ||
-               self.is_initial() {
+               self.is_grid_template() {
                 return super::grid_template::serialize_grid_template(self.grid_template_rows,
                                                                      self.grid_template_columns,
                                                                      self.grid_template_areas, dest);


### PR DESCRIPTION
Because of some unnecessary checks, it wasn't able to serialize the '40px / none' value properly before. That will fix one failure on `test_value_storage.html`

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17692)
<!-- Reviewable:end -->
