### PR TITLE
Continue after failed attempt to delete old nightly

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -331,7 +331,10 @@ class MachCommands(CommandBase):
                     full_path = path.join(base, name)
                     if force:
                         print("Removing {}".format(full_path))
-                        delete(full_path)
+                        try:
+                            delete(full_path)
+                        except OSError as e:
+                            print("Removal failed with error {}".format(e))
                     else:
                         print("Would remove {}".format(full_path))
         if not removing_anything:


### PR DESCRIPTION
Failure to catch this error broke bholley's PR https://github.com/servo/servo/pull/18048

http://build.servo.org/builders/linux-dev/builds/8616/steps/shell__1/logs/stdio.
Logs below for posterity.

```
Current Rust nightly version: 599be0d18f4c6ddf36366d2a5a2ca6dc65886896
Current Rust stable version: 1.19.0
Removing /home/servo/.servo/cargo/13d94d5fa8129a34f5c77a1bcd76983f5aed2434
Error running mach:

    ['clean-nightlies', '--keep', '3', '--force']

The error occurred in code that was called by the mach command. This is either
a bug in the called code itself or in the way that mach is calling it.

You should consider filing a bug for this issue.

If filing a bug, please include the full output of mach, including this error
message.

The details of the failure are as follows:

OSError: [Errno 2] No such file or directory:
'/home/servo/.servo/cargo/13d94d5fa8129a34f5c77a1bcd76983f5aed2434'

  File
"/home/servo/buildbot/slave/linux-dev/build/python/servo/bootstrap_commands.py",
line 334, in clean_nightlies
    delete(full_path)
  File "/home/servo/buildbot/slave/linux-dev/build/python/servo/util.py", line
28, in delete
    os.remove(path)
```

I don't know how the builder got into the edge case where the old nightly wasn't there for deletion, but in the case that removal fails for some reason, mach should just keep going. In the incredibly unlikely event that the failure to remove the file has consequences down the line, we'll have the failed remove in the log for troubleshooting. 

Also this passed tidy so if I failed to python I'll need to fix tidy as well as this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18051)
<!-- Reviewable:end -->
