### PR TITLE
Use CSS background-size property when computing the size of a paint worklet

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1171,7 +1171,17 @@ impl FragmentDisplayListBuilding for Fragment {
         // https://github.com/w3c/css-houdini-drafts/issues/417
         let unbordered_box = self.border_box - style.logical_border_width();
         let device_pixel_ratio = state.layout_context.style_context.device_pixel_ratio();
-        let size_in_au = unbordered_box.size.to_physical(style.writing_mode);
+        let unbordered_box_size_in_au = unbordered_box.size.to_physical(style.writing_mode);
+        let background_size = get_cyclic(&style.get_background().background_size.0, index).clone();
+        let size_in_au = match background_size {
+            BackgroundSize::Explicit { width, height } => {
+                Size2D::new(MaybeAuto::from_style(width, unbordered_box_size_in_au.width)
+                                 .specified_or_default(unbordered_box_size_in_au.width),
+                       MaybeAuto::from_style(height, unbordered_box_size_in_au.height)
+                                 .specified_or_default(unbordered_box_size_in_au.height))
+            },
+            _ => unbordered_box_size_in_au,
+        };
         let size_in_px = TypedSize2D::new(size_in_au.width.to_f32_px(), size_in_au.height.to_f32_px());
         let name = paint_worklet.name.clone();
 

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/geometry-background-image-tiled-001.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/geometry-background-image-tiled-001.html.ini
@@ -1,4 +1,0 @@
-[geometry-background-image-tiled-001.html]
-  type: reftest
-  expected: FAIL
-  bug: https://github.com/servo/servo/issues/17676

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/geometry-background-image-tiled-002.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/geometry-background-image-tiled-002.html.ini
@@ -1,4 +1,0 @@
-[geometry-background-image-tiled-002.html]
-  type: reftest
-  expected: FAIL
-  bug: https://github.com/servo/servo/issues/1767

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/geometry-background-image-tiled-003.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/geometry-background-image-tiled-003.html.ini
@@ -1,4 +1,0 @@
-[geometry-background-image-tiled-003.html]
-  type: reftest
-  expected: FAIL
-  bug: https://github.com/servo/servo/issues/1767


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The size of a paint worklet should be based on the background-size CSS property.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17676.
- [X] These changes do not require tests because the existing css-paint-api tests catch this.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17845)
<!-- Reviewable:end -->
