### PR TITLE
Make it possible to close a browsing context from the embedder

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -811,6 +811,13 @@ impl<Window: WindowMethods> IOCompositor<Window> {
                 }
             }
 
+            WindowEvent::CloseBrowser(ctx) => {
+                let msg = ConstellationMsg::CloseBrowser(ctx);
+                if let Err(e) = self.constellation_chan.send(msg) {
+                    warn!("Sending CloseBrowser message to constellation failed ({}).", e);
+                }
+            }
+
             WindowEvent::SelectBrowser(ctx) => {
                 let msg = ConstellationMsg::SelectBrowser(ctx);
                 if let Err(e) = self.constellation_chan.send(msg) {

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -73,6 +73,8 @@ pub enum WindowEvent {
     Reload(TopLevelBrowsingContextId),
     /// Create a new top level browsing context
     NewBrowser(ServoUrl, IpcSender<TopLevelBrowsingContextId>),
+    /// Close a top level browsing context
+    CloseBrowser(TopLevelBrowsingContextId),
     /// Make a top level browsing context visible, hiding the previous
     /// visible one.
     SelectBrowser(TopLevelBrowsingContextId),
@@ -99,6 +101,7 @@ impl Debug for WindowEvent {
             WindowEvent::ToggleWebRenderProfiler => write!(f, "ToggleWebRenderProfiler"),
             WindowEvent::Reload(..) => write!(f, "Reload"),
             WindowEvent::NewBrowser(..) => write!(f, "NewBrowser"),
+            WindowEvent::CloseBrowser(..) => write!(f, "CloseBrowser"),
             WindowEvent::SelectBrowser(..) => write!(f, "SelectBrowser"),
         }
     }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -974,8 +974,13 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             // Create a new top level browsing context. Will use response_chan to return
             // the browsing context id.
             FromCompositorMsg::NewBrowser(url, response_chan) => {
-                debug!("constellation got init load URL message");
+                debug!("constellation got NewBrowser message");
                 self.handle_new_top_level_browsing_context(url, response_chan);
+            }
+            // Close a top level browsing context.
+            FromCompositorMsg::CloseBrowser(top_level_browsing_context_id) => {
+                debug!("constellation got CloseBrowser message");
+                self.handle_close_top_level_browsing_context(top_level_browsing_context_id);
             }
             // Send frame tree to WebRender. Make it visible.
             FromCompositorMsg::SelectBrowser(top_level_browsing_context_id) => {
@@ -1538,6 +1543,11 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             load_data: load_data,
             replace_instant: None,
         });
+    }
+
+    fn handle_close_top_level_browsing_context(&mut self, top_level_browsing_context_id: TopLevelBrowsingContextId) {
+        let browsing_context_id = BrowsingContextId::from(top_level_browsing_context_id);
+        self.close_browsing_context(browsing_context_id, ExitPipelineMode::Normal);
     }
 
     fn handle_iframe_size_msg(&mut self,

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -765,6 +765,8 @@ pub enum ConstellationMsg {
     WebVREvents(Vec<PipelineId>, Vec<WebVREvent>),
     /// Create a new top level browsing context.
     NewBrowser(ServoUrl, IpcSender<TopLevelBrowsingContextId>),
+    /// Close a top level browsing context.
+    CloseBrowser(TopLevelBrowsingContextId),
     /// Make browser visible.
     SelectBrowser(TopLevelBrowsingContextId),
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #18006 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18181)
<!-- Reviewable:end -->
