### PR TITLE
Make emtpy rule can be inserted into rule tree

### DIFF
--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -210,7 +210,10 @@ impl RuleTree {
                     _ => {},
                 };
             }
-            if any_normal {
+            // We really want to ensure empty rule nodes appear in the rule tree for
+            // devtools, this condition ensures that if we find an empty rule node, we
+            // insert it at the normal level.
+            if any_normal || !any_important {
                 if matches!(level, Transitions) && found_important {
                     // There can be at most one transition, and it will come at
                     // the end of the iterator. Stash it and apply it after


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
We really want to ensure empty rule nodes appear in the rule tree for devtools, this condition ensures that if we find an empty rule node, we insert it at the normal level.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1384802](https://bugzilla.mozilla.org/show_bug.cgi?id=1384802)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because of the test cases are in Gecko.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18099)
<!-- Reviewable:end -->
