### PR TITLE
stylo: Don't ignore visited state when deciding to share style contexts

### DIFF
--- a/components/style/sharing/checks.rs
+++ b/components/style/sharing/checks.rs
@@ -10,7 +10,6 @@ use Atom;
 use bloom::StyleBloom;
 use context::{SelectorFlagsMap, SharedStyleContext};
 use dom::TElement;
-use element_state::*;
 use sharing::{StyleSharingCandidate, StyleSharingTarget};
 use stylearc::Arc;
 
@@ -66,20 +65,6 @@ pub fn have_same_class<E>(target: &mut StyleSharingTarget<E>,
     where E: TElement,
 {
     target.class_list() == candidate.class_list()
-}
-
-/// Compare element and candidate state, but ignore visitedness.  Styles don't
-/// actually changed based on visitedness (since both possibilities are computed
-/// up front), so it's safe to share styles if visitedness differs.
-pub fn have_same_state_ignoring_visitedness<E>(element: E,
-                                               candidate: &StyleSharingCandidate<E>)
-                                               -> bool
-    where E: TElement,
-{
-    let state_mask = !IN_VISITED_OR_UNVISITED_STATE;
-    let state = element.get_state() & state_mask;
-    let candidate_state = candidate.element.get_state() & state_mask;
-    state == candidate_state
 }
 
 /// Whether a given element and a candidate match the same set of "revalidation"

--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -643,7 +643,10 @@ impl<E: TElement> StyleSharingCandidateCache<E> {
             miss!(UserAndAuthorRules)
         }
 
-        if !checks::have_same_state_ignoring_visitedness(target.element, candidate) {
+        // We do not ignore visited state here, because Gecko
+        // needs to store extra bits on visited style contexts,
+        // so these contexts cannot be shared
+        if target.element.get_state() != candidate.get_state() {
             miss!(State)
         }
 


### PR DESCRIPTION
r=bz https://bugzilla.mozilla.org/show_bug.cgi?id=1381635

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17778)
<!-- Reviewable:end -->
