### PR TITLE
Implement CSS Properties & Values API in Servo.

### DIFF
--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -74,6 +74,7 @@ use style::dom::{PresentationalHintsSynthesizer, TElement, TNode, UnsafeNode};
 use style::element_state::*;
 use style::font_metrics::ServoMetricsProvider;
 use style::properties::{ComputedValues, PropertyDeclarationBlock};
+use style::properties_and_values::RegisteredPropertySet;
 use style::selector_parser::{AttrValue as SelectorAttrValue, NonTSPseudoClass, PseudoClassStringArg};
 use style::selector_parser::{PseudoElement, SelectorImpl, extended_filtering};
 use style::shared_lock::{SharedRwLock as StyleSharedRwLock, Locked as StyleLocked};
@@ -363,6 +364,10 @@ impl<'ld> ServoLayoutDocument<'ld> {
 
     pub fn style_shared_lock(&self) -> &StyleSharedRwLock {
         unsafe { self.document.style_shared_lock() }
+    }
+
+    pub fn registered_property_set(&self) -> Arc<StyleLocked<RegisteredPropertySet>> {
+        unsafe { self.document.registered_property_set() }
     }
 
     pub fn from_layout_js(doc: LayoutJS<Document>) -> ServoLayoutDocument<'ld> {

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1147,7 +1147,7 @@ impl LayoutThread {
 
         let document_shared_lock = document.style_shared_lock();
         self.document_shared_lock = Some(document_shared_lock.clone());
-        let author_guard = document_shared_lock.read();
+        let document_guard = document_shared_lock.read();
         let device = Device::new(MediaType::screen(), initial_viewport, device_pixel_ratio);
         let sheet_origins_affected_by_device_change =
             self.stylist.set_device(device, &author_guard);
@@ -1200,8 +1200,9 @@ impl LayoutThread {
         let ua_stylesheets = &*UA_STYLESHEETS;
         let ua_or_user_guard = ua_stylesheets.shared_lock.read();
         let guards = StylesheetGuards {
-            author: &author_guard,
+            author: &document_guard,
             ua_or_user: &ua_or_user_guard,
+            registered_property_set: &document_guard,
         };
 
         {
@@ -1517,12 +1518,13 @@ impl LayoutThread {
 
             // Unwrap here should not panic since self.root_flow is only ever set to Some(_)
             // in handle_reflow() where self.document_shared_lock is as well.
-            let author_shared_lock = self.document_shared_lock.clone().unwrap();
-            let author_guard = author_shared_lock.read();
+            let document_shared_lock = self.document_shared_lock.clone().unwrap();
+            let document_guard = document_shared_lock.read();
             let ua_or_user_guard = UA_STYLESHEETS.shared_lock.read();
             let guards = StylesheetGuards {
-                author: &author_guard,
+                author: &document_guard,
                 ua_or_user: &ua_or_user_guard,
+                registered_property_set: &document_guard,
             };
             let snapshots = SnapshotMap::new();
             let mut layout_context = self.build_layout_context(guards,

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -100,6 +100,7 @@ use style::context::QuirksMode;
 use style::element_state::*;
 use style::media_queries::MediaList;
 use style::properties::PropertyDeclarationBlock;
+use style::properties_and_values;
 use style::selector_parser::{PseudoElement, Snapshot};
 use style::shared_lock::{SharedRwLock as StyleSharedRwLock, Locked as StyleLocked};
 use style::stylesheet_set::StylesheetSet;
@@ -410,6 +411,7 @@ unsafe_no_jsmanaged_fields!(WebGLVertexArrayId);
 unsafe_no_jsmanaged_fields!(MediaList);
 unsafe_no_jsmanaged_fields!(WebVRGamepadHand);
 unsafe_no_jsmanaged_fields!(ScriptToConstellationChan);
+unsafe_no_jsmanaged_fields!(StyleLocked<properties_and_values::RegisteredPropertySet>);
 
 unsafe impl<'a> JSTraceable for &'a str {
     #[inline]

--- a/components/script/dom/css.rs
+++ b/components/script/dom/css.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use cssparser::{Parser, ParserInput, serialize_identifier};
+use dom::bindings::codegen::Bindings::PropertyDescriptorDictBinding::PropertyDescriptorDict;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowBinding::WindowMethods;
-use dom::bindings::error::Fallible;
+use dom::bindings::error::{Error, Fallible};
 use dom::bindings::reflector::Reflector;
 use dom::bindings::str::DOMString;
 use dom::window::Window;
@@ -64,5 +65,17 @@ impl CSS {
         } else {
             false
         }
+    }
+
+    // https://drafts.css-houdini.org/css-properties-values-api/#dom-css-registerproperty
+    pub fn RegisterProperty(win: &Window, options: &PropertyDescriptorDict) -> Result<(), Error> {
+        // STUB: Implemented by a later patch in this series.
+        Err(Error::NotSupported)
+    }
+
+    // https://drafts.css-houdini.org/css-properties-values-api/#dom-css-unregisterproperty
+    pub fn UnregisterProperty(win: &Window, name: DOMString) -> Result<(), Error> {
+        // STUB: Implemented by a later patch in this series.
+        Err(Error::NotSupported)
     }
 }

--- a/components/script/dom/css.rs
+++ b/components/script/dom/css.rs
@@ -3,18 +3,41 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use cssparser::{Parser, ParserInput, serialize_identifier};
+use dom::bindings::codegen::Bindings::DocumentBinding::DocumentBinding::DocumentMethods;
 use dom::bindings::codegen::Bindings::PropertyDescriptorDictBinding::PropertyDescriptorDict;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowBinding::WindowMethods;
 use dom::bindings::error::{Error, Fallible};
+use dom::bindings::inheritance::Castable;
 use dom::bindings::reflector::Reflector;
 use dom::bindings::str::DOMString;
+use dom::node::{Node, NodeDamage};
 use dom::window::Window;
 use dom_struct::dom_struct;
 use style::context::QuirksMode;
 use style::parser::ParserContext;
+use style::properties_and_values::{self, PropertyRegistrationResult};
 use style::stylesheets::CssRuleType;
 use style::stylesheets::supports_rule::{Declaration, parse_condition_or_declaration};
 use style_traits::PARSING_MODE_DEFAULT;
+
+fn handle_property_registration_result(
+    win: &Window,
+    result: PropertyRegistrationResult
+) -> Result<(), Error> {
+    match result {
+        PropertyRegistrationResult::Ok => {
+            // Should lead to the RestyleHint::restyle_subtree() being inserted
+            // eventually in handle_reflow due to checks in Stylist.
+            if let Some(element) = win.Document().GetDocumentElement() {
+                element.upcast::<Node>().dirty(NodeDamage::NodeStyleDamaged);
+            }
+            Ok(())
+        },
+        PropertyRegistrationResult::SyntaxError => Err(Error::Syntax),
+        PropertyRegistrationResult::InvalidModificationError => Err(Error::InvalidModification),
+        PropertyRegistrationResult::NotFoundError => Err(Error::NotFound),
+    }
+}
 
 #[dom_struct]
 pub struct CSS {
@@ -67,15 +90,40 @@ impl CSS {
         }
     }
 
-    // https://drafts.css-houdini.org/css-properties-values-api/#dom-css-registerproperty
+    /// https://drafts.css-houdini.org/css-properties-values-api/#dom-css-registerproperty
     pub fn RegisterProperty(win: &Window, options: &PropertyDescriptorDict) -> Result<(), Error> {
-        // STUB: Implemented by a later patch in this series.
-        Err(Error::NotSupported)
+        let document = win.Document();
+        let registered_property_set = document.registered_property_set();
+        let mut guard = document.style_shared_lock().write();
+        let registered_property_set = registered_property_set.write_with(&mut guard);
+        handle_property_registration_result(
+            win,
+            properties_and_values::register_property(
+                registered_property_set,
+                &ParserContext::new_for_cssom(
+                    &win.Document().url(),
+                    win.css_error_reporter(),
+                    /* rule_type */ None,
+                    PARSING_MODE_DEFAULT,
+                    win.Document().quirks_mode(),
+                ),
+                &*options.name,
+                &options.syntax,
+                options.inherits,
+                options.initialValue.as_ref().map(|x| &**x),
+            )
+        )
     }
 
-    // https://drafts.css-houdini.org/css-properties-values-api/#dom-css-unregisterproperty
+    /// https://drafts.css-houdini.org/css-properties-values-api/#dom-css-unregisterproperty
     pub fn UnregisterProperty(win: &Window, name: DOMString) -> Result<(), Error> {
-        // STUB: Implemented by a later patch in this series.
-        Err(Error::NotSupported)
+        let document = win.Document();
+        let registered_property_set = document.registered_property_set();
+        let mut guard = document.style_shared_lock().write();
+        let registered_property_set = registered_property_set.write_with(&mut guard);
+        handle_property_registration_result(
+            win,
+            properties_and_values::unregister_property(registered_property_set, &*name)
+        )
     }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -138,8 +138,9 @@ use style::attr::AttrValue;
 use style::context::{QuirksMode, ReflowGoal};
 use style::invalidation::element::restyle_hints::{RestyleHint, RESTYLE_SELF, RESTYLE_STYLE_ATTRIBUTE};
 use style::media_queries::{Device, MediaList, MediaType};
+use style::properties_and_values::RegisteredPropertySet;
 use style::selector_parser::{RestyleDamage, Snapshot};
-use style::shared_lock::{SharedRwLock as StyleSharedRwLock, SharedRwLockReadGuard};
+use style::shared_lock::{Locked as StyleLocked, SharedRwLock as StyleSharedRwLock, SharedRwLockReadGuard};
 use style::str::{HTML_SPACE_CHARACTERS, split_html_space_chars, str_join};
 use style::stylesheet_set::StylesheetSet;
 use style::stylesheets::{Stylesheet, StylesheetContents, OriginSet};
@@ -249,7 +250,8 @@ pub struct Document {
     scripts: MutNullableJS<HTMLCollection>,
     anchors: MutNullableJS<HTMLCollection>,
     applets: MutNullableJS<HTMLCollection>,
-    /// Lock use for style attributes and author-origin stylesheet objects in this document.
+    /// Lock used for style attributes, author-origin stylesheet objects, and
+    /// the registered property set in/for this document.
     /// Can be acquired once for accessing many objects.
     style_shared_lock: StyleSharedRwLock,
     /// List of stylesheets associated with nodes in this document. |None| if the list needs to be refreshed.
@@ -351,6 +353,10 @@ pub struct Document {
     /// is inserted or removed from the document.
     /// See https://html.spec.whatwg.org/multipage/#form-owner
     form_id_listener_map: DOMRefCell<HashMap<Atom, HashSet<JS<Element>>>>,
+
+    /// The set of registered custom properties.
+    #[ignore_heap_size_of = "Arc"]
+    registered_property_set: Arc<StyleLocked<RegisteredPropertySet>>,
 }
 
 #[derive(JSTraceable, HeapSizeOf)]
@@ -2041,6 +2047,7 @@ pub trait LayoutDocumentHelpers {
     unsafe fn will_paint(&self);
     unsafe fn quirks_mode(&self) -> QuirksMode;
     unsafe fn style_shared_lock(&self) -> &StyleSharedRwLock;
+    unsafe fn registered_property_set(&self) -> Arc<StyleLocked<RegisteredPropertySet>>;
 }
 
 #[allow(unsafe_code)]
@@ -2081,6 +2088,11 @@ impl LayoutDocumentHelpers for LayoutJS<Document> {
     #[inline]
     unsafe fn style_shared_lock(&self) -> &StyleSharedRwLock {
         (*self.unsafe_get()).style_shared_lock()
+    }
+
+    #[inline]
+    unsafe fn registered_property_set(&self) -> Arc<StyleLocked<RegisteredPropertySet>> {
+        (*self.unsafe_get()).registered_property_set()
     }
 }
 
@@ -2169,6 +2181,18 @@ impl Document {
             (DocumentReadyState::Complete, true)
         };
 
+        lazy_static! {
+            /// Per-process shared lock for author-origin stylesheets
+            ///
+            /// FIXME: make it per-document or per-pipeline instead:
+            /// https://github.com/servo/servo/issues/16027
+            /// (Need to figure out what to do with the style attribute
+            /// of elements adopted into another document.)
+            static ref PER_PROCESS_AUTHOR_SHARED_LOCK: StyleSharedRwLock = {
+                StyleSharedRwLock::new()
+            };
+        }
+
         Document {
             node: Node::new_document_node(),
             window: JS::from_ref(window),
@@ -2204,17 +2228,6 @@ impl Document {
             anchors: Default::default(),
             applets: Default::default(),
             style_shared_lock: {
-                lazy_static! {
-                    /// Per-process shared lock for author-origin stylesheets
-                    ///
-                    /// FIXME: make it per-document or per-pipeline instead:
-                    /// https://github.com/servo/servo/issues/16027
-                    /// (Need to figure out what to do with the style attribute
-                    /// of elements adopted into another document.)
-                    static ref PER_PROCESS_AUTHOR_SHARED_LOCK: StyleSharedRwLock = {
-                        StyleSharedRwLock::new()
-                    };
-                }
                 PER_PROCESS_AUTHOR_SHARED_LOCK.clone()
                 //StyleSharedRwLock::new()
             },
@@ -2261,6 +2274,7 @@ impl Document {
             dom_count: Cell::new(1),
             fullscreen_element: MutNullableJS::new(None),
             form_id_listener_map: Default::default(),
+            registered_property_set: Arc::new(PER_PROCESS_AUTHOR_SHARED_LOCK.wrap(Default::default())),
         }
     }
 
@@ -2679,6 +2693,10 @@ impl Document {
                         .reset_form_owner();
             }
         }
+    }
+
+    pub fn registered_property_set(&self) -> Arc<StyleLocked<RegisteredPropertySet>> {
+        self.registered_property_set.clone()
     }
 }
 

--- a/components/script/dom/webidls/CSS.webidl
+++ b/components/script/dom/webidls/CSS.webidl
@@ -17,3 +17,11 @@ partial interface CSS {
   static boolean supports(DOMString property, DOMString value);
   static boolean supports(DOMString conditionText);
 };
+
+// https://drafts.css-houdini.org/css-properties-values-api/#registering-custom-properties
+partial interface CSS {
+  [Throws,Pref="layout.css.properties-and-values.enabled"]
+  static void registerProperty(PropertyDescriptorDict descriptor);
+  [Throws,Pref="layout.css.properties-and-values.enabled"]
+  static void unregisterProperty(DOMString name);
+};

--- a/components/script/dom/webidls/PropertyDescriptorDict.webidl
+++ b/components/script/dom/webidls/PropertyDescriptorDict.webidl
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/*
+ * The origin of this IDL file is
+ * https://drafts.css-houdini.org/css-properties-values-api/#registering-custom-properties
+ */
+
+// Renamed from PropertyDescriptor to avoid conflicting with a JS class of the
+// same name.
+dictionary PropertyDescriptorDict
+{
+  required DOMString name;
+           DOMString syntax       = "*";
+           boolean inherits       = false;
+           DOMString initialValue;
+};

--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -494,6 +494,8 @@ fn compute_style_for_animation_step(context: &SharedStyleContext,
 
             // This currently ignores visited styles, which seems acceptable,
             // as existing browsers don't appear to animate visited styles.
+            let registered_property_set =
+                context.stylist.registered_property_set().read_with(context.guards.registered_property_set);
             let computed =
                 properties::apply_declarations(context.stylist.device(),
                                                /* pseudo = */ None,
@@ -506,7 +508,8 @@ fn compute_style_for_animation_step(context: &SharedStyleContext,
                                                /* visited_style = */ None,
                                                font_metrics_provider,
                                                CascadeFlags::empty(),
-                                               context.quirks_mode);
+                                               context.quirks_mode,
+                                               registered_property_set);
             computed
         }
     }

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -28,10 +28,17 @@ pub type Name = Atom;
 ///
 /// https://drafts.csswg.org/css-variables/#typedef-custom-property-name
 pub fn parse_name(s: &str) -> Result<&str, ()> {
-    if s.starts_with("--") {
-        Ok(&s[2..])
-    } else {
-        Err(())
+    let mut input = ParserInput::new(s);
+    let mut input = Parser::new(&mut input);
+
+    match input.expect_ident() {
+        Ok(_) if s.starts_with("--") => {
+            match input.expect_exhausted() {
+                Ok(()) => Ok(&s[2..]),
+                Err(_) => Err(()),
+            }
+        },
+        _ => Err(())
     }
 }
 

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -7,12 +7,11 @@
 //! [custom]: https://drafts.csswg.org/css-variables/
 
 use Atom;
-use cssparser::{Delimiter, Parser, ParserInput, SourcePosition, Token, TokenSerializationType};
+use cssparser::{self, Delimiter, Parser, ParserInput, SourcePosition, Token, TokenSerializationType};
 use parser::ParserContext;
 use properties::{CSSWideKeyword, DeclaredValue};
 use properties_and_values;
 use selectors::parser::SelectorParseError;
-use servo_arc::Arc;
 use std::ascii::AsciiExt;
 use std::borrow::{Borrow, Cow};
 use std::collections::{HashMap, HashSet};
@@ -305,7 +304,7 @@ where
     }
 
     /// Remove an item given its key.
-    fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
+    pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
         Q: Hash + Eq,
@@ -460,7 +459,7 @@ fn parse_declaration_value<'i, 't>
 
 /// Like parse_declaration_value, but accept `!` and `;` since they are only
 /// invalid at the top level
-fn parse_declaration_value_block<'i, 't>
+pub fn parse_declaration_value_block<'i, 't>
                                 (input: &mut Parser<'i, 't>,
                                  references: &mut Option<HashSet<Name>>,
                                  missing_closing_characters: &mut String)
@@ -603,34 +602,67 @@ fn parse_var_function<'i, 't>(input: &mut Parser<'i, 't>,
 
 /// Add one custom property declaration to a map, unless another with the same
 /// name was already there.
-pub fn cascade<'a>(custom_properties: &mut Option<OrderedMap<&'a Name, BorrowedSpecifiedValue<'a>>>,
-                   inherited: &'a Option<Arc<CustomPropertiesMap>>,
-                   seen: &mut HashSet<&'a Name>,
-                   name: &'a Name,
-                   specified_value: DeclaredValue<'a, Box<SpecifiedValue>>) {
+///
+/// `inherited_computed(name)` should return the computed value for inherited
+/// typed custom properties and None otherwise.
+///
+/// `handle_keyword(name, keyword)` should return `true` in the case where, if
+/// the property with name `name` is declared with CSS-wide keyword `keyword`,
+/// the property should inherit.
+pub fn cascade<'a, F, G>(
+    custom_properties: &mut Option<OrderedMap<&'a Name, BorrowedSpecifiedValue<'a>>>,
+    inherited: Option<&'a CustomPropertiesMap>,
+    inherited_computed: &F,
+    handle_keyword: G,
+    seen: &mut HashSet<&'a Name>,
+    name: &'a Name,
+    specified_value: DeclaredValue<'a, Box<SpecifiedValue>>
+)
+where F: Fn(&'a Name) -> Option<&'a properties_and_values::ComputedValue>,
+      G: Fn(&'a Name, CSSWideKeyword) -> bool,
+{
     let was_already_present = !seen.insert(name);
     if was_already_present {
         return;
     }
 
-    let map = match *custom_properties {
-        Some(ref mut map) => map,
-        None => {
-            let mut map = OrderedMap::new();
-            if let Some(ref inherited) = *inherited {
-                for name in &inherited.index {
-                    let inherited_value = inherited.get(name).unwrap();
-                    map.insert(name, BorrowedSpecifiedValue {
-                        token_stream: inherited_value,
-                        references: None,
-                        extra: BorrowedExtraData::InheritedUntyped,
-                    })
+    #[inline]
+    fn inherit<'a, F>(
+        map: &mut OrderedMap<&'a Name, BorrowedSpecifiedValue<'a>>,
+        get_computed: F,
+        name: &'a Name,
+        value: &'a ComputedValue,
+    )
+    where F: Fn(&'a Name) -> Option<&'a properties_and_values::ComputedValue>,
+    {
+        let extra =
+            get_computed(name)
+            .map(BorrowedExtraData::Precomputed)
+            .unwrap_or(BorrowedExtraData::InheritedUntyped);
+        let borrowed = BorrowedSpecifiedValue {
+            token_stream: value,
+            references: None,
+            extra: extra,
+        };
+        map.insert(name, borrowed);
+    }
+
+    if let None = *custom_properties {
+        let mut map = OrderedMap::new();
+        if let Some(ref inherited) = inherited {
+            for name in &inherited.index {
+                let inherited_value = inherited.get(name).unwrap();
+                if handle_keyword(name, CSSWideKeyword::Unset) {
+                    // We should inherit.
+                    inherit(&mut map, inherited_computed, name, inherited_value);
                 }
             }
-            *custom_properties = Some(map);
-            custom_properties.as_mut().unwrap()
         }
-    };
+        *custom_properties = Some(map);
+    }
+
+    let mut map = custom_properties.as_mut().unwrap();
+
     match specified_value {
         DeclaredValue::Value(ref specified_value) => {
             map.insert(name, BorrowedSpecifiedValue {
@@ -640,109 +672,252 @@ pub fn cascade<'a>(custom_properties: &mut Option<OrderedMap<&'a Name, BorrowedS
             });
         },
         DeclaredValue::WithVariables(_) => unreachable!(),
-        DeclaredValue::CSSWideKeyword(keyword) => match keyword {
-            CSSWideKeyword::Initial => {
-                map.remove(&name);
-            }
-            CSSWideKeyword::Unset | // Custom properties are inherited by default.
-            CSSWideKeyword::Inherit => {} // The inherited value is what we already have.
-        }
-    }
-}
-
-/// Returns the final map of applicable custom properties.
-///
-/// If there was any specified property, we've created a new map and now we need
-/// to remove any potential cycles, and wrap it in an arc.
-///
-/// Otherwise, just use the inherited custom properties map.
-pub fn finish_cascade(specified_values_map: Option<OrderedMap<&Name, BorrowedSpecifiedValue>>,
-                      inherited: &Option<Arc<CustomPropertiesMap>>)
-                      -> Option<Arc<CustomPropertiesMap>> {
-    if let Some(mut map) = specified_values_map {
-        remove_cycles(&mut map);
-        Some(Arc::new(substitute_all(map, inherited)))
-    } else {
-        inherited.clone()
-    }
-}
-
-/// https://drafts.csswg.org/css-variables/#cycles
-///
-/// The initial value of a custom property is represented by this property not
-/// being in the map.
-fn remove_cycles(map: &mut OrderedMap<&Name, BorrowedSpecifiedValue>) {
-    let mut to_remove = HashSet::new();
-    {
-        let mut visited = HashSet::new();
-        let mut stack = Vec::new();
-        for name in &map.index {
-            walk(map, name, &mut stack, &mut visited, &mut to_remove);
-
-            fn walk<'a>(map: &OrderedMap<&'a Name, BorrowedSpecifiedValue<'a>>,
-                        name: &'a Name,
-                        stack: &mut Vec<&'a Name>,
-                        visited: &mut HashSet<&'a Name>,
-                        to_remove: &mut HashSet<Name>) {
-                let already_visited_before = !visited.insert(name);
-                if already_visited_before {
-                    return
-                }
-                if let Some(value) = map.get(&name) {
-                    if let Some(references) = value.references {
-                        stack.push(name);
-                        for next in references {
-                            if let Some(position) = stack.iter().position(|&x| x == next) {
-                                // Found a cycle
-                                for &in_cycle in &stack[position..] {
-                                    to_remove.insert(in_cycle.clone());
-                                }
-                            } else {
-                                walk(map, next, stack, visited, to_remove);
-                            }
-                        }
-                        stack.pop();
+        DeclaredValue::CSSWideKeyword(keyword) => {
+            if handle_keyword(name, keyword) {
+                // We should inherit.
+                // The inherited value is what we already have, if we are an
+                // inherited custom property (whence we initialize
+                // *custom_properties above). But we might not be!
+                if !map.get(&name).is_some() {
+                    let inherited_value =
+                        inherited
+                        .as_ref()
+                        .and_then(|inherited| inherited.get(name));
+                    if let Some(inherited_value) = inherited_value {
+                        inherit(&mut map, inherited_computed, name, inherited_value);
                     }
                 }
+            } else {
+                // We should use the initial value. Remove the value we
+                // inherited, if any.
+                map.remove(&name);
             }
         }
     }
-    for name in to_remove {
-        map.remove(&name);
+}
+
+
+/// Replace `var()` functions for all custom properties.
+pub fn substitute_all<C, H>(
+    specified_values_map: &OrderedMap<&Name, BorrowedSpecifiedValue>,
+    to_substitute: &Option<HashSet<Name>>,
+    custom_properties_map: &mut CustomPropertiesMap,
+    mut compute: &mut C,
+    mut handle_invalid: &mut H,
+)
+where C: FnMut(&Name, ComputedValue) -> Result<ComputedValue, ()>,
+      H: FnMut(&Name) -> Result<ComputedValue, ()>,
+{
+    let mut invalid = HashSet::new();
+    for (&name, value) in specified_values_map.iter() {
+        if !to_substitute.as_ref().map(|x| x.contains(name)).unwrap_or(true) {
+            continue
+        }
+        // If this value is invalid at computed-time it won’t be inserted in
+        // computed_values_map. Nothing else to do.
+        let _ = substitute_one(
+            name, value, specified_values_map, None, custom_properties_map,
+            &mut invalid, &mut compute, &mut handle_invalid);
     }
 }
 
-/// Replace `var()` functions for all custom properties.
-fn substitute_all(specified_values_map: OrderedMap<&Name, BorrowedSpecifiedValue>,
-                  inherited: &Option<Arc<CustomPropertiesMap>>)
-                  -> CustomPropertiesMap {
-    let mut custom_properties_map = CustomPropertiesMap::new();
-    let mut invalid = HashSet::new();
-    for name in &specified_values_map.index {
-        let value = specified_values_map.get(name).unwrap();
+/// Identify and remove cyclical variable declarations, identify if font-size is
+/// involved in a cycle, and identify those variables that must be computed
+/// before font-size.
+///
+/// specified[p] is removed if p is involved in a cycle.
+///
+/// Finally, we return whether font-size is involved in a cycle as well as a set
+/// of those variables to compute before computing early properties, including
+/// those variables (possibly transitively) referenced by the declaration of
+/// font-size. We count references in fallbacks (as does cycle detection).
+///
+/// For the purposes of cycle detection, we imagine font-size as another
+/// variable, and create an edge in the dependency graph from a variable to
+/// font-size if the variable is in possibly_font_size_dependent and if we parse
+/// a dimension token inside. The caller should put those variables in
+/// possibly_font_size_dependent that have as a possible syntax at least one of
+/// <length>, <length-percentage>, or <transform-function> (syntaxes whose
+/// computation might involve computing absolute lengths from relative lengths).
+pub fn compute_ordering(
+    specified: &mut OrderedMap<&Name, BorrowedSpecifiedValue>,
+    referenced_by_font_size: &HashSet<Name>,
+    referenced_by_others: &HashSet<Name>,
+    possibly_font_size_dependent: &HashSet<Name>,
+) -> (bool, HashSet<Name>, HashSet<Name>) {
+    fn walk<'a>(
+        specified: &HashMap<&'a Name, BorrowedSpecifiedValue<'a>>,
+        // None if we aren't descending down font-size.
+        // Some((set, might_require_computation)) if we are descending down
+        // font-size; might_require_computation is set to true if we are looking
+        // at a dependency of a custom property that might require computation.
+        // Determine to be cyclical if the set contains us and we have an em in
+        // our declaration, or if one of our descendants in the tree (for which
+        // might_require_computation is set to true) contains an em.
+        font_size_data: Option<(&HashSet<Name>, bool)>,
+        name: &'a Name,
+        stack: &mut Vec<&'a Name>,
+        visited: &mut HashSet<&'a Name>,
+        cyclical: &mut HashSet<Name>,
+        font_size_cyclical: &mut bool,
+    ) {
+        let already_visited_before = !visited.insert(name);
+        if already_visited_before {
+            return
+        }
 
-        // If this value is invalid at computed-time it won’t be inserted in computed_values_map.
-        // Nothing else to do.
-        let _ = substitute_one(
-            name, value, &specified_values_map, inherited, None,
-            &mut custom_properties_map, &mut invalid);
+        let (declaration, references) = {
+            if let Some(declaration) = specified.get(name) {
+                if let Some(references) = declaration.references {
+                    (declaration, references)
+                } else {
+                    // No variables referenced.
+                    return
+                }
+            } else {
+                // Invalid variable reference--will handle later.
+                return
+            }
+        };
+
+        stack.push(name);
+
+        // Recurse into variable references.
+        for next in references {
+            if let Some(position) = stack.iter().position(|&x| x == next) {
+                // Found a cycle!
+                for in_cycle in &stack[position..] {
+                    cyclical.insert((*in_cycle).clone());
+                }
+            } else {
+                let font_size_data = match font_size_data {
+                    Some((possibly_font_size_dependent, false))
+                    if possibly_font_size_dependent.contains(name) => {
+                        Some((possibly_font_size_dependent, true))
+                    },
+                    _ => font_size_data,
+                };
+                walk(specified, font_size_data, next, stack, visited, cyclical,
+                     font_size_cyclical);
+            }
+        }
+
+        // If this is a registered custom property whose computation
+        // calculation requires font-size, recurse into the
+        // references for font-size.
+        let might_cause_font_size_cycle = {
+            if let Some((possibly_font_size_dependent, might_require_computation)) = font_size_data {
+                might_require_computation || possibly_font_size_dependent.contains(name)
+            } else {
+                false
+            }
+        };
+        if might_cause_font_size_cycle {
+            fn detect_ems<'i, 'tt>(input: &mut Parser<'i, 'tt>)
+                                   -> Result<bool, cssparser::ParseError<'i, ()>> {
+                while !input.is_exhausted() {
+                    let token = input.next()?.clone();
+                    // We have to descend into functions.
+                    match token {
+                        Token::Function(_) => {
+                            if input.parse_nested_block(detect_ems).unwrap() {
+                                return Ok(true)
+                            }
+                        },
+                        Token::Dimension { ref unit, .. } => {
+                            if unit.eq_ignore_ascii_case("em") ||
+                               unit.eq_ignore_ascii_case("rem") {
+                                return Ok(true)
+                            }
+                        }
+                        _ => ()
+                    }
+                }
+                Ok(false)
+            }
+
+            let mut input = ParserInput::new(&declaration.css);
+            let mut input = Parser::new(&mut input);
+
+            if detect_ems(&mut input).unwrap() {
+                // Found a cycle involving font-size!
+                *font_size_cyclical = true;
+                for in_cycle in stack.iter() {
+                    cyclical.insert((*in_cycle).clone());
+                }
+            }
+        }
+        stack.pop();
     }
 
-    custom_properties_map
+    // Identify cycles.
+
+    let mut cyclical = HashSet::new();
+    let mut font_size_cyclical = false;
+    let mut visited = HashSet::new();
+    // We recursively follow variable references in declarations, and push
+    // the current variable to the stack, so that the declaration for
+    // stack[i] has a variable reference to stack[i+1]. So if we see a
+    // reference to a variable which already appears on the stack, we know
+    // that we have a cycle.
+    let mut stack = Vec::new();
+
+    // Check variables referenced by font-size first, to identify if there is a
+    // cycle involving font-size.
+    // Then, check variables referenced by other properties which we need to
+    // check (i.e. "early" properties).
+    // Then we can just take visited to get those variables which are
+    // transitively referenced by it.
+    for name in referenced_by_font_size {
+        walk(&specified.values, Some((possibly_font_size_dependent, false)),
+             &name, &mut stack, &mut visited, &mut cyclical,
+             &mut font_size_cyclical);
+    }
+    for name in referenced_by_others {
+        walk(&specified.values, None, &name, &mut stack, &mut visited,
+             &mut cyclical, &mut font_size_cyclical);
+    }
+    let mut dependencies = visited.clone();
+    let dependencies: HashSet<Name> = dependencies.drain().map(|x| x.clone()).collect();
+
+    for name in specified.values.keys() {
+        walk(&specified.values, None, name, &mut stack, &mut visited,
+             &mut cyclical, &mut font_size_cyclical);
+    }
+
+    // If we wanted dependencies to be completely accurate, we would
+    // remove z if x depends on y depends on z yet y is involved in a cycle.
+    // But we don't really need that; we just want to include all those
+    // properties that are depended on by early properties. Properties that
+    // are in dependencies can't depend on those early properties (the only
+    // such dependency we can have here is one on font-size) because in that
+    // case we would have detected the cycle; by resetting to the initial
+    // value (which is computationally independent) we no longer have the
+    // cycle.
+    //
+    // Really, what dependencies describe is the custom properties that we can
+    // compute early and those that we must.
+
+    (font_size_cyclical, dependencies, cyclical)
 }
 
 /// Replace `var()` functions for one custom property.
 /// Also recursively record results for other custom properties referenced by `var()` functions.
 /// Return `Err(())` for invalid at computed time.
 /// or `Ok(last_token_type that was pushed to partial_computed_value)` otherwise.
-fn substitute_one(name: &Name,
-                  specified_value: &BorrowedSpecifiedValue,
-                  specified_values_map: &OrderedMap<&Name, BorrowedSpecifiedValue>,
-                  inherited: &Option<Arc<CustomPropertiesMap>>,
-                  partial_computed_value: Option<&mut ComputedValue>,
-                  custom_properties_map: &mut CustomPropertiesMap,
-                  invalid: &mut HashSet<Name>)
-                  -> Result<TokenSerializationType, ()> {
+fn substitute_one<C, H>(
+    name: &Name,
+    specified_value: &BorrowedSpecifiedValue,
+    specified_values_map: &OrderedMap<&Name, BorrowedSpecifiedValue>,
+    mut partial_computed_value: Option<&mut ComputedValue>,
+    custom_properties_map: &mut CustomPropertiesMap,
+    invalid: &mut HashSet<Name>,
+    compute: &mut C,
+    handle_invalid: &mut H,
+) -> Result<TokenSerializationType, ()>
+where C: FnMut(&Name, ComputedValue) -> Result<ComputedValue, ()>,
+      H: FnMut(&Name) -> Result<ComputedValue, ()>,
+{
     if let Some(computed_value) = custom_properties_map.get(&name) {
         if let Some(partial_computed_value) = partial_computed_value {
             partial_computed_value.push_variable(computed_value)
@@ -753,7 +928,7 @@ fn substitute_one(name: &Name,
     if invalid.contains(name) {
         return Err(());
     }
-    let computed_value = if specified_value.references.map(|set| set.is_empty()) == Some(false) {
+    let computed_value = if !specified_value.references.map(|set| set.is_empty()).unwrap_or(true) {
         let mut partial_computed_value = ComputedValue::empty();
         let mut input = ParserInput::new(&specified_value.css);
         let mut input = Parser::new(&mut input);
@@ -762,8 +937,9 @@ fn substitute_one(name: &Name,
             &mut input, &mut position, &mut partial_computed_value,
             &mut |name, partial_computed_value| {
                 if let Some(other_specified_value) = specified_values_map.get(&name) {
-                    substitute_one(name, other_specified_value, specified_values_map, inherited,
-                                   Some(partial_computed_value), custom_properties_map, invalid)
+                    substitute_one(name, other_specified_value, specified_values_map,
+                                   Some(partial_computed_value), custom_properties_map, invalid,
+                                   compute, handle_invalid)
                 } else {
                     Err(())
                 }
@@ -771,30 +947,36 @@ fn substitute_one(name: &Name,
         );
         if let Ok(last_token_type) = result {
             partial_computed_value.push_from(position, &input, last_token_type);
-            partial_computed_value
+            Ok(partial_computed_value)
         } else {
-            // Invalid at computed-value time. Use the inherited value.
-            if let Some(inherited_value) = inherited.as_ref().and_then(|i| i.values.get(name)) {
-                inherited_value.clone()
-            } else {
-                invalid.insert(name.clone());
-                return Err(())
-            }
+            Err(())
         }
     } else {
         // The specified value contains no var() reference
-        ComputedValue {
+        Ok(ComputedValue {
             css: specified_value.css.to_owned(),
             first_token_type: specified_value.first_token_type,
             last_token_type: specified_value.last_token_type,
-        }
+        })
     };
-    if let Some(partial_computed_value) = partial_computed_value {
-        partial_computed_value.push_variable(&computed_value)
-    }
-    let last_token_type = computed_value.last_token_type;
-    custom_properties_map.insert(name.clone(), computed_value);
-    Ok(last_token_type)
+
+    computed_value
+    .and_then(|x| compute(name, x))
+    .or_else(|()| {
+        let result = handle_invalid(name);
+        if let Err(()) = result {
+            invalid.insert(name.clone());
+        }
+        result
+    })
+    .and_then(|x| {
+        if let Some(ref mut partial_computed_value) = partial_computed_value {
+            partial_computed_value.push_variable(&x)
+        }
+        let last_token_type = x.last_token_type;
+        custom_properties_map.insert(name.clone(), x);
+        Ok(last_token_type)
+    })
 }
 
 /// Replace `var()` functions in an arbitrary bit of input.
@@ -846,6 +1028,8 @@ fn substitute_block<'i, 't, F>(input: &mut Parser<'i, 't>,
                         // FIXME: Add a specialized method to cssparser to do this with less work.
                         while let Ok(_) = input.next() {}
                     } else {
+                        // Try to substitute any variable references in the
+                        // fallback.
                         input.expect_comma()?;
                         let after_comma = input.state();
                         let first_token_type = input.next_including_whitespace_and_comments()
@@ -886,10 +1070,11 @@ fn substitute_block<'i, 't, F>(input: &mut Parser<'i, 't>,
     Ok(last_token_type)
 }
 
-/// Replace `var()` functions for a non-custom property.
-/// Return `Err(())` for invalid at computed time.
+/// Replace `var()` functions for a non-custom property declaration.
+/// Return `Err(..)` if the declaration should be invalid at computed-value time
+/// (that is, if resolution fails).
 pub fn substitute<'i>(input: &'i str, first_token_type: TokenSerializationType,
-                      computed_values_map: &Option<Arc<CustomPropertiesMap>>)
+                      computed_values_map: Option<&CustomPropertiesMap>)
                       -> Result<String, ParseError<'i>> {
     let mut substituted = ComputedValue::empty();
     let mut input = ParserInput::new(input);
@@ -897,7 +1082,7 @@ pub fn substitute<'i>(input: &'i str, first_token_type: TokenSerializationType,
     let mut position = (input.position(), first_token_type);
     let last_token_type = substitute_block(
         &mut input, &mut position, &mut substituted, &mut |name, substituted| {
-            if let Some(value) = computed_values_map.as_ref().and_then(|map| map.get(name)) {
+            if let Some(value) = computed_values_map.and_then(|map| map.get(name)) {
                 substituted.push_variable(value);
                 Ok(value.last_token_type)
             } else {

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -59,12 +59,17 @@ pub enum ExtraData {
     /// The specified value comes from a declaration (whence we get
     /// the UrlExtraData).
     Specified(UrlExtraData),
+
+    /// The specified value comes from an animation or an inherited typed custom
+    /// property (whence we get the properties_and_values::ComputedValue).
+    Precomputed(properties_and_values::ComputedValue),
 }
 
 impl<'a> Into<BorrowedExtraData<'a>> for &'a ExtraData {
     fn into(self) -> BorrowedExtraData<'a> {
         match *self {
             ExtraData::Specified(ref x) => BorrowedExtraData::Specified(x),
+            ExtraData::Precomputed(ref x) => BorrowedExtraData::Precomputed(x),
         }
     }
 }
@@ -79,6 +84,10 @@ pub enum BorrowedExtraData<'a> {
     /// The specified value comes from a declaration (whence we get the
     /// UrlExtraData).
     Specified(&'a UrlExtraData),
+
+    /// The specified value comes from an animation or an inherited typed custom
+    /// property (whence we get the properties_and_values::ComputedValue).
+    Precomputed(&'a properties_and_values::ComputedValue),
 
     /// The specified value comes from an inherited value for an untyped custom
     /// property, and we should just use the token stream value as the computed

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -119,6 +119,7 @@ pub mod matching;
 pub mod media_queries;
 pub mod parallel;
 pub mod parser;
+pub mod properties_and_values;
 pub mod rule_tree;
 pub mod scoped_tls;
 pub mod selector_map;

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -541,7 +541,7 @@ impl PropertyDeclarationBlock {
                          Some(ref computed_values)) => unparsed
                             .substitute_variables(
                                 id,
-                                &computed_values.custom_properties(),
+                                computed_values.get_custom_properties(),
                                 QuirksMode::NoQuirks,
                             )
                             .to_css(dest),

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -11,7 +11,7 @@
 <%namespace name="helpers" file="/helpers.mako.rs" />
 
 use app_units::Au;
-use custom_properties::CustomPropertiesMap;
+use properties_and_values::CustomPropertiesMap;
 use gecko_bindings::bindings;
 % for style_struct in data.style_structs:
 use gecko_bindings::structs::${style_struct.gecko_ffi_name};
@@ -324,7 +324,7 @@ impl ComputedValuesInner {
     }
 
     /// Gets a reference to the custom properties map (if one exists).
-    pub fn get_custom_properties(&self) -> Option<<&::custom_properties::CustomPropertiesMap> {
+    pub fn get_custom_properties(&self) -> Option<<&CustomPropertiesMap> {
         self.custom_properties.as_ref().map(|x| &**x)
     }
 

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -598,9 +598,13 @@ impl AnimationValue {
                 }
             },
             PropertyDeclaration::WithVariables(id, ref unparsed) => {
-                let custom_props = context.style().custom_properties();
-                let substituted = unparsed.substitute_variables(id, &custom_props, context.quirks_mode);
-                AnimationValue::from_declaration(&substituted, context, initial)
+                let substituted = {
+                    let custom_props = context.style().get_custom_properties();
+                    unparsed.substitute_variables(id, custom_props, context.quirks_mode)
+                };
+                AnimationValue::from_declaration(
+                    &substituted, context, initial
+                )
             },
             _ => None // non animatable properties will get included because of shorthands. ignore.
         }

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -992,7 +992,7 @@ ${helpers.predefined_type(
 
     #[derive(Clone, Debug, HasViewportPercentage, PartialEq)]
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    pub struct SpecifiedValue(Vec<SpecifiedOperation>);
+    pub struct SpecifiedValue(pub Vec<SpecifiedOperation>);
 
     impl ToCss for SpecifiedValue {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -791,7 +791,7 @@ pub enum DeclaredValueOwned<T> {
     Value(T),
     /// An unparsed value that contains `var()` functions.
     WithVariables(Arc<UnparsedValue>),
-    /// An CSS-wide keyword.
+    /// A CSS-wide keyword.
     CSSWideKeyword(CSSWideKeyword),
 }
 
@@ -1299,7 +1299,9 @@ pub enum PropertyDeclaration {
     /// An unparsed value that contains `var()` functions.
     WithVariables(LonghandId, Arc<UnparsedValue>),
     /// A custom property declaration, with the property name and the declared
-    /// value.
+    /// value. Custom properties should not use the
+    /// DeclaredValueOwned::WithVariables variant (see the assert in
+    /// ::custom_properties::cascade).
     Custom(::custom_properties::Name, DeclaredValueOwned<Box<::custom_properties::SpecifiedValue>>),
 }
 

--- a/components/style/properties_and_values.rs
+++ b/components/style/properties_and_values.rs
@@ -1,0 +1,1167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Support for the [Properties & Values API][spec].
+//!
+//! [spec]: https://drafts.css-houdini.org/css-properties-values-api-1/
+
+use Atom;
+use cssparser::{BasicParseError, ParseError, ParserInput, Parser, Token};
+use custom_properties::{self, Name};
+use parser::{Parse, ParserContext};
+use properties::CSSWideKeyword;
+use properties::longhands::transform;
+use selectors::parser::SelectorParseError;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::vec::Vec;
+use style_traits::{ParseError as StyleTraitsParseError, StyleParseError};
+use style_traits::values::{OneOrMoreSeparated, Space, ToCss};
+use values;
+use values::computed::{self, ComputedValueAsSpecified, ToComputedValue};
+use values::specified;
+
+/// A registration for a custom property.
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub struct Registration {
+    /// The custom property name, sans leading '--'.
+    pub name: Name,
+
+    /// The syntax of the custom property.
+    pub syntax: Syntax,
+
+    /// Whether the custom property is inherited down the DOM tree.
+    pub inherits: bool,
+
+    /// The initial value of the custom property.
+    ///
+    /// Ideally we'd merge this with `syntax` so that illegal states would be
+    /// unrepresentable. But while we could do that by turning the fields of the
+    /// SpecifiedVariable variants into Option<T>'s, we would need a more
+    /// expressive type system to do this with disjunctions.
+    ///
+    /// Ideally this would also be a ComputedValue. But to reuse the
+    /// to_computed_value code we need a style::values::computed::Context, which
+    /// is a real pain to construct in a nice way for both Stylo & Servo.
+    /// Instead we just store the specified value and compute this later; the
+    /// is_computationally_independent check should mean this doesn't matter.
+    pub initial_value: Option<SpecifiedValue>,
+}
+
+/// A versioned set of registered custom properties, stored on the document.
+/// The [[registeredPropertySet]] of the spec. We keep track of the version to
+/// know if we need to recompute which declarations are valid.
+#[derive(Default)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub struct RegisteredPropertySet {
+    /// The set of registered custom properties. Names are sans leading '--'.
+    registrations: HashMap<Name, Registration>,
+
+    /// The current version. Must be incremented whenever `registrations` is
+    /// modified.
+    generation: u32,
+}
+
+impl RegisteredPropertySet {
+    /// Attempt to register a custom property.
+    ///
+    /// If a custom property has already been registered with that name, return
+    /// Err(()), otherwise return Ok(()) and increment the generation.
+    pub fn register_property(&mut self, registration: Registration) -> Result<(), ()> {
+        match self.registrations.insert(registration.name.clone(), registration) {
+            Some(_) => Err(()),
+            None => {
+                self.generation += 1;
+                Ok(())
+            }
+        }
+    }
+
+    /// Attempt to unregister a custom property.
+    ///
+    /// If no custom property has been registered with that name, return
+    /// Err(()), otherwise return Ok(()) and increment the generation.
+    pub fn unregister_property(&mut self, name: &Name) -> Result<(), ()> {
+        match self.registrations.remove(name) {
+            Some(_) => {
+                self.generation += 1;
+                Ok(())
+            },
+            None => Err(())
+        }
+    }
+
+    /// Return the current generation.
+    ///
+    /// The generation is incremented every time the set of custom property
+    /// registrations changes. It's used by the Stylist to keep track of when it
+    /// has to restyle.
+    pub fn generation(&self) -> u32 {
+        self.generation
+    }
+
+    /// Attempt to get the registration for the custom property with the given
+    /// name.
+    pub fn get(&self, name: &Name) -> Option<&Registration> {
+        self.registrations.get(name)
+    }
+
+    /// Return the set of all uninherited custom properties.
+    ///
+    /// Used by style::properties::compute_early_custom_properties to insert
+    /// initial values when needed.
+    pub fn uninherited_properties(&self) -> HashSet<&Name> {
+        self.registrations
+            .iter()
+            .filter(|&(_, registration)| !registration.inherits)
+            .map(|(name, _)| name)
+            .collect()
+    }
+
+    /// Returns (computed) initial values for all custom properties except those
+    /// specified in `except`. If `except` is None, it's treated as the empty
+    /// set, and we return the initial values for all custom properties.
+    ///
+    /// Initial values are computationally idempotent, so they should not need
+    /// actual computation. Unfortunately the most convenient way to convert a
+    /// specified value to a computed value is to use the to_computed_value
+    /// method, which requires a context.
+    pub fn initial_values_except(
+        &self,
+        context: &computed::Context,
+        except: Option<&HashSet<&Name>>
+    ) -> CustomPropertiesMap {
+        let mut map = CustomPropertiesMap::new();
+        for (name, registration) in self.registrations.iter() {
+            if except.map(|x| x.contains(name)).unwrap_or(false) {
+                continue
+            }
+            if let Some(ref initial) = registration.initial_value {
+                let computed =
+                    (&initial.clone().to_computed_value(context)
+                     .expect("The initial value should never fail to compute."))
+                    .into();
+                map.insert((*name).clone(), computed);
+            }
+        }
+        map
+    }
+}
+
+/// The result of a call to register_property or unregister_property,
+/// corresponding to the errors that can be thrown by CSS.(un)registerProperty.
+///
+/// Should be kept in sync with mozilla::PropertyRegistrationResult on the Gecko
+/// side.
+pub enum PropertyRegistrationResult {
+    /// Indicates that the call was successful. The caller should return without
+    /// error.
+    Ok = 0,
+    /// Indicates that the call failed, and that the caller should throw a
+    /// SyntaxError.
+    SyntaxError,
+    /// Indicates that the call failed, and that the caller should throw an
+    /// InvalidModificationError.
+    InvalidModificationError,
+    /// Indicates that the call failed, and that the caller should throw a
+    /// NotFoundError.
+    NotFoundError,
+}
+
+/// Attempt to register a custom property.
+///
+/// This is used by the CSS.registerProperty implementations for Servo and Gecko
+/// in order to share logic. The caller should handle the returned
+/// PropertyRegistraitonResult by throwing the appropriate DOM error.
+pub fn register_property(
+    registered_property_set: &mut RegisteredPropertySet,
+    parser_context: &ParserContext,
+    name: &str,
+    syntax: &str,
+    inherits: bool,
+    initial_value: Option<&str>
+) -> PropertyRegistrationResult {
+    let name = match custom_properties::parse_name(name) {
+        Ok(name) => name,
+        Err(()) => return PropertyRegistrationResult::SyntaxError,
+    };
+
+    let syntax = match Syntax::from_string(syntax) {
+        Ok(syntax) => syntax,
+        Err(()) => return PropertyRegistrationResult::SyntaxError,
+    };
+
+    let initial_value = match initial_value {
+        Some(ref specified) => {
+            let mut input = ParserInput::new(specified);
+            let mut input = Parser::new(&mut input);
+            match syntax.parse(parser_context, &mut input) {
+                Ok(parsed) => {
+                    if parsed.is_computationally_independent() {
+                        Some(parsed)
+                    } else {
+                        return PropertyRegistrationResult::SyntaxError
+                    }
+                },
+                _ => return PropertyRegistrationResult::SyntaxError,
+            }
+        },
+        None if matches!(syntax, Syntax::Anything) => None,
+        // initialValue is required if the syntax is not '*'.
+        _ => return PropertyRegistrationResult::SyntaxError,
+    };
+
+    let result =
+        registered_property_set
+        .register_property(Registration {
+            name: name.into(),
+            syntax: syntax,
+            inherits: inherits,
+            initial_value: initial_value,
+        });
+
+    match result {
+        Ok(_) => PropertyRegistrationResult::Ok,
+        Err(_) => PropertyRegistrationResult::InvalidModificationError,
+    }
+}
+
+/// Attempt to unregister a custom property.
+///
+/// This is used by the CSS.registerProperty implementations for Servo and Gecko
+/// in order to share logic. The caller should handle the returned
+/// PropertyRegistraitonResult by throwing the appropriate DOM error.
+pub fn unregister_property(
+    registered_property_set: &mut RegisteredPropertySet,
+    name: &str
+) -> PropertyRegistrationResult {
+    let name = match custom_properties::parse_name(name) {
+        Ok(name) => name,
+        Err(()) => return PropertyRegistrationResult::SyntaxError,
+    };
+
+    let result =
+        registered_property_set
+        .unregister_property(&name.into());
+
+    match result {
+        Ok(_) => PropertyRegistrationResult::Ok,
+        Err(_) => PropertyRegistrationResult::NotFoundError,
+    }
+}
+
+
+
+/// A CSS <custom-ident>.
+///
+/// We make a newtype for Atom and implement ToCss ourselves because the
+/// ToCss implementation for atom in `style_traits::values` uses `cssparsers`'s
+/// `serialize_string` function, which writes a double-quoted CSS string. We're
+/// only storing <custom-idents>, which should be serialized as specified.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub struct Ident(pub Atom);
+
+impl ComputedValueAsSpecified for Ident {}
+
+impl ToCss for Ident {
+    #[cfg(feature = "servo")]
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        dest.write_str(&*self.0)
+    }
+
+    #[cfg(feature = "gecko")]
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        dest.write_str(&self.0.to_string())
+    }
+}
+
+impl Deref for Ident {
+    type Target = Atom;
+
+    fn deref(&self) -> &Atom {
+        &self.0
+    }
+}
+
+/// A computed <url> value.
+///
+/// FIXME: While as_str() resolves URLs on the Servo side, it currently does not
+/// resolve them on the Gecko side (see the comment on Gecko's
+/// specified::url::SpecifiedUrl implementation). That means we don't actually
+/// resolve URLs when running in Stylo yet.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub struct ComputedUrl(pub String);
+
+impl ComputedUrl {
+    #[cfg(feature = "servo")]
+    fn from_specified(url: &specified::url::SpecifiedUrl) -> Result<ComputedUrl, ()> {
+        url.url().map(|x| ComputedUrl(x.as_str().to_owned())).ok_or(())
+    }
+
+    #[cfg(feature = "gecko")]
+    fn from_specified(url: &specified::url::SpecifiedUrl) -> Result<ComputedUrl, ()> {
+        // Doesn't work.
+        // url.extra_data.join(url.as_str()).map(|x| ComputedUrl(x.as_str().to_owned())).ok_or(())
+        Ok(ComputedUrl(url.as_str().to_owned()))
+        // Note: the Gecko binding doesn't currently output resolved URLs.
+    }
+}
+
+impl ToCss for ComputedUrl {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+        dest.write_str("url(")?;
+        self.0.to_css(dest)?;
+        dest.write_str(")")
+    }
+}
+
+/// A basic custom property syntax string for a custom property that, used to
+/// build up disjunctions and list terms.
+#[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub enum Type {
+    /// Syntax to allow any valid <length> value.
+    Length,
+    /// Syntax to allow any valid <number> value.
+    Number,
+    /// Syntax to allow any valid <percentage> value.
+    Percentage,
+    /// Syntax to allow any valid <length> or <percentage> value, or any valid
+    /// <calc()> expression combining <length> and <percentage> components.
+    LengthPercentage,
+    /// Syntax to allow any valid <color> value.
+    Color,
+    /// Syntax to allow any valid <image> value.
+    Image,
+    /// Syntax to allow any valid <url> value.
+    Url,
+    /// Syntax to allow any valid <integer> value.
+    Integer,
+    /// Syntax to allow any valid <angle> value.
+    Angle,
+    /// Syntax to allow any valid <time> value.
+    Time,
+    // FIXME: We should support <resolution> values as well.
+    /// Syntax to allow any valid <transform-list> value.
+    TransformList,
+    /// Syntax to allow any valid <custom-ident> value.
+    CustomIdent,
+    /// Syntax to allow a specific identifier (matching the <custom-ident>
+    /// production, compared codepoint-wise).
+    SpecificIdent(Ident),
+}
+
+
+impl Type {
+    /// Attempt to parse `input` as this type.
+    pub fn parse<'i, 't>(
+        &self,
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<SpecifiedValueItem, StyleTraitsParseError<'i>>
+    {
+        #[cfg(feature = "servo")]
+        fn idents_eq(a: &Atom, b: &str) -> bool {
+            a == b
+        }
+
+        #[cfg(feature = "gecko")]
+        fn idents_eq(a: &Atom, b: &str) -> bool {
+            *a == b.into()
+        }
+
+        macro_rules! parse {
+            ($_self:expr, $context:expr, $input:expr,
+
+             $($typ:ident => $fn:path),*) => {
+                match $_self {
+                    $(
+                        Type::$typ => {
+                            $fn(context, input).map(|x| {
+                                SpecifiedValueItem::$typ(x)
+                            })
+                        }
+                    ), *
+
+                    // We need to actually compare SpecificIdents,
+                    // unfortunately.
+                    Type::SpecificIdent(ref x) => {
+                        $input.expect_ident_cloned().and_then(|y| {
+                            if idents_eq(&**x, &*y) {
+                                Ok(SpecifiedValueItem::SpecificIdent(x.clone()))
+                            } else {
+                                Err(BasicParseError::UnexpectedToken(Token::Ident(y)).into())
+                            }
+                        }).map_err(|e| e.into())
+                    },
+                }
+            };
+        }
+
+        fn parse_custom_ident<'i, 't>(
+            _context: &ParserContext,
+            input: &mut Parser<'i, 't>,
+        ) -> Result<Ident, StyleTraitsParseError<'i>> {
+            input.expect_ident_cloned()
+                 .map(|x| Ident((&*x).into()))
+                 .map_err(|e| e.into())
+        }
+
+        parse! {
+            *self, context, input,
+
+            Length => specified::Length::parse,
+            Number => specified::Number::parse,
+            Percentage => specified::Percentage::parse,
+            LengthPercentage => specified::LengthOrPercentage::parse,
+            Color => specified::Color::parse,
+            Image => specified::Image::parse,
+            Url => specified::url::SpecifiedUrl::parse,
+            Integer => specified::Integer::parse,
+            Angle => specified::Angle::parse,
+            Time => specified::Time::parse,
+            TransformList => transform::parse,
+            CustomIdent => parse_custom_ident
+        }
+    }
+}
+
+
+/// A custom property syntax string that is either some basic syntax string
+/// (e.g. some <url> value) or some list term. A list term syntax string allows
+/// a space-separated list of one or more repetitions of the type specified by
+/// the string. Used to build up disjunctions.
+#[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub struct Term {
+    /// The type of the term (e.g. <integer>).
+    pub typ: Type,
+    /// Whether or not the term is a list, i.e., if the syntax string was
+    /// <integer>+.
+    pub list: bool,
+}
+
+/// A custom property syntax string.
+#[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub enum Syntax {
+    /// Syntax to allow any token stream (written '*').
+    Anything,
+    /// Syntax to allow some disjunction of terms (possibly list terms), which
+    /// allows any value matching one of the items in the combination, matched
+    /// in specified order (written 'a | b | ...').
+    Disjunction(Vec<Term>),
+}
+
+impl Syntax {
+    /// Parse a syntax string given to `CSS.registerProperty`.
+    pub fn from_string(input: &str) -> Result<Syntax, ()> {
+        // Syntax strings are DOMStrings, but in Servo we assume they are valid
+        // UTF-8. See
+        // https://doc.servo.org/script/dom/bindings/str/struct.DOMString.html
+        // . This justifies iteration by |char|.
+
+        // Can identifiers in syntax strings contain escapes? No.
+        //
+        // "Currently the answer is no - I've clarified the "literal ident"
+        //  part to be specifically a name-start char followed by 0+ name chars.
+        //  Would prefer to avoid having to do CSS parsing on the syntax string.
+        //  ^_^"
+        // https://github.com/w3c/css-houdini-drafts/issues/112
+        //
+        // A 'specific ident' is any sequence consisting of a name-start code
+        // point, followed by zero
+        // or more name code points, which matches the <custom-ident>
+        // production
+        // https://drafts.css-houdini.org/css-properties-values-api-1/#supported-syntax-strings
+        //
+        // ...
+        // This generic data type is denoted by <custom-ident>, and represents
+        // any valid CSS identifier that would not be misinterpreted as a
+        // pre-defined keyword in that property’s value definition.
+        // https://drafts.csswg.org/css-values-4/#identifier-value
+        //
+        // So! In order to make sure specific identifiers don't contain
+        // escapes, we need to check for escapes, which are only introduced by
+        // backslashes, which shouldn't show up anyhow.
+        // https://drafts.csswg.org/css-syntax-3/#escaping
+        let mut contains_backslash = false;
+        for c in input.chars() {
+            if c == '\\' {
+                contains_backslash = true;
+                break
+            }
+        }
+        if contains_backslash {
+            return Err(())
+        }
+
+        // The parsed syntax string, which we'll build up as we scan tokens.
+        let mut syntax = None;
+
+        // The syntax string isn't really CSS, but hopefully this maximizes
+        // code reuse.
+        let mut parser_input = ParserInput::new(input);
+        let mut parser = Parser::new(&mut parser_input);
+
+        #[derive(Debug)]
+        enum State {
+            // *.
+            AfterAsterisk,
+            // <.
+            AfterOpenAngle,
+            // +.
+            AfterPlus,
+            // <type>.
+            // ident.
+            AfterType { after_whitespace: bool },
+            // <type.
+            AfterTypeName,
+            // .
+            // |.
+            Start { after_bar: bool },
+        }
+
+        let mut state = State::Start { after_bar: false };
+
+        /// Add a `Type` to the disjunction. It might turn out this is a list
+        /// term, in which case we'll modify the `Term` later.
+        fn push_type(syntax: &mut Option<Syntax>, t: Type) {
+            if let Some(Syntax::Disjunction(ref mut ts)) = *syntax {
+                ts.push(Term { typ: t, list: false })
+            } else { unreachable!() }
+        }
+
+        /// Signal that we expect to be parsing some term in a disjunction.
+        fn expect_disjunction(syntax: &mut Option<Syntax>) {
+            if let Some(Syntax::Disjunction(_)) = *syntax {
+                // Good!
+            } else {
+                assert!(*syntax == None);
+                *syntax = Some(Syntax::Disjunction(vec![]))
+            }
+        }
+
+        /// Handle the next token in the syntax string (including whitespace).
+        fn handle_token(syntax: &mut Option<Syntax>, state: State, token: &Token) -> Result<State, ()> {
+            debug!("{:?} - {:?}", state, token);
+            match (state, token) {
+                (_, &Token::Comment(_)) => Err(()),
+
+                (State::Start { .. }, &Token::WhiteSpace(_)) => {
+                    // Ignore whitespace.
+                    Ok(State::Start { after_bar: false })
+                },
+                (State::Start { after_bar: false }, &Token::Delim('*')) => {
+                    // If we see a '*', that should be it (modulo whitespace).
+                    if syntax != &None {
+                        Err(())
+                    } else {
+                        *syntax = Some(Syntax::Anything);
+                        Ok(State::AfterAsterisk)
+                    }
+                },
+                (State::Start { .. }, &Token::Delim('<')) => {
+                    // A '<' should mean we're in the start of a '<type>'.
+                    expect_disjunction(syntax);
+                    Ok(State::AfterOpenAngle)
+                },
+                (State::Start { .. }, &Token::Ident(ref id)) => {
+                    // An identifier by itself should mean we're about to see a
+                    // specific identifier. Note that for <custom-idents> we
+                    // have that they "[must] not be misinterpreted as a
+                    // pre-defined keyword in that property’s value
+                    // definition". Here that means CSS-wide keywords!
+                    expect_disjunction(syntax);
+                    match CSSWideKeyword::from_ident(id) {
+                        Some(_) => Err(()), None => {
+                            push_type(syntax, Type::SpecificIdent(Ident((**id).into())));
+                            Ok(State::AfterType { after_whitespace: false })
+                        }
+                    }
+                },
+                (State::Start { .. }, _) => Err(()),
+
+                (State::AfterOpenAngle, &Token::Ident(ref id)) => {
+                    // We should be in something like '<length>' here.
+                    // https://drafts.css-houdini.org/css-properties-values-api/#supported-syntax-strings
+                    push_type(syntax, match &**id {
+                        "length" => Type::Length,
+                        "number" => Type::Number,
+                        "percentage" => Type::Percentage,
+                        "length-percentage" => Type::LengthPercentage,
+                        "color" => Type::Color,
+                        "image" => Type::Image,
+                        "url" => Type::Url,
+                        "integer" => Type::Integer,
+                        "angle" => Type::Angle,
+                        "time" => Type::Time,
+                        //"resolution" => Type::Resolution,
+                        "transform-list" => Type::TransformList,
+                        "custom-ident" => Type::CustomIdent,
+                        _ => return Err(())
+                    });
+                    Ok(State::AfterTypeName)
+                },
+                (State::AfterOpenAngle, _) => Err(()),
+
+                (State::AfterTypeName, &Token::Delim('>')) => {
+                    // This should be the end of something like '<length>'.
+                    Ok(State::AfterType { after_whitespace: false })
+                },
+                (State::AfterTypeName, _) => Err(()),
+
+                (State::AfterType { .. }, &Token::WhiteSpace(_)) => {
+                    // Ignore whitespace.
+                    Ok(State::AfterType { after_whitespace: true })
+                },
+                (State::AfterType { after_whitespace: false }, &Token::Delim('+')) => {
+                    // We should be following some type.
+                    // We should panic if we're not, because we should only get
+                    // here from Start -> AfterOpenAngle -> AfterTypeName (in
+                    // the case of something like '<length>') or
+                    // Start (in the case of something like 'my-ident'), both
+                    // of which should have pushed a type.
+                    if let Some(Syntax::Disjunction(ref mut ts)) = *syntax {
+                        let term = &mut ts.last_mut().unwrap();
+                        if term.typ == Type::TransformList {
+                            // <transform-list>+ is specifically disallowed.
+                            return Err(())
+                        }
+                        term.list = true
+                    } else { unreachable!() }
+                    Ok(State::AfterPlus)
+                },
+                (State::AfterType { .. }, &Token::Delim('|')) => {
+                    // Some other term in the disjunction should follow.
+                    Ok(State::Start { after_bar: true })
+                },
+                (State::AfterType { .. }, _) => Err(()),
+
+                (State::AfterAsterisk, &Token::WhiteSpace(_)) => Ok(State::AfterAsterisk),
+                (State::AfterAsterisk, _) => Err(()),
+                (State::AfterPlus, &Token::WhiteSpace(_)) => Ok(State::AfterPlus),
+                (State::AfterPlus, &Token::Delim('|')) => {
+                    // Some other term in the disjunction should follow.
+                    Ok(State::Start { after_bar: true })
+                }
+                (State::AfterPlus, _) => Err(()),
+            }
+        }
+
+        // Loop over all of the tokens in the syntax string.
+        loop {
+            match parser.next_including_whitespace_and_comments() {
+                Err(BasicParseError::EndOfInput) => {
+                    match state {
+                        State::Start { after_bar: false } |
+                        State::AfterType { .. } |
+                        State::AfterAsterisk |
+                        State::AfterPlus => break,
+
+                        // We shouldn't reach EOF in the middle of something.
+                        State::Start { after_bar: true } |
+                        State::AfterOpenAngle |
+                        State::AfterTypeName => return Err(())
+                    }
+                },
+                Err(_) => return Err(()),
+                Ok(token) => {
+                    match handle_token(&mut syntax, state, token) {
+                        Ok(s) => state = s,
+                        Err(()) => return Err(())
+                    }
+                }
+            }
+        }
+
+        syntax.ok_or(())
+    }
+
+    /// Parse some value following this syntax.
+    ///
+    /// It's the responsibility of the caller to appropriately delimit the
+    /// input, and to make sure that the expected amount of input was consumed.
+    /// This should accordingly be called with a delimited parser.
+    /// This is a difference from the `parse` function provided by the `Parse`
+    /// trait, along with the fact that this returns a `SpecifiedValue`
+    /// rather than `Self`.
+    pub fn parse<'i, 't>(
+        &self,
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>
+    ) -> Result<SpecifiedValue, StyleTraitsParseError<'i>> {
+        let start = input.state();
+
+        // Check to make sure the entirety of the input isn't some CSS-wide
+        // keyword.
+        if let Ok(ident) = input.expect_ident_cloned() {
+            if input.is_exhausted() {
+                match CSSWideKeyword::from_ident(&ident) {
+                    Some(_) => return Err(BasicParseError::UnexpectedToken(Token::Ident(ident)).into()),
+                    None => (),
+                }
+            }
+        }
+
+        input.reset(&start);
+
+        match *self {
+            Syntax::Anything => {
+                custom_properties::SpecifiedValue::parse(context, input)
+                    // Don't allow variable references: they should have been
+                    // expanded by now.
+                    .and_then(|x| {
+                        if x.has_references() {
+                            Err(BasicParseError::UnexpectedToken(Token::Function("var".into())).into())
+                        } else {
+                            Ok(x)
+                        }
+                    })
+                    .map(|x| SpecifiedValue::Item(SpecifiedValueItem::TokenStream(*x)))
+            },
+            Syntax::Disjunction(ref terms) => {
+                for term in terms {
+                    if term.list {
+                        let mut outputs = Vec::new();
+                        loop {
+                            // TODO(jyc) Extend parse_until_before to take
+                            // space as a delimiter?
+                            match term.typ.parse(context, input) {
+                                Err(_) => break,
+                                Ok(x) => outputs.push(x)
+                            }
+                            // Need at least one.
+                            if input.is_exhausted() {
+                                return Ok(SpecifiedValue::List(outputs))
+                            }
+                            if let Err(_) = input.expect_whitespace() {
+                                break
+                            }
+                        }
+                    } else {
+                        // If we fail to parse, try again!
+                        if let Ok(x) = term.typ.parse(context, input) {
+                            return Ok(SpecifiedValue::Item(x))
+                        }
+                    }
+                    input.reset(&start)
+                }
+                Err(ParseError::Custom(SelectorParseError::Custom(StyleParseError::UnspecifiedError)))
+            },
+        }
+    }
+}
+
+/// A single specified typed value.
+#[derive(Clone, ToCss)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub enum SpecifiedValueItem {
+    /// A single specified <length> value.
+    Length(specified::Length),
+    /// A single specified <number> value.
+    Number(specified::Number),
+    /// A single specified <percentage> value.
+    Percentage(specified::Percentage),
+    /// A single specified <length-percentage> value.
+    LengthPercentage(specified::LengthOrPercentage),
+    /// A single specified <color> value.
+    Color(specified::Color),
+    /// A single specified <image> value.
+    Image(specified::Image),
+    /// A single specified <url> value.
+    Url(specified::url::SpecifiedUrl),
+    /// A single specified <integer> value.
+    Integer(specified::Integer),
+    /// A single specified <angle> value.
+    Angle(specified::Angle),
+    /// A single specified <time> value.
+    Time(specified::Time),
+    // FIXME: We should support <resolution> as well.
+    /// A single specified <transform-list> value (note that this is composed of
+    /// multiple <transform-functions>.
+    TransformList(transform::SpecifiedValue),
+    /// A single specified <custom-ident> value.
+    CustomIdent(Ident),
+    /// A single specified <custom-ident> value that matches the specific ident
+    /// contained herein.
+    SpecificIdent(Ident),
+    /// A <token-stream> value.
+    TokenStream(custom_properties::SpecifiedValue),
+}
+
+impl OneOrMoreSeparated for SpecifiedValueItem {
+    type S = Space;
+}
+
+impl SpecifiedValueItem {
+    /// Returns whether or not this specified value is computationally
+    /// independent, that is, 'if it can be converted into a computed value
+    /// using only the value of the property on the element, and "global"
+    /// information that cannot be changed by CSS.'
+    /// https://drafts.css-houdini.org/css-properties-values-api-1/#computationally-independent
+    pub fn is_computationally_independent(&self) -> bool {
+        use self::specified::{CalcLengthOrPercentage, Length, LengthOrPercentage, LengthOrPercentageOrNumber};
+        use self::specified::NoCalcLength;
+        use self::transform::SpecifiedOperation;
+        use self::values::Either::*;
+        use self::values::generics::transform::Matrix;
+
+        fn check_no_calc_length(length: &NoCalcLength) -> bool {
+            match *length {
+                NoCalcLength::Absolute(_) => true,
+                // FIXME: 0em should be computationally independent.
+                NoCalcLength::FontRelative(_) => false,
+                NoCalcLength::ViewportPercentage(_) => false,
+                NoCalcLength::ServoCharacterWidth(_) => false,
+                // mozmm, depends on DPI. Computation resolves to lengths in
+                // pixels and percentages, so these are not computationally
+                // independent.
+                #[cfg(feature = "gecko")]
+                NoCalcLength::Physical(_) => false,
+            }
+        }
+
+        fn check_calc(calc: &Box<CalcLengthOrPercentage>) -> bool {
+            for part in &[&(**calc).em, &(**calc).ex, &(**calc).ch, &(**calc).rem] {
+                match **part {
+                    None => (),
+                    Some(x) => {
+                        if x != 0.0 {
+                            return false
+                        }
+                    },
+                }
+            }
+            true
+        }
+
+        fn check_length(length: &Length) -> bool {
+            match *length {
+                Length::NoCalc(ref length) => check_no_calc_length(length),
+                Length::Calc(ref calc) => check_calc(calc),
+            }
+        }
+
+        fn check_length_or_percentage(length_or_percentage: &LengthOrPercentage) -> bool {
+            match *length_or_percentage {
+                LengthOrPercentage::Length(ref length) => check_no_calc_length(length),
+                LengthOrPercentage::Percentage(_) => true,
+                LengthOrPercentage::Calc(ref calc) => check_calc(calc),
+            }
+        }
+
+        fn check_lo_po_number(lo_po_number: &LengthOrPercentageOrNumber) -> bool {
+            match *lo_po_number {
+                First(_) => true,
+                Second(ref length_or_percentage) => check_length_or_percentage(length_or_percentage),
+            }
+        }
+
+        fn check_transform_list(transform_list: &transform::SpecifiedValue) -> bool {
+            transform_list.0.iter().all(|operation| {
+                match *operation {
+                    SpecifiedOperation::Matrix(_) => true,
+                    SpecifiedOperation::PrefixedMatrix(Matrix { ref e, ref f, .. }) => {
+                        check_lo_po_number(e) &&
+                        check_lo_po_number(f)
+                    },
+                    SpecifiedOperation::Matrix3D { .. } => true,
+                    SpecifiedOperation::PrefixedMatrix3D { ref m41, ref m42, ref m43, .. } => {
+                        check_lo_po_number(m41) &&
+                        check_lo_po_number(m42) &&
+                        (match *m43 {
+                            First(ref length) => check_length(length),
+                            Second(_) => true,
+                        })
+                    },
+                    SpecifiedOperation::Skew(_, _) => true,
+                    SpecifiedOperation::SkewX(_) => true,
+                    SpecifiedOperation::SkewY(_) => true,
+                    SpecifiedOperation::Translate(ref tx, ref ty) => {
+                        check_length_or_percentage(tx) &&
+                        (match ty {
+                            &Some(ref ty) => check_length_or_percentage(ty),
+                            &None => true,
+                        })
+                    },
+                    SpecifiedOperation::TranslateX(ref tx) => check_length_or_percentage(tx),
+                    SpecifiedOperation::TranslateY(ref ty) => check_length_or_percentage(ty),
+                    SpecifiedOperation::TranslateZ(ref length) => check_length(length),
+                    SpecifiedOperation::Translate3D(ref tx, ref ty, ref tz) => {
+                        check_length_or_percentage(tx) &&
+                        check_length_or_percentage(ty) &&
+                        check_length(tz)
+                    },
+                    SpecifiedOperation::Scale(_, _) => true,
+                    SpecifiedOperation::ScaleX(_) => true,
+                    SpecifiedOperation::ScaleY(_) => true,
+                    SpecifiedOperation::ScaleZ(_) => true,
+                    SpecifiedOperation::Scale3D(_, _, _) => true,
+                    SpecifiedOperation::Rotate(_) => true,
+                    SpecifiedOperation::RotateX(_) => true,
+                    SpecifiedOperation::RotateY(_) => true,
+                    SpecifiedOperation::RotateZ(_) => true,
+                    SpecifiedOperation::Rotate3D(_, _, _, _) => true,
+                    SpecifiedOperation::Perspective(ref length) => check_length(length),
+                    SpecifiedOperation::InterpolateMatrix { ref from_list, ref to_list, .. } => {
+                        check_transform_list(from_list) &&
+                        check_transform_list(to_list)
+                    },
+                    SpecifiedOperation::AccumulateMatrix { ref from_list, ref to_list, .. } => {
+                        check_transform_list(from_list) &&
+                        check_transform_list(to_list)
+                    },
+                }
+            })
+        }
+
+        use self::SpecifiedValueItem::*;
+
+        match *self {
+            Length(ref length) => check_length(length),
+            Number(_) => true,
+            Percentage(_) => true,
+            LengthPercentage(ref length_or_percentage) => check_length_or_percentage(length_or_percentage),
+            Color(_) => true,
+            Image(_) => true,
+            Url(_) => true,
+            Integer(_) => true,
+            Angle(_) => true,
+            Time(_) => true,
+            TransformList(ref transform_list) => check_transform_list(transform_list),
+            CustomIdent(_) => true,
+            SpecificIdent(_) => true,
+            TokenStream(_) => true,
+        }
+    }
+
+    /// Attempts to convert this specified value to a computed value using the
+    /// given context.
+    pub fn to_computed_value(&self, context: &computed::Context) -> Result<ComputedValueItem, ()> {
+        macro_rules! compute {
+            ($_self:expr, $context:expr,
+
+             $($typ:ident),*) => {
+                match $_self {
+                    $(
+                        SpecifiedValueItem::$typ(ref value) => {
+                            Ok(ComputedValueItem::$typ(value.to_computed_value($context)))
+                        }
+                    ), *
+
+                    // Special cases.
+                    // Would put in the match syntax, but we can't have things
+                    // expand to match cases.
+
+                    SpecifiedValueItem::Url(ref url) =>
+                        ComputedUrl::from_specified(url).map(|x| ComputedValueItem::Url(x)),
+                    SpecifiedValueItem::CustomIdent(ref ident) =>
+                        Ok(ComputedValueItem::CustomIdent(ident.clone())),
+                    SpecifiedValueItem::SpecificIdent(ref ident) =>
+                        Ok(ComputedValueItem::SpecificIdent(ident.clone())),
+                    SpecifiedValueItem::TokenStream(ref stream) =>
+                        Ok(ComputedValueItem::TokenStream(stream.token_stream.clone())),
+                }
+            };
+        }
+
+        compute! {
+            *self, context,
+
+            Length, Number, Percentage, LengthPercentage, Color, Image, Integer,
+            Angle, Time, TransformList
+        }
+    }
+}
+
+/// A specified typed value.
+///
+/// A value can either be a single item or a list of items.
+#[derive(Clone, ToCss)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub enum SpecifiedValue {
+    /// A single specified value.
+    Item(SpecifiedValueItem),
+    /// A list of one or more specified values.
+    /// Note that we cannot have lists of <transform-lists>.
+    List(Vec<SpecifiedValueItem>),
+}
+
+/// If `list` and `x` are both `Ok(..)`, append the contents of `x` to `list`.
+/// To be used as an argument to fold to convert a sequence of `Result<T, E>`s
+/// to a `Result<Vec<T>, E>` (pulling the `Result` outside).
+fn all<T, E>(list: Result<Vec<T>, E>, x: Result<T, E>) -> Result<Vec<T>, E> {
+    list.and_then(|mut list| {
+        x.map(move |x| {
+            list.push(x);
+            list
+        })
+    })
+}
+
+impl SpecifiedValue {
+    /// Returns whether or not this specified value is computationally
+    /// independent.
+    /// See the comment on SpecifiedValueItem::is_computationally_independent.
+    pub fn is_computationally_independent(&self) -> bool {
+        match *self {
+            SpecifiedValue::Item(ref item) => item.is_computationally_independent(),
+            SpecifiedValue::List(ref items) => items.iter().all(|x| x.is_computationally_independent()),
+        }
+    }
+
+    /// Attempts to convert this specified value to a computed value.
+    pub fn to_computed_value(&self, context: &computed::Context) -> Result<ComputedValue, ()> {
+        match *self {
+            SpecifiedValue::Item(ref item) => {
+                item.to_computed_value(context).map(|x| ComputedValue::Item(x))
+            }
+            SpecifiedValue::List(ref items) => {
+                // All of the items must compute successfully.
+                items.iter()
+                    .map(|x| x.to_computed_value(context))
+                    .fold(Ok(Vec::new()), all)
+                    .map(ComputedValue::List)
+            },
+        }
+    }
+}
+
+/// A single computed typed value.
+#[derive(Clone, Debug, PartialEq, ToCss)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub enum ComputedValueItem {
+    /// A single computed <length> value.
+    Length(computed::Length),
+    /// A single computed <number> value.
+    Number(computed::Number),
+    /// A single computed <percentage> value.
+    Percentage(computed::Percentage),
+    /// A single computed <length-percentage> value.
+    LengthPercentage(computed::LengthOrPercentage),
+    /// A single computed <color> value.
+    Color(computed::Color),
+    /// A single computed <image> value.
+    Image(computed::Image),
+    /// A single computed <url> value.
+    Url(ComputedUrl),
+    /// A single computed <integer> value.
+    Integer(computed::Integer),
+    /// A single computed <angle> value.
+    Angle(computed::Angle),
+    /// A single computed <time> value.
+    Time(computed::Time),
+    // FIXME: We should support <resolution> values as well.
+    /// A single computed <transform-list> value (note that this is composed of
+    /// multiple <transform-functions>.
+    TransformList(transform::computed_value::T),
+    /// A single computed <custom-ident> value.
+    CustomIdent(Ident),
+    /// A single specified <custom-ident> value that matches the specific ident
+    /// contained herein.
+    SpecificIdent(Ident),
+    /// A computed <token-stream> value (the same as an uncomputed
+    /// <token-stream> value).
+    TokenStream(custom_properties::TokenStream),
+}
+
+/// A computed typed value.
+#[derive(Clone, Debug, PartialEq, ToCss)]
+#[cfg_attr(feature = "servo", derive(HeapSizeOf))]
+pub enum ComputedValue {
+    /// A single value.
+    Item(ComputedValueItem),
+    /// A list of one or more values.
+    List(Vec<ComputedValueItem>),
+}
+
+impl OneOrMoreSeparated for ComputedValueItem {
+    type S = Space;
+}
+
+/// A map from CSS variable names to CSS variable computed values, used for
+/// resolving.
+///
+/// This composes a custom_properties::CustomPropertiesMap, which maps CSS
+/// variable names to their token stream values.
+///
+/// We also keep track of whether or not this contains any uninherited
+/// properties, in order to just clone an Arc when possible.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CustomPropertiesMap {
+    untyped_map: custom_properties::CustomPropertiesMap,
+    typed_map: HashMap<Name, ComputedValue>,
+    has_uninherited: bool,
+}
+
+impl CustomPropertiesMap {
+    /// Creates a new custom properties map.
+    pub fn new() -> Self {
+        CustomPropertiesMap {
+            untyped_map: custom_properties::CustomPropertiesMap::new(),
+            typed_map: Default::default(),
+            has_uninherited: false,
+        }
+    }
+
+    // We reuse almost everything from custom_properties::CustomPropertiesMap
+    // due to our Deref implementation.
+
+    /// Insert both an uncomputed and computed value for a typed custom property
+    /// if they have not previously been inserted. This must not be called for
+    /// untyped custom properties. The untyped custom property is not inserted
+    /// if it is not provided (currently this is only used so that
+    /// custom_properties::substitute_one doesn't need to be aware of typed
+    /// custom properties).
+    pub fn insert_typed(
+        &mut self,
+        name: &Name,
+        untyped_value: Option<custom_properties::ComputedValue>,
+        typed_value: ComputedValue,
+    ) {
+        debug_assert!(!self.typed_map.contains_key(name));
+        if let Some(untyped_value) = untyped_value {
+            self.untyped_map.insert(name.clone(), untyped_value);
+        }
+        self.typed_map.insert(name.clone(), typed_value);
+    }
+
+    /// Get the (typed) computed value.
+    /// It is not an error to call this with an untyped custom property: in that
+    /// case we just return None (callers should themselves check whether or not
+    /// a property has been registered).
+    pub fn get_typed(&self, name: &Name) -> Option<&ComputedValue> {
+        self.typed_map.get(name)
+    }
+
+    /// Mark that this map contains a non-initial value for an uninherited
+    /// custom property.
+    pub fn set_has_uninherited(&mut self) {
+        self.has_uninherited = true
+    }
+
+    /// Return whether this map contains a non-initial value for an uninherited
+    /// custom property.
+    pub fn has_uninherited(&self) -> bool {
+        self.has_uninherited
+    }
+}
+
+impl Deref for CustomPropertiesMap {
+    type Target = custom_properties::CustomPropertiesMap;
+
+    fn deref(&self) -> &Self::Target {
+        &self.untyped_map
+    }
+}
+
+impl DerefMut for CustomPropertiesMap {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.untyped_map
+    }
+}

--- a/components/style/shared_lock.rs
+++ b/components/style/shared_lock.rs
@@ -260,14 +260,18 @@ pub struct StylesheetGuards<'a> {
 
     /// For user-agent-origin and user-origin stylesheets
     pub ua_or_user: &'a SharedRwLockReadGuard<'a>,
+
+    /// For the registered property set.
+    pub registered_property_set: &'a SharedRwLockReadGuard<'a>,
 }
 
 impl<'a> StylesheetGuards<'a> {
-    /// Same guard for all origins
+    /// Same guard for all origins. Used by Stylo.
     pub fn same(guard: &'a SharedRwLockReadGuard<'a>) -> Self {
         StylesheetGuards {
             author: guard,
             ua_or_user: guard,
+            registered_property_set: guard,
         }
     }
 }

--- a/components/style/style_resolver.rs
+++ b/components/style/style_resolver.rs
@@ -486,7 +486,8 @@ where
                 Some(&mut cascade_info),
                 &self.context.thread_local.font_metrics_provider,
                 cascade_flags,
-                self.context.shared.quirks_mode
+                self.context.shared.quirks_mode,
+                self.context.shared.stylist.registered_property_set(),
             );
 
         cascade_info.finish(&self.element.as_node());

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -36,6 +36,7 @@ use selectors::visitor::SelectorVisitor;
 use servo_arc::{Arc, ArcBorrow};
 use shared_lock::{Locked, SharedRwLockReadGuard, StylesheetGuards};
 use smallvec::VecLike;
+use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::ops;
 use style_traits::viewport::ViewportConstraints;
@@ -731,7 +732,11 @@ impl Stylist {
                             None,
                             font_metrics,
                             cascade_flags,
-                            self.quirks_mode)
+                            self.quirks_mode,
+                            self.registered_property_set
+                                .as_ref()
+                                .expect("set_registered_property_set should have been called")
+                                .borrow())
     }
 
     /// Returns the style for an anonymous box of the given type.
@@ -904,7 +909,11 @@ impl Stylist {
                                     None,
                                     font_metrics,
                                     cascade_flags,
-                                    self.quirks_mode);
+                                    self.quirks_mode,
+                                    self.registered_property_set
+                                        .as_ref()
+                                        .expect("The registered property set must be set beforehand.")
+                                        .borrow());
 
             Some(computed)
         } else {
@@ -930,7 +939,11 @@ impl Stylist {
                             None,
                             font_metrics,
                             cascade_flags,
-                            self.quirks_mode)
+                            self.quirks_mode,
+                            self.registered_property_set
+                                .as_ref()
+                                .expect("The registered property set must be set beforehand.")
+                                .borrow())
     }
 
     fn has_rules_for_pseudo(&self, pseudo: &PseudoElement) -> bool {
@@ -1504,7 +1517,12 @@ impl Stylist {
                             None,
                             &metrics,
                             CascadeFlags::empty(),
-                            self.quirks_mode)
+                            self.quirks_mode,
+                            self.registered_property_set
+                                .as_ref()
+                                .expect("set_registered_property_set should \
+                                         have been called.")
+                                .borrow())
     }
 
     /// Accessor for a shared reference to the device.

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -21,6 +21,7 @@ use properties::{AnimationRules, PropertyDeclarationBlock};
 #[cfg(feature = "servo")]
 use properties::INHERIT_ALL;
 use properties::IS_LINK;
+use properties_and_values::RegisteredPropertySet;
 use rule_tree::{CascadeLevel, RuleTree, StyleSource};
 use selector_map::{PrecomputedHashMap, SelectorMap, SelectorMapEntry};
 use selector_parser::{SelectorImpl, PerPseudoElementMap, PseudoElement};
@@ -391,6 +392,16 @@ pub struct Stylist {
 
     /// The total number of times the stylist has been rebuilt.
     num_rebuilds: usize,
+
+    /// The set of registered custom properties associated with the document.
+    /// Should be initialized as soon as possible.
+    #[cfg_attr(feature = "servo", ignore_heap_size_of = "Arc")]
+    registered_property_set: Option<Arc<Locked<RegisteredPropertySet>>>,
+
+    /// The registered property set generation at the time that rebuild was last
+    /// called. Used to keep track of whether or not we need to actually
+    /// rebuild, similar to is_device_dirty.
+    last_used_registered_property_set_generation: Option<u32>,
 }
 
 /// What cascade levels to include when styling elements.
@@ -428,6 +439,8 @@ impl Stylist {
             cascade_data: Default::default(),
             rule_tree: RuleTree::new(),
             num_rebuilds: 0,
+            registered_property_set: None,
+            last_used_registered_property_set_generation: None,
         }
     }
 
@@ -456,6 +469,38 @@ impl Stylist {
     pub fn num_invalidations(&self) -> usize {
         self.cascade_data.iter_origins()
             .map(|(d, _)| d.invalidation_map.len()).sum()
+    }
+
+    /// Set the registered property set associated with the document this
+    /// Stylist is styling.
+    pub fn set_registered_property_set(
+        &mut self,
+        registered_property_set: Arc<Locked<RegisteredPropertySet>>
+    ) {
+        debug_assert!(if let Some(ref old) = self.registered_property_set {
+            Arc::ptr_eq(old, &registered_property_set)
+        } else { true });
+        self.registered_property_set = Some(registered_property_set);
+    }
+
+    /// Get the registered property set associated with the document this
+    /// Stylist is styling. Panics if there is none set.
+    pub fn registered_property_set(&self) -> &Locked<RegisteredPropertySet> {
+        self.registered_property_set
+            .as_ref()
+            .map(|x| &**x)
+            .expect("set_registered_property_set should have been called.")
+    }
+
+    /// Returns whether the registered property set was updated since the last
+    /// time the Stylist was flushed.
+    pub fn registered_property_set_updated(&self, guard: &SharedRwLockReadGuard) -> bool {
+        let registered_property_set =
+            self.registered_property_set.as_ref()
+            .expect("set_registered_property_set must be called.")
+            .read_with(guard);
+
+        self.last_used_registered_property_set_generation != Some(registered_property_set.generation())
     }
 
     /// Invokes `f` with the `InvalidationMap` for each origin.

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -59,6 +59,7 @@
   "layout.column-gap.enabled": false,
   "layout.column-width.enabled": false,
   "layout.columns.enabled": false,
+  "layout.css.properties-and-values.enabled": false,
   "layout.text-orientation.enabled": false,
   "layout.viewport.enabled": false,
   "layout.writing-mode.enabled": false,

--- a/tests/wpt/metadata/css-properties-values-api/__dir__.ini
+++ b/tests/wpt/metadata/css-properties-values-api/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [layout.css.properties-and-values.enabled:true]

--- a/tests/wpt/metadata/css-properties-values-api/animation.html.ini
+++ b/tests/wpt/metadata/css-properties-values-api/animation.html.ini
@@ -1,0 +1,59 @@
+[animation.html]
+  type: testharness
+  [anim: {"keyframes":"number","property":"--number","syntax":"<number>","halfway":"0.5"}]
+    expected: FAIL
+
+  [anim: {"keyframes":"transform","property":"--transform","syntax":"<transform-function>","halfway":"rotate(90deg)"}]
+    expected: FAIL
+
+  [anim: {"keyframes":"list1","property":"--list","syntax":"<number>+","halfway":"0.5 1.0"}]
+    expected: FAIL
+
+  [anim: {"keyframes":"lp","property":"--lp","syntax":"<length-percentage>","halfway":"calc(7 + 30%)"}]
+    expected: FAIL
+
+  [anim: {"keyframes":"length","property":"--length","syntax":"<length>","halfway":"5px"}]
+    expected: FAIL
+
+  [anim: {"keyframes":"percentage","property":"--percentage","syntax":"<percentage>","halfway":"50%"}]
+    expected: FAIL
+
+  [anim: {"keyframes":"integer","property":"--integer","syntax":"<integer>","halfway":"5"}]
+    expected: FAIL
+
+  [anim: {"keyframes":"lps1","property":"--lps","syntax":"<length-percentage>+","halfway":"50px 50% calc(50px + 50%)"}]
+    expected: FAIL
+
+  [anim: {"keyframes":"lps2","property":"--lps","syntax":"<length-percentage>+","halfway":"calc(75px + 0%) calc(0px + 75%) calc(25px + 25%)"}]
+    expected: FAIL
+
+  [anim #2: {"syntax":"<number>","keyframes":["0","1"\],"checks":{"0.4":"0.4","0.6":"0.6"}}]
+    expected: FAIL
+
+  [anim #2: {"syntax":"<angle>","keyframes":["0deg","90deg"\],"checks":{"0.4":"0deg","0.6":"90deg"}}]
+    expected: FAIL
+
+  [anim #2: {"syntax":"<time>","keyframes":["3s","9s"\],"checks":{"0.4":"3s","0.6":"9s"}}]
+    expected: FAIL
+
+  [anim #2: {"syntax":"<resolution>","keyframes":["96dpi","144dpi"\],"checks":{"0.4":"96dpi","0.6":"144dpi"}}]
+    expected: FAIL
+
+  [anim #2: {"syntax":"<custom-ident>","keyframes":["doing-good","is-in-our-code"\],"checks":{"0.4":"doing-good","0.6":"is-in-our-code"}}]
+    expected: FAIL
+
+  [anim #2: {"syntax":"Mozilla | Firefox","keyframes":["Mozilla","Firefox"\],"checks":{"0.4":"Mozilla","0.6":"Firefox"}}]
+    expected: FAIL
+
+  [anim #2: {"syntax":"<url>","keyframes":["url(\\"http://mozilla.com/\\")","url(\\"http://firefox.com/\\")"\],"checks":{"0.4":"url(\\"http://mozilla.com/\\")","0.6":"url(\\"http://firefox.com/\\")"}}]
+    expected: FAIL
+
+  [anim #2: {"syntax":"*","keyframes":["youve never seen the real numbers","like this before"\],"checks":{"0.4":"youve never seen the real numbers","0.6":"like this before"}}]
+    expected: FAIL
+
+  [Custom properties without initial values missing in keyframes should be removed.]
+    expected: FAIL
+
+  [Custom properties in missing keyframes using computed values should be filled in.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css-properties-values-api/computed-values.html.ini
+++ b/tests/wpt/metadata/css-properties-values-api/computed-values.html.ini
@@ -1,0 +1,92 @@
+[computed-values.html]
+  type: testharness
+  [computed value: {"syntax":"<transform-function>","declared":"rotate(0deg)","expected":"rotate(0deg)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-function>","declared":"rotate(0grad)","expected":"rotate(0grad)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-function>","declared":"rotate(0rad)","expected":"rotate(0rad)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-function>","declared":"rotate(0turn)","expected":"rotate(0turn)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<color>","declared":"#abcdef01","expected":"rgb(171, 205, 239, 0.004)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<color>","declared":"red","expected":"red"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<integer>","declared":"calc(0.5 * 2 * 3)","expected":""}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<resolution>","declared":"50dppx","expected":"50dppx"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-function>","declared":"matrix(1, 0, 1, 0, 1, 1)","expected":"matrix(1, 0, 1, 0, 1, 1)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-list>","declared":"rotate(0deg)","expected":"rotate(0deg)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-list>","declared":"rotate(0grad)","expected":"rotate(0grad)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-list>","declared":"rotate(0rad)","expected":"rotate(0rad)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-list>","declared":"rotate(0turn)","expected":"rotate(0turn)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-list>","declared":"matrix(1, 0, 1, 0, 1, 1)","expected":"matrix(1, 0, 1, 0, 1, 1)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<length-percentage>","declared":"calc(20px - 20px - 30%)","expected":"calc(0px + -30%)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<length> | <percentage>","declared":"calc(15%)","expected":"15%"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<length-percentage>","declared":"calc(13px + 27%)","expected":"calc(13px + 27%)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-list>","initial":"rotate(10deg)","declared":"rotate(0deg)","expected":"rotate(0deg)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-list>","initial":"rotate(10grad)","declared":"rotate(0grad)","expected":"rotate(0grad)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-list>","initial":"rotate(10rad)","declared":"rotate(0rad)","expected":"rotate(0rad)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-list>","initial":"rotate(10turn)","declared":"rotate(0turn)","expected":"rotate(0turn)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<length-percentage>","initial":"10px","declared":"calc(70% - 70% + 20px)","expected":"calc(0% + 30px)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<length-percentage>","initial":"10px","declared":"calc(20px - 20px - 30%)","expected":"calc(-30% + 0px)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<length> | <percentage>","initial":"10px","declared":"calc(15%)","expected":"15%"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<length-percentage>","initial":"10px","declared":"calc(27% + 13px)","expected":"calc(27% + 13px)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<color>","initial":"red","declared":"#abcdef01","expected":"rgb(171, 205, 239, 0.004)"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<color>","initial":"green","declared":"red","expected":"red"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<integer>","initial":"10","declared":"calc(0.5 * 2 * 3)","expected":"10"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<resolution>","initial":"10dppx","declared":"50dppx","expected":"50dppx"}]
+    expected: FAIL
+
+  [computed value: {"syntax":"<transform-list>","initial":"scale(10)","declared":"matrix(1, 0, 1, 0, 1, 1)","expected":"matrix(1, 0, 1, 0, 1, 1)"}]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css-properties-values-api/family.html.ini
+++ b/tests/wpt/metadata/css-properties-values-api/family.html.ini
@@ -1,0 +1,5 @@
+[family.html]
+  type: testharness
+  [family: Transform function arguments should be computed.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css-properties-values-api/independence.html.ini
+++ b/tests/wpt/metadata/css-properties-values-api/independence.html.ini
@@ -1,0 +1,17 @@
+[independence.html]
+  type: testharness
+  [independence fail: {"syntax":"<transform-function>","initialValue":"translateX(5em)"}]
+    expected: FAIL
+
+  [independence fail: {"syntax":"<color> | <transform-function>+","initialValue":"translateX(-10em)"}]
+    expected: FAIL
+
+  [independence pass: {"syntax":"<transform-function>","initialValue":"translateX(5px)"}]
+    expected: FAIL
+
+  [independence pass: {"syntax":"<transform-function>+","initialValue":"translateX(5px) translateX(-10px)"}]
+    expected: FAIL
+
+  [independence pass: {"syntax":"<transform-list>+","initialValue":"translateX(5px) translateX(-10px)"}]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css-properties-values-api/syntax.html.ini
+++ b/tests/wpt/metadata/css-properties-values-api/syntax.html.ini
@@ -1,0 +1,17 @@
+[syntax.html]
+  type: testharness
+  [valid syntax: {"syntax":"<color>  +"}]
+    expected: FAIL
+
+  [syntax pass: {"syntax":"<transform-function>","initialValue":"translateX(5px)"}]
+    expected: FAIL
+
+  [syntax pass: {"syntax":"<resolution>","initialValue":"5dpi"}]
+    expected: FAIL
+
+  [invalid syntax: {"syntax":"revert"}]
+    expected: FAIL
+
+  [invalid syntax: {"syntax":"revert","initialValue":"revert"}]
+    expected: FAIL
+

--- a/tests/wpt/metadata/fetch/api/cors/cors-preflight.any.js.ini
+++ b/tests/wpt/metadata/fetch/api/cors/cors-preflight.any.js.ini
@@ -21,6 +21,7 @@
   [CORS [PUT\] [several headers\], server allows]
     expected: FAIL
 
+
 [cors-preflight.any.worker.html]
   type: testharness
   [CORS [PATCH\], server allows]
@@ -43,3 +44,4 @@
 
   [CORS [PUT\] [several headers\], server allows]
     expected: FAIL
+

--- a/tests/wpt/web-platform-tests/css-properties-values-api/animation.html
+++ b/tests/wpt/web-platform-tests/css-properties-values-api/animation.html
@@ -1,0 +1,355 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Bug 1273706 - Animation (CSS Properties &amp; Values)</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api/#animation-behavior-of-custom-properties" />
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="common.js"></script>
+
+<!-- Styles used to test custom properties going through the whole system
+     correctly. -->
+<style type="text/css">
+div#container {
+  font-size: 16px;
+}
+
+@keyframes number {
+  from { --number: 0; }
+  to { --number: 1; }
+}
+
+@keyframes transform {
+  from { --transform: rotate(0deg); }
+  to { --transform: rotate(180deg); }
+}
+
+@keyframes list1 {
+  from { --list: 0 0; }
+  to { --list: 1 2; }
+}
+
+@keyframes lp {
+  from { --lp: calc(0 + 15%); }
+  to { --lp: calc(45% + 14); }
+}
+
+@keyframes length {
+  from { --length: 0px; }
+  to { --length: 10px; }
+}
+
+@keyframes percentage {
+  from { --percentage: 0%; }
+  to { --percentage: 100%; }
+}
+
+@keyframes integer {
+  from { --integer: 0; }
+  to { --integer: 10; }
+}
+
+@keyframes lps1 {
+  from { --lps: 0px 0% calc(0px + 0%); }
+  to { --lps: 100px 100% calc(100px + 100%); }
+}
+
+@keyframes lps2 {
+  from { --lps: calc(50px + 0%) calc(0px + 50%) calc(50px + 50%); }
+  to { --lps: calc(100px + 0%) calc(0px + 100%) calc(0px + 0%); }
+}
+
+@keyframes missing {
+  from { --number: 0; }
+}
+</style>
+
+<!-- Some dummy elements that we will use for testing. -->
+<div id="container">
+  <div id="sandbox"></div>
+</div>
+
+<script>
+// Test specifications.
+let animTests = [
+  { keyframes: "number",
+    property: "--number",
+    syntax: "<number>",
+    halfway: "0.5"
+  },
+  { keyframes: "transform",
+    property: "--transform",
+    syntax: "<transform-function>",
+    halfway: "rotate(90deg)"
+  },
+  { keyframes: "list1",
+    property: "--list",
+    syntax: "<number>+",
+    halfway: "0.5 1.0"
+  },
+  { keyframes: "lp",
+    property: "--lp",
+    syntax: "<length-percentage>",
+    halfway: "calc(7 + 30%)"
+  },
+  { keyframes: "length",
+    property: "--length",
+    syntax: "<length>",
+    halfway: "5px",
+  },
+  { keyframes: "percentage",
+    property: "--percentage",
+    syntax: "<percentage>",
+    halfway: "50%",
+  },
+  { keyframes: "integer",
+    property: "--integer",
+    syntax: "<integer>",
+    halfway: "5",
+  },
+  { keyframes: "lps1",
+    property: "--lps",
+    syntax: "<length-percentage>+",
+    halfway: "50px 50% calc(50px + 50%)",
+  },
+  { keyframes: "lps2",
+    property: "--lps",
+    syntax: "<length-percentage>+",
+    halfway: "calc(75px + 0%) calc(0px + 75%) calc(25px + 25%)",
+  },
+];
+
+let animTests2 = [
+  { syntax: "<number>",
+    keyframes: [
+      "0",
+      "1",
+    ],
+    checks: {
+      "0.4": "0.4",
+      "0.6": "0.6",
+    },
+  },
+
+  // These are uninterpolable values.
+  // They should be flip at 50%.
+
+  { syntax: "<angle>",
+    keyframes: [
+      "0deg",
+      "90deg",
+    ],
+    checks: {
+      "0.4": "0deg",
+      "0.6": "90deg",
+    },
+  },
+
+  { syntax: "<time>",
+    keyframes: [
+      "3s",
+      "9s",
+    ],
+    checks: {
+      "0.4": "3s",
+      "0.6": "9s",
+    },
+  },
+
+  { syntax: "<resolution>",
+    keyframes: [
+      "96dpi",
+      "144dpi",
+    ],
+    checks: {
+      "0.4": "96dpi",
+      "0.6": "144dpi",
+    },
+  },
+
+  { syntax: "<custom-ident>",
+    keyframes: [
+      "doing-good",
+      "is-in-our-code",
+    ],
+    checks: {
+      "0.4": "doing-good",
+      "0.6": "is-in-our-code",
+    },
+  },
+
+  { syntax: "Mozilla | Firefox",
+    keyframes: [
+      "Mozilla",
+      "Firefox",
+    ],
+    checks: {
+      "0.4": "Mozilla",
+      "0.6": "Firefox",
+    },
+  },
+
+  // <url>s need to carry around a principal too, so it's worth testing that we
+  // are able to pass them around correctly (the others are all just unparsed
+  // strings).
+  { syntax: "<url>",
+    keyframes: [
+      "url(\"http://mozilla.com/\")",
+      "url(\"http://firefox.com/\")",
+    ],
+    checks: {
+      "0.4": "url(\"http://mozilla.com/\")",
+      "0.6": "url(\"http://firefox.com/\")",
+    },
+  },
+
+  { syntax: "*",
+    keyframes: [
+      "youve never seen the real numbers",
+      "like this before",
+    ],
+    checks: {
+      "0.4": "youve never seen the real numbers",
+      "0.6": "like this before",
+    },
+  },
+];
+
+let sandbox = document.getElementById("sandbox");
+
+for (let spec of animTests) {
+  let { keyframes, property, syntax, halfway } = spec;
+  test(function () {
+    try {
+      CSS.registerProperty({ name: property, syntax: syntax });
+
+      // Store into |computedExpected| the computed value we get from specifying
+      // |halfway|. This should normalize the value.
+      sandbox.style.setProperty(property, halfway);
+      let computedExpected = window.getComputedStyle(sandbox)
+                                   .getPropertyValue(property);
+      sandbox.style.removeProperty(property);
+
+      sandbox.style.setProperty("animation-name", keyframes);
+      sandbox.style.setProperty("animation-duration", "1s");
+      sandbox.style.setProperty("animation-timing-function", "linear");
+
+      let anim = sandbox.getAnimations()[0];
+      anim.pause();
+      anim.currentTime = 500;
+
+      let computed = window.getComputedStyle(sandbox)
+                           .getPropertyValue(property);
+      assert_equals(computed, computedExpected,
+                    "halfway value equals expected value");
+    } finally {
+      sandbox.style.removeProperty("animation-name");
+      sandbox.style.removeProperty("animation-duration");
+      sandbox.style.removeProperty("animation-timing-function");
+      CSS.unregisterProperty(property);
+    }
+  }, "anim: " + JSON.stringify(spec));
+}
+
+for (let spec of animTests2) {
+  let { keyframes, initial, syntax, checks } = spec;
+  test(function () {
+    try {
+      CSS.registerProperty({ name: "--test", syntax: syntax });
+
+      let anim = sandbox.animate(
+                   keyframes.map(value => ({ "--test": value })), 1000);
+      try {
+        anim.pause();
+        for (let point in checks) {
+          let time = parseFloat(point);
+          anim.currentTime = time * 1000;
+          let computed = window.getComputedStyle(sandbox)
+                               .getPropertyValue("--test");
+          assert_equals(computed, checks[point],
+                        `value at time ${time} equals expected value`);
+        }
+      } finally {
+        anim.cancel();
+      }
+    } finally {
+      sandbox.style.removeProperty("--test");
+      CSS.unregisterProperty("--test");
+    }
+  }, "anim #2: " + JSON.stringify(spec));
+}
+
+// Make sure that we fill in missing keyframe values.
+// It's possible to have custom properties without initial values (i.e. they
+// have invalid initial values).
+// CSS Animations says:
+//   If a ‘0%’ or ‘from’ keyframe is not specified, then the user agent
+//   constructs a ‘0%’ keyframe using the computed values of the properties
+//   being animated. If a ‘100%’ or ‘to’ keyframe is not specified, then the
+//   user agent constructs a ‘100%’ keyframe using the computed values of the
+//   properties being animated.
+// But for a custom property without an initial value, it's not possible to
+// fill in a value.
+
+test(function () {
+  CSS.registerProperty({ name: "--number", syntax: "<number>" });
+
+  sandbox.style.setProperty("animation-name", "missing");
+  sandbox.style.setProperty("animation-duration", "1s");
+  sandbox.style.setProperty("animation-timing-function", "linear");
+
+  let anim = sandbox.getAnimations()[0];
+  anim.pause();
+  anim.currentTime = 500;
+
+  try {
+    assert_equals(window.getComputedStyle(sandbox)
+                        .getPropertyValue("--number"),
+                  "",
+                  "There should be no animation if there is no property to " +
+                  "fall back on.");
+    // Shouldn't segfault while uncomputing values either!
+    for (let keyframe of anim.effect.getKeyframes()) {
+      assert_equals(keyframe["--number"], undefined,
+        "Shouldn't have --number in keyframes when we were missing a " +
+        "keyframe value.");
+    }
+  } finally {
+    CSS.unregisterProperty("--number");
+    sandbox.style.removeProperty("animation-name");
+    sandbox.style.removeProperty("animation-duration");
+    sandbox.style.removeProperty("animation-timing-function");
+  }
+}, "Custom properties without initial values missing in keyframes should be " +
+   "removed.");
+
+test(function () {
+  CSS.registerProperty({ name: "--number", syntax: "<number>" });
+
+  sandbox.style.setProperty("animation-name", "missing");
+  sandbox.style.setProperty("animation-duration", "1s");
+  sandbox.style.setProperty("animation-timing-function", "linear");
+  sandbox.style.setProperty("--number", "1");
+
+  let anim = sandbox.getAnimations()[0];
+  anim.pause();
+  anim.currentTime = 500;
+
+  try {
+    assert_equals(window.getComputedStyle(sandbox)
+                        .getPropertyValue("--number"),
+                  "0.5",
+                  "Animation value should have been filled in using computed " +
+                  "value.");
+    for (let keyframe of anim.effect.getKeyframes()) {
+      assert_true(keyframe["--number"] != undefined,
+        "Should have --number in keyframes, serialized as a custom property.");
+    }
+  } finally {
+    CSS.unregisterProperty("--number");
+    sandbox.style.removeProperty("animation-name");
+    sandbox.style.removeProperty("animation-duration");
+    sandbox.style.removeProperty("animation-timing-function");
+  }
+}, "Custom properties in missing keyframes using computed values should be " +
+   "filled in.");
+</script>

--- a/tests/wpt/web-platform-tests/css-properties-values-api/common.js
+++ b/tests/wpt/web-platform-tests/css-properties-values-api/common.js
@@ -1,0 +1,45 @@
+let expectFail = function (testName, specs, type, message) {
+  for (let spec of specs) {
+    test(function () {
+      if (!spec.name) {
+        spec.name = "--test-property";
+      }
+      let caught = null;
+      try {
+        CSS.registerProperty(spec);
+      } catch (e) {
+        caught = e;
+      }
+      let passed = caught instanceof DOMException && caught.name == type;
+      try {
+        assert_true(passed, message + " " + JSON.stringify(spec));
+      } finally {
+        if (!passed) {
+          CSS.unregisterProperty(spec.name);
+        }
+      }
+    }, testName + ": " + JSON.stringify(spec));
+  }
+};
+
+let expectSucceed = function (testName, specs, message) {
+  for (let spec of specs) {
+    test(function () {
+      if (!spec.name) {
+        spec.name = "--test-property";
+      }
+      let caught = null;
+      try {
+        CSS.registerProperty(spec);
+      } catch (e) {
+        caught = e;
+      }
+      let passed = !caught;
+      assert_true(passed, message + " " + JSON.stringify(spec));
+      if (passed) {
+        CSS.unregisterProperty(spec.name);
+      }
+    }, testName + ": " + JSON.stringify(spec));
+  }
+};
+

--- a/tests/wpt/web-platform-tests/css-properties-values-api/computed-values.html
+++ b/tests/wpt/web-platform-tests/css-properties-values-api/computed-values.html
@@ -1,0 +1,392 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Bug 1273706 - Computed Values (CSS Properties &amp; Values)</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api/#calculation-of-computed-values" />
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<style type="text/css">
+div#container {
+  font-size: 16px;
+}
+</style>
+
+<div id="container">
+  <div id="sandbox"></div>
+</div>
+<a id="link" href="/"></a>
+
+<script>
+let baseURL = document.getElementById("link").href;
+let sandbox = document.getElementById("sandbox");
+
+// https://drafts.csswg.org/cssom/#serialize-a-css-value
+
+// The initial values aren't relevant, but unfortunately they are required by
+// the spec... Try to choose something distinct from the expected value.
+let computedValueTests = [
+  // Parsing & computing (incl. serializing) lists of idents.
+  {
+    syntax: "a+ | <custom-ident>+",
+    initial: "a",
+    declared: "a a a a b c d",
+    expected: "a a a a b c d",
+  },
+  // Angle units by themselves and in transform functions.
+  {
+    syntax: "<angle>",
+    initial: "10deg",
+    declared: "0deg",
+    expected: "0deg",
+  },
+  {
+    syntax: "<angle>",
+    initial: "10grad",
+    declared: "0grad",
+    expected: "0grad",
+  },
+  {
+    syntax: "<angle>",
+    initial: "10rad",
+    declared: "0rad",
+    expected: "0rad",
+  },
+  {
+    syntax: "<angle>",
+    initial: "10turn",
+    declared: "0turn",
+    expected: "0turn",
+  },
+  {
+    syntax: "<transform-list>",
+    initial: "rotate(10deg)",
+    declared: "rotate(0deg)",
+    expected: "rotate(0deg)",
+  },
+  {
+    syntax: "<transform-list>",
+    initial: "rotate(10grad)",
+    declared: "rotate(0grad)",
+    expected: "rotate(0grad)",
+  },
+  {
+    syntax: "<transform-list>",
+    initial: "rotate(10rad)",
+    declared: "rotate(0rad)",
+    expected: "rotate(0rad)",
+  },
+  {
+    syntax: "<transform-list>",
+    initial: "rotate(10turn)",
+    declared: "rotate(0turn)",
+    expected: "rotate(0turn)",
+  },
+  // Correctly serializing unitless 0 in '<length> | <percentage>'.
+  { syntax: "<length> | <percentage>",
+    initial: "10px",
+    declared: "0",
+    expected: "0px",
+  },
+
+  // Normalization of <length-percentage> values [1].
+  // Note also that (at time of writing) there's a pending change [2] to the
+  // spec for serializing calc()s [3]: we should output the percentage first,
+  // then the number.
+  // [1]: https://drafts.css-houdini.org/css-properties-values-api/#calculation-of-computed-values
+  // [2]: https://github.com/w3c/csswg-drafts/issues/1731
+  // [3]: https://drafts.csswg.org/css-values/#calc-serialize
+
+  { syntax: "<length-percentage>",
+    initial: "10px",
+    declared: "calc(70% - 70% + 20px)",
+    expected: "calc(0% + 30px)",
+  },
+  {
+    syntax: "<length-percentage>",
+    initial: "10px",
+    declared: "calc(20px - 20px - 30%)",
+    expected: "calc(-30% + 0px)",
+  },
+  // Should simplify calc(Xpx) to Xpx
+  { syntax: "<length-percentage>",
+    initial: "10px",
+    declared: "calc(20px - 17px)",
+    expected: "3px",
+  },
+  // Should simplify calc(X%) to X%
+  { syntax: "<length-percentage>",
+    initial: "10px",
+    declared: "calc(15% + 5%)",
+    expected: "20%",
+  },
+  { syntax: "<percentage> | <length>",
+    initial: "10%",
+    declared: "calc(15px)",
+    expected: "15px",
+  },
+  { syntax: "<length> | <percentage>",
+    initial: "10px",
+    declared: "calc(15%)",
+    expected: "15%",
+  },
+
+  // Test basic computation of each of the basic syntax strings.
+
+  { syntax: "<length>",
+    initial: "10px",
+    declared: "10px",
+    expected: "10px",
+  },
+
+  { syntax: "<number>",
+    initial: "10",
+    declared: "3.1415",
+    expected: "3.1415",
+  },
+  { syntax: "<number>",
+    initial: "10",
+    declared: "calc(1 * 2 + 3 / 4)",
+    expected: "2.75",
+  },
+  { syntax: "<number>",
+    initial: "10",
+    declared: "calc(1 / 0)",
+    expected: "10",
+  },
+
+  { syntax: "<percentage>",
+    initial: "10%",
+    declared: "2.7%",
+    expected: "2.7%",
+  },
+
+  { syntax: "<length-percentage>",
+    initial: "10px",
+    declared: "calc(27% + 13px)",
+    expected: "calc(27% + 13px)",
+  },
+
+  { syntax: "<color>",
+    initial: "red",
+    declared: "#abcdef01",
+    expected: "rgb(171, 205, 239, 0.004)",
+  },
+  { syntax: "<color>",
+    initial: "green",
+    declared: "red",
+    expected: "red",
+  },
+  { syntax: "<color>",
+    initial: "red",
+    declared: "currentcolor",
+    expected: "currentcolor",
+  },
+
+  { syntax: "<image>",
+    initial: "url(\"http://example.com/loss.jpg\")",
+    declared: "url(\"http://example.com/some_image.jpg\")",
+    expected: "url(\"http://example.com/some_image.jpg\")",
+  },
+
+  { syntax: "<image>",
+    initial: "url(\"http://example.com/loss.jpg\")",
+    declared: "linear-gradient(45deg, white, black)",
+    expected: "linear-gradient(45deg, rgb(255, 255, 255), rgb(0, 0, 0))",
+  },
+
+  { syntax: "<image>",
+    initial: "url(\"http://example.com/loss.jpg\")",
+    testProperty: "background-image",
+    declared: "radial-gradient(2em at 60px 50% , #000000 0%, #000000 14px, rgba(0, 0, 0, 0.3) 18px, rgba(0, 0, 0, 0) 4em)",
+    expected: "radial-gradient(32px at 60px 50%, rgb(0, 0, 0) 0%, rgb(0, 0, 0) 14px, rgba(0, 0, 0, 0.3) 18px, transparent 64px)",
+    // This is the serialization result we get in Gecko from calling
+    // getComputedStyle and getPropertyValue on a background-image property set
+    // to this value.
+    // But because this doesn't seem to be fully specified, we set
+    // 'background-image' to 'expected' and compare with the computed style off
+    // of that. The browser should at the least be consistent.
+  },
+
+  { syntax: "<url>",
+    initial: "url(\"http://example.com/loss.jpg\")",
+    declared: "url(\"http://example.com/\")",
+    expected: "url(\"http://example.com/\")",
+  },
+
+  { syntax: "<url>",
+    initial: "url(\"http://example.com/loss.jpg\")",
+    declared: "url(\"/some_link\")",
+    expected: "url(\"" + baseURL + "some_link\")",
+  },
+
+  { syntax: "<integer>",
+    initial: "10",
+    declared: "42",
+    expected: "42",
+  },
+  { syntax: "<integer>",
+    initial: "10",
+    declared: "calc(1 + 2 * 3 / 6)",
+    // Any divisions in <integer> calc()s cause the whole thing to be invalid.
+    expected: "10",
+  },
+  { syntax: "<integer>",
+    initial: "10",
+    declared: "calc(1 + 2 * 3)",
+    expected: "7",
+  },
+  { syntax: "<integer>",
+    initial: "10",
+    declared: "calc(1 + 2 + 3)",
+    expected: "6",
+  },
+  { syntax: "<integer>",
+    initial: "10",
+    declared: "calc(1 * 2 * 3)",
+    expected: "6",
+  },
+  { syntax: "<integer>",
+    initial: "10",
+    declared: "calc(0.5 * 2 * 3)",
+    expected: "10",
+  },
+  // Additive coefficients should be resolved.
+  { syntax: "<integer>",
+    initial: "10",
+    declared: "calc((1 + 2) * 3)",
+    expected: "9",
+  },
+  { syntax: "<integer>",
+    initial: "10",
+    declared: "calc((1 * 2) * 3)",
+    expected: "6",
+  },
+  { syntax: "<integer>",
+    initial: "10",
+    declared: "calc(1 * (2 * 3))",
+    expected: "6",
+  },
+  // This isn't unitless zero -- this is an integral zero!
+  { syntax: "<integer>",
+    initial: "10",
+    declared: "calc(0)",
+    expected: "0",
+  },
+  { syntax: "<integer>",
+    initial: "10",
+    declared: "calc(((0) * 3) + 7)",
+    expected: "7",
+  },
+
+  { syntax: "<angle>",
+    initial: "10deg",
+    declared: "37deg",
+    expected: "37deg",
+  },
+
+  { syntax: "<time>",
+    initial: "10s",
+    declared: "5s",
+    expected: "5s",
+  },
+
+  { syntax: "<resolution>",
+    initial: "10dppx",
+    declared: "50dppx",
+    expected: "50dppx",
+  },
+
+  { syntax: "<transform-list>",
+    initial: "scale(10)",
+    declared: "matrix(1, 0, 1, 0, 1, 1)",
+    expected: "matrix(1, 0, 1, 0, 1, 1)",
+  },
+
+  { syntax: "Mozilla | Firefox",
+    initial: "Firefox",
+    declared: "Mozilla",
+    expected: "Mozilla",
+  },
+
+  { syntax: "<custom-ident>",
+    initial: "Netscape",
+    declared: "Mozilla",
+    expected: "Mozilla",
+  },
+
+  { syntax: "*",
+    initial: "begining",
+    declared: " ",
+    expected: " ",
+  },
+
+  { syntax: "*",
+    initial: "end",
+    declared: "i was the shadow of the waxwing slain",
+    expected: "i was the shadow of the waxwing slain",
+  },
+
+  // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertyvalue
+  // We should return the empty string when there is no declaration (in this
+  // case, beacuse couldn't compute.)
+
+  { syntax: "<length>",
+    initial: "10px",
+    declared: "calc(5px + 7%)",
+    expected: "10px",
+  },
+
+  { syntax: "<percentage>",
+    initial: "10%",
+    declared: "calc(7% + 5px)",
+    expected: "10%",
+  },
+
+  { syntax: "<length>",
+    initial: "10px",
+    declared: "Mozilla",
+    expected: "10px",
+  },
+
+  { syntax: "<length>+",
+    initial: "10px",
+    declared: "5px calc(5px + 7%) 1em",
+    // This should be invalid at parse time.
+    expected: "10px",
+  },
+];
+
+
+// This also tests setting styles with custom properties through the 'style'
+// attribute, which takes a different path to the parser (this isn't CSSOM!)
+
+for (let spec of computedValueTests) {
+  let { syntax, initial, declared, expected } = spec;
+  test(function () {
+    try {
+      CSS.registerProperty({ name: "--computed", syntax: syntax, initialValue: initial });
+      sandbox.setAttribute("style", `--computed:${declared};`);
+
+      let computedValue = window.getComputedStyle(sandbox)
+                                .getPropertyValue("--computed");
+
+      // If 'test-property' is supplied, compare with the serialization we get
+      // from setting the same value on test-property.
+      let expectedNormalized = expected;
+      if (spec.testProperty) {
+        sandbox.setAttribute("style", `${spec.testProperty}:${expected};`);
+        expectedNormalized = window.getComputedStyle(sandbox)
+                                   .getPropertyValue(spec.testProperty);
+      }
+
+      assert_equals(computedValue, expectedNormalized,
+                    "computed value equals expected value");
+
+    } finally {
+      sandbox.removeAttribute("style");
+      CSS.unregisterProperty("--computed");
+    }
+  }, "computed value: " + JSON.stringify(spec));
+}
+
+</script>

--- a/tests/wpt/web-platform-tests/css-properties-values-api/family.html
+++ b/tests/wpt/web-platform-tests/css-properties-values-api/family.html
@@ -1,0 +1,266 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Bug 1273706 - Inheritance &amp; Cacading (CSS Properties &amp; Values)</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api/" />
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<style type="text/css">
+div#container {
+  font-size: 16px;
+}
+</style>
+
+<div id="container">
+  <div id="grandparent">
+    <div id="parent">
+      <div id="child"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+let grandparent = document.getElementById("grandparent");
+let parent = document.getElementById("parent");
+let child = document.getElementById("child");
+
+// { registrations: [
+//     { name: <custom property name with '--' prefix>,
+//       syntax: <custom property syntax>,
+//       inherits: bool,
+//       initialValue: <computationally idempotent initial value>
+//     },
+//     ...
+//   ],
+//   grandparent: <style for grandparent element>,
+//   parent: <style for parent element>,
+//   child: <style for child element>,
+//   expected: {
+//     <computed property>: <expected value string for the child>,
+//     ...
+//   },
+// }
+let familyTests = [
+  { title: "Registered custom properties should have syntax '*' by default.",
+    registrations: [
+      { name: "--a",
+        inherits: false,
+        initialValue: "some tokens",
+      },
+    ],
+    child: "--a: i am a token stream;",
+    expected: {
+      "--a": " i am a token stream",
+    },
+  },
+  { title: "Basic uninherited property.",
+    registrations: [
+      { name: "--a",
+        syntax: "<integer>",
+        inherits: false,
+        initialValue: "0",
+      },
+    ],
+    parent: "--a: 1;",
+    expected: {
+      "--a": "0",
+    },
+  },
+  { title: "Transform function arguments should be computed.",
+    registrations: [
+      { name: "--a",
+        syntax: "<transform-function>",
+        inherits: true,
+        initialValue: "translateX(10px)",
+      },
+    ],
+    parent: "font-size: 10px;",
+    child: "--a: translateX(5em);",
+    expected: {
+      "--a": "translateX(50px)",
+    },
+  },
+  { title: "If no initialValue is provided and the syntax is *, then a " +
+           "special initial value is used. This initial value must be " +
+           "considered parseable by registerProperty() but invalid at " +
+           "computed value time.",
+    registrations: [
+      { name: "--a",
+        syntax: "*",
+        inherits: true,
+      },
+    ],
+    parent: "--b: happy birthday; --b: hi var(--a);",
+    expected: {
+      // 'happy birthday' is overwritten in the cascade, and the var(--a)
+      // substitution is illegal.
+      "--b": "",
+    },
+  },
+  { title: "Same as the previous test, with a fallback (i.e. we shouldn't " +
+           "quit before resolving).",
+    registrations: [
+      { name: "--a",
+        syntax: "*",
+        inherits: true,
+      },
+    ],
+    parent: "--b: happy birthday; --b: hi var(--a,to you);",
+    expected: {
+      // The leading space is part of the value!
+      "--b": " hi to you",
+    },
+  },
+  { title: "Make sure we calculate font-relative lengths in lengths and " +
+           "length-percentages.",
+    registrations: [
+      { name: "--a",
+        syntax: "<length>",
+        inherits: true,
+        initialValue: "10px",
+      },
+      { name: "--b",
+        syntax: "<length-percentage>",
+        inherits: true,
+        initialValue: "10px",
+      },
+    ],
+    parent: "font-size: 15px",
+    child: "--a: 1em; --b: calc(1em + 20%);",
+    // Note also that (at time of writing) there's a pending change [1] to the
+    // spec for serializing calc()s [2]: we should output the percentage first,
+    // then the number.
+    // [1]: https://github.com/w3c/csswg-drafts/issues/1731
+    // [2]: https://drafts.csswg.org/css-values/#calc-serialize
+    expected: {
+      "--a": "15px",
+      "--b": "calc(20% + 15px)",
+    },
+  },
+  { title: "Make sure we set initial values on the root, even if nothing is " +
+           "ever specified.",
+    registrations: [
+      { name: "--a",
+        syntax: "<number>",
+        initialValue: "42",
+        inherits: true,
+      },
+    ],
+    expected: {
+      "--a": "42",
+    },
+  },
+  { title: "We should parse 'inherit' correctly in token stream values.",
+    registrations: [
+      { name: "--a",
+        syntax: "*",
+        inherits: false,
+        initialValue: "some tokens",
+      },
+    ],
+    parent: "--a: some-value",
+    child: "--a: inherit",
+    expected: {
+      "--a": " some-value",
+    },
+  },
+  { title: "We should parse 'inherit' correctly in list values.",
+    registrations: [
+      { name: "--a",
+        syntax: "<number>+",
+        inherits: false,
+        initialValue: "10",
+      },
+    ],
+    parent: "--a: 4 8 15",
+    child: "--a: inherit",
+    expected: {
+      "--a": "4 8 15",
+    },
+  },
+  { title: "We should handle dependencies between custom properties and " +
+           "font-size correctly when computing.",
+    registrations: [
+      { name: "--length-a",
+        syntax: "<length>",
+        inherits: false,
+        initialValue: "7px",
+      },
+      { name: "--length-b",
+        syntax: "<length>",
+        inherits: false,
+        initialValue: "7px",
+      },
+    ],
+    child: "--tokens: var(--length-a); " +
+           "--length-a: calc(5px + 5px); " +
+           "--length-b: 2em;" +
+           "font-size: var(--tokens); ",
+    expected: {
+      "--tokens": " 10px",
+      "--length-a": "10px",
+      "--length-b": "20px",
+      "font-size": "10px",
+    },
+    // If we don't correctly compute dependencies, then we would expect
+    // font-size's declaration to end up being invalid at computed-value time
+    // due to --length-a being substituted into --tokens before being computed,
+    // or for --length-b to end up computing to 32px (we define font-size to be
+    // 16px at the top of this test file). The order of computation we want is
+    // --length-a → --tokens → font-size → --length-b.
+  },
+  { title: "If declarations for custom properties and font-size are involved " +
+           "in a cycle, all involved properties should compute to their " +
+           "initial values.",
+    registrations: [
+      { name: "--a",
+        syntax: "<length>",
+        inherits: false,
+        initialValue: "7px",
+      },
+      { name: "--b",
+        syntax: "*",
+        inherits: false,
+        initialValue: "initial-value",
+      }
+    ],
+    child: "--a: 5em; " +
+           "--b: var(--a); " +
+           "font-size: var(--b)",
+    expected: {
+      "--a": "7px",
+      "--b": "initial-value",
+      "font-size": "16px",
+    }
+  },
+];
+
+for (let spec of familyTests) {
+  test(function () {
+    let registered = [];
+    try {
+      for (let registration of spec.registrations) {
+        CSS.registerProperty(registration);
+        registered.push(registration.name);
+      }
+
+      grandparent.setAttribute("style", spec.grandparent || "");
+      parent.setAttribute("style", spec.parent || "");
+      child.setAttribute("style", spec.child || "");
+
+      for (let key in spec.expected) {
+        assert_equals(window.getComputedStyle(child).getPropertyValue(key),
+          spec.expected[key], "property value equals expected value");
+      }
+    } finally {
+      grandparent.removeAttribute("style");
+      parent.removeAttribute("style");
+      child.removeAttribute("style");
+
+      for (let name of registered) {
+        CSS.unregisterProperty(name);
+      }
+    }
+  }, "family: " + spec.title);
+}
+</script>

--- a/tests/wpt/web-platform-tests/css-properties-values-api/independence.html
+++ b/tests/wpt/web-platform-tests/css-properties-values-api/independence.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Bug 1273706 - Computational Independence (CSS Properties &amp; Values)</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api/#computationally-independent" />
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
+<script>
+let independencePassTests = [
+  // https://github.com/w3c/css-houdini-drafts/issues/247
+  { syntax: "<color>", initialValue: "currentColor" },
+  { syntax: "<length>", initialValue: "5px" },
+  { syntax: "<length>", initialValue: "calc(5px + 7px)" },
+  { syntax: "<transform-list>", initialValue: "translateX(5px)" },
+  { syntax: "<transform-list>+", initialValue: "translateX(5px) translateX(-10px)" },
+  { syntax: "<custom-ident>+", initialValue: "does the code inherit the legacy of Netscape" },
+  // <percentage>s just compute to <percentage>s, not pixels.
+  { syntax: "<percentage>", initialValue: "0%" },
+];
+
+let independenceFailTests = [
+  { syntax: "<color>", initialValue: "inherit" },
+  { syntax: "<length>", initialValue: "5em" },
+  { syntax: "<length>", initialValue: "calc(5px + 5em)" },
+  { syntax: "<transform-list>", initialValue: "translateX(5em)" },
+  { syntax: "<integer> | <length>+", initialValue: "5px 0 -5em 0 12px" },
+  { syntax: "<color> | <transform-list>+", initialValue: "translateX(-10em)" },
+  { syntax: "<number>+", initialValue: "1 2 3 4 initial" },
+  { syntax: "*", initialValue: "inherit" },
+];
+
+expectFail("independence fail", independenceFailTests, "SyntaxError",
+  "Initial values that are not computationally independent must trigger a " +
+  "SyntaxError.");
+
+expectSucceed("independence pass", independencePassTests,
+  "Initial values that are computationally independent must not trigger a " +
+  "SyntaxError.");
+</script>

--- a/tests/wpt/web-platform-tests/css-properties-values-api/naming.html
+++ b/tests/wpt/web-platform-tests/css-properties-values-api/naming.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Bug 1273706 - (CSS Properties &amp; Values)</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api/#the-registerproperty-function" />
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
+
+<script>
+let invalidNameTests = [
+  // https://drafts.csswg.org/css-syntax-3/#typedef-ident-token
+  { name: "-" },
+  { name: " " },
+  { name: "--!" },
+];
+
+let validNameTests = [
+  { name: "--" },
+  { name: "--5" },
+  { name: "--a" },
+  { name: "--A" },
+  { name: "--ç" },
+  { name: "--\\n" },
+];
+
+expectFail("invalid name", invalidNameTests, "SyntaxError",
+  "Attempting to register properties with a name that doesn’t correspond " +
+  "to the <custom-property-name> production must cause registerProperty() " +
+  "to throw a SyntaxError.");
+
+expectSucceed("valid name", validNameTests, "Allow valid custom property names.");
+</script>

--- a/tests/wpt/web-platform-tests/css-properties-values-api/registration.html
+++ b/tests/wpt/web-platform-tests/css-properties-values-api/registration.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Bug 1273706 - Registration (CSS Properties &amp; Values)</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api/#the-registerproperty-function" />
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id="sandbox"></div>
+<script>
+let sandbox = document.getElementById("sandbox");
+
+test(function () {
+  let caughtError = false;
+  try {
+    CSS.registerProperty({ syntax: "<integer>", inherits: false,
+                           initialValue: "0" });
+  } catch (e) {
+    caughtError = true;
+  }
+  assert_true(caughtError, "caught error");
+}, "Attempting to register a property without a name should result in an " +
+   "error.");
+
+test(function () {
+  let caughtDuplicate = false;
+  CSS.registerProperty({ name: "--duplicate-ime" });
+  try {
+    CSS.registerProperty({ name: "--duplicate-ime" });
+    CSS.unregisterProperty("--duplicate-ime");
+  } catch (e) {
+    caughtDuplicate =
+      e instanceof DOMException &&
+      e.name == "InvalidModificationError";
+  }
+  assert_true(caughtDuplicate, "caught exception");
+}, "Attempting to register a property with a name that has already been " +
+   "registered should result in an InvalidModificationError.");
+
+test(function () {
+  let caughtNotFound = false;
+  try {
+    CSS.unregisterProperty("--not-found-nfe");
+  } catch (e) {
+    caughtNotFound =
+      e instanceof DOMException &&
+      e.name == "NotFoundError";
+  }
+  assert_true(caughtNotFound, "caught exception");
+}, "Attempting to unregister a property that doesn't exist should result in " +
+   "a NotFoundError.");
+</script>

--- a/tests/wpt/web-platform-tests/css-properties-values-api/syntax.html
+++ b/tests/wpt/web-platform-tests/css-properties-values-api/syntax.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Bug 1273706 - Syntax (CSS Properties &amp; Values)</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api/#supported-syntax-strings" />
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
+<script>
+let invalidSyntaxTests = [
+  // Unfortunately, an invalid syntax and an invalid initialValue both lead to
+  // SyntaxErrors. We try to pick an initialValue that would pass with the
+  // syntax we think the syntax we give might erroneously parse as, but we can't
+  // be sure that the error is coming from the right place.
+  { syntax: "<number>+ <color>", initialValue: "1" },
+  { syntax: "<i-do-not-exist>+", initialValue: "i-do-not-exist" },
+  { syntax: "", initialValue: "" },
+  { syntax: "<number> || <color>", initialValue: "1" },
+  { syntax: "|", initialValue: "something" },
+  { syntax: "+", initialValue: "calc(5 + 7)" },
+  { syntax: "   ", initialValue: "calc(5 + 7)" },
+  { syntax: "initial", initialValue: "initial" },
+  { syntax: "inherit", iniitialValue: "inherit" },
+  { syntax: "unset", initialValue: "unset"  },
+  { syntax: "revert", initialValue: "revert" },
+  { syntax: "* worn out places", initialValue: "worn" },
+  { syntax: "* | worn | out | faces", initialValue: "worn" },
+  { syntax: "*+", initialValue: "token stream" },
+  // https://github.com/w3c/css-houdini-drafts/issues/112#issuecomment-246874717
+  { syntax: "<color>  +", initialValue: "green" },
+  { syntax: "a | | b", initialValue: "a" },
+];
+
+let validSyntaxTests = [
+  { syntax: "*", initialValue: "hi there" },
+  { syntax: "<color>", initialValue: "green" },
+  { syntax: " <color> ", initialValue: "green" },
+
+  // Allow some CSS keywords, just not the CSS-wide keywords or revert.
+  { syntax: "center", initialValue: "center" },
+];
+
+let syntaxFailTests = [
+  { syntax: "<color>", initialValue: "5px" },
+  { syntax: "<transform-function>", initialValue: "red" },
+  { syntax: "<transform-function>+", initialValue: " " },
+  { syntax: "<resolution>", initialValue: "calc(0)" },
+  { syntax: "<custom-ident>", initialValue: "5px" },
+  { syntax: "to-me", initialValue: "who-are-you" },
+  { syntax: "case-sensitive", initialValue: "CaSe-SeNsITiVe" },
+  { syntax: "<number>+", initialValue: "1 2 initial 3" },
+  { syntax: "*", initialValue: "initial" },
+  // https://drafts.csswg.org/css-variables/#syntax
+  // "While <declaration-value> must represent at least one token, that one
+  //  token may be whitespace. This implies that --foo: ; is valid, and the
+  //  corresponding var(--foo) call would have a single space as its
+  //  substitution value, but --foo:; is invalid."
+  { syntax: "*", initialValue: "" },
+];
+
+let syntaxPassTests = [
+  { syntax: "*", initialValue: "all around me are familiar faces" },
+  { syntax: "*", initialValue: "translateX(5px) 5em 73" },
+  { syntax: "<number>", initialValue: "5" },
+  { syntax: "<number> | <color>", initialValue: "red" },
+  { syntax: "<number>+", initialValue: "4 8 15 16 23 42" },
+  { syntax: "<number>+ | <url>", initialValue: "url(http://mozilla.org)" },
+  { syntax: "<transform-function>", initialValue: "translateX(5px)" },
+  { syntax: "<resolution>", initialValue: "5dpi" },
+  { syntax: "<custom-ident>", initialValue: "doesnt-really-matter" },
+  { syntax: "to-me", initialValue: "to-me" },
+  { syntax: "to-me | just-a-poor-boy", initialValue: "just-a-poor-boy" },
+  // https://drafts.csswg.org/css-variables/#syntax
+  // "While <declaration-value> must represent at least one token, that one
+  //  token may be whitespace. This implies that --foo: ; is valid, and the
+  //  corresponding var(--foo) call would have a single space as its
+  //  substitution value, but --foo:; is invalid."
+  { syntax: "*", initialValue: " " },
+];
+
+// Testing functions.
+
+expectFail("invalid syntax", invalidSyntaxTests, "SyntaxError",
+  "Invalid syntaxes must trigger a SyntaxError.");
+
+expectSucceed("valid syntax", validSyntaxTests,
+  "Valid syntaxes must not trigger a SyntaxError.");
+
+expectFail("syntax fail", syntaxFailTests, "SyntaxError",
+  "Initial values that are syntactically invalid must trigger a " +
+  "SyntaxError.");
+
+expectSucceed("syntax pass", syntaxPassTests,
+  "Initial values that are syntactically valid must not trigger a " +
+  "SyntaxError.");
+</script>


### PR DESCRIPTION
Here are some patches to implement the CSS Properties & Values API in Servo! I have a simple patch to implement it in Firefox via Stylo afterwards. I also have patches to implement animations for these in Stylo, but not in Servo.

One-line Gecko change to ServoBindings.toml required as a consequence of replacing custom_properties::CustomPropertiesMap with properties_and_values::CustomPropertiesMap in the ComputedValues.

Animations patches involve much more changes to Stylo than Servo, so I think those should be reviewed separately & through the Stylo process.

Some disabled tests:
- We don't implement `<transform-list>` serialization.
- We don't serialize colors according to spec & as Gecko does.
- We don't round floats correctly (see servo/rust-cssparser#173).
- We don't implement `<resolution>`.

It's not clear whether or not we actually need initialValue (see w3c/css-houdini-drafts#286).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #17155 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18167)
<!-- Reviewable:end -->
