### PR TITLE
Don't retrieve the CSS source when a parse error is reported.

### DIFF
--- a/ports/geckolib/error_reporter.rs
+++ b/ports/geckolib/error_reporter.rs
@@ -299,7 +299,8 @@ impl ParseErrorReporter for ErrorReporter {
 
         let name = error.to_gecko_message();
         let param = error.error_param().into_str();
-        let source = input.current_line();
+        // The CSS source text is unused and will be removed in bug 1381188.
+        let source = "";
         unsafe {
             Gecko_ReportUnexpectedCSSError(self.0,
                                            name.as_ptr() as *const _,


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1381045 retrieving the CSS source is an unnecessary performance hit for Stylo.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they are tested by Gecko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17738)
<!-- Reviewable:end -->
