### PR TITLE
style: Don't remain in an invalid state when encountering an at-rule in the wrong place.

### DIFF
--- a/components/style/stylesheets/stylesheet.rs
+++ b/components/style/stylesheets/stylesheet.rs
@@ -337,6 +337,7 @@ impl Stylesheet {
             loader: stylesheet_loader,
             context: context,
             state: State::Start,
+            had_hierarchy_error: false,
             namespaces: Some(namespaces),
         };
 


### PR DESCRIPTION
Currently, attempting to parse an at-rule that is out of place, such as
an @import rule after a regular style rule, will cause the parser state
to be set to Invalid.  This will cause any following at-rule to be
rejected until we encounter a regular style rule, at which point we'll
go back to the Body state.  There's nothing in the CSS specs about
needing to reject all following at-rules (or, as the comment above
Invalid says, ignoring the entire rest of the style sheet).

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17918)
<!-- Reviewable:end -->
