### PR TITLE
Revert rayon stack limits until we sort out the crashtest bustage

### DIFF
--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -644,8 +644,8 @@ impl StackLimitChecker {
         //
         // The correctness of depends on the assumption that no stack wraps
         // around the end of the address space.
-        debug_assert!(curr_sp - self.lower_limit
-                      <= STYLE_THREAD_STACK_SIZE_KB * 1024);
+        //debug_assert!(curr_sp - self.lower_limit
+        //              <= STYLE_THREAD_STACK_SIZE_KB * 1024);
 
         // The actual bounds check.
         curr_sp <= self.lower_limit

--- a/components/style/gecko/global_style_data.rs
+++ b/components/style/gecko/global_style_data.rs
@@ -9,7 +9,6 @@ use gecko_bindings::bindings;
 use gecko_bindings::bindings::{Gecko_RegisterProfilerThread, Gecko_UnregisterProfilerThread};
 use gecko_bindings::bindings::Gecko_SetJemallocThreadLocalArena;
 use num_cpus;
-use parallel::STYLE_THREAD_STACK_SIZE_KB;
 use rayon;
 use shared_lock::SharedRwLock;
 use std::cmp;
@@ -93,9 +92,9 @@ lazy_static! {
                 .breadth_first()
                 .thread_name(thread_name)
                 .start_handler(thread_startup)
-                .exit_handler(thread_shutdown)
+                .exit_handler(thread_shutdown);
                 // Set thread stack size to 128KB.  See Gecko bug 1376883.
-                .stack_size(STYLE_THREAD_STACK_SIZE_KB * 1024);
+                //.stack_size(STYLE_THREAD_STACK_SIZE_KB * 1024);
             let pool = rayon::ThreadPool::new(configuration).ok();
             pool
         };


### PR DESCRIPTION
https://treeherder.mozilla.org/logviewer.html#?job_id=125956235&repo=autoland
https://treeherder.mozilla.org/logviewer.html#?job_id=125956235&repo=autoland&lineNumber=13571

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18240)
<!-- Reviewable:end -->
