### PR TITLE
style: Avoid dropping the other threads' TLS contexts too early.

### DIFF
--- a/components/style/driver.rs
+++ b/components/style/driver.rs
@@ -115,7 +115,7 @@ where
         let mut aggregate =
             mem::replace(&mut context.thread_local.statistics, Default::default());
         let parallel = maybe_tls.is_some();
-        if let Some(tls) = maybe_tls {
+        if let Some(ref mut tls) = maybe_tls {
             let slots = unsafe { tls.unsafe_get() };
             aggregate = slots.iter().fold(aggregate, |acc, t| {
                 match *t.borrow() {

--- a/components/style/driver.rs
+++ b/components/style/driver.rs
@@ -13,7 +13,6 @@ use parallel;
 use parallel::{DispatchMode, WORK_UNIT_MAX};
 use rayon;
 use scoped_tls::ScopedTLS;
-use std::borrow::Borrow;
 use std::collections::VecDeque;
 use std::mem;
 use time;
@@ -120,7 +119,7 @@ where
             aggregate = slots.iter().fold(aggregate, |acc, t| {
                 match *t.borrow() {
                     None => acc,
-                    Some(ref cx) => &cx.borrow().statistics + &acc,
+                    Some(ref cx) => &cx.statistics + &acc,
                 }
             });
         }


### PR DESCRIPTION
When collecting style statistics, we have this path that moves the TLS contexts
to be dropped before the local context.

Since destroying the TLS context runs the sequential task queue, that means that
sequential tasks would be executed sooner than usual, before we drop the main
thread TLS context.

Since we have that reuse of the main thread context's bloom filter, and some
tasks end up creating one (Servo_StyleSet_GetBaseComputedValuesForElement, I'm
looking at you), we may borrow the bloom filter before we're done with it on the
traversal code path.

This was hitting on YouTube, when DUMP_STYLE_STATISTICS was used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18366)
<!-- Reviewable:end -->
