### PR TITLE
Move fast checks into earlier Travis task.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ matrix:
          - ./mach test-tidy --no-progress --all
          - ./mach test-tidy --no-progress --self-test
          - bash etc/ci/check_no_panic.sh
-         - bash etc/ci/lockfile_changed.sh
          - bash etc/ci/manifest_changed.sh
       cache: false
     - sudo: 9000
@@ -20,6 +19,7 @@ matrix:
          - ./mach clean
          - ./mach build-geckolib
          - ./mach test-stylo
+         - bash etc/ci/lockfile_changed.sh
       cache:
         directories:
           - .cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
       script:
          - ./mach test-tidy --no-progress --all
          - ./mach test-tidy --no-progress --self-test
+         - bash etc/ci/check_no_panic.sh
+         - bash etc/ci/lockfile_changed.sh
+         - bash etc/ci/manifest_changed.sh
       cache: false
     - sudo: 9000
       dist: trusty
@@ -17,9 +20,6 @@ matrix:
          - ./mach clean
          - ./mach build-geckolib
          - ./mach test-stylo
-         - bash etc/ci/check_no_panic.sh
-         - bash etc/ci/lockfile_changed.sh
-         - bash etc/ci/manifest_changed.sh
       cache:
         directories:
           - .cargo


### PR DESCRIPTION
This allows quicker feedback about whether the manifest needs updating; otherwise it has to wait until all builds and tests are complete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18193)
<!-- Reviewable:end -->
