### PR TITLE
style: Avoid looping through every selector more than twice.

### DIFF
--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -20,7 +20,7 @@ use style::selector_parser::{SelectorImpl, SelectorParser};
 use style::shared_lock::SharedRwLock;
 use style::stylesheets::StyleRule;
 use style::stylist::{Stylist, Rule};
-use style::stylist::needs_revalidation;
+use style::stylist::needs_revalidation_for_testing;
 use style::thread_state;
 
 /// Helper method to get some Rules from selector strings.
@@ -126,7 +126,7 @@ fn test_revalidation_selectors() {
         // Selectors in the ancestor chain (needed for cousin sharing).
         "p:first-child span",
     ]).into_iter()
-      .filter(|s| needs_revalidation(&s))
+      .filter(|s| needs_revalidation_for_testing(&s))
       .collect::<Vec<_>>();
 
     let reference = parse_selectors(&[


### PR DESCRIPTION
I've left the Invalidation stuff on its own since that's more complex, but I
think this may help a bit (perhaps not too much though?) with the slow rebuild
times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17939)
<!-- Reviewable:end -->
