### PR TITLE
update mach.bat if use VS buildtool for Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,12 @@ list of installed components. It is not on by default.
 > If you encountered errors with the environment above, do the following for a workaround:
 > 1.  Download and install [Build Tools for Visual Studio 2017](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15)
 > 2.  Install `python2.7 x86-x64` and `virtualenv`
-> 3.  Since `mach.bat` cannot find the prompt, you should execute `Developer Command Prompt for VS 2017` manually in the Windows menu. ( You may need to choose the type, such as `x86_x64 Cross Tools Command Prompt for VS 2017`, manually if it cannot recognize type correctly. )
-> 4. `cd to/the/path/servo`
-> 5. `python mach build -d`
+> 3.  Run `mach.bat build -d`. 
+
+>If you have troubles with `x64 type` prompt as `mach.bat` set by default:  
+> 1. you may need to choose and launch the type manually, such as `x86_x64 Cross Tools Command Prompt for VS 2017` in the Windows menu.)
+> 2. `cd to/the/path/servo`
+> 3. `python mach build -d`
 
 #### Cross-compilation for Android
 

--- a/mach.bat
+++ b/mach.bat
@@ -10,7 +10,7 @@ set VC14VARS=%VS140COMNTOOLS%..\..\VC\vcvarsall.bat
 IF EXIST "%VC14VARS%" (
   set "VS_VCVARS=%VC14VARS%"
 ) ELSE (
-  for %%e in (Enterprise Professional Community) do (
+  for %%e in (Enterprise Professional Community BuildTools) do (
     IF EXIST "%ProgramFiles32%\Microsoft Visual Studio\2017\%%e\VC\Auxiliary\Build\vcvarsall.bat" (
       set "VS_VCVARS=%ProgramFiles32%\Microsoft Visual Studio\2017\%%e\VC\Auxiliary\Build\vcvarsall.bat"
     )


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Add path in `mach.bat`. If user only install VS buildtool, they now can use `mach.bat`
And therefore modify `README`

Continue to PR #18145 

r? @larsbergstrom 
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18421)
<!-- Reviewable:end -->
