### PR TITLE
User Timing API

### DIFF
--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -595,3 +595,42 @@ macro_rules! rooted_vec {
         let mut $name = $crate::dom::bindings::trace::RootedVec::from_iter(&mut root, $iter);
     }
 }
+
+/// DOM struct implementation for simple interfaces inheriting from PerformanceEntry.
+macro_rules! impl_performance_entry_struct(
+    ($binding:ident, $struct:ident, $type:expr) => (
+        use dom::bindings::codegen::Bindings::$binding;
+        use dom::bindings::js::Root;
+        use dom::bindings::reflector::reflect_dom_object;
+        use dom::bindings::str::DOMString;
+        use dom::globalscope::GlobalScope;
+        use dom::performanceentry::PerformanceEntry;
+        use dom_struct::dom_struct;
+
+        #[dom_struct]
+        pub struct $struct {
+            entry: PerformanceEntry,
+        }
+
+        impl $struct {
+            fn new_inherited(name: DOMString, start_time: f64, duration: f64)
+                -> $struct {
+                $struct {
+                    entry: PerformanceEntry::new_inherited(name,
+                                                           DOMString::from($type),
+                                                           start_time,
+                                                           duration)
+                }
+            }
+
+            #[allow(unrooted_must_root)]
+            pub fn new(global: &GlobalScope,
+                       name: DOMString,
+                       start_time: f64,
+                       duration: f64) -> Root<$struct> {
+                let entry = $struct::new_inherited(name, start_time, duration);
+                reflect_dom_object(box entry, global, $binding::Wrap)
+            }
+        }
+    );
+);

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -399,6 +399,8 @@ pub mod paintsize;
 pub mod paintworkletglobalscope;
 pub mod performance;
 pub mod performanceentry;
+pub mod performancemark;
+pub mod performancemeasure;
 pub mod performanceobserver;
 pub mod performanceobserverentrylist;
 pub mod performancepainttiming;

--- a/components/script/dom/performancemark.rs
+++ b/components/script/dom/performancemark.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+impl_performance_entry_struct!(PerformanceMarkBinding,
+                               PerformanceMark,
+                               "mark");

--- a/components/script/dom/performancemeasure.rs
+++ b/components/script/dom/performancemeasure.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+impl_performance_entry_struct!(PerformanceMeasureBinding,
+                               PerformanceMeasure,
+                               "measure");

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -22,8 +22,8 @@ use std::rc::Rc;
 
 /// List of allowed performance entry types.
 const VALID_ENTRY_TYPES: &'static [&'static str] = &[
-    // "mark", XXX User Timing API
-    // "measure", XXX User Timing API
+    "mark", // User Timing API
+    "measure", // User Timing API
     // "resource", XXX Resource Timing API
     // "server", XXX Server Timing API
     "paint", // Paint Timing API

--- a/components/script/dom/webidls/Performance.webidl
+++ b/components/script/dom/webidls/Performance.webidl
@@ -28,3 +28,14 @@ partial interface Performance {
   PerformanceEntryList getEntriesByName(DOMString name,
                                         optional DOMString type);
 };
+
+// https://w3c.github.io/user-timing/#extensions-performance-interface
+[Exposed=(Window,Worker)]
+partial interface Performance {
+  [Throws]
+  void mark(DOMString markName);
+  void clearMarks(optional DOMString markName);
+  [Throws]
+  void measure(DOMString measureName, optional DOMString startMark, optional DOMString endMark);
+  void clearMeasures(optional DOMString measureName);
+};

--- a/components/script/dom/webidls/PerformanceMark.webidl
+++ b/components/script/dom/webidls/PerformanceMark.webidl
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * The origin of this IDL file is
+ * https://w3c.github.io/user-timing/#performancemark
+ */
+
+[Exposed=(Window,Worker)]
+interface PerformanceMark : PerformanceEntry {
+};

--- a/components/script/dom/webidls/PerformanceMeasure.webidl
+++ b/components/script/dom/webidls/PerformanceMeasure.webidl
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * The origin of this IDL file is
+ * https://w3c.github.io/user-timing/#performancemeasure
+ */
+
+[Exposed=(Window,Worker)]
+interface PerformanceMeasure : PerformanceEntry {
+};

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -45,6 +45,8 @@ skip: true
       skip: true
       [script_scheduling]
         skip: false
+[performance-timeline]
+  skip: false
 [quirks-mode]
   skip: false
 [referrer-policy]

--- a/tests/wpt/metadata/performance-timeline/case-sensitivity.any.js.ini
+++ b/tests/wpt/metadata/performance-timeline/case-sensitivity.any.js.ini
@@ -1,0 +1,17 @@
+[case-sensitivity.any.worker.html]
+  type: testharness
+  [getEntriesByType values are case sensitive]
+    expected: FAIL
+
+  [getEntriesByName values are case sensitive]
+    expected: FAIL
+
+
+[case-sensitivity.any.html]
+  type: testharness
+  [getEntriesByType values are case sensitive]
+    expected: FAIL
+
+  [getEntriesByName values are case sensitive]
+    expected: FAIL
+

--- a/tests/wpt/metadata/performance-timeline/po-disconnect.any.js.ini
+++ b/tests/wpt/metadata/performance-timeline/po-disconnect.any.js.ini
@@ -1,0 +1,13 @@
+[po-disconnect.any.html]
+  type: testharness
+  expected: TIMEOUT
+  [An observer disconnected after a mark must receive the mark]
+    expected: TIMEOUT
+
+
+[po-disconnect.any.worker.html]
+  type: testharness
+  expected: TIMEOUT
+  [An observer disconnected after a mark must receive the mark]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/performance-timeline/po-navigation.html.ini
+++ b/tests/wpt/metadata/performance-timeline/po-navigation.html.ini
@@ -1,0 +1,5 @@
+[po-navigation.html]
+  type: testharness
+  [navigation entry is observable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/performance-timeline/po-observe.any.js.ini
+++ b/tests/wpt/metadata/performance-timeline/po-observe.any.js.ini
@@ -1,0 +1,11 @@
+[po-observe.any.worker.html]
+  type: testharness
+  [replace observer if already present]
+    expected: FAIL
+
+
+[po-observe.any.html]
+  type: testharness
+  [replace observer if already present]
+    expected: FAIL
+

--- a/tests/wpt/metadata/performance-timeline/po-resource.html.ini
+++ b/tests/wpt/metadata/performance-timeline/po-resource.html.ini
@@ -1,0 +1,5 @@
+[po-resource.html]
+  type: testharness
+  [resource entries are observable]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -27988,7 +27988,7 @@
    "testharness"
   ],
   "mozilla/interfaces.html": [
-   "a7ed38b6069caffd87d9573978e6ef9938d87753",
+   "66e66d3bdfa3bebd5bf3d711c0737fb394efe973",
    "testharness"
   ],
   "mozilla/interfaces.js": [
@@ -27996,7 +27996,7 @@
    "support"
   ],
   "mozilla/interfaces.worker.js": [
-   "fb5537ec0753e3a1c56dff957bcc1c0660dcb7b9",
+   "c9dcc4f24540914b3be1ef18f13b721773eb76be",
    "testharness"
   ],
   "mozilla/iterable.html": [

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.html
@@ -161,6 +161,8 @@ test_interfaces([
   "PageTransitionEvent",
   "Performance",
   "PerformanceEntry",
+  "PerformanceMark",
+  "PerformanceMeasure",
   "PerformanceObserver",
   "PerformanceObserverEntryList",
   "PerformancePaintTiming",

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
@@ -34,6 +34,8 @@ test_interfaces([
   "MessageEvent",
   "Performance",
   "PerformanceEntry",
+  "PerformanceMark",
+  "PerformanceMeasure",
   "PerformanceObserver",
   "PerformanceObserverEntryList",
   "PerformancePaintTiming",


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #18109 
- [X] There are tests for these changes. I enabled the peformance-timeline API WPTs but some of them are still failing because of implementation bugs or missing APIs (Resource Timing, for instance) the tests are dependent of. I'll file issues to fix them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18283)
<!-- Reviewable:end -->
