### PR TITLE
Use namespace id instead of atom in synthesize_presentational_hints_for_legacy_attributes

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1534,9 +1534,9 @@ impl<'le> PresentationalHintsSynthesizer for GeckoElement<'le> {
             };
         };
 
-        let ns = self.get_namespace();
+        let ns = self.namespace_id();
         // <th> elements get a default MozCenterOrInherit which may get overridden
-        if ns == &*Namespace(atom!("http://www.w3.org/1999/xhtml")) {
+        if ns == structs::kNameSpaceID_XHTML as i32 {
             if self.get_local_name().as_ptr() == atom!("th").as_ptr() {
                 hints.push(TH_RULE.clone());
             } else if self.get_local_name().as_ptr() == atom!("table").as_ptr() &&
@@ -1544,7 +1544,7 @@ impl<'le> PresentationalHintsSynthesizer for GeckoElement<'le> {
                 hints.push(TABLE_COLOR_RULE.clone());
             }
         }
-        if ns == &*Namespace(atom!("http://www.w3.org/2000/svg")) {
+        if ns == structs::kNameSpaceID_SVG as i32 {
             if self.get_local_name().as_ptr() == atom!("text").as_ptr() {
                 hints.push(SVG_TEXT_DISABLE_ZOOM_RULE.clone());
             }
@@ -1621,7 +1621,7 @@ impl<'le> PresentationalHintsSynthesizer for GeckoElement<'le> {
             hints.push(ApplicableDeclarationBlock::from_declarations(arc, ServoCascadeLevel::PresHints))
         }
         // MathML's default lang has precedence over both `lang` and `xml:lang`
-        if ns == &*Namespace(atom!("http://www.w3.org/1998/Math/MathML")) {
+        if ns == structs::kNameSpaceID_MathML as i32 {
             if self.get_local_name().as_ptr() == atom!("math").as_ptr() {
                 hints.push(MATHML_LANG_RULE.clone());
             }


### PR DESCRIPTION
Using namespace id fixes this issue because in Gecko, the pref of MathML (as well as SVG) works in the way that we choose a different namespace id (the disabled id) for the elements. Those ids are mapped to the same namespace atom as normal ids, which means if we use the atom, we would treat the elements like normal mathml elements.

https://bugzilla.mozilla.org/show_bug.cgi?id=1388881

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18033)
<!-- Reviewable:end -->
