### PR TITLE
Use drain() over IntoIter on a few SmallVecs

### DIFF
--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -1528,7 +1528,7 @@ fn parse_compound_selector<'i, 't, P, E, Impl>(
                 }
 
                 builder.push_simple_selector(Component::PseudoElement(p));
-                for state_selector in state_selectors.into_iter() {
+                for state_selector in state_selectors.drain() {
                     builder.push_simple_selector(state_selector);
                 }
 

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -939,7 +939,7 @@ impl Stylist {
             if !declarations.is_empty() {
                 let rule_node =
                     self.rule_tree.insert_ordered_rules_with_important(
-                        declarations.into_iter().map(|a| a.order_and_level()),
+                        declarations.drain().map(|a| a.order_and_level()),
                         guards);
                 if rule_node != *self.rule_tree.root() {
                     inputs.visited_rules = Some(rule_node);


### PR DESCRIPTION
This is all the ones I could find in style/ and selectors/.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1374848

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17952)
<!-- Reviewable:end -->
