### PR TITLE
Iterate through properties in priority order when computing keyframes

### DIFF
--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -46,6 +46,11 @@ def to_camel_case_lower(ident):
     return camel[0].lower() + camel[1:]
 
 
+# https://drafts.csswg.org/cssom/#css-property-to-idl-attribute
+def to_idl_name(ident):
+    return re.sub("-([a-z])", lambda m: m.group(1).upper(), ident)
+
+
 def parse_aliases(value):
     aliases = {}
     for pair in value.split():


### PR DESCRIPTION
This is largely just a translation of Gecko's PropertyPriorityIterator[1] into rust with the exception that IDL sort order is only defined for shorthands since that's all we currently require.

[1] http://searchfox.org/mozilla-central/rev/3a3af33f513071ea829debdfbc628caebcdf6996/dom/animation/KeyframeUtils.cpp#151

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy --stylo` does not report any errors
- [x] These changes fix (Gecko bug 1371493)[https://bugzilla.mozilla.org/show_bug.cgi?id=1371493].
- [x] There are tests for these changes in the Gecko codebase

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17831)
<!-- Reviewable:end -->
