### PR TITLE
Devirtualize CSS error reporting.

### DIFF
--- a/components/script/dom/css.rs
+++ b/components/script/dom/css.rs
@@ -38,7 +38,6 @@ impl CSS {
         let url = win.Document().url();
         let context = ParserContext::new_for_cssom(
             &url,
-            win.css_error_reporter(),
             Some(CssRuleType::Style),
             PARSING_MODE_DEFAULT,
             QuirksMode::NoQuirks
@@ -55,7 +54,6 @@ impl CSS {
             let url = win.Document().url();
             let context = ParserContext::new_for_cssom(
                 &url,
-                win.css_error_reporter(),
                 Some(CssRuleType::Style),
                 PARSING_MODE_DEFAULT,
                 QuirksMode::NoQuirks

--- a/components/script/dom/cssmediarule.rs
+++ b/components/script/dom/cssmediarule.rs
@@ -75,7 +75,7 @@ impl CSSMediaRule {
         let win = global.as_window();
         let url = win.get_url();
         let quirks_mode = win.Document().quirks_mode();
-        let context = ParserContext::new_for_cssom(&url, win.css_error_reporter(), Some(CssRuleType::Media),
+        let context = ParserContext::new_for_cssom(&url, Some(CssRuleType::Media),
                                                    PARSING_MODE_DEFAULT,
                                                    quirks_mode);
         let new_medialist = parse_media_query_list(&context, &mut input);

--- a/components/script/dom/csssupportsrule.rs
+++ b/components/script/dom/csssupportsrule.rs
@@ -63,7 +63,7 @@ impl CSSSupportsRule {
             let win = global.as_window();
             let url = win.Document().url();
             let quirks_mode = win.Document().quirks_mode();
-            let context = ParserContext::new_for_cssom(&url, win.css_error_reporter(), Some(CssRuleType::Supports),
+            let context = ParserContext::new_for_cssom(&url, Some(CssRuleType::Supports),
                                                        PARSING_MODE_DEFAULT,
                                                        quirks_mode);
             let enabled = cond.eval(&context);

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -285,9 +285,8 @@ impl HTMLLinkElement {
 
         let mut input = ParserInput::new(&mq_str);
         let mut css_parser = CssParser::new(&mut input);
-        let win = document.window();
         let doc_url = document.url();
-        let context = CssParserContext::new_for_cssom(&doc_url, win.css_error_reporter(), Some(CssRuleType::Media),
+        let context = CssParserContext::new_for_cssom(&doc_url, Some(CssRuleType::Media),
                                                       PARSING_MODE_DEFAULT,
                                                       document.quirks_mode());
         let media = parse_media_query_list(&context, &mut css_parser);

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -86,7 +86,6 @@ impl HTMLStyleElement {
         let data = node.GetTextContent().expect("Element.textContent must be a string");
         let url = win.get_url();
         let context = CssParserContext::new_for_cssom(&url,
-                                                      win.css_error_reporter(),
                                                       Some(CssRuleType::Media),
                                                       PARSING_MODE_DEFAULT,
                                                       doc.quirks_mode());

--- a/components/script/dom/medialist.rs
+++ b/components/script/dom/medialist.rs
@@ -77,7 +77,7 @@ impl MediaListMethods for MediaList {
         let win = global.as_window();
         let url = win.get_url();
         let quirks_mode = win.Document().quirks_mode();
-        let context = ParserContext::new_for_cssom(&url, win.css_error_reporter(), Some(CssRuleType::Media),
+        let context = ParserContext::new_for_cssom(&url, Some(CssRuleType::Media),
                                                    PARSING_MODE_DEFAULT,
                                                    quirks_mode);
         *media_queries = parse_media_query_list(&context, &mut parser);
@@ -114,7 +114,7 @@ impl MediaListMethods for MediaList {
         let win = global.as_window();
         let url = win.get_url();
         let quirks_mode = win.Document().quirks_mode();
-        let context = ParserContext::new_for_cssom(&url, win.css_error_reporter(), Some(CssRuleType::Media),
+        let context = ParserContext::new_for_cssom(&url, Some(CssRuleType::Media),
                                                    PARSING_MODE_DEFAULT,
                                                    quirks_mode);
         let m = MediaQuery::parse(&context, &mut parser);
@@ -143,7 +143,7 @@ impl MediaListMethods for MediaList {
         let win = global.as_window();
         let url = win.get_url();
         let quirks_mode = win.Document().quirks_mode();
-        let context = ParserContext::new_for_cssom(&url, win.css_error_reporter(), Some(CssRuleType::Media),
+        let context = ParserContext::new_for_cssom(&url, Some(CssRuleType::Media),
                                                    PARSING_MODE_DEFAULT,
                                                    quirks_mode);
         let m = MediaQuery::parse(&context, &mut parser);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -105,7 +105,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Sender, channel};
 use std::sync::mpsc::TryRecvError::{Disconnected, Empty};
 use style::context::ReflowGoal;
-use style::error_reporting::ParseErrorReporter;
 use style::media_queries;
 use style::parser::ParserContext as CssParserContext;
 use style::properties::PropertyId;
@@ -377,7 +376,7 @@ impl Window {
          &self.bluetooth_extra_permission_data
     }
 
-    pub fn css_error_reporter(&self) -> &ParseErrorReporter {
+    pub fn css_error_reporter(&self) -> &CSSErrorReporter {
         &self.error_reporter
     }
 
@@ -1012,7 +1011,7 @@ impl WindowMethods for Window {
         let mut parser = Parser::new(&mut input);
         let url = self.get_url();
         let quirks_mode = self.Document().quirks_mode();
-        let context = CssParserContext::new_for_cssom(&url, self.css_error_reporter(), Some(CssRuleType::Media),
+        let context = CssParserContext::new_for_cssom(&url, Some(CssRuleType::Media),
                                                       PARSING_MODE_DEFAULT,
                                                       quirks_mode);
         let media_query_list = media_queries::parse_media_query_list(&context, &mut parser);

--- a/components/style/counter_style/mod.rs
+++ b/components/style/counter_style/mod.rs
@@ -9,10 +9,10 @@
 use Atom;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser};
 use cssparser::{Parser, Token, serialize_identifier, BasicParseError, CowRcStr};
-use error_reporting::ContextualParseError;
+use error_reporting::{ContextualParseError, ParseErrorReporter};
 #[cfg(feature = "gecko")] use gecko::rules::CounterStyleDescriptors;
 #[cfg(feature = "gecko")] use gecko_bindings::structs::nsCSSCounterDesc;
-use parser::{ParserContext, Parse};
+use parser::{ParserContext, ParserErrorContext, Parse};
 use selectors::parser::SelectorParseError;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use std::ascii::AsciiExt;
@@ -50,8 +50,13 @@ pub fn parse_counter_style_name<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Cu
 }
 
 /// Parse the body (inside `{}`) of an @counter-style rule
-pub fn parse_counter_style_body<'i, 't>(name: CustomIdent, context: &ParserContext, input: &mut Parser<'i, 't>)
-                                        -> Result<CounterStyleRuleData, ParseError<'i>> {
+pub fn parse_counter_style_body<'i, 't, R>(name: CustomIdent,
+                                           context: &ParserContext,
+                                           error_context: &ParserErrorContext<R>,
+                                           input: &mut Parser<'i, 't>)
+                                           -> Result<CounterStyleRuleData, ParseError<'i>>
+    where R: ParseErrorReporter
+{
     let start = input.current_source_location();
     let mut rule = CounterStyleRuleData::empty(name);
     {
@@ -63,7 +68,7 @@ pub fn parse_counter_style_body<'i, 't>(name: CustomIdent, context: &ParserConte
         while let Some(declaration) = iter.next() {
             if let Err(err) = declaration {
                 let error = ContextualParseError::UnsupportedCounterStyleDescriptorDeclaration(err.slice, err.error);
-                context.log_css_error(err.location, error)
+                context.log_css_error(error_context, err.location, error)
             }
         }
     }
@@ -95,7 +100,7 @@ pub fn parse_counter_style_body<'i, 't>(name: CustomIdent, context: &ParserConte
         _ => None
     };
     if let Some(error) = error {
-        context.log_css_error(start, error);
+        context.log_css_error(error_context, start, error);
         Err(StyleParseError::UnspecifiedError.into())
     } else {
         Ok(rule)

--- a/components/style/encoding_support.rs
+++ b/components/style/encoding_support.rs
@@ -49,17 +49,19 @@ impl Stylesheet {
     ///
     /// Takes care of decoding the network bytes and forwards the resulting
     /// string to `Stylesheet::from_str`.
-    pub fn from_bytes(bytes: &[u8],
-                      url_data: UrlExtraData,
-                      protocol_encoding_label: Option<&str>,
-                      environment_encoding: Option<EncodingRef>,
-                      origin: Origin,
-                      media: MediaList,
-                      shared_lock: SharedRwLock,
-                      stylesheet_loader: Option<&StylesheetLoader>,
-                      error_reporter: &ParseErrorReporter,
-                      quirks_mode: QuirksMode)
-                      -> Stylesheet {
+    pub fn from_bytes<R>(bytes: &[u8],
+                         url_data: UrlExtraData,
+                         protocol_encoding_label: Option<&str>,
+                         environment_encoding: Option<EncodingRef>,
+                         origin: Origin,
+                         media: MediaList,
+                         shared_lock: SharedRwLock,
+                         stylesheet_loader: Option<&StylesheetLoader>,
+                         error_reporter: &R,
+                         quirks_mode: QuirksMode)
+                         -> Stylesheet
+        where R: ParseErrorReporter
+    {
         let (string, _) = decode_stylesheet_bytes(
             bytes, protocol_encoding_label, environment_encoding);
         Stylesheet::from_str(&string,
@@ -75,13 +77,15 @@ impl Stylesheet {
 
     /// Updates an empty stylesheet with a set of bytes that reached over the
     /// network.
-    pub fn update_from_bytes(existing: &Stylesheet,
-                             bytes: &[u8],
-                             protocol_encoding_label: Option<&str>,
-                             environment_encoding: Option<EncodingRef>,
-                             url_data: UrlExtraData,
-                             stylesheet_loader: Option<&StylesheetLoader>,
-                             error_reporter: &ParseErrorReporter) {
+    pub fn update_from_bytes<R>(existing: &Stylesheet,
+                                bytes: &[u8],
+                                protocol_encoding_label: Option<&str>,
+                                environment_encoding: Option<EncodingRef>,
+                                url_data: UrlExtraData,
+                                stylesheet_loader: Option<&StylesheetLoader>,
+                                error_reporter: &R)
+        where R: ParseErrorReporter
+    {
         let (string, _) = decode_stylesheet_bytes(
             bytes, protocol_encoding_label, environment_encoding);
         Self::update_from_str(existing,

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -13,10 +13,10 @@ use computed_values::{font_feature_settings, font_stretch, font_style, font_weig
 use computed_values::font_family::FamilyName;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser};
 use cssparser::{SourceLocation, CowRcStr};
-use error_reporting::ContextualParseError;
+use error_reporting::{ContextualParseError, ParseErrorReporter};
 #[cfg(feature = "gecko")] use gecko_bindings::structs::CSSFontFaceDescriptors;
 #[cfg(feature = "gecko")] use cssparser::UnicodeRange;
-use parser::{ParserContext, Parse};
+use parser::{ParserContext, ParserErrorContext, Parse};
 #[cfg(feature = "gecko")]
 use properties::longhands::font_language_override;
 use selectors::parser::SelectorParseError;
@@ -108,8 +108,13 @@ impl Parse for FontWeight {
 /// Parse the block inside a `@font-face` rule.
 ///
 /// Note that the prelude parsing code lives in the `stylesheets` module.
-pub fn parse_font_face_block(context: &ParserContext, input: &mut Parser, location: SourceLocation)
-    -> FontFaceRuleData {
+pub fn parse_font_face_block<R>(context: &ParserContext,
+                                error_context: &ParserErrorContext<R>,
+                                input: &mut Parser,
+                                location: SourceLocation)
+                                -> FontFaceRuleData
+    where R: ParseErrorReporter
+{
     let mut rule = FontFaceRuleData::empty(location);
     {
         let parser = FontFaceRuleParser {
@@ -120,7 +125,7 @@ pub fn parse_font_face_block(context: &ParserContext, input: &mut Parser, locati
         while let Some(declaration) = iter.next() {
             if let Err(err) = declaration {
                 let error = ContextualParseError::UnsupportedFontFaceDescriptor(err.slice, err.error);
-                context.log_css_error(err.location, error)
+                context.log_css_error(error_context, err.location, error)
             }
         }
     }

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -467,10 +467,13 @@ impl<'le> fmt::Debug for GeckoElement<'le> {
 
 impl<'le> GeckoElement<'le> {
     /// Parse the style attribute of an element.
-    pub fn parse_style_attribute(value: &str,
-                                 url_data: &UrlExtraData,
-                                 quirks_mode: QuirksMode,
-                                 reporter: &ParseErrorReporter) -> PropertyDeclarationBlock {
+    pub fn parse_style_attribute<R>(value: &str,
+                                    url_data: &UrlExtraData,
+                                    quirks_mode: QuirksMode,
+                                    reporter: &R)
+                                    -> PropertyDeclarationBlock
+        where R: ParseErrorReporter
+    {
         parse_style_attribute(value, url_data, reporter, quirks_mode)
     }
 

--- a/components/style/parser.rs
+++ b/components/style/parser.rs
@@ -38,6 +38,12 @@ pub fn assert_parsing_mode_match() {
     }
 }
 
+/// The context required to report a parse error.
+pub struct ParserErrorContext<'a, R: 'a> {
+    /// An error reporter to report syntax errors.
+    pub error_reporter: &'a R,
+}
+
 /// The data that the parser needs from outside in order to parse a stylesheet.
 pub struct ParserContext<'a> {
     /// The `Origin` of the stylesheet, whether it's a user, author or
@@ -45,8 +51,6 @@ pub struct ParserContext<'a> {
     pub stylesheet_origin: Origin,
     /// The extra data we need for resolving url values.
     pub url_data: &'a UrlExtraData,
-    /// An error reporter to report syntax errors.
-    pub error_reporter: &'a ParseErrorReporter,
     /// The current rule type, if any.
     pub rule_type: Option<CssRuleType>,
     /// Line number offsets for inline stylesheets
@@ -64,7 +68,6 @@ impl<'a> ParserContext<'a> {
     pub fn new(
         stylesheet_origin: Origin,
         url_data: &'a UrlExtraData,
-        error_reporter: &'a ParseErrorReporter,
         rule_type: Option<CssRuleType>,
         parsing_mode: ParsingMode,
         quirks_mode: QuirksMode,
@@ -72,7 +75,6 @@ impl<'a> ParserContext<'a> {
         ParserContext {
             stylesheet_origin: stylesheet_origin,
             url_data: url_data,
-            error_reporter: error_reporter,
             rule_type: rule_type,
             line_number_offset: 0u64,
             parsing_mode: parsing_mode,
@@ -84,7 +86,6 @@ impl<'a> ParserContext<'a> {
     /// Create a parser context for on-the-fly parsing in CSSOM
     pub fn new_for_cssom(
         url_data: &'a UrlExtraData,
-        error_reporter: &'a ParseErrorReporter,
         rule_type: Option<CssRuleType>,
         parsing_mode: ParsingMode,
         quirks_mode: QuirksMode
@@ -92,7 +93,6 @@ impl<'a> ParserContext<'a> {
         Self::new(
             Origin::Author,
             url_data,
-            error_reporter,
             rule_type,
             parsing_mode,
             quirks_mode,
@@ -108,7 +108,6 @@ impl<'a> ParserContext<'a> {
         ParserContext {
             stylesheet_origin: context.stylesheet_origin,
             url_data: context.url_data,
-            error_reporter: context.error_reporter,
             rule_type: Some(rule_type),
             line_number_offset: context.line_number_offset,
             parsing_mode: context.parsing_mode,
@@ -121,7 +120,6 @@ impl<'a> ParserContext<'a> {
     pub fn new_with_line_number_offset(
         stylesheet_origin: Origin,
         url_data: &'a UrlExtraData,
-        error_reporter: &'a ParseErrorReporter,
         line_number_offset: u64,
         parsing_mode: ParsingMode,
         quirks_mode: QuirksMode,
@@ -129,7 +127,6 @@ impl<'a> ParserContext<'a> {
         ParserContext {
             stylesheet_origin: stylesheet_origin,
             url_data: url_data,
-            error_reporter: error_reporter,
             rule_type: None,
             line_number_offset: line_number_offset,
             parsing_mode: parsing_mode,
@@ -144,12 +141,17 @@ impl<'a> ParserContext<'a> {
     }
 
     /// Record a CSS parse error with this context’s error reporting.
-    pub fn log_css_error(&self, location: SourceLocation, error: ContextualParseError) {
+    pub fn log_css_error<R>(&self,
+                            context: &ParserErrorContext<R>,
+                            location: SourceLocation,
+                            error: ContextualParseError)
+        where R: ParseErrorReporter
+    {
         let location = SourceLocation {
             line: location.line + self.line_number_offset as u32,
             column: location.column,
         };
-        self.error_reporter.report_error(self.url_data, location, error)
+        context.error_reporter.report_error(self.url_data, location, error)
     }
 }
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -23,7 +23,6 @@ use cssparser::ParserInput;
 #[cfg(feature = "servo")] use euclid::SideOffsets2D;
 use computed_values;
 use context::QuirksMode;
-use error_reporting::NullReporter;
 use font_metrics::FontMetricsProvider;
 #[cfg(feature = "gecko")] use gecko_bindings::bindings;
 #[cfg(feature = "gecko")] use gecko_bindings::structs::{self, nsCSSPropertyID};
@@ -828,10 +827,8 @@ impl UnparsedValue {
         .ok()
         .and_then(|css| {
             // As of this writing, only the base URL is used for property values:
-            let reporter = NullReporter;
             let context = ParserContext::new(Origin::Author,
                                              &self.url_data,
-                                             &reporter,
                                              None,
                                              PARSING_MODE_DEFAULT,
                                              quirks_mode);

--- a/components/style/stylesheets/mod.rs
+++ b/components/style/stylesheets/mod.rs
@@ -26,7 +26,7 @@ pub mod viewport_rule;
 
 use cssparser::{parse_one_rule, Parser, ParserInput};
 use error_reporting::NullReporter;
-use parser::ParserContext;
+use parser::{ParserContext, ParserErrorContext};
 use servo_arc::Arc;
 use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked, SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt;
@@ -230,7 +230,6 @@ impl CssRule {
         let context = ParserContext::new(
             parent_stylesheet_contents.origin,
             &url_data,
-            &error_reporter,
             None,
             PARSING_MODE_DEFAULT,
             parent_stylesheet_contents.quirks_mode,
@@ -246,6 +245,7 @@ impl CssRule {
         let mut rule_parser = TopLevelRuleParser {
             stylesheet_origin: parent_stylesheet_contents.origin,
             context: context,
+            error_context: ParserErrorContext { error_reporter: &error_reporter },
             shared_lock: &shared_lock,
             loader: loader,
             state: state,

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -11,11 +11,11 @@ use app_units::Au;
 use context::QuirksMode;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser, parse_important};
 use cssparser::{CowRcStr, ToCss as ParserToCss};
-use error_reporting::ContextualParseError;
+use error_reporting::{ContextualParseError, ParseErrorReporter};
 use euclid::TypedSize2D;
 use font_metrics::get_metrics_provider_for_product;
 use media_queries::Device;
-use parser::{Parse, ParserContext};
+use parser::{ParserContext, ParserErrorContext};
 use properties::StyleBuilder;
 use selectors::parser::SelectorParseError;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
@@ -346,8 +346,14 @@ fn is_whitespace_separator_or_equals(c: &char) -> bool {
     WHITESPACE.contains(c) || SEPARATOR.contains(c) || *c == '='
 }
 
-impl Parse for ViewportRule {
-    fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
+impl ViewportRule {
+    /// Parse a single @viewport rule.
+    pub fn parse<'i, 't, R>(context: &ParserContext,
+                            error_context: &ParserErrorContext<R>,
+                            input: &mut Parser<'i, 't>)
+                            -> Result<Self, ParseError<'i>>
+        where R: ParseErrorReporter
+    {
         let parser = ViewportRuleParser { context: context };
 
         let mut cascade = Cascade::new();
@@ -361,7 +367,7 @@ impl Parse for ViewportRule {
                 }
                 Err(err) => {
                     let error = ContextualParseError::UnsupportedViewportDescriptorDeclaration(err.slice, err.error);
-                    context.log_css_error(err.location, error);
+                    context.log_css_error(error_context, err.location, error);
                 }
             }
         }

--- a/tests/unit/style/parsing/length.rs
+++ b/tests/unit/style/parsing/length.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use cssparser::{Parser, ParserInput};
-use media_queries::CSSErrorReporterTest;
 use parsing::parse;
 use style::context::QuirksMode;
 use style::parser::{Parse, ParserContext};
@@ -41,8 +40,7 @@ fn test_parsing_modes() {
 
     // In SVG length mode, non-zero lengths are assumed to be px.
     let url = ::servo_url::ServoUrl::parse("http://localhost").unwrap();
-    let reporter = CSSErrorReporterTest;
-    let context = ParserContext::new(Origin::Author, &url, &reporter,
+    let context = ParserContext::new(Origin::Author, &url,
                                      Some(CssRuleType::Style), PARSING_MODE_ALLOW_UNITLESS_LENGTH,
                                      QuirksMode::NoQuirks);
     let mut input = ParserInput::new("1");

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -5,7 +5,6 @@
 //! Tests for parsing and serialization of values/properties
 
 use cssparser::{Parser, ParserInput};
-use media_queries::CSSErrorReporterTest;
 use style::context::QuirksMode;
 use style::parser::ParserContext;
 use style::stylesheets::{CssRuleType, Origin};
@@ -20,8 +19,7 @@ where F: for<'t> Fn(&ParserContext, &mut Parser<'static, 't>) -> Result<T, Parse
 fn parse_input<'i: 't, 't, T, F>(f: F, input: &'t mut ParserInput<'i>) -> Result<T, ParseError<'i>>
 where F: Fn(&ParserContext, &mut Parser<'i, 't>) -> Result<T, ParseError<'i>> {
     let url = ::servo_url::ServoUrl::parse("http://localhost").unwrap();
-    let reporter = CSSErrorReporterTest;
-    let context = ParserContext::new(Origin::Author, &url, &reporter, Some(CssRuleType::Style),
+    let context = ParserContext::new(Origin::Author, &url, Some(CssRuleType::Style),
                                      PARSING_MODE_DEFAULT,
                                      QuirksMode::NoQuirks);
     let mut parser = Parser::new(input);

--- a/tests/unit/style/parsing/value.rs
+++ b/tests/unit/style/parsing/value.rs
@@ -4,7 +4,6 @@
 
 use app_units::Au;
 use cssparser::{Parser, ParserInput};
-use media_queries::CSSErrorReporterTest;
 use style::context::QuirksMode;
 use style::parser::ParserContext;
 use style::stylesheets::{CssRuleType, Origin};
@@ -23,8 +22,7 @@ fn length_has_viewport_percentage() {
 fn test_parsing_allo_all_numeric_values() {
     // In SVG length mode, non-zero lengths are assumed to be px.
     let url = ::servo_url::ServoUrl::parse("http://localhost").unwrap();
-    let reporter = CSSErrorReporterTest;
-    let context = ParserContext::new(Origin::Author, &url, &reporter,
+    let context = ParserContext::new(Origin::Author, &url,
                                      Some(CssRuleType::Style), PARSING_MODE_ALLOW_ALL_NUMERIC_VALUES,
                                      QuirksMode::NoQuirks);
     let mut input = ParserInput::new("-1");

--- a/tests/unit/style/properties/background.rs
+++ b/tests/unit/style/properties/background.rs
@@ -7,5 +7,5 @@ use style::properties::longhands::background_size;
 
 #[test]
 fn background_size_should_reject_negative_values() {
-    assert!(parse(background_size::parse, "-40% -40%").is_err());
+    assert!(parse(|c, _, i| background_size::parse(c, i), "-40% -40%").is_err());
 }

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -426,7 +426,7 @@ mod shorthand_serialization {
                 border-left: 4px solid; \
                 border-image: none;";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -568,7 +568,7 @@ mod shorthand_serialization {
                 background-origin: border-box; \
                 background-clip: padding-box;";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -592,7 +592,7 @@ mod shorthand_serialization {
                 background-origin: padding-box; \
                 background-clip: padding-box;";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -616,7 +616,7 @@ mod shorthand_serialization {
                 background-origin: border-box, padding-box; \
                 background-clip: padding-box, padding-box;";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -647,7 +647,7 @@ mod shorthand_serialization {
                 background-origin: border-box; \
                 background-clip: padding-box, padding-box;";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -661,7 +661,7 @@ mod shorthand_serialization {
             let block_text = "\
                 background-position-x: 30px;\
                 background-position-y: bottom 20px;";
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
             let serialization = block.to_css_string();
             assert_eq!(serialization, "background-position: left 30px bottom 20px;");
 
@@ -670,7 +670,7 @@ mod shorthand_serialization {
             let block_text = "\
                 background-position-x: center;\
                 background-position-y: 20px;";
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
             let serialization = block.to_css_string();
             assert_eq!(serialization, "background-position: center 20px;");
         }
@@ -755,7 +755,7 @@ mod shorthand_serialization {
                 animation-iteration-count: infinite;\
                 animation-play-state: paused;";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -774,7 +774,7 @@ mod shorthand_serialization {
                 animation-iteration-count: infinite, 2;\
                 animation-play-state: paused, running;";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -800,7 +800,7 @@ mod shorthand_serialization {
                 animation-iteration-count: infinite, 2; \
                 animation-play-state: paused, running;";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -817,7 +817,7 @@ mod shorthand_serialization {
                               animation-iteration-count: infinite, 2; \
                               animation-play-state: paused, running;";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -835,7 +835,7 @@ mod shorthand_serialization {
                               transition-delay: 4s; \
                               transition-timing-function: cubic-bezier(0.2, 5, 0.5, 2);";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -849,7 +849,7 @@ mod shorthand_serialization {
                               transition-delay: 4s, 5s; \
                               transition-timing-function: cubic-bezier(0.2, 5, 0.5, 2), ease;";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -871,7 +871,7 @@ mod shorthand_serialization {
                               transition-delay: 4s, 5s; \
                               transition-timing-function: cubic-bezier(0.2, 5, 0.5, 2), ease;";
 
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -884,7 +884,7 @@ mod shorthand_serialization {
                               transition-duration: 3s; \
                               transition-delay: 4s; \
                               transition-timing-function: steps(2, start);";
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -897,7 +897,7 @@ mod shorthand_serialization {
                               transition-duration: 3s; \
                               transition-delay: 4s; \
                               transition-timing-function: frames(2);";
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
 
@@ -910,7 +910,7 @@ mod shorthand_serialization {
         #[test]
         fn css_wide_keywords_should_be_parsed() {
             let block_text = "--a:inherit;";
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
             assert_eq!(serialization, "--a: inherit;");
@@ -919,7 +919,7 @@ mod shorthand_serialization {
         #[test]
         fn non_keyword_custom_property_should_be_unparsed() {
             let block_text = "--main-color: #06c;";
-            let block = parse(|c, i| Ok(parse_property_declaration_list(c, i)), block_text).unwrap();
+            let block = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), block_text).unwrap();
 
             let serialization = block.to_css_string();
             assert_eq!(serialization, block_text);
@@ -949,7 +949,7 @@ mod shorthand_serialization {
             let shadow_decl = BoxShadowList(vec![shadow_val]);
             properties.push(PropertyDeclaration::BoxShadow(shadow_decl));
             let shadow_css = "box-shadow: 1px 2px 3px 4px;";
-            let shadow = parse(|c, i| Ok(parse_property_declaration_list(c, i)), shadow_css).unwrap();
+            let shadow = parse(|c, e, i| Ok(parse_property_declaration_list(c, e, i)), shadow_css).unwrap();
 
             assert_eq!(shadow.to_css_string(), shadow_css);
         }

--- a/tests/unit/style/viewport.rs
+++ b/tests/unit/style/viewport.rs
@@ -11,7 +11,7 @@ use servo_config::prefs::{PREFS, PrefValue};
 use servo_url::ServoUrl;
 use style::context::QuirksMode;
 use style::media_queries::{Device, MediaList, MediaType};
-use style::parser::{Parse, ParserContext};
+use style::parser::{Parse, ParserContext, ParserErrorContext};
 use style::shared_lock::SharedRwLock;
 use style::stylesheets::{CssRuleType, Stylesheet, StylesheetInDocument, Origin};
 use style::stylesheets::viewport_rule::*;
@@ -302,14 +302,14 @@ fn multiple_stylesheets_cascading() {
 #[test]
 fn constrain_viewport() {
     let url = ServoUrl::parse("http://localhost").unwrap();
-    let reporter = CSSErrorReporterTest;
-    let context = ParserContext::new(Origin::Author, &url, &reporter, Some(CssRuleType::Viewport),
+    let context = ParserContext::new(Origin::Author, &url, Some(CssRuleType::Viewport),
                                      PARSING_MODE_DEFAULT,
                                      QuirksMode::NoQuirks);
+    let error_context = ParserErrorContext { error_reporter: &CSSErrorReporterTest };
 
     macro_rules! from_css {
         ($css:expr) => {
-            &ViewportRule::parse(&context, &mut Parser::new(&mut $css)).unwrap()
+            &ViewportRule::parse(&context, &error_context, &mut Parser::new(&mut $css)).unwrap()
         }
     }
 


### PR DESCRIPTION
This removes a trait object from the path of reporting a CSS error.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18209)
<!-- Reviewable:end -->
