### PR TITLE
Use cssparser's new_with_line_number_offset

### DIFF
--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -98,7 +98,7 @@ impl HTMLStyleElement {
                                          shared_lock, Some(&loader),
                                          win.css_error_reporter(),
                                          doc.quirks_mode(),
-                                         self.line_number);
+                                         self.line_number as u32);
 
         let sheet = Arc::new(sheet);
 

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -37,7 +37,7 @@ bitflags = "0.7"
 bit-vec = "0.4.3"
 byteorder = "1.0"
 cfg-if = "0.1.0"
-cssparser = "0.19.3"
+cssparser = "0.19.5"
 encoding = {version = "0.2", optional = true}
 euclid = "0.15"
 fnv = "1.0"

--- a/components/style/encoding_support.rs
+++ b/components/style/encoding_support.rs
@@ -72,7 +72,7 @@ impl Stylesheet {
                              stylesheet_loader,
                              error_reporter,
                              quirks_mode,
-                             0u64)
+                             0)
     }
 
     /// Updates an empty stylesheet with a set of bytes that reached over the

--- a/components/style/parser.rs
+++ b/components/style/parser.rs
@@ -53,8 +53,6 @@ pub struct ParserContext<'a> {
     pub url_data: &'a UrlExtraData,
     /// The current rule type, if any.
     pub rule_type: Option<CssRuleType>,
-    /// Line number offsets for inline stylesheets
-    pub line_number_offset: u64,
     /// The mode to use when parsing.
     pub parsing_mode: ParsingMode,
     /// The quirks mode of this stylesheet.
@@ -76,7 +74,6 @@ impl<'a> ParserContext<'a> {
             stylesheet_origin: stylesheet_origin,
             url_data: url_data,
             rule_type: rule_type,
-            line_number_offset: 0u64,
             parsing_mode: parsing_mode,
             quirks_mode: quirks_mode,
             namespaces: None,
@@ -109,29 +106,9 @@ impl<'a> ParserContext<'a> {
             stylesheet_origin: context.stylesheet_origin,
             url_data: context.url_data,
             rule_type: Some(rule_type),
-            line_number_offset: context.line_number_offset,
             parsing_mode: context.parsing_mode,
             quirks_mode: context.quirks_mode,
             namespaces: Some(namespaces),
-        }
-    }
-
-    /// Create a parser context for inline CSS which accepts additional line offset argument.
-    pub fn new_with_line_number_offset(
-        stylesheet_origin: Origin,
-        url_data: &'a UrlExtraData,
-        line_number_offset: u64,
-        parsing_mode: ParsingMode,
-        quirks_mode: QuirksMode,
-    ) -> ParserContext<'a> {
-        ParserContext {
-            stylesheet_origin: stylesheet_origin,
-            url_data: url_data,
-            rule_type: None,
-            line_number_offset: line_number_offset,
-            parsing_mode: parsing_mode,
-            quirks_mode: quirks_mode,
-            namespaces: None,
         }
     }
 
@@ -148,7 +125,7 @@ impl<'a> ParserContext<'a> {
         where R: ParseErrorReporter
     {
         let location = SourceLocation {
-            line: location.line + self.line_number_offset as u32,
+            line: location.line,
             column: location.column,
         };
         context.error_reporter.report_error(self.url_data, location, error)

--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -160,10 +160,7 @@ impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, 
         name: CowRcStr<'i>,
         input: &mut Parser<'i, 't>
     ) -> Result<AtRuleType<AtRulePrelude, CssRule>, ParseError<'i>> {
-        let location = get_location_with_offset(
-            input.current_source_location(),
-            self.context.line_number_offset,
-        );
+        let location = get_location_with_offset(input.current_source_location());
         match_ignore_ascii_case! { &*name,
             "import" => {
                 if self.state > State::Imports {
@@ -334,11 +331,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
         name: CowRcStr<'i>,
         input: &mut Parser<'i, 't>
     ) -> Result<AtRuleType<AtRulePrelude, CssRule>, ParseError<'i>> {
-        let location =
-            get_location_with_offset(
-                input.current_source_location(),
-                self.context.line_number_offset
-            );
+        let location = get_location_with_offset(input.current_source_location());
 
         match_ignore_ascii_case! { &*name,
             "media" => {
@@ -545,8 +538,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for NestedRulePa
             url_data: Some(self.context.url_data),
         };
 
-        let location = get_location_with_offset(input.current_source_location(),
-                                                self.context.line_number_offset);
+        let location = get_location_with_offset(input.current_source_location());
         let selectors = SelectorList::parse(&selector_parser, input)?;
 
         Ok(QualifiedRuleParserPrelude {
@@ -575,13 +567,10 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for NestedRulePa
     }
 }
 
-/// Calculates the location of a rule's source given an offset.
-fn get_location_with_offset(
-    location: SourceLocation,
-    offset: u64
-) -> SourceLocation {
+/// Adjust a location's column to accommodate DevTools.
+fn get_location_with_offset(location: SourceLocation) -> SourceLocation {
     SourceLocation {
-        line: location.line + offset as u32,
+        line: location.line,
         // Column offsets are not yet supported, but Gecko devtools expect 1-based columns.
         column: location.column + 1,
     }

--- a/components/style/stylesheets/stylesheet.rs
+++ b/components/style/stylesheets/stylesheet.rs
@@ -73,7 +73,7 @@ impl StylesheetContents {
         stylesheet_loader: Option<&StylesheetLoader>,
         error_reporter: &R,
         quirks_mode: QuirksMode,
-        line_number_offset: u64
+        line_number_offset: u32
     ) -> Self {
         let namespaces = RwLock::new(Namespaces::default());
         let (rules, source_map_url) = Stylesheet::parse_rules(
@@ -311,7 +311,7 @@ impl Stylesheet {
                               url_data: UrlExtraData,
                               stylesheet_loader: Option<&StylesheetLoader>,
                               error_reporter: &R,
-                              line_number_offset: u64)
+                              line_number_offset: u32)
         where R: ParseErrorReporter
     {
         let namespaces = RwLock::new(Namespaces::default());
@@ -349,17 +349,17 @@ impl Stylesheet {
         stylesheet_loader: Option<&StylesheetLoader>,
         error_reporter: &R,
         quirks_mode: QuirksMode,
-        line_number_offset: u64
+        line_number_offset: u32
     ) -> (Vec<CssRule>, Option<String>) {
         let mut rules = Vec::new();
-        let mut input = ParserInput::new(css);
+        let mut input = ParserInput::new_with_line_number_offset(css, line_number_offset);
         let mut input = Parser::new(&mut input);
 
         let context =
-            ParserContext::new_with_line_number_offset(
+            ParserContext::new(
                 origin,
                 url_data,
-                line_number_offset,
+                None,
                 PARSING_MODE_DEFAULT,
                 quirks_mode
             );
@@ -410,7 +410,7 @@ impl Stylesheet {
         stylesheet_loader: Option<&StylesheetLoader>,
         error_reporter: &R,
         quirks_mode: QuirksMode,
-        line_number_offset: u64)
+        line_number_offset: u32)
         -> Stylesheet
     {
         let contents = StylesheetContents::from_str(

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -894,7 +894,7 @@ pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(
     Arc::new(StylesheetContents::from_str(
         input, url_data.clone(), origin,
         &global_style_data.shared_lock, loader, &reporter,
-        quirks_mode.into(), line_number_offset as u64)
+        quirks_mode.into(), line_number_offset)
     ).into_strong()
 }
 

--- a/tests/unit/style/media_queries.rs
+++ b/tests/unit/style/media_queries.rs
@@ -37,7 +37,7 @@ fn test_media_rule<F>(css: &str, callback: F)
     let media_list = Arc::new(lock.wrap(MediaList::empty()));
     let stylesheet = Stylesheet::from_str(
         css, url, Origin::Author, media_list, lock,
-        None, &CSSErrorReporterTest, QuirksMode::NoQuirks, 0u64);
+        None, &CSSErrorReporterTest, QuirksMode::NoQuirks, 0);
     let dummy = Device::new(MediaType::screen(), TypedSize2D::new(200.0, 100.0), ScaleFactor::new(1.0));
     let mut rule_count = 0;
     let guard = stylesheet.shared_lock.read();
@@ -56,7 +56,7 @@ fn media_query_test(device: &Device, css: &str, expected_rule_count: usize) {
     let media_list = Arc::new(lock.wrap(MediaList::empty()));
     let ss = Stylesheet::from_str(
         css, url, Origin::Author, media_list, lock,
-        None, &CSSErrorReporterTest, QuirksMode::NoQuirks, 0u64);
+        None, &CSSErrorReporterTest, QuirksMode::NoQuirks, 0);
     let mut rule_count = 0;
     ss.effective_style_rules(device, &ss.shared_lock.read(), |_| rule_count += 1);
     assert!(rule_count == expected_rule_count, css.to_owned());

--- a/tests/unit/style/rule_tree/bench.rs
+++ b/tests/unit/style/rule_tree/bench.rs
@@ -57,7 +57,7 @@ fn parse_rules(css: &str) -> Vec<(StyleSource, CascadeLevel)> {
                                  None,
                                  &ErrorringErrorReporter,
                                  QuirksMode::NoQuirks,
-                                 0u64);
+                                 0);
     let guard = s.shared_lock.read();
     let rules = s.contents.rules.read_with(&guard);
     rules.0.iter().filter_map(|rule| {

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -70,7 +70,7 @@ fn test_parse_stylesheet() {
     let lock = SharedRwLock::new();
     let media = Arc::new(lock.wrap(MediaList::empty()));
     let stylesheet = Stylesheet::from_str(css, url.clone(), Origin::UserAgent, media, lock,
-                                          None, &CSSErrorReporterTest, QuirksMode::NoQuirks, 0u64);
+                                          None, &CSSErrorReporterTest, QuirksMode::NoQuirks, 0);
     let mut namespaces = Namespaces::default();
     namespaces.default = Some((ns!(html), ()));
     let expected = Stylesheet {
@@ -304,7 +304,7 @@ fn test_report_error_stylesheet() {
     let lock = SharedRwLock::new();
     let media = Arc::new(lock.wrap(MediaList::empty()));
     Stylesheet::from_str(css, url.clone(), Origin::UserAgent, media, lock,
-                         None, &error_reporter, QuirksMode::NoQuirks, 5u64);
+                         None, &error_reporter, QuirksMode::NoQuirks, 5);
 
     let mut errors = errors.lock().unwrap();
 
@@ -341,7 +341,7 @@ fn test_no_report_unrecognized_vendor_properties() {
     let lock = SharedRwLock::new();
     let media = Arc::new(lock.wrap(MediaList::empty()));
     Stylesheet::from_str(css, url, Origin::UserAgent, media, lock,
-                         None, &error_reporter, QuirksMode::NoQuirks, 0u64);
+                         None, &error_reporter, QuirksMode::NoQuirks, 0);
 
     let mut errors = errors.lock().unwrap();
     let error = errors.pop().unwrap();
@@ -364,7 +364,7 @@ fn test_source_map_url() {
         let media = Arc::new(lock.wrap(MediaList::empty()));
         let stylesheet = Stylesheet::from_str(test.0, url.clone(), Origin::UserAgent, media, lock,
                                               None, &CSSErrorReporterTest, QuirksMode::NoQuirks,
-                                              0u64);
+                                              0);
         let url_opt = stylesheet.contents.source_map_url.read();
         assert_eq!(*url_opt, test.1);
     }

--- a/tests/unit/style/viewport.rs
+++ b/tests/unit/style/viewport.rs
@@ -35,7 +35,7 @@ macro_rules! stylesheet {
             None,
             &$error_reporter,
             QuirksMode::NoQuirks,
-            0u64
+            0
         ))
     }
 }


### PR DESCRIPTION
cssparser provides a way to set the initial line number on a
ParserInput.  This patch changes servo to use this facility, rather than
reimplement the same functionality itself.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #_N/A_ (github issue number if applicable).

- [ ] There are tests for these changes OR
- [x] These changes do not require tests because pre-existing tests cover this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18276)
<!-- Reviewable:end -->
