### PR TITLE
Disable /_mozilla/css/animations/transition-raf.html.ini

### DIFF
--- a/tests/wpt/mozilla/meta/css/animations/transition-raf.html.ini
+++ b/tests/wpt/mozilla/meta/css/animations/transition-raf.html.ini
@@ -1,0 +1,3 @@
+[transition-raf.html]
+  type: testharness
+  disabled: https://github.com/servo/servo/issues/13865


### PR DESCRIPTION
Transitions are just very broken, so this test is flacky.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18174)
<!-- Reviewable:end -->
