### PR TITLE
remove workspace key for components/atoms

### DIFF
--- a/components/atoms/Cargo.toml
+++ b/components/atoms/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 publish = false
 build = "build.rs"
-workspace = "../.."
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
Cargo will already traverse up the directory hierarchy to find an
appropriate workspace, so we don't need to specify anything here.  This
change brings components/atoms/Cargo.toml in line with other Cargo.toml
files in the tree.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because compilation is sufficient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17890)
<!-- Reviewable:end -->
