### PR TITLE
style: Preserve font-family identifier sequence when serializing.

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -2181,7 +2181,7 @@ fn static_assert() {
     }
 
     pub fn set_font_family(&mut self, v: longhands::font_family::computed_value::T) {
-        use properties::longhands::font_family::computed_value::FontFamily;
+        use properties::longhands::font_family::computed_value::{FontFamily, FamilyNameSyntax};
 
         let list = &mut self.gecko.mFont.fontlist;
         unsafe { Gecko_FontFamilyList_Clear(list); }
@@ -2191,7 +2191,8 @@ fn static_assert() {
         for family in &v.0 {
             match *family {
                 FontFamily::FamilyName(ref f) => {
-                    unsafe { Gecko_FontFamilyList_AppendNamed(list, f.name.as_ptr(), f.quoted); }
+                    let quoted = matches!(f.syntax, FamilyNameSyntax::Quoted);
+                    unsafe { Gecko_FontFamilyList_AppendNamed(list, f.name.as_ptr(), quoted); }
                 }
                 FontFamily::Generic(ref name) => {
                     let (family_type, generic) = FontFamily::generic(name);
@@ -2222,7 +2223,8 @@ fn static_assert() {
     }
 
     pub fn clone_font_family(&self) -> longhands::font_family::computed_value::T {
-        use properties::longhands::font_family::computed_value::{FontFamily, FamilyName};
+        use cssparser::serialize_identifier;
+        use properties::longhands::font_family::computed_value::{FontFamily, FamilyName, FamilyNameSyntax};
         use gecko_bindings::structs::FontFamilyType;
         use gecko_string_cache::Atom;
 
@@ -2235,13 +2237,18 @@ fn static_assert() {
                     FontFamilyType::eFamily_cursive => FontFamily::Generic(atom!("cursive")),
                     FontFamilyType::eFamily_fantasy => FontFamily::Generic(atom!("fantasy")),
                     FontFamilyType::eFamily_moz_fixed => FontFamily::Generic(Atom::from("-moz-fixed")),
-                    FontFamilyType::eFamily_named => FontFamily::FamilyName(FamilyName {
-                        name: (&*gecko_font_family_name.mName).into(),
-                        quoted: false
-                    }),
+                    FontFamilyType::eFamily_named => {
+                        let name = Atom::from(&*gecko_font_family_name.mName);
+                        let mut serialization = String::new();
+                        serialize_identifier(&name.to_string(), &mut serialization).unwrap();
+                        FontFamily::FamilyName(FamilyName {
+                            name: name.clone(),
+                            syntax: FamilyNameSyntax::Identifiers(serialization),
+                        })
+                    },
                     FontFamilyType::eFamily_named_quoted => FontFamily::FamilyName(FamilyName {
                         name: (&*gecko_font_family_name.mName).into(),
-                        quoted: true
+                        syntax: FamilyNameSyntax::Quoted,
                     }),
                     x => panic!("Found unexpected font FontFamilyType: {:?}", x),
                 }

--- a/tests/unit/gfx/font_cache_thread.rs
+++ b/tests/unit/gfx/font_cache_thread.rs
@@ -5,7 +5,7 @@
 use cssparser::SourceLocation;
 use gfx::font_cache_thread::FontCacheThread;
 use ipc_channel::ipc;
-use style::computed_values::font_family::FamilyName;
+use style::computed_values::font_family::{FamilyName, FamilyNameSyntax};
 use style::font_face::{FontFaceRuleData, Source};
 
 #[test]
@@ -15,11 +15,11 @@ fn test_local_web_font() {
     let font_cache_thread = FontCacheThread::new(inp_chan, None);
     let family_name = FamilyName {
         name: From::from("test family"),
-        quoted: true,
+        syntax: FamilyNameSyntax::Quoted,
     };
     let variant_name = FamilyName {
         name: From::from("test font face"),
-        quoted: true,
+        syntax: FamilyNameSyntax::Quoted,
     };
     let font_face_rule = FontFaceRuleData {
         family: Some(family_name.clone()),

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -14,7 +14,7 @@ use servo_url::ServoUrl;
 use std::borrow::ToOwned;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
-use style::computed_values::font_family::FamilyName;
+use style::computed_values::font_family::{FamilyName, FamilyNameSyntax};
 use style::context::QuirksMode;
 use style::error_reporting::{ParseErrorReporter, ContextualParseError};
 use style::media_queries::MediaList;
@@ -254,7 +254,7 @@ fn test_parse_stylesheet() {
                 CssRule::FontFeatureValues(Arc::new(stylesheet.shared_lock.wrap(FontFeatureValuesRule {
                     family_names: vec![FamilyName {
                         name: Atom::from("test"),
-                        quoted: false,
+                        syntax: FamilyNameSyntax::Identifiers(String::from("test")),
                     }],
                     swash: vec![
                         FFVDeclaration {


### PR DESCRIPTION
Reviewed by Emilio in https://bugzilla.mozilla.org/show_bug.cgi?id=1384398.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17981)
<!-- Reviewable:end -->
