### PR TITLE
layout: Avoid creating multiple scroll roots for sticky tables.

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -2594,6 +2594,10 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
 
         let new_scroll_root_id = ClipId::new(self.fragment.unique_id(IdType::OverflowClip),
                                              state.layout_context.id.to_webrender());
+        if state.has_scroll_root(new_scroll_root_id) {
+            return;
+        }
+
         let parent_id = self.clip_and_scroll_info(state.layout_context.id).scroll_node_id;
         state.add_scroll_root(
             ScrollRoot {


### PR DESCRIPTION
This checks for multiple scroll roots for a given flow in `setup_scroll_root_for_position`, which can happen for tables. Mostly cargo-culted from `setup_scroll_root_for_overflow`, as mentioned in #18441, so let me know if this is the wrong thing to do.

Also, I wasn't sure where to add the testcase @mateon1 created. I also would like his permission (and preferred name/email) to add a separate test commit on his behalf, so I have not included it here yet.

r? @mrobinson

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #18441 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18490)
<!-- Reviewable:end -->
