### PR TITLE
stylo: Expose -moz-system-metric and -moz-empty-except-children-with-localname

### DIFF
--- a/components/style/gecko/non_ts_pseudo_class_list.rs
+++ b/components/style/gecko/non_ts_pseudo_class_list.rs
@@ -59,7 +59,9 @@ macro_rules! apply_non_ts_list {
                 ("-moz-drag-over", MozDragOver, mozDragOver, IN_DRAGOVER_STATE, _),
                 ("target", Target, target, IN_TARGET_STATE, _),
                 ("indeterminate", Indeterminate, indeterminate, IN_INDETERMINATE_STATE, _),
+                // FIXME(emilio): Unship this for content docs (bug 1396073).
                 ("-moz-devtools-highlighted", MozDevtoolsHighlighted, mozDevtoolsHighlighted, IN_DEVTOOLS_HIGHLIGHTED_STATE, _),
+                // FIXME(emilio): Unship this for content docs (bug 1396073).
                 ("-moz-styleeditor-transitioning", MozStyleeditorTransitioning, mozStyleeditorTransitioning, IN_STYLEEDITOR_TRANSITIONING_STATE, _),
                 ("fullscreen", Fullscreen, fullscreen, IN_FULLSCREEN_STATE, PSEUDO_CLASS_ENABLED_IN_UA_SHEETS_AND_CHROME),
                 ("-moz-full-screen", MozFullScreen, mozFullScreen, IN_FULLSCREEN_STATE, _),
@@ -116,9 +118,11 @@ macro_rules! apply_non_ts_list {
                 ("-moz-window-inactive", MozWindowInactive, mozWindowInactive, _, _),
             ],
             string: [
-                ("-moz-system-metric", MozSystemMetric, mozSystemMetric, _, PSEUDO_CLASS_ENABLED_IN_UA_SHEETS),
+                // FIXME(emilio): Unship this for content docs (bug 1396066).
+                ("-moz-system-metric", MozSystemMetric, mozSystemMetric, _, _),
+                // FIXME(emilio): Unship this for content docs (bug 1396073).
                 ("-moz-empty-except-children-with-localname", MozEmptyExceptChildrenWithLocalname,
-                 mozEmptyExceptChildrenWithLocalname, _, PSEUDO_CLASS_ENABLED_IN_UA_SHEETS),
+                 mozEmptyExceptChildrenWithLocalname, _, _),
                 ("lang", Lang, lang, _, _),
             ],
             keyword: [


### PR DESCRIPTION
They don't have the flag in Gecko.

Though I wonder if we could unship them from non-UA sheets.

Bug: 1396048
Reviewed-by: bholley
MozReview-Commit-ID: LGzGDjCZpJC

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18350)
<!-- Reviewable:end -->
