### PR TITLE
More grid serialization and parsing fixes

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1469,7 +1469,7 @@ fn static_assert() {
                         &mut ${self_grid}.mRepeatAutoLineNameListAfter, 0);
                 }
             },
-            GridTemplateComponent::Subgrid(mut list) => {
+            GridTemplateComponent::Subgrid(list) => {
                 ${self_grid}.set_mIsSubgrid(true);
                 let names_length = match list.fill_idx {
                     Some(_) => list.names.len() - 1,
@@ -1486,14 +1486,15 @@ fn static_assert() {
                         &mut ${self_grid}.mRepeatAutoLineNameListAfter, 0);
                 }
 
+                let mut names = list.names.into_vec();
                 if let Some(idx) = list.fill_idx {
                     ${self_grid}.set_mIsAutoFill(true);
                     ${self_grid}.mRepeatAutoIndex = idx as i16;
-                    set_line_names(&list.names.swap_remove(idx as usize),
+                    set_line_names(&names.swap_remove(idx as usize),
                                    &mut ${self_grid}.mRepeatAutoLineNameListBefore);
                 }
 
-                for (servo_names, gecko_names) in list.names.iter().zip(${self_grid}.mLineNameLists.iter_mut()) {
+                for (servo_names, gecko_names) in names.iter().zip(${self_grid}.mLineNameLists.iter_mut()) {
                     set_line_names(servo_names, gecko_names);
                 }
             },

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1319,10 +1319,11 @@ fn static_assert() {
         let ident = v.ident.as_ref().map_or(&[] as &[_], |ident| ident.0.as_slice());
         self.gecko.${value.gecko}.mLineName.assign(ident);
         self.gecko.${value.gecko}.mHasSpan = v.is_span;
-        self.gecko.${value.gecko}.mInteger = v.line_num.map(|i| {
+        if let Some(integer) = v.line_num {
             // clamping the integer between a range
-            cmp::max(nsStyleGridLine_kMinLine, cmp::min(i.value(), nsStyleGridLine_kMaxLine))
-        }).unwrap_or(0);
+            self.gecko.${value.gecko}.mInteger = cmp::max(nsStyleGridLine_kMinLine,
+                cmp::min(integer.value(), nsStyleGridLine_kMaxLine));
+        }
     }
 
     pub fn copy_${value.name}_from(&mut self, other: &Self) {

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -278,34 +278,35 @@
             }
         % endfor
 
-        let first_line_names = input.try(parse_line_names).unwrap_or(vec![]);
+        let first_line_names = input.try(parse_line_names).unwrap_or(vec![].into_boxed_slice());
         if let Ok(s) = input.try(Parser::expect_string) {
             let mut strings = vec![];
             let mut values = vec![];
             let mut line_names = vec![];
-            let mut names = first_line_names;
+            let mut names = first_line_names.into_vec();
             let mut string = s.into_owned().into_boxed_str();
             loop {
-                line_names.push(names);
+                line_names.push(names.into_boxed_slice());
                 strings.push(string);
                 let size = input.try(|i| TrackSize::parse(context, i)).unwrap_or_default();
                 values.push(size);
-                names = input.try(parse_line_names).unwrap_or(vec![]);
+                names = input.try(parse_line_names).unwrap_or(vec![].into_boxed_slice()).into_vec();
                 if let Ok(v) = input.try(parse_line_names) {
-                    names.extend(v);
+                    names.extend(v.into_vec());
                 }
 
                 string = match input.try(Parser::expect_string) {
                     Ok(s) => s.into_owned().into_boxed_str(),
                     _ => {      // only the named area determines whether we should bail out
-                        line_names.push(names);
+                        line_names.push(names.into_boxed_slice());
                         break
                     },
                 };
             }
 
             if line_names.len() == values.len() {
-                line_names.push(vec![]);        // should be one longer than track sizes
+                // should be one longer than track sizes
+                line_names.push(vec![].into_boxed_slice());
             }
 
             let template_areas = TemplateAreas::from_vec(strings)
@@ -313,7 +314,7 @@
             let template_rows = TrackList {
                 list_type: TrackListType::Normal,
                 values: values,
-                line_names: line_names,
+                line_names: line_names.into_boxed_slice(),
                 auto_repeat: None,
             };
 

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -252,7 +252,6 @@
                                        -> Result<(GridTemplateComponent,
                                                   GridTemplateComponent,
                                                   Either<TemplateAreas, None_>), ParseError<'i>> {
-
         // Other shorthand sub properties also parse `none` and `subgrid` keywords and this
         // shorthand should know after these keywords there is nothing to parse. Otherwise it
         // gets confused and rejects the sub properties that contains `none` or `subgrid`.

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -374,7 +374,10 @@
             Either::First(ref areas) => {
                 let track_list = match *template_rows {
                     GenericGridTemplateComponent::TrackList(ref list) => list,
-                    _ => unreachable!(),        // should exist!
+                    // Others template components shouldn't exist with normal shorthand values.
+                    // But if we need to serialize a group of longhand sub-properties for
+                    // the shorthand, we should be able to return empty string instead of crashing.
+                    _ => return Ok(()),
                 };
 
                 let mut names_iter = track_list.line_names.iter();

--- a/components/style/values/generics/grid.rs
+++ b/components/style/values/generics/grid.rs
@@ -701,3 +701,13 @@ pub enum GridTemplateComponent<L> {
     /// A `subgrid <line-name-list>?`
     Subgrid(LineNameList),
 }
+
+impl<L> GridTemplateComponent<L> {
+    /// Returns length of the <track-list>s <track-size>
+    pub fn track_list_len(&self) -> usize {
+        match *self {
+            GridTemplateComponent::TrackList(ref tracklist) => tracklist.values.len(),
+            _ => 0,
+        }
+    }
+}

--- a/components/style/values/generics/grid.rs
+++ b/components/style/values/generics/grid.rs
@@ -354,8 +354,13 @@ pub enum RepeatCount {
 
 impl Parse for RepeatCount {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
-        if let Ok(i) = input.try(|i| Integer::parse(context, i)) {
+        // Maximum number of repeat is 10000. The greater numbers should be clamped.
+        const MAX_LINE: i32 = 10000;
+        if let Ok(mut i) = input.try(|i| Integer::parse(context, i)) {
             if i.value() > 0 {
+                if i.value() > MAX_LINE {
+                    i = Integer::new(MAX_LINE);
+                }
                 Ok(RepeatCount::Number(i))
             } else {
                 Err(StyleParseError::UnspecifiedError.into())

--- a/components/style/values/generics/grid.rs
+++ b/components/style/values/generics/grid.rs
@@ -119,9 +119,7 @@ impl Parse for GridLine {
                 if i.value() <= 0 {       // disallow negative integers for grid spans
                     return Err(StyleParseError::UnspecifiedError.into())
                 }
-            } else if grid_line.ident.is_some() {       // integer could be omitted
-                grid_line.line_num = Some(Integer::new(1));
-            } else {
+            } else if grid_line.ident.is_none() {       // integer could be omitted
                 return Err(StyleParseError::UnspecifiedError.into())
             }
         }

--- a/components/style/values/specified/grid.rs
+++ b/components/style/values/specified/grid.rs
@@ -187,6 +187,8 @@ impl Parse for TrackList<LengthOrPercentage> {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
         // Merge the line names while parsing values. The resulting values will
         // all be bunch of `<track-size>` and one <auto-repeat>.
+        // FIXME: We need to decide which way is better for repeat function in
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1382369.
         //
         // For example,
         // `[a b] 100px [c d] repeat(1, 30px [g]) [h]` will be merged as `[a b] 100px [c d] 30px [g h]`

--- a/components/style/values/specified/grid.rs
+++ b/components/style/values/specified/grid.rs
@@ -81,7 +81,7 @@ impl Parse for TrackSize<LengthOrPercentage> {
 /// Parse the grid line names into a vector of owned strings.
 ///
 /// https://drafts.csswg.org/css-grid/#typedef-line-names
-pub fn parse_line_names<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Vec<CustomIdent>, ParseError<'i>> {
+pub fn parse_line_names<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Box<[CustomIdent]>, ParseError<'i>> {
     input.expect_square_bracket_block()?;
     input.parse_nested_block(|input| {
         let mut values = vec![];
@@ -90,7 +90,7 @@ pub fn parse_line_names<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Vec<Custom
             values.push(ident);
         }
 
-        Ok(values)
+        Ok(values.into_boxed_slice())
     })
 }
 
@@ -128,7 +128,7 @@ impl TrackRepeat<LengthOrPercentage> {
                 let mut current_names;
 
                 loop {
-                    current_names = input.try(parse_line_names).unwrap_or(vec![]);
+                    current_names = input.try(parse_line_names).unwrap_or(vec![].into_boxed_slice());
                     if let Ok(track_size) = input.try(|i| TrackSize::parse(context, i)) {
                         if !track_size.is_fixed() {
                             if is_auto {
@@ -150,7 +150,7 @@ impl TrackRepeat<LengthOrPercentage> {
                             // one `TrackSize`. But in current version of the spec, this is deprecated
                             // but we are adding this for gecko parity. We should remove this when
                             // gecko implements new spec.
-                            names.push(input.try(parse_line_names).unwrap_or(vec![]));
+                            names.push(input.try(parse_line_names).unwrap_or(vec![].into_boxed_slice()));
                             break
                         }
                     } else {
@@ -167,7 +167,7 @@ impl TrackRepeat<LengthOrPercentage> {
                 let repeat = TrackRepeat {
                     count: count,
                     track_sizes: values,
-                    line_names: names,
+                    line_names: names.into_boxed_slice(),
                 };
 
                 Ok((repeat, repeat_type))
@@ -205,7 +205,7 @@ impl Parse for TrackList<LengthOrPercentage> {
         let mut atleast_one_not_fixed = false;
 
         loop {
-            current_names.append(&mut input.try(parse_line_names).unwrap_or(vec![]));
+            current_names.extend_from_slice(&mut input.try(parse_line_names).unwrap_or(vec![].into_boxed_slice()));
             if let Ok(track_size) = input.try(|i| TrackSize::parse(context, i)) {
                 if !track_size.is_fixed() {
                     atleast_one_not_fixed = true;
@@ -215,7 +215,8 @@ impl Parse for TrackList<LengthOrPercentage> {
                     }
                 }
 
-                names.push(mem::replace(&mut current_names, vec![]));
+                let vec = mem::replace(&mut current_names, vec![]);
+                names.push(vec.into_boxed_slice());
                 values.push(track_size);
             } else if let Ok((repeat, type_)) = input.try(|i| TrackRepeat::parse_with_repeat_type(context, i)) {
                 if list_type == TrackListType::Explicit {
@@ -237,7 +238,8 @@ impl Parse for TrackList<LengthOrPercentage> {
 
                         list_type = TrackListType::Auto(values.len() as u16);
                         auto_repeat = Some(repeat);
-                        names.push(mem::replace(&mut current_names, vec![]));
+                        let vec = mem::replace(&mut current_names, vec![]);
+                        names.push(vec.into_boxed_slice());
                         continue
                     },
                     RepeatType::Fixed => (),
@@ -245,10 +247,11 @@ impl Parse for TrackList<LengthOrPercentage> {
 
                 // If the repeat count is numeric, we axpand and merge the values.
                 let mut repeat = repeat.expand();
-                let mut repeat_names_iter = repeat.line_names.drain(..);
+                let mut repeat_names_iter = repeat.line_names.iter();
                 for (size, repeat_names) in repeat.track_sizes.drain(..).zip(&mut repeat_names_iter) {
                     current_names.extend_from_slice(&repeat_names);
-                    names.push(mem::replace(&mut current_names, vec![]));
+                    let vec = mem::replace(&mut current_names, vec![]);
+                    names.push(vec.into_boxed_slice());
                     values.push(size);
                 }
 
@@ -260,7 +263,7 @@ impl Parse for TrackList<LengthOrPercentage> {
                     return Err(StyleParseError::UnspecifiedError.into())
                 }
 
-                names.push(current_names);
+                names.push(current_names.into_boxed_slice());
                 break
             }
         }
@@ -268,7 +271,7 @@ impl Parse for TrackList<LengthOrPercentage> {
         Ok(TrackList {
             list_type: list_type,
             values: values,
-            line_names: names,
+            line_names: names.into_boxed_slice(),
             auto_repeat: auto_repeat,
         })
     }

--- a/tests/unit/style/parsing/position.rs
+++ b/tests/unit/style/parsing/position.rs
@@ -237,7 +237,7 @@ fn test_computed_grid_template_rows_colums() {
 
     assert_computed_serialization(grid_template_rows::parse,
         "10px repeat(2, 1fr auto minmax(200px, 1fr))",
-        "10px minmax(auto, 1fr) auto minmax(200px, 1fr) minmax(auto, 1fr) auto minmax(200px, 1fr)");
+        "10px 1fr auto minmax(200px, 1fr) 1fr auto minmax(200px, 1fr)");
 
     assert_computed_serialization(grid_template_rows::parse,
         "subgrid [a] [] repeat(auto-fill, [])", "subgrid [a] [] repeat(auto-fill, [])");


### PR DESCRIPTION
These are the bugs I discovered while I was re-enabling the disabled grid mochitests. Now all grid mochitests are passing! Additionally I converted `Vec<CustomIdent>`'s into `Box<[CustomIdent]>`. We are storing so many line names in vectors. These should help a bit.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17776)
<!-- Reviewable:end -->
