### PR TITLE
Use Option<RGBA> for color in shadow

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1411,7 +1411,7 @@ impl FragmentDisplayListBuilding for Fragment {
             state.add_display_item(DisplayItem::BoxShadow(box BoxShadowDisplayItem {
                 base: base,
                 box_bounds: *absolute_bounds,
-                color: style.resolve_color(box_shadow.base.color).to_gfx_color(),
+                color: box_shadow.base.color.unwrap_or(style.get_color().color).to_gfx_color(),
                 offset: Vector2D::new(box_shadow.base.horizontal, box_shadow.base.vertical),
                 blur_radius: box_shadow.base.blur.0,
                 spread_radius: box_shadow.spread,
@@ -2133,7 +2133,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 base: base.clone(),
                 blur_radius: shadow.blur.0,
                 offset: Vector2D::new(shadow.horizontal, shadow.vertical),
-                color: self.style().resolve_color(shadow.color).to_gfx_color(),
+                color: shadow.color.unwrap_or(self.style().get_color().color).to_gfx_color(),
             }));
         }
 

--- a/components/style/gecko_bindings/sugar/ns_css_shadow_item.rs
+++ b/components/style/gecko_bindings/sugar/ns_css_shadow_item.rs
@@ -7,7 +7,7 @@
 use app_units::Au;
 use gecko::values::{convert_rgba_to_nscolor, convert_nscolor_to_rgba};
 use gecko_bindings::structs::nsCSSShadowItem;
-use values::computed::Color;
+use values::computed::RGBAColor;
 use values::computed::effects::{BoxShadow, SimpleShadow};
 
 impl nsCSSShadowItem {
@@ -37,23 +37,23 @@ impl nsCSSShadowItem {
         self.mRadius = shadow.blur.value();
         self.mSpread = 0;
         self.mInset = false;
-        if shadow.color.is_currentcolor() {
+        if let Some(color) = shadow.color {
+            self.mHasColor = true;
+            self.mColor = convert_rgba_to_nscolor(&color);
+        } else {
             // TODO handle currentColor
             // https://bugzilla.mozilla.org/show_bug.cgi?id=760345
             self.mHasColor = false;
             self.mColor = 0;
-        } else {
-            self.mHasColor = true;
-            self.mColor = convert_rgba_to_nscolor(&shadow.color.color);
         }
     }
 
     #[inline]
-    fn extract_color(&self) -> Color {
+    fn extract_color(&self) -> Option<RGBAColor> {
         if self.mHasColor {
-            Color::rgba(convert_nscolor_to_rgba(self.mColor))
+            Some(convert_nscolor_to_rgba(self.mColor))
         } else {
-            Color::currentcolor()
+            None
         }
     }
 

--- a/components/style/values/animated/effects.rs
+++ b/components/style/values/animated/effects.rs
@@ -12,7 +12,7 @@ use std::cmp;
 #[cfg(not(feature = "gecko"))]
 use values::Impossible;
 use values::animated::{ToAnimatedValue, ToAnimatedZero};
-use values::animated::color::Color;
+use values::animated::color::RGBA;
 use values::computed::{Angle, NonNegativeNumber};
 use values::computed::length::{Length, NonNegativeLength};
 use values::distance::{ComputeSquaredDistance, SquaredDistance};
@@ -34,7 +34,7 @@ pub type TextShadowList = ShadowList<SimpleShadow>;
 pub struct ShadowList<Shadow>(Vec<Shadow>);
 
 /// An animated value for a single `box-shadow`.
-pub type BoxShadow = GenericBoxShadow<Color, Length, NonNegativeLength, Length>;
+pub type BoxShadow = GenericBoxShadow<Option<RGBA>, Length, NonNegativeLength, Length>;
 
 /// An animated value for the `filter` property.
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
@@ -50,7 +50,7 @@ pub type Filter = GenericFilter<Angle, NonNegativeNumber, NonNegativeLength, Sim
 pub type Filter = GenericFilter<Angle, NonNegativeNumber, NonNegativeLength, Impossible>;
 
 /// An animated value for the `drop-shadow()` filter.
-pub type SimpleShadow = GenericSimpleShadow<Color, Length, NonNegativeLength>;
+pub type SimpleShadow = GenericSimpleShadow<Option<RGBA>, Length, NonNegativeLength>;
 
 impl ToAnimatedValue for ComputedBoxShadowList {
     type AnimatedValue = BoxShadowList;
@@ -245,7 +245,7 @@ impl ToAnimatedZero for SimpleShadow {
     #[inline]
     fn to_animated_zero(&self) -> Result<Self, ()> {
         Ok(SimpleShadow {
-            color: Color::transparent(),
+            color: Some(RGBA::transparent()),
             horizontal: self.horizontal.to_animated_zero()?,
             vertical: self.vertical.to_animated_zero()?,
             blur: self.blur.to_animated_zero()?,

--- a/components/style/values/computed/effects.rs
+++ b/components/style/values/computed/effects.rs
@@ -7,14 +7,14 @@
 #[cfg(not(feature = "gecko"))]
 use values::Impossible;
 use values::computed::{Angle, NonNegativeNumber};
-use values::computed::color::Color;
+use values::computed::color::RGBAColor;
 use values::computed::length::{Length, NonNegativeLength};
 use values::generics::effects::BoxShadow as GenericBoxShadow;
 use values::generics::effects::Filter as GenericFilter;
 use values::generics::effects::SimpleShadow as GenericSimpleShadow;
 
 /// A computed value for a single shadow of the `box-shadow` property.
-pub type BoxShadow = GenericBoxShadow<Color, Length, NonNegativeLength, Length>;
+pub type BoxShadow = GenericBoxShadow<Option<RGBAColor>, Length, NonNegativeLength, Length>;
 
 /// A computed value for a single `filter`.
 #[cfg(feature = "gecko")]
@@ -25,4 +25,4 @@ pub type Filter = GenericFilter<Angle, NonNegativeNumber, NonNegativeLength, Sim
 pub type Filter = GenericFilter<Angle, NonNegativeNumber, NonNegativeLength, Impossible>;
 
 /// A computed value for the `drop-shadow()` filter.
-pub type SimpleShadow = GenericSimpleShadow<Color, Length, NonNegativeLength>;
+pub type SimpleShadow = GenericSimpleShadow<Option<RGBAColor>, Length, NonNegativeLength>;


### PR DESCRIPTION
This fixes [bug 1390697](https://bugzilla.mozilla.org/show_bug.cgi?id=1390697) by downgrading the support of currentcolor in shadow to what Gecko currently supports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18136)
<!-- Reviewable:end -->
