### PR TITLE
stylo: Set the NS_STYLE_IS_TEXT_COMBINED flag.

### DIFF
--- a/components/style/properties/computed_value_flags.rs
+++ b/components/style/properties/computed_value_flags.rs
@@ -28,5 +28,10 @@ bitflags! {
         /// This bit is propagated to all children of line participants.
         /// It is currently used by ruby to make its content unbreakable.
         const SHOULD_SUPPRESS_LINEBREAK = 1 << 1,
+
+        /// A flag used to mark text that that has text-combine-upright.
+        ///
+        /// This is used from Gecko's layout engine.
+        const IS_TEXT_COMBINED = 1 << 2,
     }
 }

--- a/components/style/style_adjuster.rs
+++ b/components/style/style_adjuster.rs
@@ -107,6 +107,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     fn adjust_for_text_combine_upright(&mut self) {
         use computed_values::text_combine_upright::T as text_combine_upright;
         use computed_values::writing_mode::T as writing_mode;
+        use properties::computed_value_flags::IS_TEXT_COMBINED;
 
         let writing_mode =
             self.style.get_inheritedbox().clone_writing_mode();
@@ -115,6 +116,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
 
         if writing_mode != writing_mode::horizontal_tb &&
            text_combine_upright == text_combine_upright::all {
+            self.style.flags.insert(IS_TEXT_COMBINED);
             self.style.mutate_inheritedbox().set_writing_mode(writing_mode::horizontal_tb);
         }
     }
@@ -409,6 +411,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
             self.style.reset_border_struct();
             self.style.reset_padding_struct();
         }
+
         // Force bidi isolation on all internal ruby boxes and ruby container
         // per spec https://drafts.csswg.org/css-ruby-1/#bidi
         if self_display.is_ruby_type() {

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1742,6 +1742,9 @@ pub extern "C" fn Servo_ComputedValues_GetStyleBits(values: ServoStyleContextBor
     if flags.contains(SHOULD_SUPPRESS_LINEBREAK) {
         result |= structs::NS_STYLE_SUPPRESS_LINEBREAK as u64;
     }
+    if flags.contains(IS_TEXT_COMBINED) {
+        result |= structs::NS_STYLE_IS_TEXT_COMBINED as u64;
+    }
     result
 }
 


### PR DESCRIPTION
This should fix at least
layout/reftests/writing-mode/1135361-ruby-justify-1.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17819)
<!-- Reviewable:end -->
