### PR TITLE
Fix fixed position items with parents with CSS clips

### DIFF
--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -32,7 +32,7 @@ impl Epoch {
 pub struct StackingContextId(
     /// The identifier for this StackingContext, derived from the Flow's memory address
     /// and fragment type.  As a space optimization, these are combined into a single word.
-    u64
+    pub u64
 );
 
 impl StackingContextId {

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -63,7 +63,7 @@ use table_colgroup::TableColGroupFlow;
 use table_row::TableRowFlow;
 use table_rowgroup::TableRowGroupFlow;
 use table_wrapper::TableWrapperFlow;
-use webrender_api::ClipId;
+use webrender_api::ClipAndScrollInfo;
 
 /// Virtual methods that make up a float context.
 ///
@@ -431,12 +431,12 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
     /// children of this flow.
     fn print_extra_flow_children(&self, _: &mut PrintTree) { }
 
-    fn scroll_root_id(&self, pipeline_id: PipelineId) -> ClipId {
-        match base(self).scroll_root_id {
-            Some(id) => id,
+    fn clip_and_scroll_info(&self, pipeline_id: PipelineId) -> ClipAndScrollInfo {
+        match base(self).clip_and_scroll_info {
+            Some(info) => info,
             None => {
-                warn!("Tried to access scroll root id on Flow before assignment");
-                pipeline_id.root_scroll_node()
+                debug_assert!(false, "Tried to access scroll root id on Flow before assignment");
+                pipeline_id.root_clip_and_scroll_info()
             }
         }
     }
@@ -969,7 +969,7 @@ pub struct BaseFlow {
     /// list construction.
     pub stacking_context_id: StackingContextId,
 
-    pub scroll_root_id: Option<ClipId>,
+    pub clip_and_scroll_info: Option<ClipAndScrollInfo>,
 }
 
 impl fmt::Debug for BaseFlow {
@@ -1111,7 +1111,7 @@ impl BaseFlow {
             writing_mode: writing_mode,
             thread_id: 0,
             stacking_context_id: StackingContextId::root(),
-            scroll_root_id: None,
+            clip_and_scroll_info: None,
         }
     }
 

--- a/components/layout/table_colgroup.rs
+++ b/components/layout/table_colgroup.rs
@@ -94,9 +94,8 @@ impl Flow for TableColGroupFlow {
 
     fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
         self.base.stacking_context_id = state.current_stacking_context_id;
-        self.base.scroll_root_id = Some(state.current_scroll_root_id);
+        self.base.clip_and_scroll_info = Some(state.current_clip_and_scroll_info);
     }
-
 
     fn repair_style(&mut self, _: &::ServoArc<ComputedValues>) {}
 

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -222,8 +222,9 @@ impl<'a> BuildDisplayList<'a> {
         let parent_stacking_context_id = self.state.current_stacking_context_id;
         self.state.current_stacking_context_id = flow::base(flow).stacking_context_id;
 
-        let parent_scroll_root_id = self.state.current_scroll_root_id;
-        self.state.current_scroll_root_id = flow.scroll_root_id(self.state.layout_context.id);
+        let parent_clip_and_scroll_info = self.state.current_clip_and_scroll_info;
+        self.state.current_clip_and_scroll_info =
+            flow.clip_and_scroll_info(self.state.layout_context.id);
 
         if self.should_process() {
             flow.build_display_list(&mut self.state);
@@ -235,7 +236,7 @@ impl<'a> BuildDisplayList<'a> {
         }
 
         self.state.current_stacking_context_id = parent_stacking_context_id;
-        self.state.current_scroll_root_id = parent_scroll_root_id;
+        self.state.current_clip_and_scroll_info = parent_clip_and_scroll_info;
     }
 
     #[inline]

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -16,8 +16,8 @@ use msg::constellation_msg::PipelineId;
 use style::computed_values::{image_rendering, mix_blend_mode, transform_style};
 use style::values::computed::{BorderStyle, Filter};
 use style::values::generics::effects::Filter as GenericFilter;
-use webrender_api::{self, ClipId, ComplexClipRegion, DisplayListBuilder, ExtendMode};
-use webrender_api::LayoutTransform;
+use webrender_api::{self, ClipAndScrollInfo, ComplexClipRegion, DisplayListBuilder};
+use webrender_api::{ExtendMode, LayoutTransform};
 
 pub trait WebRenderDisplayListConverter {
     fn convert_to_webrender(&self, pipeline_id: PipelineId) -> DisplayListBuilder;
@@ -26,7 +26,7 @@ pub trait WebRenderDisplayListConverter {
 trait WebRenderDisplayItemConverter {
     fn convert_to_webrender(&self,
                             builder: &mut DisplayListBuilder,
-                            current_scroll_root_id: &mut ClipId);
+                            current_clip_and_scroll_info: &mut ClipAndScrollInfo);
 }
 
 trait ToBorderStyle {
@@ -222,16 +222,15 @@ impl ToTransformStyle for transform_style::T {
 impl WebRenderDisplayListConverter for DisplayList {
     fn convert_to_webrender(&self, pipeline_id: PipelineId) -> DisplayListBuilder {
         let traversal = DisplayListTraversal::new(self);
-        let webrender_pipeline_id = pipeline_id.to_webrender();
-        let mut builder = DisplayListBuilder::with_capacity(webrender_pipeline_id,
+        let mut builder = DisplayListBuilder::with_capacity(pipeline_id.to_webrender(),
                                                             self.bounds().size.to_sizef(),
                                                             1024 * 1024); // 1 MB of space
 
-        let mut current_scroll_root_id = ClipId::root_scroll_node(webrender_pipeline_id);
-        builder.push_clip_id(current_scroll_root_id);
+        let mut current_clip_and_scroll_info = pipeline_id.root_clip_and_scroll_info();
+        builder.push_clip_and_scroll_info(current_clip_and_scroll_info);
 
         for item in traversal {
-            item.convert_to_webrender(&mut builder, &mut current_scroll_root_id);
+            item.convert_to_webrender(&mut builder, &mut current_clip_and_scroll_info);
         }
         builder
     }
@@ -240,12 +239,12 @@ impl WebRenderDisplayListConverter for DisplayList {
 impl WebRenderDisplayItemConverter for DisplayItem {
     fn convert_to_webrender(&self,
                             builder: &mut DisplayListBuilder,
-                            current_scroll_root_id: &mut ClipId) {
-        let scroll_root_id = self.base().scroll_root_id;
-        if scroll_root_id != *current_scroll_root_id {
+                            current_clip_and_scroll_info: &mut ClipAndScrollInfo) {
+        let clip_and_scroll_info = self.base().clip_and_scroll_info;
+        if clip_and_scroll_info != *current_clip_and_scroll_info {
             builder.pop_clip_id();
-            builder.push_clip_id(scroll_root_id);
-            *current_scroll_root_id = scroll_root_id;
+            builder.push_clip_and_scroll_info(clip_and_scroll_info);
+            *current_clip_and_scroll_info = clip_and_scroll_info;
         }
 
         match *self {

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -248,6 +248,10 @@ impl PipelineId {
     pub fn root_scroll_node(&self) -> webrender_api::ClipId {
         webrender_api::ClipId::root_scroll_node(self.to_webrender())
     }
+
+    pub fn root_clip_and_scroll_info(&self) -> webrender_api::ClipAndScrollInfo {
+        webrender_api::ClipAndScrollInfo::simple(self.root_scroll_node())
+    }
 }
 
 impl fmt::Display for PipelineId {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1583,6 +1583,18 @@
      {}
     ]
    ],
+   "css/fixed_position_css_clip.html": [
+    [
+     "/_mozilla/css/fixed_position_css_clip.html",
+     [
+      [
+       "/_mozilla/css/fixed_position_css_clip_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/fixed_width_overrides_child_intrinsic_width_a.html": [
     [
      "/_mozilla/css/fixed_width_overrides_child_intrinsic_width_a.html",
@@ -8175,6 +8187,11 @@
     ]
    ],
    "css/fixed_percent_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "css/fixed_position_css_clip_ref.html": [
     [
      {}
     ]
@@ -23062,6 +23079,14 @@
   ],
   "css/fixed_percent_ref.html": [
    "fe23d2dc9a4507b3b632518a53f21900d0e4d1d7",
+   "support"
+  ],
+  "css/fixed_position_css_clip.html": [
+   "2bf1fb572a72fbb4a7a35b8c8b08960b48ccf408",
+   "reftest"
+  ],
+  "css/fixed_position_css_clip_ref.html": [
+   "ad0341fc9f843177ccf53a1667b5016c234b7651",
    "support"
   ],
   "css/fixed_width_overrides_child_intrinsic_width_a.html": [

--- a/tests/wpt/mozilla/tests/css/fixed_position_css_clip.html
+++ b/tests/wpt/mozilla/tests/css/fixed_position_css_clip.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Fixed position elements should be clipped by parent CSS clips</title>
+        <link rel="match" href="fixed_position_css_clip_ref.html">
+        <style>
+        body {
+          margin: 0px;
+        }
+
+        #base {
+          position: absolute;
+          left; 0px;
+          top: 0px;
+          background: red;
+          width: 100px;
+          height: 100px;
+          clip: rect(0, auto, auto, 0);
+        }
+
+        #fixed {
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          background: green;
+        }
+        </style>
+    </head>
+    <body>
+        <div id="base">
+          <!-- Even though this fixed position child is positioned and clipped by the
+               containing block, it should also be clipped by the CSS clip of its
+               non-containing block parent. -->
+          <div id="fixed"></div>
+        </div>
+    </body>
+</html>

--- a/tests/wpt/mozilla/tests/css/fixed_position_css_clip_ref.html
+++ b/tests/wpt/mozilla/tests/css/fixed_position_css_clip_ref.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Fixed position elements should be clipped by parent CSS clips</title>
+        <style>
+        body {
+          margin: 0px;
+        }
+
+        #box {
+          left; 0px;
+          top: 0px;
+          background: green;
+          width: 100px;
+          height: 100px;
+          clip: rect(0, auto, auto, 0);
+        }
+        </style>
+    </head>
+    <body>
+        <div id="box">
+    </body>
+</html>


### PR DESCRIPTION
In order to properly handle CSS clipping, we need to keep track of what
the different kinds of clips that we have. On one hand, clipping due to
overflow rules should respect the containing block hierarchy, while CSS
clipping should respect the flow tree hierarchy. In order to represent
the complexity of items that are scrolled via one clip/scroll frame and
clipped by another we keep track of that status with a
ClipAndScrollInfo.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17923)
<!-- Reviewable:end -->
