### PR TITLE
stylo: remove bogus optimization check in replace_rules() for visited styles.

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -647,14 +647,12 @@ pub trait MatchMethods : TElement {
             CascadeVisitedMode::Unvisited,
             cascade_inputs,
         );
-        if !context.shared.traversal_flags.for_animation_only() {
-            result |= self.replace_rules_internal(
-                replacements,
-                context,
-                CascadeVisitedMode::Visited,
-                cascade_inputs
-            );
-        }
+        result |= self.replace_rules_internal(
+            replacements,
+            context,
+            CascadeVisitedMode::Visited,
+            cascade_inputs
+        );
         result
     }
 


### PR DESCRIPTION
We skipped updating the rule nodes for visited rules during animation-only restyle.
However, this causes isseus that visited style overrides animation styles on visited element.
So, it turns out that we should update the visited rules even during animation-only restyle.

Gecko bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1381235

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17889)
<!-- Reviewable:end -->
