### PR TITLE
Replace write! with to_css and write_str in some ToCss impls

### DIFF
--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -32,7 +32,7 @@ use string_cache::Atom;
 use style_traits::{CSSPixel, DevicePixel};
 use style_traits::{ToCss, ParseError, StyleParseError};
 use style_traits::viewport::ViewportConstraints;
-use values::{CSSFloat, specified, CustomIdent};
+use values::{CSSFloat, specified, CustomIdent, serialize_dimension};
 use values::computed::{self, ToComputedValue};
 
 /// The `Device` in Gecko wraps a pres context, has a default values computed,
@@ -287,9 +287,9 @@ impl ToCss for Resolution {
         where W: fmt::Write,
     {
         match *self {
-            Resolution::Dpi(v) => write!(dest, "{}dpi", v),
-            Resolution::Dppx(v) => write!(dest, "{}dppx", v),
-            Resolution::Dpcm(v) => write!(dest, "{}dpcm", v),
+            Resolution::Dpi(v) => serialize_dimension(v, "dpi", dest),
+            Resolution::Dppx(v) => serialize_dimension(v, "dppx", dest),
+            Resolution::Dpcm(v) => serialize_dimension(v, "dpcm", dest),
         }
     }
 }
@@ -386,8 +386,8 @@ impl MediaExpressionValue {
     {
         match *self {
             MediaExpressionValue::Length(ref l) => l.to_css(dest),
-            MediaExpressionValue::Integer(v) => write!(dest, "{}", v),
-            MediaExpressionValue::Float(v) => write!(dest, "{}", v),
+            MediaExpressionValue::Integer(v) => v.to_css(dest),
+            MediaExpressionValue::Float(v) => v.to_css(dest),
             MediaExpressionValue::BoolInteger(v) => {
                 dest.write_str(if v { "1" } else { "0" })
             },

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -201,7 +201,7 @@ pub fn serialize_comma_separated_list<W, T>(dest: &mut W,
     list[0].to_css(dest)?;
 
     for item in list.iter().skip(1) {
-        write!(dest, ", ")?;
+        dest.write_str(", ")?;
         item.to_css(dest)?;
     }
 

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -2316,7 +2316,7 @@ https://drafts.csswg.org/css-fonts-4/#low-level-font-variation-settings-control-
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
             match *self {
                 SpecifiedValue::Auto => dest.write_str("auto"),
-                SpecifiedValue::Relative(rel) => write!(dest, "{}", rel),
+                SpecifiedValue::Relative(rel) => rel.to_css(dest),
                 // can only be specified by pres attrs; should not
                 // serialize to anything else
                 SpecifiedValue::Absolute(_) => Ok(()),

--- a/components/style/properties/shorthand/background.mako.rs
+++ b/components/style/properties/shorthand/background.mako.rs
@@ -148,36 +148,36 @@
                 % endfor
 
                 if i != 0 {
-                    write!(dest, ", ")?;
+                    dest.write_str(", ")?;
                 }
 
                 if i == len - 1 {
                     self.background_color.to_css(dest)?;
-                    write!(dest, " ")?;
+                    dest.write_str(" ")?;
                 }
 
                 image.to_css(dest)?;
                 % for name in "repeat attachment".split():
-                    write!(dest, " ")?;
+                    dest.write_str(" ")?;
                     ${name}.to_css(dest)?;
                 % endfor
 
-                write!(dest, " ")?;
+                dest.write_str(" ")?;
                 Position {
                     horizontal: position_x.clone(),
                     vertical: position_y.clone()
                 }.to_css(dest)?;
 
                 if *size != background_size::single_value::get_initial_specified_value() {
-                    write!(dest, " / ")?;
+                    dest.write_str(" / ")?;
                     size.to_css(dest)?;
                 }
 
                 if *origin != Origin::padding_box || *clip != Clip::border_box {
-                    write!(dest, " ")?;
+                    dest.write_str(" ")?;
                     origin.to_css(dest)?;
                     if *clip != From::from(*origin) {
-                        write!(dest, " ")?;
+                        dest.write_str(" ")?;
                         clip.to_css(dest)?;
                     }
                 }

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -21,7 +21,7 @@ use style_traits::{PARSING_MODE_DEFAULT, ToCss, ParseError, StyleParseError};
 use style_traits::PropertyDeclarationParseError;
 use stylesheets::{CssRuleType, StylesheetContents};
 use stylesheets::rule_parser::VendorPrefix;
-use values::KeyframesName;
+use values::{KeyframesName, serialize_percentage};
 
 /// A [`@keyframes`][keyframes] rule.
 ///
@@ -115,7 +115,7 @@ impl ::std::cmp::Eq for KeyframePercentage { }
 
 impl ToCss for KeyframePercentage {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-        write!(dest, "{}%", self.0 * 100.0)
+        serialize_percentage(self.0, dest)
     }
 }
 

--- a/components/style/values/computed/percentage.rs
+++ b/components/style/values/computed/percentage.rs
@@ -7,7 +7,7 @@
 use properties::animated_properties::Animatable;
 use std::fmt;
 use style_traits::ToCss;
-use values::CSSFloat;
+use values::{CSSFloat, serialize_percentage};
 use values::animated::ToAnimatedZero;
 
 /// A computed percentage.
@@ -55,6 +55,6 @@ impl ToCss for Percentage {
     where
         W: fmt::Write,
     {
-        write!(dest, "{}%", self.0 * 100.)
+        serialize_percentage(self.0, dest)
     }
 }

--- a/components/style/values/generics/grid.rs
+++ b/components/style/values/generics/grid.rs
@@ -9,7 +9,7 @@ use cssparser::Parser;
 use parser::{Parse, ParserContext};
 use std::{fmt, mem, usize};
 use style_traits::{ToCss, ParseError, StyleParseError};
-use values::{CSSFloat, CustomIdent};
+use values::{CSSFloat, CustomIdent, serialize_dimension};
 use values::computed::{ComputedValueAsSpecified, Context, ToComputedValue};
 use values::specified::Integer;
 use values::specified::grid::parse_line_names;
@@ -58,7 +58,7 @@ impl ToCss for GridLine {
         }
 
         if let Some(i) = self.line_num {
-            write!(dest, " {}", i.value())?;
+            i.value().to_css(dest)?;
         }
 
         if let Some(ref s) = self.ident {
@@ -169,7 +169,7 @@ impl<L: ToCss> ToCss for TrackBreadth<L> {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         match *self {
             TrackBreadth::Breadth(ref lop) => lop.to_css(dest),
-            TrackBreadth::Flex(ref value) => write!(dest, "{}fr", value),
+            TrackBreadth::Flex(ref value) => serialize_dimension(*value, "fr", dest),
             TrackBreadth::Keyword(ref k) => k.to_css(dest),
         }
     }

--- a/components/style/values/mod.rs
+++ b/components/style/values/mod.rs
@@ -36,6 +36,22 @@ define_keyword_type!(None_, "none");
 define_keyword_type!(Auto, "auto");
 define_keyword_type!(Normal, "normal");
 
+/// Serialize a normalized value into percentage.
+pub fn serialize_percentage<W>(value: CSSFloat, dest: &mut W)
+    -> fmt::Result where W: fmt::Write
+{
+    (value * 100.).to_css(dest)?;
+    dest.write_str("%")
+}
+
+/// Serialize a value with given unit into dest.
+pub fn serialize_dimension<W>(value: CSSFloat, unit: &str, dest: &mut W)
+    -> fmt::Result where W: fmt::Write
+{
+    value.to_css(dest)?;
+    dest.write_str(unit)
+}
+
 /// Convenience void type to disable some properties and values through types.
 #[cfg_attr(feature = "servo", derive(Deserialize, HeapSizeOf, Serialize))]
 #[derive(Clone, Copy, Debug, HasViewportPercentage, PartialEq, ToComputedValue, ToCss)]

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -19,7 +19,7 @@ use style_traits::values::specified::AllowedLengthType;
 use stylesheets::CssRuleType;
 use super::{AllowQuirks, Number, ToComputedValue, Percentage};
 use values::{Auto, CSSFloat, Either, FONT_MEDIUM_PX, None_, Normal};
-use values::ExtremumLength;
+use values::{ExtremumLength, serialize_dimension};
 use values::computed::{self, Context};
 use values::generics::NonNegative;
 use values::specified::NonNegativeNumber;
@@ -71,10 +71,10 @@ impl ToCss for FontRelativeLength {
         where W: fmt::Write
     {
         match *self {
-            FontRelativeLength::Em(length) => write!(dest, "{}em", length),
-            FontRelativeLength::Ex(length) => write!(dest, "{}ex", length),
-            FontRelativeLength::Ch(length) => write!(dest, "{}ch", length),
-            FontRelativeLength::Rem(length) => write!(dest, "{}rem", length)
+            FontRelativeLength::Em(length) => serialize_dimension(length, "em", dest),
+            FontRelativeLength::Ex(length) => serialize_dimension(length, "ex", dest),
+            FontRelativeLength::Ch(length) => serialize_dimension(length, "ch", dest),
+            FontRelativeLength::Rem(length) => serialize_dimension(length, "rem", dest)
         }
     }
 }
@@ -192,10 +192,10 @@ impl HasViewportPercentage for ViewportPercentageLength {
 impl ToCss for ViewportPercentageLength {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         match *self {
-            ViewportPercentageLength::Vw(length) => write!(dest, "{}vw", length),
-            ViewportPercentageLength::Vh(length) => write!(dest, "{}vh", length),
-            ViewportPercentageLength::Vmin(length) => write!(dest, "{}vmin", length),
-            ViewportPercentageLength::Vmax(length) => write!(dest, "{}vmax", length)
+            ViewportPercentageLength::Vw(length) => serialize_dimension(length, "vw", dest),
+            ViewportPercentageLength::Vh(length) => serialize_dimension(length, "vh", dest),
+            ViewportPercentageLength::Vmin(length) => serialize_dimension(length, "vmin", dest),
+            ViewportPercentageLength::Vmax(length) => serialize_dimension(length, "vmax", dest)
         }
     }
 }
@@ -318,13 +318,13 @@ impl From<AbsoluteLength> for Au {
 impl ToCss for AbsoluteLength {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         match *self {
-            AbsoluteLength::Px(length) => write!(dest, "{}px", length),
-            AbsoluteLength::In(length) => write!(dest, "{}in", length),
-            AbsoluteLength::Cm(length) => write!(dest, "{}cm", length),
-            AbsoluteLength::Mm(length) => write!(dest, "{}mm", length),
-            AbsoluteLength::Q(length) => write!(dest, "{}q", length),
-            AbsoluteLength::Pt(length) => write!(dest, "{}pt", length),
-            AbsoluteLength::Pc(length) => write!(dest, "{}pc", length),
+            AbsoluteLength::Px(length) => serialize_dimension(length, "px", dest),
+            AbsoluteLength::In(length) => serialize_dimension(length, "in", dest),
+            AbsoluteLength::Cm(length) => serialize_dimension(length, "cm", dest),
+            AbsoluteLength::Mm(length) => serialize_dimension(length, "mm", dest),
+            AbsoluteLength::Q(length) => serialize_dimension(length, "q", dest),
+            AbsoluteLength::Pt(length) => serialize_dimension(length, "pt", dest),
+            AbsoluteLength::Pc(length) => serialize_dimension(length, "pc", dest),
         }
     }
 }
@@ -376,7 +376,7 @@ impl PhysicalLength {
 #[cfg(feature = "gecko")]
 impl ToCss for PhysicalLength {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-        write!(dest, "{}mozmm", self.0)
+        serialize_dimension(self.0, "mozmm", dest)
     }
 }
 

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -440,7 +440,7 @@ impl ToCss for Integer {
         if self.was_calc {
             dest.write_str("calc(")?;
         }
-        write!(dest, "{}", self.value)?;
+        self.value.to_css(dest)?;
         if self.was_calc {
             dest.write_str(")")?;
         }

--- a/components/style/values/specified/percentage.rs
+++ b/components/style/values/specified/percentage.rs
@@ -10,7 +10,7 @@ use std::ascii::AsciiExt;
 use std::fmt;
 use style_traits::{ParseError, ToCss};
 use style_traits::values::specified::AllowedNumericType;
-use values::CSSFloat;
+use values::{CSSFloat, serialize_percentage};
 use values::computed::{Context, ToComputedValue};
 use values::computed::percentage::Percentage as ComputedPercentage;
 use values::specified::calc::CalcNode;
@@ -38,7 +38,7 @@ impl ToCss for Percentage {
             dest.write_str("calc(")?;
         }
 
-        write!(dest, "{}%", self.value * 100.)?;
+        serialize_percentage(self.value, dest)?;
 
         if self.calc_clamping_mode.is_some() {
             dest.write_str(")")?;


### PR DESCRIPTION
Some of this is necessary for fixing things like [bug 1370779](https://bugzilla.mozilla.org/show_bug.cgi?id=1370779) because otherwise we would still not be using the new numeric serialization algorithm from cssparser crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18159)
<!-- Reviewable:end -->
