### PR TITLE
style: pass a borrow instead of an Arc

### DIFF
--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -9,7 +9,6 @@ use gecko_bindings::structs;
 use gecko_bindings::structs::{nsChangeHint, nsStyleContext, nsStyleStructID};
 use matching::{StyleChange, StyleDifference};
 use properties::ComputedValues;
-use servo_arc::Arc;
 use std::ops::{BitAnd, BitOr, BitOrAssign, Not};
 
 /// The representation of Gecko's restyle damage is just a wrapper over
@@ -49,7 +48,7 @@ impl GeckoRestyleDamage {
     pub fn compute_style_difference(
         source: &nsStyleContext,
         old_style: &ComputedValues,
-        new_style: &Arc<ComputedValues>,
+        new_style: &ComputedValues,
     ) -> StyleDifference {
         let mut any_style_changed: bool = false;
         let hint = unsafe {

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -341,7 +341,7 @@ trait PrivateMatchMethods: TElement {
                              shared_context: &SharedStyleContext,
                              restyle: &mut RestyleData,
                              old_values: &ComputedValues,
-                             new_values: &Arc<ComputedValues>,
+                             new_values: &ComputedValues,
                              pseudo: Option<&PseudoElement>)
                              -> ChildCascadeRequirement {
         // Don't accumulate damage if we're in a forgetful traversal.
@@ -360,7 +360,7 @@ trait PrivateMatchMethods: TElement {
             restyle.reconstructed_self_or_ancestor();
 
         let difference =
-            self.compute_style_difference(&old_values, &new_values, pseudo);
+            self.compute_style_difference(old_values, new_values, pseudo);
 
         if !skip_applying_damage {
             restyle.damage |= difference.damage;
@@ -389,10 +389,10 @@ trait PrivateMatchMethods: TElement {
                              _shared_context: &SharedStyleContext,
                              restyle: &mut RestyleData,
                              old_values: &ComputedValues,
-                             new_values: &Arc<ComputedValues>,
+                             new_values: &ComputedValues,
                              pseudo: Option<&PseudoElement>)
                              -> ChildCascadeRequirement {
-        let difference = self.compute_style_difference(&old_values, &new_values, pseudo);
+        let difference = self.compute_style_difference(old_values, new_values, pseudo);
         restyle.damage |= difference.damage;
         match difference.change {
             StyleChange::Changed => ChildCascadeRequirement::MustCascadeChildren,
@@ -657,7 +657,7 @@ pub trait MatchMethods : TElement {
                          shared_context: &SharedStyleContext,
                          restyle: &mut RestyleData,
                          old_values: Option<&ComputedValues>,
-                         new_values: &Arc<ComputedValues>,
+                         new_values: &ComputedValues,
                          pseudo: Option<&PseudoElement>)
                          -> ChildCascadeRequirement {
         let old_values = match old_values {
@@ -817,7 +817,7 @@ pub trait MatchMethods : TElement {
     fn compute_style_difference(
         &self,
         old_values: &ComputedValues,
-        new_values: &Arc<ComputedValues>,
+        new_values: &ComputedValues,
         pseudo: Option<&PseudoElement>
     ) -> StyleDifference {
         debug_assert!(pseudo.map_or(true, |p| p.is_eager()));


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1380133 has landed,
permitting us to pass a plain borrow into Gecko_CalcStyleDifference;
propagate this through style.

Closes #17795.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18148)
<!-- Reviewable:end -->
