### PR TITLE
Remove integrity metadata checking with "no-cors"

### DIFF
--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -324,10 +324,6 @@ impl Request {
                     "The mode is 'no-cors' but the method is not a cors-safelisted method".to_string()));
             }
             // Step 30.2
-            if !borrowed_request.integrity_metadata.is_empty() {
-                return Err(Error::Type("Integrity metadata is not an empty string".to_string()));
-            }
-            // Step 30.3
             r.Headers().set_guard(Guard::RequestNoCors);
         }
 

--- a/tests/wpt/web-platform-tests/fetch/api/request/request-error.html
+++ b/tests/wpt/web-platform-tests/fetch/api/request/request-error.html
@@ -53,12 +53,6 @@
 
       test(function() {
         assert_throws(new TypeError() ,
-                      function() { new Request("", {"mode" : "no-cors", "integrity" : "not  an empty string"}); },
-                      "Expect TypeError exception");
-      },"RequestInit's mode is no-cors and integrity is not empty");
-
-      test(function() {
-        assert_throws(new TypeError() ,
                       function() { new Request("", {"mode" : "cors", "cache" : "only-if-cached"}); },
                       "Expect TypeError exception");
       },"RequestInit's cache mode is only-if-cached and mode is not same-origin");


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Deleted `integrity metadata` check and its tests case according to this: https://github.com/whatwg/fetch/pull/584

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #18345 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

I've deleted the tests of this case, but we probably should add `a success one` for this, since I have no idea about the folder and name, I will wait for whatwg provider it and copy from them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18369)
<!-- Reviewable:end -->
