### PR TITLE
style: Less ID revalidation selectors.

### DIFF
--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -83,13 +83,12 @@ fn test_revalidation_selectors() {
         "div > span",
 
         // ID selectors.
-        "#foo1", // FIXME(bz) This one should not be a revalidation
-                // selector once we fix
-                // https://bugzilla.mozilla.org/show_bug.cgi?id=1369611
+        "#foo1",
         "#foo2::before",
         "#foo3 > span",
-        "#foo1 > span", // FIXME(bz) This one should not be a
-                        // revalidation selector either.
+        "#foo1 > span", // FIXME(bz): This one should not be a
+                        // revalidation selector, since #foo1 should be in the
+                        // rule hash.
 
         // Attribute selectors.
         "div[foo]",
@@ -131,8 +130,6 @@ fn test_revalidation_selectors() {
 
     let reference = parse_selectors(&[
         // ID selectors.
-        "#foo1",
-        "#foo2::before",
         "#foo3 > span",
         "#foo1 > span",
 


### PR DESCRIPTION
Avoid adding id selectors that are in the rule hash keyed by that ID to the list
of revalidation selectors.

This partially fixes bug 1369611 (we could look at the rule hash itself to avoid
inserting some more into the list of revalidation selectors).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17966)
<!-- Reviewable:end -->
