### PR TITLE
constellation: Remove unused title attribute from Pipeline struct

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -75,9 +75,6 @@ pub struct Pipeline {
     /// to a hash URL.
     pub url: ServoUrl,
 
-    /// The title of the most recently-loaded page.
-    pub title: Option<String>,
-
     /// Whether this pipeline is currently running animations. Pipelines that are running
     /// animations cause composites to be continually scheduled.
     pub running_animations: bool,
@@ -316,7 +313,6 @@ impl Pipeline {
             layout_chan: layout_chan,
             compositor_proxy: compositor_proxy,
             url: url,
-            title: None,
             children: vec!(),
             running_animations: false,
             visible: visible,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removes title attribute from constellation::Pipeline since it is never used

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #15714 

- [X] These changes do not require tests because it's a very simple cleanup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17784)
<!-- Reviewable:end -->
