### PR TITLE
Store COW strings in CSS parser errors when possible.

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1478,7 +1478,7 @@ impl PropertyDeclaration {
                     Ok(keyword) => DeclaredValueOwned::CSSWideKeyword(keyword),
                     Err(_) => match ::custom_properties::SpecifiedValue::parse(context, input) {
                         Ok(value) => DeclaredValueOwned::Value(value),
-                        Err(_) => return Err(PropertyDeclarationParseError::InvalidValue(name.to_string())),
+                        Err(_) => return Err(PropertyDeclarationParseError::InvalidValue(name.to_string().into())),
                     }
                 };
                 declarations.push(PropertyDeclaration::Custom(name, value));

--- a/components/style_traits/lib.rs
+++ b/components/style_traits/lib.rs
@@ -124,7 +124,7 @@ pub enum PropertyDeclarationParseError<'i> {
     /// The property declaration was for a disabled experimental property.
     ExperimentalProperty,
     /// The property declaration contained an invalid value.
-    InvalidValue(String),
+    InvalidValue(CompactCowStr<'i>),
     /// The declaration contained an animation property, and we were parsing
     /// this as a keyframe block (so that property should be ignored).
     ///

--- a/ports/geckolib/error_reporter.rs
+++ b/ports/geckolib/error_reporter.rs
@@ -224,7 +224,7 @@ impl<'a> ErrorHelpers<'a> for ContextualParseError<'a> {
             (_, CssParseError::Custom(SelectorParseError::Custom(
                 StyleParseError::PropertyDeclaration(
                     PropertyDeclarationParseError::InvalidValue(property))))) =>
-                ErrorString::Snippet(property.into()),
+                ErrorString::Snippet(property),
 
             (_, CssParseError::Custom(SelectorParseError::UnexpectedIdent(ident))) =>
                 ErrorString::Ident(ident),


### PR DESCRIPTION
This should be a straightforward performance improvement in pages with lots of CSS property values that the parser does not understand.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there's no functional difference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17787)
<!-- Reviewable:end -->
