### PR TITLE
stylo: We've had bitfield accessors for a while now.

### DIFF
--- a/components/style/gecko_string_cache/mod.rs
+++ b/components/style/gecko_string_cache/mod.rs
@@ -156,11 +156,8 @@ impl WeakAtom {
     /// Returns the length of the atom string.
     #[inline]
     pub fn len(&self) -> u32 {
-        // FIXME(emilio): re-introduce bitfield accessors:
-        //
-        // https://github.com/servo/rust-bindgen/issues/519
         unsafe {
-            (*self.as_ptr())._bitfield_1 & 0x7FFFFFFF
+            (*self.as_ptr()).mLength()
         }
     }
 


### PR DESCRIPTION
This will allow my work in bug 1362338 to not break stylo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18014)
<!-- Reviewable:end -->
