### PR TITLE
Update to cssparser 0.19, count line numbers during tokenization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ version = "0.0.1"
 dependencies = [
  "azure 0.20.0 (git+https://github.com/servo/rust-azure)",
  "canvas_traits 0.0.1",
- "cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -340,7 +340,7 @@ dependencies = [
 name = "canvas_traits"
 version = "0.0.1"
 dependencies = [
- "cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cssparser-macros 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1026,7 +1026,7 @@ name = "geckoservo"
 version = "0.0.1"
 dependencies = [
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1094,7 +1094,7 @@ dependencies = [
 name = "gfx_tests"
 version = "0.0.1"
 dependencies = [
- "cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
  "ipc-channel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
@@ -2467,7 +2467,7 @@ dependencies = [
  "caseless 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deny_public_fields 0.0.1",
  "devtools_traits 0.0.1",
  "dom_struct 0.0.1",
@@ -2540,7 +2540,7 @@ dependencies = [
  "app_units 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
- "cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2614,7 +2614,7 @@ name = "selectors"
 version = "0.19.0"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3013,7 +3013,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3068,7 +3068,7 @@ version = "0.0.1"
 dependencies = [
  "app_units 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3090,7 +3090,7 @@ version = "0.0.1"
 dependencies = [
  "app_units 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3105,7 +3105,7 @@ name = "stylo_tests"
 version = "0.0.1"
 dependencies = [
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "geckoservo 0.0.1",
@@ -3694,7 +3694,7 @@ dependencies = [
 "checksum core-foundation-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "41115a6aa5d3e1e5ef98148373f25971d1fad53818553f216495f9e67e90a624"
 "checksum core-graphics 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a9f841e9637adec70838c537cae52cb4c751cc6514ad05669b51d107c2021c79"
 "checksum core-text 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "16ce16d9ed00181016c11ff48e561314bec92bfbce9fe48f319366618d4e5de6"
-"checksum cssparser 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7cf65dc20c985b085db316cf6e824fbccd4fa2c4641b57b8f42e06b0edb1052d"
+"checksum cssparser 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f3a5464ebae36626f28254b60d1abbba951417383192bcea65578b40fbec1a47"
 "checksum cssparser-macros 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "079adec4af52bb5275eadd004292028c79eb3c5f5b4ee8086a36d4197032f6df"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum dbus 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4aee01fb76ada3e5e7ca642ea6664ebf7308a810739ca2aca44909a1191ac254"

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 [dependencies]
 azure = {git = "https://github.com/servo/rust-azure"}
 canvas_traits = {path = "../canvas_traits"}
-cssparser = "0.18"
+cssparser = "0.19"
 euclid = "0.15"
 gleam = "0.4"
 ipc-channel = "0.8"

--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -10,7 +10,7 @@ name = "canvas_traits"
 path = "lib.rs"
 
 [dependencies]
-cssparser = "0.18"
+cssparser = "0.19"
 euclid = "0.15"
 heapsize = "0.4"
 heapsize_derive = "0.1"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -34,7 +34,7 @@ byteorder = "1.0"
 canvas_traits = {path = "../canvas_traits"}
 caseless = "0.1.0"
 cookie = "0.6"
-cssparser = "0.18"
+cssparser = "0.19"
 deny_public_fields = {path = "../deny_public_fields"}
 devtools_traits = {path = "../devtools_traits"}
 dom_struct = {path = "../dom_struct"}

--- a/components/script_layout_interface/Cargo.toml
+++ b/components/script_layout_interface/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 app_units = "0.5"
 atomic_refcell = "0.1"
 canvas_traits = {path = "../canvas_traits"}
-cssparser = "0.18"
+cssparser = "0.19"
 euclid = "0.15"
 gfx_traits = {path = "../gfx_traits"}
 heapsize = "0.4"

--- a/components/script_layout_interface/reporter.rs
+++ b/components/script_layout_interface/reporter.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cssparser::{Parser, SourcePosition};
+use cssparser::SourceLocation;
 use ipc_channel::ipc::IpcSender;
 use log;
 use msg::constellation_msg::PipelineId;
@@ -22,18 +22,14 @@ pub struct CSSErrorReporter {
 }
 
 impl ParseErrorReporter for CSSErrorReporter {
-    fn report_error<'a>(&self,
-                        input: &mut Parser,
-                        position: SourcePosition,
-                        error: ContextualParseError<'a>,
-                        url: &ServoUrl,
-                        line_number_offset: u64) {
-        let location = input.source_location(position);
-        let line_offset = location.line + line_number_offset as u32;
+    fn report_error(&self,
+                    url: &ServoUrl,
+                    location: SourceLocation,
+                    error: ContextualParseError) {
         if log_enabled!(log::LogLevel::Info) {
             info!("Url:\t{}\n{}:{} {}",
                   url.as_str(),
-                  line_offset,
+                  location.line,
                   location.column,
                   error.to_string())
         }

--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -25,7 +25,7 @@ unstable = []
 [dependencies]
 bitflags = "0.7"
 matches = "0.1"
-cssparser = "0.18"
+cssparser = "0.19"
 log = "0.3"
 fnv = "1.0"
 phf = "0.7.18"

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -37,7 +37,7 @@ bitflags = "0.7"
 bit-vec = "0.4.3"
 byteorder = "1.0"
 cfg-if = "0.1.0"
-cssparser = "0.18"
+cssparser = "0.19"
 encoding = {version = "0.2", optional = true}
 euclid = "0.15"
 fnv = "1.0"

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -234,9 +234,9 @@ fn parse_declaration_value<'i, 't>
                           -> Result<(TokenSerializationType, TokenSerializationType), ParseError<'i>> {
     input.parse_until_before(Delimiter::Bang | Delimiter::Semicolon, |input| {
         // Need at least one token
-        let start_position = input.position();
+        let start = input.state();
         input.next_including_whitespace()?;
-        input.reset(start_position);
+        input.reset(&start);
 
         parse_declaration_value_block(input, references, missing_closing_characters)
     })
@@ -293,11 +293,11 @@ fn parse_declaration_value_block<'i, 't>
                 return Err(StyleParseError::UnbalancedCloseCurlyBracketInDeclarationValueBlock.into()),
             Token::Function(ref name) => {
                 if name.eq_ignore_ascii_case("var") {
-                    let position = input.position();
+                    let args_start = input.state();
                     input.parse_nested_block(|input| {
                         parse_var_function(input, references)
                     })?;
-                    input.reset(position);
+                    input.reset(&args_start);
                 }
                 nested!();
                 check_closed!(")");
@@ -629,13 +629,13 @@ fn substitute_block<'i, 't, F>(input: &mut Parser<'i, 't>,
                         while let Ok(_) = input.next() {}
                     } else {
                         input.expect_comma()?;
-                        let position = input.position();
+                        let after_comma = input.state();
                         let first_token_type = input.next_including_whitespace_and_comments()
                             // parse_var_function() ensures that .unwrap() will not fail.
                             .unwrap()
                             .serialization_type();
-                        input.reset(position);
-                        let mut position = (position, first_token_type);
+                        input.reset(&after_comma);
+                        let mut position = (after_comma.position(), first_token_type);
                         last_token_type = substitute_block(
                             input, &mut position, partial_computed_value, substitute_one)?;
                         partial_computed_value.push_from(position, input, last_token_type);

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -16,7 +16,7 @@ use cssparser::{SourceLocation, CowRcStr};
 use error_reporting::ContextualParseError;
 #[cfg(feature = "gecko")] use gecko_bindings::structs::CSSFontFaceDescriptors;
 #[cfg(feature = "gecko")] use cssparser::UnicodeRange;
-use parser::{ParserContext, log_css_error, Parse};
+use parser::{ParserContext, Parse};
 #[cfg(feature = "gecko")]
 use properties::longhands::font_language_override;
 use selectors::parser::SelectorParseError;
@@ -119,10 +119,8 @@ pub fn parse_font_face_block(context: &ParserContext, input: &mut Parser, locati
         let mut iter = DeclarationListParser::new(input, parser);
         while let Some(declaration) = iter.next() {
             if let Err(err) = declaration {
-                let pos = err.span.start;
-                let error = ContextualParseError::UnsupportedFontFaceDescriptor(
-                    iter.input.slice(err.span), err.error);
-                log_css_error(iter.input, pos, error, context);
+                let error = ContextualParseError::UnsupportedFontFaceDescriptor(err.slice, err.error);
+                context.log_css_error(err.location, error)
             }
         }
     }

--- a/components/style/parser.rs
+++ b/components/style/parser.rs
@@ -5,7 +5,7 @@
 //! The context within which CSS code is parsed.
 
 use context::QuirksMode;
-use cssparser::{Parser, SourcePosition, UnicodeRange};
+use cssparser::{Parser, SourceLocation, UnicodeRange};
 use error_reporting::{ParseErrorReporter, ContextualParseError};
 use style_traits::{OneOrMoreSeparated, ParseError, ParsingMode, Separator};
 #[cfg(feature = "gecko")]
@@ -133,20 +133,15 @@ impl<'a> ParserContext<'a> {
     pub fn rule_type(&self) -> CssRuleType {
         self.rule_type.expect("Rule type expected, but none was found.")
     }
-}
 
-/// Defaults to a no-op.
-/// Set a `RUST_LOG=style::errors` environment variable
-/// to log CSS parse errors to stderr.
-pub fn log_css_error<'a>(input: &mut Parser,
-                         position: SourcePosition,
-                         error: ContextualParseError<'a>,
-                         parsercontext: &ParserContext) {
-    let url_data = parsercontext.url_data;
-    let line_number_offset = parsercontext.line_number_offset;
-    parsercontext.error_reporter.report_error(input, position,
-                                              error, url_data,
-                                              line_number_offset);
+    /// Record a CSS parse error with this context’s error reporting.
+    pub fn log_css_error(&self, location: SourceLocation, error: ContextualParseError) {
+        let location = SourceLocation {
+            line: location.line + self.line_number_offset as u32,
+            column: location.column,
+        };
+        self.error_reporter.report_error(self.url_data, location, error)
+    }
 }
 
 // XXXManishearth Replace all specified value parse impls with impls of this

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1502,12 +1502,12 @@ impl PropertyDeclaration {
                     PropertyDeclaration::CSSWideKeyword(id, keyword)
                 }).or_else(|()| {
                     input.look_for_var_functions();
-                    let start = input.position();
+                    let start = input.state();
                     input.parse_entirely(|input| id.parse_value(context, input))
                     .or_else(|err| {
                         while let Ok(_) = input.next() {}  // Look for var() after the error.
                         if input.seen_var_functions() {
-                            input.reset(start);
+                            input.reset(&start);
                             let (first_token_type, css) =
                                 ::custom_properties::parse_non_custom_with_var(input).map_err(|e| {
                                     PropertyDeclarationParseError::InvalidValue(id.name().into(),
@@ -1540,13 +1540,13 @@ impl PropertyDeclaration {
                     Ok(())
                 } else {
                     input.look_for_var_functions();
-                    let start = input.position();
+                    let start = input.state();
                     // Not using parse_entirely here: each ${shorthand.ident}::parse_into function
                     // needs to do so *before* pushing to `declarations`.
                     id.parse_into(declarations, context, input).or_else(|err| {
                         while let Ok(_) = input.next() {}  // Look for var() after the error.
                         if input.seen_var_functions() {
-                            input.reset(start);
+                            input.reset(&start);
                             let (first_token_type, css) =
                                 ::custom_properties::parse_non_custom_with_var(input).map_err(|e| {
                                     PropertyDeclarationParseError::InvalidValue(id.name().into(),

--- a/components/style/stylesheets/font_feature_values_rule.rs
+++ b/components/style/stylesheets/font_feature_values_rule.rs
@@ -11,7 +11,7 @@ use computed_values::font_family::FamilyName;
 use cssparser::{AtRuleParser, AtRuleType, BasicParseError, DeclarationListParser, DeclarationParser, Parser};
 use cssparser::{CowRcStr, RuleListParser, SourceLocation, QualifiedRuleParser, Token, serialize_identifier};
 use error_reporting::ContextualParseError;
-use parser::{ParserContext, log_css_error, Parse};
+use parser::{ParserContext, Parse};
 use selectors::parser::SelectorParseError;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt;
@@ -222,10 +222,8 @@ macro_rules! font_feature_values_blocks {
                     });
                     while let Some(result) = iter.next() {
                         if let Err(err) = result {
-                            let pos = err.span.start;
-                            let error = ContextualParseError::UnsupportedRule(
-                                iter.input.slice(err.span), err.error);
-                            log_css_error(iter.input, pos, error, context);
+                            let error = ContextualParseError::UnsupportedRule(err.slice, err.error);
+                            context.log_css_error(err.location, error);
                         }
                     }
                 }
@@ -338,10 +336,9 @@ macro_rules! font_feature_values_blocks {
                             let mut iter = DeclarationListParser::new(input, parser);
                             while let Some(declaration) = iter.next() {
                                 if let Err(err) = declaration {
-                                    let pos = err.span.start;
                                     let error = ContextualParseError::UnsupportedKeyframePropertyDeclaration(
-                                        iter.input.slice(err.span), err.error);
-                                    log_css_error(iter.input, pos, error, &context);
+                                        err.slice, err.error);
+                                    context.log_css_error(err.location, error);
                                 }
                             }
                         },

--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -12,7 +12,7 @@ use cssparser::{CowRcStr, SourceLocation, BasicParseError};
 use error_reporting::ContextualParseError;
 use font_face::parse_font_face_block;
 use media_queries::{parse_media_query_list, MediaList};
-use parser::{Parse, ParserContext, log_css_error};
+use parser::{Parse, ParserContext};
 use properties::parse_property_declaration_list;
 use selector_parser::{SelectorImpl, SelectorParser};
 use selectors::SelectorList;
@@ -318,10 +318,8 @@ impl<'a, 'b> NestedRuleParser<'a, 'b> {
             match result {
                 Ok(rule) => rules.push(rule),
                 Err(err) => {
-                    let pos = err.span.start;
-                    let error = ContextualParseError::UnsupportedRule(
-                        iter.input.slice(err.span), err.error);
-                    log_css_error(iter.input, pos, error, self.context);
+                    let error = ContextualParseError::UnsupportedRule(err.slice, err.error);
+                    self.context.log_css_error(err.location, error);
                 }
             }
         }

--- a/components/style/stylesheets/stylesheet.rs
+++ b/components/style/stylesheets/stylesheet.rs
@@ -9,7 +9,7 @@ use error_reporting::{ParseErrorReporter, ContextualParseError};
 use fnv::FnvHashMap;
 use media_queries::{MediaList, Device};
 use parking_lot::RwLock;
-use parser::{ParserContext, log_css_error};
+use parser::ParserContext;
 use servo_arc::Arc;
 use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked, SharedRwLock, SharedRwLockReadGuard};
 use std::mem;
@@ -351,10 +351,8 @@ impl Stylesheet {
                 match result {
                     Ok(rule) => rules.push(rule),
                     Err(err) => {
-                        let pos = err.span.start;
-                        let error = ContextualParseError::InvalidRule(
-                            iter.input.slice(err.span), err.error);
-                        log_css_error(iter.input, pos, error, iter.parser.context());
+                        let error = ContextualParseError::InvalidRule(err.slice, err.error);
+                        iter.parser.context().log_css_error(err.location, error);
                     }
                 }
             }

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -15,7 +15,7 @@ use error_reporting::ContextualParseError;
 use euclid::TypedSize2D;
 use font_metrics::get_metrics_provider_for_product;
 use media_queries::Device;
-use parser::{Parse, ParserContext, log_css_error};
+use parser::{Parse, ParserContext};
 use properties::StyleBuilder;
 use selectors::parser::SelectorParseError;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
@@ -360,10 +360,8 @@ impl Parse for ViewportRule {
                     }
                 }
                 Err(err) => {
-                    let pos = err.span.start;
-                    let error = ContextualParseError::UnsupportedViewportDescriptorDeclaration(
-                        parser.input.slice(err.span), err.error);
-                    log_css_error(parser.input, pos, error, &context);
+                    let error = ContextualParseError::UnsupportedViewportDescriptorDeclaration(err.slice, err.error);
+                    context.log_css_error(err.location, error);
                 }
             }
         }

--- a/components/style/values/specified/calc.rs
+++ b/components/style/values/specified/calc.rs
@@ -194,7 +194,7 @@ impl CalcNode {
         let mut root = Self::parse_product(context, input, expected_unit)?;
 
         loop {
-            let position = input.position();
+            let start = input.state();
             match input.next_including_whitespace() {
                 Ok(&Token::WhiteSpace(_)) => {
                     if input.is_exhausted() {
@@ -220,7 +220,7 @@ impl CalcNode {
                     }
                 }
                 _ => {
-                    input.reset(position);
+                    input.reset(&start);
                     break
                 }
             }
@@ -247,7 +247,7 @@ impl CalcNode {
         let mut root = Self::parse_one(context, input, expected_unit)?;
 
         loop {
-            let position = input.position();
+            let start = input.state();
             match input.next() {
                 Ok(&Token::Delim('*')) => {
                     let rhs = Self::parse_one(context, input, expected_unit)?;
@@ -261,7 +261,7 @@ impl CalcNode {
                     root = new_root;
                 }
                 _ => {
-                    input.reset(position);
+                    input.reset(&start);
                     break
                 }
             }

--- a/components/style/values/specified/color.rs
+++ b/components/style/values/specified/color.rs
@@ -70,12 +70,12 @@ impl Parse for Color {
         // Currently we only store authored value for color keywords,
         // because all browsers serialize those values as keywords for
         // specified value.
-        let start_position = input.position();
+        let start = input.state();
         let authored = match input.next() {
             Ok(&Token::Ident(ref s)) => Some(s.to_lowercase().into_boxed_str()),
             _ => None,
         };
-        input.reset(start_position);
+        input.reset(&start);
         match input.try(CSSParserColor::parse) {
             Ok(value) =>
                 Ok(match value {

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -16,7 +16,7 @@ gecko = []
 [dependencies]
 app_units = "0.5"
 bitflags = "0.7"
-cssparser = "0.18"
+cssparser = "0.19"
 euclid = "0.15"
 heapsize = {version = "0.4", optional = true}
 heapsize_derive = {version = "0.1", optional = true}

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -15,7 +15,7 @@ gecko_debug = ["style/gecko_debug"]
 
 [dependencies]
 atomic_refcell = "0.1"
-cssparser = "0.18"
+cssparser = "0.19"
 env_logger = {version = "0.4", default-features = false} # disable `regex` to reduce code size
 libc = "0.2"
 log = {version = "0.3.5", features = ["release_max_level_info"]}

--- a/ports/geckolib/error_reporter.rs
+++ b/ports/geckolib/error_reporter.rs
@@ -6,7 +6,7 @@
 
 #![allow(unsafe_code)]
 
-use cssparser::{Parser, SourcePosition, ParseError as CssParseError, Token, BasicParseError};
+use cssparser::{SourceLocation, ParseError as CssParseError, Token, BasicParseError};
 use cssparser::CowRcStr;
 use selectors::parser::SelectorParseError;
 use std::ptr;
@@ -330,15 +330,10 @@ impl<'a> ErrorHelpers<'a> for ContextualParseError<'a> {
 }
 
 impl ParseErrorReporter for ErrorReporter {
-    fn report_error<'a>(&self,
-                        input: &mut Parser,
-                        position: SourcePosition,
-                        error: ContextualParseError<'a>,
-                        _url: &UrlExtraData,
-                        line_number_offset: u64) {
-        let location = input.source_location(position);
-        let line_number = location.line + line_number_offset as u32;
-
+    fn report_error(&self,
+                    _url: &UrlExtraData,
+                    location: SourceLocation,
+                    error: ContextualParseError) {
         let (pre, name, action) = error.to_gecko_message();
         let suffix = match action {
             Action::Nothing => ptr::null(),
@@ -362,8 +357,8 @@ impl ParseErrorReporter for ErrorReporter {
                                            suffix as *const _,
                                            source.as_ptr() as *const _,
                                            source.len() as u32,
-                                           line_number as u32,
-                                           location.column as u32);
+                                           location.line,
+                                           location.column);
         }
     }
 }

--- a/tests/unit/gfx/Cargo.toml
+++ b/tests/unit/gfx/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
-cssparser = "0.18"
+cssparser = "0.19"
 gfx = {path = "../../../components/gfx"}
 ipc-channel = "0.8"
 style = {path = "../../../components/style"}

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 byteorder = "1.0"
 app_units = "0.5"
-cssparser = "0.18"
+cssparser = "0.19"
 euclid = "0.15"
 html5ever = "0.18"
 parking_lot = "0.4"

--- a/tests/unit/style/media_queries.rs
+++ b/tests/unit/style/media_queries.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cssparser::{Parser, SourcePosition};
+use cssparser::SourceLocation;
 use euclid::ScaleFactor;
 use euclid::TypedSize2D;
 use servo_arc::Arc;
@@ -21,12 +21,10 @@ use style_traits::ToCss;
 pub struct CSSErrorReporterTest;
 
 impl ParseErrorReporter for CSSErrorReporterTest {
-    fn report_error<'a>(&self,
-                        _input: &mut Parser,
-                        _position: SourcePosition,
-                        _error: ContextualParseError<'a>,
-                        _url: &ServoUrl,
-                        _line_number_offset: u64) {
+    fn report_error(&self,
+                    _url: &ServoUrl,
+                    _location: SourceLocation,
+                    _error: ContextualParseError) {
     }
 }
 

--- a/tests/unit/style/rule_tree/bench.rs
+++ b/tests/unit/style/rule_tree/bench.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cssparser::{Parser, SourcePosition};
+use cssparser::SourceLocation;
 use rayon;
 use servo_arc::Arc;
 use servo_url::ServoUrl;
@@ -18,15 +18,11 @@ use test::{self, Bencher};
 
 struct ErrorringErrorReporter;
 impl ParseErrorReporter for ErrorringErrorReporter {
-    fn report_error<'a>(&self,
-                        input: &mut Parser,
-                        position: SourcePosition,
-                        error: ContextualParseError<'a>,
-                        url: &ServoUrl,
-                        line_number_offset: u64) {
-        let location = input.source_location(position);
-        let line_offset = location.line + line_number_offset as u32;
-        panic!("CSS error: {}\t\n{}:{} {}", url.as_str(), line_offset, location.column, error.to_string());
+    fn report_error(&self,
+                    url: &ServoUrl,
+                    location: SourceLocation,
+                    error: ContextualParseError) {
+        panic!("CSS error: {}\t\n{}:{} {}", url.as_str(), location.line, location.column, error.to_string());
     }
 }
 

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cssparser::{self, Parser as CssParser, SourcePosition, SourceLocation};
+use cssparser::{self, SourceLocation};
 use html5ever::{Namespace as NsAtom};
 use media_queries::CSSErrorReporterTest;
 use parking_lot::RwLock;
@@ -270,21 +270,15 @@ impl CSSInvalidErrorReporterTest {
 }
 
 impl ParseErrorReporter for CSSInvalidErrorReporterTest {
-    fn report_error<'a>(&self,
-                        input: &mut CssParser,
-                        position: SourcePosition,
-                        error: ContextualParseError<'a>,
-                        url: &ServoUrl,
-                        line_number_offset: u64) {
-
-        let location = input.source_location(position);
-        let line_offset = location.line + line_number_offset as u32;
-
+    fn report_error(&self,
+                    url: &ServoUrl,
+                    location: SourceLocation,
+                    error: ContextualParseError) {
         let mut errors = self.errors.lock().unwrap();
         errors.push(
             CSSError{
                 url: url.clone(),
-                line: line_offset,
+                line: location.line,
                 column: location.column,
                 message: error.to_string()
             }

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -14,7 +14,6 @@ use style::context::QuirksMode;
 use style::media_queries::{Device, MediaType};
 use style::properties::{PropertyDeclarationBlock, PropertyDeclaration};
 use style::properties::{longhands, Importance};
-use style::rule_tree::CascadeLevel;
 use style::selector_map::{self, SelectorMap};
 use style::selector_parser::{SelectorImpl, SelectorParser};
 use style::shared_lock::SharedRwLock;

--- a/tests/unit/stylo/Cargo.toml
+++ b/tests/unit/stylo/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 
 [dependencies]
 atomic_refcell = "0.1"
-cssparser = "0.18"
+cssparser = "0.19"
 env_logger = "0.4"
 euclid = "0.15"
 geckoservo = {path = "../../../ports/geckolib"}


### PR DESCRIPTION
https://github.com/servo/rust-cssparser/pull/177

Also simplify the `ParseErrorReporter` trait a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18025)
<!-- Reviewable:end -->
