### PR TITLE
Take a `u8` pointer and a length instead of `nsACString` pointer from Gecko.

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1930,7 +1930,8 @@ extern "C" {
     pub fn Servo_StyleSheet_FromUTF8Bytes(loader: *mut Loader,
                                           gecko_stylesheet:
                                               *mut ServoStyleSheet,
-                                          data: *const nsACString,
+                                          data: *const u8,
+                                          data_len: usize,
                                           parsing_mode: SheetParsingMode,
                                           extra_data:
                                               *mut RawGeckoURLExtraData,

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -862,7 +862,8 @@ pub extern "C" fn Servo_StyleSheet_Empty(mode: SheetParsingMode) -> RawServoStyl
 pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(
     loader: *mut Loader,
     stylesheet: *mut ServoStyleSheet,
-    data: *const nsACString,
+    data: *const u8,
+    data_len: usize,
     mode: SheetParsingMode,
     extra_data: *mut URLExtraData,
     line_number_offset: u32,
@@ -870,7 +871,7 @@ pub extern "C" fn Servo_StyleSheet_FromUTF8Bytes(
     reusable_sheets: *mut LoaderReusableStyleSheets
 ) -> RawServoStyleSheetContentsStrong {
     let global_style_data = &*GLOBAL_STYLE_DATA;
-    let input = unsafe { data.as_ref().unwrap().as_str_unchecked() };
+    let input = unsafe { ::std::str::from_utf8_unchecked(::std::slice::from_raw_parts(data, data_len)) };
 
     let origin = match mode {
         SheetParsingMode::eAuthorSheetFeatures => Origin::Author,


### PR DESCRIPTION
This is the Servo side change of [bug 1354989](https://bugzilla.mozilla.org/show_bug.cgi?id=1354989).

- [ ] `./mach build -d` does not report any errors

Fails for unrelated reason when building `servo-skia`.

- [x] `./mach test-tidy` does not report any errors

- [x] These changes do not require tests because this changes the Gecko interface and m-c not burning is the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18347)
<!-- Reviewable:end -->
