### PR TITLE
style: pass old ComputedValues from Element data into Gecko_CalcStyleDifference

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -161,7 +161,9 @@ pub fn recalc_style_for_animations(context: &LayoutContext,
                                            &mut fragment.style,
                                            &ServoMetricsProvider);
                 let difference =
-                    RestyleDamage::compute_style_difference(&old_style, &fragment.style);
+                    RestyleDamage::compute_style_difference(&old_style,
+                                                            &old_style,
+                                                            &fragment.style);
                 damage |= difference.damage;
             }
         }

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1041,8 +1041,9 @@ extern "C" {
      -> CSSPseudoElementType;
 }
 extern "C" {
-    pub fn Gecko_CalcStyleDifference(oldstyle: *mut nsStyleContext,
-                                     newstyle: ServoComputedValuesBorrowed,
+    pub fn Gecko_CalcStyleDifference(old_style: *const ServoStyleContext,
+                                     new_style: *const ServoStyleContext,
+                                     old_style_bits: u64,
                                      any_style_changed: *mut bool)
      -> nsChangeHint;
 }

--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -55,7 +55,7 @@ impl GeckoRestyleDamage {
         let mut any_style_changed: bool = false;
         let hint = unsafe {
             bindings::Gecko_CalcStyleDifference(context,
-                                                &new_style,
+                                                new_style.as_style_context(),
                                                 &mut any_style_changed)
         };
         let change = if any_style_changed { StyleChange::Changed } else { StyleChange::Unchanged };

--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -48,14 +48,14 @@ impl GeckoRestyleDamage {
     /// accessed from layout.
     pub fn compute_style_difference(
         source: &nsStyleContext,
-        new_style: &Arc<ComputedValues>
+        old_style: &ComputedValues,
+        new_style: &Arc<ComputedValues>,
     ) -> StyleDifference {
-        // TODO(emilio): Const-ify this?
-        let context = source as *const nsStyleContext as *mut nsStyleContext;
         let mut any_style_changed: bool = false;
         let hint = unsafe {
-            bindings::Gecko_CalcStyleDifference(context,
+            bindings::Gecko_CalcStyleDifference(old_style.as_style_context(),
                                                 new_style.as_style_context(),
+                                                source.mBits,
                                                 &mut any_style_changed)
         };
         let change = if any_style_changed { StyleChange::Changed } else { StyleChange::Unchanged };

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -768,7 +768,7 @@ pub trait MatchMethods : TElement {
     ) -> StyleDifference {
         debug_assert!(pseudo.map_or(true, |p| p.is_eager()));
         if let Some(source) = self.existing_style_for_restyle_damage(old_values, pseudo) {
-            return RestyleDamage::compute_style_difference(source, new_values)
+            return RestyleDamage::compute_style_difference(source, old_values, new_values)
         }
 
         let new_display = new_values.get_box().clone_display();

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -137,6 +137,10 @@ impl ComputedValues {
         let atom = Atom::from(atom);
         PseudoElement::from_atom(&atom)
     }
+
+    pub fn as_style_context(&self) -> &::gecko_bindings::structs::mozilla::ServoStyleContext {
+        &self.0
+    }
 }
 
 impl Drop for ComputedValues {

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -60,7 +60,8 @@ impl HeapSizeOf for ServoRestyleDamage {
 impl ServoRestyleDamage {
     /// Compute the `StyleDifference` (including the appropriate restyle damage)
     /// for a given style change between `old` and `new`.
-    pub fn compute_style_difference(old: &ComputedValues,
+    pub fn compute_style_difference(_source: &ComputedValues,
+                                    old: &ComputedValues,
                                     new: &ComputedValues)
                                     -> StyleDifference {
         let damage = compute_damage(old, new);


### PR DESCRIPTION
This is the Servo-side part of https://bugzilla.mozilla.org/show_bug.cgi?id=1380133.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17796)
<!-- Reviewable:end -->
