### PR TITLE
style: Move color to use predefined_type.

### DIFF
--- a/components/style/properties/longhand/color.mako.rs
+++ b/components/style/properties/longhand/color.mako.rs
@@ -8,134 +8,107 @@
 
 <% from data import to_rust_ident %>
 
-<%helpers:longhand name="color" need_clone="True"
-                   animation_value_type="AnimatedRGBA"
-                   ignored_when_colors_disabled="True"
-                   flags="APPLIES_TO_FIRST_LETTER APPLIES_TO_FIRST_LINE APPLIES_TO_PLACEHOLDER"
-                   spec="https://drafts.csswg.org/css-color/#color">
-    use cssparser::RGBA;
-    use values::specified::{AllowQuirks, Color};
+${helpers.predefined_type(
+    "color",
+    "ColorPropertyValue",
+    "::cssparser::RGBA::new(0, 0, 0, 255)",
+    animation_value_type="AnimatedRGBA",
+    flags="APPLIES_TO_FIRST_LETTER APPLIES_TO_FIRST_LINE APPLIES_TO_PLACEHOLDER",
+    ignored_when_colors_disabled="True",
+    spec="https://drafts.csswg.org/css-color/#color",
+    need_clone="True"
+)}
 
-    impl ToComputedValue for SpecifiedValue {
-        type ComputedValue = computed_value::T;
+// FIXME(#15973): Add servo support for system colors
+//
+// FIXME(emilio): Move outside of mako.
+% if product == "gecko":
+pub mod system_colors {
+    <%
+        # These are actually parsed. See nsCSSProps::kColorKTable
+        system_colors = """activeborder activecaption appworkspace background buttonface
+                           buttonhighlight buttonshadow buttontext captiontext graytext highlight
+                           highlighttext inactiveborder inactivecaption inactivecaptiontext
+                           infobackground infotext menu menutext scrollbar threeddarkshadow
+                           threedface threedhighlight threedlightshadow threedshadow window
+                           windowframe windowtext -moz-buttondefault -moz-buttonhoverface
+                           -moz-buttonhovertext -moz-cellhighlight -moz-cellhighlighttext
+                           -moz-eventreerow -moz-field -moz-fieldtext -moz-dialog -moz-dialogtext
+                           -moz-dragtargetzone -moz-gtk-info-bar-text -moz-html-cellhighlight
+                           -moz-html-cellhighlighttext -moz-mac-buttonactivetext
+                           -moz-mac-chrome-active -moz-mac-chrome-inactive
+                           -moz-mac-defaultbuttontext -moz-mac-focusring -moz-mac-menuselect
+                           -moz-mac-menushadow -moz-mac-menutextdisable -moz-mac-menutextselect
+                           -moz-mac-disabledtoolbartext -moz-mac-secondaryhighlight
+                           -moz-menuhover -moz-menuhovertext -moz-menubartext -moz-menubarhovertext
+                           -moz-oddtreerow -moz-win-mediatext -moz-win-communicationstext
+                           -moz-win-accentcolor -moz-win-accentcolortext
+                           -moz-nativehyperlinktext -moz-comboboxtext -moz-combobox""".split()
+
+        # These are not parsed but must be serialized
+        # They are only ever set directly by Gecko
+        extra_colors = """WindowBackground WindowForeground WidgetBackground WidgetForeground
+                          WidgetSelectBackground WidgetSelectForeground Widget3DHighlight Widget3DShadow
+                          TextBackground TextForeground TextSelectBackground TextSelectForeground
+                          TextSelectForegroundCustom TextSelectBackgroundDisabled TextSelectBackgroundAttention
+                          TextHighlightBackground TextHighlightForeground IMERawInputBackground
+                          IMERawInputForeground IMERawInputUnderline IMESelectedRawTextBackground
+                          IMESelectedRawTextForeground IMESelectedRawTextUnderline
+                          IMEConvertedTextBackground IMEConvertedTextForeground IMEConvertedTextUnderline
+                          IMESelectedConvertedTextBackground IMESelectedConvertedTextForeground
+                          IMESelectedConvertedTextUnderline SpellCheckerUnderline""".split()
+    %>
+    use cssparser::Parser;
+    use gecko_bindings::bindings::Gecko_GetLookAndFeelSystemColor;
+    use gecko_bindings::structs::root::mozilla::LookAndFeel_ColorID;
+    use std::fmt;
+    use style_traits::ToCss;
+    use values::computed::{Context, ToComputedValue};
+
+    pub type SystemColor = LookAndFeel_ColorID;
+
+    impl ToCss for SystemColor {
+        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
+            let s = match *self {
+                % for color in system_colors + extra_colors:
+                    LookAndFeel_ColorID::eColorID_${to_rust_ident(color)} => "${color}",
+                % endfor
+                LookAndFeel_ColorID::eColorID_LAST_COLOR => unreachable!(),
+            };
+            dest.write_str(s)
+        }
+    }
+
+    impl ToComputedValue for SystemColor {
+        type ComputedValue = u32; // nscolor
 
         #[inline]
-        fn to_computed_value(&self, context: &Context) -> computed_value::T {
-            self.0.to_computed_value(context)
-                .to_rgba(context.builder.get_parent_color().clone_color())
+        fn to_computed_value(&self, cx: &Context) -> Self::ComputedValue {
+            unsafe {
+                Gecko_GetLookAndFeelSystemColor(*self as i32,
+                                                cx.device().pres_context())
+            }
         }
 
         #[inline]
-        fn from_computed_value(computed: &computed_value::T) -> Self {
-            SpecifiedValue(Color::rgba(*computed).into())
+        fn from_computed_value(_: &Self::ComputedValue) -> Self {
+            unreachable!()
         }
     }
 
-    #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-    #[derive(Clone, Debug, PartialEq, ToCss)]
-    pub struct SpecifiedValue(pub Color);
-
-    pub mod computed_value {
-        use cssparser;
-        pub type T = cssparser::RGBA;
-    }
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        RGBA::new(0, 0, 0, 255) // black
-    }
-    pub fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue, ParseError<'i>> {
-        Color::parse_quirky(context, input, AllowQuirks::Yes).map(SpecifiedValue)
-    }
-
-    // FIXME(#15973): Add servo support for system colors
-    % if product == "gecko":
-        <%
-            # These are actually parsed. See nsCSSProps::kColorKTable
-            system_colors = """activeborder activecaption appworkspace background buttonface
-                               buttonhighlight buttonshadow buttontext captiontext graytext highlight
-                               highlighttext inactiveborder inactivecaption inactivecaptiontext
-                               infobackground infotext menu menutext scrollbar threeddarkshadow
-                               threedface threedhighlight threedlightshadow threedshadow window
-                               windowframe windowtext -moz-buttondefault -moz-buttonhoverface
-                               -moz-buttonhovertext -moz-cellhighlight -moz-cellhighlighttext
-                               -moz-eventreerow -moz-field -moz-fieldtext -moz-dialog -moz-dialogtext
-                               -moz-dragtargetzone -moz-gtk-info-bar-text -moz-html-cellhighlight
-                               -moz-html-cellhighlighttext -moz-mac-buttonactivetext
-                               -moz-mac-chrome-active -moz-mac-chrome-inactive
-                               -moz-mac-defaultbuttontext -moz-mac-focusring -moz-mac-menuselect
-                               -moz-mac-menushadow -moz-mac-menutextdisable -moz-mac-menutextselect
-                               -moz-mac-disabledtoolbartext -moz-mac-secondaryhighlight
-                               -moz-menuhover -moz-menuhovertext -moz-menubartext -moz-menubarhovertext
-                               -moz-oddtreerow -moz-win-mediatext -moz-win-communicationstext
-                               -moz-win-accentcolor -moz-win-accentcolortext
-                               -moz-nativehyperlinktext -moz-comboboxtext -moz-combobox""".split()
-
-            # These are not parsed but must be serialized
-            # They are only ever set directly by Gecko
-            extra_colors = """WindowBackground WindowForeground WidgetBackground WidgetForeground
-                              WidgetSelectBackground WidgetSelectForeground Widget3DHighlight Widget3DShadow
-                              TextBackground TextForeground TextSelectBackground TextSelectForeground
-                              TextSelectForegroundCustom TextSelectBackgroundDisabled TextSelectBackgroundAttention
-                              TextHighlightBackground TextHighlightForeground IMERawInputBackground
-                              IMERawInputForeground IMERawInputUnderline IMESelectedRawTextBackground
-                              IMESelectedRawTextForeground IMESelectedRawTextUnderline
-                              IMEConvertedTextBackground IMEConvertedTextForeground IMEConvertedTextUnderline
-                              IMESelectedConvertedTextBackground IMESelectedConvertedTextForeground
-                              IMESelectedConvertedTextUnderline SpellCheckerUnderline""".split()
-        %>
-        use gecko_bindings::bindings::Gecko_GetLookAndFeelSystemColor;
-        use gecko_bindings::structs::root::mozilla::LookAndFeel_ColorID;
-        use std::fmt;
-        use style_traits::ToCss;
-
-        pub type SystemColor = LookAndFeel_ColorID;
-
-        impl ToCss for SystemColor {
-            fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-                let s = match *self {
-                    % for color in system_colors + extra_colors:
-                        LookAndFeel_ColorID::eColorID_${to_rust_ident(color)} => "${color}",
+    impl SystemColor {
+        pub fn parse<'i, 't>(input: &mut Parser<'i, 't>,) -> Result<Self, ()> {
+            ascii_case_insensitive_phf_map! {
+                color_name -> SystemColor = {
+                    % for color in system_colors:
+                        "${color}" => LookAndFeel_ColorID::eColorID_${to_rust_ident(color)},
                     % endfor
-                    LookAndFeel_ColorID::eColorID_LAST_COLOR => unreachable!(),
-                };
-                dest.write_str(s)
-            }
-        }
-
-        impl ToComputedValue for SystemColor {
-            type ComputedValue = u32; // nscolor
-            #[inline]
-            fn to_computed_value(&self, cx: &Context) -> Self::ComputedValue {
-                unsafe {
-                    Gecko_GetLookAndFeelSystemColor(*self as i32,
-                                                    cx.device().pres_context())
                 }
             }
 
-            #[inline]
-            fn from_computed_value(_: &Self::ComputedValue) -> Self {
-                unreachable!()
-            }
+            let ident = input.expect_ident().map_err(|_| ())?;
+            color_name(ident).cloned().ok_or(())
         }
-
-        impl SystemColor {
-            pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
-                ascii_case_insensitive_phf_map! {
-                    color_name -> SystemColor = {
-                        % for color in system_colors:
-                            "${color}" => LookAndFeel_ColorID::eColorID_${to_rust_ident(color)},
-                        % endfor
-                    }
-                }
-
-                let ident = input.expect_ident()?;
-                if let Some(color) = color_name(&ident) {
-                    Ok(*color)
-                } else {
-                    Err(SelectorParseError::UnexpectedIdent(ident.clone()).into())
-                }
-            }
-        }
-    % endif
-</%helpers:longhand>
+    }
+}
+% endif

--- a/components/style/values/computed/color.rs
+++ b/components/style/values/computed/color.rs
@@ -26,6 +26,9 @@ pub struct Color {
 /// Computed value type for the specified RGBAColor.
 pub type RGBAColor = RGBA;
 
+/// The computed value of the `color` property.
+pub type ColorPropertyValue = RGBA;
+
 impl Color {
     /// Returns a numeric color representing the given RGBA value.
     pub fn rgba(rgba: RGBA) -> Color {

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -35,7 +35,7 @@ pub use self::background::BackgroundSize;
 pub use self::border::{BorderImageSlice, BorderImageWidth, BorderImageSideWidth};
 pub use self::border::{BorderRadius, BorderCornerRadius};
 pub use self::box_::VerticalAlign;
-pub use self::color::{Color, RGBAColor};
+pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};
 pub use self::flex::FlexBasis;
 pub use self::image::{Gradient, GradientItem, Image, ImageLayer, LineDirection, MozImageRect};

--- a/components/style/values/specified/color.rs
+++ b/components/style/values/specified/color.rs
@@ -10,7 +10,7 @@ use gecko_bindings::structs::nscolor;
 use itoa;
 use parser::{ParserContext, Parse};
 #[cfg(feature = "gecko")]
-use properties::longhands::color::SystemColor;
+use properties::longhands::system_colors::SystemColor;
 use std::fmt;
 use std::io::Write;
 use style_traits::{ToCss, ParseError, StyleParseError, ValueParseError};
@@ -327,5 +327,34 @@ impl ToComputedValue for RGBAColor {
 impl From<Color> for RGBAColor {
     fn from(color: Color) -> RGBAColor {
         RGBAColor(color)
+    }
+}
+
+/// Specified value for the "color" property, which resolves the `currentcolor`
+/// keyword to the parent color instead of self's color.
+#[derive(Clone, Debug, PartialEq, ToCss)]
+pub struct ColorPropertyValue(pub Color);
+
+impl ToComputedValue for ColorPropertyValue {
+    type ComputedValue = RGBA;
+
+    #[inline]
+    fn to_computed_value(&self, context: &Context) -> RGBA {
+        self.0.to_computed_value(context)
+            .to_rgba(context.builder.get_parent_color().clone_color())
+    }
+
+    #[inline]
+    fn from_computed_value(computed: &RGBA) -> Self {
+        ColorPropertyValue(Color::rgba(*computed).into())
+    }
+}
+
+impl Parse for ColorPropertyValue {
+    fn parse<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self, ParseError<'i>> {
+        Color::parse_quirky(context, input, AllowQuirks::Yes).map(ColorPropertyValue)
     }
 }

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -32,7 +32,7 @@ pub use self::background::BackgroundSize;
 pub use self::border::{BorderCornerRadius, BorderImageSlice, BorderImageWidth};
 pub use self::border::{BorderImageSideWidth, BorderRadius, BorderSideWidth};
 pub use self::box_::VerticalAlign;
-pub use self::color::{Color, RGBAColor};
+pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};
 pub use self::flex::FlexBasis;
 #[cfg(feature = "gecko")]


### PR DESCRIPTION
I want to play with autogenerating style structs, and color is the smallest
struct out there.

However, moving it out of the mako file is a requirement. This patch does that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18359)
<!-- Reviewable:end -->
