### PR TITLE
Improve debug log related to selector matching

### DIFF
--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -519,12 +519,12 @@ fn matches_complex_selector_internal<E, F>(mut selector_iter: SelectorIter<E::Im
 {
     *relevant_link = relevant_link.examine_potential_link(element, &mut context.shared);
 
+    debug!("Matching complex selector {:?} for {:?}, relevant link {:?}",
+           selector_iter, element, relevant_link);
+
     let matches_all_simple_selectors = selector_iter.all(|simple| {
         matches_simple_selector(simple, element, context, &relevant_link, flags_setter)
     });
-
-    debug!("Matching for {:?}, simple selector {:?}, relevant link {:?}",
-           element, selector_iter, relevant_link);
 
     let combinator = selector_iter.next_sequence();
     let siblings = combinator.map_or(false, |c| c.is_sibling());

--- a/components/style/style_resolver.rs
+++ b/components/style/style_resolver.rs
@@ -356,7 +356,7 @@ where
         );
 
         if log_enabled!(Trace) {
-            trace!("Matched rules:");
+            trace!("Matched rules for {:?}:", self.element);
             for rn in rule_node.self_and_ancestors() {
                 let source = rn.style_source();
                 if source.is_some() {


### PR DESCRIPTION
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it only modifies debug log

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18213)
<!-- Reviewable:end -->
