### PR TITLE
Correct "is sorted" check in profile statistics

### DIFF
--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -328,7 +328,7 @@ impl Profiler {
     /// Get tuple (mean, median, min, max) for profiler statistics.
     pub fn get_statistics(data: &[f64]) -> (f64, f64, f64, f64) {
         data.iter().fold(-f64::INFINITY, |a, &b| {
-            debug_assert!(a < b, "Data must be sorted");
+            debug_assert!(a <= b, "Data must be sorted");
             b
         });
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Correct the debug_assert check for whether or not statistics collected by the --profile flag are sorted.
I'm not sure how I could add a test for this change, and whether that is necessary.

I also wonder if it makes sense to replace the sort_by calls (currently using explicit comparisons) in this file with something like
```
data.sort_by(|a, b| a.partial_cmp(b).expect("no NaN in collected statistics"))
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #18270 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18272)
<!-- Reviewable:end -->
