### PR TITLE
WebRender update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "freetype"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo-freetype-sys 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3478,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.48.0"
-source = "git+https://github.com/servo/webrender#6dd3ddb0453697d3271f52133d88c182aa2f3b08"
+source = "git+https://github.com/servo/webrender#b13a3b8f776b2ef4d5672173c9a3aa77c7b87936"
 dependencies = [
  "app_units 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3489,7 +3498,7 @@ dependencies = [
  "core-text 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwrote 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "freetype 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gamma-lut 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3507,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.48.0"
-source = "git+https://github.com/servo/webrender#6dd3ddb0453697d3271f52133d88c182aa2f3b08"
+source = "git+https://github.com/servo/webrender#b13a3b8f776b2ef4d5672173c9a3aa77c7b87936"
 dependencies = [
  "app_units 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3516,6 +3525,7 @@ dependencies = [
  "core-graphics 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwrote 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3729,6 +3739,7 @@ dependencies = [
 "checksum fontsan 0.3.2 (git+https://github.com/servo/fontsan)" = "<none>"
 "checksum foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e4056b9bd47f8ac5ba12be771f77a0dae796d1bbaaf5fd0b9c2d38b69b8a29d"
 "checksum freetype 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fde23272c687e4570aefec06cb71174ec0f5284b725deac4e77ba2665d635faf"
+"checksum freetype 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "398b8a11884898184d55aca9806f002b3cf68f0e860e0cbb4586f834ee39b0e7"
 "checksum futf 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "51f93f3de6ba1794dcd5810b3546d004600a59a98266487c8407bc4b24e398f3"
 "checksum futures 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "55f0008e13fc853f79ea8fc86e931486860d4c4c156cdffb59fa5f7fa833660a"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -585,27 +585,25 @@ impl<'a> CanvasPaintThread<'a> {
             };
             let data = webrender_api::ImageData::Raw(Arc::new(element.into()));
 
+            let mut resources = webrender_api::ResourceUpdates::new();
+
             match self.image_key {
                 Some(image_key) => {
                     debug!("Updating image {:?}.", image_key);
-                    self.webrender_api.update_image(image_key,
-                                                    descriptor,
-                                                    data,
-                                                    None);
+                    resources.update_image(image_key, descriptor, data, None);
                 }
                 None => {
                     self.image_key = Some(self.webrender_api.generate_image_key());
                     debug!("New image {:?}.", self.image_key);
-                    self.webrender_api.add_image(self.image_key.unwrap(),
-                                                 descriptor,
-                                                 data,
-                                                 None);
+                    resources.add_image(self.image_key.unwrap(), descriptor, data, None);
                 }
             }
 
             if let Some(image_key) = mem::replace(&mut self.very_old_image_key, self.old_image_key.take()) {
-                self.webrender_api.delete_image(image_key);
+                resources.delete_image(image_key);
             }
+
+            self.webrender_api.update_resources(resources);
 
             let data = CanvasImageData {
                 image_key: self.image_key.unwrap(),
@@ -764,12 +762,14 @@ impl<'a> CanvasPaintThread<'a> {
 
 impl<'a> Drop for CanvasPaintThread<'a> {
     fn drop(&mut self) {
+        let mut resources = webrender_api::ResourceUpdates::new();
         if let Some(image_key) = self.old_image_key.take() {
-            self.webrender_api.delete_image(image_key);
+            resources.delete_image(image_key);
         }
         if let Some(image_key) = self.very_old_image_key.take() {
-            self.webrender_api.delete_image(image_key);
+            resources.delete_image(image_key);
         }
+        self.webrender_api.update_resources(resources);
     }
 }
 

--- a/components/canvas/webgl_paint_thread.rs
+++ b/components/canvas/webgl_paint_thread.rs
@@ -281,25 +281,23 @@ impl WebGLPaintThread {
                 };
                 let data = webrender_api::ImageData::Raw(Arc::new(pixels));
 
+                let mut resources = webrender_api::ResourceUpdates::new();
+
                 match *image_key {
                     Some(image_key) => {
-                        webrender_api.update_image(image_key,
-                                                   descriptor,
-                                                   data,
-                                                   None);
+                        resources.update_image(image_key, descriptor, data, None);
                     }
                     None => {
                         *image_key = Some(webrender_api.generate_image_key());
-                        webrender_api.add_image(image_key.unwrap(),
-                                                descriptor,
-                                                data,
-                                                None);
+                        resources.add_image(image_key.unwrap(), descriptor, data, None);
                     }
                 }
 
                 if let Some(image_key) = mem::replace(very_old_image_key, old_image_key.take()) {
-                    webrender_api.delete_image(image_key);
+                    resources.delete_image(image_key);
                 }
+
+                webrender_api.update_resources(resources);
 
                 let image_data = CanvasImageData {
                     image_key: image_key.unwrap(),
@@ -357,15 +355,17 @@ impl Drop for WebGLPaintThread {
             very_old_image_key,
             ..
         } = self.data {
+            let mut resources = webrender_api::ResourceUpdates::new();
             if let Some(image_key) = image_key {
-                webrender_api.delete_image(image_key);
+                resources.delete_image(image_key);
             }
             if let Some(image_key) = old_image_key {
-                webrender_api.delete_image(image_key);
+                resources.delete_image(image_key);
             }
             if let Some(image_key) = very_old_image_key {
-                webrender_api.delete_image(image_key);
+                resources.delete_image(image_key);
             }
+            webrender_api.update_resources(resources);
         }
     }
 }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -819,8 +819,9 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             }
 
             WindowEvent::ToggleWebRenderProfiler => {
-                let profiler_enabled = self.webrender.get_profiler_enabled();
-                self.webrender.set_profiler_enabled(!profiler_enabled);
+                let mut flags = self.webrender.get_debug_flags();
+                flags.toggle(webrender::renderer::PROFILER_DBG);
+                self.webrender.set_debug_flags(flags);
                 self.webrender_api.generate_frame(self.webrender_document, None);
             }
         }

--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -347,12 +347,14 @@ impl FontCache {
         if let Some(ref webrender_api) = self.webrender_api {
             let webrender_fonts = &mut self.webrender_fonts;
             font_key = Some(*webrender_fonts.entry(template.identifier.clone()).or_insert_with(|| {
+                let mut resources = webrender_api::ResourceUpdates::new();
                 let font_key = webrender_api.generate_font_key();
                 match (template.bytes_if_in_memory(), template.native_font()) {
-                    (Some(bytes), _) => webrender_api.add_raw_font(font_key, bytes, 0),
-                    (None, Some(native_font)) => webrender_api.add_native_font(font_key, native_font),
-                    (None, None) => webrender_api.add_raw_font(font_key, template.bytes().clone(), 0),
+                    (Some(bytes), _) => resources.add_raw_font(font_key, bytes, 0),
+                    (None, Some(native_font)) => resources.add_native_font(font_key, native_font),
+                    (None, None) => resources.add_raw_font(font_key, template.bytes().clone(), 0),
                 }
+                webrender_api.update_resources(resources);
                 font_key
             }));
         }

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1067,7 +1067,9 @@ impl LayoutThread {
                 Some(get_root_flow_background_color(layout_root)),
                 viewport_size,
                 builder.finalize(),
-                true);
+                true,
+                webrender_api::ResourceUpdates::new()
+            );
             self.webrender_api.generate_frame(self.webrender_document, None);
         });
     }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -79,7 +79,9 @@ fn set_webrender_image_key(webrender_api: &webrender_api::RenderApi, image: &mut
     };
     let data = webrender_api::ImageData::new(bytes);
     let image_key = webrender_api.generate_image_key();
-    webrender_api.add_image(image_key, descriptor, data, None);
+    let mut resources = webrender_api::ResourceUpdates::new();
+    resources.add_image(image_key, descriptor, data, None);
+    webrender_api.update_resources(resources);
     image.id = Some(image_key);
 }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -174,11 +174,17 @@ impl<Window> Browser<Window> where Window: WindowMethods + 'static {
                 None
             };
 
+            let debug_flags = if opts.webrender_stats {
+                webrender::renderer::PROFILER_DBG
+            } else {
+                webrender::renderer::DebugFlags::default()
+            };
+
             webrender::Renderer::new(window.gl(), webrender::RendererOptions {
                 device_pixel_ratio: device_pixel_ratio,
                 resource_override_path: Some(resource_path),
                 enable_aa: opts.enable_text_antialiasing,
-                enable_profiler: opts.webrender_stats,
+                debug_flags,
                 enable_batcher: opts.webrender_batch,
                 debug: opts.webrender_debug,
                 recorder: recorder,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The webrender API has changed a bit recently:
 - Image and font addition/updates/deletion are grouped into `ResourceUpdate`s that are applied atomically.
 - Enabling the profiler and other debugging tools is now exposed in a single bitflags.
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors

Updating webrender imported an extra version of freetype which upsets test-tidy (looking into it).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18013)
<!-- Reviewable:end -->
