### PR TITLE
Reduce duplication in generated ServoComputedData::to_declaration_block.

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -342,29 +342,27 @@ impl ComputedValuesInner {
     pub fn is_multicol(&self) -> bool { false }
 
     pub fn to_declaration_block(&self, property: PropertyDeclarationId) -> PropertyDeclarationBlock {
-        match property {
+        let value = match property {
             % for prop in data.longhands:
                 % if prop.animatable:
                     PropertyDeclarationId::Longhand(LonghandId::${prop.camel_case}) => {
-                         PropertyDeclarationBlock::with_one(
-                            PropertyDeclaration::${prop.camel_case}(
-                                % if prop.boxed:
-                                    Box::new(
-                                % endif
-                                longhands::${prop.ident}::SpecifiedValue::from_computed_value(
-                                  &self.get_${prop.style_struct.ident.strip("_")}().clone_${prop.ident}())
-                                % if prop.boxed:
-                                    )
-                                % endif
-                            ),
-                            Importance::Normal
+                        PropertyDeclaration::${prop.camel_case}(
+                            % if prop.boxed:
+                                Box::new(
+                            % endif
+                            longhands::${prop.ident}::SpecifiedValue::from_computed_value(
+                              &self.get_${prop.style_struct.ident.strip("_")}().clone_${prop.ident}())
+                            % if prop.boxed:
+                                )
+                            % endif
                         )
                     },
                 % endif
             % endfor
             PropertyDeclarationId::Custom(_name) => unimplemented!(),
             _ => unimplemented!()
-        }
+        };
+        PropertyDeclarationBlock::with_one(value, Importance::Normal)
     }
 }
 


### PR DESCRIPTION
This reduces the size of the code in libXUL by 23.4k according to bloaty.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18396)
<!-- Reviewable:end -->
