### PR TITLE
Enqueue attribute changed callback when replacing attr

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1674,6 +1674,15 @@ impl ElementMethods for Element {
             }
 
             // Step 4.
+            if self.get_custom_element_definition().is_some() {
+                let old_name = old_attr.local_name().clone();
+                let old_value = DOMString::from(&**old_attr.value());
+                let new_value = DOMString::from(&**attr.value());
+                let namespace = old_attr.namespace().clone();
+                let reaction = CallbackReaction::AttributeChanged(old_name, Some(old_value),
+                    Some(new_value), namespace);
+                ScriptThread::enqueue_callback_reaction(self, reaction, None);
+            }
             self.will_mutate_attr(attr);
             attr.set_owner(Some(self));
             self.attrs.borrow_mut()[position] = JS::from_ref(attr);

--- a/tests/wpt/metadata/custom-elements/reactions/Element.html.ini
+++ b/tests/wpt/metadata/custom-elements/reactions/Element.html.ini
@@ -6,12 +6,6 @@
   [slot on Element must enqueue an attributeChanged reaction when replacing an existing attribute]
     expected: FAIL
 
-  [setAttributeNode on Element must enqueue an attributeChanged reaction when replacing an existing attribute]
-    expected: FAIL
-
-  [setAttributeNodeNS on Element must enqueue an attributeChanged reaction when replacing an existing attribute]
-    expected: FAIL
-
   [insertAdjacentHTML on Element must enqueue a connected reaction for a newly constructed custom element]
     expected: FAIL
 

--- a/tests/wpt/metadata/custom-elements/reactions/NamedNodeMap.html.ini
+++ b/tests/wpt/metadata/custom-elements/reactions/NamedNodeMap.html.ini
@@ -1,8 +1,0 @@
-[NamedNodeMap.html]
-  type: testharness
-  [setNamedItem on NamedNodeMap must enqueue an attributeChanged reaction when replacing an existing attribute]
-    expected: FAIL
-
-  [setNamedItemNS on NamedNodeMap must enqueue an attributeChanged reaction when replacing an existing attribute]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/css/get-computed-style-for-url.html.ini
+++ b/tests/wpt/mozilla/meta/css/get-computed-style-for-url.html.ini
@@ -1,6 +1,5 @@
 [get-computed-style-for-url.html]
   type: testharness
-
   [getComputedStyle(elem) for url() listStyle uses the resolved URL and elem.style uses the original URL]
     expected: FAIL
     bug: https://github.com/servo/servo/issues/18015


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18074)
<!-- Reviewable:end -->
