### PR TITLE
Don't clear animation only dirty bit during style recalc

### DIFF
--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -563,9 +563,6 @@ where
         } else {
             element.has_dirty_descendants()
         };
-    if flags.for_animation_only() {
-        unsafe { element.unset_animation_only_dirty_descendants(); }
-    }
 
     // Before examining each child individually, try to prove that our children
     // don't need style processing. They need processing if any of the following


### PR DESCRIPTION
Unless the element is in a display:none subtree.

After bug 1356141, the setup of animation-only dirty bit should have matched
to normal dirty bit's one (Though they don't match in post traversal due to
throttled animation flush). An unset_animation_only_dirty_descendants call
removed in this patch cleared dirty bits which are needed for post traversal if
there is a second animation-only traversal and if there is no need to restyle
for the second animation-only traversal.

The reftest in this patch fails without either this fix or the fix for bug
1367975.

See [Gecko bug 1384435 comment 12](https://bugzilla.mozilla.org/show_bug.cgi?id=1384435#c12)
for more detail what's going on at that time.

<!-- Please describe your changes on the following line: -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1384435
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18005)
<!-- Reviewable:end -->
