### PR TITLE
Disable position:sticky tests

### DIFF
--- a/tests/wpt/mozilla/meta/css/css-position-3/__dir__.ini
+++ b/tests/wpt/mozilla/meta/css/css-position-3/__dir__.ini
@@ -1,0 +1,1 @@
+disabled: Sending multiple scrolling positions to WebRender is very flaky in the test harness


### PR DESCRIPTION
Sending scroll positions to Webender is way too flaky to run the
position:sticky tests at this time. We need to disable them for now, so
that other Servo work can continue.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18463)
<!-- Reviewable:end -->
