### PR TITLE
Harden assert for creating atom from raw pointer

### DIFF
--- a/components/style/gecko_string_cache/mod.rs
+++ b/components/style/gecko_string_cache/mod.rs
@@ -265,7 +265,7 @@ impl Atom {
     /// called on it.
     #[inline]
     pub unsafe fn from_addrefed(ptr: *mut nsIAtom) -> Self {
-        debug_assert!(!ptr.is_null());
+        assert!(!ptr.is_null());
         unsafe {
             Atom(WeakAtom::new(ptr))
         }
@@ -378,7 +378,7 @@ impl From<String> for Atom {
 impl From<*mut nsIAtom> for Atom {
     #[inline]
     fn from(ptr: *mut nsIAtom) -> Atom {
-        debug_assert!(!ptr.is_null());
+        assert!(!ptr.is_null());
         unsafe {
             let ret = Atom(WeakAtom::new(ptr));
             if !ret.is_static() {


### PR DESCRIPTION
One of Stylo's common assertion turns out to be from having a null Atom (see [Gecko 1385925 bug comment 7](https://bugzilla.mozilla.org/show_bug.cgi?id=1385925#c7)). It would be helpful if we can catch this kind of crash earlier via a release-assertion.

This may regress performance to some extent which I'm not sure. But we can probably have it there for diagnosis for now, and remove later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18302)
<!-- Reviewable:end -->
