### PR TITLE
Avoid creating a stylo thread pool in e10s parent processes

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1569,6 +1569,9 @@ extern "C" {
     pub fn Gecko_RegisterNamespace(ns: *mut nsIAtom) -> i32;
 }
 extern "C" {
+    pub fn Gecko_ShouldCreateStyleThreadPool() -> bool;
+}
+extern "C" {
     pub fn Gecko_Construct_Default_nsStyleFont(ptr: *mut nsStyleFont,
                                                pres_context:
                                                    RawGeckoPresContextBorrowed);

--- a/components/style/gecko/global_style_data.rs
+++ b/components/style/gecko/global_style_data.rs
@@ -5,6 +5,7 @@
 //! Global style data
 
 use context::StyleSystemOptions;
+use gecko_bindings::bindings;
 use gecko_bindings::bindings::{Gecko_RegisterProfilerThread, Gecko_UnregisterProfilerThread};
 use gecko_bindings::bindings::Gecko_SetJemallocThreadLocalArena;
 use num_cpus;
@@ -78,7 +79,7 @@ lazy_static! {
             }
         }
 
-        let pool = if num_threads < 1 {
+        let pool = if num_threads < 1 || unsafe { !bindings::Gecko_ShouldCreateStyleThreadPool() } {
             None
         } else {
             let configuration = rayon::Configuration::new()


### PR DESCRIPTION
Reviewed in https://bugzilla.mozilla.org/show_bug.cgi?id=1375911

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18137)
<!-- Reviewable:end -->
