### PR TITLE
Add animation value related with stroke-dasharray / stroke-dashoffset / stroke-width.

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -43,18 +43,20 @@ use values::animated::effects::BoxShadowList as AnimatedBoxShadowList;
 use values::animated::effects::Filter as AnimatedFilter;
 use values::animated::effects::FilterList as AnimatedFilterList;
 use values::animated::effects::TextShadowList as AnimatedTextShadowList;
-use values::computed::{Angle, LengthOrPercentageOrAuto, LengthOrPercentageOrNone};
-use values::computed::{BorderCornerRadius, ClipRect};
-use values::computed::{CalcLengthOrPercentage, Context, ComputedValueAsSpecified, ComputedUrl};
-use values::computed::{LengthOrPercentage, MaxLength, MozLength, Percentage, ToComputedValue};
-use values::computed::{NonNegativeAu, NonNegativeNumber, PositiveIntegerOrAuto};
+use values::computed::{Angle, BorderCornerRadius, CalcLengthOrPercentage};
+use values::computed::{ClipRect, Context, ComputedUrl, ComputedValueAsSpecified};
+use values::computed::{LengthOrPercentage, LengthOrPercentageOrAuto};
+use values::computed::{LengthOrPercentageOrNone, MaxLength, MozLength, NonNegativeAu};
+use values::computed::{NonNegativeNumber, Number, NumberOrPercentage, Percentage};
+use values::computed::{PositiveIntegerOrAuto, ToComputedValue};
 use values::computed::length::{NonNegativeLengthOrAuto, NonNegativeLengthOrNormal};
 use values::computed::length::NonNegativeLengthOrPercentage;
 use values::distance::{ComputeSquaredDistance, SquaredDistance};
 use values::generics::{GreaterThanOrEqualToOne, NonNegative};
 use values::generics::effects::Filter;
 use values::generics::position as generic_position;
-use values::generics::svg::{SVGLength, SVGOpacity, SVGPaint, SVGPaintKind, SVGStrokeDashArray};
+use values::generics::svg::{SVGLength,  SvgLengthOrPercentageOrNumber, SVGPaint};
+use values::generics::svg::{SVGPaintKind, SVGStrokeDashArray, SVGOpacity};
 
 /// A trait used to implement various procedures used during animation.
 pub trait Animatable: Sized {
@@ -781,6 +783,7 @@ impl ToAnimatedZero for AnimationValue {
 impl RepeatableListAnimatable for LengthOrPercentage {}
 impl RepeatableListAnimatable for Either<f32, LengthOrPercentage> {}
 impl RepeatableListAnimatable for Either<NonNegativeNumber, NonNegativeLengthOrPercentage> {}
+impl RepeatableListAnimatable for SvgLengthOrPercentageOrNumber<NonNegativeLengthOrPercentage, NonNegativeNumber> {}
 
 macro_rules! repeated_vec_impl {
     ($($ty:ty),*) => {
@@ -1016,7 +1019,12 @@ impl Animatable for LengthOrPercentage {
 impl ToAnimatedZero for LengthOrPercentage {
     #[inline]
     fn to_animated_zero(&self) -> Result<Self, ()> {
-        Ok(LengthOrPercentage::zero())
+        match self {
+            &LengthOrPercentage::Length(_) | &LengthOrPercentage::Calc(_) =>
+                Ok(LengthOrPercentage::zero()),
+            &LengthOrPercentage::Percentage(_) =>
+                Ok(LengthOrPercentage::Percentage(Percentage::zero())),
+        }
     }
 }
 
@@ -2496,6 +2504,120 @@ impl ToAnimatedZero for IntermediateSVGPaintKind {
     }
 }
 
+impl From<NonNegativeLengthOrPercentage> for NumberOrPercentage {
+    fn from(lop: NonNegativeLengthOrPercentage) -> NumberOrPercentage {
+        lop.0.into()
+    }
+}
+
+impl From<NonNegativeNumber> for NumberOrPercentage {
+    fn from(num: NonNegativeNumber) -> NumberOrPercentage {
+        num.0.into()
+    }
+}
+
+impl From<LengthOrPercentage> for NumberOrPercentage {
+    fn from(lop: LengthOrPercentage) -> NumberOrPercentage {
+        match lop {
+            LengthOrPercentage::Length(len) => NumberOrPercentage::Number(len.to_f32_px()),
+            LengthOrPercentage::Percentage(p) => NumberOrPercentage::Percentage(p),
+            LengthOrPercentage::Calc(_) => {
+                panic!("We dont't expected calc interpolation for SvgLengthOrPercentageOrNumber");
+            },
+        }
+    }
+}
+
+impl From<Number> for NumberOrPercentage {
+    fn from(num: Number) -> NumberOrPercentage {
+        NumberOrPercentage::Number(num)
+    }
+}
+
+fn convert_to_number_or_percentage<LengthOrPercentageType, NumberType>(
+    from: SvgLengthOrPercentageOrNumber<LengthOrPercentageType, NumberType>)
+    -> NumberOrPercentage
+    where LengthOrPercentageType: Into<NumberOrPercentage>,
+          NumberType: Into<NumberOrPercentage>
+{
+    match from {
+        SvgLengthOrPercentageOrNumber::LengthOrPercentage(lop) => {
+            lop.into()
+        }
+        SvgLengthOrPercentageOrNumber::Number(num) => {
+            num.into()
+        }
+    }
+}
+
+fn convert_from_number_or_percentage<LengthOrPercentageType, NumberType>(
+    from: NumberOrPercentage)
+    -> SvgLengthOrPercentageOrNumber<LengthOrPercentageType, NumberType>
+    where LengthOrPercentageType: From<LengthOrPercentage>,
+          NumberType: From<Number>
+{
+    match from {
+        NumberOrPercentage::Number(num) =>
+            SvgLengthOrPercentageOrNumber::Number(num.into()),
+        NumberOrPercentage::Percentage(p) =>
+            SvgLengthOrPercentageOrNumber::LengthOrPercentage(
+                (LengthOrPercentage::Percentage(p)).into())
+    }
+}
+
+impl <LengthOrPercentageType, NumberType> Animatable for
+    SvgLengthOrPercentageOrNumber<LengthOrPercentageType, NumberType>
+    where LengthOrPercentageType: Animatable + Into<NumberOrPercentage> + From<LengthOrPercentage> + Copy,
+          NumberType: Animatable + Into<NumberOrPercentage> + From<Number>,
+          SvgLengthOrPercentageOrNumber<LengthOrPercentageType, NumberType>: Copy,
+          LengthOrPercentage: From<LengthOrPercentageType>
+{
+    #[inline]
+    fn add_weighted(&self, other: &Self, self_portion: f64, other_portion: f64) -> Result<Self, ()> {
+        if self.has_calc() || other.has_calc() {
+            // TODO: We need to treat calc value.
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=1386967
+            return Err(());
+        }
+
+        let from_value = convert_to_number_or_percentage(*self);
+        let to_value = convert_to_number_or_percentage(*other);
+
+        match (from_value, to_value) {
+            (NumberOrPercentage::Number(from),
+             NumberOrPercentage::Number(to)) => {
+                from.add_weighted(&to, self_portion, other_portion)
+                    .map(|num| NumberOrPercentage::Number(num))
+                    .map(|nop| convert_from_number_or_percentage(nop))
+            },
+            (NumberOrPercentage::Percentage(from),
+             NumberOrPercentage::Percentage(to)) => {
+                from.add_weighted(&to, self_portion, other_portion)
+                    .map(|p| NumberOrPercentage::Percentage(p))
+                    .map(|nop| convert_from_number_or_percentage(nop))
+            },
+            _ => Err(()),
+        }
+    }
+}
+
+impl <LengthOrPercentageType, NumberType> ToAnimatedZero for
+    SvgLengthOrPercentageOrNumber<LengthOrPercentageType, NumberType>
+    where LengthOrPercentageType: ToAnimatedZero, NumberType: ToAnimatedZero
+{
+    #[inline]
+    fn to_animated_zero(&self) -> Result<Self, ()> {
+        match self {
+            &SvgLengthOrPercentageOrNumber::LengthOrPercentage(ref lop) =>
+                lop.to_animated_zero()
+                    .map(SvgLengthOrPercentageOrNumber::LengthOrPercentage),
+            &SvgLengthOrPercentageOrNumber::Number(ref num) =>
+                num.to_animated_zero()
+                    .map(SvgLengthOrPercentageOrNumber::Number),
+        }
+    }
+}
+
 impl<LengthType> Animatable for SVGLength<LengthType>
         where LengthType: Animatable + Clone
 {
@@ -2522,6 +2644,7 @@ impl<LengthType> ToAnimatedZero for SVGLength<LengthType> where LengthType : ToA
     }
 }
 
+/// https://www.w3.org/TR/SVG11/painting.html#StrokeDasharrayProperty
 impl<LengthType> Animatable for SVGStrokeDashArray<LengthType>
     where LengthType : RepeatableListAnimatable + Clone
 {
@@ -2536,6 +2659,18 @@ impl<LengthType> Animatable for SVGStrokeDashArray<LengthType>
                 Ok(if self_portion > other_portion { self.clone() } else { other.clone() })
             }
         }
+    }
+
+    /// stroke-dasharray is non-additive
+    #[inline]
+    fn add(&self, _other: &Self) -> Result<Self, ()> {
+        Err(())
+    }
+
+    /// stroke-dasharray is non-additive
+    #[inline]
+    fn accumulate(&self, _other: &Self, _count: u64) -> Result<Self, ()> {
+        Err(())
     }
 }
 

--- a/components/style/values/computed/length.rs
+++ b/components/style/values/computed/length.rs
@@ -606,6 +606,13 @@ impl From<LengthOrPercentage> for NonNegativeLengthOrPercentage {
     }
 }
 
+impl From<NonNegativeLengthOrPercentage> for LengthOrPercentage {
+    #[inline]
+    fn from(lop: NonNegativeLengthOrPercentage) -> LengthOrPercentage {
+        lop.0
+    }
+}
+
 impl NonNegativeLengthOrPercentage {
     /// Get zero value.
     #[inline]

--- a/components/style/values/computed/svg.rs
+++ b/components/style/values/computed/svg.rs
@@ -5,10 +5,10 @@
 //! Computed types for SVG properties.
 
 use app_units::Au;
-use values::{Either, RGBA};
-use values::computed::{LengthOrPercentageOrNumber, Opacity};
-use values::computed::{NonNegativeAu, NonNegativeLengthOrPercentageOrNumber};
-use values::computed::ComputedUrl;
+use values::RGBA;
+use values::computed::{ComputedUrl, LengthOrPercentage, NonNegativeAu};
+use values::computed::{NonNegativeNumber, NonNegativeLengthOrPercentage, Number};
+use values::computed::Opacity;
 use values::generics::svg as generic;
 
 /// Computed SVG Paint value
@@ -36,26 +36,51 @@ impl SVGPaint {
     }
 }
 
+/// A value of <length> | <percentage> | <number> for stroke-dashoffset.
+/// https://www.w3.org/TR/SVG11/painting.html#StrokeProperties
+pub type SvgLengthOrPercentageOrNumber =
+    generic::SvgLengthOrPercentageOrNumber<LengthOrPercentage, Number>;
+
 /// <length> | <percentage> | <number> | context-value
-pub type SVGLength = generic::SVGLength<LengthOrPercentageOrNumber>;
+pub type SVGLength = generic::SVGLength<SvgLengthOrPercentageOrNumber>;
 
 impl From<Au> for SVGLength {
     fn from(length: Au) -> Self {
-        generic::SVGLength::Length(Either::Second(length.into()))
+        generic::SVGLength::Length(
+            generic::SvgLengthOrPercentageOrNumber::LengthOrPercentage(length.into()))
+    }
+}
+
+/// A value of <length> | <percentage> | <number> for stroke-width/stroke-dasharray.
+/// https://www.w3.org/TR/SVG11/painting.html#StrokeProperties
+pub type NonNegativeSvgLengthOrPercentageOrNumber =
+    generic::SvgLengthOrPercentageOrNumber<NonNegativeLengthOrPercentage, NonNegativeNumber>;
+
+impl Into<NonNegativeSvgLengthOrPercentageOrNumber> for SvgLengthOrPercentageOrNumber {
+    fn into(self) -> NonNegativeSvgLengthOrPercentageOrNumber {
+        match self {
+            generic::SvgLengthOrPercentageOrNumber::LengthOrPercentage(lop) =>{
+                generic::SvgLengthOrPercentageOrNumber::LengthOrPercentage(lop.into())
+            },
+            generic::SvgLengthOrPercentageOrNumber::Number(num) => {
+                generic::SvgLengthOrPercentageOrNumber::Number(num.into())
+            },
+        }
     }
 }
 
 /// An non-negative wrapper of SVGLength.
-pub type SVGWidth = generic::SVGLength<NonNegativeLengthOrPercentageOrNumber>;
+pub type SVGWidth = generic::SVGLength<NonNegativeSvgLengthOrPercentageOrNumber>;
 
 impl From<NonNegativeAu> for SVGWidth {
     fn from(length: NonNegativeAu) -> Self {
-        generic::SVGLength::Length(Either::Second(length.into()))
+        generic::SVGLength::Length(
+            generic::SvgLengthOrPercentageOrNumber::LengthOrPercentage(length.into()))
     }
 }
 
 /// [ <length> | <percentage> | <number> ]# | context-value
-pub type SVGStrokeDashArray = generic::SVGStrokeDashArray<NonNegativeLengthOrPercentageOrNumber>;
+pub type SVGStrokeDashArray = generic::SVGStrokeDashArray<NonNegativeSvgLengthOrPercentageOrNumber>;
 
 impl Default for SVGStrokeDashArray {
     fn default() -> Self {

--- a/components/style/values/specified/svg.rs
+++ b/components/style/values/specified/svg.rs
@@ -8,7 +8,8 @@ use cssparser::Parser;
 use parser::{Parse, ParserContext};
 use style_traits::{CommaWithSpace, ParseError, Separator, StyleParseError};
 use values::generics::svg as generic;
-use values::specified::{LengthOrPercentageOrNumber, NonNegativeLengthOrPercentageOrNumber, Opacity, SpecifiedUrl};
+use values::specified::{LengthOrPercentage, NonNegativeLengthOrPercentage, NonNegativeNumber};
+use values::specified::{Number, Opacity, SpecifiedUrl};
 use values::specified::color::RGBAColor;
 
 /// Specified SVG Paint value
@@ -42,50 +43,60 @@ fn parse_context_value<'i, 't, T>(input: &mut Parser<'i, 't>, value: T)
     Err(StyleParseError::UnspecifiedError.into())
 }
 
+/// A value of <length> | <percentage> | <number> for stroke-dashoffset.
+/// https://www.w3.org/TR/SVG11/painting.html#StrokeProperties
+pub type SvgLengthOrPercentageOrNumber =
+    generic::SvgLengthOrPercentageOrNumber<LengthOrPercentage, Number>;
+
 /// <length> | <percentage> | <number> | context-value
-pub type SVGLength = generic::SVGLength<LengthOrPercentageOrNumber>;
+pub type SVGLength = generic::SVGLength<SvgLengthOrPercentageOrNumber>;
 
 impl Parse for SVGLength {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                      -> Result<Self, ParseError<'i>> {
-        input.try(|i| LengthOrPercentageOrNumber::parse(context, i))
+        input.try(|i| SvgLengthOrPercentageOrNumber::parse(context, i))
              .map(Into::into)
              .or_else(|_| parse_context_value(input, generic::SVGLength::ContextValue))
     }
 }
 
-impl From<LengthOrPercentageOrNumber> for SVGLength {
-    fn from(length: LengthOrPercentageOrNumber) -> Self {
+impl From<SvgLengthOrPercentageOrNumber> for SVGLength {
+    fn from(length: SvgLengthOrPercentageOrNumber) -> Self {
         generic::SVGLength::Length(length)
     }
 }
 
+/// A value of <length> | <percentage> | <number> for stroke-width/stroke-dasharray.
+/// https://www.w3.org/TR/SVG11/painting.html#StrokeProperties
+pub type NonNegativeSvgLengthOrPercentageOrNumber =
+    generic::SvgLengthOrPercentageOrNumber<NonNegativeLengthOrPercentage, NonNegativeNumber>;
+
 /// A non-negative version of SVGLength.
-pub type SVGWidth = generic::SVGLength<NonNegativeLengthOrPercentageOrNumber>;
+pub type SVGWidth = generic::SVGLength<NonNegativeSvgLengthOrPercentageOrNumber>;
 
 impl Parse for SVGWidth {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                      -> Result<Self, ParseError<'i>> {
-        input.try(|i| NonNegativeLengthOrPercentageOrNumber::parse(context, i))
+        input.try(|i| NonNegativeSvgLengthOrPercentageOrNumber::parse(context, i))
              .map(Into::into)
              .or_else(|_| parse_context_value(input, generic::SVGLength::ContextValue))
     }
 }
 
-impl From<NonNegativeLengthOrPercentageOrNumber> for SVGWidth {
-    fn from(length: NonNegativeLengthOrPercentageOrNumber) -> Self {
+impl From<NonNegativeSvgLengthOrPercentageOrNumber> for SVGWidth {
+    fn from(length: NonNegativeSvgLengthOrPercentageOrNumber) -> Self {
         generic::SVGLength::Length(length)
     }
 }
 
 /// [ <length> | <percentage> | <number> ]# | context-value
-pub type SVGStrokeDashArray = generic::SVGStrokeDashArray<NonNegativeLengthOrPercentageOrNumber>;
+pub type SVGStrokeDashArray = generic::SVGStrokeDashArray<NonNegativeSvgLengthOrPercentageOrNumber>;
 
 impl Parse for SVGStrokeDashArray {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                      -> Result<Self, ParseError<'i>> {
         if let Ok(values) = input.try(|i| CommaWithSpace::parse(i, |i| {
-            NonNegativeLengthOrPercentageOrNumber::parse(context, i)
+            NonNegativeSvgLengthOrPercentageOrNumber::parse(context, i)
         })) {
             Ok(generic::SVGStrokeDashArray::Values(values))
         } else if let Ok(_) = input.try(|i| i.expect_ident_matching("none")) {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is a PR for https://bugzilla.mozilla.org/show_bug.cgi?id=1369614

This patch will:
 * Add animation value conversion of LengthOrPercentage in order to interpolate length and number.
 * Add animation value of Vec<LengthOrPercentage> in order to interpolate the stroke-dasharray.

Spec is as follow:
https://svgwg.org/svg2-draft/painting.html#StrokeDashing

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
There are tests for these changes, a test case will be landed in wpt in https://bugzilla.mozilla.org/show_bug.cgi?id=1369614.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17288)
<!-- Reviewable:end -->
