### PR TITLE
servo: Move FontComputationData to the end of ServoComputedValues to make size check easier, make it NonZero

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1984,10 +1984,10 @@ extern "C" {
      -> ServoStyleContextStrong;
 }
 extern "C" {
-    pub fn Servo_StyleContext_AddRef(ctx: ServoStyleContextBorrowed);
+    pub fn Servo_StyleContext_AddRef(ctx: &ServoStyleContext);
 }
 extern "C" {
-    pub fn Servo_StyleContext_Release(ctx: ServoStyleContextBorrowed);
+    pub fn Servo_StyleContext_Release(ctx: &ServoStyleContext);
 }
 extern "C" {
     pub fn Servo_StyleSet_MightHaveAttributeDependency(set:

--- a/components/style/gecko/generated/structs_debug.rs
+++ b/components/style/gecko/generated/structs_debug.rs
@@ -7572,6 +7572,19 @@ pub mod root {
             FirstLetterContinuation = 1,
             PlaceholderFrame = 2,
         }
+        #[repr(u32)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+        pub enum ServoKeywordSize {
+            Empty = 0,
+            XXSmall = 1,
+            XSmall = 2,
+            Small = 3,
+            Medium = 4,
+            Large = 5,
+            XLarge = 6,
+            XXLarge = 7,
+            XXXLarge = 8,
+        }
         #[repr(C)]
         #[derive(Debug)]
         pub struct ServoStyleContext {
@@ -7581,7 +7594,7 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_ServoStyleContext() {
-            assert_eq!(::std::mem::size_of::<ServoStyleContext>() , 272usize ,
+            assert_eq!(::std::mem::size_of::<ServoStyleContext>() , 264usize ,
                        concat ! (
                        "Size of: " , stringify ! ( ServoStyleContext ) ));
             assert_eq! (::std::mem::align_of::<ServoStyleContext>() , 8usize ,
@@ -21006,7 +21019,7 @@ pub mod root {
         pub Effects: ::gecko_bindings::structs::ServoRawOffsetArc<root::mozilla::GeckoEffects>,
         pub custom_properties: ::gecko_bindings::structs::ServoCustomPropertiesMap,
         pub writing_mode: ::gecko_bindings::structs::ServoWritingMode,
-        pub font_computation_data: ::gecko_bindings::structs::ServoFontComputationData,
+        pub flags: ::gecko_bindings::structs::ServoComputedValueFlags,
         /// The rule node representing the ordered list of rules matched for this
   /// node.  Can be None for default values and text nodes.  This is
   /// essentially an optimization to avoid referencing the root rule node.
@@ -21015,11 +21028,11 @@ pub mod root {
   /// relevant link for this element. A element's "relevant link" is the
   /// element being matched if it is a link or the nearest ancestor link.
         pub visited_style: ::gecko_bindings::structs::ServoVisitedStyle,
-        pub flags: ::gecko_bindings::structs::ServoComputedValueFlags,
+        pub font_computation_data: ::gecko_bindings::structs::ServoFontComputationData,
     }
     #[test]
     fn bindgen_test_layout_ServoComputedValues() {
-        assert_eq!(::std::mem::size_of::<ServoComputedValues>() , 232usize ,
+        assert_eq!(::std::mem::size_of::<ServoComputedValues>() , 224usize ,
                    concat ! (
                    "Size of: " , stringify ! ( ServoComputedValues ) ));
         assert_eq! (::std::mem::align_of::<ServoComputedValues>() , 8usize ,
@@ -21154,27 +21167,27 @@ pub mod root {
                     "Alignment of field: " , stringify ! ( ServoComputedValues
                     ) , "::" , stringify ! ( writing_mode ) ));
         assert_eq! (unsafe {
-                    & ( * ( 0 as * const ServoComputedValues ) ) .
-                    font_computation_data as * const _ as usize } , 196usize ,
-                    concat ! (
+                    & ( * ( 0 as * const ServoComputedValues ) ) . flags as *
+                    const _ as usize } , 193usize , concat ! (
                     "Alignment of field: " , stringify ! ( ServoComputedValues
-                    ) , "::" , stringify ! ( font_computation_data ) ));
+                    ) , "::" , stringify ! ( flags ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const ServoComputedValues ) ) . rules as *
-                    const _ as usize } , 208usize , concat ! (
+                    const _ as usize } , 200usize , concat ! (
                     "Alignment of field: " , stringify ! ( ServoComputedValues
                     ) , "::" , stringify ! ( rules ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const ServoComputedValues ) ) .
-                    visited_style as * const _ as usize } , 216usize , concat
+                    visited_style as * const _ as usize } , 208usize , concat
                     ! (
                     "Alignment of field: " , stringify ! ( ServoComputedValues
                     ) , "::" , stringify ! ( visited_style ) ));
         assert_eq! (unsafe {
-                    & ( * ( 0 as * const ServoComputedValues ) ) . flags as *
-                    const _ as usize } , 224usize , concat ! (
+                    & ( * ( 0 as * const ServoComputedValues ) ) .
+                    font_computation_data as * const _ as usize } , 216usize ,
+                    concat ! (
                     "Alignment of field: " , stringify ! ( ServoComputedValues
-                    ) , "::" , stringify ! ( flags ) ));
+                    ) , "::" , stringify ! ( font_computation_data ) ));
     }
     #[repr(C)]
     #[derive(Debug, Copy)]

--- a/components/style/gecko/generated/structs_release.rs
+++ b/components/style/gecko/generated/structs_release.rs
@@ -7420,6 +7420,19 @@ pub mod root {
             FirstLetterContinuation = 1,
             PlaceholderFrame = 2,
         }
+        #[repr(u32)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+        pub enum ServoKeywordSize {
+            Empty = 0,
+            XXSmall = 1,
+            XSmall = 2,
+            Small = 3,
+            Medium = 4,
+            Large = 5,
+            XLarge = 6,
+            XXLarge = 7,
+            XXXLarge = 8,
+        }
         #[repr(C)]
         #[derive(Debug)]
         pub struct ServoStyleContext {
@@ -7429,7 +7442,7 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_ServoStyleContext() {
-            assert_eq!(::std::mem::size_of::<ServoStyleContext>() , 272usize ,
+            assert_eq!(::std::mem::size_of::<ServoStyleContext>() , 264usize ,
                        concat ! (
                        "Size of: " , stringify ! ( ServoStyleContext ) ));
             assert_eq! (::std::mem::align_of::<ServoStyleContext>() , 8usize ,
@@ -20622,7 +20635,7 @@ pub mod root {
         pub Effects: ::gecko_bindings::structs::ServoRawOffsetArc<root::mozilla::GeckoEffects>,
         pub custom_properties: ::gecko_bindings::structs::ServoCustomPropertiesMap,
         pub writing_mode: ::gecko_bindings::structs::ServoWritingMode,
-        pub font_computation_data: ::gecko_bindings::structs::ServoFontComputationData,
+        pub flags: ::gecko_bindings::structs::ServoComputedValueFlags,
         /// The rule node representing the ordered list of rules matched for this
   /// node.  Can be None for default values and text nodes.  This is
   /// essentially an optimization to avoid referencing the root rule node.
@@ -20631,11 +20644,11 @@ pub mod root {
   /// relevant link for this element. A element's "relevant link" is the
   /// element being matched if it is a link or the nearest ancestor link.
         pub visited_style: ::gecko_bindings::structs::ServoVisitedStyle,
-        pub flags: ::gecko_bindings::structs::ServoComputedValueFlags,
+        pub font_computation_data: ::gecko_bindings::structs::ServoFontComputationData,
     }
     #[test]
     fn bindgen_test_layout_ServoComputedValues() {
-        assert_eq!(::std::mem::size_of::<ServoComputedValues>() , 232usize ,
+        assert_eq!(::std::mem::size_of::<ServoComputedValues>() , 224usize ,
                    concat ! (
                    "Size of: " , stringify ! ( ServoComputedValues ) ));
         assert_eq! (::std::mem::align_of::<ServoComputedValues>() , 8usize ,
@@ -20770,27 +20783,27 @@ pub mod root {
                     "Alignment of field: " , stringify ! ( ServoComputedValues
                     ) , "::" , stringify ! ( writing_mode ) ));
         assert_eq! (unsafe {
-                    & ( * ( 0 as * const ServoComputedValues ) ) .
-                    font_computation_data as * const _ as usize } , 196usize ,
-                    concat ! (
+                    & ( * ( 0 as * const ServoComputedValues ) ) . flags as *
+                    const _ as usize } , 193usize , concat ! (
                     "Alignment of field: " , stringify ! ( ServoComputedValues
-                    ) , "::" , stringify ! ( font_computation_data ) ));
+                    ) , "::" , stringify ! ( flags ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const ServoComputedValues ) ) . rules as *
-                    const _ as usize } , 208usize , concat ! (
+                    const _ as usize } , 200usize , concat ! (
                     "Alignment of field: " , stringify ! ( ServoComputedValues
                     ) , "::" , stringify ! ( rules ) ));
         assert_eq! (unsafe {
                     & ( * ( 0 as * const ServoComputedValues ) ) .
-                    visited_style as * const _ as usize } , 216usize , concat
+                    visited_style as * const _ as usize } , 208usize , concat
                     ! (
                     "Alignment of field: " , stringify ! ( ServoComputedValues
                     ) , "::" , stringify ! ( visited_style ) ));
         assert_eq! (unsafe {
-                    & ( * ( 0 as * const ServoComputedValues ) ) . flags as *
-                    const _ as usize } , 224usize , concat ! (
+                    & ( * ( 0 as * const ServoComputedValues ) ) .
+                    font_computation_data as * const _ as usize } , 216usize ,
+                    concat ! (
                     "Alignment of field: " , stringify ! ( ServoComputedValues
-                    ) , "::" , stringify ! ( flags ) ));
+                    ) , "::" , stringify ! ( font_computation_data ) ));
     }
     #[repr(C)]
     #[derive(Debug, Copy)]

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -620,16 +620,18 @@ ${helpers.single_keyword_system("font-variant-caps",
     #[derive(Debug, Copy, Clone, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub enum KeywordSize {
-        XXSmall = 0,
-        XSmall = 1,
-        Small = 2,
-        Medium = 3,
-        Large = 4,
-        XLarge = 5,
-        XXLarge = 6,
+        XXSmall = 1, // This is to enable the NonZero optimization
+                     // which simplifies the representation of Option<KeywordSize>
+                     // in bindgen
+        XSmall,
+        Small,
+        Medium,
+        Large,
+        XLarge,
+        XXLarge,
         // This is not a real font keyword and will not parse
         // HTML font-size 7 corresponds to this value
-        XXXLarge = 7,
+        XXXLarge,
     }
 
     pub use self::KeywordSize::*;
@@ -644,6 +646,19 @@ ${helpers.single_keyword_system("font-variant-caps",
                 "large" => Ok(Large),
                 "x-large" => Ok(XLarge),
                 "xx-large" => Ok(XXLarge),
+            }
+        }
+
+        pub fn html_size(&self) -> u8 {
+            match *self {
+                KeywordSize::XXSmall => 0,
+                KeywordSize::XSmall => 1,
+                KeywordSize::Small => 2,
+                KeywordSize::Medium => 3,
+                KeywordSize::Large => 4,
+                KeywordSize::XLarge => 5,
+                KeywordSize::XXLarge => 6,
+                KeywordSize::XXXLarge => 7,
             }
         }
     }
@@ -731,7 +746,7 @@ ${helpers.single_keyword_system("font-variant-caps",
                 }) };
 
                 let base_size_px = au_to_int_px(base_size as f32);
-                let html_size = *self as usize;
+                let html_size = self.html_size() as usize;
                 if base_size_px >= 9 && base_size_px <= 16 {
                     Au::from_px(FONT_SIZE_MAPPING[(base_size_px - 9) as usize][html_size])
                 } else {


### PR DESCRIPTION
We fail bindgen layout tests on 32 bit because FontComputationData does not accurately reflect the size/alignment of the rust-side replacement.

We move it to the end so that alignment is more straightforward, and
use a NonZero enum so that the representation can be more accurately
handled on the C++ side.


r=emilio https://bugzilla.mozilla.org/show_bug.cgi?id=1382190

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17803)
<!-- Reviewable:end -->
