### PR TITLE
style: Only store applicable ::before / ::after pseudo styles during the traversal.

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -702,7 +702,7 @@ pub fn process_resolved_style_request<'a, N>(context: &LayoutContext,
         thread_local: &mut tlc,
     };
 
-    let styles = resolve_style(&mut context, element, RuleInclusion::All, false);
+    let styles = resolve_style(&mut context, element, RuleInclusion::All, false, pseudo.as_ref());
     let style = styles.primary();
     let longhand_id = match *property {
         PropertyId::Longhand(id) => id,

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -123,7 +123,7 @@ trait PrivateMatchMethods: TElement {
         primary_style: &Arc<ComputedValues>
     ) -> Option<Arc<ComputedValues>> {
         use context::CascadeInputs;
-        use style_resolver::StyleResolverForElement;
+        use style_resolver::{PseudoElementResolution, StyleResolverForElement};
         use stylist::RuleInclusion;
 
         let rule_node = primary_style.rules();
@@ -143,8 +143,9 @@ trait PrivateMatchMethods: TElement {
                 visited_rules: primary_style.get_visited_style().and_then(|s| s.rules.clone()),
             };
 
+        // Actually `PseudoElementResolution` doesn't really matter.
         let style =
-            StyleResolverForElement::new(*self, context, RuleInclusion::All)
+            StyleResolverForElement::new(*self, context, RuleInclusion::All, PseudoElementResolution::IfApplicable)
                 .cascade_style_and_visited_with_default_parents(inputs);
 
         Some(style)

--- a/components/style/properties/computed_value_flags.rs
+++ b/components/style/properties/computed_value_flags.rs
@@ -44,5 +44,17 @@ bitflags! {
         /// A flag used to mark styles which are in a display: none subtree, or
         /// under one.
         const IS_IN_DISPLAY_NONE_SUBTREE = 1 << 5,
+
+        /// Whether this style inherits the `display` property.
+        ///
+        /// This is important because it may affect our optimizations to avoid
+        /// computing the style of pseudo-elements, given whether the
+        /// pseudo-element is generated depends on the `display` value.
+        const INHERITS_DISPLAY = 1 << 6,
+
+        /// Whether this style inherits the `content` property.
+        ///
+        /// Important because of the same reason.
+        const INHERITS_CONTENT = 1 << 7,
     }
 }

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2691,6 +2691,14 @@ impl<'a> StyleBuilder<'a> {
             self.inherited_style_ignoring_first_line.get_${property.style_struct.name_lower}();
         % endif
 
+        % if property.ident == "content":
+        self.flags.insert(::properties::computed_value_flags::INHERITS_CONTENT);
+        % endif
+
+        % if property.ident == "display":
+        self.flags.insert(::properties::computed_value_flags::INHERITS_DISPLAY);
+        % endif
+
         self.${property.style_struct.ident}.mutate()
             .copy_${property.ident}_from(
                 inherited_struct,

--- a/components/style/style_resolver.rs
+++ b/components/style/style_resolver.rs
@@ -15,11 +15,21 @@ use properties::{AnimationRules, CascadeFlags, ComputedValues};
 use properties::{IS_LINK, IS_ROOT_ELEMENT, IS_VISITED_LINK};
 use properties::{PROHIBIT_DISPLAY_CONTENTS, SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP};
 use properties::{VISITED_DEPENDENT_ONLY, cascade};
+use properties::longhands::display::computed_value::T as display;
 use rule_tree::StrongRuleNode;
 use selector_parser::{PseudoElement, SelectorImpl};
 use selectors::matching::{ElementSelectorFlags, MatchingContext, MatchingMode, VisitedHandlingMode};
 use servo_arc::Arc;
 use stylist::RuleInclusion;
+
+/// Whether pseudo-elements should be resolved or not.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PseudoElementResolution {
+    /// Only resolve pseudo-styles if possibly applicable.
+    IfApplicable,
+    /// Force pseudo-element resolution.
+    Force,
+}
 
 /// A struct that takes care of resolving the style of a given element.
 pub struct StyleResolverForElement<'a, 'ctx, 'le, E>
@@ -31,6 +41,7 @@ where
     element: E,
     context: &'a mut StyleContext<'ctx, E>,
     rule_inclusion: RuleInclusion,
+    pseudo_resolution: PseudoElementResolution,
     _marker: ::std::marker::PhantomData<&'le E>,
 }
 
@@ -66,6 +77,29 @@ where
     f(parent_style.map(|x| &**x), layout_parent_style.map(|s| &**s))
 }
 
+fn eager_pseudo_is_definitely_not_generated(
+    pseudo: &PseudoElement,
+    style: &ComputedValues,
+) -> bool {
+    use properties::computed_value_flags::{INHERITS_CONTENT, INHERITS_DISPLAY};
+
+    if !pseudo.is_before_or_after() {
+        return false;
+    }
+
+    if !style.flags.intersects(INHERITS_DISPLAY) &&
+       style.get_box().clone_display() == display::none {
+        return true;
+    }
+
+    if !style.flags.intersects(INHERITS_CONTENT) &&
+       style.ineffective_content_property() {
+        return true;
+    }
+
+    false
+}
+
 impl<'a, 'ctx, 'le, E> StyleResolverForElement<'a, 'ctx, 'le, E>
 where
     'ctx: 'a,
@@ -77,11 +111,13 @@ where
         element: E,
         context: &'a mut StyleContext<'ctx, E>,
         rule_inclusion: RuleInclusion,
+        pseudo_resolution: PseudoElementResolution,
     ) -> Self {
         Self {
             element,
             context,
             rule_inclusion,
+            pseudo_resolution,
             _marker: ::std::marker::PhantomData,
         }
     }
@@ -250,15 +286,21 @@ where
                 for (i, inputs) in pseudo_array.iter_mut().enumerate() {
                     if let Some(inputs) = inputs.take() {
                         let pseudo = PseudoElement::from_eager_index(i);
-                        pseudo_styles.set(
-                            &pseudo,
+
+                        let style =
                             self.cascade_style_and_visited(
                                 inputs,
                                 Some(&*primary_style.style),
                                 layout_parent_style_for_pseudo,
                                 Some(&pseudo),
-                            )
-                        )
+                            );
+
+                        if !matches!(self.pseudo_resolution, PseudoElementResolution::Force) &&
+                           eager_pseudo_is_definitely_not_generated(&pseudo, &style) {
+                            continue;
+                        }
+
+                        pseudo_styles.set(&pseudo, style);
                     }
                 }
             }


### PR DESCRIPTION
This should help memory usage quite a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18215)
<!-- Reviewable:end -->
