### PR TITLE
Update WR (switch to new text-decorations API in WR).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,7 +3465,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.48.0"
-source = "git+https://github.com/servo/webrender#b83c200c657f6b6fb17d09f329ba77803420b46a"
+source = "git+https://github.com/servo/webrender#8fd634882111415a65da67e947f26eb170234f2f"
 dependencies = [
  "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.48.0"
-source = "git+https://github.com/servo/webrender#b83c200c657f6b6fb17d09f329ba77803420b46a"
+source = "git+https://github.com/servo/webrender#8fd634882111415a65da67e947f26eb170234f2f"
 dependencies = [
  "app_units 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -1146,7 +1146,8 @@ pub struct LineDisplayItem {
     pub color: ColorF,
 
     /// The line segment style.
-    pub style: border_style::T
+    #[ignore_heap_size_of = "enum type in webrender"]
+    pub style: webrender_api::LineStyle,
 }
 
 /// Paints a box shadow per CSS-BACKGROUNDS.

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -71,7 +71,7 @@ use style_traits::CSSPixel;
 use style_traits::cursor::Cursor;
 use table_cell::CollapsedBordersForCell;
 use webrender_api::{ClipId, ColorF, ComplexClipRegion, GradientStop, LocalClip, RepeatMode};
-use webrender_api::{ScrollPolicy, TransformStyle};
+use webrender_api::{LineStyle, ScrollPolicy, TransformStyle};
 use webrender_helpers::{ToBorderRadius, ToMixBlendMode, ToRectF, ToTransformStyle};
 
 trait ResolvePercentage {
@@ -1651,7 +1651,7 @@ impl FragmentDisplayListBuilding for Fragment {
         state.add_display_item(DisplayItem::Line(box LineDisplayItem {
             base: base,
             color: ColorF::rgb(0, 200, 0),
-            style: border_style::T::dashed,
+            style: LineStyle::Dashed,
         }));
     }
 
@@ -2217,9 +2217,10 @@ impl FragmentDisplayListBuilding for Fragment {
             self.style.get_cursor(Cursor::Default),
             DisplayListSection::Content);
 
-        state.add_display_item(DisplayItem::SolidColor(box SolidColorDisplayItem {
+        state.add_display_item(DisplayItem::Line(box LineDisplayItem {
             base: base,
             color: color.to_gfx_color(),
+            style: LineStyle::Solid,
         }));
     }
 

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -432,8 +432,16 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                                              rect.size,
                                              webrender_api::LayoutSize::zero());
             }
-            DisplayItem::Line(..) => {
-                println!("TODO DisplayItem::Line");
+            DisplayItem::Line(ref item) => {
+                let box_bounds = item.base.bounds.to_rectf();
+                builder.push_line(Some(item.base.local_clip),
+                                  box_bounds.origin.y + box_bounds.size.height,
+                                  box_bounds.origin.x,
+                                  box_bounds.origin.x + box_bounds.size.width,
+                                  webrender_api::LineOrientation::Horizontal,
+                                  box_bounds.size.height,
+                                  item.color,
+                                  item.style);
             }
             DisplayItem::BoxShadow(ref item) => {
                 let rect = item.base.bounds.to_rectf();


### PR DESCRIPTION
This only makes use of the "Solid" text decoration type, which
matches the existing support. WR now supports dotted, dashed
and wavy text decorations, but supporting those will need some
extra work in Servo to pass through the correct values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17814)
<!-- Reviewable:end -->
