### PR TITLE
Placed worklets implementation behind a pref

### DIFF
--- a/components/script/dom/webidls/CSSStyleValue.webidl
+++ b/components/script/dom/webidls/CSSStyleValue.webidl
@@ -4,7 +4,7 @@
 
 // https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue
 // NOTE: should this be exposed to Window?
-[Exposed=(Worklet)]
+[Pref="dom.worklet.enabled", Exposed=(Worklet)]
 interface CSSStyleValue {
     stringifier;
     // static CSSStyleValue? parse(DOMString property, DOMString cssText);

--- a/components/script/dom/webidls/PaintRenderingContext2D.webidl
+++ b/components/script/dom/webidls/PaintRenderingContext2D.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // https://drafts.css-houdini.org/css-paint-api/#paintrenderingcontext2d
-[Exposed=PaintWorklet]
+[Pref="dom.worklet.enabled", Exposed=PaintWorklet]
 interface PaintRenderingContext2D {
 };
 PaintRenderingContext2D implements CanvasState;

--- a/components/script/dom/webidls/PaintSize.webidl
+++ b/components/script/dom/webidls/PaintSize.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // https://drafts.css-houdini.org/css-paint-api/#paintsize
-[Exposed=PaintWorklet]
+[Pref="dom.worklet.enabled", Exposed=PaintWorklet]
 interface PaintSize {
     readonly attribute double width;
     readonly attribute double height;

--- a/components/script/dom/webidls/PaintWorkletGlobalScope.webidl
+++ b/components/script/dom/webidls/PaintWorkletGlobalScope.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // https://drafts.css-houdini.org/css-paint-api/#paintworkletglobalscope
-[Global=(Worklet,PaintWorklet), Exposed=PaintWorklet]
+[Global=(Worklet,PaintWorklet), Pref="dom.worklet.enabled", Exposed=PaintWorklet]
 interface PaintWorkletGlobalScope : WorkletGlobalScope {
     [Throws] void registerPaint(DOMString name, VoidFunction paintCtor);
 };

--- a/components/script/dom/webidls/StylePropertyMapReadOnly.webidl
+++ b/components/script/dom/webidls/StylePropertyMapReadOnly.webidl
@@ -4,7 +4,7 @@
 
 // https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly
 // NOTE: should this be exposed to Window?
-[Exposed=(Worklet)]
+[Pref="dom.worklet.enabled", Exposed=(Worklet)]
 interface StylePropertyMapReadOnly {
     CSSStyleValue? get(DOMString property);
     // sequence<CSSStyleValue> getAll(DOMString property);

--- a/components/script/dom/webidls/TestWorkletGlobalScope.webidl
+++ b/components/script/dom/webidls/TestWorkletGlobalScope.webidl
@@ -5,7 +5,7 @@
 // This interface is entirely internal to Servo, and should not be accessible to
 // web pages.
 
-[Global=(Worklet,TestWorklet), Exposed=TestWorklet]
+[Global=(Worklet,TestWorklet), Pref="dom.worklet.enabled", Exposed=TestWorklet]
 interface TestWorkletGlobalScope : WorkletGlobalScope {
     void registerKeyValue(DOMString key, DOMString value);
 };

--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -206,5 +206,5 @@ partial interface Window {
 
 // https://drafts.css-houdini.org/css-paint-api-1/#paint-worklet
 partial interface Window {
-    [SameObject] readonly attribute Worklet paintWorklet;
+    [SameObject, Pref="dom.worklet.enabled"] readonly attribute Worklet paintWorklet;
 };

--- a/components/script/dom/webidls/Worklet.webidl
+++ b/components/script/dom/webidls/Worklet.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // https://drafts.css-houdini.org/worklets/#worklet
-[Exposed=(Window)]
+[Pref="dom.worklet.enabled", Exposed=(Window)]
 interface Worklet {
     [NewObject] Promise<void> addModule(USVString moduleURL, optional WorkletOptions options);
 };

--- a/components/script/dom/webidls/WorkletGlobalScope.webidl
+++ b/components/script/dom/webidls/WorkletGlobalScope.webidl
@@ -5,6 +5,6 @@
 // https://drafts.css-houdini.org/worklets/#workletglobalscope
 // TODO: The spec IDL doesn't make this a subclass of EventTarget
 //       https://github.com/whatwg/html/issues/2611
-[Exposed=Worklet]
+[Pref="dom.worklet.enabled", Exposed=Worklet]
 interface WorkletGlobalScope: GlobalScope {
 };

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -27241,7 +27241,7 @@
    "testharness"
   ],
   "mozilla/interfaces.html": [
-   "ffdc606aaf989ef8bcdecef8cef8764bbb2ae1b2",
+   "c884fee8603f93099ffd0acc30f0ab0cbee5b5f8",
    "testharness"
   ],
   "mozilla/interfaces.js": [

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/__dir__.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [dom.worklet.enabled:true]

--- a/tests/wpt/mozilla/meta/mozilla/worklets/__dir__.ini
+++ b/tests/wpt/mozilla/meta/mozilla/worklets/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [dom.worklet.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.html
@@ -201,7 +201,6 @@ test_interfaces([
   "WebSocket",
   "Window",
   "Worker",
-  "Worklet",
   "XMLDocument",
   "XMLHttpRequest",
   "XMLHttpRequestEventTarget",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

At the moment, worklets are always exposed, even though their spec is still a draft. This PR hides them behind a pref.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17680.
- [X] These changes do not require tests because the existing worklet tests do the job.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17763)
<!-- Reviewable:end -->
