### PR TITLE
add support for Gecko style difference noticing custom property changes

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -2685,6 +2685,13 @@ extern "C" {
      -> u64;
 }
 extern "C" {
+    pub fn Servo_ComputedValues_EqualCustomProperties(first:
+                                                          ServoComputedValuesBorrowed,
+                                                      second:
+                                                          ServoComputedValuesBorrowed)
+     -> bool;
+}
+extern "C" {
     pub fn Servo_ComputedValues_GetStyleRuleList(values:
                                                      ServoComputedValuesBorrowed,
                                                  rules:

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -192,6 +192,11 @@ impl ComputedValues {
         self.visited_style.clone()
     }
 
+    /// Gets a reference to the custom properties map (if one exists).
+    pub fn get_custom_properties(&self) -> Option<<&::custom_properties::CustomPropertiesMap> {
+        self.custom_properties.as_ref().map(|x| &**x)
+    }
+
     pub fn custom_properties(&self) -> Option<Arc<CustomPropertiesMap>> {
         self.custom_properties.clone()
     }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1742,6 +1742,16 @@ pub extern "C" fn Servo_ComputedValues_SpecifiesAnimationsOrTransitions(values: 
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_ComputedValues_EqualCustomProperties(
+    first: ServoComputedValuesBorrowed,
+    second: ServoComputedValuesBorrowed
+) -> bool {
+    let first = ComputedValues::as_arc(&first);
+    let second = ComputedValues::as_arc(&second);
+    first.get_custom_properties() == second.get_custom_properties()
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_ComputedValues_GetStyleRuleList(values: ServoComputedValuesBorrowed,
                                                         rules: RawGeckoServoStyleRuleListBorrowedMut) {
     let values = ComputedValues::as_arc(&values);


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1380224.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17724)
<!-- Reviewable:end -->
