### PR TITLE
Stop aborting release builds if we've missed invalidations before calling Servo_ResolveStyle

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2781,8 +2781,8 @@ pub extern "C" fn Servo_ResolveStyle(element: RawGeckoElementBorrowed,
 
     // TODO(emilio): Downgrade to debug assertions when close to release.
     assert!(data.has_styles(), "Resolving style on unstyled element");
-    assert!(element.has_current_styles(&*data),
-            "Resolving style on element without current styles");
+    debug_assert!(element.has_current_styles(&*data),
+                  "Resolving style on element without current styles");
     data.styles.primary().clone().into_strong()
 }
 


### PR DESCRIPTION
A lot of people are hitting this in [1]. I think having style (just potentially out-of-date) is less likely to cause weird crashes than failing to style the element entirely, so it's not worth inflicting this level of crashiness on the dogfood population.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1381475

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17757)
<!-- Reviewable:end -->
