### PR TITLE
Don't allow interpolating SVGPaintKind::None.

### DIFF
--- a/components/style/values/generics/svg.rs
+++ b/components/style/values/generics/svg.rs
@@ -35,6 +35,7 @@ pub struct SVGPaint<ColorType, UrlPaintServer> {
 #[derive(ToAnimatedValue, ToAnimatedZero, ToComputedValue, ToCss)]
 pub enum SVGPaintKind<ColorType, UrlPaintServer> {
     /// `none`
+    #[animation(error)]
     None,
     /// `<color>`
     Color(ColorType),


### PR DESCRIPTION
This is a PR for https://bugzilla.mozilla.org/show_bug.cgi?id=1396483 

PR #18103 disallowed interpolation between fill:none and fill:none, but that change was regressed by the refactoring in PR #18239.
This patch restores the intended behavior, disabling animation of SVGPaintKind::None.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ x ] `./mach build -d` does not report any errors
- [ x ] `./mach test-tidy` does not report any errors

<!-- Either: -->
There are already these tests in dom/smil/tests of gecko, this PR will enable these tests.
For detail, see https://bugzilla.mozilla.org/show_bug.cgi?id=1396483 .

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18364)
<!-- Reviewable:end -->
