### PR TITLE
Improve font layout in Linux / Freetype platforms.

### DIFF
--- a/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-contain.htm.ini
+++ b/tests/wpt/metadata-css/css-backgrounds-3_dev/html4/background-size-contain.htm.ini
@@ -1,4 +1,0 @@
-[background-size-contain.htm]
-  type: reftest
-  expected:
-    if os == "linux": FAIL


### PR DESCRIPTION
This patch contains two small changes:

* Fix the font size calculation that is passed to Freetype. This
  now matches exactly how Webrender and Gecko calculate font size
  to pass to layout.
* Enable light hinting by default for fonts when using Freetype.
  We should make this configurable in the future, but this is a
  better default than no hinting (and matches what most Linux
  distros default to).

These two changes (along with the pending WR update) fix a lot
of the font layout issues on Linux. There is still at least one
remaining issue with hidpi displays on Linux that will be fixed
in a follow up patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17706)
<!-- Reviewable:end -->
