### PR TITLE
CSS parsing optimizations

### DIFF
--- a/ports/geckolib/error_reporter.rs
+++ b/ports/geckolib/error_reporter.rs
@@ -77,7 +77,7 @@ fn escape_css_ident(ident: &str) -> String {
         return ident.into()
     }
 
-    let mut escaped = String::new();
+    let mut escaped = String::with_capacity(ident.len());
 
     // A leading dash does not need to be escaped as long as it is not the
     // *only* character in the identifier.


### PR DESCRIPTION
These address some small inefficiencies that showed up while profiling the myspace talos test.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17967)
<!-- Reviewable:end -->
