### PR TITLE
Handle single X keyword value in LegacyPosition

### DIFF
--- a/components/style/values/specified/position.rs
+++ b/components/style/values/specified/position.rs
@@ -320,11 +320,6 @@ impl LegacyPosition {
                 return Ok(Self::new(x_pos, y_pos));
             },
             Ok(OriginComponent::Side(x_keyword)) => {
-                if input.try(|i| i.expect_ident_matching("center")).is_ok() {
-                    let x_pos = OriginComponent::Side(x_keyword);
-                    let y_pos = OriginComponent::Center;
-                    return Ok(Self::new(x_pos, y_pos));
-                }
                 if let Ok(y_keyword) = input.try(Y::parse) {
                     let x_pos = OriginComponent::Side(x_keyword);
                     let y_pos = OriginComponent::Side(y_keyword);
@@ -334,6 +329,8 @@ impl LegacyPosition {
                 if let Ok(y_lop) = input.try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks)) {
                     return Ok(Self::new(x_pos, OriginComponent::Length(y_lop)))
                 }
+                let _ = input.try(|i| i.expect_ident_matching("center"));
+                return Ok(Self::new(x_pos, OriginComponent::Center));
             },
             Ok(x_pos @ OriginComponent::Length(_)) => {
                 if let Ok(y_keyword) = input.try(Y::parse) {
@@ -344,9 +341,8 @@ impl LegacyPosition {
                     let y_pos = OriginComponent::Length(y_lop);
                     return Ok(Self::new(x_pos, y_pos));
                 }
-                let y_pos = OriginComponent::Center;
                 let _ = input.try(|i| i.expect_ident_matching("center"));
-                return Ok(Self::new(x_pos, y_pos));
+                return Ok(Self::new(x_pos, OriginComponent::Center));
             },
             Err(_) => {},
         }


### PR DESCRIPTION
This is reviewed by emilio in bugzilla.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1391432](https://bugzilla.mozilla.org/show_bug.cgi?id=1391432)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18144)
<!-- Reviewable:end -->
