### PR TITLE
style: Move all origin-specific cascade data to PerOriginCascadeData

### DIFF
--- a/components/selectors/bloom.rs
+++ b/components/selectors/bloom.rs
@@ -6,6 +6,7 @@
 //! for selector matching.
 
 use fnv::FnvHasher;
+use std::fmt::{self, Debug};
 use std::hash::{Hash, Hasher};
 
 // The top 8 bits of the 32-bit hash value are not used by the bloom filter.
@@ -138,6 +139,18 @@ impl<S> CountingBloomFilter<S> where S: BloomStorage {
     #[inline]
     pub fn might_contain<T: Hash>(&self, elem: &T) -> bool {
         self.might_contain_hash(hash(elem))
+    }
+}
+
+impl<S> Debug for CountingBloomFilter<S> where S: BloomStorage {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut slots_used = 0;
+        for i in 0..ARRAY_SIZE {
+            if !self.storage.slot_is_empty(i) {
+                slots_used += 1;
+            }
+        }
+        write!(f, "BloomFilter({}/{})", slots_used, ARRAY_SIZE)
     }
 }
 

--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -533,7 +533,7 @@ pub fn maybe_start_animations(context: &SharedStyleContext,
             continue
         }
 
-        if let Some(ref anim) = context.stylist.animations().get(name) {
+        if let Some(ref anim) = context.stylist.get_animation(name) {
             debug!("maybe_start_animations: animation {} found", name);
 
             // If this animation doesn't have any keyframe, we can just continue
@@ -637,7 +637,7 @@ pub fn update_style_for_animation(context: &SharedStyleContext,
                 KeyframesRunningState::Paused(progress) => started_at + duration * progress,
             };
 
-            let animation = match context.stylist.animations().get(name) {
+            let animation = match context.stylist.get_animation(name) {
                 None => {
                     warn!("update_style_for_animation: Animation {:?} not found", name);
                     return;

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -394,7 +394,7 @@ impl TraversalStatistics {
         self.traversal_time_ms = (time::precise_time_s() - start) * 1000.0;
         self.selectors = stylist.num_selectors() as u32;
         self.revalidation_selectors = stylist.num_revalidation_selectors() as u32;
-        self.dependency_selectors = stylist.invalidation_map().len() as u32;
+        self.dependency_selectors = stylist.num_invalidations() as u32;
         self.declarations = stylist.num_declarations() as u32;
         self.stylist_rebuilds = stylist.num_rebuilds() as u32;
     }

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -387,16 +387,16 @@ impl TraversalStatistics {
               D: DomTraversal<E>,
     {
         let threshold = traversal.shared_context().options.style_statistics_threshold;
+        let stylist = traversal.shared_context().stylist;
 
         self.is_parallel = Some(traversal.is_parallel());
         self.is_large = Some(self.elements_traversed as usize >= threshold);
         self.traversal_time_ms = (time::precise_time_s() - start) * 1000.0;
-        self.selectors = traversal.shared_context().stylist.num_selectors() as u32;
-        self.revalidation_selectors = traversal.shared_context().stylist.num_revalidation_selectors() as u32;
-        self.dependency_selectors =
-            traversal.shared_context().stylist.invalidation_map().len() as u32;
-        self.declarations = traversal.shared_context().stylist.num_declarations() as u32;
-        self.stylist_rebuilds = traversal.shared_context().stylist.num_rebuilds() as u32;
+        self.selectors = stylist.num_selectors() as u32;
+        self.revalidation_selectors = stylist.num_revalidation_selectors() as u32;
+        self.dependency_selectors = stylist.invalidation_map().len() as u32;
+        self.declarations = stylist.num_declarations() as u32;
+        self.stylist_rebuilds = stylist.num_rebuilds() as u32;
     }
 
     /// Returns whether this traversal is 'large' in order to avoid console spam

--- a/components/style/invalidation/element/invalidation_map.rs
+++ b/components/style/invalidation/element/invalidation_map.rs
@@ -109,7 +109,7 @@ impl SelectorMapEntry for Dependency {
 
 /// The same, but for state selectors, which can track more exactly what state
 /// do they track.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct StateDependency {
     /// The other dependency fields.
@@ -132,6 +132,7 @@ impl SelectorMapEntry for StateDependency {
 /// In particular, we want to lookup as few things as possible to get the fewer
 /// selectors the better, so this looks up by id, class, or looks at the list of
 /// state/other attribute affecting selectors.
+#[derive(Debug)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct InvalidationMap {
     /// A map from a given class name to all the selectors with that class

--- a/components/style/invalidation/element/invalidator.rs
+++ b/components/style/invalidation/element/invalidator.rs
@@ -213,9 +213,9 @@ impl<'a, 'b: 'a, E> TreeStyleInvalidator<'a, 'b, E>
                 invalidates_self: false,
             };
 
-            collector.collect_dependencies_in_invalidation_map(
-                shared_context.stylist.invalidation_map(),
-            );
+            shared_context.stylist.each_invalidation_map(|invalidation_map| {
+                collector.collect_dependencies_in_invalidation_map(invalidation_map);
+            });
 
             // TODO(emilio): Consider storing dependencies from the UA sheet in
             // a different map. If we do that, we can skip the stuff on the
@@ -223,9 +223,9 @@ impl<'a, 'b: 'a, E> TreeStyleInvalidator<'a, 'b, E>
             // just at that map.
             let _cut_off_inheritance =
                 self.element.each_xbl_stylist(|stylist| {
-                    collector.collect_dependencies_in_invalidation_map(
-                        stylist.invalidation_map(),
-                    );
+                    stylist.each_invalidation_map(|invalidation_map| {
+                        collector.collect_dependencies_in_invalidation_map(invalidation_map);
+                    });
                 });
 
             collector.invalidates_self

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -1635,6 +1635,11 @@ impl CascadeData {
     }
 }
 
+/// Iterator over `PerOriginCascadeData`, from highest level (user) to lowest
+/// (user agent).
+///
+/// We rely on this specific order for correctly looking up animations
+/// (prioritizing rules at higher cascade levels), among other things.
 struct CascadeDataIter<'a> {
     cascade_data: &'a CascadeData,
     cur: usize,
@@ -1645,9 +1650,9 @@ impl<'a> Iterator for CascadeDataIter<'a> {
 
     fn next(&mut self) -> Option<&'a PerOriginCascadeData> {
         let result = match self.cur {
-            0 => &self.cascade_data.user_agent,
+            0 => &self.cascade_data.user,
             1 => &self.cascade_data.author,
-            2 => &self.cascade_data.user,
+            2 => &self.cascade_data.user_agent,
             _ => return None,
         };
         self.cur += 1;

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -97,9 +97,6 @@ pub struct Stylist {
     /// The rule tree, that stores the results of selector matching.
     rule_tree: RuleTree,
 
-    /// A map with all the animations indexed by name.
-    animations: PrecomputedHashMap<Atom, KeyframesAnimation>,
-
     /// Applicable declarations for a given non-eagerly cascaded pseudo-element.
     /// These are eagerly computed once, and then used to resolve the new
     /// computed values on the fly on layout.
@@ -235,7 +232,6 @@ impl Stylist {
             effective_media_query_results: EffectiveMediaQueryResults::new(),
 
             cascade_data: CascadeData::new(),
-            animations: Default::default(),
             precomputed_pseudo_element_decls: PerPseudoElementMap::default(),
             rules_source_order: 0,
             rule_tree: RuleTree::new(),
@@ -303,7 +299,6 @@ impl Stylist {
         self.is_device_dirty = true;
         // preserve current quirks_mode value
         self.cascade_data.clear();
-        self.animations.clear(); // Or set to Default::default()?
         self.precomputed_pseudo_element_decls.clear();
         self.rules_source_order = 0;
         // We want to keep rule_tree around across stylist rebuilds.
@@ -538,14 +533,15 @@ impl Stylist {
                     debug!("Found valid keyframes rule: {:?}", *keyframes_rule);
 
                     // Don't let a prefixed keyframes animation override a non-prefixed one.
-                    let needs_insertion = keyframes_rule.vendor_prefix.is_none() ||
-                        self.animations.get(keyframes_rule.name.as_atom()).map_or(true, |rule|
-                            rule.vendor_prefix.is_some());
+                    let needs_insertion =
+                        keyframes_rule.vendor_prefix.is_none() ||
+                        origin_cascade_data.animations.get(keyframes_rule.name.as_atom())
+                            .map_or(true, |rule| rule.vendor_prefix.is_some());
                     if needs_insertion {
                         let animation = KeyframesAnimation::from_keyframes(
                             &keyframes_rule.keyframes, keyframes_rule.vendor_prefix.clone(), guard);
                         debug!("Found valid keyframe animation: {:?}", animation);
-                        self.animations.insert(keyframes_rule.name.as_atom().clone(), animation);
+                        origin_cascade_data.animations.insert(keyframes_rule.name.as_atom().clone(), animation);
                     }
                 }
                 #[cfg(feature = "gecko")]
@@ -1326,7 +1322,10 @@ impl Stylist {
     /// Returns the registered `@keyframes` animation for the specified name.
     #[inline]
     pub fn get_animation(&self, name: &Atom) -> Option<&KeyframesAnimation> {
-        self.animations.get(name)
+        self.cascade_data
+            .iter_origins()
+            .filter_map(|d| d.animations.get(name))
+            .next()
     }
 
     /// Computes the match results of a given element against the set of
@@ -1667,6 +1666,10 @@ struct PerOriginCascadeData {
     /// Rules from stylesheets at this `CascadeData`'s origin that correspond
     /// to a given pseudo-element.
     pseudos_map: PerPseudoElementMap<SelectorMap<Rule>>,
+
+    /// A map with all the animations at this `CascadeData`'s origin, indexed
+    /// by name.
+    animations: PrecomputedHashMap<Atom, KeyframesAnimation>,
 }
 
 impl PerOriginCascadeData {
@@ -1674,6 +1677,7 @@ impl PerOriginCascadeData {
         Self {
             element_map: SelectorMap::new(),
             pseudos_map: PerPseudoElementMap::default(),
+            animations: Default::default(),
         }
     }
 
@@ -1686,7 +1690,9 @@ impl PerOriginCascadeData {
     }
 
     fn clear(&mut self) {
-        *self = Self::new();
+        self.element_map = SelectorMap::new();
+        self.pseudos_map = Default::default();
+        self.animations = Default::default();
     }
 
     fn has_rules_for_pseudo(&self, pseudo: &PseudoElement) -> bool {

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -1327,10 +1327,10 @@ impl Stylist {
         self.is_device_dirty
     }
 
-    /// Returns the map of registered `@keyframes` animations.
+    /// Returns the registered `@keyframes` animation for the specified name.
     #[inline]
-    pub fn animations(&self) -> &PrecomputedHashMap<Atom, KeyframesAnimation> {
-        &self.animations
+    pub fn get_animation(&self, name: &Atom) -> Option<&KeyframesAnimation> {
+        self.animations.get(name)
     }
 
     /// Computes the match results of a given element against the set of

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -3286,7 +3286,7 @@ pub extern "C" fn Servo_StyleSet_GetKeyframesForName(raw_data: RawServoStyleSetB
     let data = PerDocumentStyleData::from_ffi(raw_data).borrow();
     let name = unsafe { Atom::from(name.as_ref().unwrap().as_str_unchecked()) };
 
-    let animation = match data.stylist.animations().get(&name) {
+    let animation = match data.stylist.get_animation(&name) {
         Some(animation) => animation,
         None => return false,
     };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is a preliminary refactoring in preparation for only rebuilding cascade data for origins that have a change. https://bugzilla.mozilla.org/show_bug.cgi?id=1382925

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18017)
<!-- Reviewable:end -->
