### PR TITLE
Remove unused selector visitor argument.

### DIFF
--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -272,7 +272,7 @@ impl<Impl: SelectorImpl> SelectorMethods for Selector<Impl> {
         let mut current = self.iter();
         let mut combinator = None;
         loop {
-            if !visitor.visit_complex_selector(current.clone(), combinator) {
+            if !visitor.visit_complex_selector(combinator) {
                 return false;
             }
 

--- a/components/selectors/visitor.rs
+++ b/components/selectors/visitor.rs
@@ -39,7 +39,6 @@ pub trait SelectorVisitor {
     /// Gets the combinator to the right of the selector, or `None` if the
     /// selector is the rightmost one.
     fn visit_complex_selector(&mut self,
-                              _: SelectorIter<Self::Impl>,
                               _combinator_to_right: Option<Combinator>)
                               -> bool {
         true

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -1652,7 +1652,6 @@ impl<'a> SelectorVisitor for StylistSelectorVisitor<'a> {
 
     fn visit_complex_selector(
         &mut self,
-        _: SelectorIter<SelectorImpl>,
         combinator: Option<Combinator>
     ) -> bool {
         self.needs_revalidation =


### PR DESCRIPTION
The real win here is avoiding cloning the iterator when nobody actually uses it.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18225)
<!-- Reviewable:end -->
