### PR TITLE
style: Don't unconditionally generate Calc values when converting background-size from Gecko.

### DIFF
--- a/components/style/gecko/conversions.rs
+++ b/components/style/gecko/conversions.rs
@@ -102,6 +102,16 @@ impl From<nsStyleCoord_CalcValue> for LengthOrPercentage {
     }
 }
 
+impl From<nsStyleCoord_CalcValue> for LengthOrPercentageOrAuto {
+    fn from(other: nsStyleCoord_CalcValue) -> LengthOrPercentageOrAuto {
+        match (other.mHasPercent, other.mLength) {
+            (false, _) => LengthOrPercentageOrAuto::Length(Au(other.mLength)),
+            (true, 0) => LengthOrPercentageOrAuto::Percentage(Percentage(other.mPercent)),
+            _ => LengthOrPercentageOrAuto::Calc(other.into()),
+        }
+    }
+}
+
 impl From<Angle> for CoordDataValue {
     fn from(reference: Angle) -> Self {
         match reference {

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3434,7 +3434,7 @@ fn static_assert() {
                 LengthOrPercentageOrAuto::Auto
             } else {
                 debug_assert!(ty == DimensionType::eLengthPercentage as u8);
-                LengthOrPercentageOrAuto::Calc(value.into())
+                value.into()
             }
         }
 


### PR DESCRIPTION
Bug: 1385140
MozReview-Commit-ID: ERwq50WSvLV

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17906)
<!-- Reviewable:end -->
