### PR TITLE
style: Handle the root rule node correctly on the stylist pseudo-element code.

### DIFF
--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -910,8 +910,11 @@ impl Stylist {
         if !declarations.is_empty() {
             let rule_node =
                 self.rule_tree.compute_rule_node(&mut declarations, guards);
-            debug_assert!(rule_node != *self.rule_tree.root());
-            inputs.rules = Some(rule_node);
+            // The rule node could be the root in the case of empty declaration
+            // blocks.
+            if rule_node != *self.rule_tree.root() {
+                inputs.rules = Some(rule_node);
+            }
         }
 
         if is_probe && inputs.rules.is_none() {


### PR DESCRIPTION
We skip them on the rule tree anyway.

This will make the assertion failing in bug 1386773 to really hold.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17949)
<!-- Reviewable:end -->
