### PR TITLE
stylo: Store location information for keyframe rules.

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -2337,9 +2337,10 @@ extern "C" {
      -> u32;
 }
 extern "C" {
-    pub fn Servo_KeyframesRule_GetKeyframe(rule:
-                                               RawServoKeyframesRuleBorrowed,
-                                           index: u32)
+    pub fn Servo_KeyframesRule_GetKeyframeAt(rule:
+                                                 RawServoKeyframesRuleBorrowed,
+                                             index: u32, line: *mut u32,
+                                             column: *mut u32)
      -> RawServoKeyframeStrong;
 }
 extern "C" {

--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -587,7 +587,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for NestedRulePa
 }
 
 /// Adjust a location's column to accommodate DevTools.
-fn get_location_with_offset(location: SourceLocation) -> SourceLocation {
+pub fn get_location_with_offset(location: SourceLocation) -> SourceLocation {
     SourceLocation {
         line: location.line,
         // Column offsets are not yet supported, but Gecko devtools expect 1-based columns.

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1509,11 +1509,16 @@ pub extern "C" fn Servo_KeyframesRule_GetCount(rule: RawServoKeyframesRuleBorrow
 }
 
 #[no_mangle]
-pub extern "C" fn Servo_KeyframesRule_GetKeyframe(rule: RawServoKeyframesRuleBorrowed, index: u32)
-                                                  -> RawServoKeyframeStrong {
-    read_locked_arc(rule, |rule: &KeyframesRule| {
-        rule.keyframes[index as usize].clone().into_strong()
-    })
+pub extern "C" fn Servo_KeyframesRule_GetKeyframeAt(rule: RawServoKeyframesRuleBorrowed, index: u32,
+                                                    line: *mut u32, column: *mut u32) -> RawServoKeyframeStrong {
+    let global_style_data = &*GLOBAL_STYLE_DATA;
+    let guard = global_style_data.shared_lock.read();
+    let key = Locked::<KeyframesRule>::as_arc(&rule).read_with(&guard)
+                  .keyframes[index as usize].clone();
+    let location = key.read_with(&guard).source_location;
+    *unsafe { line.as_mut().unwrap() } = location.line as u32;
+    *unsafe { column.as_mut().unwrap() } = location.column as u32;
+    key.into_strong()
 }
 
 #[no_mangle]

--- a/tests/unit/style/keyframes.rs
+++ b/tests/unit/style/keyframes.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use cssparser::SourceLocation;
 use servo_arc::Arc;
 use style::properties::{PropertyDeclaration, PropertyDeclarationBlock, Importance};
 use style::properties::animated_properties::AnimatableLonghand;
@@ -29,10 +30,12 @@ fn test_empty_keyframe() {
 #[test]
 fn test_no_property_in_keyframe() {
     let shared_lock = SharedRwLock::new();
+    let dummy_location = SourceLocation { line: 0, column: 0 };
     let keyframes = vec![
         Arc::new(shared_lock.wrap(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(1.)]),
-            block: Arc::new(shared_lock.wrap(PropertyDeclarationBlock::new()))
+            block: Arc::new(shared_lock.wrap(PropertyDeclarationBlock::new())),
+            source_location: dummy_location,
         })),
     ];
     let animation = KeyframesAnimation::from_keyframes(&keyframes,
@@ -73,15 +76,18 @@ fn test_missing_property_in_initial_keyframe() {
             block
         }));
 
+    let dummy_location = SourceLocation { line: 0, column: 0 };
     let keyframes = vec![
         Arc::new(shared_lock.wrap(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(0.)]),
             block: declarations_on_initial_keyframe.clone(),
+            source_location: dummy_location,
         })),
 
         Arc::new(shared_lock.wrap(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(1.)]),
             block: declarations_on_final_keyframe.clone(),
+            source_location: dummy_location,
         })),
     ];
     let animation = KeyframesAnimation::from_keyframes(&keyframes,
@@ -133,15 +139,18 @@ fn test_missing_property_in_final_keyframe() {
             Importance::Normal,
         )));
 
+    let dummy_location = SourceLocation { line: 0, column: 0 };
     let keyframes = vec![
         Arc::new(shared_lock.wrap(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(0.)]),
             block: declarations_on_initial_keyframe.clone(),
+            source_location: dummy_location,
         })),
 
         Arc::new(shared_lock.wrap(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(1.)]),
             block: declarations_on_final_keyframe.clone(),
+            source_location: dummy_location,
         })),
     ];
     let animation = KeyframesAnimation::from_keyframes(&keyframes,
@@ -186,14 +195,17 @@ fn test_missing_keyframe_in_both_of_initial_and_final_keyframe() {
             block
         }));
 
+    let dummy_location = SourceLocation { line: 0, column: 0 };
     let keyframes = vec![
         Arc::new(shared_lock.wrap(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(0.)]),
-            block: Arc::new(shared_lock.wrap(PropertyDeclarationBlock::new()))
+            block: Arc::new(shared_lock.wrap(PropertyDeclarationBlock::new())),
+            source_location: dummy_location,
         })),
         Arc::new(shared_lock.wrap(Keyframe {
             selector: KeyframeSelector::new_for_unit_testing(vec![KeyframePercentage::new(0.5)]),
             block: declarations.clone(),
+            source_location: dummy_location,
         })),
     ];
     let animation = KeyframesAnimation::from_keyframes(&keyframes,

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -217,7 +217,11 @@ fn test_parse_stylesheet() {
                                 (PropertyDeclaration::Width(
                                     LengthOrPercentageOrAuto::Percentage(Percentage(0.))),
                                  Importance::Normal),
-                            ])))
+                            ]))),
+                            source_location: SourceLocation {
+                                line: 17,
+                                column: 13,
+                            },
                         })),
                         Arc::new(stylesheet.shared_lock.wrap(Keyframe {
                             selector: KeyframeSelector::new_for_unit_testing(
@@ -231,6 +235,10 @@ fn test_parse_stylesheet() {
                                         vec![TimingFunction::ease()])),
                                  Importance::Normal),
                             ]))),
+                            source_location: SourceLocation {
+                                line: 18,
+                                column: 13,
+                            },
                         })),
                     ],
                     vendor_prefix: None,


### PR DESCRIPTION
So far, we only store location info for the whole Keyframes block, not for each
of the keyframe rule. Without this info, the devtool can't present the rules
on the devtool panel properly.

In this patch, we collect the source location info while parsing keyframe selector.
The binding function, Servo_KeyframesRule_GetKeyframe, is also fixed (and renamed
to Servo_KeyframesRule_GetKeyframeAt to match the fix) to accept line and column
parameters from Gecko, so we can pass/set them with the source location from Servo.

This is the servo part of [Bug 1394994](https://bugzilla.mozilla.org/show_bug.cgi?id=1394994).

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1394994](https://bugzilla.mozilla.org/show_bug.cgi?id=1394994)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18365)
<!-- Reviewable:end -->
