### PR TITLE
Replace downcast with is

### DIFF
--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -91,7 +91,7 @@ impl CharacterDataMethods for CharacterData {
         // If this is a Text node, we might need to re-parse (say, if our parent
         // is a <style> element.) We don't need to if this is a Comment or
         // ProcessingInstruction.
-        if let Some(_) = self.downcast::<Text>() {
+        if self.is::<Text>() {
             if let Some(parent_node) = node.GetParentNode() {
                 let mutation = ChildrenMutation::ChangeText;
                 vtable_for(&parent_node).children_changed(&mutation);

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -392,7 +392,7 @@ pub fn handle_is_selected(documents: &Documents,
             else if let Some(option_element) = node.downcast::<HTMLOptionElement>() {
                 Ok(option_element.Selected())
             }
-            else if let Some(_) = node.downcast::<HTMLElement>() {
+            else if node.is::<HTMLElement>() {
                 Ok(false) // regular elements are not selectable
             } else {
                 Err(())


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I searched for all places where `if let Some(_) = self.downcast::` and replaced them with `::is`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [X] These changes fix #17697 (github issue number if applicable).

<!-- Either: -->
- [X] These changes do not require tests because `if let Some(_) = self.downcast::<Text>()` should be equivalent to `if self.is::<Text>()`

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17950)
<!-- Reviewable:end -->
