### PR TITLE
style: Skip matching :nth-child if element is the root of anonymous subtree

### DIFF
--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -776,6 +776,10 @@ fn matches_generic_nth_child<E, F>(element: &E,
     where E: Element,
           F: FnMut(&E, ElementSelectorFlags),
 {
+    if element.ignores_nth_child_selectors() {
+        return false;
+    }
+
     flags_setter(element, if is_from_end {
         HAS_SLOW_SELECTOR
     } else {

--- a/components/selectors/tree.rs
+++ b/components/selectors/tree.rs
@@ -86,6 +86,12 @@ pub trait Element: Sized + Debug {
     /// if the parent node is a `DocumentFragment`.
     fn is_root(&self) -> bool;
 
+    /// Returns whether this element should ignore matching nth child
+    /// selector.
+    fn ignores_nth_child_selectors(&self) -> bool {
+        false
+    }
+
     /// Return true if we want to stop lookup ancestor of the current
     /// element while matching complex selectors with descendant/child
     /// combinator.


### PR DESCRIPTION
This was reviewed in https://bugzilla.mozilla.org/show_bug.cgi?id=1382102

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18104)
<!-- Reviewable:end -->
