### PR TITLE
stylo: Fix skip_root_and_item_display_fixup.

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -238,7 +238,6 @@ impl<'ln> GeckoNode<'ln> {
     /// This logic is duplicated in Gecko's nsIContent::IsInAnonymousSubtree.
     #[inline]
     fn is_in_anonymous_subtree(&self) -> bool {
-        use gecko_bindings::structs::NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE;
         use gecko_bindings::structs::NODE_IS_IN_SHADOW_TREE;
         self.flags() & (NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE as u32) != 0 ||
         ((self.flags() & (NODE_IS_IN_SHADOW_TREE as u32) == 0) &&
@@ -1144,7 +1143,7 @@ impl<'le> TElement for GeckoElement<'le> {
         // level native anonymous content subtree roots, since they're not
         // really roots from the style fixup perspective.  Checking that we
         // are NAC handles both cases.
-        self.flags() & (NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE as u32) != 0
+        self.is_native_anonymous()
     }
 
     unsafe fn set_selector_flags(&self, flags: ElementSelectorFlags) {


### PR DESCRIPTION
The check isn't doing what the comment is saying.

XBL subtrees for video controls all have the
NODE_IS_IN_NATIVE_ANONYMOUS_SUBTREE flag, but not all of them are NAC
themselves, so we may incorrectly miss blockification.

Bug: 1366163
Reviewed-by: heycam
MozReview-Commit-ID: Oq3W258Lz2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18009)
<!-- Reviewable:end -->
