### PR TITLE
Bypass the lock in get_property_value

### DIFF
--- a/components/style/shared_lock.rs
+++ b/components/style/shared_lock.rs
@@ -176,6 +176,13 @@ impl<T> Locked<T> {
         }
     }
 
+    /// Access the data for reading without verifying the lock. Use with caution.
+    #[cfg(feature = "gecko")]
+    pub unsafe fn read_unchecked<'a>(&'a self) -> &'a T {
+        let ptr = self.data.get();
+        &*ptr
+    }
+
     /// Access the data for writing.
     pub fn write_with<'a>(&'a self, guard: &'a mut SharedRwLockWriteGuard) -> &'a mut T {
         assert!(self.same_lock_as(&guard.0),


### PR DESCRIPTION
This measurably improves performance - see https://bugzilla.mozilla.org/show_bug.cgi?id=1355599#c21

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18386)
<!-- Reviewable:end -->
