### PR TITLE
Apply line break suppression to text when in any ruby

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1821,7 +1821,7 @@ pub extern "C" fn Servo_ComputedValues_Inherit(
 
         if for_text {
             StyleAdjuster::new(&mut style)
-                .adjust_for_text();
+                .adjust_for_text(reference);
         }
 
         style.build()


### PR DESCRIPTION
This should fix [bug 1388904](https://bugzilla.mozilla.org/show_bug.cgi?id=1388904).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18075)
<!-- Reviewable:end -->
