### PR TITLE
Correct bug references in css-paint-api WPT metadata.

### DIFF
--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/geometry-background-image-003.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/geometry-background-image-003.html.ini
@@ -1,4 +1,4 @@
 [geometry-background-image-003.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17674
+  bug: https://github.com/w3c/web-platform-tests/issues/6601

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/geometry-border-image-005.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/geometry-border-image-005.html.ini
@@ -1,4 +1,4 @@
 [geometry-border-image-005.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17451
+  bug: https://github.com/w3c/web-platform-tests/issues/6610

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/paint2d-zoom.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/paint2d-zoom.html.ini
@@ -1,4 +1,4 @@
 [paint2d-zoom.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17674
+  bug: https://github.com/w3c/web-platform-tests/issues/6610

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-002.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-002.html.ini
@@ -1,4 +1,4 @@
 [parse-input-arguments-002.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17435
+  bug: https://github.com/servo/servo/issues/17852

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-003.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-003.html.ini
@@ -1,4 +1,4 @@
 [parse-input-arguments-003.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17435
+  bug: https://github.com/servo/servo/issues/17852

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-005.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-005.html.ini
@@ -1,4 +1,4 @@
 [parse-input-arguments-005.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17435
+  bug: https://github.com/servo/servo/issues/17852

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-006.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-006.html.ini
@@ -1,4 +1,4 @@
 [parse-input-arguments-006.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17435
+  bug: https://github.com/servo/servo/issues/17852

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-008.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-008.html.ini
@@ -1,4 +1,4 @@
 [parse-input-arguments-008.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17435
+  bug: https://github.com/servo/servo/issues/17852

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-009.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-009.html.ini
@@ -1,4 +1,4 @@
 [parse-input-arguments-009.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17435
+  bug: https://github.com/servo/servo/issues/17852

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-010.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-010.html.ini
@@ -1,4 +1,4 @@
 [parse-input-arguments-010.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17435
+  bug: https://github.com/servo/servo/issues/17852

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-011.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-011.html.ini
@@ -1,4 +1,4 @@
 [parse-input-arguments-011.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17435
+  bug: https://github.com/servo/servo/issues/17852

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-012.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-012.html.ini
@@ -1,4 +1,4 @@
 [parse-input-arguments-012.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17435
+  bug: https://github.com/servo/servo/issues/17852

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-016.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/parse-input-arguments-016.html.ini
@@ -1,4 +1,4 @@
 [parse-input-arguments-016.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17435
+  bug: https://github.com/servo/servo/issues/17852


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Some of the bug references in the css-paint-api .ini files were wrong.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because we don't test .ini files

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17853)
<!-- Reviewable:end -->
