### PR TITLE
Rework MediaType to be an atom-based struct instead of an enum.

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -70,3 +70,6 @@ gattserverdisconnected
 onchange
 
 reftest-wait
+
+screen
+print

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -481,7 +481,7 @@ impl LayoutThread {
         // The device pixel ratio is incorrect (it does not have the hidpi value),
         // but it will be set correctly when the initial reflow takes place.
         let device = Device::new(
-            MediaType::Screen,
+            MediaType::screen(),
             opts::get().initial_window_size.to_f32() * ScaleFactor::new(1.0),
             ScaleFactor::new(opts::get().device_pixels_per_px.unwrap_or(1.0)));
 
@@ -1156,7 +1156,7 @@ impl LayoutThread {
         let document_shared_lock = document.style_shared_lock();
         self.document_shared_lock = Some(document_shared_lock.clone());
         let author_guard = document_shared_lock.read();
-        let device = Device::new(MediaType::Screen, initial_viewport, device_pixel_ratio);
+        let device = Device::new(MediaType::screen(), initial_viewport, device_pixel_ratio);
         self.stylist.set_device(device, &author_guard, &data.document_stylesheets);
 
         self.viewport_size =

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -77,7 +77,7 @@ impl MediaQueryList {
         if let Some(window_size) = self.document.window().window_size() {
             let viewport_size = window_size.initial_viewport;
             let device_pixel_ratio = window_size.device_pixel_ratio;
-            let device = Device::new(MediaType::Screen, viewport_size, device_pixel_ratio);
+            let device = Device::new(MediaType::screen(), viewport_size, device_pixel_ratio);
             self.media_query_list.evaluate(&device, self.document.quirks_mode())
         } else {
             false

--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -18,6 +18,7 @@ use gecko_bindings::structs::{nsCSSKeyword, nsCSSProps_KTableEntry, nsCSSValue, 
 use gecko_bindings::structs::{nsMediaExpression_Range, nsMediaFeature};
 use gecko_bindings::structs::{nsMediaFeature_ValueType, nsMediaFeature_RangeType, nsMediaFeature_RequirementFlags};
 use gecko_bindings::structs::{nsPresContext, RawGeckoPresContextOwned};
+use gecko_bindings::structs::nsIAtom;
 use media_queries::MediaType;
 use parser::ParserContext;
 use properties::{ComputedValues, StyleBuilder};
@@ -31,7 +32,7 @@ use string_cache::Atom;
 use style_traits::{CSSPixel, DevicePixel};
 use style_traits::{ToCss, ParseError, StyleParseError};
 use style_traits::viewport::ViewportConstraints;
-use values::{CSSFloat, specified};
+use values::{CSSFloat, specified, CustomIdent};
 use values::computed::{self, ToComputedValue};
 
 /// The `Device` in Gecko wraps a pres context, has a default values computed,
@@ -140,15 +141,16 @@ impl Device {
     /// Returns the current media type of the device.
     pub fn media_type(&self) -> MediaType {
         unsafe {
-            // FIXME(emilio): Gecko allows emulating random media with
-            // mIsEmulatingMedia / mMediaEmulated . Refactor both sides so that
-            // is supported (probably just making MediaType an Atom).
-            if self.pres_context().mMedium == atom!("screen").as_ptr() {
-                MediaType::Screen
+            // Gecko allows emulating random media with mIsEmulatingMedia and
+            // mMediaEmulated.
+            let context = self.pres_context();
+            let medium_to_use = if context.mIsEmulatingMedia() != 0 {
+                context.mMediaEmulated.raw::<nsIAtom>()
             } else {
-                debug_assert!(self.pres_context().mMedium == atom!("print").as_ptr());
-                MediaType::Print
-            }
+                context.mMedium
+            };
+
+            MediaType(CustomIdent(Atom::from(medium_to_use)))
         }
     }
 

--- a/components/style/str.rs
+++ b/components/style/str.rs
@@ -8,6 +8,7 @@
 
 use num_traits::ToPrimitive;
 use std::ascii::AsciiExt;
+use std::borrow::Cow;
 use std::convert::AsRef;
 use std::iter::{Filter, Peekable};
 use std::str::Split;
@@ -150,4 +151,14 @@ pub fn str_join<I, T>(strs: I, join: &str) -> String
 pub fn starts_with_ignore_ascii_case(string: &str, prefix: &str) -> bool {
     string.len() >= prefix.len() &&
       string.as_bytes()[0..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
+}
+
+/// Returns an ascii lowercase version of a string, only allocating if needed.
+pub fn string_as_ascii_lowercase<'a>(input: &'a str) -> Cow<'a, str> {
+    if input.bytes().any(|c| matches!(c, b'A'...b'Z')) {
+        input.to_ascii_lowercase().into()
+    } else {
+        // Already ascii lowercase.
+        Cow::Borrowed(input)
+    }
 }

--- a/tests/unit/style/media_queries.rs
+++ b/tests/unit/style/media_queries.rs
@@ -15,7 +15,7 @@ use style::media_queries::*;
 use style::servo::media_queries::*;
 use style::shared_lock::SharedRwLock;
 use style::stylesheets::{AllRules, Stylesheet, StylesheetInDocument, Origin, CssRule};
-use style::values::specified;
+use style::values::{CustomIdent, specified};
 use style_traits::ToCss;
 
 pub struct CSSErrorReporterTest;
@@ -40,7 +40,7 @@ fn test_media_rule<F>(css: &str, callback: F)
     let stylesheet = Stylesheet::from_str(
         css, url, Origin::Author, media_list, lock,
         None, &CSSErrorReporterTest, QuirksMode::NoQuirks, 0u64);
-    let dummy = Device::new(MediaType::Screen, TypedSize2D::new(200.0, 100.0), ScaleFactor::new(1.0));
+    let dummy = Device::new(MediaType::screen(), TypedSize2D::new(200.0, 100.0), ScaleFactor::new(1.0));
     let mut rule_count = 0;
     let guard = stylesheet.shared_lock.read();
     for rule in stylesheet.iter_rules::<AllRules>(&dummy, &guard) {
@@ -77,7 +77,7 @@ fn test_mq_screen() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == None, css.to_owned());
-        assert!(q.media_type == MediaQueryType::Known(MediaType::Screen), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(MediaType::screen()), css.to_owned());
         assert!(q.expressions.len() == 0, css.to_owned());
     });
 
@@ -85,7 +85,7 @@ fn test_mq_screen() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == Some(Qualifier::Only), css.to_owned());
-        assert!(q.media_type == MediaQueryType::Known(MediaType::Screen), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(MediaType::screen()), css.to_owned());
         assert!(q.expressions.len() == 0, css.to_owned());
     });
 
@@ -93,7 +93,7 @@ fn test_mq_screen() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == Some(Qualifier::Not), css.to_owned());
-        assert!(q.media_type == MediaQueryType::Known(MediaType::Screen), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(MediaType::screen()), css.to_owned());
         assert!(q.expressions.len() == 0, css.to_owned());
     });
 }
@@ -104,7 +104,7 @@ fn test_mq_print() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == None, css.to_owned());
-        assert!(q.media_type == MediaQueryType::Known(MediaType::Print), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(MediaType::print()), css.to_owned());
         assert!(q.expressions.len() == 0, css.to_owned());
     });
 
@@ -112,7 +112,7 @@ fn test_mq_print() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == Some(Qualifier::Only), css.to_owned());
-        assert!(q.media_type == MediaQueryType::Known(MediaType::Print), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(MediaType::print()), css.to_owned());
         assert!(q.expressions.len() == 0, css.to_owned());
     });
 
@@ -120,7 +120,7 @@ fn test_mq_print() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == Some(Qualifier::Not), css.to_owned());
-        assert!(q.media_type == MediaQueryType::Known(MediaType::Print), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(MediaType::print()), css.to_owned());
         assert!(q.expressions.len() == 0, css.to_owned());
     });
 }
@@ -131,7 +131,8 @@ fn test_mq_unknown() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == None, css.to_owned());
-        assert!(q.media_type == MediaQueryType::Unknown(Atom::from("fridge")), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(
+            MediaType(CustomIdent(Atom::from("fridge")))), css.to_owned());
         assert!(q.expressions.len() == 0, css.to_owned());
     });
 
@@ -139,7 +140,8 @@ fn test_mq_unknown() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == Some(Qualifier::Only), css.to_owned());
-        assert!(q.media_type == MediaQueryType::Unknown(Atom::from("glass")), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(
+            MediaType(CustomIdent(Atom::from("glass")))), css.to_owned());
         assert!(q.expressions.len() == 0, css.to_owned());
     });
 
@@ -147,7 +149,8 @@ fn test_mq_unknown() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == Some(Qualifier::Not), css.to_owned());
-        assert!(q.media_type == MediaQueryType::Unknown(Atom::from("wood")), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(
+            MediaType(CustomIdent(Atom::from("wood")))), css.to_owned());
         assert!(q.expressions.len() == 0, css.to_owned());
     });
 }
@@ -185,12 +188,12 @@ fn test_mq_or() {
         assert!(list.media_queries.len() == 2, css.to_owned());
         let q0 = &list.media_queries[0];
         assert!(q0.qualifier == None, css.to_owned());
-        assert!(q0.media_type == MediaQueryType::Known(MediaType::Screen), css.to_owned());
+        assert!(q0.media_type == MediaQueryType::Concrete(MediaType::screen()), css.to_owned());
         assert!(q0.expressions.len() == 0, css.to_owned());
 
         let q1 = &list.media_queries[1];
         assert!(q1.qualifier == None, css.to_owned());
-        assert!(q1.media_type == MediaQueryType::Known(MediaType::Print), css.to_owned());
+        assert!(q1.media_type == MediaQueryType::Concrete(MediaType::print()), css.to_owned());
         assert!(q1.expressions.len() == 0, css.to_owned());
     });
 }
@@ -228,7 +231,7 @@ fn test_mq_expressions() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == None, css.to_owned());
-        assert!(q.media_type == MediaQueryType::Known(MediaType::Screen), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(MediaType::screen()), css.to_owned());
         assert!(q.expressions.len() == 1, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
             ExpressionKind::Width(Range::Min(ref w)) => assert!(*w == specified::Length::from_px(100.)),
@@ -240,7 +243,7 @@ fn test_mq_expressions() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == None, css.to_owned());
-        assert!(q.media_type == MediaQueryType::Known(MediaType::Print), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(MediaType::print()), css.to_owned());
         assert!(q.expressions.len() == 1, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
             ExpressionKind::Width(Range::Max(ref w)) => assert!(*w == specified::Length::from_px(43.)),
@@ -252,7 +255,7 @@ fn test_mq_expressions() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == None, css.to_owned());
-        assert!(q.media_type == MediaQueryType::Known(MediaType::Print), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(MediaType::print()), css.to_owned());
         assert!(q.expressions.len() == 1, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
             ExpressionKind::Width(Range::Eq(ref w)) => assert!(*w == specified::Length::from_px(43.)),
@@ -264,7 +267,8 @@ fn test_mq_expressions() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == None, css.to_owned());
-        assert!(q.media_type == MediaQueryType::Unknown(Atom::from("fridge")), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(
+            MediaType(CustomIdent(Atom::from("fridge")))), css.to_owned());
         assert!(q.expressions.len() == 1, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
             ExpressionKind::Width(Range::Max(ref w)) => assert!(*w == specified::Length::from_px(52.)),
@@ -305,7 +309,7 @@ fn test_mq_multiple_expressions() {
         assert!(list.media_queries.len() == 1, css.to_owned());
         let q = &list.media_queries[0];
         assert!(q.qualifier == Some(Qualifier::Not), css.to_owned());
-        assert!(q.media_type == MediaQueryType::Known(MediaType::Screen), css.to_owned());
+        assert!(q.media_type == MediaQueryType::Concrete(MediaType::screen()), css.to_owned());
         assert!(q.expressions.len() == 2, css.to_owned());
         match *q.expressions[0].kind_for_testing() {
             ExpressionKind::Width(Range::Min(ref w)) => assert!(*w == specified::Length::from_px(100.)),
@@ -343,7 +347,7 @@ fn test_mq_malformed_expressions() {
 
 #[test]
 fn test_matching_simple() {
-    let device = Device::new(MediaType::Screen, TypedSize2D::new(200.0, 100.0), ScaleFactor::new(1.0));
+    let device = Device::new(MediaType::screen(), TypedSize2D::new(200.0, 100.0), ScaleFactor::new(1.0));
 
     media_query_test(&device, "@media not all { a { color: red; } }", 0);
     media_query_test(&device, "@media not screen { a { color: red; } }", 0);
@@ -359,7 +363,7 @@ fn test_matching_simple() {
 
 #[test]
 fn test_matching_width() {
-    let device = Device::new(MediaType::Screen, TypedSize2D::new(200.0, 100.0), ScaleFactor::new(1.0));
+    let device = Device::new(MediaType::screen(), TypedSize2D::new(200.0, 100.0), ScaleFactor::new(1.0));
 
     media_query_test(&device, "@media { a { color: red; } }", 1);
 
@@ -400,7 +404,7 @@ fn test_matching_width() {
 
 #[test]
 fn test_matching_invalid() {
-    let device = Device::new(MediaType::Screen, TypedSize2D::new(200.0, 100.0), ScaleFactor::new(1.0));
+    let device = Device::new(MediaType::screen(), TypedSize2D::new(200.0, 100.0), ScaleFactor::new(1.0));
 
     media_query_test(&device, "@media fridge { a { color: red; } }", 0);
     media_query_test(&device, "@media screen and (height: 100px) { a { color: red; } }", 0);

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -223,7 +223,7 @@ fn test_insert() {
 }
 
 fn mock_stylist() -> Stylist {
-    let device = Device::new(MediaType::Screen, TypedSize2D::new(0f32, 0f32), ScaleFactor::new(1.0));
+    let device = Device::new(MediaType::screen(), TypedSize2D::new(0f32, 0f32), ScaleFactor::new(1.0));
     Stylist::new(device, QuirksMode::NoQuirks)
 }
 
@@ -231,9 +231,9 @@ fn mock_stylist() -> Stylist {
 fn test_stylist_device_accessors() {
     thread_state::initialize(thread_state::LAYOUT);
     let stylist = mock_stylist();
-    assert_eq!(stylist.device().media_type(), MediaType::Screen);
+    assert_eq!(stylist.device().media_type(), MediaType::screen());
     let mut stylist_mut = mock_stylist();
-    assert_eq!(stylist_mut.device_mut().media_type(), MediaType::Screen);
+    assert_eq!(stylist_mut.device_mut().media_type(), MediaType::screen());
 }
 
 #[test]

--- a/tests/unit/style/viewport.rs
+++ b/tests/unit/style/viewport.rs
@@ -97,7 +97,7 @@ macro_rules! viewport_length {
 
 #[test]
 fn empty_viewport_rule() {
-    let device = Device::new(MediaType::Screen, TypedSize2D::new(800., 600.), ScaleFactor::new(1.0));
+    let device = Device::new(MediaType::screen(), TypedSize2D::new(800., 600.), ScaleFactor::new(1.0));
 
     test_viewport_rule("@viewport {}", &device, |declarations, css| {
         println!("{}", css);
@@ -120,7 +120,7 @@ macro_rules! assert_decl_eq {
 
 #[test]
 fn simple_viewport_rules() {
-    let device = Device::new(MediaType::Screen, TypedSize2D::new(800., 600.), ScaleFactor::new(1.0));
+    let device = Device::new(MediaType::screen(), TypedSize2D::new(800., 600.), ScaleFactor::new(1.0));
 
     test_viewport_rule("@viewport { width: auto; height: auto;\
                                     zoom: auto; min-zoom: 0; max-zoom: 200%;\
@@ -192,7 +192,7 @@ fn simple_meta_viewport_contents() {
 
 #[test]
 fn cascading_within_viewport_rule() {
-    let device = Device::new(MediaType::Screen, TypedSize2D::new(800., 600.), ScaleFactor::new(1.0));
+    let device = Device::new(MediaType::screen(), TypedSize2D::new(800., 600.), ScaleFactor::new(1.0));
 
     // normal order of appearance
     test_viewport_rule("@viewport { min-width: 200px; min-width: auto; }",
@@ -258,7 +258,7 @@ fn cascading_within_viewport_rule() {
 #[test]
 fn multiple_stylesheets_cascading() {
     PREFS.set("layout.viewport.enabled", PrefValue::Boolean(true));
-    let device = Device::new(MediaType::Screen, TypedSize2D::new(800., 600.), ScaleFactor::new(1.0));
+    let device = Device::new(MediaType::screen(), TypedSize2D::new(800., 600.), ScaleFactor::new(1.0));
     let error_reporter = CSSErrorReporterTest;
     let shared_lock = SharedRwLock::new();
     let stylesheets = vec![
@@ -314,7 +314,7 @@ fn constrain_viewport() {
     }
 
     let initial_viewport = TypedSize2D::new(800., 600.);
-    let device = Device::new(MediaType::Screen, initial_viewport, ScaleFactor::new(1.0));
+    let device = Device::new(MediaType::screen(), initial_viewport, ScaleFactor::new(1.0));
     let mut input = ParserInput::new("");
     assert_eq!(ViewportConstraints::maybe_new(&device, from_css!(input), QuirksMode::NoQuirks), None);
 
@@ -363,7 +363,7 @@ fn constrain_viewport() {
                }));
 
     let initial_viewport = TypedSize2D::new(200., 150.);
-    let device = Device::new(MediaType::Screen, initial_viewport, ScaleFactor::new(1.0));
+    let device = Device::new(MediaType::screen(), initial_viewport, ScaleFactor::new(1.0));
     let mut input = ParserInput::new("width: 320px auto");
     assert_eq!(ViewportConstraints::maybe_new(&device, from_css!(input), QuirksMode::NoQuirks),
                Some(ViewportConstraints {


### PR DESCRIPTION
MozReview-Commit-ID: 1Tfrs9PBkhA

<!-- Please describe your changes on the following line: -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1371395
https://reviewboard.mozilla.org/r/163194/

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18024)
<!-- Reviewable:end -->
