### PR TITLE
Measure selectors.

### DIFF
--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -423,7 +423,6 @@ impl<Impl: SelectorImpl> Selector<Impl> {
         ))
     }
 
-
     /// Returns an iterator over this selector in matching order (right-to-left).
     /// When a combinator is reached, the iterator will return None, and
     /// next_sequence() may be called to continue to the next sequence.
@@ -493,6 +492,11 @@ impl<Impl: SelectorImpl> Selector<Impl> {
     /// Returns count of simple selectors and combinators in the Selector.
     pub fn len(&self) -> usize {
         self.0.slice.len()
+    }
+
+    /// Returns the address on the heap of the ThinArc for memory reporting.
+    pub fn thin_arc_heap_ptr(&self) -> *const ::std::os::raw::c_void {
+        self.0.heap_ptr()
     }
 }
 

--- a/components/servo_arc/lib.rs
+++ b/components/servo_arc/lib.rs
@@ -676,6 +676,12 @@ impl<H: 'static, T: 'static> ThinArc<H, T> {
         // Forward the result.
         result
     }
+
+    /// Returns the address on the heap of the ThinArc itself -- not the T
+    /// within it -- for memory reporting.
+    pub fn heap_ptr(&self) -> *const c_void {
+        self.ptr as *const ArcInner<T> as *const c_void
+    }
 }
 
 impl<H, T> Deref for ThinArc<H, T> {

--- a/components/style/stylesheets/document_rule.rs
+++ b/components/style/stylesheets/document_rule.rs
@@ -13,7 +13,7 @@ use servo_arc::Arc;
 use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked, SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt;
 use style_traits::{ToCss, ParseError, StyleParseError};
-use stylesheets::CssRules;
+use stylesheets::{CssRules, MallocSizeOfFn, MallocSizeOfWithGuard};
 use values::specified::url::SpecifiedUrl;
 
 #[derive(Debug)]
@@ -25,6 +25,15 @@ pub struct DocumentRule {
     pub rules: Arc<Locked<CssRules>>,
     /// The line and column of the rule's source code.
     pub source_location: SourceLocation,
+}
+
+impl DocumentRule {
+    /// Measure heap usage.
+    pub fn malloc_size_of_children(&self, guard: &SharedRwLockReadGuard,
+                                   malloc_size_of: MallocSizeOfFn) -> usize {
+        // Measurement of other fields may be added later.
+        self.rules.read_with(guard).malloc_size_of_children(guard, malloc_size_of)
+    }
 }
 
 impl ToCssWithGuard for DocumentRule {

--- a/components/style/stylesheets/media_rule.rs
+++ b/components/style/stylesheets/media_rule.rs
@@ -12,7 +12,7 @@ use servo_arc::Arc;
 use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked, SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt;
 use style_traits::ToCss;
-use stylesheets::CssRules;
+use stylesheets::{CssRules, MallocSizeOfFn, MallocSizeOfWithGuard};
 
 /// An [`@media`][media] urle.
 ///
@@ -25,6 +25,15 @@ pub struct MediaRule {
     pub rules: Arc<Locked<CssRules>>,
     /// The source position where this media rule was found.
     pub source_location: SourceLocation,
+}
+
+impl MediaRule {
+    /// Measure heap usage.
+    pub fn malloc_size_of_children(&self, guard: &SharedRwLockReadGuard,
+                                   malloc_size_of: MallocSizeOfFn) -> usize {
+        // Measurement of other fields may be added later.
+        self.rules.read_with(guard).malloc_size_of_children(guard, malloc_size_of)
+    }
 }
 
 impl ToCssWithGuard for MediaRule {

--- a/components/style/stylesheets/mod.rs
+++ b/components/style/stylesheets/mod.rs
@@ -116,21 +116,40 @@ impl MallocSizeOfWithGuard for CssRule {
         malloc_size_of: MallocSizeOfFn
     ) -> usize {
         match *self {
+            // Not all fields are currently fully measured. Extra measurement
+            // may be added later.
+
+            CssRule::Namespace(_) => 0,
+
+            // We don't need to measure ImportRule::stylesheet because we measure
+            // it on the C++ side in the child list of the ServoStyleSheet.
+            CssRule::Import(_) => 0,
+
             CssRule::Style(ref lock) => {
                 lock.read_with(guard).malloc_size_of_children(guard, malloc_size_of)
             },
-            // Measurement of these fields may be added later.
-            CssRule::Import(_) => 0,
-            CssRule::Media(_) => 0,
+
+            CssRule::Media(ref lock) => {
+                lock.read_with(guard).malloc_size_of_children(guard, malloc_size_of)
+            },
+
             CssRule::FontFace(_) => 0,
             CssRule::FontFeatureValues(_) => 0,
             CssRule::CounterStyle(_) => 0,
-            CssRule::Keyframes(_) => 0,
-            CssRule::Namespace(_) => 0,
             CssRule::Viewport(_) => 0,
-            CssRule::Supports(_) => 0,
-            CssRule::Page(_) => 0,
-            CssRule::Document(_)  => 0,
+            CssRule::Keyframes(_) => 0,
+
+            CssRule::Supports(ref lock) => {
+                lock.read_with(guard).malloc_size_of_children(guard, malloc_size_of)
+            },
+
+            CssRule::Page(ref lock) => {
+                lock.read_with(guard).malloc_size_of_children(guard, malloc_size_of)
+            },
+
+            CssRule::Document(ref lock) => {
+                lock.read_with(guard).malloc_size_of_children(guard, malloc_size_of)
+            },
         }
     }
 }

--- a/components/style/stylesheets/page_rule.rs
+++ b/components/style/stylesheets/page_rule.rs
@@ -12,6 +12,7 @@ use servo_arc::Arc;
 use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked, SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt;
 use style_traits::ToCss;
+use stylesheets::{MallocSizeOf, MallocSizeOfFn};
 
 /// A [`@page`][page] rule.
 ///
@@ -28,6 +29,15 @@ pub struct PageRule {
     pub block: Arc<Locked<PropertyDeclarationBlock>>,
     /// The source position this rule was found at.
     pub source_location: SourceLocation,
+}
+
+impl PageRule {
+    /// Measure heap usage.
+    pub fn malloc_size_of_children(&self, guard: &SharedRwLockReadGuard,
+                                   malloc_size_of: MallocSizeOfFn) -> usize {
+        // Measurement of other fields may be added later.
+        self.block.read_with(guard).malloc_size_of_children(malloc_size_of)
+    }
 }
 
 impl ToCssWithGuard for PageRule {

--- a/components/style/stylesheets/supports_rule.rs
+++ b/components/style/stylesheets/supports_rule.rs
@@ -13,7 +13,7 @@ use servo_arc::Arc;
 use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked, SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt;
 use style_traits::{ToCss, ParseError, StyleParseError};
-use stylesheets::{CssRuleType, CssRules};
+use stylesheets::{CssRuleType, CssRules, MallocSizeOfFn, MallocSizeOfWithGuard};
 
 /// An [`@supports`][supports] rule.
 ///
@@ -28,6 +28,15 @@ pub struct SupportsRule {
     pub enabled: bool,
     /// The line and column of the rule's source code.
     pub source_location: SourceLocation,
+}
+
+impl SupportsRule {
+    /// Measure heap usage.
+    pub fn malloc_size_of_children(&self, guard: &SharedRwLockReadGuard,
+                                   malloc_size_of: MallocSizeOfFn) -> usize {
+        // Measurement of other fields may be added later.
+        self.rules.read_with(guard).malloc_size_of_children(guard, malloc_size_of)
+    }
 }
 
 impl ToCssWithGuard for SupportsRule {


### PR DESCRIPTION
This patch adds measurement of Selectors within StyleRule. This requires
exposing the pointer within ThinArc.

The patch also adds measurement of the several CssRule variants, in order to
measure nested CssRules (and PropertyDeclarationBlocks) within them:
DocumentRule, MediaRule, PageRule, SupportsRule.

<!-- Please describe your changes on the following line: -->

r? @heycam 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because testing is in Gecko.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18400)
<!-- Reviewable:end -->
