### PR TITLE
stylo: Remove the visited bit for now since it doesn't account for the pref.

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1737,7 +1737,8 @@ pub extern "C" fn Servo_ComputedValues_GetStyleBits(values: ServoStyleContextBor
     let flags = values.flags;
     let mut result = 0;
     if flags.contains(IS_RELEVANT_LINK_VISITED) {
-        result |= structs::NS_STYLE_RELEVANT_LINK_VISITED as u64;
+        // FIXME(emilio): This doesn't account for the pref.
+        // result |= structs::NS_STYLE_RELEVANT_LINK_VISITED as u64;
     }
     if flags.contains(HAS_TEXT_DECORATION_LINES) {
         result |= structs::NS_STYLE_HAS_TEXT_DECORATION_LINES as u64;


### PR DESCRIPTION
I'll fix before landing the Gecko changes for bug 1383307, so this doesn't break
anything yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17826)
<!-- Reviewable:end -->
