### PR TITLE
MatrixDecomposed3D.add_weighted() is called with zero value for other…

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -2274,7 +2274,7 @@ impl Animatable for MatrixDecomposed3D {
         use std::f64;
 
         debug_assert!((self_portion + other_portion - 1.0f64).abs() <= f64::EPSILON ||
-                      other_portion == 1.0f64,
+                      other_portion == 1.0f64 || other_portion == 0.0f64,
                       "add_weighted should only be used for interpolating or accumulating transforms");
 
         let mut sum = *self;


### PR DESCRIPTION
…_portion in case of iteration composite.

In the case where we accumulate transform:none onto decomposed matrix for
iteration composite whose iteration count is over 2, we pass zero
other_portion and self_portion which is over 1.0.  We should care about the
case.

https://bugzilla.mozilla.org/show_bug.cgi?id=1383493

<!-- Please describe your changes on the following line: -->
---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17879)
<!-- Reviewable:end -->
