### PR TITLE
stylo: Remove a lot of the restyle damage related complexity.

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -161,9 +161,10 @@ pub fn recalc_style_for_animations(context: &LayoutContext,
                                            &mut fragment.style,
                                            &ServoMetricsProvider);
                 let difference =
-                    RestyleDamage::compute_style_difference(&old_style,
-                                                            &old_style,
-                                                            &fragment.style);
+                    RestyleDamage::compute_style_difference(
+                        &old_style,
+                        &fragment.style,
+                    );
                 damage |= difference.damage;
             }
         }

--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -444,14 +444,6 @@ impl<'le> TElement for ServoLayoutElement<'le> {
         }
     }
 
-    #[inline]
-    fn existing_style_for_restyle_damage<'a>(&'a self,
-                                             current_cv: &'a ComputedValues,
-                                             _pseudo_element: Option<&PseudoElement>)
-                                             -> Option<&'a ComputedValues> {
-        Some(current_cv)
-    }
-
     fn has_dirty_descendants(&self) -> bool {
         unsafe { self.as_node().node.get_flag(HAS_DIRTY_DESCENDANTS) }
     }

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -20,7 +20,7 @@ use properties::{AnimationRules, ComputedValues, PropertyDeclarationBlock};
 #[cfg(feature = "gecko")] use properties::animated_properties::AnimationValue;
 #[cfg(feature = "gecko")] use properties::animated_properties::TransitionProperty;
 use rule_tree::CascadeLevel;
-use selector_parser::{AttrValue, ElementExt, PreExistingComputedValues};
+use selector_parser::{AttrValue, ElementExt};
 use selector_parser::{PseudoClassStringArg, PseudoElement};
 use selectors::matching::{ElementSelectorFlags, VisitedHandlingMode};
 use selectors::sink::Push;
@@ -377,18 +377,6 @@ pub trait TElement : Eq + PartialEq + Debug + Hash + Sized + Copy + Clone +
 
     /// Internal iterator for the classes of this element.
     fn each_class<F>(&self, callback: F) where F: FnMut(&Atom);
-
-    /// Get the pre-existing style to calculate restyle damage (change hints).
-    ///
-    /// This needs to be generic since it varies between Servo and Gecko.
-    ///
-    /// XXX(emilio): It's a bit unfortunate we need to pass the current computed
-    /// values as an argument here, but otherwise Servo would crash due to
-    /// double borrows to return it.
-    fn existing_style_for_restyle_damage<'a>(&'a self,
-                                             current_computed_values: &'a ComputedValues,
-                                             pseudo: Option<&PseudoElement>)
-                                             -> Option<&'a PreExistingComputedValues>;
 
     /// Whether a given element may generate a pseudo-element.
     ///

--- a/components/style/gecko/pseudo_element.rs
+++ b/components/style/gecko/pseudo_element.rs
@@ -75,10 +75,22 @@ impl PseudoElement {
         EAGER_PSEUDOS[i].clone()
     }
 
-    /// Whether this pseudo-element is ::before or ::after.
+    /// Whether the current pseudo element is ::before or ::after.
     #[inline]
     pub fn is_before_or_after(&self) -> bool {
-        matches!(*self, PseudoElement::Before | PseudoElement::After)
+        self.is_before() || self.is_after()
+    }
+
+    /// Whether this pseudo-element is the ::before pseudo.
+    #[inline]
+    pub fn is_before(&self) -> bool {
+        *self == PseudoElement::Before
+    }
+
+    /// Whether this pseudo-element is the ::after pseudo.
+    #[inline]
+    pub fn is_after(&self) -> bool {
+        *self == PseudoElement::After
     }
 
     /// Whether this pseudo-element is ::first-letter.

--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -6,7 +6,7 @@
 
 use gecko_bindings::bindings;
 use gecko_bindings::structs;
-use gecko_bindings::structs::{nsChangeHint, nsStyleContext, nsStyleStructID};
+use gecko_bindings::structs::nsChangeHint;
 use matching::{StyleChange, StyleDifference};
 use properties::ComputedValues;
 use std::ops::{BitAnd, BitOr, BitOrAssign, Not};
@@ -46,47 +46,20 @@ impl GeckoRestyleDamage {
     /// structs, so they effectively only diff structs that have ever been
     /// accessed from layout.
     pub fn compute_style_difference(
-        source: &nsStyleContext,
         old_style: &ComputedValues,
         new_style: &ComputedValues,
     ) -> StyleDifference {
         let mut any_style_changed: bool = false;
         let hint = unsafe {
-            bindings::Gecko_CalcStyleDifference(old_style,
-                                                new_style,
-                                                source.mBits,
-                                                &mut any_style_changed)
+            bindings::Gecko_CalcStyleDifference(
+                old_style,
+                new_style,
+                structs::NS_STYLE_INHERIT_MASK as u64,
+                &mut any_style_changed
+            )
         };
         let change = if any_style_changed { StyleChange::Changed } else { StyleChange::Unchanged };
         StyleDifference::new(GeckoRestyleDamage(nsChangeHint(hint)), change)
-    }
-
-    /// Computes the `StyleDifference` between the two `ComputedValues` objects
-    /// for the case where the old and new style are both `display: none`.
-    ///
-    /// In general we don't need to generate damage for such elements, but we
-    /// do need to generate a frame reconstruction for `-moz-binding` changes,
-    /// so that we can start loading the new binding.
-    pub fn compute_undisplayed_style_difference(
-        old_style: &ComputedValues,
-        new_style: &ComputedValues,
-    ) -> StyleDifference {
-        let mut any_style_changed: bool = false;
-
-        // Just compute the Display struct's difference.
-        let display_struct_bit = 1 << (nsStyleStructID::eStyleStruct_Display as u32);
-        let hint = unsafe {
-            bindings::Gecko_CalcStyleDifference(old_style,
-                                                new_style,
-                                                display_struct_bit,
-                                                &mut any_style_changed)
-        };
-
-        // Only pay attention to a reconstruct change hint.
-        let damage = GeckoRestyleDamage(nsChangeHint(hint)) & Self::reconstruct();
-
-        let change = if damage.is_empty() { StyleChange::Changed } else { StyleChange::Unchanged };
-        StyleDifference::new(damage, change)
     }
 
     /// Returns true if this restyle damage contains all the damage of |other|.

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -45,7 +45,6 @@ use gecko_bindings::bindings::Gecko_GetExtraContentStyleDeclarations;
 use gecko_bindings::bindings::Gecko_GetHTMLPresentationAttrDeclarationBlock;
 use gecko_bindings::bindings::Gecko_GetSMILOverrideDeclarationBlock;
 use gecko_bindings::bindings::Gecko_GetStyleAttrDeclarationBlock;
-use gecko_bindings::bindings::Gecko_GetStyleContext;
 use gecko_bindings::bindings::Gecko_GetUnvisitedLinkAttrDeclarationBlock;
 use gecko_bindings::bindings::Gecko_GetVisitedLinkAttrDeclarationBlock;
 use gecko_bindings::bindings::Gecko_IsSignificantChild;
@@ -55,7 +54,7 @@ use gecko_bindings::bindings::Gecko_UnsetDirtyStyleAttr;
 use gecko_bindings::bindings::Gecko_UpdateAnimations;
 use gecko_bindings::structs;
 use gecko_bindings::structs::{RawGeckoElement, RawGeckoNode, RawGeckoXBLBinding};
-use gecko_bindings::structs::{nsIAtom, nsIContent, nsINode_BooleanFlag, nsStyleContext};
+use gecko_bindings::structs::{nsIAtom, nsIContent, nsINode_BooleanFlag};
 use gecko_bindings::structs::ELEMENT_HANDLED_SNAPSHOT;
 use gecko_bindings::structs::ELEMENT_HAS_ANIMATION_ONLY_DIRTY_DESCENDANTS_FOR_SERVO;
 use gecko_bindings::structs::ELEMENT_HAS_DIRTY_DESCENDANTS_FOR_SERVO;
@@ -1018,18 +1017,6 @@ impl<'le> TElement for GeckoElement<'le> {
         snapshot_helpers::each_class(self.0,
                                      callback,
                                      Gecko_ClassOrClassList)
-    }
-
-    fn existing_style_for_restyle_damage<'a>(&'a self,
-                                             _existing_values: &'a ComputedValues,
-                                             pseudo: Option<&PseudoElement>)
-                                             -> Option<&'a nsStyleContext> {
-        // TODO(emilio): Migrate this to CSSPseudoElementType.
-        let atom_ptr = pseudo.map_or(ptr::null_mut(), |p| p.atom().as_ptr());
-        unsafe {
-            let context_ptr = Gecko_GetStyleContext(self.0, atom_ptr);
-            context_ptr.as_ref()
-        }
     }
 
     fn has_snapshot(&self) -> bool {

--- a/components/style/selector_parser.rs
+++ b/components/style/selector_parser.rs
@@ -35,16 +35,6 @@ pub use servo::restyle_damage::ServoRestyleDamage as RestyleDamage;
 #[cfg(feature = "gecko")]
 pub use gecko::restyle_damage::GeckoRestyleDamage as RestyleDamage;
 
-/// A type that represents the previous computed values needed for restyle
-/// damage calculation.
-#[cfg(feature = "servo")]
-pub type PreExistingComputedValues = ::properties::ComputedValues;
-
-/// A type that represents the previous computed values needed for restyle
-/// damage calculation.
-#[cfg(feature = "gecko")]
-pub type PreExistingComputedValues = ::gecko_bindings::structs::nsStyleContext;
-
 /// Servo's selector parser.
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct SelectorParser<'a> {

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -60,24 +60,13 @@ impl HeapSizeOf for ServoRestyleDamage {
 impl ServoRestyleDamage {
     /// Compute the `StyleDifference` (including the appropriate restyle damage)
     /// for a given style change between `old` and `new`.
-    pub fn compute_style_difference(_source: &ComputedValues,
-                                    old: &ComputedValues,
-                                    new: &ComputedValues)
-                                    -> StyleDifference {
+    pub fn compute_style_difference(
+        old: &ComputedValues,
+        new: &ComputedValues,
+    ) -> StyleDifference {
         let damage = compute_damage(old, new);
         let change = if damage.is_empty() { StyleChange::Unchanged } else { StyleChange::Changed };
         StyleDifference::new(damage, change)
-    }
-
-    /// Computes the `StyleDifference` between the two `ComputedValues` objects
-    /// for the case where the old and new style are both `display: none`.
-    ///
-    /// For Servo we never need to generate any damage for such elements.
-    pub fn compute_undisplayed_style_difference(
-        _old_style: &ComputedValues,
-        _new_style: &ComputedValues,
-    ) -> StyleDifference {
-        StyleDifference::new(Self::empty(), StyleChange::Unchanged)
     }
 
     /// Returns a bitmask that represents a flow that needs to be rebuilt and

--- a/components/style/servo/selector_parser.rs
+++ b/components/style/servo/selector_parser.rs
@@ -130,10 +130,22 @@ impl PseudoElement {
         result
     }
 
-    /// Whether the current pseudo element is :before or :after.
+    /// Whether the current pseudo element is ::before or ::after.
     #[inline]
     pub fn is_before_or_after(&self) -> bool {
-        matches!(*self, PseudoElement::After | PseudoElement::Before)
+        self.is_before() || self.is_after()
+    }
+
+    /// Whether this pseudo-element is the ::before pseudo.
+    #[inline]
+    pub fn is_before(&self) -> bool {
+        *self == PseudoElement::Before
+    }
+
+    /// Whether this pseudo-element is the ::after pseudo.
+    #[inline]
+    pub fn is_after(&self) -> bool {
+        *self == PseudoElement::After
     }
 
     /// Whether the current pseudo element is :first-letter


### PR DESCRIPTION
The only reason why we had the `existing_style_for_style_damage` bit is to apply
some optimizations that we don't have anymore.

I still want to reintroduce a few of them, at least for the non-eager
pseudo-element case... But I think I won't need this at all.

This allows us to remove a fair amount of Gecko code too.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18153)
<!-- Reviewable:end -->
