### PR TITLE
style: allow out-of-range opacity values for SMIL animations

### DIFF
--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -642,6 +642,7 @@ impl Expression {
             in_media_query: true,
             // TODO: pass the correct value here.
             quirks_mode: quirks_mode,
+            for_smil_animation: false,
         };
 
         let required_value = match self.value {

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2996,6 +2996,7 @@ where
         cached_system_font: None,
         in_media_query: false,
         quirks_mode: quirks_mode,
+        for_smil_animation: false,
     };
 
     let ignore_colors = !device.use_document_colors();

--- a/components/style/servo/media_queries.rs
+++ b/components/style/servo/media_queries.rs
@@ -246,6 +246,7 @@ impl Range<specified::Length> {
             in_media_query: true,
             cached_system_font: None,
             quirks_mode: quirks_mode,
+            for_smil_animation: false,
         };
 
         match *self {

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -709,6 +709,7 @@ impl MaybeNew for ViewportConstraints {
             cached_system_font: None,
             in_media_query: false,
             quirks_mode: quirks_mode,
+            for_smil_animation: false,
         };
 
         // DEVICE-ADAPT § 9.3 Resolving 'extend-to-zoom'

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -95,6 +95,12 @@ pub struct Context<'a> {
 
     /// The quirks mode of this context.
     pub quirks_mode: QuirksMode,
+
+    /// Whether this computation is being done for a SMIL animation.
+    ///
+    /// This is used to allow certain properties to generate out-of-range
+    /// values, which SMIL allows.
+    pub for_smil_animation: bool,
 }
 
 impl<'a> Context<'a> {

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -563,7 +563,14 @@ impl ToComputedValue for Opacity {
 
     #[inline]
     fn to_computed_value(&self, context: &Context) -> CSSFloat {
-        self.0.to_computed_value(context).min(1.0).max(0.0)
+        let value = self.0.to_computed_value(context);
+        if context.for_smil_animation {
+            // SMIL expects to be able to interpolate between out-of-range
+            // opacity values.
+            value
+        } else {
+            value.min(1.0).max(0.0)
+        }
     }
 
     #[inline]

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2907,6 +2907,7 @@ fn create_context<'a>(
     style: &'a ComputedValues,
     parent_style: Option<&'a ComputedValues>,
     pseudo: Option<&'a PseudoElement>,
+    for_smil_animation: bool,
 ) -> Context<'a> {
     Context {
         is_root_element: false,
@@ -2920,6 +2921,7 @@ fn create_context<'a>(
         cached_system_font: None,
         in_media_query: false,
         quirks_mode: per_doc_data.stylist.quirks_mode(),
+        for_smil_animation,
     }
 }
 
@@ -2989,7 +2991,14 @@ pub extern "C" fn Servo_GetComputedKeyframeValues(keyframes: RawGeckoKeyframeLis
     let parent_style = parent_data.as_ref().map(|d| d.styles.primary()).map(|x| &**x);
 
     let pseudo = style.pseudo();
-    let mut context = create_context(&data, &metrics, &style, parent_style, pseudo.as_ref());
+    let mut context = create_context(
+        &data,
+        &metrics,
+        &style,
+        parent_style,
+        pseudo.as_ref(),
+        /* for_smil_animation = */ false,
+    );
 
     let global_style_data = &*GLOBAL_STYLE_DATA;
     let guard = global_style_data.shared_lock.read();
@@ -3069,7 +3078,14 @@ pub extern "C" fn Servo_GetAnimationValues(declarations: RawServoDeclarationBloc
     let parent_style = parent_data.as_ref().map(|d| d.styles.primary()).map(|x| &**x);
 
     let pseudo = style.pseudo();
-    let mut context = create_context(&data, &metrics, &style, parent_style, pseudo.as_ref());
+    let mut context = create_context(
+        &data,
+        &metrics,
+        &style,
+        parent_style,
+        pseudo.as_ref(),
+        /* for_smil_animation = */ true
+    );
 
     let default_values = data.default_computed_values();
     let global_style_data = &*GLOBAL_STYLE_DATA;
@@ -3098,7 +3114,14 @@ pub extern "C" fn Servo_AnimationValue_Compute(element: RawGeckoElementBorrowed,
     let parent_style = parent_data.as_ref().map(|d| d.styles.primary()).map(|x| &**x);
 
     let pseudo = style.pseudo();
-    let mut context = create_context(&data, &metrics, style, parent_style, pseudo.as_ref());
+    let mut context = create_context(
+        &data,
+        &metrics,
+        style,
+        parent_style,
+        pseudo.as_ref(),
+        /* for_smil_animation = */ false
+    );
 
     let default_values = data.default_computed_values();
     let global_style_data = &*GLOBAL_STYLE_DATA;

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -60,6 +60,7 @@ fn assert_computed_serialization<C, F, T>(f: F, input: &'static str, output: &st
         font_metrics_provider: &ServoMetricsProvider,
         in_media_query: false,
         quirks_mode: QuirksMode::NoQuirks,
+        for_smil_animation: false,
     };
 
     let parsed = parse(f, input).unwrap();


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1371150.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17839)
<!-- Reviewable:end -->
