### PR TITLE
Refactor `.sort_by()` calls to use `.partial_cmp()`

### DIFF
--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -355,13 +355,7 @@ impl Profiler {
                 write!(file, "_category_\t_incremental?_\t_iframe?_\t_url_\t_mean (ms)_\t\
                     _median (ms)_\t_min (ms)_\t_max (ms)_\t_events_\n").unwrap();
                 for (&(ref category, ref meta), ref mut data) in &mut self.buckets {
-                    data.sort_by(|a, b| {
-                        if a < b {
-                            Ordering::Less
-                        } else {
-                            Ordering::Greater
-                        }
-                    });
+                    data.sort_by(|a, b| a.partial_cmp(b).expect("No NaN values in profiles"));
                     let data_len = data.len();
                     if data_len > 0 {
                         let (mean, median, min, max) = Self::get_statistics(data);
@@ -380,13 +374,7 @@ impl Profiler {
                          "            _url_", "    _mean (ms)_", "  _median (ms)_",
                          "     _min (ms)_", "     _max (ms)_", "      _events_").unwrap();
                 for (&(ref category, ref meta), ref mut data) in &mut self.buckets {
-                    data.sort_by(|a, b| {
-                        if a < b {
-                            Ordering::Less
-                        } else {
-                            Ordering::Greater
-                        }
-                    });
+                    data.sort_by(|a, b| a.partial_cmp(b).expect("No NaN values in profiles"));
                     let data_len = data.len();
                     if data_len > 0 {
                         let (mean, median, min, max) = Self::get_statistics(data);
@@ -418,13 +406,7 @@ impl Profiler {
                 let client = create_client(credentials, hosts);
 
                 for (&(ref category, ref meta), ref mut data) in &mut self.buckets {
-                    data.sort_by(|a, b| {
-                        if a < b {
-                            Ordering::Less
-                        } else {
-                            Ordering::Greater
-                        }
-                    });
+                    data.sort_by(|a, b| a.partial_cmp(b).expect("No NaN values in profiles"));
                     let data_len = data.len();
                     if data_len > 0 {
                         let (mean, median, min, max) = Self::get_statistics(data);


### PR DESCRIPTION
Changes the closures passed to `sort_by` in this file with a simpler, and more correct version.

Previously, potential NaNs in the array would float to the top. Either way, the program would crash, as the `get_statistics` function asserts the array it gets is sorted, which always fails with a NaN.  
Because of that, this change should not affect functionality.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because statistics collected by --profile should not have NaN values in the first place.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18351)
<!-- Reviewable:end -->
