### PR TITLE
Change selector::to_css function to handle combinators in between universal selectors.

### DIFF
--- a/tests/unit/style/parsing/selectors.rs
+++ b/tests/unit/style/parsing/selectors.rs
@@ -25,4 +25,6 @@ fn test_selectors() {
     assert_roundtrip!(parse_selector, "svg|circle");
     assert_roundtrip!(parse_selector, "p:before", "p::before");
     assert_roundtrip!(parse_selector, "[border=\"0\"]:-servo-nonzero-border ~ ::-servo-details-summary");
+    assert_roundtrip!(parse_selector, "* > *");
+    assert_roundtrip!(parse_selector, "*|* + *", "* + *");
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1391169
https://reviewboard.mozilla.org/r/172368/

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18344)
<!-- Reviewable:end -->
