### PR TITLE
Call may_have_animations() for parent element in the case where the t…

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1089,6 +1089,16 @@ impl<'le> TElement for GeckoElement<'le> {
 
     #[inline]
     fn may_have_animations(&self) -> bool {
+        if let Some(pseudo) = self.implemented_pseudo_element() {
+            if !pseudo.is_before_or_after() {
+                return false;
+            }
+            return self.parent_element()
+                       .map_or(false, |p| {
+                           p.as_node()
+                            .get_bool_flag(nsINode_BooleanFlag::ElementHasAnimations)
+            });
+        }
         self.as_node().get_bool_flag(nsINode_BooleanFlag::ElementHasAnimations)
     }
 


### PR DESCRIPTION
…arget is pseudo element.

In case of pseudo elements ElementHasAnimations is set on the parent element.

updating-animation-on-pseudo-element.html fails without this patch, succeeds
with this patch.

<!-- Please describe your changes on the following line: -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1367278
---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17793)
<!-- Reviewable:end -->
