### PR TITLE
Disable stylo size-checking tests for 32-bit

### DIFF
--- a/tests/unit/stylo/lib.rs
+++ b/tests/unit/stylo/lib.rs
@@ -13,6 +13,7 @@ extern crate selectors;
 extern crate style_traits;
 
 mod sanity_checks;
+#[cfg(target_pointer_width = "64")]
 mod size_of;
 mod specified_values;
 

--- a/tests/unit/stylo/specified_values.rs
+++ b/tests/unit/stylo/specified_values.rs
@@ -4,7 +4,7 @@
 
 use style;
 
-#[test]
+#[cfg(all(test, target_pointer_width = "64"))]
 fn size_of_specified_values() {
     use std::mem::size_of;
     let threshold = 24;

--- a/tests/unit/stylo/specified_values.rs
+++ b/tests/unit/stylo/specified_values.rs
@@ -17,7 +17,7 @@ fn size_of_specified_values() {
                 let size = size_of::<style::properties::longhands::$name::SpecifiedValue>();
                 let is_boxed = $boxed;
                 if (!is_boxed && size > threshold) || (is_boxed && size <= threshold) {
-                    bad_properties.push(("$name", size, is_boxed));
+                    bad_properties.push((stringify!($name), size, is_boxed));
                 }
             )+
         }


### PR DESCRIPTION
The stylo tests that check for sizes of various things are intended for 64-bit platforms, not for 32-bit platforms, so we should just disable them there.  Servo's CI doesn't run them on 32-bit platforms, but Gecko's CI will soonish.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because tests are just being disabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18245)
<!-- Reviewable:end -->
