### PR TITLE
stylo: Fix Y scale computation while decomposing a 3D matrix.

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -2146,7 +2146,7 @@ fn decompose_3d_matrix(mut matrix: ComputedMatrix) -> Result<MatrixDecomposed3D,
     row[1] = combine(row[1], row[0], 1.0, -skew.0);
 
     // Now, compute Y scale and normalize 2nd row.
-    let row1len = (row[0][0] * row[0][0] + row[0][1] * row[0][1] + row[0][2] * row[0][2]).sqrt();
+    let row1len = (row[1][0] * row[1][0] + row[1][1] * row[1][1] + row[1][2] * row[1][2]).sqrt();
     scale.1 = row1len;
     row[1] = [row[1][0] / row1len, row[1][1] / row1len, row[1][2] / row1len];
     skew.0 /= scale.1;


### PR DESCRIPTION
While decomposing a 3D matrix, we should normalize the 2nd row right after the
Y scale computation. However, we accidentally use the length of the 1st row to
do the normalization. This causes the wrong Scale3D function while decomposing,
and then leads to the wrong decomposed 3D matrix.

Here, we correct it by using the right value (the length of the 2nd row).

r=hiro https://bugzilla.mozilla.org/show_bug.cgi?id=1381196

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17789)
<!-- Reviewable:end -->
