### PR TITLE
style: Ensure we generate a ReconstructFrame hint when -moz-binding changes on a display:none root.

### DIFF
--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -6,7 +6,7 @@
 
 use gecko_bindings::bindings;
 use gecko_bindings::structs;
-use gecko_bindings::structs::{nsChangeHint, nsStyleContext};
+use gecko_bindings::structs::{nsChangeHint, nsStyleContext, nsStyleStructID};
 use matching::{StyleChange, StyleDifference};
 use properties::ComputedValues;
 use servo_arc::Arc;
@@ -60,6 +60,34 @@ impl GeckoRestyleDamage {
         };
         let change = if any_style_changed { StyleChange::Changed } else { StyleChange::Unchanged };
         StyleDifference::new(GeckoRestyleDamage(hint), change)
+    }
+
+    /// Computes the `StyleDifference` between the two `ComputedValues` objects
+    /// for the case where the old and new style are both `display: none`.
+    ///
+    /// In general we don't need to generate damage for such elements, but we
+    /// do need to generate a frame reconstruction for `-moz-binding` changes,
+    /// so that we can start loading the new binding.
+    pub fn compute_undisplayed_style_difference(
+        old_style: &ComputedValues,
+        new_style: &ComputedValues,
+    ) -> StyleDifference {
+        let mut any_style_changed: bool = false;
+
+        // Just compute the Display struct's difference.
+        let display_struct_bit = 1 << (nsStyleStructID::eStyleStruct_Display as u32);
+        let hint = unsafe {
+            bindings::Gecko_CalcStyleDifference(old_style,
+                                                new_style,
+                                                display_struct_bit,
+                                                &mut any_style_changed)
+        };
+
+        // Only pay attention to a reconstruct change hint.
+        let damage = GeckoRestyleDamage(hint) & Self::reconstruct();
+
+        let change = if damage.is_empty() { StyleChange::Changed } else { StyleChange::Unchanged };
+        StyleDifference::new(damage, change)
     }
 
     /// Returns true if this restyle damage contains all the damage of |other|.

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -783,8 +783,11 @@ pub trait MatchMethods : TElement {
         // This happens with display:none elements, and not-yet-existing
         // pseudo-elements.
         if new_style_is_display_none && old_style_is_display_none {
-            // The style remains display:none. No need for damage.
-            return StyleDifference::new(RestyleDamage::empty(), StyleChange::Unchanged)
+            // The style remains display:none.  The only case we need to care
+            // about is if -moz-binding changed, and to generate a reconstruct
+            // so that we can start the binding load.  Otherwise, there is no
+            // need for damage.
+            return RestyleDamage::compute_undisplayed_style_difference(old_values, new_values);
         }
 
         if pseudo.map_or(false, |p| p.is_before_or_after()) {

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -69,6 +69,17 @@ impl ServoRestyleDamage {
         StyleDifference::new(damage, change)
     }
 
+    /// Computes the `StyleDifference` between the two `ComputedValues` objects
+    /// for the case where the old and new style are both `display: none`.
+    ///
+    /// For Servo we never need to generate any damage for such elements.
+    pub fn compute_undisplayed_style_difference(
+        _old_style: &ComputedValues,
+        _new_style: &ComputedValues,
+    ) -> StyleDifference {
+        StyleDifference::new(Self::empty(), StyleChange::Unchanged)
+    }
+
     /// Returns a bitmask that represents a flow that needs to be rebuilt and
     /// reflowed.
     ///


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1375383.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17849)
<!-- Reviewable:end -->
