### PR TITLE
style: Remove uninlineable function in PropertyDeclarationIterator.

### DIFF
--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -97,12 +97,7 @@ impl<'a> Iterator for PropertyDeclarationIterator<'a> {
     type Item = &'a PropertyDeclaration;
     #[inline]
     fn next(&mut self) -> Option<&'a PropertyDeclaration> {
-        // we use this function because a closure won't be `Clone`
-        fn get_declaration(dec: &(PropertyDeclaration, Importance))
-            -> &PropertyDeclaration {
-            &dec.0
-        }
-        self.iter.next().map(get_declaration as fn(_) -> _)
+        self.iter.next().map(|&(ref decl, _)| decl)
     }
 }
 


### PR DESCRIPTION
That literally made no sense, and is probably leftover from where we passed Map
directly there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18282)
<!-- Reviewable:end -->
