### PR TITLE
Fix WebGL texture_float and texture_half_float detection on some GPUs

### DIFF
--- a/components/script/dom/webgl_extensions/ext/oestexturefloat.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturefloat.rs
@@ -32,7 +32,8 @@ impl WebGLExtension for OESTextureFloat {
 
     fn is_supported(ext: &WebGLExtensions) -> bool {
         ext.supports_any_gl_extension(&["GL_OES_texture_float",
-                                        "GL_ARB_texture_float"])
+                                        "GL_ARB_texture_float",
+                                        "GL_EXT_color_buffer_float"])
     }
 
     fn enable(ext: &WebGLExtensions) {

--- a/components/script/dom/webgl_extensions/ext/oestexturehalffloat.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturehalffloat.rs
@@ -33,7 +33,8 @@ impl WebGLExtension for OESTextureHalfFloat {
     fn is_supported(ext: &WebGLExtensions) -> bool {
         ext.supports_any_gl_extension(&["GL_OES_texture_half_float",
                                         "GL_ARB_half_float_pixel",
-                                        "GL_NV_half_float"])
+                                        "GL_NV_half_float",
+                                        "GL_EXT_color_buffer_half_float"])
     }
 
     fn enable(ext: &WebGLExtensions) {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fix WebGL texture_float and texture_half_float detection on some GPUs. Some of them use different extension names.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18383)
<!-- Reviewable:end -->
