### PR TITLE
style: Avoid scanning the longhand id twice in the fast path of PropertyDeclarationBlock::parse_common

### DIFF
--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -402,12 +402,14 @@ impl PropertyDeclarationBlock {
         importance: Importance,
         overwrite_more_important_and_reuse_slot: bool
     ) -> bool {
-        let definitely_new = if let PropertyDeclarationId::Longhand(id) = declaration.id() {
-            !self.longhands.contains(id)
-        } else {
-            false  // For custom properties, always scan
+        let longhand_id = match declaration.id() {
+            PropertyDeclarationId::Longhand(id) => Some(id),
+            PropertyDeclarationId::Custom(..) => None,
         };
 
+        let definitely_new = longhand_id.map_or(false, |id| {
+            !self.longhands.contains(id)
+        });
 
         if !definitely_new {
             let mut index_to_remove = None;
@@ -449,7 +451,7 @@ impl PropertyDeclarationBlock {
             }
         }
 
-        if let PropertyDeclarationId::Longhand(id) = declaration.id() {
+        if let Some(id) = longhand_id {
             self.longhands.insert(id);
         }
         self.declarations.push((declaration, importance));


### PR DESCRIPTION
This makes the overhead of this function much lower according to `perf`.

And in general makes sense, removing overhead from the fast path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18281)
<!-- Reviewable:end -->
