### PR TITLE
PerformanceObserverInit.buffered

### DIFF
--- a/components/script/dom/performanceentry.rs
+++ b/components/script/dom/performanceentry.rs
@@ -51,6 +51,10 @@ impl PerformanceEntry {
     pub fn name(&self) -> &DOMString {
         &self.name
     }
+
+    pub fn start_time(&self) -> f64 {
+        self.start_time
+    }
 }
 
 impl PerformanceEntryMethods for PerformanceEntry {

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -89,23 +89,30 @@ impl PerformanceObserver {
     pub fn entries(&self) -> DOMPerformanceEntryList {
         self.entries.borrow().clone()
     }
+
+    pub fn set_entries(&self, entries: DOMPerformanceEntryList) {
+        *self.entries.borrow_mut() = entries;
+    }
 }
 
 impl PerformanceObserverMethods for PerformanceObserver {
     // https://w3c.github.io/performance-timeline/#dom-performanceobserver-observe()
     fn Observe(&self, options: &PerformanceObserverInit) -> Fallible<()> {
+        // step 1
         // Make sure the client is asking to observe events from allowed entry types.
         let entry_types = options.entryTypes.iter()
                                             .filter(|e| VALID_ENTRY_TYPES.contains(&e.as_ref()))
                                             .map(|e| e.clone())
                                             .collect::<Vec<DOMString>>();
+        // step 2
         // There must be at least one valid entry type.
         if entry_types.is_empty() {
             return Err((Error::Type("entryTypes cannot be empty".to_string())));
         }
 
         let performance = self.global().as_window().Performance();
-        performance.add_observer(self, entry_types);
+        // step 3-4-5
+        performance.add_observer(self, entry_types, options.buffered);
         Ok(())
     }
 

--- a/components/script/dom/webidls/PerformanceObserver.webidl
+++ b/components/script/dom/webidls/PerformanceObserver.webidl
@@ -8,6 +8,7 @@
 
 dictionary PerformanceObserverInit {
   required sequence<DOMString> entryTypes;
+  boolean buffered = false;
 };
 
 callback PerformanceObserverCallback = void (PerformanceObserverEntryList entries, PerformanceObserver observer);


### PR DESCRIPTION
Per #18108, add `buffered` flag in the `PerformanceObserverInit` dict.
Per W3C spec, when `buffered` is set, `PerformanceObserver.observe()` method adds the entries buffered in the `Performance` instance into the observer's entry buffer.
One step is the implementation of the [filter by name and type](https://w3c.github.io/performance-timeline/#filter-buffer-by-name-and-type) algorithm. Don't think that the sort operation is useful in this case, but the spec states that this algorithm is to be used.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #18108
- [X] These changes do not require tests (yet) because the timeline API is not powered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18176)
<!-- Reviewable:end -->
