### PR TITLE
Add support for legacy table attribute cellpadding

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -136,7 +136,8 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 use style::attr::AttrValue;
 use style::context::{QuirksMode, ReflowGoal};
-use style::invalidation::element::restyle_hints::{RestyleHint, RESTYLE_SELF, RESTYLE_STYLE_ATTRIBUTE};
+use style::invalidation::element::restyle_hints::{RESTYLE_SELF, RESTYLE_STYLE_ATTRIBUTE, RESTYLE_DESCENDANTS};
+use style::invalidation::element::restyle_hints::RestyleHint;
 use style::media_queries::{Device, MediaList, MediaType};
 use style::selector_parser::{RestyleDamage, Snapshot};
 use style::shared_lock::{SharedRwLock as StyleSharedRwLock, SharedRwLockReadGuard};
@@ -2503,6 +2504,12 @@ impl Document {
         if attr.local_name() == &local_name!("width") ||
            attr.local_name() == &local_name!("height") {
             entry.hint.insert(RESTYLE_SELF);
+        }
+
+        // FIXME: This is only true for table elements.
+        // Fix when these hints are populated in a virtual method
+        if attr.local_name() == &local_name!("cellpadding") {
+            entry.hint.insert(RESTYLE_DESCENDANTS);
         }
 
         let snapshot = entry.snapshot.as_mut().unwrap();

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -746,6 +746,30 @@ impl LayoutElementHelpers for LayoutJS<Element> {
                 shared_lock,
                 PropertyDeclaration::BorderRightWidth(width_value)));
         }
+
+        let cellpadding = if let Some(this) = self.downcast::<HTMLTableCellElement>() {
+            this.get_inherited_cellpadding()
+        } else {
+            None
+        };
+
+        if let Some(cellpadding) = cellpadding {
+            let length: specified::NonNegativeLengthOrPercentage =
+                specified::NoCalcLength::from_px(cellpadding as f32).into();
+
+            hints.push(from_declaration(
+                shared_lock,
+                PropertyDeclaration::PaddingTop(length.clone())));
+            hints.push(from_declaration(
+                shared_lock,
+                PropertyDeclaration::PaddingLeft(length.clone())));
+            hints.push(from_declaration(
+                shared_lock,
+                PropertyDeclaration::PaddingBottom(length.clone())));
+            hints.push(from_declaration(
+                shared_lock,
+                PropertyDeclaration::PaddingRight(length.clone())));
+        };
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -129,8 +129,7 @@ impl HTMLTableCellElementLayoutHelpers for LayoutJS<HTMLTableCellElement> {
         }
     }
 
-    fn get_inherited_cellpadding(&self) -> Option<u32>
-    {
+    fn get_inherited_cellpadding(&self) -> Option<u32> {
         unsafe {
             // Follow chain: Cell -> Row -> Section -> Table
             self.upcast::<Node>().parent_node_ref()

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -32,6 +32,7 @@ pub struct HTMLTableElement {
     htmlelement: HTMLElement,
     border: Cell<Option<u32>>,
     cellspacing: Cell<Option<u32>>,
+    cellpadding: Cell<Option<u32>>,
     tbodies: MutNullableJS<HTMLCollection>,
 }
 
@@ -56,6 +57,7 @@ impl HTMLTableElement {
             htmlelement: HTMLElement::new_inherited(local_name, prefix, document),
             border: Cell::new(None),
             cellspacing: Cell::new(None),
+            cellpadding: Cell::new(None),
             tbodies: Default::default(),
         }
     }
@@ -377,6 +379,7 @@ pub trait HTMLTableElementLayoutHelpers {
     fn get_border(&self) -> Option<u32>;
     fn get_cellspacing(&self) -> Option<u32>;
     fn get_width(&self) -> LengthOrPercentageOrAuto;
+    fn get_legacy_cellpadding(&self) -> Option<u32>;
 }
 
 impl HTMLTableElementLayoutHelpers for LayoutJS<HTMLTableElement> {
@@ -401,6 +404,13 @@ impl HTMLTableElementLayoutHelpers for LayoutJS<HTMLTableElement> {
     fn get_cellspacing(&self) -> Option<u32> {
         unsafe {
             (*self.unsafe_get()).cellspacing.get()
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn get_legacy_cellpadding(&self) -> Option<u32> {
+        unsafe {
+            (*self.unsafe_get()).cellpadding.get()
         }
     }
 
@@ -432,6 +442,11 @@ impl VirtualMethods for HTMLTableElement {
             }
             local_name!("cellspacing") => {
                 self.cellspacing.set(mutation.new_value(attr).and_then(|value| {
+                    parse_unsigned_integer(value.chars()).ok()
+                }));
+            },
+            local_name!("cellpadding") => {
+                self.cellpadding.set(mutation.new_value(attr).and_then(|value| {
                     parse_unsigned_integer(value.chars()).ok()
                 }));
             },

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -24287,11 +24287,11 @@
    "support"
   ],
   "css/legacy_cellpadding_attribute.html": [
-   "57ac037caf916a686a89ac7ad53d9415a77a6375",
+   "e8614220cf9c91945aff51120a6a84670ee8c123",
    "reftest"
   ],
   "css/legacy_cellpadding_attribute_ref.html": [
-   "a5fac3aaf63fd55385e4dcd6b034c6889ea3f8aa",
+   "069d177b4ac32edd97906fbcb7e62b66580fc438",
    "support"
   ],
   "css/legacy_cellspacing_attribute_a.html": [

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -8933,6 +8933,11 @@
      {}
     ]
    ],
+   "css/legacy_cellpadding_attribute_ref.html": [
+    [
+     {}
+    ]
+   ],
    "css/legacy_input_size_attribute_override_ref.html": [
     [
      {}
@@ -24279,6 +24284,14 @@
   ],
   "css/layerization_z_order_ref.html": [
    "dee6400bb5777fac749fd075628ca6c460c5ef7b",
+   "support"
+  ],
+  "css/legacy_cellpadding_attribute.html": [
+   "57ac037caf916a686a89ac7ad53d9415a77a6375",
+   "reftest"
+  ],
+  "css/legacy_cellpadding_attribute_ref.html": [
+   "a5fac3aaf63fd55385e4dcd6b034c6889ea3f8aa",
    "support"
   ],
   "css/legacy_cellspacing_attribute_a.html": [

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -3287,6 +3287,18 @@
      {}
     ]
    ],
+   "css/legacy_cellpadding_attribute.html": [
+    [
+     "/_mozilla/css/legacy_cellpadding_attribute.html",
+     [
+      [
+       "/_mozilla/css/legacy_cellpadding_attribute_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/legacy_cellspacing_attribute_a.html": [
     [
      "/_mozilla/css/legacy_cellspacing_attribute_a.html",

--- a/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute.html
+++ b/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that the legacy `cellpadding` attribute works. -->
+<style>
+body, html {
+    margin: 0;
+}
+table {
+    border-spacing: 0;
+}
+td {
+    width: 30px;
+    height: 30px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<table cellpadding="5">
+    <tr><td></td></tr>
+    <tr><td></td></tr>
+</table>
+</body>
+</html>

--- a/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute.html
+++ b/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <!-- Tests that the legacy `cellpadding` attribute works. -->
+<link rel=match href=legacy_cellpadding_attribute_ref.html>
 <style>
 body, html {
     margin: 0;

--- a/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute.html
+++ b/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute.html
@@ -22,5 +22,9 @@ td {
     <tr><td></td></tr>
     <tr><td></td></tr>
 </table>
+<table cellpadding="5">
+    <td></td>
+    <td></td>
+</table>
 </body>
 </html>

--- a/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute_ref.html
+++ b/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute_ref.html
@@ -2,7 +2,6 @@
 <html>
 <head>
 <!-- Tests that the legacy `cellpadding` attribute works. -->
-<link rel=match href=border_padding_ref.html>
 <style>
 body, html {
     margin: 0;

--- a/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute_ref.html
+++ b/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute_ref.html
@@ -22,5 +22,9 @@ td {
     <tr><td></td></tr>
     <tr><td></td></tr>
 </table>
+<table>
+    <td></td>
+    <td></td>
+</table>
 </body>
 </html>

--- a/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute_ref.html
+++ b/tests/wpt/mozilla/tests/css/legacy_cellpadding_attribute_ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Tests that the legacy `cellpadding` attribute works. -->
+<link rel=match href=border_padding_ref.html>
+<style>
+body, html {
+    margin: 0;
+}
+table {
+    border-spacing: 0;
+}
+td {
+    padding: 5px;
+    width: 30px;
+    height: 30px;
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<table>
+    <tr><td></td></tr>
+    <tr><td></td></tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
Handle the parent table element's `cellpadding` attribute value during table cell layout.

When `synthesize_presentational_hints_for_legacy_attributes` is called with an `HTMLTableCellElement`, look along a fixed path for the parent table element using `LayoutJS<Node>::parent_node_ref()`.

As touched on in #12609, another implementation worth evaluating would be for the `HTMLTableElementMethods::InsertRow` method to pass down the table's cellpadding value, and then for the `HTMLTableRowElementMethods::InsertCell` to pass it to each Cell. This would remove the need for the parent table lookup for every cell during layout, at the expense of extra memory per cell. This value needs to be mutable at the table level, as the property can be updated. Let me know if this method seems more appropriate. I haven't gone down this route so far because I wasn't clear on which of Rust's reference wrappers would be best suited for this.

Hacker News rendering improvement:
![cellpadding](https://user-images.githubusercontent.com/720498/29496021-efe5f144-85c1-11e7-8d3d-f963ebfe81f3.png)

There are a few issues running the tests on Windows right now - no headless mode implemented, and seems a lot of the test expectations aren't right. I'm relying on the CI here.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12609

<!-- Either: -->
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18161)
<!-- Reviewable:end -->
