### PR TITLE
Implement CanvasRenderingContext2d.fillText's "unimplemented" message

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -133,6 +133,7 @@ impl<'a> CanvasPaintThread<'a> {
                 match msg.unwrap() {
                     CanvasMsg::Canvas2d(message) => {
                         match message {
+                            Canvas2dMsg::FillText(text, x, y, max_width) => painter.fill_text(text, x, y, max_width),
                             Canvas2dMsg::FillRect(ref rect) => painter.fill_rect(rect),
                             Canvas2dMsg::StrokeRect(ref rect) => painter.stroke_rect(rect),
                             Canvas2dMsg::ClearRect(ref rect) => painter.clear_rect(rect),
@@ -226,6 +227,10 @@ impl<'a> CanvasPaintThread<'a> {
             self.drawtarget.set_transform(&self.state.transform);
             self.drawtarget.pop_clip();
         }
+    }
+
+    fn fill_text(&self, text: String, x: f64, y: f64, max_width: Option<f64>) {
+        error!("Unimplemented canvas2d.fillText. Values received: {}, {}, {}, {:?}.", text, x, y, max_width);
     }
 
     fn fill_rect(&self, rect: &Rect<f32>) {

--- a/components/canvas_traits/canvas.rs
+++ b/components/canvas_traits/canvas.rs
@@ -43,6 +43,7 @@ pub enum Canvas2dMsg {
     Clip,
     ClosePath,
     Fill,
+    FillText(String, f64, f64, Option<f64>),
     FillRect(Rect<f32>),
     GetImageData(Rect<i32>, Size2D<f64>, IpcSender<Vec<u8>>),
     IsPointInPath(f64, f64, FillRule, IpcSender<bool>),

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -800,6 +800,13 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
         receiver.recv().unwrap()
     }
 
+    // https://html.spec.whatwg.org/multipage/#dom-context-2d-filltext
+    fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>) {
+        let parsed_text: String = text.into();
+        self.ipc_renderer.send(CanvasMsg::Canvas2d(Canvas2dMsg::FillText(parsed_text, x, y, max_width))).unwrap();
+        self.mark_as_dirty();
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
     fn DrawImage(&self,
                  image: CanvasImageSource,

--- a/components/script/dom/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script/dom/webidls/CanvasRenderingContext2D.webidl
@@ -153,8 +153,9 @@ interface CanvasUserInterface {
 [NoInterfaceObject]
 interface CanvasText {
   // text (see also the CanvasDrawingStyles interface)
-  //void fillText(DOMString text, unrestricted double x, unrestricted double y,
-  //              optional unrestricted double maxWidth);
+  [Pref="dom.canvas-text.enabled"]
+  void fillText(DOMString text, unrestricted double x, unrestricted double y,
+                optional unrestricted double maxWidth);
   //void strokeText(DOMString text, unrestricted double x, unrestricted double y,
   //                optional unrestricted double maxWidth);
   //TextMetrics measureText(DOMString text);
@@ -264,4 +265,3 @@ interface CanvasPath {
   //                             double rotation, double startAngle, double endAngle,
   //                             boolean anticlockwise);
 };
-

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -1,6 +1,7 @@
 {
   "dom.bluetooth.enabled": false,
   "dom.bluetooth.testing.enabled": false,
+  "dom.canvas-text.enabled": false,
   "dom.compositionevent.enabled": false,
   "dom.customelements.enabled": false,
   "dom.forcetouch.enabled": false,

--- a/tests/html/test_canvas_filltext.html
+++ b/tests/html/test_canvas_filltext.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<body>
+<canvas id="tutorial" style="border:1px solid #d3d3d3"></canvas>
+<script type="text/javascript">
+
+canvas = document.getElementById('tutorial');
+canvas.width = 200;
+canvas.height = 200;
+
+var ctx = canvas.getContext('2d');
+ctx.fillText('Test', 10.0, 10.0);
+
+ctx.fillText('Test truncated', 30.0, 20.0, 5.0);
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Basic skeleton for implementing CanvasRenderingContext2d.fillText,  only adding methods and parameters in the right place, and a basic test, with some `println!()`.

<!-- Please describe your changes on the following line: -->

This is only the beginning. It were my first couple of hours looking at Rust and Servo.

However, I have _no clue_ how to get the text to render now (basically go from the `println!()` to something else).

It's also possible I messed something up with the `DOMString.parse()` but not entirely sure.

I'm doing this PR as a starting point to get help and learn more about this, _or_ at least maybe save someone some time while implementing this, if no one's able to take the time and show me where/how.

Because it's still a work-in-progress, I'm leaving the boxes below unchecked (even though there are no errors).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #11681 and #17963

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18020)
<!-- Reviewable:end -->
