### PR TITLE
Issue 17882: Remove rendering_threads option in the CEF port

### DIFF
--- a/ports/cef/types.rs
+++ b/ports/cef/types.rs
@@ -727,11 +727,6 @@ pub struct cef_settings {
   // of the background color but will be otherwise ignored.
   //
   pub background_color: cef_color_t,
-
-  //
-  // Determines how many rendering threads are used.
-  //
-  pub rendering_threads: c_int,
 }
 
 //


### PR DESCRIPTION
Fixes issue 17882 by removing rendering_threads option in the CEF port
r?@highfive

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17905)
<!-- Reviewable:end -->
