### PR TITLE
stylo: fix border-radius longhand specified values serialization

### DIFF
--- a/components/style/gecko/conversions.rs
+++ b/components/style/gecko/conversions.rs
@@ -700,7 +700,8 @@ pub mod basic_shape {
                     LengthOrPercentage::from_gecko_style_coord(&other.data_at(index))
                         .expect("<border-radius> should be a length, percentage, or calc value"),
                     LengthOrPercentage::from_gecko_style_coord(&other.data_at(index + 1))
-                        .expect("<border-radius> should be a length, percentage, or calc value"))
+                        .expect("<border-radius> should be a length, percentage, or calc value"),
+                    true /* height specified */)
             };
 
             GenericBorderRadius {

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -967,7 +967,7 @@ def set_gecko_property(ffi_name, expr):
             let height = GeckoStyleCoordConvertible::from_gecko_style_coord(
                             &self.gecko.${gecko_ffi_name}.data_at(${y_index}))
                             .expect("Failed to clone ${ident}");
-            BorderCornerRadius::new(width, height)
+            BorderCornerRadius::new(width, height, true /* height specified */)
         }
     % endif
 </%def>

--- a/components/style/values/animated/mod.rs
+++ b/components/style/values/animated/mod.rs
@@ -349,7 +349,8 @@ impl ToAnimatedValue for ComputedBorderCornerRadius {
     #[inline]
     fn from_animated_value(animated: Self::AnimatedValue) -> Self {
         ComputedBorderCornerRadius::new(animated.0.width.clamp_to_non_negative(),
-                                        animated.0.height.clamp_to_non_negative())
+                                        animated.0.height.clamp_to_non_negative(),
+                                        true /* height specified */)
     }
 }
 

--- a/components/style/values/specified/border.rs
+++ b/components/style/values/specified/border.rs
@@ -132,17 +132,19 @@ impl Parse for BorderImageSlice {
 impl Parse for BorderRadius {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
         let widths = Rect::parse_with(context, input, LengthOrPercentage::parse_non_negative)?;
+        let mut heights_specified = true;
         let heights = if input.try(|i| i.expect_delim('/')).is_ok() {
             Rect::parse_with(context, input, LengthOrPercentage::parse_non_negative)?
         } else {
+            heights_specified = false;
             widths.clone()
         };
 
         Ok(GenericBorderRadius {
-            top_left: BorderCornerRadius::new(widths.0, heights.0),
-            top_right: BorderCornerRadius::new(widths.1, heights.1),
-            bottom_right: BorderCornerRadius::new(widths.2, heights.2),
-            bottom_left: BorderCornerRadius::new(widths.3, heights.3),
+            top_left: BorderCornerRadius::new(widths.0, heights.0, heights_specified),
+            top_right: BorderCornerRadius::new(widths.1, heights.1, heights_specified),
+            bottom_right: BorderCornerRadius::new(widths.2, heights.2, heights_specified),
+            bottom_left: BorderCornerRadius::new(widths.3, heights.3, heights_specified),
         })
     }
 }
@@ -150,9 +152,13 @@ impl Parse for BorderRadius {
 impl Parse for BorderCornerRadius {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
         let first = LengthOrPercentage::parse_non_negative(context, input)?;
+        let mut heights_specified = true;
         let second = input
             .try(|i| LengthOrPercentage::parse_non_negative(context, i))
-            .unwrap_or_else(|_| first.clone());
-        Ok(Self::new(first, second))
+            .unwrap_or_else(|_| {
+                heights_specified = false;
+                first.clone()
+            });
+        Ok(Self::new(first, second, heights_specified))
     }
 }


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fixes part of [bug 1397619](https://bugzilla.mozilla.org/show_bug.cgi?id=1397619).
- [X] There are tests for these changes attached to bugzilla

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18458)
<!-- Reviewable:end -->
