### PR TITLE
stylo: Fix error reporting for invalid values in property alias

### DIFF
--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -934,7 +934,8 @@ pub fn parse_one_declaration_into<R>(declarations: &mut SourcePropertyDeclaratio
     let start_position = parser.position();
     let start_location = parser.current_source_location();
     parser.parse_entirely(|parser| {
-        PropertyDeclaration::parse_into(declarations, id, &context, parser)
+        let name = id.name().into();
+        PropertyDeclaration::parse_into(declarations, id, name, &context, parser)
             .map_err(|e| e.into())
     }).map_err(|err| {
         let error = ContextualParseError::UnsupportedPropertyDeclaration(
@@ -983,7 +984,7 @@ impl<'a, 'b, 'i> DeclarationParser<'i> for PropertyDeclarationParser<'a, 'b> {
             }
         };
         input.parse_until_before(Delimiter::Bang, |input| {
-            PropertyDeclaration::parse_into(self.declarations, id, self.context, input)
+            PropertyDeclaration::parse_into(self.declarations, id, name, self.context, input)
                 .map_err(|e| e.into())
         })?;
         let importance = match input.try(parse_important) {

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -18,7 +18,7 @@ use std::{fmt, mem, ops};
 #[cfg(feature = "gecko")] use std::ptr;
 
 #[cfg(feature = "servo")] use cssparser::RGBA;
-use cssparser::{Parser, TokenSerializationType, serialize_identifier};
+use cssparser::{CowRcStr, Parser, TokenSerializationType, serialize_identifier};
 use cssparser::ParserInput;
 #[cfg(feature = "servo")] use euclid::SideOffsets2D;
 use computed_values;
@@ -1527,12 +1527,13 @@ impl PropertyDeclaration {
     /// to Importance::Normal. Parsing Importance values is the job of PropertyDeclarationParser,
     /// we only set them here so that we don't have to reallocate
     pub fn parse_into<'i, 't>(declarations: &mut SourcePropertyDeclaration,
-                              id: PropertyId, context: &ParserContext, input: &mut Parser<'i, 't>)
+                              id: PropertyId, name: CowRcStr<'i>,
+                              context: &ParserContext, input: &mut Parser<'i, 't>)
                               -> Result<(), PropertyDeclarationParseError<'i>> {
         assert!(declarations.is_empty());
         let start = input.state();
         match id {
-            PropertyId::Custom(name) => {
+            PropertyId::Custom(property_name) => {
                 // FIXME: fully implement https://github.com/w3c/csswg-drafts/issues/774
                 // before adding skip_whitespace here.
                 // This probably affects some test results.
@@ -1544,7 +1545,7 @@ impl PropertyDeclaration {
                         ValueParseError::from_parse_error(e))),
                     }
                 };
-                declarations.push(PropertyDeclaration::Custom(name, value));
+                declarations.push(PropertyDeclaration::Custom(property_name, value));
                 Ok(())
             }
             PropertyId::Longhand(id) => {
@@ -1560,7 +1561,7 @@ impl PropertyDeclaration {
                             input.reset(&start);
                             let (first_token_type, css) =
                                 ::custom_properties::parse_non_custom_with_var(input).map_err(|e| {
-                                    PropertyDeclarationParseError::InvalidValue(id.name().into(),
+                                    PropertyDeclarationParseError::InvalidValue(name,
                                         ValueParseError::from_parse_error(e))
                                 })?;
                             Ok(PropertyDeclaration::WithVariables(id, Arc::new(UnparsedValue {
@@ -1570,7 +1571,7 @@ impl PropertyDeclaration {
                                 from_shorthand: None,
                             })))
                         } else {
-                            Err(PropertyDeclarationParseError::InvalidValue(id.name().into(),
+                            Err(PropertyDeclarationParseError::InvalidValue(name,
                                 ValueParseError::from_parse_error(err)))
                         }
                     })
@@ -1599,7 +1600,7 @@ impl PropertyDeclaration {
                             input.reset(&start);
                             let (first_token_type, css) =
                                 ::custom_properties::parse_non_custom_with_var(input).map_err(|e| {
-                                    PropertyDeclarationParseError::InvalidValue(id.name().into(),
+                                    PropertyDeclarationParseError::InvalidValue(name,
                                         ValueParseError::from_parse_error(e))
                                 })?;
                             let unparsed = Arc::new(UnparsedValue {
@@ -1619,7 +1620,7 @@ impl PropertyDeclaration {
                             }
                             Ok(())
                         } else {
-                            Err(PropertyDeclarationParseError::InvalidValue(id.name().into(),
+                            Err(PropertyDeclarationParseError::InvalidValue(name,
                                 ValueParseError::from_parse_error(err)))
                         }
                     })

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -583,8 +583,8 @@ impl<'a, 'b, 'i> DeclarationParser<'i> for KeyframeDeclarationParser<'a, 'b> {
         let property_context = PropertyParserContext::new(self.context);
 
         let id = PropertyId::parse(&name, Some(&property_context))
-            .map_err(|()| PropertyDeclarationParseError::UnknownProperty(name))?;
-        match PropertyDeclaration::parse_into(self.declarations, id, self.context, input) {
+            .map_err(|()| PropertyDeclarationParseError::UnknownProperty(name.clone()))?;
+        match PropertyDeclaration::parse_into(self.declarations, id, name, self.context, input) {
             Ok(()) => {
                 // In case there is still unparsed text in the declaration, we should roll back.
                 input.expect_exhausted().map_err(|e| e.into())

--- a/components/style/stylesheets/supports_rule.rs
+++ b/components/style/stylesheets/supports_rule.rs
@@ -265,7 +265,7 @@ impl Declaration {
 
             let mut declarations = SourcePropertyDeclaration::new();
             input.parse_until_before(Delimiter::Bang, |input| {
-                PropertyDeclaration::parse_into(&mut declarations, id, &context, input)
+                PropertyDeclaration::parse_into(&mut declarations, id, prop.into(), &context, input)
                     .map_err(|e| StyleParseError::PropertyDeclaration(e).into())
             })?;
             let _ = input.try(parse_important);


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [bug 1384221](https://bugzilla.mozilla.org/show_bug.cgi?id=1384221)
- [X] There are [tests](https://bug1384221.bmoattachments.org/attachment.cgi?id=8906527) for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18444)
<!-- Reviewable:end -->
