### PR TITLE
stylo: Fix the computation of the interpolation of FontWeight.

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -1421,7 +1421,7 @@ impl Animatable for FontWeight {
         let b = other.0 as f64;
         const NORMAL: f64 = 400.;
         let weight = (a - NORMAL) * self_portion + (b - NORMAL) * other_portion + NORMAL;
-        let weight = (weight.min(100.).max(900.) / 100.).round() * 100.;
+        let weight = (weight.max(100.).min(900.) / 100.).round() * 100.;
         Ok(FontWeight(weight as u16))
     }
 


### PR DESCRIPTION
Interpolated result of FontWeight is wrong because clamping code is incorrect.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1387948](https://bugzilla.mozilla.org/show_bug.cgi?id=1387948).
- [X] These changes do not require tests because Gecko has tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18007)
<!-- Reviewable:end -->
