### PR TITLE
Cleanup @font-face rule constructor

### DIFF
--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -110,8 +110,7 @@ impl Parse for FontWeight {
 /// Note that the prelude parsing code lives in the `stylesheets` module.
 pub fn parse_font_face_block(context: &ParserContext, input: &mut Parser, location: SourceLocation)
     -> FontFaceRuleData {
-    let mut rule = FontFaceRuleData::empty();
-    rule.source_location = location;
+    let mut rule = FontFaceRuleData::empty(location);
     {
         let parser = FontFaceRuleParser {
             context: context,
@@ -229,15 +228,12 @@ macro_rules! font_face_descriptors_common {
         }
 
         impl FontFaceRuleData {
-            fn empty() -> Self {
+            fn empty(location: SourceLocation) -> Self {
                 FontFaceRuleData {
                     $(
                         $ident: None,
                     )*
-                    source_location: SourceLocation {
-                        line: 0,
-                        column: 0,
-                    },
+                    source_location: location,
                 }
             }
 


### PR DESCRIPTION
Passing SourceLocation into constructor instead of assigning
immediately after construction cleans up the code and helps to
prevent leaving an invalid SourceLocation in the future.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because it's just a cleanup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17877)
<!-- Reviewable:end -->
