### PR TITLE
fix windows build issue #18055

### DIFF
--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -37,11 +37,7 @@ def host_platform():
     elif os_type == "android":
         os_type = "linux-androideabi"
     elif os_type == "windows":
-        # If we are in a Visual Studio environment, use msvc
-        if os.getenv("PLATFORM") is not None:
-            os_type = "pc-windows-msvc"
-        else:
-            os_type = "unknown"
+        os_type = "pc-windows-msvc"
     elif os_type == "freebsd":
         os_type = "unknown-freebsd"
     else:
@@ -52,16 +48,7 @@ def host_platform():
 def host_triple():
     os_type = host_platform()
     cpu_type = platform.machine().lower()
-    if os_type.endswith("-msvc"):
-        # vcvars*.bat should set it properly
-        platform_env = os.environ.get("PLATFORM").upper()
-        if platform_env == "X86":
-            cpu_type = "i686"
-        elif platform_env == "X64":
-            cpu_type = "x86_64"
-        else:
-            cpu_type = "unknown"
-    elif cpu_type in ["i386", "i486", "i686", "i768", "x86"]:
+    if cpu_type in ["i386", "i486", "i686", "i768", "x86"]:
         cpu_type = "i686"
     elif cpu_type in ["x86_64", "x86-64", "x64", "amd64"]:
         cpu_type = "x86_64"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
With some reasons, the windows and VS environment do not set the `env("PLATFORM")` variable. 
So, there's no need to check the variable, and set `os_type` equl to `pc-windows-msvc` as default. Then the script can get correct url to download `rustc`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #18055 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18145)
<!-- Reviewable:end -->
