### PR TITLE
style: Avoid parsing negative padding in the padding shorthand.

### DIFF
--- a/components/style/properties/shorthand/padding.mako.rs
+++ b/components/style/properties/shorthand/padding.mako.rs
@@ -4,6 +4,6 @@
 
 <%namespace name="helpers" file="/helpers.mako.rs" />
 
-${helpers.four_sides_shorthand("padding", "padding-%s", "specified::LengthOrPercentage::parse",
+${helpers.four_sides_shorthand("padding", "padding-%s", "specified::LengthOrPercentage::parse_non_negative",
                                spec="https://drafts.csswg.org/css-box-3/#propdef-padding",
                                allow_quirks=True)}

--- a/tests/wpt/metadata-css/css21_dev/html4/c5510-padn-002.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/c5510-padn-002.htm.ini
@@ -1,3 +1,0 @@
-[c5510-padn-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/padding-009.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/padding-009.htm.ini
@@ -1,3 +1,0 @@
-[padding-009.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1380492

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17705)
<!-- Reviewable:end -->
