### PR TITLE
Avoid random python address to be added to generated files

### DIFF
--- a/components/style/properties/build.py
+++ b/components/style/properties/build.py
@@ -4,6 +4,7 @@
 
 import json
 import os.path
+import re
 import sys
 
 BASE = os.path.dirname(__file__.replace('\\', '/'))
@@ -15,6 +16,8 @@ from mako.lookup import TemplateLookup
 from mako.template import Template
 
 import data
+
+RE_PYTHON_ADDR = re.compile(r'<.+? object at 0x[0-9a-fA-F]+>')
 
 
 def main():
@@ -68,7 +71,12 @@ def render(filename, **context):
 def write(directory, filename, content):
     if not os.path.exists(directory):
         os.makedirs(directory)
-    open(os.path.join(directory, filename), "wb").write(content)
+    full_path = os.path.join(directory, filename)
+    open(full_path, "wb").write(content)
+
+    python_addr = RE_PYTHON_ADDR.search(content)
+    if python_addr:
+        abort("Found \"{}\" in {} ({})".format(python_addr.group(0), filename, full_path))
 
 
 def write_html(properties):


### PR DESCRIPTION
This would catch cases like #17691 and avoid regressing [bug 1380327](https://bugzilla.mozilla.org/show_bug.cgi?id=1380327) in this manner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17702)
<!-- Reviewable:end -->
