### PR TITLE
Remove unused SelectorIter import

### DIFF
--- a/components/selectors/visitor.rs
+++ b/components/selectors/visitor.rs
@@ -7,7 +7,7 @@
 #![deny(missing_docs)]
 
 use attr::NamespaceConstraint;
-use parser::{Combinator, Component, SelectorImpl, SelectorIter};
+use parser::{Combinator, Component, SelectorImpl};
 
 /// A trait to visit selector properties.
 ///


### PR DESCRIPTION
Follow up of #18225

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18232)
<!-- Reviewable:end -->
