### PR TITLE
style: fix alignment in call to get_all_matching_rules.

### DIFF
--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -1203,7 +1203,7 @@ impl Stylist {
                                                   &rule_hash_target,
                                                   applicable_declarations,
                                                   context,
-                                              self.quirks_mode,
+                                                  self.quirks_mode,
                                                   flags_setter,
                                                   CascadeLevel::AuthorNormal);
             } else {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17881)
<!-- Reviewable:end -->
