### PR TITLE
Fix warning in scroll root id assignment to TableColGroupFlow

### DIFF
--- a/components/layout/table_colgroup.rs
+++ b/components/layout/table_colgroup.rs
@@ -92,7 +92,11 @@ impl Flow for TableColGroupFlow {
     // Table columns are invisible.
     fn build_display_list(&mut self, _: &mut DisplayListBuildState) { }
 
-    fn collect_stacking_contexts(&mut self, _: &mut DisplayListBuildState) {}
+    fn collect_stacking_contexts(&mut self, state: &mut DisplayListBuildState) {
+        self.base.stacking_context_id = state.current_stacking_context_id;
+        self.base.scroll_root_id = Some(state.current_scroll_root_id);
+    }
+
 
     fn repair_style(&mut self, _: &::ServoArc<ComputedValues>) {}
 


### PR DESCRIPTION
The traversal currently expects every flow to have a scroll root id
assigned, even if it doesn't produce any display items. This change
fixes the error that arises from this situation.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they do not change behavior, just fix a runtime warning.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17960)
<!-- Reviewable:end -->
