### PR TITLE
style: Revert font-family serialization commit #17972

### DIFF
--- a/tests/unit/gfx/font_cache_thread.rs
+++ b/tests/unit/gfx/font_cache_thread.rs
@@ -5,7 +5,7 @@
 use cssparser::SourceLocation;
 use gfx::font_cache_thread::FontCacheThread;
 use ipc_channel::ipc;
-use style::computed_values::font_family::{FamilyName, FamilyNameSyntax};
+use style::computed_values::font_family::FamilyName;
 use style::font_face::{FontFaceRuleData, Source};
 
 #[test]
@@ -15,11 +15,11 @@ fn test_local_web_font() {
     let font_cache_thread = FontCacheThread::new(inp_chan, None);
     let family_name = FamilyName {
         name: From::from("test family"),
-        syntax: FamilyNameSyntax::Quoted,
+        quoted: true,
     };
     let variant_name = FamilyName {
         name: From::from("test font face"),
-        syntax: FamilyNameSyntax::Quoted,
+        quoted: true,
     };
     let font_face_rule = FontFaceRuleData {
         family: Some(family_name.clone()),

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -14,7 +14,7 @@ use servo_url::ServoUrl;
 use std::borrow::ToOwned;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
-use style::computed_values::font_family::{FamilyName, FamilyNameSyntax};
+use style::computed_values::font_family::FamilyName;
 use style::context::QuirksMode;
 use style::error_reporting::{ParseErrorReporter, ContextualParseError};
 use style::media_queries::MediaList;
@@ -254,7 +254,7 @@ fn test_parse_stylesheet() {
                 CssRule::FontFeatureValues(Arc::new(stylesheet.shared_lock.wrap(FontFeatureValuesRule {
                     family_names: vec![FamilyName {
                         name: Atom::from("test"),
-                        syntax: FamilyNameSyntax::Identifiers(vec![Atom::from("test")]),
+                        quoted: false,
                     }],
                     swash: vec![
                         FFVDeclaration {


### PR DESCRIPTION
This reverts commit 4f525f6fa04195cdb93fc4394fbc0c78f2626bd7.

I accidentally included some unrelated changes in #17972, so backing out here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17979)
<!-- Reviewable:end -->
