### PR TITLE
Add message suffixes to stylo error reports.

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -2844,5 +2844,6 @@ extern "C" {
                                           source:
                                               *const ::std::os::raw::c_char,
                                           sourceLen: u32, lineNumber: u32,
-                                          colNumber: u32, aURI: *mut nsIURI);
+                                          colNumber: u32, aURI: *mut nsIURI,
+                                          followup: *const ::std::os::raw::c_char);
 }


### PR DESCRIPTION
This is the Servo-side part of https://bugzilla.mozilla.org/show_bug.cgi?id=1381137. This allows us to add the "Declaration dropped" or "Skipped to next declaration" messages after relevant CSS errors that are reported.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17859)
<!-- Reviewable:end -->
