### PR TITLE
Implement getProperties for StylePropertyMapReadOnly

### DIFF
--- a/components/script/dom/stylepropertymapreadonly.rs
+++ b/components/script/dom/stylepropertymapreadonly.rs
@@ -16,6 +16,7 @@ use servo_atoms::Atom;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::iter::Iterator;
+use style::custom_properties;
 
 #[dom_struct]
 pub struct StylePropertyMapReadOnly {
@@ -73,14 +74,14 @@ impl StylePropertyMapReadOnlyMethods for StylePropertyMapReadOnly {
         // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymap-getproperties
         // requires this sort order
         result.sort_by(|key1, key2| {
-            if key1.starts_with("-") {
-                if key2.starts_with("-") {
+            if let Ok(key1) = custom_properties::parse_name(key1) {
+                if let Ok(key2) = custom_properties::parse_name(key2) {
                     key1.cmp(key2)
                 } else {
                     Ordering::Greater
                 }
             } else {
-                if key2.starts_with("-") {
+                if let Ok(_) = custom_properties::parse_name(key2) {
                     Ordering::Less
                 } else {
                     key1.cmp(key2)

--- a/components/script/dom/stylepropertymapreadonly.rs
+++ b/components/script/dom/stylepropertymapreadonly.rs
@@ -13,6 +13,7 @@ use dom::cssstylevalue::CSSStyleValue;
 use dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
 use servo_atoms::Atom;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::iter::Iterator;
 
@@ -62,5 +63,30 @@ impl StylePropertyMapReadOnlyMethods for StylePropertyMapReadOnly {
     fn Has(&self, property: DOMString) -> bool {
         // TODO: avoid constructing an Atom
         self.entries.contains_key(&Atom::from(property))
+    }
+
+    /// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getproperties
+    fn GetProperties(&self) -> Vec<DOMString> {
+        let mut result: Vec<DOMString> = self.entries.keys()
+            .map(|key| DOMString::from(&**key))
+            .collect();
+        // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymap-getproperties
+        // requires this sort order
+        result.sort_by(|key1, key2| {
+            if key1.starts_with("-") {
+                if key2.starts_with("-") {
+                    key1.cmp(key2)
+                } else {
+                    Ordering::Greater
+                }
+            } else {
+                if key2.starts_with("-") {
+                    Ordering::Less
+                } else {
+                    key1.cmp(key2)
+                }
+            }
+        });
+        result
     }
 }

--- a/components/script/dom/webidls/StylePropertyMapReadOnly.webidl
+++ b/components/script/dom/webidls/StylePropertyMapReadOnly.webidl
@@ -10,6 +10,7 @@ interface StylePropertyMapReadOnly {
     // sequence<CSSStyleValue> getAll(DOMString property);
     boolean has(DOMString property);
     // iterable<DOMString, (CSSStyleValue or sequence<CSSStyleValue>)>;
-    // sequence<DOMString> getProperties();
+    sequence<DOMString> getProperties();
+    // https://github.com/w3c/css-houdini-drafts/issues/268
     // stringifier;
 };

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/style-background-image.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/style-background-image.html.ini
@@ -1,4 +1,4 @@
 [style-background-image.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17579
+  bug: https://github.com/servo/servo/issues/17378

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/style-before-pseudo.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/style-before-pseudo.html.ini
@@ -1,4 +1,4 @@
 [style-before-pseudo.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17579
+  bug: https://github.com/servo/servo/issues/17854

--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/style-first-letter-pseudo.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/style-first-letter-pseudo.html.ini
@@ -1,4 +1,4 @@
 [style-first-letter-pseudo.html]
   type: reftest
   expected: FAIL
-  bug: https://github.com/servo/servo/issues/17579
+  bug: https://github.com/servo/servo/issues/17854


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Implement `getProperties` for `StylePropertyMapReadOnly`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17579.
- [X] These changes do not require tests because the existing css-paint-api tests catch this (rather annoyingly, they all fail for different reasons, sigh)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17855)
<!-- Reviewable:end -->
