### PR TITLE
Remove Gecko_GetMediaFeatures and access nsMediaFeatures::features directly

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -78,7 +78,6 @@ use gecko_bindings::structs::nsFont;
 use gecko_bindings::structs::nsIAtom;
 use gecko_bindings::structs::nsIURI;
 use gecko_bindings::structs::nsCompatibility;
-use gecko_bindings::structs::nsMediaFeature;
 use gecko_bindings::structs::nsRestyleHint;
 use gecko_bindings::structs::nsStyleBackground;
 unsafe impl Send for nsStyleBackground {}
@@ -1484,9 +1483,6 @@ extern "C" {
 }
 extern "C" {
     pub fn Gecko_StyleSheet_Release(aSheet: *const ServoStyleSheet);
-}
-extern "C" {
-    pub fn Gecko_GetMediaFeatures() -> *const nsMediaFeature;
 }
 extern "C" {
     pub fn Gecko_LookupCSSKeyword(string: *const u8, len: u32)

--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -13,6 +13,7 @@ use euclid::Size2D;
 use font_metrics::get_metrics_provider_for_product;
 use gecko::values::convert_nscolor_to_rgba;
 use gecko_bindings::bindings;
+use gecko_bindings::structs;
 use gecko_bindings::structs::{nsCSSKeyword, nsCSSProps_KTableEntry, nsCSSValue, nsCSSUnit, nsStringBuffer};
 use gecko_bindings::structs::{nsMediaExpression_Range, nsMediaFeature};
 use gecko_bindings::structs::{nsMediaFeature_ValueType, nsMediaFeature_RangeType, nsMediaFeature_RequirementFlags};
@@ -425,13 +426,8 @@ impl MediaExpressionValue {
 fn find_feature<F>(mut f: F) -> Option<&'static nsMediaFeature>
     where F: FnMut(&'static nsMediaFeature) -> bool,
 {
-    // FIXME(emilio): With build-time bindgen, we would be able to use
-    // structs::nsMediaFeatures_features. That would unfortunately break MSVC
-    // builds, or require one bindings file per platform.
-    //
-    // I'm not into any of those, so meanwhile let's use a FFI function.
     unsafe {
-        let mut features = bindings::Gecko_GetMediaFeatures();
+        let mut features = structs::nsMediaFeatures_features.as_ptr();
         while !(*features).mName.is_null() {
             if f(&*features) {
                 return Some(&*features);
@@ -439,7 +435,6 @@ fn find_feature<F>(mut f: F) -> Option<&'static nsMediaFeature>
             features = features.offset(1);
         }
     }
-
     None
 }
 


### PR DESCRIPTION
This is the Servo side change of [bug 1385529](https://bugzilla.mozilla.org/show_bug.cgi?id=1385529).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17915)
<!-- Reviewable:end -->
