### PR TITLE
Implement ToAnimatedZero for MozLength

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -1364,7 +1364,14 @@ impl Animatable for MozLength {
 
 impl ToAnimatedZero for MozLength {
     #[inline]
-    fn to_animated_zero(&self) -> Result<Self, ()> { Err(()) }
+    fn to_animated_zero(&self) -> Result<Self, ()> {
+        match *self {
+            MozLength::LengthOrPercentageOrAuto(ref length) => {
+                Ok(MozLength::LengthOrPercentageOrAuto(length.to_animated_zero()?))
+            },
+            _ => Err(())
+        }
+    }
 }
 
 /// https://drafts.csswg.org/css-transitions/#animtype-lpcalc

--- a/components/style/values/computed/length.rs
+++ b/components/style/values/computed/length.rs
@@ -574,7 +574,7 @@ impl LengthOrNumber {
 pub type LengthOrNormal = Either<Length, Normal>;
 
 /// A value suitable for a `min-width`, `min-height`, `width` or `height` property.
-/// See specified/values/length.rs for more details.
+/// See values/specified/length.rs for more details.
 #[allow(missing_docs)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Copy, Debug, PartialEq, ToCss)]
@@ -618,7 +618,7 @@ impl ToComputedValue for specified::MozLength {
 }
 
 /// A value suitable for a `max-width` or `max-height` property.
-/// See specified/values/length.rs for more details.
+/// See values/specified/length.rs for more details.
 #[allow(missing_docs)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Copy, Debug, PartialEq, ToCss)]


### PR DESCRIPTION
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1382168](https://bugzilla.mozilla.org/show_bug.cgi?id=1382168)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17986)
<!-- Reviewable:end -->
