### PR TITLE
Buffer perf notifications in paint timing test

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -27532,7 +27532,7 @@
    "testharness"
   ],
   "mozilla/paint_timing.html": [
-   "8cf0400c36168b57c386253d647b61013896d325",
+   "fb1100bdf9a5a3516f40fbb36e89714fe860830b",
    "testharness"
   ],
   "mozilla/parentNode_querySelector.html": [

--- a/tests/wpt/mozilla/tests/mozilla/paint_timing.html
+++ b/tests/wpt/mozilla/tests/mozilla/paint_timing.html
@@ -14,5 +14,5 @@ var observer = new PerformanceObserver(t.step_func_done(list => {
     assert_equals(entry.duration, 0, "Duration is 0");
   });
 }));
-observer.observe({entryTypes: ['paint']});
+observer.observe({entryTypes: ['paint'], buffered: true});
 </script>


### PR DESCRIPTION
Paint timing notifications may be fired before the observer starts observing, so we need to buffer these notifications.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #18219

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18233)
<!-- Reviewable:end -->
