### PR TITLE
Have check_allowed_in read gPropertyEabled table directly

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1419,9 +1419,6 @@ extern "C" {
                                                               *mut nsCSSValueSharedList);
 }
 extern "C" {
-    pub fn Gecko_PropertyId_IsPrefEnabled(id: nsCSSPropertyID) -> bool;
-}
-extern "C" {
     pub fn Gecko_nsStyleFont_SetLang(font: *mut nsStyleFont,
                                      atom: *mut nsIAtom);
 }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1184,8 +1184,9 @@ impl PropertyId {
                 }
             % endif
             % if product == "gecko":
+                use gecko_bindings::structs;
                 let id = self.to_nscsspropertyid().unwrap();
-                unsafe { bindings::Gecko_PropertyId_IsPrefEnabled(id) }
+                unsafe { structs::nsCSSProps_gPropertyEnabled[id as usize] }
             % endif
         };
 


### PR DESCRIPTION
This is the Servo side change of [bug 1381690](https://bugzilla.mozilla.org/show_bug.cgi?id=1381690).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17913)
<!-- Reviewable:end -->
