### PR TITLE
Make font-display descriptor behind the pref

### DIFF
--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -210,6 +210,16 @@ impl Parse for Source {
     }
 }
 
+macro_rules! is_descriptor_enabled {
+    ("font-display") => {
+        unsafe {
+            use gecko_bindings::structs::mozilla;
+            mozilla::StylePrefs_sFontDisplayEnabled
+        }
+    };
+    ($name: tt) => { true }
+}
+
 macro_rules! font_face_descriptors_common {
     (
         $( #[$doc: meta] $name: tt $ident: ident / $gecko_ident: ident: $ty: ty, )*
@@ -275,7 +285,7 @@ macro_rules! font_face_descriptors_common {
                               -> Result<(), ParseError<'i>> {
                 match_ignore_ascii_case! { &*name,
                     $(
-                        $name => {
+                        $name if is_descriptor_enabled!($name) => {
                             // DeclarationParser also calls parse_entirely
                             // so we’d normally not need to,
                             // but in this case we do because we set the value as a side effect

--- a/components/style/gecko/generated/structs_debug.rs
+++ b/components/style/gecko/generated/structs_debug.rs
@@ -9046,6 +9046,10 @@ pub mod root {
             pub _address: u8,
         }
         extern "C" {
+            #[link_name = "_ZN7mozilla10StylePrefs19sFontDisplayEnabledE"]
+            pub static mut StylePrefs_sFontDisplayEnabled: bool;
+        }
+        extern "C" {
             #[link_name = "_ZN7mozilla10StylePrefs19sOpentypeSVGEnabledE"]
             pub static mut StylePrefs_sOpentypeSVGEnabled: bool;
         }

--- a/components/style/gecko/generated/structs_release.rs
+++ b/components/style/gecko/generated/structs_release.rs
@@ -8892,6 +8892,10 @@ pub mod root {
             pub _address: u8,
         }
         extern "C" {
+            #[link_name = "_ZN7mozilla10StylePrefs19sFontDisplayEnabledE"]
+            pub static mut StylePrefs_sFontDisplayEnabled: bool;
+        }
+        extern "C" {
             #[link_name = "_ZN7mozilla10StylePrefs19sOpentypeSVGEnabledE"]
             pub static mut StylePrefs_sOpentypeSVGEnabled: bool;
         }


### PR DESCRIPTION
This is the Servo side change of [bug 1386871](https://bugzilla.mozilla.org/show_bug.cgi?id=1386871).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17961)
<!-- Reviewable:end -->
