### PR TITLE
Update parser state only after rule is successfully parsed

### DIFF
--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -169,7 +169,6 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
                     return Err(StyleParseError::UnexpectedImportRule.into())
                 }
 
-                self.state = State::Imports;
                 let url_string = input.expect_url_or_string()?.as_ref().to_owned();
                 let specified_url = SpecifiedUrl::parse_from_string(url_string, &self.context)?;
 
@@ -187,6 +186,7 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
                     media,
                 );
 
+                self.state = State::Imports;
                 return Ok(AtRuleType::WithoutBlock(CssRule::Import(import_rule)))
             },
             "namespace" => {
@@ -195,7 +195,6 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
                     self.had_hierarchy_error = true;
                     return Err(StyleParseError::UnexpectedNamespaceRule.into())
                 }
-                self.state = State::Namespaces;
 
                 let prefix_result = input.try(|i| i.expect_ident_cloned());
                 let maybe_namespace = match input.expect_url_or_string() {
@@ -220,6 +219,7 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
                     None
                 };
 
+                self.state = State::Namespaces;
                 return Ok(AtRuleType::WithoutBlock(CssRule::Namespace(Arc::new(
                     self.shared_lock.wrap(NamespaceRule {
                         prefix: opt_prefix,
@@ -236,7 +236,6 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
             }
             _ => {}
         }
-        self.state = State::Body;
 
         AtRuleParser::parse_prelude(&mut self.nested(), name, input)
     }
@@ -248,6 +247,7 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
         input: &mut Parser<'i, 't>
     ) -> Result<CssRule, ParseError<'i>> {
         AtRuleParser::parse_block(&mut self.nested(), prelude, input)
+            .map(|rule| { self.state = State::Body; rule })
     }
 }
 
@@ -266,7 +266,6 @@ impl<'a, 'i> QualifiedRuleParser<'i> for TopLevelRuleParser<'a> {
         &mut self,
         input: &mut Parser<'i, 't>,
     ) -> Result<QualifiedRuleParserPrelude, ParseError<'i>> {
-        self.state = State::Body;
         QualifiedRuleParser::parse_prelude(&mut self.nested(), input)
     }
 
@@ -277,6 +276,7 @@ impl<'a, 'i> QualifiedRuleParser<'i> for TopLevelRuleParser<'a> {
         input: &mut Parser<'i, 't>
     ) -> Result<CssRule, ParseError<'i>> {
         QualifiedRuleParser::parse_block(&mut self.nested(), prelude, input)
+            .map(|result| { self.state = State::Body; result })
     }
 }
 

--- a/tests/wpt/metadata-css/css21_dev/html4/at-import-009.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/at-import-009.htm.ini
@@ -1,3 +1,0 @@
-[at-import-009.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/at-import-010.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/at-import-010.htm.ini
@@ -1,3 +1,0 @@
-[at-import-010.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/at-rule-008.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/at-rule-008.htm.ini
@@ -1,3 +1,0 @@
-[at-rule-008.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/at-rule-009.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/at-rule-009.htm.ini
@@ -1,3 +1,0 @@
-[at-rule-009.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
This is expected to fix several web-platform tests mentioned in [bug 1389187](https://bugzilla.mozilla.org/show_bug.cgi?id=1389187).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18139)
<!-- Reviewable:end -->
