### PR TITLE
Add initial iOS User-Agent

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -448,6 +448,7 @@ pub fn multiprocess() -> bool {
 enum UserAgent {
     Desktop,
     Android,
+    iOS
 }
 
 fn default_user_agent_string(agent: UserAgent) -> &'static str {
@@ -478,13 +479,19 @@ fn default_user_agent_string(agent: UserAgent) -> &'static str {
         UserAgent::Android => {
             "Mozilla/5.0 (Android; Mobile; rv:55.0) Servo/1.0 Firefox/55.0"
         }
+        UserAgent::iOS => {
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X; rv:55.0) Servo/1.0 Firefox/55.0"
+        }
     }
 }
 
 #[cfg(target_os = "android")]
 const DEFAULT_USER_AGENT: UserAgent = UserAgent::Android;
 
-#[cfg(not(target_os = "android"))]
+#[cfg(target_os = "ios")]
+const DEFAULT_USER_AGENT: UserAgent = UserAgent::iOS;
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 const DEFAULT_USER_AGENT: UserAgent = UserAgent::Desktop;
 
 pub fn default_opts() -> Opts {
@@ -584,7 +591,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     opts.optopt("", "resolution", "Set window resolution.", "1024x740");
     opts.optopt("u",
                 "user-agent",
-                "Set custom user agent string (or android / desktop for platform default)",
+                "Set custom user agent string (or ios / android / desktop for platform default)",
                 "NCSA Mosaic/1.0 (X11;SunOS 4.1.4 sun4m)");
     opts.optflag("M", "multiprocess", "Run in multiprocess mode");
     opts.optflag("S", "sandbox", "Run in a sandbox if multiprocess");
@@ -766,6 +773,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     }
 
     let user_agent = match opt_match.opt_str("u") {
+        Some(ref ua) if ua == "ios" => default_user_agent_string(UserAgent::iOS).into(),
         Some(ref ua) if ua == "android" => default_user_agent_string(UserAgent::Android).into(),
         Some(ref ua) if ua == "desktop" => default_user_agent_string(UserAgent::Desktop).into(),
         Some(ua) => ua.into(),


### PR DESCRIPTION
This commit adds an initial iOS User-Agent as discussed here : https://github.com/servo/servo/issues/18154#issuecomment-324382850

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes (continues to) fix #18154.

<!-- Either: -->
- [X] These changes do not require tests because too little is done

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18205)
<!-- Reviewable:end -->
