### PR TITLE
Remove explicit lifetime arguments on a method call.

### DIFF
--- a/components/style/stylesheets/stylesheet.rs
+++ b/components/style/stylesheets/stylesheet.rs
@@ -240,7 +240,7 @@ pub trait StylesheetInDocument {
         device: &'a Device,
         guard: &'a SharedRwLockReadGuard<'b>
     ) -> EffectiveRulesIterator<'a, 'b> {
-        self.iter_rules::<'a, 'b, EffectiveRules>(device, guard)
+        self.iter_rules::<EffectiveRules>(device, guard)
     }
 
     rule_filter! {


### PR DESCRIPTION
This causes a warning it today’s Nightly: https://github.com/rust-lang/rust/issues/42868

… which makes the build fail because we use `#![deny(warnings)]`. This warning is planned to become a hard error in a future Rust version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17785)
<!-- Reviewable:end -->
