### PR TITLE
Parse at-rule without block in two stages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
  "azure 0.20.1 (git+https://github.com/servo/rust-azure)",
  "canvas_traits 0.0.1",
  "compositing 0.0.1",
- "cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -343,7 +343,7 @@ dependencies = [
 name = "canvas_traits"
 version = "0.0.1"
 dependencies = [
- "cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -591,12 +591,13 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.19.5"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cssparser-macros 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dtoa-short 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "procedural-masquerade 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1071,7 +1072,7 @@ name = "geckoservo"
 version = "0.0.1"
 dependencies = [
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1139,7 +1140,7 @@ dependencies = [
 name = "gfx_tests"
 version = "0.0.1"
 dependencies = [
- "cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
  "ipc-channel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
@@ -2531,7 +2532,7 @@ dependencies = [
  "caseless 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deny_public_fields 0.0.1",
  "devtools_traits 0.0.1",
  "dom_struct 0.0.1",
@@ -2603,7 +2604,7 @@ dependencies = [
  "app_units 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
- "cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2675,7 +2676,7 @@ name = "selectors"
 version = "0.19.0"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3074,7 +3075,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3130,7 +3131,7 @@ version = "0.0.1"
 dependencies = [
  "app_units 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3152,7 +3153,7 @@ version = "0.0.1"
 dependencies = [
  "app_units 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3167,7 +3168,7 @@ name = "stylo_tests"
 version = "0.0.1"
 dependencies = [
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "geckoservo 0.0.1",
@@ -3756,7 +3757,7 @@ dependencies = [
 "checksum core-foundation-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "41115a6aa5d3e1e5ef98148373f25971d1fad53818553f216495f9e67e90a624"
 "checksum core-graphics 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a9f841e9637adec70838c537cae52cb4c751cc6514ad05669b51d107c2021c79"
 "checksum core-text 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "16ce16d9ed00181016c11ff48e561314bec92bfbce9fe48f319366618d4e5de6"
-"checksum cssparser 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dc476dc0960774aa1cabfd0044de7d4585a8f2f8a3ef72e6d9d1e16c1e2492b1"
+"checksum cssparser 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2334576d63647dd96a6238cc3fb1d51b2aae3eb98872de157ae35c0b2e358fd2"
 "checksum cssparser-macros 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "079adec4af52bb5275eadd004292028c79eb3c5f5b4ee8086a36d4197032f6df"
 "checksum darling 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9861a8495606435477df581bc858ccf15a3469747edf175b94a4704fd9aaedac"
 "checksum darling_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1486a8b00b45062c997f767738178b43219133dd0c8c826cb811e60563810821"

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 azure = {git = "https://github.com/servo/rust-azure"}
 canvas_traits = {path = "../canvas_traits"}
 compositing = {path = "../compositing"}
-cssparser = "0.19"
+cssparser = "0.20"
 euclid = "0.15"
 fnv = "1.0"
 gleam = "0.4"

--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -10,7 +10,7 @@ name = "canvas_traits"
 path = "lib.rs"
 
 [dependencies]
-cssparser = "0.19"
+cssparser = "0.20"
 euclid = "0.15"
 heapsize = "0.4"
 heapsize_derive = "0.1"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -33,7 +33,7 @@ byteorder = "1.0"
 canvas_traits = {path = "../canvas_traits"}
 caseless = "0.1.0"
 cookie = "0.6"
-cssparser = "0.19"
+cssparser = "0.20"
 deny_public_fields = {path = "../deny_public_fields"}
 devtools_traits = {path = "../devtools_traits"}
 dom_struct = {path = "../dom_struct"}

--- a/components/script_layout_interface/Cargo.toml
+++ b/components/script_layout_interface/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 app_units = "0.5"
 atomic_refcell = "0.1"
 canvas_traits = {path = "../canvas_traits"}
-cssparser = "0.19"
+cssparser = "0.20"
 euclid = "0.15"
 gfx_traits = {path = "../gfx_traits"}
 heapsize = "0.4"

--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -25,7 +25,7 @@ unstable = []
 [dependencies]
 bitflags = "0.7"
 matches = "0.1"
-cssparser = "0.19.3"
+cssparser = "0.20"
 log = "0.3"
 fnv = "1.0"
 phf = "0.7.18"

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -37,7 +37,7 @@ bitflags = "0.7"
 bit-vec = "0.4.3"
 byteorder = "1.0"
 cfg-if = "0.1.0"
-cssparser = "0.19.5"
+cssparser = "0.20"
 encoding = {version = "0.2", optional = true}
 euclid = "0.15"
 fnv = "1.0"

--- a/components/style/counter_style/mod.rs
+++ b/components/style/counter_style/mod.rs
@@ -114,7 +114,8 @@ struct CounterStyleRuleParser<'a, 'b: 'a> {
 
 /// Default methods reject all at rules.
 impl<'a, 'b, 'i> AtRuleParser<'i> for CounterStyleRuleParser<'a, 'b> {
-    type Prelude = ();
+    type PreludeNoBlock = ();
+    type PreludeBlock = ();
     type AtRule = ();
     type Error = SelectorParseError<'i, StyleParseError<'i>>;
 }

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -179,7 +179,8 @@ struct FontFaceRuleParser<'a, 'b: 'a> {
 
 /// Default methods reject all at rules.
 impl<'a, 'b, 'i> AtRuleParser<'i> for FontFaceRuleParser<'a, 'b> {
-    type Prelude = ();
+    type PreludeNoBlock = ();
+    type PreludeBlock = ();
     type AtRule = ();
     type Error = SelectorParseError<'i, StyleParseError<'i>>;
 }

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -953,7 +953,8 @@ struct PropertyDeclarationParser<'a, 'b: 'a> {
 
 /// Default methods reject all at rules.
 impl<'a, 'b, 'i> AtRuleParser<'i> for PropertyDeclarationParser<'a, 'b> {
-    type Prelude = ();
+    type PreludeNoBlock = ();
+    type PreludeBlock = ();
     type AtRule = Importance;
     type Error = SelectorParseError<'i, StyleParseError<'i>>;
 }

--- a/components/style/stylesheets/font_feature_values_rule.rs
+++ b/components/style/stylesheets/font_feature_values_rule.rs
@@ -193,7 +193,8 @@ struct FFVDeclarationsParser<'a, 'b: 'a, T: 'a> {
 
 /// Default methods reject all at rules.
 impl<'a, 'b, 'i, T> AtRuleParser<'i> for FFVDeclarationsParser<'a, 'b, T> {
-    type Prelude = ();
+    type PreludeNoBlock = ();
+    type PreludeBlock = ();
     type AtRule = ();
     type Error = SelectorParseError<'i, StyleParseError<'i>>;
 }
@@ -389,14 +390,15 @@ macro_rules! font_feature_values_blocks {
         }
 
         impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for FontFeatureValuesRuleParser<'a, R> {
-            type Prelude = BlockType;
+            type PreludeNoBlock = ();
+            type PreludeBlock = BlockType;
             type AtRule = ();
             type Error = SelectorParseError<'i, StyleParseError<'i>>;
 
             fn parse_prelude<'t>(&mut self,
                                  name: CowRcStr<'i>,
                                  _input: &mut Parser<'i, 't>)
-                                 -> Result<AtRuleType<Self::Prelude, Self::AtRule>, ParseError<'i>> {
+                                 -> Result<AtRuleType<(), BlockType>, ParseError<'i>> {
                 match_ignore_ascii_case! { &*name,
                     $(
                         $name => Ok(AtRuleType::WithBlock(BlockType::$ident_camel)),
@@ -407,7 +409,7 @@ macro_rules! font_feature_values_blocks {
 
             fn parse_block<'t>(
                 &mut self,
-                prelude: Self::Prelude,
+                prelude: BlockType,
                 input: &mut Parser<'i, 't>
             ) -> Result<Self::AtRule, ParseError<'i>> {
                 debug_assert_eq!(self.context.rule_type(), CssRuleType::FontFeatureValues);

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -476,9 +476,9 @@ pub fn parse_keyframe_list<R>(
     }).filter_map(Result::ok).collect()
 }
 
-enum Void {}
 impl<'a, 'i, R> AtRuleParser<'i> for KeyframeListParser<'a, R> {
-    type Prelude = Void;
+    type PreludeNoBlock = ();
+    type PreludeBlock = ();
     type AtRule = Arc<Locked<Keyframe>>;
     type Error = SelectorParseError<'i, StyleParseError<'i>>;
 }
@@ -543,7 +543,8 @@ struct KeyframeDeclarationParser<'a, 'b: 'a> {
 
 /// Default methods reject all at rules.
 impl<'a, 'b, 'i> AtRuleParser<'i> for KeyframeDeclarationParser<'a, 'b> {
-    type Prelude = ();
+    type PreludeNoBlock = ();
+    type PreludeBlock = ();
     type AtRule = ();
     type Error = SelectorParseError<'i, StyleParseError<'i>>;
 }

--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -111,8 +111,8 @@ pub enum VendorPrefix {
     WebKit,
 }
 
-/// A rule prelude for a given at-rule.
-pub enum AtRulePrelude {
+/// A rule prelude for at-rule with block.
+pub enum AtRuleBlockPrelude {
     /// A @font-face rule prelude.
     FontFace(SourceLocation),
     /// A @font-feature-values rule prelude, with its FamilyName list.
@@ -133,25 +133,31 @@ pub enum AtRulePrelude {
     Document(DocumentCondition, SourceLocation),
 }
 
+/// A rule prelude for at-rule without block.
+pub enum AtRuleNonBlockPrelude {
+    /// A @import rule prelude.
+    Import(SpecifiedUrl, Arc<Locked<MediaList>>, SourceLocation),
+    /// A @namespace rule prelude.
+    Namespace(Option<Prefix>, Namespace, SourceLocation),
+}
+
 
 #[cfg(feature = "gecko")]
-fn register_namespace(ns: &Namespace) -> Result<i32, ()> {
+fn register_namespace(ns: &Namespace) -> i32 {
     use gecko_bindings::bindings;
     let id = unsafe { bindings::Gecko_RegisterNamespace(ns.0.as_ptr()) };
-    if id == -1 {
-        Err(())
-    } else {
-        Ok(id)
-    }
+    debug_assert!(id >= 0);
+    id
 }
 
 #[cfg(feature = "servo")]
-fn register_namespace(_: &Namespace) -> Result<(), ()> {
-    Ok(()) // servo doesn't use namespace ids
+fn register_namespace(_: &Namespace) {
+    // servo doesn't use namespace ids
 }
 
 impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, R> {
-    type Prelude = AtRulePrelude;
+    type PreludeNoBlock = AtRuleNonBlockPrelude;
+    type PreludeBlock = AtRuleBlockPrelude;
     type AtRule = CssRule;
     type Error = SelectorParseError<'i, StyleParseError<'i>>;
 
@@ -159,7 +165,7 @@ impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, 
         &mut self,
         name: CowRcStr<'i>,
         input: &mut Parser<'i, 't>
-    ) -> Result<AtRuleType<AtRulePrelude, CssRule>, ParseError<'i>> {
+    ) -> Result<AtRuleType<AtRuleNonBlockPrelude, AtRuleBlockPrelude>, ParseError<'i>> {
         let location = get_location_with_offset(input.current_source_location());
         match_ignore_ascii_case! { &*name,
             "import" => {
@@ -175,19 +181,8 @@ impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, 
                 let media = parse_media_query_list(&self.context, input);
                 let media = Arc::new(self.shared_lock.wrap(media));
 
-                let loader =
-                    self.loader.expect("Expected a stylesheet loader for @import");
-
-                let import_rule = loader.request_stylesheet(
-                    specified_url,
-                    location,
-                    &self.context,
-                    &self.shared_lock,
-                    media,
-                );
-
-                self.state = State::Imports;
-                return Ok(AtRuleType::WithoutBlock(CssRule::Import(import_rule)))
+                let prelude = AtRuleNonBlockPrelude::Import(specified_url, media, location);
+                return Ok(AtRuleType::WithoutBlock(prelude));
             },
             "namespace" => {
                 if self.state > State::Namespaces {
@@ -196,7 +191,8 @@ impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, 
                     return Err(StyleParseError::UnexpectedNamespaceRule.into())
                 }
 
-                let prefix_result = input.try(|i| i.expect_ident_cloned());
+                let prefix = input.try(|i| i.expect_ident_cloned())
+                                  .map(|s| Prefix::from(s.as_ref())).ok();
                 let maybe_namespace = match input.expect_url_or_string() {
                     Ok(url_or_string) => url_or_string,
                     Err(BasicParseError::UnexpectedToken(t)) =>
@@ -204,29 +200,8 @@ impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, 
                     Err(e) => return Err(e.into()),
                 };
                 let url = Namespace::from(maybe_namespace.as_ref());
-
-                let id = register_namespace(&url)
-                    .map_err(|()| StyleParseError::UnspecifiedError)?;
-
-                let opt_prefix = if let Ok(prefix) = prefix_result {
-                    let prefix = Prefix::from(prefix.as_ref());
-                    self.namespaces
-                        .prefixes
-                        .insert(prefix.clone(), (url.clone(), id));
-                    Some(prefix)
-                } else {
-                    self.namespaces.default = Some((url.clone(), id));
-                    None
-                };
-
-                self.state = State::Namespaces;
-                return Ok(AtRuleType::WithoutBlock(CssRule::Namespace(Arc::new(
-                    self.shared_lock.wrap(NamespaceRule {
-                        prefix: opt_prefix,
-                        url: url,
-                        source_location: location,
-                    })
-                ))))
+                let prelude = AtRuleNonBlockPrelude::Namespace(prefix, url, location);
+                return Ok(AtRuleType::WithoutBlock(prelude));
             },
             // @charset is removed by rust-cssparser if it’s the first rule in the stylesheet
             // anything left is invalid.
@@ -243,11 +218,54 @@ impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, 
     #[inline]
     fn parse_block<'t>(
         &mut self,
-        prelude: AtRulePrelude,
+        prelude: AtRuleBlockPrelude,
         input: &mut Parser<'i, 't>
     ) -> Result<CssRule, ParseError<'i>> {
         AtRuleParser::parse_block(&mut self.nested(), prelude, input)
             .map(|rule| { self.state = State::Body; rule })
+    }
+
+    #[inline]
+    fn rule_without_block(&mut self, prelude: AtRuleNonBlockPrelude) -> CssRule {
+        match prelude {
+            AtRuleNonBlockPrelude::Import(specified_url, media, location) => {
+                let loader =
+                    self.loader.expect("Expected a stylesheet loader for @import");
+
+                let import_rule = loader.request_stylesheet(
+                    specified_url,
+                    location,
+                    &self.context,
+                    &self.shared_lock,
+                    media,
+                );
+
+                self.state = State::Imports;
+                CssRule::Import(import_rule)
+            }
+            AtRuleNonBlockPrelude::Namespace(prefix, url, location) => {
+                let id = register_namespace(&url);
+
+                let opt_prefix = if let Some(prefix) = prefix {
+                    self.namespaces
+                        .prefixes
+                        .insert(prefix.clone(), (url.clone(), id));
+                    Some(prefix)
+                } else {
+                    self.namespaces.default = Some((url.clone(), id));
+                    None
+                };
+
+                self.state = State::Namespaces;
+                CssRule::Namespace(Arc::new(
+                    self.shared_lock.wrap(NamespaceRule {
+                        prefix: opt_prefix,
+                        url: url,
+                        source_location: location,
+                    })
+                ))
+            }
+        }
     }
 }
 
@@ -322,7 +340,8 @@ impl<'a, 'b, R: ParseErrorReporter> NestedRuleParser<'a, 'b, R> {
 }
 
 impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a, 'b, R> {
-    type Prelude = AtRulePrelude;
+    type PreludeNoBlock = AtRuleNonBlockPrelude;
+    type PreludeBlock = AtRuleBlockPrelude;
     type AtRule = CssRule;
     type Error = SelectorParseError<'i, StyleParseError<'i>>;
 
@@ -330,21 +349,21 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
         &mut self,
         name: CowRcStr<'i>,
         input: &mut Parser<'i, 't>
-    ) -> Result<AtRuleType<AtRulePrelude, CssRule>, ParseError<'i>> {
+    ) -> Result<AtRuleType<AtRuleNonBlockPrelude, AtRuleBlockPrelude>, ParseError<'i>> {
         let location = get_location_with_offset(input.current_source_location());
 
         match_ignore_ascii_case! { &*name,
             "media" => {
                 let media_queries = parse_media_query_list(self.context, input);
                 let arc = Arc::new(self.shared_lock.wrap(media_queries));
-                Ok(AtRuleType::WithBlock(AtRulePrelude::Media(arc, location)))
+                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Media(arc, location)))
             },
             "supports" => {
                 let cond = SupportsCondition::parse(input)?;
-                Ok(AtRuleType::WithBlock(AtRulePrelude::Supports(cond, location)))
+                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Supports(cond, location)))
             },
             "font-face" => {
-                Ok(AtRuleType::WithBlock(AtRulePrelude::FontFace(location)))
+                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::FontFace(location)))
             },
             "font-feature-values" => {
                 if !cfg!(feature = "gecko") {
@@ -352,7 +371,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                     return Err(StyleParseError::UnsupportedAtRule(name.clone()).into())
                 }
                 let family_names = parse_family_name_list(self.context, input)?;
-                Ok(AtRuleType::WithBlock(AtRulePrelude::FontFeatureValues(family_names, location)))
+                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::FontFeatureValues(family_names, location)))
             },
             "counter-style" => {
                 if !cfg!(feature = "gecko") {
@@ -366,11 +385,11 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                 if name.0 == atom!("decimal") || name.0 == atom!("disc") {
                     return Err(StyleParseError::UnspecifiedError.into())
                 }
-                Ok(AtRuleType::WithBlock(AtRulePrelude::CounterStyle(name)))
+                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::CounterStyle(name)))
             },
             "viewport" => {
                 if viewport_rule::enabled() {
-                    Ok(AtRuleType::WithBlock(AtRulePrelude::Viewport))
+                    Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Viewport))
                 } else {
                     Err(StyleParseError::UnsupportedAtRule(name.clone()).into())
                 }
@@ -390,11 +409,11 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                 }
                 let name = KeyframesName::parse(self.context, input)?;
 
-                Ok(AtRuleType::WithBlock(AtRulePrelude::Keyframes(name, prefix, location)))
+                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Keyframes(name, prefix, location)))
             },
             "page" => {
                 if cfg!(feature = "gecko") {
-                    Ok(AtRuleType::WithBlock(AtRulePrelude::Page(location)))
+                    Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Page(location)))
                 } else {
                     Err(StyleParseError::UnsupportedAtRule(name.clone()).into())
                 }
@@ -402,7 +421,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
             "-moz-document" => {
                 if cfg!(feature = "gecko") {
                     let cond = DocumentCondition::parse(self.context, input)?;
-                    Ok(AtRuleType::WithBlock(AtRulePrelude::Document(cond, location)))
+                    Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Document(cond, location)))
                 } else {
                     Err(StyleParseError::UnsupportedAtRule(name.clone()).into())
                 }
@@ -413,11 +432,11 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
 
     fn parse_block<'t>(
         &mut self,
-        prelude: AtRulePrelude,
+        prelude: AtRuleBlockPrelude,
         input: &mut Parser<'i, 't>
     ) -> Result<CssRule, ParseError<'i>> {
         match prelude {
-            AtRulePrelude::FontFace(location) => {
+            AtRuleBlockPrelude::FontFace(location) => {
                 let context =
                     ParserContext::new_with_rule_type(
                         self.context,
@@ -428,7 +447,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                 Ok(CssRule::FontFace(Arc::new(self.shared_lock.wrap(
                    parse_font_face_block(&context, self.error_context, input, location).into()))))
             }
-            AtRulePrelude::FontFeatureValues(family_names, location) => {
+            AtRuleBlockPrelude::FontFeatureValues(family_names, location) => {
                 let context =
                     ParserContext::new_with_rule_type(
                         self.context,
@@ -438,7 +457,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                 Ok(CssRule::FontFeatureValues(Arc::new(self.shared_lock.wrap(
                     FontFeatureValuesRule::parse(&context, self.error_context, input, family_names, location)))))
             }
-            AtRulePrelude::CounterStyle(name) => {
+            AtRuleBlockPrelude::CounterStyle(name) => {
                 let context =
                     ParserContext::new_with_rule_type(
                         self.context,
@@ -448,14 +467,14 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                 Ok(CssRule::CounterStyle(Arc::new(self.shared_lock.wrap(
                    parse_counter_style_body(name, &context, self.error_context, input)?.into()))))
             }
-            AtRulePrelude::Media(media_queries, location) => {
+            AtRuleBlockPrelude::Media(media_queries, location) => {
                 Ok(CssRule::Media(Arc::new(self.shared_lock.wrap(MediaRule {
                     media_queries: media_queries,
                     rules: self.parse_nested_rules(input, CssRuleType::Media),
                     source_location: location,
                 }))))
             }
-            AtRulePrelude::Supports(cond, location) => {
+            AtRuleBlockPrelude::Supports(cond, location) => {
                 let eval_context =
                     ParserContext::new_with_rule_type(
                         self.context,
@@ -470,7 +489,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                     source_location: location,
                 }))))
             }
-            AtRulePrelude::Viewport => {
+            AtRuleBlockPrelude::Viewport => {
                 let context =
                     ParserContext::new_with_rule_type(
                         self.context,
@@ -480,7 +499,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                 Ok(CssRule::Viewport(Arc::new(self.shared_lock.wrap(
                    ViewportRule::parse(&context, self.error_context, input)?))))
             }
-            AtRulePrelude::Keyframes(name, prefix, location) => {
+            AtRuleBlockPrelude::Keyframes(name, prefix, location) => {
                 let context =
                     ParserContext::new_with_rule_type(
                         self.context,
@@ -495,7 +514,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                     source_location: location,
                 }))))
             }
-            AtRulePrelude::Page(location) => {
+            AtRuleBlockPrelude::Page(location) => {
                 let context =
                     ParserContext::new_with_rule_type(
                         self.context,
@@ -508,7 +527,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                     source_location: location,
                 }))))
             }
-            AtRulePrelude::Document(cond, location) => {
+            AtRuleBlockPrelude::Document(cond, location) => {
                 if cfg!(feature = "gecko") {
                     Ok(CssRule::Document(Arc::new(self.shared_lock.wrap(DocumentRule {
                         condition: cond,

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -271,7 +271,8 @@ fn parse_shorthand<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
 }
 
 impl<'a, 'b, 'i> AtRuleParser<'i> for ViewportRuleParser<'a, 'b> {
-    type Prelude = ();
+    type PreludeNoBlock = ();
+    type PreludeBlock = ();
     type AtRule = Vec<ViewportDescriptorDeclaration>;
     type Error = SelectorParseError<'i, StyleParseError<'i>>;
 }

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -16,7 +16,7 @@ gecko = []
 [dependencies]
 app_units = "0.5"
 bitflags = "0.7"
-cssparser = "0.19"
+cssparser = "0.20"
 euclid = "0.15"
 heapsize = {version = "0.4", optional = true}
 heapsize_derive = {version = "0.1", optional = true}

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -15,7 +15,7 @@ gecko_debug = ["style/gecko_debug"]
 
 [dependencies]
 atomic_refcell = "0.1"
-cssparser = "0.19"
+cssparser = "0.20"
 env_logger = {version = "0.4", default-features = false} # disable `regex` to reduce code size
 libc = "0.2"
 log = {version = "0.3.5", features = ["release_max_level_info"]}

--- a/tests/unit/gfx/Cargo.toml
+++ b/tests/unit/gfx/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
-cssparser = "0.19"
+cssparser = "0.20"
 gfx = {path = "../../../components/gfx"}
 ipc-channel = "0.8"
 style = {path = "../../../components/style"}

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 byteorder = "1.0"
 app_units = "0.5"
-cssparser = "0.19"
+cssparser = "0.20"
 euclid = "0.15"
 html5ever = "0.19"
 parking_lot = "0.4"

--- a/tests/unit/stylo/Cargo.toml
+++ b/tests/unit/stylo/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 
 [dependencies]
 atomic_refcell = "0.1"
-cssparser = "0.19"
+cssparser = "0.20"
 env_logger = "0.4"
 euclid = "0.15"
 geckoservo = {path = "../../../ports/geckolib"}


### PR DESCRIPTION
This is the Servo side change necessary for servo/rust-cssparser#180.

----

This also pulls in other changes from cssparser 0.20.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18336)
<!-- Reviewable:end -->
