### PR TITLE
Remove WindowNavigateMsg

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -35,7 +35,7 @@ use time::{precise_time_ns, precise_time_s};
 use touch::{TouchHandler, TouchAction};
 use webrender;
 use webrender_api::{self, ClipId, LayoutPoint, LayoutVector2D, ScrollEventPhase, ScrollLocation, ScrollClamping};
-use windowing::{self, MouseWindowEvent, WindowEvent, WindowMethods, WindowNavigateMsg};
+use windowing::{self, MouseWindowEvent, WindowEvent, WindowMethods};
 
 #[derive(Debug, PartialEq)]
 enum UnableToComposite {
@@ -1294,11 +1294,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         });
     }
 
-    fn on_navigation_window_event(&self, direction: WindowNavigateMsg) {
-        let direction = match direction {
-            windowing::WindowNavigateMsg::Forward => TraversalDirection::Forward(1),
-            windowing::WindowNavigateMsg::Back => TraversalDirection::Back(1),
-        };
+    fn on_navigation_window_event(&self, direction: TraversalDirection) {
         let top_level_browsing_context_id = match self.root_pipeline {
             Some(ref pipeline) => pipeline.top_level_browsing_context_id,
             None => return warn!("Sending navigation to constellation with no root pipeline."),

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -8,7 +8,7 @@ use compositor_thread::EventLoopWaker;
 use euclid::{Point2D, Size2D};
 use euclid::{TypedPoint2D, TypedRect, ScaleFactor, TypedSize2D};
 use gleam::gl;
-use msg::constellation_msg::{Key, KeyModifiers, KeyState};
+use msg::constellation_msg::{Key, KeyModifiers, KeyState, TraversalDirection};
 use net_traits::net_error_list::NetError;
 use script_traits::{DevicePixel, LoadData, MouseButton, TouchEventType, TouchId, TouchpadPressurePhase};
 use servo_geometry::DeviceIndependentPixel;
@@ -23,12 +23,6 @@ pub enum MouseWindowEvent {
     Click(MouseButton, TypedPoint2D<f32, DevicePixel>),
     MouseDown(MouseButton, TypedPoint2D<f32, DevicePixel>),
     MouseUp(MouseButton, TypedPoint2D<f32, DevicePixel>),
-}
-
-#[derive(Clone)]
-pub enum WindowNavigateMsg {
-    Forward,
-    Back,
 }
 
 /// Events that the windowing system sends to Servo.
@@ -66,7 +60,7 @@ pub enum WindowEvent {
     /// Sent when the user resets zoom to default.
     ResetZoom,
     /// Sent when the user uses chrome navigation (i.e. backspace or shift-backspace).
-    Navigation(WindowNavigateMsg),
+    Navigation(TraversalDirection),
     /// Sent when the user quits the application
     Quit,
     /// Sent when a key input state changes

--- a/ports/cef/browser.rs
+++ b/ports/cef/browser.rs
@@ -8,13 +8,14 @@ use frame::{ServoCefFrame, ServoCefFrameExtensions};
 use interfaces::{CefBrowser, CefBrowserHost, CefClient, CefFrame, CefRequestContext};
 use interfaces::{cef_browser_t, cef_browser_host_t, cef_client_t, cef_frame_t};
 use interfaces::{cef_request_context_t};
+use msg::constellation_msg::TraversalDirection;
 use servo::Browser;
 use servo::servo_url::ServoUrl;
 use types::{cef_browser_settings_t, cef_string_t, cef_window_info_t, cef_window_handle_t};
 use window;
 use wrappers::CefWrap;
 
-use compositing::windowing::{WindowNavigateMsg, WindowEvent};
+use compositing::windowing::WindowEvent;
 use glutin_app;
 use libc::c_int;
 use std::cell::{Cell, RefCell};
@@ -69,11 +70,11 @@ cef_class_impl! {
         }}
 
         fn go_back(&this,) -> () {{
-            this.send_window_event(WindowEvent::Navigation(WindowNavigateMsg::Back));
+            this.send_window_event(WindowEvent::Navigation(TraversalDirection::Back(1)));
         }}
 
         fn go_forward(&this,) -> () {{
-            this.send_window_event(WindowEvent::Navigation(WindowNavigateMsg::Forward));
+            this.send_window_event(WindowEvent::Navigation(TraversalDirection::Forward(1)));
         }}
 
         // Returns the main (top-level) frame for the browser window.

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -6,7 +6,7 @@
 
 use NestedEventLoopListener;
 use compositing::compositor_thread::EventLoopWaker;
-use compositing::windowing::{AnimationState, MouseWindowEvent, WindowNavigateMsg};
+use compositing::windowing::{AnimationState, MouseWindowEvent};
 use compositing::windowing::{WindowEvent, WindowMethods};
 use euclid::{Point2D, Size2D, TypedPoint2D, TypedVector2D, TypedRect, ScaleFactor, TypedSize2D};
 #[cfg(target_os = "windows")]
@@ -20,7 +20,7 @@ use glutin::TouchPhase;
 #[cfg(target_os = "macos")]
 use glutin::os::macos::{ActivationPolicy, WindowBuilderExt};
 use msg::constellation_msg::{self, Key};
-use msg::constellation_msg::{ALT, CONTROL, KeyState, NONE, SHIFT, SUPER};
+use msg::constellation_msg::{ALT, CONTROL, KeyState, NONE, SHIFT, SUPER, TraversalDirection};
 use net_traits::net_error_list::NetError;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use osmesa_sys;
@@ -930,10 +930,10 @@ impl Window {
     fn platform_handle_key(&self, key: Key, mods: constellation_msg::KeyModifiers) {
         match (mods, key) {
             (CMD_OR_CONTROL, Key::LeftBracket) => {
-                self.event_queue.borrow_mut().push(WindowEvent::Navigation(WindowNavigateMsg::Back));
+                self.event_queue.borrow_mut().push(WindowEvent::Navigation(TraversalDirection::Back(1)));
             }
             (CMD_OR_CONTROL, Key::RightBracket) => {
-                self.event_queue.borrow_mut().push(WindowEvent::Navigation(WindowNavigateMsg::Forward));
+                self.event_queue.borrow_mut().push(WindowEvent::Navigation(TraversalDirection::Forward(1)));
             }
             _ => {}
         }
@@ -1220,10 +1220,10 @@ impl WindowMethods for Window {
             }
 
             (NONE, None, Key::NavigateForward) => {
-                self.event_queue.borrow_mut().push(WindowEvent::Navigation(WindowNavigateMsg::Forward));
+                self.event_queue.borrow_mut().push(WindowEvent::Navigation(TraversalDirection::Forward(1)));
             }
             (NONE, None, Key::NavigateBackward) => {
-                self.event_queue.borrow_mut().push(WindowEvent::Navigation(WindowNavigateMsg::Back));
+                self.event_queue.borrow_mut().push(WindowEvent::Navigation(TraversalDirection::Back(1)));
             }
 
             (NONE, None, Key::Escape) => {
@@ -1233,10 +1233,10 @@ impl WindowMethods for Window {
             }
 
             (CMD_OR_ALT, None, Key::Right) => {
-                self.event_queue.borrow_mut().push(WindowEvent::Navigation(WindowNavigateMsg::Forward));
+                self.event_queue.borrow_mut().push(WindowEvent::Navigation(TraversalDirection::Forward(1)));
             }
             (CMD_OR_ALT, None, Key::Left) => {
-                self.event_queue.borrow_mut().push(WindowEvent::Navigation(WindowNavigateMsg::Back));
+                self.event_queue.borrow_mut().push(WindowEvent::Navigation(TraversalDirection::Back(1)));
             }
 
             (NONE, None, Key::PageDown) => {


### PR DESCRIPTION
Two reasons:

- We want to be able to jump further in history from the embedder.
- We don't want to have an extra translation step in the compositor, where `WindowNavigateMsg` is translated to `TraversalDirection`


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17726)
<!-- Reviewable:end -->
