### PR TITLE
Fix the broken links to the page of the Rust Programming Language

### DIFF
--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -60,7 +60,7 @@ This guide only covers the most important options. Be sure to look at all the av
 
 Even if you have never seen any Rust code, it's not too hard to read Servo's code. But there are some basics things one must know:
 
-- [Match](https://doc.rust-lang.org/book/match.html) and [Patterns](https://doc.rust-lang.org/book/patterns.html)
+- [Match](https://doc.rust-lang.org/book/first-edition/match.html) and [Patterns](https://doc.rust-lang.org/book/first-edition/patterns.html)
 - [Options](http://rustbyexample.com/std/option.html)
 - [Expression](http://rustbyexample.com/expression.html)
 - [Traits](http://rustbyexample.com/trait.html)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
We need to update the links of Match and Patterns in Some basic
Rust section.
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it updates the wiki page.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18120)
<!-- Reviewable:end -->
