### PR TITLE
use cargo manifest path to find build.py

### DIFF
--- a/components/style/build.rs
+++ b/components/style/build.rs
@@ -69,7 +69,8 @@ fn generate_properties() {
         }
     }
 
-    let script = Path::new(file!()).parent().unwrap().join("properties").join("build.py");
+    let script = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("properties").join("build.py");
     let product = if cfg!(feature = "gecko") { "gecko" } else { "servo" };
     let status = Command::new(&*PYTHON)
         .arg(&script)


### PR DESCRIPTION
Without this, build.py can't be found when servo is built as a dependency.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18363)
<!-- Reviewable:end -->
