### PR TITLE
Update WR (mac driver crash, box shadow sharing).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,7 +3540,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.50.0"
-source = "git+https://github.com/servo/webrender#eee6067ba4c9e3bb0edfe125919eee8163ba1de5"
+source = "git+https://github.com/servo/webrender#e7c60ad67ca9c0732be18c3df25b686f12d652ca"
 dependencies = [
  "app_units 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.50.0"
-source = "git+https://github.com/servo/webrender#eee6067ba4c9e3bb0edfe125919eee8163ba1de5"
+source = "git+https://github.com/servo/webrender#e7c60ad67ca9c0732be18c3df25b686f12d652ca"
 dependencies = [
  "app_units 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1285,7 +1285,8 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             debug!("compositor: compositing");
 
             // Paint the scene.
-            self.webrender.render(self.frame_size);
+            // TODO(gw): Take notice of any errors the renderer returns!
+            self.webrender.render(self.frame_size).ok();
         });
 
         // If there are pending paint metrics, we check if any of the painted epochs is


### PR DESCRIPTION
* Works around a driver / kernel crash on some mac machines.
* Allow more sharing of box shadow and clip render tasks.
* Some shader tidy ups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18339)
<!-- Reviewable:end -->
