### PR TITLE
Report more specific CSS selector errors

### DIFF
--- a/components/selectors/builder.rs
+++ b/components/selectors/builder.rs
@@ -90,6 +90,12 @@ impl<Impl: SelectorImpl> SelectorBuilder<Impl> {
         self.simple_selectors.is_empty()
     }
 
+    /// Returns true if combinators have ever been pushed to this builder.
+    #[inline(always)]
+    pub fn has_combinators(&self) -> bool {
+        !self.combinators.is_empty()
+    }
+
     /// Consumes the builder, producing a Selector.
     #[inline(always)]
     pub fn build(&mut self, parsed_pseudo: bool) -> ThinArc<SpecificityAndFlags, Component<Impl>> {

--- a/components/style/gecko/selector_parser.rs
+++ b/components/style/gecko/selector_parser.rs
@@ -308,7 +308,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
              keyword: [$(($k_css:expr, $k_name:ident, $k_gecko_type:tt, $k_state:tt, $k_flags:tt),)*]) => {
                 match_ignore_ascii_case! { &name,
                     $($css => NonTSPseudoClass::$name,)*
-                    _ => return Err(::selectors::parser::SelectorParseError::UnexpectedIdent(
+                    _ => return Err(::selectors::parser::SelectorParseError::UnsupportedPseudoClassOrElement(
                         name.clone()).into())
                 }
             }
@@ -317,7 +317,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
         if self.is_pseudo_class_enabled(&pseudo_class) {
             Ok(pseudo_class)
         } else {
-            Err(SelectorParseError::UnexpectedIdent(name).into())
+            Err(SelectorParseError::UnsupportedPseudoClassOrElement(name).into())
         }
     }
 
@@ -354,7 +354,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
                         }
                         NonTSPseudoClass::MozAny(selectors.into_boxed_slice())
                     }
-                    _ => return Err(SelectorParseError::UnexpectedIdent(name.clone()).into())
+                    _ => return Err(SelectorParseError::UnsupportedPseudoClassOrElement(name.clone()).into())
                 }
             }
         }
@@ -362,13 +362,13 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
         if self.is_pseudo_class_enabled(&pseudo_class) {
             Ok(pseudo_class)
         } else {
-            Err(SelectorParseError::UnexpectedIdent(name).into())
+            Err(SelectorParseError::UnsupportedPseudoClassOrElement(name).into())
         }
     }
 
     fn parse_pseudo_element(&self, name: CowRcStr<'i>) -> Result<PseudoElement, ParseError<'i>> {
         PseudoElement::from_slice(&name, self.in_user_agent_stylesheet())
-            .ok_or(SelectorParseError::UnexpectedIdent(name.clone()).into())
+            .ok_or(SelectorParseError::UnsupportedPseudoClassOrElement(name.clone()).into())
     }
 
     fn parse_functional_pseudo_element<'t>(&self, name: CowRcStr<'i>,
@@ -392,7 +392,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
                 return Ok(pseudo);
             }
         }
-        Err(SelectorParseError::UnexpectedIdent(name.clone()).into())
+        Err(SelectorParseError::UnsupportedPseudoClassOrElement(name.clone()).into())
     }
 
     fn default_namespace(&self) -> Option<Namespace> {

--- a/ports/geckolib/error_reporter.rs
+++ b/ports/geckolib/error_reporter.rs
@@ -250,6 +250,9 @@ fn extract_error_params<'a>(err: ParseError<'a>) -> Option<ErrorParams<'a>> {
                 PropertyDeclarationParseError::InvalidValue(property, Some(e))))) =>
             (Some(ErrorString::Snippet(property.into())), Some(extract_value_error_param(e))),
 
+        CssParseError::Custom(SelectorParseError::UnexpectedTokenInAttributeSelector(t)) =>
+            (None, Some(ErrorString::UnexpectedToken(t))),
+
         CssParseError::Custom(SelectorParseError::UnsupportedPseudoClassOrElement(p)) =>
             (None, Some(ErrorString::Ident(p))),
 
@@ -330,6 +333,8 @@ impl<'a> ErrorHelpers<'a> for ContextualParseError<'a> {
                 (b"PEAtNSUnexpected\0", Action::Nothing),
             ContextualParseError::InvalidRule(_, ref err) => {
                 let prefix = match *err {
+                    CssParseError::Custom(SelectorParseError::UnexpectedTokenInAttributeSelector(_)) =>
+                        Some(&b"PEAttSelUnexpected\0"[..]),
                     CssParseError::Custom(SelectorParseError::UnsupportedPseudoClassOrElement(_)) =>
                         Some(&b"PEPseudoSelUnknown\0"[..]),
                     _ => None,

--- a/ports/geckolib/error_reporter.rs
+++ b/ports/geckolib/error_reporter.rs
@@ -255,6 +255,7 @@ fn extract_error_params<'a>(err: ParseError<'a>) -> Option<ErrorParams<'a>> {
         CssParseError::Custom(SelectorParseError::ExplicitNamespaceUnexpectedToken(t)) |
         CssParseError::Custom(SelectorParseError::PseudoElementExpectedIdent(t)) |
         CssParseError::Custom(SelectorParseError::NoIdentForPseudo(t)) |
+        CssParseError::Custom(SelectorParseError::ClassNeedsIdent(t)) |
         CssParseError::Custom(SelectorParseError::PseudoElementExpectedColon(t)) =>
             (None, Some(ErrorString::UnexpectedToken(t))),
 
@@ -267,6 +268,9 @@ fn extract_error_params<'a>(err: ParseError<'a>) -> Option<ErrorParams<'a>> {
         CssParseError::Custom(SelectorParseError::EmptySelector) |
         CssParseError::Custom(SelectorParseError::DanglingCombinator) =>
             (None, None),
+
+        CssParseError::Custom(SelectorParseError::EmptyNegation) =>
+            (None, Some(ErrorString::Snippet(")".into()))),
 
         err => match extract_error_param(err) {
             Some(e) => (Some(e), None),
@@ -368,6 +372,10 @@ impl<'a> ErrorHelpers<'a> for ContextualParseError<'a> {
                         Some(&b"PEPseudoClassArgNotIdent\0"[..]),
                     CssParseError::Custom(SelectorParseError::PseudoElementExpectedIdent(_)) =>
                         Some(&b"PEPseudoSelBadName\0"[..]),
+                    CssParseError::Custom(SelectorParseError::ClassNeedsIdent(_)) =>
+                        Some(&b"PEClassSelNotIdent\0"[..]),
+                    CssParseError::Custom(SelectorParseError::EmptyNegation) =>
+                        Some(&b"PENegationBadArg\0"[..]),
                     _ => None,
                 };
                 return (prefix, b"PEBadSelectorRSIgnored\0", Action::Nothing);

--- a/ports/geckolib/error_reporter.rs
+++ b/ports/geckolib/error_reporter.rs
@@ -203,7 +203,9 @@ fn extract_error_param<'a>(err: ParseError<'a>) -> Option<ErrorString<'a>> {
         CssParseError::Basic(BasicParseError::UnexpectedToken(t)) =>
             ErrorString::UnexpectedToken(t),
 
-        CssParseError::Basic(BasicParseError::AtRuleInvalid(i)) =>
+        CssParseError::Basic(BasicParseError::AtRuleInvalid(i)) |
+        CssParseError::Custom(SelectorParseError::Custom(
+            StyleParseError::UnsupportedAtRule(i))) =>
             ErrorString::Snippet(format!("@{}", escape_css_ident(&i)).into()),
 
         CssParseError::Custom(SelectorParseError::Custom(
@@ -344,6 +346,12 @@ impl<'a> ErrorHelpers<'a> for ContextualParseError<'a> {
                 _, CssParseError::Custom(SelectorParseError::Custom(
                 StyleParseError::UnexpectedTokenWithinNamespace(_)))) =>
                 (b"PEAtNSUnexpected\0", Action::Nothing),
+            ContextualParseError::InvalidRule(
+                _, CssParseError::Basic(BasicParseError::AtRuleInvalid(_))) |
+            ContextualParseError::InvalidRule(
+                _, CssParseError::Custom(SelectorParseError::Custom(
+                    StyleParseError::UnsupportedAtRule(_)))) =>
+                (b"PEUnknownAtRule\0", Action::Nothing),
             ContextualParseError::InvalidRule(_, ref err) => {
                 let prefix = match *err {
                     CssParseError::Custom(SelectorParseError::UnexpectedTokenInAttributeSelector(_)) =>


### PR DESCRIPTION
Report more specific errors for invalid CSS selectors. Reviewed by @heycam in https://bugzilla.mozilla.org/show_bug.cgi?id=1384216.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18290)
<!-- Reviewable:end -->
