### PR TITLE
Silenced camel case warning for the iOS enum variant

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -448,6 +448,7 @@ pub fn multiprocess() -> bool {
 enum UserAgent {
     Desktop,
     Android,
+    #[allow(non_camel_case_types)]
     iOS
 }
 


### PR DESCRIPTION
Fix a simple warning.
---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

This change is obviously too trivial for tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18247)
<!-- Reviewable:end -->
