### PR TITLE
stylo: Add a pref checking mechanism for alias properties

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -744,7 +744,8 @@ impl LayoutThread {
             Msg::RegisterPaint(name, mut properties, painter) => {
                 debug!("Registering the painter");
                 let properties = properties.drain(..)
-                    .filter_map(|name| PropertyId::parse(&*name).ok().map(|id| (name.clone(), id)))
+                    .filter_map(|name| PropertyId::parse(&*name, None)
+                        .ok().map(|id| (name.clone(), id)))
                     .filter(|&(_, ref id)| id.as_shorthand().is_err())
                     .collect();
                 let registered_painter = RegisteredPainterImpl {

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -296,7 +296,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertyvalue
     fn GetPropertyValue(&self, property: DOMString) -> DOMString {
-        let id = if let Ok(id) = PropertyId::parse(&property) {
+        let id = if let Ok(id) = PropertyId::parse(&property, None) {
             id
         } else {
             // Unkwown property
@@ -307,7 +307,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertypriority
     fn GetPropertyPriority(&self, property: DOMString) -> DOMString {
-        let id = if let Ok(id) = PropertyId::parse(&property) {
+        let id = if let Ok(id) = PropertyId::parse(&property, None) {
             id
         } else {
             // Unkwown property
@@ -331,7 +331,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
                    priority: DOMString)
                    -> ErrorResult {
         // Step 3
-        let id = if let Ok(id) = PropertyId::parse(&property) {
+        let id = if let Ok(id) = PropertyId::parse(&property, None) {
             id
         } else {
             // Unknown property
@@ -348,7 +348,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
         }
 
         // Step 2 & 3
-        let id = match PropertyId::parse(&property) {
+        let id = match PropertyId::parse(&property, None) {
             Ok(id) => id,
             Err(..) => return Ok(()), // Unkwown property
         };
@@ -380,7 +380,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
             return Err(Error::NoModificationAllowed);
         }
 
-        let id = if let Ok(id) = PropertyId::parse(&property) {
+        let id = if let Ok(id) = PropertyId::parse(&property, None) {
             id
         } else {
             // Unkwown property, cannot be there to remove.

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -512,12 +512,6 @@ extern "C" {
     pub fn Servo_StyleSet_Drop(ptr: RawServoStyleSetOwned);
 }
 extern "C" {
-    pub fn Gecko_ChildrenCount(node: RawGeckoNodeBorrowed) -> u32;
-}
-extern "C" {
-    pub fn Gecko_NodeIsElement(node: RawGeckoNodeBorrowed) -> bool;
-}
-extern "C" {
     pub fn Gecko_IsInDocument(node: RawGeckoNodeBorrowed) -> bool;
 }
 extern "C" {
@@ -596,9 +590,6 @@ extern "C" {
     pub fn Gecko_DocumentState(aDocument: *const nsIDocument) -> u64;
 }
 extern "C" {
-    pub fn Gecko_IsTextNode(node: RawGeckoNodeBorrowed) -> bool;
-}
-extern "C" {
     pub fn Gecko_IsRootElement(element: RawGeckoElementBorrowed) -> bool;
 }
 extern "C" {
@@ -606,14 +597,7 @@ extern "C" {
                                 element: RawGeckoElementBorrowed) -> bool;
 }
 extern "C" {
-    pub fn Gecko_LocalName(element: RawGeckoElementBorrowed) -> *mut nsIAtom;
-}
-extern "C" {
     pub fn Gecko_Namespace(element: RawGeckoElementBorrowed) -> *mut nsIAtom;
-}
-extern "C" {
-    pub fn Gecko_GetElementId(element: RawGeckoElementBorrowed)
-     -> *mut nsIAtom;
 }
 extern "C" {
     pub fn Gecko_MatchLang(element: RawGeckoElementBorrowed,
@@ -1074,9 +1058,6 @@ extern "C" {
      -> *mut nsStyleContentData_CounterFunction;
 }
 extern "C" {
-    pub fn Gecko_GetNodeFlags(node: RawGeckoNodeBorrowed) -> u32;
-}
-extern "C" {
     pub fn Gecko_SetNodeFlags(node: RawGeckoNodeBorrowed, flags: u32);
 }
 extern "C" {
@@ -1103,10 +1084,6 @@ extern "C" {
                                      new_style: ServoStyleContextBorrowed,
                                      old_style_bits: u64,
                                      any_style_changed: *mut bool) -> u32;
-}
-extern "C" {
-    pub fn Gecko_HintsHandledForDescendants(aHint: nsChangeHint)
-     -> nsChangeHint;
 }
 extern "C" {
     pub fn Gecko_GetElementSnapshot(table: *const ServoElementSnapshotTable,

--- a/components/style/gecko/generated/structs_debug.rs
+++ b/components/style/gecko/generated/structs_debug.rs
@@ -299,11 +299,6 @@ pub mod root {
     pub const NS_STYLE_BORDER_IMAGE_REPEAT_SPACE: ::std::os::raw::c_uint = 3;
     pub const NS_STYLE_BORDER_IMAGE_SLICE_NOFILL: ::std::os::raw::c_uint = 0;
     pub const NS_STYLE_BORDER_IMAGE_SLICE_FILL: ::std::os::raw::c_uint = 1;
-    pub const NS_STYLE_CONTENT_OPEN_QUOTE: ::std::os::raw::c_uint = 0;
-    pub const NS_STYLE_CONTENT_CLOSE_QUOTE: ::std::os::raw::c_uint = 1;
-    pub const NS_STYLE_CONTENT_NO_OPEN_QUOTE: ::std::os::raw::c_uint = 2;
-    pub const NS_STYLE_CONTENT_NO_CLOSE_QUOTE: ::std::os::raw::c_uint = 3;
-    pub const NS_STYLE_CONTENT_ALT_CONTENT: ::std::os::raw::c_uint = 4;
     pub const NS_STYLE_CURSOR_AUTO: ::std::os::raw::c_uint = 1;
     pub const NS_STYLE_CURSOR_CROSSHAIR: ::std::os::raw::c_uint = 2;
     pub const NS_STYLE_CURSOR_DEFAULT: ::std::os::raw::c_uint = 3;
@@ -6310,91 +6305,96 @@ pub mod root {
             eUseCounter_property_FillOpacity = 4,
             eUseCounter_XMLDocument_async_getter = 5,
             eUseCounter_XMLDocument_async_setter = 6,
-            eUseCounter_PushManager_subscribe = 7,
-            eUseCounter_PushSubscription_unsubscribe = 8,
-            eUseCounter_Window_sidebar_getter = 9,
-            eUseCounter_Window_sidebar_setter = 10,
-            eUseCounter_External_addSearchEngine = 11,
-            eUseCounter_OfflineResourceList_swapCache = 12,
-            eUseCounter_OfflineResourceList_update = 13,
-            eUseCounter_OfflineResourceList_status_getter = 14,
-            eUseCounter_OfflineResourceList_status_setter = 15,
-            eUseCounter_OfflineResourceList_onchecking_getter = 16,
-            eUseCounter_OfflineResourceList_onchecking_setter = 17,
-            eUseCounter_OfflineResourceList_onerror_getter = 18,
-            eUseCounter_OfflineResourceList_onerror_setter = 19,
-            eUseCounter_OfflineResourceList_onnoupdate_getter = 20,
-            eUseCounter_OfflineResourceList_onnoupdate_setter = 21,
-            eUseCounter_OfflineResourceList_ondownloading_getter = 22,
-            eUseCounter_OfflineResourceList_ondownloading_setter = 23,
-            eUseCounter_OfflineResourceList_onprogress_getter = 24,
-            eUseCounter_OfflineResourceList_onprogress_setter = 25,
-            eUseCounter_OfflineResourceList_onupdateready_getter = 26,
-            eUseCounter_OfflineResourceList_onupdateready_setter = 27,
-            eUseCounter_OfflineResourceList_oncached_getter = 28,
-            eUseCounter_OfflineResourceList_oncached_setter = 29,
-            eUseCounter_OfflineResourceList_onobsolete_getter = 30,
-            eUseCounter_OfflineResourceList_onobsolete_setter = 31,
-            eUseCounter_IDBDatabase_createMutableFile = 32,
-            eUseCounter_IDBDatabase_mozCreateFileHandle = 33,
-            eUseCounter_IDBMutableFile_open = 34,
-            eUseCounter_IDBMutableFile_getFile = 35,
-            eUseCounter_DataTransfer_addElement = 36,
-            eUseCounter_DataTransfer_mozItemCount_getter = 37,
-            eUseCounter_DataTransfer_mozItemCount_setter = 38,
-            eUseCounter_DataTransfer_mozCursor_getter = 39,
-            eUseCounter_DataTransfer_mozCursor_setter = 40,
-            eUseCounter_DataTransfer_mozTypesAt = 41,
-            eUseCounter_DataTransfer_mozClearDataAt = 42,
-            eUseCounter_DataTransfer_mozSetDataAt = 43,
-            eUseCounter_DataTransfer_mozGetDataAt = 44,
-            eUseCounter_DataTransfer_mozUserCancelled_getter = 45,
-            eUseCounter_DataTransfer_mozUserCancelled_setter = 46,
-            eUseCounter_DataTransfer_mozSourceNode_getter = 47,
-            eUseCounter_DataTransfer_mozSourceNode_setter = 48,
-            eUseCounter_GetAttributeNode = 49,
-            eUseCounter_SetAttributeNode = 50,
-            eUseCounter_GetAttributeNodeNS = 51,
-            eUseCounter_SetAttributeNodeNS = 52,
-            eUseCounter_RemoveAttributeNode = 53,
-            eUseCounter_CreateAttribute = 54,
-            eUseCounter_CreateAttributeNS = 55,
-            eUseCounter_NodeValue = 56,
-            eUseCounter_TextContent = 57,
-            eUseCounter_EnablePrivilege = 58,
-            eUseCounter_DOMExceptionCode = 59,
-            eUseCounter_NoExposedProps = 60,
-            eUseCounter_MutationEvent = 61,
-            eUseCounter_Components = 62,
-            eUseCounter_PrefixedVisibilityAPI = 63,
-            eUseCounter_NodeIteratorDetach = 64,
-            eUseCounter_LenientThis = 65,
-            eUseCounter_GetPreventDefault = 66,
-            eUseCounter_GetSetUserData = 67,
-            eUseCounter_MozGetAsFile = 68,
-            eUseCounter_UseOfCaptureEvents = 69,
-            eUseCounter_UseOfReleaseEvents = 70,
-            eUseCounter_UseOfDOM3LoadMethod = 71,
-            eUseCounter_ChromeUseOfDOM3LoadMethod = 72,
-            eUseCounter_ShowModalDialog = 73,
-            eUseCounter_Window_Content = 74,
-            eUseCounter_SyncXMLHttpRequest = 75,
-            eUseCounter_Window_Cc_ontrollers = 76,
-            eUseCounter_ImportXULIntoContent = 77,
-            eUseCounter_PannerNodeDoppler = 78,
-            eUseCounter_NavigatorGetUserMedia = 79,
-            eUseCounter_WebrtcDeprecatedPrefix = 80,
-            eUseCounter_RTCPeerConnectionGetStreams = 81,
-            eUseCounter_AppCache = 82,
-            eUseCounter_PrefixedImageSmoothingEnabled = 83,
-            eUseCounter_PrefixedFullscreenAPI = 84,
-            eUseCounter_LenientSetter = 85,
-            eUseCounter_FileLastModifiedDate = 86,
-            eUseCounter_ImageBitmapRenderingContext_TransferImageBitmap = 87,
-            eUseCounter_URLCreateObjectURL_MediaStream = 88,
-            eUseCounter_XMLBaseAttribute = 89,
-            eUseCounter_XMLBaseAttributeForStyleAttr = 90,
-            eUseCounter_Count = 91,
+            eUseCounter_DOMError_name_getter = 7,
+            eUseCounter_DOMError_name_setter = 8,
+            eUseCounter_DOMError_message_getter = 9,
+            eUseCounter_DOMError_message_setter = 10,
+            eUseCounter_custom_DOMErrorConstructor = 11,
+            eUseCounter_PushManager_subscribe = 12,
+            eUseCounter_PushSubscription_unsubscribe = 13,
+            eUseCounter_Window_sidebar_getter = 14,
+            eUseCounter_Window_sidebar_setter = 15,
+            eUseCounter_External_addSearchEngine = 16,
+            eUseCounter_OfflineResourceList_swapCache = 17,
+            eUseCounter_OfflineResourceList_update = 18,
+            eUseCounter_OfflineResourceList_status_getter = 19,
+            eUseCounter_OfflineResourceList_status_setter = 20,
+            eUseCounter_OfflineResourceList_onchecking_getter = 21,
+            eUseCounter_OfflineResourceList_onchecking_setter = 22,
+            eUseCounter_OfflineResourceList_onerror_getter = 23,
+            eUseCounter_OfflineResourceList_onerror_setter = 24,
+            eUseCounter_OfflineResourceList_onnoupdate_getter = 25,
+            eUseCounter_OfflineResourceList_onnoupdate_setter = 26,
+            eUseCounter_OfflineResourceList_ondownloading_getter = 27,
+            eUseCounter_OfflineResourceList_ondownloading_setter = 28,
+            eUseCounter_OfflineResourceList_onprogress_getter = 29,
+            eUseCounter_OfflineResourceList_onprogress_setter = 30,
+            eUseCounter_OfflineResourceList_onupdateready_getter = 31,
+            eUseCounter_OfflineResourceList_onupdateready_setter = 32,
+            eUseCounter_OfflineResourceList_oncached_getter = 33,
+            eUseCounter_OfflineResourceList_oncached_setter = 34,
+            eUseCounter_OfflineResourceList_onobsolete_getter = 35,
+            eUseCounter_OfflineResourceList_onobsolete_setter = 36,
+            eUseCounter_IDBDatabase_createMutableFile = 37,
+            eUseCounter_IDBDatabase_mozCreateFileHandle = 38,
+            eUseCounter_IDBMutableFile_open = 39,
+            eUseCounter_IDBMutableFile_getFile = 40,
+            eUseCounter_DataTransfer_addElement = 41,
+            eUseCounter_DataTransfer_mozItemCount_getter = 42,
+            eUseCounter_DataTransfer_mozItemCount_setter = 43,
+            eUseCounter_DataTransfer_mozCursor_getter = 44,
+            eUseCounter_DataTransfer_mozCursor_setter = 45,
+            eUseCounter_DataTransfer_mozTypesAt = 46,
+            eUseCounter_DataTransfer_mozClearDataAt = 47,
+            eUseCounter_DataTransfer_mozSetDataAt = 48,
+            eUseCounter_DataTransfer_mozGetDataAt = 49,
+            eUseCounter_DataTransfer_mozUserCancelled_getter = 50,
+            eUseCounter_DataTransfer_mozUserCancelled_setter = 51,
+            eUseCounter_DataTransfer_mozSourceNode_getter = 52,
+            eUseCounter_DataTransfer_mozSourceNode_setter = 53,
+            eUseCounter_GetAttributeNode = 54,
+            eUseCounter_SetAttributeNode = 55,
+            eUseCounter_GetAttributeNodeNS = 56,
+            eUseCounter_SetAttributeNodeNS = 57,
+            eUseCounter_RemoveAttributeNode = 58,
+            eUseCounter_CreateAttribute = 59,
+            eUseCounter_CreateAttributeNS = 60,
+            eUseCounter_NodeValue = 61,
+            eUseCounter_TextContent = 62,
+            eUseCounter_EnablePrivilege = 63,
+            eUseCounter_DOMExceptionCode = 64,
+            eUseCounter_NoExposedProps = 65,
+            eUseCounter_MutationEvent = 66,
+            eUseCounter_Components = 67,
+            eUseCounter_PrefixedVisibilityAPI = 68,
+            eUseCounter_NodeIteratorDetach = 69,
+            eUseCounter_LenientThis = 70,
+            eUseCounter_GetPreventDefault = 71,
+            eUseCounter_GetSetUserData = 72,
+            eUseCounter_MozGetAsFile = 73,
+            eUseCounter_UseOfCaptureEvents = 74,
+            eUseCounter_UseOfReleaseEvents = 75,
+            eUseCounter_UseOfDOM3LoadMethod = 76,
+            eUseCounter_ChromeUseOfDOM3LoadMethod = 77,
+            eUseCounter_ShowModalDialog = 78,
+            eUseCounter_Window_Content = 79,
+            eUseCounter_SyncXMLHttpRequest = 80,
+            eUseCounter_Window_Cc_ontrollers = 81,
+            eUseCounter_ImportXULIntoContent = 82,
+            eUseCounter_PannerNodeDoppler = 83,
+            eUseCounter_NavigatorGetUserMedia = 84,
+            eUseCounter_WebrtcDeprecatedPrefix = 85,
+            eUseCounter_RTCPeerConnectionGetStreams = 86,
+            eUseCounter_AppCache = 87,
+            eUseCounter_PrefixedImageSmoothingEnabled = 88,
+            eUseCounter_PrefixedFullscreenAPI = 89,
+            eUseCounter_LenientSetter = 90,
+            eUseCounter_FileLastModifiedDate = 91,
+            eUseCounter_ImageBitmapRenderingContext_TransferImageBitmap = 92,
+            eUseCounter_URLCreateObjectURL_MediaStream = 93,
+            eUseCounter_XMLBaseAttribute = 94,
+            eUseCounter_XMLBaseAttributeForStyleAttr = 95,
+            eUseCounter_Count = 96,
         }
         #[repr(C)]
         #[derive(Debug)]
@@ -7583,6 +7583,127 @@ pub mod root {
         pub const SERVO_PREF_ENABLED_overflow_wrap: bool = false;
         pub const SERVO_PREF_ENABLED_writing_mode: bool = false;
         pub const SERVO_PREF_ENABLED_z_index: bool = false;
+        pub const SERVO_PREF_ENABLED_word_wrap: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_transform_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_perspective_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_perspective: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transform_style: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_backface_visibility: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_border_image: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transition: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transition_delay: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transition_duration: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transition_property: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transition_timing_function: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__moz_animation: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_delay: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_direction: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_duration: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_fill_mode: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_iteration_count: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__moz_animation_name: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_play_state: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_timing_function: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__moz_box_sizing: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_font_feature_settings: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_font_language_override: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_padding_end: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_padding_start: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_margin_end: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_margin_start: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_end: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_end_color: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_end_style: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_end_width: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_start: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_start_color: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_start_style: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_start_width: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_hyphens: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_count: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_fill: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_gap: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_rule: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_rule_color: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_rule_style: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_rule_width: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_width: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_columns: bool = false;
+        pub const SERVO_PREF_ENABLED__webkit_animation: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_delay: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_direction: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_duration: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_fill_mode: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_iteration_count: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_name: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_play_state: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_timing_function: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_filter: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_text_size_adjust: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transform: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transform_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transform_style: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_backface_visibility: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_perspective: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_perspective_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transition: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transition_delay: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transition_duration: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transition_property: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transition_timing_function: bool
+                  =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_border_radius: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_border_top_left_radius: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_border_top_right_radius: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_border_bottom_left_radius: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_border_bottom_right_radius: bool
+                  =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_background_clip: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_background_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_background_size: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_border_image: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_shadow: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_sizing: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_flex: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_ordinal_group: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_orient: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_direction: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_align: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_pack: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_direction: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_wrap: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_flow: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_order: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_grow: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_shrink: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_basis: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_justify_content: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_align_items: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_align_self: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_align_content: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_user_select: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_clip: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_composite: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_image: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_position: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_position_x: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_position_y: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_repeat: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_size: bool = true;
         /// This class holds all non-tree-structural state of an element that might be
         /// used for selector matching eventually.
         ///
@@ -16139,7 +16260,8 @@ pub mod root {
         ParserHasNotified = 28,
         MayBeApzAware = 29,
         ElementMayHaveAnonymousChildren = 30,
-        BooleanFlagCount = 31,
+        NodeMayHaveChildrenWithLayoutBoxesDisabled = 31,
+        BooleanFlagCount = 32,
     }
     #[repr(C)]
     #[derive(Debug, Copy)]
@@ -33669,7 +33791,7 @@ pub mod root {
                    root::nsTArray<root::mozilla::gfx::FontVariation> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_228218_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_228717_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsCSSSelector>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34025,7 +34147,7 @@ pub mod root {
                    root::mozilla::binding_danger::TErrorResult ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_230049_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_230548_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34186,7 +34308,7 @@ pub mod root {
                    root::JS::DeletePolicy ) ));
     }
     #[test]
-    fn __bindgen_test_layout_iterator_open0_input_iterator_tag_UniquePtr_open1_JSErrorNotes_Note_DeletePolicy_open2_JSErrorNotes_Note_close2_close1_long__bindgen_ty_id_235668__bindgen_ty_id_235675_close0_instantiation() {
+    fn __bindgen_test_layout_iterator_open0_input_iterator_tag_UniquePtr_open1_JSErrorNotes_Note_DeletePolicy_open2_JSErrorNotes_Note_close2_close1_long__bindgen_ty_id_236167__bindgen_ty_id_236174_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::std::iterator>() , 1usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34434,7 +34556,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::StyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_238167_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_238666_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34502,7 +34624,7 @@ pub mod root {
                    root::nsCOMPtr<root::nsIObserver> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_238469_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_238968_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34614,7 +34736,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::URLExtraData> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_NotNull_open0__bindgen_ty_id_239011_close0_instantiation() {
+    fn __bindgen_test_layout_NotNull_open0__bindgen_ty_id_239510_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::mozilla::NotNull<*const root::mozilla::Encoding>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35018,7 +35140,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::StyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239432_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239931_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35108,7 +35230,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239831_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_240330_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35209,7 +35331,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_240802_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_241301_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35298,7 +35420,7 @@ pub mod root {
                    root::RefPtr<root::nsCSSFontFaceRule> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_241107_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_241606_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35309,7 +35431,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_241112_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_241611_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35366,7 +35488,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::CSSStyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_241603_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_242102_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36014,7 +36136,7 @@ pub mod root {
                    root::nsCOMPtr<root::nsIWeakReference> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_244459_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_244958_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut ::std::os::raw::c_void>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36093,7 +36215,7 @@ pub mod root {
                    root::mozilla::DefaultDelete ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_250749_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_251248_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::AudioContext>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36126,7 +36248,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::dom::CallbackObject> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_Heap_open0__bindgen_ty_id_251918_close0_instantiation() {
+    fn __bindgen_test_layout_Heap_open0__bindgen_ty_id_252417_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::JS::Heap<*mut root::JSObject>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36137,7 +36259,7 @@ pub mod root {
                    root::JS::Heap<*mut root::JSObject> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_Heap_open0__bindgen_ty_id_251922_close0_instantiation() {
+    fn __bindgen_test_layout_Heap_open0__bindgen_ty_id_252421_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::JS::Heap<*mut root::JSObject>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36159,7 +36281,7 @@ pub mod root {
                    root::nsCOMPtr<root::nsIGlobalObject> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_TenuredHeap_open0__bindgen_ty_id_251929_close0_instantiation() {
+    fn __bindgen_test_layout_TenuredHeap_open0__bindgen_ty_id_252428_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::JS::TenuredHeap>() , 8usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36238,7 +36360,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_253034_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_253533_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsISupports>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36433,7 +36555,7 @@ pub mod root {
                    root::nsTArray<f64> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_254482_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_254981_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36538,7 +36660,7 @@ pub mod root {
                    root::nsRefPtrHashKey<root::nsIAtom> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_256911_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_257410_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::CounterStyle>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37239,7 +37361,7 @@ pub mod root {
                    root::RefPtr<root::nsStyleImageRequest> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_259466_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_259968_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsISupports>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37476,7 +37598,7 @@ pub mod root {
                    root::nsCOMPtr<root::nsIURI> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_267278_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_267780_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37487,7 +37609,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_267283_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_267785_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37575,7 +37697,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::dom::ShadowRoot> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_267396_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_267898_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37862,7 +37984,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_268982_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_269484_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37884,7 +38006,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::dom::Element> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_269144_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_269646_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37895,7 +38017,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_269149_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_269651_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -38027,7 +38149,7 @@ pub mod root {
                    root::nsTArray<root::mozilla::gfx::FontVariation> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_271684_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_272182_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::css::DocumentRule>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -38038,7 +38160,7 @@ pub mod root {
                    root::nsTArray<*mut root::mozilla::css::DocumentRule> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_271692_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_272190_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::css::DocumentRule>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (

--- a/components/style/gecko/generated/structs_release.rs
+++ b/components/style/gecko/generated/structs_release.rs
@@ -299,11 +299,6 @@ pub mod root {
     pub const NS_STYLE_BORDER_IMAGE_REPEAT_SPACE: ::std::os::raw::c_uint = 3;
     pub const NS_STYLE_BORDER_IMAGE_SLICE_NOFILL: ::std::os::raw::c_uint = 0;
     pub const NS_STYLE_BORDER_IMAGE_SLICE_FILL: ::std::os::raw::c_uint = 1;
-    pub const NS_STYLE_CONTENT_OPEN_QUOTE: ::std::os::raw::c_uint = 0;
-    pub const NS_STYLE_CONTENT_CLOSE_QUOTE: ::std::os::raw::c_uint = 1;
-    pub const NS_STYLE_CONTENT_NO_OPEN_QUOTE: ::std::os::raw::c_uint = 2;
-    pub const NS_STYLE_CONTENT_NO_CLOSE_QUOTE: ::std::os::raw::c_uint = 3;
-    pub const NS_STYLE_CONTENT_ALT_CONTENT: ::std::os::raw::c_uint = 4;
     pub const NS_STYLE_CURSOR_AUTO: ::std::os::raw::c_uint = 1;
     pub const NS_STYLE_CURSOR_CROSSHAIR: ::std::os::raw::c_uint = 2;
     pub const NS_STYLE_CURSOR_DEFAULT: ::std::os::raw::c_uint = 3;
@@ -6191,91 +6186,96 @@ pub mod root {
             eUseCounter_property_FillOpacity = 4,
             eUseCounter_XMLDocument_async_getter = 5,
             eUseCounter_XMLDocument_async_setter = 6,
-            eUseCounter_PushManager_subscribe = 7,
-            eUseCounter_PushSubscription_unsubscribe = 8,
-            eUseCounter_Window_sidebar_getter = 9,
-            eUseCounter_Window_sidebar_setter = 10,
-            eUseCounter_External_addSearchEngine = 11,
-            eUseCounter_OfflineResourceList_swapCache = 12,
-            eUseCounter_OfflineResourceList_update = 13,
-            eUseCounter_OfflineResourceList_status_getter = 14,
-            eUseCounter_OfflineResourceList_status_setter = 15,
-            eUseCounter_OfflineResourceList_onchecking_getter = 16,
-            eUseCounter_OfflineResourceList_onchecking_setter = 17,
-            eUseCounter_OfflineResourceList_onerror_getter = 18,
-            eUseCounter_OfflineResourceList_onerror_setter = 19,
-            eUseCounter_OfflineResourceList_onnoupdate_getter = 20,
-            eUseCounter_OfflineResourceList_onnoupdate_setter = 21,
-            eUseCounter_OfflineResourceList_ondownloading_getter = 22,
-            eUseCounter_OfflineResourceList_ondownloading_setter = 23,
-            eUseCounter_OfflineResourceList_onprogress_getter = 24,
-            eUseCounter_OfflineResourceList_onprogress_setter = 25,
-            eUseCounter_OfflineResourceList_onupdateready_getter = 26,
-            eUseCounter_OfflineResourceList_onupdateready_setter = 27,
-            eUseCounter_OfflineResourceList_oncached_getter = 28,
-            eUseCounter_OfflineResourceList_oncached_setter = 29,
-            eUseCounter_OfflineResourceList_onobsolete_getter = 30,
-            eUseCounter_OfflineResourceList_onobsolete_setter = 31,
-            eUseCounter_IDBDatabase_createMutableFile = 32,
-            eUseCounter_IDBDatabase_mozCreateFileHandle = 33,
-            eUseCounter_IDBMutableFile_open = 34,
-            eUseCounter_IDBMutableFile_getFile = 35,
-            eUseCounter_DataTransfer_addElement = 36,
-            eUseCounter_DataTransfer_mozItemCount_getter = 37,
-            eUseCounter_DataTransfer_mozItemCount_setter = 38,
-            eUseCounter_DataTransfer_mozCursor_getter = 39,
-            eUseCounter_DataTransfer_mozCursor_setter = 40,
-            eUseCounter_DataTransfer_mozTypesAt = 41,
-            eUseCounter_DataTransfer_mozClearDataAt = 42,
-            eUseCounter_DataTransfer_mozSetDataAt = 43,
-            eUseCounter_DataTransfer_mozGetDataAt = 44,
-            eUseCounter_DataTransfer_mozUserCancelled_getter = 45,
-            eUseCounter_DataTransfer_mozUserCancelled_setter = 46,
-            eUseCounter_DataTransfer_mozSourceNode_getter = 47,
-            eUseCounter_DataTransfer_mozSourceNode_setter = 48,
-            eUseCounter_GetAttributeNode = 49,
-            eUseCounter_SetAttributeNode = 50,
-            eUseCounter_GetAttributeNodeNS = 51,
-            eUseCounter_SetAttributeNodeNS = 52,
-            eUseCounter_RemoveAttributeNode = 53,
-            eUseCounter_CreateAttribute = 54,
-            eUseCounter_CreateAttributeNS = 55,
-            eUseCounter_NodeValue = 56,
-            eUseCounter_TextContent = 57,
-            eUseCounter_EnablePrivilege = 58,
-            eUseCounter_DOMExceptionCode = 59,
-            eUseCounter_NoExposedProps = 60,
-            eUseCounter_MutationEvent = 61,
-            eUseCounter_Components = 62,
-            eUseCounter_PrefixedVisibilityAPI = 63,
-            eUseCounter_NodeIteratorDetach = 64,
-            eUseCounter_LenientThis = 65,
-            eUseCounter_GetPreventDefault = 66,
-            eUseCounter_GetSetUserData = 67,
-            eUseCounter_MozGetAsFile = 68,
-            eUseCounter_UseOfCaptureEvents = 69,
-            eUseCounter_UseOfReleaseEvents = 70,
-            eUseCounter_UseOfDOM3LoadMethod = 71,
-            eUseCounter_ChromeUseOfDOM3LoadMethod = 72,
-            eUseCounter_ShowModalDialog = 73,
-            eUseCounter_Window_Content = 74,
-            eUseCounter_SyncXMLHttpRequest = 75,
-            eUseCounter_Window_Cc_ontrollers = 76,
-            eUseCounter_ImportXULIntoContent = 77,
-            eUseCounter_PannerNodeDoppler = 78,
-            eUseCounter_NavigatorGetUserMedia = 79,
-            eUseCounter_WebrtcDeprecatedPrefix = 80,
-            eUseCounter_RTCPeerConnectionGetStreams = 81,
-            eUseCounter_AppCache = 82,
-            eUseCounter_PrefixedImageSmoothingEnabled = 83,
-            eUseCounter_PrefixedFullscreenAPI = 84,
-            eUseCounter_LenientSetter = 85,
-            eUseCounter_FileLastModifiedDate = 86,
-            eUseCounter_ImageBitmapRenderingContext_TransferImageBitmap = 87,
-            eUseCounter_URLCreateObjectURL_MediaStream = 88,
-            eUseCounter_XMLBaseAttribute = 89,
-            eUseCounter_XMLBaseAttributeForStyleAttr = 90,
-            eUseCounter_Count = 91,
+            eUseCounter_DOMError_name_getter = 7,
+            eUseCounter_DOMError_name_setter = 8,
+            eUseCounter_DOMError_message_getter = 9,
+            eUseCounter_DOMError_message_setter = 10,
+            eUseCounter_custom_DOMErrorConstructor = 11,
+            eUseCounter_PushManager_subscribe = 12,
+            eUseCounter_PushSubscription_unsubscribe = 13,
+            eUseCounter_Window_sidebar_getter = 14,
+            eUseCounter_Window_sidebar_setter = 15,
+            eUseCounter_External_addSearchEngine = 16,
+            eUseCounter_OfflineResourceList_swapCache = 17,
+            eUseCounter_OfflineResourceList_update = 18,
+            eUseCounter_OfflineResourceList_status_getter = 19,
+            eUseCounter_OfflineResourceList_status_setter = 20,
+            eUseCounter_OfflineResourceList_onchecking_getter = 21,
+            eUseCounter_OfflineResourceList_onchecking_setter = 22,
+            eUseCounter_OfflineResourceList_onerror_getter = 23,
+            eUseCounter_OfflineResourceList_onerror_setter = 24,
+            eUseCounter_OfflineResourceList_onnoupdate_getter = 25,
+            eUseCounter_OfflineResourceList_onnoupdate_setter = 26,
+            eUseCounter_OfflineResourceList_ondownloading_getter = 27,
+            eUseCounter_OfflineResourceList_ondownloading_setter = 28,
+            eUseCounter_OfflineResourceList_onprogress_getter = 29,
+            eUseCounter_OfflineResourceList_onprogress_setter = 30,
+            eUseCounter_OfflineResourceList_onupdateready_getter = 31,
+            eUseCounter_OfflineResourceList_onupdateready_setter = 32,
+            eUseCounter_OfflineResourceList_oncached_getter = 33,
+            eUseCounter_OfflineResourceList_oncached_setter = 34,
+            eUseCounter_OfflineResourceList_onobsolete_getter = 35,
+            eUseCounter_OfflineResourceList_onobsolete_setter = 36,
+            eUseCounter_IDBDatabase_createMutableFile = 37,
+            eUseCounter_IDBDatabase_mozCreateFileHandle = 38,
+            eUseCounter_IDBMutableFile_open = 39,
+            eUseCounter_IDBMutableFile_getFile = 40,
+            eUseCounter_DataTransfer_addElement = 41,
+            eUseCounter_DataTransfer_mozItemCount_getter = 42,
+            eUseCounter_DataTransfer_mozItemCount_setter = 43,
+            eUseCounter_DataTransfer_mozCursor_getter = 44,
+            eUseCounter_DataTransfer_mozCursor_setter = 45,
+            eUseCounter_DataTransfer_mozTypesAt = 46,
+            eUseCounter_DataTransfer_mozClearDataAt = 47,
+            eUseCounter_DataTransfer_mozSetDataAt = 48,
+            eUseCounter_DataTransfer_mozGetDataAt = 49,
+            eUseCounter_DataTransfer_mozUserCancelled_getter = 50,
+            eUseCounter_DataTransfer_mozUserCancelled_setter = 51,
+            eUseCounter_DataTransfer_mozSourceNode_getter = 52,
+            eUseCounter_DataTransfer_mozSourceNode_setter = 53,
+            eUseCounter_GetAttributeNode = 54,
+            eUseCounter_SetAttributeNode = 55,
+            eUseCounter_GetAttributeNodeNS = 56,
+            eUseCounter_SetAttributeNodeNS = 57,
+            eUseCounter_RemoveAttributeNode = 58,
+            eUseCounter_CreateAttribute = 59,
+            eUseCounter_CreateAttributeNS = 60,
+            eUseCounter_NodeValue = 61,
+            eUseCounter_TextContent = 62,
+            eUseCounter_EnablePrivilege = 63,
+            eUseCounter_DOMExceptionCode = 64,
+            eUseCounter_NoExposedProps = 65,
+            eUseCounter_MutationEvent = 66,
+            eUseCounter_Components = 67,
+            eUseCounter_PrefixedVisibilityAPI = 68,
+            eUseCounter_NodeIteratorDetach = 69,
+            eUseCounter_LenientThis = 70,
+            eUseCounter_GetPreventDefault = 71,
+            eUseCounter_GetSetUserData = 72,
+            eUseCounter_MozGetAsFile = 73,
+            eUseCounter_UseOfCaptureEvents = 74,
+            eUseCounter_UseOfReleaseEvents = 75,
+            eUseCounter_UseOfDOM3LoadMethod = 76,
+            eUseCounter_ChromeUseOfDOM3LoadMethod = 77,
+            eUseCounter_ShowModalDialog = 78,
+            eUseCounter_Window_Content = 79,
+            eUseCounter_SyncXMLHttpRequest = 80,
+            eUseCounter_Window_Cc_ontrollers = 81,
+            eUseCounter_ImportXULIntoContent = 82,
+            eUseCounter_PannerNodeDoppler = 83,
+            eUseCounter_NavigatorGetUserMedia = 84,
+            eUseCounter_WebrtcDeprecatedPrefix = 85,
+            eUseCounter_RTCPeerConnectionGetStreams = 86,
+            eUseCounter_AppCache = 87,
+            eUseCounter_PrefixedImageSmoothingEnabled = 88,
+            eUseCounter_PrefixedFullscreenAPI = 89,
+            eUseCounter_LenientSetter = 90,
+            eUseCounter_FileLastModifiedDate = 91,
+            eUseCounter_ImageBitmapRenderingContext_TransferImageBitmap = 92,
+            eUseCounter_URLCreateObjectURL_MediaStream = 93,
+            eUseCounter_XMLBaseAttribute = 94,
+            eUseCounter_XMLBaseAttributeForStyleAttr = 95,
+            eUseCounter_Count = 96,
         }
         #[repr(C)]
         #[derive(Debug)]
@@ -7437,6 +7437,127 @@ pub mod root {
         pub const SERVO_PREF_ENABLED_overflow_wrap: bool = false;
         pub const SERVO_PREF_ENABLED_writing_mode: bool = false;
         pub const SERVO_PREF_ENABLED_z_index: bool = false;
+        pub const SERVO_PREF_ENABLED_word_wrap: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_transform_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_perspective_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_perspective: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transform_style: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_backface_visibility: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_border_image: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transition: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transition_delay: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transition_duration: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transition_property: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_transition_timing_function: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__moz_animation: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_delay: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_direction: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_duration: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_fill_mode: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_iteration_count: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__moz_animation_name: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_play_state: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_animation_timing_function: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__moz_box_sizing: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_font_feature_settings: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_font_language_override: bool = true;
+        pub const SERVO_PREF_ENABLED__moz_padding_end: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_padding_start: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_margin_end: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_margin_start: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_end: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_end_color: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_end_style: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_end_width: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_start: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_start_color: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_start_style: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_border_start_width: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_hyphens: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_count: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_fill: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_gap: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_rule: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_rule_color: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_rule_style: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_rule_width: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_column_width: bool = false;
+        pub const SERVO_PREF_ENABLED__moz_columns: bool = false;
+        pub const SERVO_PREF_ENABLED__webkit_animation: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_delay: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_direction: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_duration: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_fill_mode: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_iteration_count: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_name: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_play_state: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_animation_timing_function: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_filter: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_text_size_adjust: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transform: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transform_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transform_style: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_backface_visibility: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_perspective: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_perspective_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transition: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transition_delay: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transition_duration: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transition_property: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_transition_timing_function: bool
+                  =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_border_radius: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_border_top_left_radius: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_border_top_right_radius: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_border_bottom_left_radius: bool =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_border_bottom_right_radius: bool
+                  =
+            true;
+        pub const SERVO_PREF_ENABLED__webkit_background_clip: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_background_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_background_size: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_border_image: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_shadow: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_sizing: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_flex: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_ordinal_group: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_orient: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_direction: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_align: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_box_pack: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_direction: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_wrap: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_flow: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_order: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_grow: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_shrink: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_flex_basis: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_justify_content: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_align_items: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_align_self: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_align_content: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_user_select: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_clip: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_composite: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_image: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_origin: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_position: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_position_x: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_position_y: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_repeat: bool = true;
+        pub const SERVO_PREF_ENABLED__webkit_mask_size: bool = true;
         /// This class holds all non-tree-structural state of an element that might be
         /// used for selector matching eventually.
         ///
@@ -15930,7 +16051,8 @@ pub mod root {
         ParserHasNotified = 28,
         MayBeApzAware = 29,
         ElementMayHaveAnonymousChildren = 30,
-        BooleanFlagCount = 31,
+        NodeMayHaveChildrenWithLayoutBoxesDisabled = 31,
+        BooleanFlagCount = 32,
     }
     #[repr(C)]
     #[derive(Debug, Copy)]
@@ -33177,7 +33299,7 @@ pub mod root {
                    root::nsTArray<root::mozilla::gfx::FontVariation> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_225850_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_226349_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsCSSSelector>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33533,7 +33655,7 @@ pub mod root {
                    root::mozilla::binding_danger::TErrorResult ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_227647_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_228146_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33694,7 +33816,7 @@ pub mod root {
                    root::JS::DeletePolicy ) ));
     }
     #[test]
-    fn __bindgen_test_layout_iterator_open0_input_iterator_tag_UniquePtr_open1_JSErrorNotes_Note_DeletePolicy_open2_JSErrorNotes_Note_close2_close1_long__bindgen_ty_id_233238__bindgen_ty_id_233245_close0_instantiation() {
+    fn __bindgen_test_layout_iterator_open0_input_iterator_tag_UniquePtr_open1_JSErrorNotes_Note_DeletePolicy_open2_JSErrorNotes_Note_close2_close1_long__bindgen_ty_id_233737__bindgen_ty_id_233744_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::std::iterator>() , 1usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33942,7 +34064,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::StyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_235735_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236234_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34010,7 +34132,7 @@ pub mod root {
                    root::nsCOMPtr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236037_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236536_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34122,7 +34244,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::URLExtraData> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_NotNull_open0__bindgen_ty_id_236579_close0_instantiation() {
+    fn __bindgen_test_layout_NotNull_open0__bindgen_ty_id_237078_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::mozilla::NotNull<*const root::mozilla::Encoding>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34524,7 +34646,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::StyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236998_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_237497_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34614,7 +34736,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_237395_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_237894_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34715,7 +34837,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_238356_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_238855_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34804,7 +34926,7 @@ pub mod root {
                    root::RefPtr<root::nsCSSFontFaceRule> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_238659_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239158_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34815,7 +34937,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_238664_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239163_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34872,7 +34994,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::CSSStyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239139_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239638_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35507,7 +35629,7 @@ pub mod root {
                    root::nsCOMPtr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_241965_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_242464_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut ::std::os::raw::c_void>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35586,7 +35708,7 @@ pub mod root {
                    root::mozilla::DefaultDelete ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_248238_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_248737_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::AudioContext>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35619,7 +35741,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::dom::CallbackObject> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_Heap_open0__bindgen_ty_id_249407_close0_instantiation() {
+    fn __bindgen_test_layout_Heap_open0__bindgen_ty_id_249906_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::JS::Heap<*mut root::JSObject>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35630,7 +35752,7 @@ pub mod root {
                    root::JS::Heap<*mut root::JSObject> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_Heap_open0__bindgen_ty_id_249411_close0_instantiation() {
+    fn __bindgen_test_layout_Heap_open0__bindgen_ty_id_249910_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::JS::Heap<*mut root::JSObject>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35652,7 +35774,7 @@ pub mod root {
                    root::nsCOMPtr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_TenuredHeap_open0__bindgen_ty_id_249418_close0_instantiation() {
+    fn __bindgen_test_layout_TenuredHeap_open0__bindgen_ty_id_249917_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::JS::TenuredHeap>() , 8usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35731,7 +35853,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_250523_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_251022_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsISupports>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35926,7 +36048,7 @@ pub mod root {
                    root::nsTArray<f64> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_251971_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_252470_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36031,7 +36153,7 @@ pub mod root {
                    root::nsRefPtrHashKey<root::nsIAtom> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_254365_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_254864_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::CounterStyle>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36732,7 +36854,7 @@ pub mod root {
                    root::RefPtr<root::nsStyleImageRequest> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_256844_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_257346_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsISupports>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36969,7 +37091,7 @@ pub mod root {
                    root::nsCOMPtr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_264656_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_265158_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36980,7 +37102,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_264661_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_265163_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37068,7 +37190,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::dom::ShadowRoot> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_264774_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_265276_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37355,7 +37477,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_266354_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_266856_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37377,7 +37499,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::dom::Element> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_266512_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_267014_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37388,7 +37510,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_266517_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_267019_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37520,7 +37642,7 @@ pub mod root {
                    root::nsTArray<root::mozilla::gfx::FontVariation> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_269042_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_269540_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::css::DocumentRule>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37531,7 +37653,7 @@ pub mod root {
                    root::nsTArray<*mut root::mozilla::css::DocumentRule> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_269048_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_269546_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::css::DocumentRule>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -947,7 +947,8 @@ impl<'a, 'b, 'i> DeclarationParser<'i> for PropertyDeclarationParser<'a, 'b> {
 
     fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                        -> Result<Importance, ParseError<'i>> {
-        let id = match PropertyId::parse(&name) {
+        let prop_context = PropertyParserContext::new(self.context);
+        let id = match PropertyId::parse(&name, Some(&prop_context)) {
             Ok(id) => id,
             Err(()) => {
                 return Err(if is_non_mozilla_vendor_identifier(&name) {

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3505,7 +3505,7 @@ fn static_assert() {
                         Gecko_AppendWillChange(&mut self.gecko, feature.0.as_ptr());
                     }
 
-                    if let Ok(prop_id) = PropertyId::parse(&feature.0.to_string()) {
+                    if let Ok(prop_id) = PropertyId::parse(&feature.0.to_string(), None) {
                         match prop_id.as_shorthand() {
                             Ok(shorthand) => {
                                 for longhand in shorthand.longhands() {

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -8,7 +8,7 @@ use cssparser::{AtRuleParser, Parser, QualifiedRuleParser, RuleListParser, Parse
 use cssparser::{DeclarationListParser, DeclarationParser, parse_one_rule, SourceLocation};
 use error_reporting::{NullReporter, ContextualParseError};
 use parser::ParserContext;
-use properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, PropertyId};
+use properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, PropertyId, PropertyParserContext};
 use properties::{PropertyDeclarationId, LonghandId, SourcePropertyDeclaration};
 use properties::LonghandIdSet;
 use properties::animated_properties::AnimatableLonghand;
@@ -532,7 +532,9 @@ impl<'a, 'b, 'i> DeclarationParser<'i> for KeyframeDeclarationParser<'a, 'b> {
 
     fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                        -> Result<(), ParseError<'i>> {
-        let id = PropertyId::parse(&name)
+        let property_context = PropertyParserContext::new(self.context);
+
+        let id = PropertyId::parse(&name, Some(&property_context))
             .map_err(|()| PropertyDeclarationParseError::UnknownProperty(name))?;
         match PropertyDeclaration::parse_into(self.declarations, id, self.context, input) {
             Ok(()) => {

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2190,7 +2190,7 @@ pub extern "C" fn Servo_DeclarationBlock_GetNthProperty(declarations: RawServoDe
 macro_rules! get_property_id_from_property {
     ($property: ident, $ret: expr) => {{
         let property = unsafe { $property.as_ref().unwrap().as_str_unchecked() };
-        match PropertyId::parse(property.into()) {
+        match PropertyId::parse(property.into(), None) {
             Ok(property_id) => property_id,
             Err(_) => { return $ret; }
         }


### PR DESCRIPTION
This pr reviewed by Manishearth and xidorn in bugzilla.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1344314](https://bugzilla.mozilla.org/show_bug.cgi?id=1344314)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18115)
<!-- Reviewable:end -->
