### PR TITLE
fix Windows build issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ pip install virtualenv
 3. Install Git for Windows (https://git-scm.com/download/win). DO allow it to add git.exe to the PATH (default
 settings for the installer are fine).
 
-4. Install Visual Studio Community 2017 (https://www.visualstudio.com/). You MUST add "Visual C++" to the
-list of installed components. It is not on by default.
+4. Install [Visual Studio Community 2015 Update 3](https://www.visualstudio.com/vs/older-downloads/). You MUST add "Visual C++ and Windows 10 SDK" to the list of installed components. It is not on by default.
+> Note: Visual Studio Community 2017 is currently not supported yet.
 
 #### Cross-compilation for Android
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
It is not able to build on Windows by following README.
As AppVeyor CI use VS 2015, it seems the script is designed for VS 2015.

I try three environment:
- [ ] Windows10 + VS2017
>not work at the beginning
- [ ] Windows10 + VS1017 with 2015 tool
> PR #18145 can solve download `rustc` problem, but build failed.
- [x] Windows10 + VS2015
> Work pretty well.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #18055 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18157)
<!-- Reviewable:end -->
