### PR TITLE
style: Don't stop looking at the sharing cache for various reasons.

### DIFF
--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -595,16 +595,6 @@ impl<E: TElement> StyleSharingCandidateCache<E> {
                 }
                 Err(miss) => {
                     debug!("Cache miss: {:?}", miss);
-
-                    // Cache miss, let's see what kind of failure to decide
-                    // whether we keep trying or not.
-                    match miss {
-                        // Too expensive failure, give up, we don't want another
-                        // one of these.
-                        CacheMiss::PresHints |
-                        CacheMiss::Revalidation => break,
-                        _ => {}
-                    }
                 }
             }
         }


### PR DESCRIPTION
All the information that made those failures expensive is now lazily computed
and cached, or eagerly computed anyway, so seems not worth to stop iteration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17717)
<!-- Reviewable:end -->
