### PR TITLE
style: Remove Stylist::is_device_dirty.

### DIFF
--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -437,20 +437,22 @@ pub fn start_transitions_if_applicable(new_animations_sender: &Sender<Animation>
                                                                      old_style,
                                                                      Arc::make_mut(new_style));
         for property_animation in property_animations {
-            // Per [1], don't trigger a new transition if the end state for that transition is
-            // the same as that of a transition that's already running on the same node.
-            //
-            // [1]: https://drafts.csswg.org/css-transitions/#starting
-            if possibly_expired_animations.iter().any(|animation| {
-                    animation.has_the_same_end_value_as(&property_animation)
-                }) {
-                continue
-            }
-
             // Set the property to the initial value.
+            //
             // NB: get_mut is guaranteed to succeed since we called make_mut()
             // above.
             property_animation.update(Arc::get_mut(new_style).unwrap(), 0.0);
+
+            // Per [1], don't trigger a new transition if the end state for that
+            // transition is the same as that of a transition that's already
+            // running on the same node.
+            //
+            // [1]: https://drafts.csswg.org/css-transitions/#starting
+            if possibly_expired_animations.iter().any(|animation| {
+                animation.has_the_same_end_value_as(&property_animation)
+            }) {
+                continue
+            }
 
             // Kick off the animation.
             let box_style = new_style.get_box();

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -24766,7 +24766,7 @@
    "support"
   ],
   "css/offset_properties_inline.html": [
-   "e879ede3d52eed5ebdd90e988380ba4fa365817a",
+   "ed9cf0062ff6b08dc0cc578a0ae6acce146bec10",
    "testharness"
   ],
   "css/ol_japanese_iroha_a.html": [

--- a/tests/wpt/mozilla/tests/css/offset_properties_inline.html
+++ b/tests/wpt/mozilla/tests/css/offset_properties_inline.html
@@ -30,6 +30,7 @@
   -->
 </div>
 <script>
+window.onload = function() {
   var realOffsetParent = document.getElementById('real-offset-parent');
   var inline1 = document.getElementById('inline-1');
   var inline2 = document.getElementById('inline-2');
@@ -79,5 +80,6 @@
     assert_equals(inline3.offsetHeight, 10,
       "offsetHeight of #inline-3 should be 10.");
   }, "offsetHeight");
+}
 </script>
 </body>


### PR DESCRIPTION
More progress on unifying how Gecko and Servo track stylist dirtiness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18143)
<!-- Reviewable:end -->
