### PR TITLE
First step toward iOS Support

### DIFF
--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -41,5 +41,5 @@ servo_url = {path = "../url"}
 webvr_traits = {path = "../webvr_traits"}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 
-[target.'cfg(not(target_os = "windows"))'.dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(target_os = "ios")))'.dependencies]
 gaol = {git = "https://github.com/servo/gaol"}

--- a/components/constellation/lib.rs
+++ b/components/constellation/lib.rs
@@ -16,7 +16,7 @@ extern crate compositing;
 extern crate debugger;
 extern crate devtools_traits;
 extern crate euclid;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
 extern crate gaol;
 extern crate gfx;
 extern crate gfx_traits;
@@ -46,11 +46,11 @@ mod constellation;
 mod event_loop;
 mod network_listener;
 mod pipeline;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
 mod sandboxing;
 mod timer_scheduler;
 
 pub use constellation::{Constellation, FromCompositorLogger, FromScriptLogger, InitialConstellationState};
 pub use pipeline::UnprivilegedPipelineContent;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
 pub use sandboxing::content_process_sandbox_profile;

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -535,7 +535,7 @@ impl UnprivilegedPipelineContent {
         }
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
     pub fn spawn_multiprocess(self) -> Result<(), Error> {
         use gaol::sandbox::{self, Sandbox, SandboxMethods};
         use ipc_channel::ipc::IpcOneShotServer;
@@ -583,9 +583,9 @@ impl UnprivilegedPipelineContent {
         Ok(())
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "ios"))]
     pub fn spawn_multiprocess(self) -> Result<(), Error> {
-        error!("Multiprocess is not supported on Windows.");
+        error!("Multiprocess is not supported on Windows or iOS.");
         process::exit(1);
     }
 

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -24,7 +24,6 @@ serde_json = "1.0"
 tinyfiledialogs = "2.5.9"
 
 [dependencies]
-angle = {git = "https://github.com/servo/angle", branch = "servo"}
 app_units = "0.5"
 audio-video-metadata = "0.1.2"
 base64 = "0.5.2"
@@ -94,3 +93,6 @@ xml5ever = {version = "0.9"}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 webvr = {path = "../webvr"}
 webvr_traits = {path = "../webvr_traits"}
+
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+angle = {git = "https://github.com/servo/angle", branch = "servo"}

--- a/components/script/dom/navigatorinfo.rs
+++ b/components/script/dom/navigatorinfo.rs
@@ -36,6 +36,11 @@ pub fn Platform() -> DOMString {
     DOMString::from("Mac")
 }
 
+#[cfg(target_os = "ios")]
+pub fn Platform() -> DOMString {
+    DOMString::from("iOS")
+}
+
 pub fn UserAgent() -> DOMString {
     DOMString::from(&*opts::get().user_agent)
 }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -54,5 +54,5 @@ webdriver_server = {path = "../webdriver_server", optional = true}
 webvr = {path = "../webvr"}
 webvr_traits = {path = "../webvr_traits"}
 
-[target.'cfg(not(target_os = "windows"))'.dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(target_os = "ios")))'.dependencies]
 gaol = {git = "https://github.com/servo/gaol"}

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -18,7 +18,7 @@
 //! `WindowMethods` trait.
 
 extern crate env_logger;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
 extern crate gaol;
 extern crate gleam;
 extern crate log;
@@ -76,10 +76,10 @@ use compositing::windowing::WindowEvent;
 use compositing::windowing::WindowMethods;
 use constellation::{Constellation, InitialConstellationState, UnprivilegedPipelineContent};
 use constellation::{FromCompositorLogger, FromScriptLogger};
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
 use constellation::content_process_sandbox_profile;
 use env_logger::Logger as EnvLogger;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
 use gaol::sandbox::{ChildSandbox, ChildSandboxMethods};
 use gfx::font_cache_thread::FontCacheThread;
 use ipc_channel::ipc::{self, IpcSender};
@@ -433,13 +433,13 @@ pub unsafe extern fn __errno_location() -> *mut i32 {
     __errno()
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
 fn create_sandbox() {
     ChildSandbox::new(content_process_sandbox_profile()).activate()
         .expect("Failed to activate sandbox!");
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "ios"))]
 fn create_sandbox() {
-    panic!("Sandboxing is not supported on Windows.");
+    panic!("Sandboxing is not supported on Windows or iOS.");
 }


### PR DESCRIPTION
This mostly prevents Gaol/sandboxing to be used during compilation.
There are a number of issues with : `expat-sys`, `servo-freetype-sys`, `fontsan`, `heartbeats-simple-sys`, `mozjs_sys`.

Also modified `components/script/dom/navigatorinfo.rs` in order to add iOS.

```rust
#[cfg(target_os = "ios")]
pub fn Platform() -> DOMString {
    DOMString::from("iOS")
}
```

See here for more informations : https://github.com/servo/servo/issues/18154

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes partially work on #18154 

- [X] These changes do not require tests because it deals with the compile toolchain

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18189)
<!-- Reviewable:end -->
