### PR TITLE
style: Only zoom absolute lengths.

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -844,8 +844,11 @@ ${helpers.single_keyword_system("font-variant-caps",
         }
 
         /// Compute it against a given base font size
-        pub fn to_computed_value_against(&self, context: &Context, base_size: FontBaseSize)
-                                         -> NonNegativeAu {
+        pub fn to_computed_value_against(
+            &self,
+            context: &Context,
+            base_size: FontBaseSize,
+        ) -> NonNegativeAu {
             use values::specified::length::FontRelativeLength;
             match *self {
                 SpecifiedValue::Length(LengthOrPercentage::Length(
@@ -856,8 +859,12 @@ ${helpers.single_keyword_system("font-variant-caps",
                         NoCalcLength::ServoCharacterWidth(value))) => {
                     value.to_computed_value(base_size.resolve(context)).into()
                 }
-                SpecifiedValue::Length(LengthOrPercentage::Length(ref l)) => {
+                SpecifiedValue::Length(LengthOrPercentage::Length(
+                        NoCalcLength::Absolute(ref l))) => {
                     context.maybe_zoom_text(l.to_computed_value(context).into())
+                }
+                SpecifiedValue::Length(LengthOrPercentage::Length(ref l)) => {
+                    l.to_computed_value(context).into()
                 }
                 SpecifiedValue::Length(LengthOrPercentage::Percentage(pc)) => {
                     base_size.resolve(context).scale_by(pc.0).into()

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -135,8 +135,7 @@ impl<'a> Context<'a> {
         &self.builder
     }
 
-
-    /// Apply text-zoom if enabled
+    /// Apply text-zoom if enabled.
     #[cfg(feature = "gecko")]
     pub fn maybe_zoom_text(&self, size: NonNegativeAu) -> NonNegativeAu {
         // We disable zoom for <svg:text> by unsetting the


### PR DESCRIPTION
As silly as it may seem to specify font-sizes using viewport units, we weren't
handling zoom for them correctly either.

Bug: 1388588
Reviewed-by: Manishearth
MozReview-Commit-ID: 3Q6phYAu5CE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18022)
<!-- Reviewable:end -->
