### PR TITLE
Prioritize parsing non-custom property names.

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1011,10 +1011,6 @@ impl PropertyId {
     /// will be used. It is `Origin::Author` for stylesheet_origin and
     /// `CssRuleType::Style` for rule_type.
     pub fn parse(property_name: &str, context: Option< &PropertyParserContext>) -> Result<Self, ()> {
-        if let Ok(name) = ::custom_properties::parse_name(property_name) {
-            return Ok(PropertyId::Custom(::custom_properties::Name::from(name)))
-        }
-
         // FIXME(https://github.com/rust-lang/rust/issues/33156): remove this enum and use PropertyId
         // when stable Rust allows destructors in statics.
         // ShorthandAlias is not used in servo build. That's why we need to allow dead_code.
@@ -1071,7 +1067,8 @@ impl PropertyId {
             Some(&StaticId::ShorthandAlias(id, alias)) => {
                 (PropertyId::Shorthand(id), Some(alias))
             },
-            None => return Err(()),
+            None => return ::custom_properties::parse_name(property_name)
+                .map(|name| PropertyId::Custom(::custom_properties::Name::from(name))),
         };
         id.check_allowed_in(alias, context).map_err(|_| ())?;
         Ok(id)


### PR DESCRIPTION
This should cause a slight improvement in the common case where we are parsing non-custom property names.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18279)
<!-- Reviewable:end -->
