### PR TITLE
Add an animated value for SvgLengthOrPercentageOrNumber.

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -2292,8 +2292,12 @@ impl From<NonNegativeNumber> for NumberOrPercentage {
 impl From<LengthOrPercentage> for NumberOrPercentage {
     fn from(lop: LengthOrPercentage) -> NumberOrPercentage {
         match lop {
-            LengthOrPercentage::Length(len) => NumberOrPercentage::Number(len.to_f32_px()),
-            LengthOrPercentage::Percentage(p) => NumberOrPercentage::Percentage(p),
+            LengthOrPercentage::Length(len) => {
+                NumberOrPercentage::Number(len.to_f32_px())
+            },
+            LengthOrPercentage::Percentage(p) => {
+                NumberOrPercentage::Percentage(p)
+            },
             LengthOrPercentage::Calc(_) => {
                 panic!("We dont't expected calc interpolation for SvgLengthOrPercentageOrNumber");
             },
@@ -2307,31 +2311,33 @@ impl From<Number> for NumberOrPercentage {
     }
 }
 
-fn convert_to_number_or_percentage<LengthOrPercentageType, NumberType>(
-    from: SvgLengthOrPercentageOrNumber<LengthOrPercentageType, NumberType>)
+fn convert_to_number_or_percentage<L, N>(from: SvgLengthOrPercentageOrNumber<L, N>)
     -> NumberOrPercentage
-    where LengthOrPercentageType: Into<NumberOrPercentage>,
-          NumberType: Into<NumberOrPercentage>
+    where
+        L: Into<NumberOrPercentage>,
+        N: Into<NumberOrPercentage>
 {
     match from {
-        SvgLengthOrPercentageOrNumber::LengthOrPercentage(lop) => {
+        SvgLengthOrPercentageOrNumber::LengthOrPercentage(lop) =>
+        {
             lop.into()
         }
-        SvgLengthOrPercentageOrNumber::Number(num) => {
+        SvgLengthOrPercentageOrNumber::Number(num) =>
+        {
             num.into()
         }
     }
 }
 
-fn convert_from_number_or_percentage<LengthOrPercentageType, NumberType>(
-    from: NumberOrPercentage)
-    -> SvgLengthOrPercentageOrNumber<LengthOrPercentageType, NumberType>
-    where LengthOrPercentageType: From<LengthOrPercentage>,
-          NumberType: From<Number>
+fn convert_from_number_or_percentage<L, N>(from: NumberOrPercentage)
+    -> SvgLengthOrPercentageOrNumber<L, N>
+    where
+        L: From<LengthOrPercentage>,
+        N: From<Number>
 {
     match from {
         NumberOrPercentage::Number(num) =>
-            SvgLengthOrPercentageOrNumber::Number(num.into()),
+            SvgLengthOrPercentageOrNumber::Number(From::from(num)),
         NumberOrPercentage::Percentage(p) =>
             SvgLengthOrPercentageOrNumber::LengthOrPercentage(
                 (LengthOrPercentage::Percentage(p)).into())

--- a/components/style/properties/longhand/inherited_svg.mako.rs
+++ b/components/style/properties/longhand/inherited_svg.mako.rs
@@ -68,7 +68,7 @@ ${helpers.predefined_type(
     "::values::computed::NonNegativeAu::from_px(1).into()",
     products="gecko",
     boxed="True",
-    animation_value_type="::values::computed::SVGWidth",
+    animation_value_type="<::values::computed::SVGWidth as ToAnimatedValue>::AnimatedValue",
     spec="https://www.w3.org/TR/SVG2/painting.html#StrokeWidth")}
 
 ${helpers.single_keyword("stroke-linecap", "butt round square",
@@ -94,7 +94,7 @@ ${helpers.predefined_type(
     "SVGStrokeDashArray",
     "Default::default()",
     products="gecko",
-    animation_value_type="::values::computed::SVGStrokeDashArray",
+    animation_value_type="<::values::computed::SVGStrokeDashArray as ToAnimatedValue>::AnimatedValue",
     spec="https://www.w3.org/TR/SVG2/painting.html#StrokeDashing",
 )}
 
@@ -103,7 +103,7 @@ ${helpers.predefined_type(
     "Au(0).into()",
     products="gecko",
     boxed="True",
-    animation_value_type="ComputedValue",
+    animation_value_type="<::values::computed::SVGLength as ToAnimatedValue>::AnimatedValue",
     spec="https://www.w3.org/TR/SVG2/painting.html#StrokeDashing")}
 
 // Section 14 - Clipping, Masking and Compositing

--- a/components/style/values/animated/mod.rs
+++ b/components/style/values/animated/mod.rs
@@ -27,6 +27,7 @@ use values::specified::url::SpecifiedUrl;
 
 pub mod color;
 pub mod effects;
+pub mod svg;
 
 /// Animate from one value to another.
 ///

--- a/components/style/values/animated/svg.rs
+++ b/components/style/values/animated/svg.rs
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Animated types for CSS values in SVG
+
+use values::computed::{Number, Percentage};
+use values::computed::length::CalcLengthOrPercentage;
+
+/// Stroke-* value support unit less value, so servo interpolate length value as
+/// number unlike computed value and specified value.
+#[derive(Animate, Clone, ComputeSquaredDistance, Copy, Debug, PartialEq, ToAnimatedZero)]
+pub enum SvgLengthOrPercentageOrNumber {
+    /// Real number value.
+    Number(Number),
+    /// Percentage value.
+    Percentage(Percentage),
+    /// Calc value, this type can hold percentage value. For present, percentage
+    /// value store the Percentage type.(i.e. Servo doesn't use CalcLengthOrPercentage
+    /// for storing the percentage value)
+    /// TODO: We need to support interpolation of calc value.
+    /// https://bugzilla.mozilla.org/show_bug.cgi?id=1386967
+    #[animation(error)]
+    Calc(CalcLengthOrPercentage),
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is a PR for https://bugzilla.mozilla.org/show_bug.cgi?id=1390367

This patch will add an animated value for SvgLengthOrPercentageOrNumber in order to support SMIL animation with fill='freeze'.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
There are already these tests in dom/smil/tests of gecko, this PR will enable these tests.
For detail, see https://bugzilla.mozilla.org/show_bug.cgi?id=1390367.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/17288)
<!-- Reviewable:end -->
