### PR TITLE
stylo: Don't apply the rotation if it cannot be normalized.

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -1416,8 +1416,7 @@ ${helpers.predefined_type(
                         let ay = ay.to_computed_value(context);
                         let az = az.to_computed_value(context);
                         let theta = theta.to_computed_value(context);
-                        let len = (ax * ax + ay * ay + az * az).sqrt();
-                        result.push(computed_value::ComputedOperation::Rotate(ax / len, ay / len, az / len, theta));
+                        result.push(computed_value::ComputedOperation::Rotate(ax, ay, az, theta));
                     }
                     SpecifiedOperation::Skew(theta_x, None) => {
                         let theta_x = theta_x.to_computed_value(context);


### PR DESCRIPTION
According to the spec, the computed value of transform is as specified, but
with relative lengths converted into absolute lengths, so in Gecko, we do
nothing while computing the value of rotate3d(), and do normalization in
ProcessRotate3D(). If the direction cannot be normalized, we treat it as
an identity matrix.

However, in Servo, we do normalization in to_computed_value(), and looks
like we are trying to normalize any kind of direction vectors, so according
to the spec, let's move the normalization into Fragment::transform_matrix(),
and return an identity matrix if we cannot normalize its direction vector.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1388216](https://bugzilla.mozilla.org/show_bug.cgi?id=1388216).
- [X] These changes do not require tests because the added test is on Gecko side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18016)
<!-- Reviewable:end -->
