### PR TITLE
layout: Stop call normal block size assignment for flex container

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1429,6 +1429,9 @@ impl BlockFlow {
     /// Determines the type of formatting context this is. See the definition of
     /// `FormattingContextType`.
     pub fn formatting_context_type(&self) -> FormattingContextType {
+        if self.is_inline_flex_item() || self.is_block_flex_item() {
+            return FormattingContextType::Other
+        }
         let style = self.fragment.style();
         if style.get_box().float != float::T::none {
             return FormattingContextType::Other

--- a/components/layout/flex.rs
+++ b/components/layout/flex.rs
@@ -7,7 +7,7 @@
 #![deny(unsafe_code)]
 
 use app_units::{Au, MAX_AU};
-use block::{BlockFlow, MarginsMayCollapseFlag};
+use block::{AbsoluteAssignBSizesTraversal, BlockFlow, MarginsMayCollapseFlag};
 use context::LayoutContext;
 use display_list_builder::{DisplayListBuildState, FlexFlowDisplayListBuilding};
 use euclid::Point2D;
@@ -17,6 +17,7 @@ use flow::{Flow, FlowClass, ImmutableFlowUtils, OpaqueFlow};
 use flow::{INLINE_POSITION_IS_STATIC, IS_ABSOLUTELY_POSITIONED};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
 use layout_debug;
+use model::{AdjoiningMargins, CollapsibleMargins};
 use model::{IntrinsicISizes, MaybeAuto, SizeConstraint};
 use std::cmp::{max, min};
 use std::ops::Range;
@@ -28,6 +29,7 @@ use style::servo::restyle_damage::{REFLOW, REFLOW_OUT_OF_FLOW};
 use style::values::computed::{LengthOrPercentage, LengthOrPercentageOrAuto, LengthOrPercentageOrNone};
 use style::values::computed::flex::FlexBasis;
 use style::values::generics::flex::FlexBasis as GenericFlexBasis;
+use traversal::PreorderFlowTraversal;
 
 /// The size of an axis. May be a specified size, a min/max
 /// constraint, or an unlimited size
@@ -802,7 +804,6 @@ impl FlexFlow {
         let total_block_size = total_cross_size + self.block_flow.fragment.border_padding.block_start_end();
         self.block_flow.fragment.border_box.size.block = total_block_size;
         self.block_flow.base.position.size.block = total_block_size;
-
     }
 }
 
@@ -939,13 +940,29 @@ impl Flow for FlexFlow {
     }
 
     fn assign_block_size(&mut self, layout_context: &LayoutContext) {
-        self.block_flow
-            .assign_block_size_block_base(layout_context,
-                                          None,
-                                          MarginsMayCollapseFlag::MarginsMayNotCollapse);
         match self.main_mode {
-            Direction::Inline => self.inline_mode_assign_block_size(layout_context),
-            Direction::Block => self.block_mode_assign_block_size(),
+            Direction::Inline => {
+                self.inline_mode_assign_block_size(layout_context);
+                let block_start = AdjoiningMargins::from_margin(self.block_flow.fragment.margin.block_start);
+                let block_end = AdjoiningMargins::from_margin(self.block_flow.fragment.margin.block_end);
+                self.block_flow.base.collapsible_margins = CollapsibleMargins::Collapse(block_start, block_end);
+
+                // TODO(stshine): assign proper static position for absolute descendants.
+                if (&*self as &Flow).contains_roots_of_absolute_flow_tree() {
+                    // Assign block-sizes for all flows in this absolute flow tree.
+                    // This is preorder because the block-size of an absolute flow may depend on
+                    // the block-size of its containing block, which may also be an absolute flow.
+                    let assign_abs_b_sizes = AbsoluteAssignBSizesTraversal(layout_context.shared_context());
+                    assign_abs_b_sizes.traverse_absolute_flows(&mut *self);
+                }
+            }
+            Direction::Block =>{
+                self.block_flow
+                    .assign_block_size_block_base(layout_context,
+                                                  None,
+                                                  MarginsMayCollapseFlag::MarginsMayNotCollapse);
+                self.block_mode_assign_block_size();
+            }
         }
     }
 

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -1279,9 +1279,7 @@ impl<'a> ImmutableFlowUtils for &'a Flow {
                     return Some(base(kid).position.start.b + baseline_offset)
                 }
             }
-            if kid.is_block_like() &&
-                    kid.as_block().formatting_context_type() == FormattingContextType::None &&
-                    !base(kid).flags.contains(IS_ABSOLUTELY_POSITIONED) {
+            if kid.is_block_like() && !base(kid).flags.contains(IS_ABSOLUTELY_POSITIONED) {
                 if let Some(baseline_offset) = kid.baseline_offset_of_last_line_box_in_flow() {
                     return Some(base(kid).position.start.b + baseline_offset)
                 }

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox-margin-auto-horiz-002.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox-margin-auto-horiz-002.htm.ini
@@ -1,3 +1,0 @@
-[flexbox-margin-auto-horiz-002.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_item-float.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_item-float.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_item-float.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_rowspan-overflow-automatic.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_rowspan-overflow-automatic.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_rowspan-overflow-automatic.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_rowspan-overflow.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_rowspan-overflow.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_rowspan-overflow.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_rowspan.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_rowspan.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_rowspan.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-abspos.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-abspos.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_stf-abspos.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-float.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-float.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_stf-float.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-inline-block.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-inline-block.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_stf-inline-block.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-table-cell.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-table-cell.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_stf-table-cell.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-table-row-group.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-table-row-group.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_stf-table-row-group.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-table-row.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-table-row.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_stf-table-row.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-table.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexbox_stf-table.htm.ini
@@ -1,3 +1,0 @@
-[flexbox_stf-table.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexible-box-float.htm.ini
+++ b/tests/wpt/metadata-css/css-flexbox-1_dev/html/flexible-box-float.htm.ini
@@ -1,3 +1,0 @@
-[flexible-box-float.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
No need to call the `assign_block_size_block_base()` method of normal block in flex.rs since it is implemented for CSS2.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14813 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18175)
<!-- Reviewable:end -->
