### PR TITLE
Properly set default direction of prefixed linear gradients

### DIFF
--- a/components/style/values/computed/image.rs
+++ b/components/style/values/computed/image.rs
@@ -78,10 +78,13 @@ pub type ColorStop = GenericColorStop<RGBA, LengthOrPercentage>;
 pub type MozImageRect = GenericMozImageRect<NumberOrPercentage, ComputedUrl>;
 
 impl GenericLineDirection for LineDirection {
-    fn points_downwards(&self) -> bool {
+    fn points_downwards(&self, compat_mode: CompatMode) -> bool {
         match *self {
             LineDirection::Angle(angle) => angle.radians() == PI,
-            LineDirection::Vertical(Y::Bottom) => true,
+            LineDirection::Vertical(Y::Bottom)
+                if compat_mode == CompatMode::Modern => true,
+            LineDirection::Vertical(Y::Top)
+                if compat_mode != CompatMode::Modern => true,
             LineDirection::Corner(..) => false,
             #[cfg(feature = "gecko")]
             LineDirection::MozPosition(_, _) => false,

--- a/components/style/values/generics/image.rs
+++ b/components/style/values/generics/image.rs
@@ -230,7 +230,8 @@ impl<D, L, LoP, P, C, A> ToCss for Gradient<D, L, LoP, P, C, A>
         dest.write_str(self.kind.label())?;
         dest.write_str("-gradient(")?;
         let mut skip_comma = match self.kind {
-            GradientKind::Linear(ref direction) if direction.points_downwards() => true,
+            GradientKind::Linear(ref direction)
+                if direction.points_downwards(self.compat_mode) => true,
             GradientKind::Linear(ref direction) => {
                 direction.to_css(dest, self.compat_mode)?;
                 false
@@ -287,7 +288,7 @@ impl<D, L, LoP, P, A> GradientKind<D, L, LoP, P, A> {
 /// The direction of a linear gradient.
 pub trait LineDirection {
     /// Whether this direction points towards, and thus can be omitted.
-    fn points_downwards(&self) -> bool;
+    fn points_downwards(&self, compat_mode: CompatMode) -> bool;
 
     /// Serialises this direction according to the compatibility mode.
     fn to_css<W>(&self, dest: &mut W, compat_mode: CompatMode) -> fmt::Result

--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -526,7 +526,10 @@ impl GradientKind {
             input.expect_comma()?;
             d
         } else {
-            LineDirection::Vertical(Y::Bottom)
+            match *compat_mode {
+                CompatMode::Modern => LineDirection::Vertical(Y::Bottom),
+                _ => LineDirection::Vertical(Y::Top),
+            }
         };
         Ok(GenericGradientKind::Linear(direction))
     }
@@ -615,10 +618,13 @@ impl GradientKind {
 }
 
 impl GenericsLineDirection for LineDirection {
-    fn points_downwards(&self) -> bool {
+    fn points_downwards(&self, compat_mode: CompatMode) -> bool {
         match *self {
             LineDirection::Angle(ref angle) => angle.radians() == PI,
-            LineDirection::Vertical(Y::Bottom) => true,
+            LineDirection::Vertical(Y::Bottom)
+                if compat_mode == CompatMode::Modern => true,
+            LineDirection::Vertical(Y::Top)
+                if compat_mode != CompatMode::Modern => true,
             _ => false,
         }
     }


### PR DESCRIPTION
The default linear gradient direction is `to bottom`. This correspondes to
`top` keyword in prefixed linear gradients. We should preserve the default value.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1395189](https://bugzilla.mozilla.org/show_bug.cgi?id=1395189)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18321)
<!-- Reviewable:end -->
