### PR TITLE
Store raw string for prop decl in @supports

### DIFF
--- a/components/script/dom/css.rs
+++ b/components/script/dom/css.rs
@@ -30,7 +30,11 @@ impl CSS {
 
     /// https://drafts.csswg.org/css-conditional/#dom-css-supports
     pub fn Supports(win: &Window, property: DOMString, value: DOMString) -> bool {
-        let decl = Declaration { prop: property.into(), val: value.into() };
+        let mut decl = String::new();
+        serialize_identifier(&property, &mut decl).unwrap();
+        decl.push_str(": ");
+        decl.push_str(&value);
+        let decl = Declaration(decl);
         let url = win.Document().url();
         let context = ParserContext::new_for_cssom(&url, win.css_error_reporter(), Some(CssRuleType::Supports),
                                                    PARSING_MODE_DEFAULT,


### PR DESCRIPTION
This fixes the serialization issue of `@supports` rule that whitespaces are not preserved like in other browsers.

It makes the work a bit redundant (the property name and colon is parsed twice), but I suppose this isn't a big deal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17813)
<!-- Reviewable:end -->
