### PR TITLE
Don't allow interpolating 'fill:none' with 'fill:none'

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -2478,7 +2478,6 @@ impl Animatable for IntermediateSVGPaintKind {
             }
             // FIXME context values should be interpolable with colors
             // Gecko doesn't implement this behavior either.
-            (&SVGPaintKind::None, &SVGPaintKind::None) => Ok(SVGPaintKind::None),
             (&SVGPaintKind::ContextFill, &SVGPaintKind::ContextFill) => Ok(SVGPaintKind::ContextFill),
             (&SVGPaintKind::ContextStroke, &SVGPaintKind::ContextStroke) => Ok(SVGPaintKind::ContextStroke),
             _ => Err(())


### PR DESCRIPTION
From [Gecko bug 1390364](https://bugzilla.mozilla.org/show_bug.cgi?id=1390364).

In SMIL we don't expect the 'none' value of the 'fill' property to be additive and hence the following animation should have no effect:

```svg
  <rect width="100" height="100" y="100" fill="blue">
    <animate attributeName="fill" dur="3s" from="red" by="none"/>
  </rect>
```

Although SMIL doesn't make this entirely clear, [it says](https://www.w3.org/TR/smil-animation/#AnimFuncValues) that "by animation" and "from-by animation" may only be used "with attributes that support addition (e.g.  most numeric attributes)" and [SVG says](https://www.w3.org/TR/SVG11/animate.html#AnimationAttributesAndProperties) that `<paint>`s are "only additive if each value can be converted to an RGB color". As a result, the animation above should have no effect.

By extrapolation, animating from 'none' by 'none' should also have no effect:

```svg
  <rect width="100" height="100" y="100" fill="blue">
    <animate attributeName="fill" dur="3s" from="none" by="none"/>
  </rect>
```

However, in Servo's interpolation of `<paint>`s we special case the interpolation and addition of 'none' such that if both values are 'none' it is allowed.

We should disallow this in order to produce the expected behavior and in order to match Gecko's behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18103)
<!-- Reviewable:end -->
