### PR TITLE
Make replace_rules_internal return true only if important rules changed.

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -703,15 +703,17 @@ pub trait MatchMethods : TElement {
         let replace_rule_node = |level: CascadeLevel,
                                  pdb: Option<ArcBorrow<Locked<PropertyDeclarationBlock>>>,
                                  path: &mut StrongRuleNode| -> bool {
+            let mut important_rules_changed = false;
             let new_node = stylist.rule_tree()
-                                  .update_rule_at_level(level, pdb, path, guards);
-            match new_node {
-                Some(n) => {
-                    *path = n;
-                    level.is_important()
-                },
-                None => false,
+                                  .update_rule_at_level(level,
+                                                        pdb,
+                                                        path,
+                                                        guards,
+                                                        &mut important_rules_changed);
+            if let Some(n) = new_node {
+                *path = n;
             }
+            important_rules_changed
         };
 
         if !context.shared.traversal_flags.for_animation_only() {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1367975

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17951)
<!-- Reviewable:end -->
