### PR TITLE
Use `Filter buffer by name and type` algorithm implementation

### DIFF
--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -35,24 +35,6 @@ impl PerformanceEntryList {
         }
     }
 
-    pub fn get_entries(&self) -> Vec<Root<PerformanceEntry>> {
-        self.entries.clone()
-    }
-
-    pub fn get_entries_by_type(&self, entry_type: DOMString) -> Vec<Root<PerformanceEntry>> {
-        self.entries.iter().filter(|e| *e.entry_type() == entry_type)
-                           .map(|e| e.clone())
-                           .collect()
-    }
-
-    pub fn get_entries_by_name(&self, name: DOMString, entry_type: Option<DOMString>)
-        -> Vec<Root<PerformanceEntry>> {
-        self.entries.iter().filter(|e|
-            *e.name() == name &&
-            entry_type.as_ref().map_or(true, |type_| *e.entry_type() == *type_)
-        ).map(|e| e.clone()).collect()
-    }
-
     pub fn get_entries_by_name_and_type(&self, name: Option<DOMString>, entry_type: Option<DOMString>)
         -> Vec<Root<PerformanceEntry>> {
         let mut res = self.entries.iter().filter(|e|
@@ -254,17 +236,17 @@ impl PerformanceMethods for Performance {
 
     // https://www.w3.org/TR/performance-timeline-2/#dom-performance-getentries
     fn GetEntries(&self) -> Vec<Root<PerformanceEntry>> {
-        self.entries.borrow().get_entries()
+        self.entries.borrow().get_entries_by_name_and_type(None, None)
     }
 
     // https://www.w3.org/TR/performance-timeline-2/#dom-performance-getentriesbytype
     fn GetEntriesByType(&self, entry_type: DOMString) -> Vec<Root<PerformanceEntry>> {
-        self.entries.borrow().get_entries_by_type(entry_type)
+        self.entries.borrow().get_entries_by_name_and_type(None, Some(entry_type))
     }
 
     // https://www.w3.org/TR/performance-timeline-2/#dom-performance-getentriesbyname
     fn GetEntriesByName(&self, name: DOMString, entry_type: Option<DOMString>)
         -> Vec<Root<PerformanceEntry>> {
-        self.entries.borrow().get_entries_by_name(name, entry_type)
+        self.entries.borrow().get_entries_by_name_and_type(Some(name), entry_type)
     }
 }

--- a/components/script/dom/performanceobserverentrylist.rs
+++ b/components/script/dom/performanceobserverentrylist.rs
@@ -38,17 +38,17 @@ impl PerformanceObserverEntryList {
 impl PerformanceObserverEntryListMethods for PerformanceObserverEntryList {
     // https://w3c.github.io/performance-timeline/#dom-performanceobserver
     fn GetEntries(&self) -> Vec<Root<PerformanceEntry>> {
-        self.entries.borrow().get_entries()
+        self.entries.borrow().get_entries_by_name_and_type(None, None)
     }
 
     // https://w3c.github.io/performance-timeline/#dom-performanceobserver
     fn GetEntriesByType(&self, entry_type: DOMString) -> Vec<Root<PerformanceEntry>> {
-        self.entries.borrow().get_entries_by_type(entry_type)
+        self.entries.borrow().get_entries_by_name_and_type(None, Some(entry_type))
     }
 
     // https://w3c.github.io/performance-timeline/#dom-performanceobserver
     fn GetEntriesByName(&self, name: DOMString, entry_type: Option<DOMString>)
         -> Vec<Root<PerformanceEntry>> {
-        self.entries.borrow().get_entries_by_name(name, entry_type)
+        self.entries.borrow().get_entries_by_name_and_type(Some(name), entry_type)
     }
 }


### PR DESCRIPTION
Following #18176, it uses the new implementation and removes the old one.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #18186 
- [x] These changes do not require tests because it’s only internal changes in `components/script/dom/performance.rs`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18269)
<!-- Reviewable:end -->
