### PR TITLE
geckolib: Return @font-face rules to Gecko in the expected cascade order.

### DIFF
--- a/components/style/stylesheets/origin.rs
+++ b/components/style/stylesheets/origin.rs
@@ -64,6 +64,17 @@ impl<T> PerOrigin<T> {
         PerOriginIter {
             data: &self,
             cur: 0,
+            rev: false,
+        }
+    }
+
+    /// Iterates over references to per-origin extra style data, from lowest
+    /// level (user agent) to highest (author).
+    pub fn iter_origins_rev(&self) -> PerOriginIter<T> {
+        PerOriginIter {
+            data: &self,
+            cur: 2,
+            rev: true,
         }
     }
 
@@ -99,7 +110,8 @@ impl<T> PerOriginClear for PerOrigin<T> where T: PerOriginClear {
 /// @counter-style and @keyframes rules.
 pub struct PerOriginIter<'a, T: 'a> {
     data: &'a PerOrigin<T>,
-    cur: usize,
+    cur: i8,
+    rev: bool,
 }
 
 impl<'a, T> Iterator for PerOriginIter<'a, T> where T: 'a {
@@ -112,7 +124,7 @@ impl<'a, T> Iterator for PerOriginIter<'a, T> where T: 'a {
             2 => (&self.data.user_agent, Origin::UserAgent),
             _ => return None,
         };
-        self.cur += 1;
+        self.cur += if self.rev { -1 } else { 1 };
         Some(result)
     }
 }
@@ -125,7 +137,7 @@ impl<'a, T> Iterator for PerOriginIter<'a, T> where T: 'a {
 /// each time from `next()`.
 pub struct PerOriginIterMut<'a, T: 'a> {
     data: *mut PerOrigin<T>,
-    cur: usize,
+    cur: i8,
     _marker: PhantomData<&'a mut PerOrigin<T>>,
 }
 

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -3449,8 +3449,10 @@ pub extern "C" fn Servo_StyleSet_GetFontFaceRules(raw_data: RawServoStyleSetBorr
         .map(|(d, _)| d.font_faces.len() as u32)
         .sum();
 
+    // Reversed iterator because Gecko expects rules to appear sorted
+    // UserAgent first, Author last.
     let font_face_iter = data.extra_style_data
-        .iter_origins()
+        .iter_origins_rev()
         .flat_map(|(d, o)| d.font_faces.iter().zip(iter::repeat(o)));
 
     unsafe { rules.set_len(len) };


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1389937.  Reviewed by Xidorn there.  Waiting until try server is back up and running before landing this, though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18067)
<!-- Reviewable:end -->
