### PR TITLE
geckolib: Add friendly panic message to Servo_HasAuthorSpecifiedRules.

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1610,7 +1610,10 @@ pub extern "C" fn Servo_HasAuthorSpecifiedRules(element: RawGeckoElementBorrowed
 {
     let element = GeckoElement(element);
 
-    let data = element.borrow_data().unwrap();
+    let data =
+        element.borrow_data()
+        .expect("calling Servo_HasAuthorSpecifiedRules on an unstyled element");
+
     let primary_style = data.styles.primary();
 
     let guard = (*GLOBAL_STYLE_DATA).shared_lock.read();


### PR DESCRIPTION
This just adds a friendlier panic message when `Servo_HasAuthorSpecifiedRules` is called with an unstyled element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17920)
<!-- Reviewable:end -->
