### PR TITLE
Try to update running CSS animations when CSS rules are changed.

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -170,12 +170,12 @@ trait PrivateMatchMethods: TElement {
 
             // If the traverse is triggered by CSS rule changes, we need to
             // try to update all CSS animations on the element if the element
-            // has CSS animation style regardless of whether the animation is
-            // running or not.
+            // has or will have CSS animation style regardless of whether the
+            // animation is running or not.
             // TODO: We should check which @keyframes changed/added/deleted
             // and update only animations corresponding to those @keyframes.
             (context.shared.traversal_flags.contains(traversal_flags::ForCSSRuleChanges) &&
-             has_new_animation_style) ||
+             (has_new_animation_style || has_animations)) ||
             !old_box_style.animations_equals(new_box_style) ||
              (old_display_style == display::T::none &&
               new_display_style != display::T::none &&


### PR DESCRIPTION
In the case where values in CSS rules changed directly by CSSOM, the old
value in the CSS rule block is immediately replaced by the new one. So if
the element, which is applied to the CSS rule, has running animations, the
new value is used during cascading process in animation-only restyle. Thus
in a subsequent normal restyle, we can't tell whether the value in the CSS
rule has changed or not. As a result, transitions may not be triggered
(bug 1393323) and CSS animations may not be cancelled if the updated
animation-name is 'none' (bug 1392851).

For the latter case of CSS animations where animation-name has been updated to
'none', this patch introduces a workaround whereby we trigger an update of
running animations whenever the traversal is triggered by changes to CSS rules
and we have existing CSS animations.

<!-- Please describe your changes on the following line: -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1392851

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18214)
<!-- Reviewable:end -->
