### PR TITLE
style: Fix a typo that makes us resolve styles for the whole spin to the root.

### DIFF
--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -449,7 +449,7 @@ where
     let mut ancestor = element.traversal_parent();
     while let Some(current) = ancestor {
         if rule_inclusion == RuleInclusion::All {
-            if let Some(data) = element.borrow_data() {
+            if let Some(data) = current.borrow_data() {
                 if let Some(ancestor_style) = data.styles.get_primary() {
                     style = Some(ancestor_style.clone());
                     break;


### PR DESCRIPTION
For undisplayed elements, at least.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17751)
<!-- Reviewable:end -->
