### PR TITLE
Use the is_absolute_containing_block method everywhere

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -616,14 +616,12 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
         flow.finish();
 
         // Set up the absolute descendants.
-        let contains_positioned_fragments = flow.contains_positioned_fragments();
-        let is_absolutely_positioned = flow::base(&*flow).flags.contains(IS_ABSOLUTELY_POSITIONED);
-        if contains_positioned_fragments {
+        if flow.is_absolute_containing_block() {
             // This is the containing block for all the absolute descendants.
             flow.set_absolute_descendants(abs_descendants);
 
             abs_descendants = AbsoluteDescendants::new();
-            if is_absolutely_positioned {
+            if flow::base(&*flow).flags.contains(IS_ABSOLUTELY_POSITIONED) {
                 // This is now the only absolute flow in the subtree which hasn't yet
                 // reached its CB.
                 abs_descendants.push(flow.clone());
@@ -1060,16 +1058,13 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
 
         // The flow is done.
         flow.finish();
-        let contains_positioned_fragments = flow.contains_positioned_fragments();
-        if contains_positioned_fragments {
+        if flow.is_absolute_containing_block() {
             // This is the containing block for all the absolute descendants.
             flow.set_absolute_descendants(abs_descendants);
 
             abs_descendants = AbsoluteDescendants::new();
 
-            let is_absolutely_positioned =
-                flow::base(&*flow).flags.contains(IS_ABSOLUTELY_POSITIONED);
-            if is_absolutely_positioned {
+            if flow::base(&*flow).flags.contains(IS_ABSOLUTELY_POSITIONED) {
                 // This is now the only absolute flow in the subtree which hasn't yet
                 // reached its containing block.
                 abs_descendants.push(flow.clone());
@@ -1134,16 +1129,13 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
         legalizer.finish(&mut wrapper_flow);
         wrapper_flow.finish();
 
-        let contains_positioned_fragments = wrapper_flow.contains_positioned_fragments();
-        if contains_positioned_fragments {
+        if wrapper_flow.is_absolute_containing_block() {
             // This is the containing block for all the absolute descendants.
             wrapper_flow.set_absolute_descendants(abs_descendants);
 
             abs_descendants = AbsoluteDescendants::new();
 
-            let is_absolutely_positioned =
-                flow::base(&*wrapper_flow).flags.contains(IS_ABSOLUTELY_POSITIONED);
-            if is_absolutely_positioned {
+            if flow::base(&*wrapper_flow).flags.contains(IS_ABSOLUTELY_POSITIONED) {
                 // This is now the only absolute flow in the subtree which hasn't yet
                 // reached its containing block.
                 abs_descendants.push(wrapper_flow.clone());

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -404,7 +404,7 @@ pub trait Flow: fmt::Debug + Sync + Send + 'static {
 
     /// Returns true if this is an absolute containing block.
     fn is_absolute_containing_block(&self) -> bool {
-        false
+        self.contains_positioned_fragments()
     }
 
     /// Updates the inline position of a child flow during the assign-height traversal. At present,

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1486,7 +1486,7 @@ impl Flow for InlineFlow {
             indentation = Au(0)
         }
 
-        if self.contains_positioned_fragments() {
+        if self.is_absolute_containing_block() {
             // Assign block-sizes for all flows in this absolute flow tree.
             // This is preorder because the block-size of an absolute flow may depend on
             // the block-size of its containing block, which may also be an absolute flow.


### PR DESCRIPTION
This is a better approach than relying on
contains_positioned_fragments, because in the future other properties
will create absolute containing blocks.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18112)
<!-- Reviewable:end -->
