### PR TITLE
More codesize reductions for generated code

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -32,6 +32,7 @@ use selectors::parser::SelectorParseError;
 use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::cmp;
+use std::fmt;
 #[cfg(feature = "gecko")] use hash::FnvHashMap;
 use style_traits::ParseError;
 use super::ComputedValues;
@@ -72,7 +73,7 @@ pub trait RepeatableListAnimatable: Animate {}
 /// NOTE: This includes the 'display' property since it is animatable from SMIL even though it is
 /// not animatable from CSS animations or Web Animations. CSS transitions also does not allow
 /// animating 'display', but for CSS transitions we have the separate TransitionProperty type.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum AnimatableLonghand {
@@ -82,6 +83,19 @@ pub enum AnimatableLonghand {
             ${prop.camel_case},
         % endif
     % endfor
+}
+
+impl fmt::Debug for AnimatableLonghand {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let name = match *self {
+            % for property in data.longhands:
+                % if property.animatable:
+                    AnimatableLonghand::${property.camel_case} => "${property.camel_case}",
+                % endif
+            % endfor
+        };
+        formatter.write_str(name)
+    }
 }
 
 impl AnimatableLonghand {
@@ -204,7 +218,7 @@ pub fn nscsspropertyid_is_animatable(property: nsCSSPropertyID) -> bool {
 // beforehand.
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
-#[derive(Clone, Debug, Eq, Hash, PartialEq, ToCss, ToComputedValue)]
+#[derive(Clone, Eq, Hash, PartialEq, ToCss, ToComputedValue)]
 pub enum TransitionProperty {
     /// All, any transitionable property changing should generate a transition.
     All,
@@ -217,6 +231,25 @@ pub enum TransitionProperty {
     /// Unrecognized property which could be any non-transitionable, custom property, or
     /// unknown property.
     Unsupported(CustomIdent)
+}
+
+impl fmt::Debug for TransitionProperty {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let name = match *self {
+            % for property in data.longhands + data.shorthands_except_all():
+                % if property.transitionable:
+                    TransitionProperty::${property.camel_case} => "${property.camel_case}",
+                % endif
+            % endfor
+            TransitionProperty::All => "All",
+            TransitionProperty::Unsupported(ref ident) => {
+                formatter.write_str("Unsupported(")?;
+                ident.fmt(formatter)?;
+                return formatter.write_str(")");
+            }
+        };
+        formatter.write_str(name)
+    }
 }
 
 impl TransitionProperty {
@@ -484,7 +517,7 @@ unsafe impl HasSimpleFFI for AnimationValueMap {}
 ///
 /// FIXME: We need to add a path for custom properties, but that's trivial after
 /// this (is a similar path to that of PropertyDeclaration).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum AnimationValue {
     % for prop in data.longhands:
@@ -497,6 +530,19 @@ pub enum AnimationValue {
             % endif
         % endif
     % endfor
+}
+
+impl fmt::Debug for AnimationValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let name = match *self {
+        % for prop in data.longhands:
+            % if prop.animatable:
+                AnimationValue::${prop.camel_case}(..) => "${prop.camel_case}",
+            % endif
+        % endfor
+        };
+        formatter.write_str(name)
+    }
 }
 
 impl AnimationValue {

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -316,19 +316,20 @@ impl<'a> From< &'a TransitionProperty> for nsCSSPropertyID {
 #[allow(non_upper_case_globals)]
 impl From<nsCSSPropertyID> for TransitionProperty {
     fn from(property: nsCSSPropertyID) -> TransitionProperty {
-        match property {
+        let unsupported = match property {
             % for prop in data.longhands + data.shorthands_except_all():
                 % if prop.transitionable:
                     ${helpers.to_nscsspropertyid(prop.ident)}
-                        => TransitionProperty::${prop.camel_case},
+                        => return TransitionProperty::${prop.camel_case},
                 % else:
                     ${helpers.to_nscsspropertyid(prop.ident)}
-                        => TransitionProperty::Unsupported(CustomIdent(Atom::from("${prop.ident}"))),
+                        => "${prop.ident}",
                 % endif
             % endfor
-            nsCSSPropertyID::eCSSPropertyExtra_all_properties => TransitionProperty::All,
+            nsCSSPropertyID::eCSSPropertyExtra_all_properties => return TransitionProperty::All,
             _ => panic!("Unconvertable nsCSSPropertyID: {:?}", property),
-        }
+        };
+        TransitionProperty::Unsupported(CustomIdent(Atom::from(unsupported)))
     }
 }
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -446,7 +446,7 @@ bitflags! {
 }
 
 /// An identifier for a given longhand property.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum LonghandId {
@@ -454,6 +454,12 @@ pub enum LonghandId {
         /// ${property.name}
         ${property.camel_case} = ${i},
     % endfor
+}
+
+impl fmt::Debug for LonghandId {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(self.name())
+    }
 }
 
 impl LonghandId {
@@ -3597,13 +3603,24 @@ pub fn modify_border_style_for_inline_sides(style: &mut Arc<ComputedValues>,
 }
 
 /// An identifier for a given alias property.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum AliasId {
     % for i, property in enumerate(data.all_aliases()):
         /// ${property.name}
         ${property.camel_case} = ${i},
     % endfor
+}
+
+impl fmt::Debug for AliasId {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let name = match *self {
+            % for property in data.all_aliases():
+                AliasId::${property.camel_case} => "${property.camel_case}",
+            % endfor
+        };
+        formatter.write_str(name)
+    }
 }
 
 impl AliasId {


### PR DESCRIPTION
Bloaty says this shaves off another 20kb from style::properties-based functions. The more limited Debug implementations enable sharing the property name strings between more functions, which saves on code size in the end.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18415)
<!-- Reviewable:end -->
