### PR TITLE
Fix supports rule parsing issues with <any-value>

### DIFF
--- a/tests/unit/style/parsing/supports.rs
+++ b/tests/unit/style/parsing/supports.rs
@@ -11,4 +11,6 @@ fn test_supports_condition() {
     assert_roundtrip!(SupportsCondition::parse, "(margin: 1px)");
     assert_roundtrip!(SupportsCondition::parse, "not (--be: to be)");
     assert_roundtrip!(SupportsCondition::parse, "(color: blue) and future-extension(4)");
+    assert_roundtrip!(SupportsCondition::parse, "future-\\1 extension(4)");
+    assert_roundtrip!(SupportsCondition::parse, "((test))");
 }


### PR DESCRIPTION
This eventually fixes #15482, as well as several reftests in mozilla-central which were added for [bug 883987](https://bugzilla.mozilla.org/show_bug.cgi?id=883987).

The new function should probably be moved into cssparser crate at some point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17792)
<!-- Reviewable:end -->
