### PR TITLE
align selectors's features in geckolib and stylo_tests

### DIFF
--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -22,7 +22,11 @@ log = {version = "0.3.5", features = ["release_max_level_info"]}
 malloc_size_of = {path = "../../components/malloc_size_of"}
 nsstring_vendor = {path = "../../components/style/gecko_bindings/nsstring_vendor"}
 parking_lot = "0.4"
-selectors = {path = "../../components/selectors"}
+# Turn on gecko_like_types because of so that crates which use this
+# crate and also dev-depend on stylo_tests get reasonable behavior
+# during rebuilds.  See https://github.com/rust-lang/cargo/issues/3923
+# for the cargo problem behind this.
+selectors = {path = "../../components/selectors", features = ["gecko_like_types"]}
 servo_arc = {path = "../../components/servo_arc"}
 style = {path = "../../components/style", features = ["gecko"]}
 style_traits = {path = "../../components/style_traits"}


### PR DESCRIPTION
Gecko would like to turn on the stylo layout tests (tests/unit/stylo) in
Gecko CI.  The plan for doing this is to add the tests as a
dev-dependency of Gecko's main Rust library, from which `cargo test` can
be run in the usual fashion.

Doing this creates problems for normal development, because the stylo
tests need the `selectors` crate to be compiled with `gecko_like_types`,
whereas the `geckolib` crate does not.  So if we compile `geckolib` in a
non-test build configuration, the `selectors` crate is compiled without
`gecko_like_types`...but then if we compile `geckolib` in a test build
configuration, cargo will evict the previous rlib for the `selectors`
crate and replace it with a `selectors` compiled with gecko_like_types.
And then compiling `geckolib` in a non-test configuration repeats the
process, and so forth.

Needless to say, this is highly annoying behavior.  It is due to a bug
in cargo:

https://github.com/rust-lang/cargo/issues/3923

but it's not known when that bug will get fixed.  In the meantime, we
can just make sure that geckolib's `selectors` is compiled with the same
features as the `selectors` crate in the stylo tests.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18489)
<!-- Reviewable:end -->
