### PR TITLE
stylo: Preserve variants of 2d translate/rotate/scale functions in computed transform

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3077,6 +3077,9 @@ fn static_assert() {
                 ${transform_function_arm("ScaleY", "scaley", ["number"])}
                 ${transform_function_arm("ScaleZ", "scalez", ["number"])}
                 ${transform_function_arm("Scale", "scale3d", ["number"] * 3)}
+                ${transform_function_arm("RotateX", "rotatex", ["angle"])}
+                ${transform_function_arm("RotateY", "rotatey", ["angle"])}
+                ${transform_function_arm("RotateZ", "rotatez", ["angle"])}
                 ${transform_function_arm("Rotate", "rotate3d", ["number"] * 3 + ["angle"])}
                 ${transform_function_arm("Perspective", "perspective", ["length"])}
                 ${transform_function_arm("InterpolateMatrix", "interpolatematrix",
@@ -3204,6 +3207,9 @@ fn static_assert() {
                 ${computed_operation_arm("ScaleY", "scaley", ["number"])}
                 ${computed_operation_arm("ScaleZ", "scalez", ["number"])}
                 ${computed_operation_arm("Scale", "scale3d", ["number"] * 3)}
+                ${computed_operation_arm("RotateX", "rotatex", ["angle"])}
+                ${computed_operation_arm("RotateY", "rotatey", ["angle"])}
+                ${computed_operation_arm("RotateZ", "rotatez", ["angle"])}
                 ${computed_operation_arm("Rotate", "rotate3d", ["number"] * 3 + ["angle"])}
                 ${computed_operation_arm("Perspective", "perspective", ["length"])}
                 ${computed_operation_arm("InterpolateMatrix", "interpolatematrix",

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3073,6 +3073,9 @@ fn static_assert() {
                 ${transform_function_arm("TranslateY", "translatey", ["lop"])}
                 ${transform_function_arm("TranslateZ", "translatez", ["length"])}
                 ${transform_function_arm("Translate", "translate3d", ["lop", "lop", "length"])}
+                ${transform_function_arm("ScaleX", "scalex", ["number"])}
+                ${transform_function_arm("ScaleY", "scaley", ["number"])}
+                ${transform_function_arm("ScaleZ", "scalez", ["number"])}
                 ${transform_function_arm("Scale", "scale3d", ["number"] * 3)}
                 ${transform_function_arm("Rotate", "rotate3d", ["number"] * 3 + ["angle"])}
                 ${transform_function_arm("Perspective", "perspective", ["length"])}
@@ -3197,6 +3200,9 @@ fn static_assert() {
                 ${computed_operation_arm("TranslateY", "translatey", ["lop"])}
                 ${computed_operation_arm("TranslateZ", "translatez", ["length"])}
                 ${computed_operation_arm("Translate", "translate3d", ["lop", "lop", "length"])}
+                ${computed_operation_arm("ScaleX", "scalex", ["number"])}
+                ${computed_operation_arm("ScaleY", "scaley", ["number"])}
+                ${computed_operation_arm("ScaleZ", "scalez", ["number"])}
                 ${computed_operation_arm("Scale", "scale3d", ["number"] * 3)}
                 ${computed_operation_arm("Rotate", "rotate3d", ["number"] * 3 + ["angle"])}
                 ${computed_operation_arm("Perspective", "perspective", ["length"])}

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3069,6 +3069,9 @@ fn static_assert() {
                 ${transform_function_arm("MatrixWithPercents", "matrix3d", ["number"] * 12 + ["lop"] * 2
                                          + ["length"] + ["number"])}
                 ${transform_function_arm("Skew", "skew", ["angle"] * 2)}
+                ${transform_function_arm("TranslateX", "translatex", ["lop"])}
+                ${transform_function_arm("TranslateY", "translatey", ["lop"])}
+                ${transform_function_arm("TranslateZ", "translatez", ["length"])}
                 ${transform_function_arm("Translate", "translate3d", ["lop", "lop", "length"])}
                 ${transform_function_arm("Scale", "scale3d", ["number"] * 3)}
                 ${transform_function_arm("Rotate", "rotate3d", ["number"] * 3 + ["angle"])}
@@ -3189,6 +3192,10 @@ fn static_assert() {
             match transform_function {
                 ${computed_operation_arm("Matrix", "matrix3d", ["number"] * 16)}
                 ${computed_operation_arm("Skew", "skew", ["angle"] * 2)}
+
+                ${computed_operation_arm("TranslateX", "translatex", ["lop"])}
+                ${computed_operation_arm("TranslateY", "translatey", ["lop"])}
+                ${computed_operation_arm("TranslateZ", "translatez", ["length"])}
                 ${computed_operation_arm("Translate", "translate3d", ["lop", "lop", "length"])}
                 ${computed_operation_arm("Scale", "scale3d", ["number"] * 3)}
                 ${computed_operation_arm("Rotate", "rotate3d", ["number"] * 3 + ["angle"])}

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -1160,6 +1160,9 @@ impl ToAnimatedZero for TransformOperation {
             TransformOperation::Scale(..) => {
                 Ok(TransformOperation::Scale(1.0, 1.0, 1.0))
             },
+            TransformOperation::ScaleX(_) => Ok(TransformOperation::ScaleX(1.)),
+            TransformOperation::ScaleY(_) => Ok(TransformOperation::ScaleY(1.)),
+            TransformOperation::ScaleZ(_) => Ok(TransformOperation::ScaleZ(1.)),
             TransformOperation::Rotate(x, y, z, a) => {
                 let (x, y, z, _) = TransformList::get_normalized_vector_and_angle(x, y, z, a);
                 Ok(TransformOperation::Rotate(x, y, z, Angle::zero()))

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -1163,6 +1163,9 @@ impl ToAnimatedZero for TransformOperation {
             TransformOperation::ScaleX(_) => Ok(TransformOperation::ScaleX(1.)),
             TransformOperation::ScaleY(_) => Ok(TransformOperation::ScaleY(1.)),
             TransformOperation::ScaleZ(_) => Ok(TransformOperation::ScaleZ(1.)),
+            TransformOperation::RotateX(_) => Ok(TransformOperation::RotateX(Angle::zero())),
+            TransformOperation::RotateY(_) => Ok(TransformOperation::RotateY(Angle::zero())),
+            TransformOperation::RotateZ(_) => Ok(TransformOperation::RotateZ(Angle::zero())),
             TransformOperation::Rotate(x, y, z, a) => {
                 let (x, y, z, _) = TransformList::get_normalized_vector_and_angle(x, y, z, a);
                 Ok(TransformOperation::Rotate(x, y, z, Angle::zero()))

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -1135,6 +1135,21 @@ impl ToAnimatedZero for TransformOperation {
                     sy.to_animated_zero()?,
                 ))
             },
+            TransformOperation::TranslateX(ref tx) => {
+                Ok(TransformOperation::TranslateX(
+                    tx.to_animated_zero()?
+                ))
+            },
+            TransformOperation::TranslateY(ref ty) => {
+                Ok(TransformOperation::TranslateY(
+                    ty.to_animated_zero()?
+                ))
+            },
+            TransformOperation::TranslateZ(ref tz) => {
+                Ok(TransformOperation::TranslateZ(
+                    tz.to_animated_zero()?
+                ))
+            },
             TransformOperation::Translate(ref tx, ref ty, ref tz) => {
                 Ok(TransformOperation::Translate(
                     tx.to_animated_zero()?,

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -1231,6 +1231,30 @@ impl Animate for TransformOperation {
                 ))
             },
             (
+                &TransformOperation::TranslateX(ref from),
+                &TransformOperation::TranslateX(ref to),
+            ) => {
+                Ok(TransformOperation::TranslateX(
+                    from.animate(to, procedure)?,
+                ))
+            },
+            (
+                &TransformOperation::TranslateY(ref from),
+                &TransformOperation::TranslateY(ref to),
+            ) => {
+                Ok(TransformOperation::TranslateY(
+                    from.animate(to, procedure)?,
+                ))
+            },
+            (
+                &TransformOperation::TranslateZ(ref from),
+                &TransformOperation::TranslateZ(ref to),
+            ) => {
+                Ok(TransformOperation::TranslateZ(
+                    from.animate(to, procedure)?,
+                ))
+            },
+            (
                 &TransformOperation::Scale(ref fx, ref fy, ref fz),
                 &TransformOperation::Scale(ref tx, ref ty, ref tz),
             ) => {
@@ -1239,6 +1263,48 @@ impl Animate for TransformOperation {
                     animate_multiplicative_factor(*fy, *ty, procedure)?,
                     animate_multiplicative_factor(*fz, *tz, procedure)?,
                 ))
+            },
+            (
+                &TransformOperation::ScaleX(ref from),
+                &TransformOperation::ScaleX(ref to),
+            ) => {
+                Ok(TransformOperation::ScaleX(
+                    animate_multiplicative_factor(*from, *to, procedure)?,
+                ))
+            },
+            (
+                &TransformOperation::ScaleY(ref from),
+                &TransformOperation::ScaleY(ref to),
+            ) => {
+                Ok(TransformOperation::ScaleY(
+                    animate_multiplicative_factor(*from, *to, procedure)?,
+                ))
+            },
+            (
+                &TransformOperation::ScaleZ(ref from),
+                &TransformOperation::ScaleZ(ref to),
+            ) => {
+                Ok(TransformOperation::ScaleZ(
+                    animate_multiplicative_factor(*from, *to, procedure)?,
+                ))
+            },
+            (
+                &TransformOperation::RotateX(ref from),
+                &TransformOperation::RotateX(ref to),
+            ) => {
+                Ok(TransformOperation::RotateX(from.animate(to, procedure)?))
+            },
+            (
+                &TransformOperation::RotateY(ref from),
+                &TransformOperation::RotateY(ref to),
+            ) => {
+                Ok(TransformOperation::RotateY(from.animate(to, procedure)?))
+            },
+            (
+                &TransformOperation::RotateZ(ref from),
+                &TransformOperation::RotateZ(ref to),
+            ) => {
+                Ok(TransformOperation::RotateZ(from.animate(to, procedure)?))
             },
             (
                 &TransformOperation::Rotate(fx, fy, fz, fa),

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -689,6 +689,9 @@ ${helpers.predefined_type(
             Translate(computed::LengthOrPercentage,
                       computed::LengthOrPercentage,
                       computed::Length),
+            ScaleX(CSSFloat),
+            ScaleY(CSSFloat),
+            ScaleZ(CSSFloat),
             Scale(CSSFloat, CSSFloat, CSSFloat),
             Rotate(CSSFloat, CSSFloat, CSSFloat, computed::Angle),
             Perspective(computed::Length),
@@ -1292,15 +1295,15 @@ ${helpers.predefined_type(
                     }
                     SpecifiedOperation::ScaleX(sx) => {
                         let sx = sx.to_computed_value(context);
-                        result.push(computed_value::ComputedOperation::Scale(sx, 1.0, 1.0));
+                        result.push(computed_value::ComputedOperation::ScaleX(sx));
                     }
                     SpecifiedOperation::ScaleY(sy) => {
                         let sy = sy.to_computed_value(context);
-                        result.push(computed_value::ComputedOperation::Scale(1.0, sy, 1.0));
+                        result.push(computed_value::ComputedOperation::ScaleY(sy));
                     }
                     SpecifiedOperation::ScaleZ(sz) => {
                         let sz = sz.to_computed_value(context);
-                        result.push(computed_value::ComputedOperation::Scale(1.0, 1.0, sz));
+                        result.push(computed_value::ComputedOperation::ScaleZ(sz));
                     }
                     SpecifiedOperation::Scale3D(sx, sy, sz) => {
                         let sx = sx.to_computed_value(context);
@@ -1434,6 +1437,18 @@ ${helpers.predefined_type(
                                               ToComputedValue::from_computed_value(tx),
                                               ToComputedValue::from_computed_value(ty),
                                               ToComputedValue::from_computed_value(tz)));
+                        }
+                        computed_value::ComputedOperation::ScaleX(ref sx) => {
+                            result.push(SpecifiedOperation::ScaleX(
+                                              ToComputedValue::from_computed_value(sx)));
+                        }
+                        computed_value::ComputedOperation::ScaleY(ref sy) => {
+                            result.push(SpecifiedOperation::ScaleY(
+                                              ToComputedValue::from_computed_value(sy)));
+                        }
+                        computed_value::ComputedOperation::ScaleZ(ref sz) => {
+                            result.push(SpecifiedOperation::ScaleZ(
+                                              ToComputedValue::from_computed_value(sz)));
                         }
                         computed_value::ComputedOperation::Scale(ref sx, ref sy, ref sz) => {
                             result.push(SpecifiedOperation::Scale3D(

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -693,6 +693,9 @@ ${helpers.predefined_type(
             ScaleY(CSSFloat),
             ScaleZ(CSSFloat),
             Scale(CSSFloat, CSSFloat, CSSFloat),
+            RotateX(computed::Angle),
+            RotateY(computed::Angle),
+            RotateZ(computed::Angle),
             Rotate(CSSFloat, CSSFloat, CSSFloat, computed::Angle),
             Perspective(computed::Length),
             // For mismatched transform lists.
@@ -1317,15 +1320,15 @@ ${helpers.predefined_type(
                     }
                     SpecifiedOperation::RotateX(theta) => {
                         let theta = theta.to_computed_value(context);
-                        result.push(computed_value::ComputedOperation::Rotate(1.0, 0.0, 0.0, theta));
+                        result.push(computed_value::ComputedOperation::RotateX(theta));
                     }
                     SpecifiedOperation::RotateY(theta) => {
                         let theta = theta.to_computed_value(context);
-                        result.push(computed_value::ComputedOperation::Rotate(0.0, 1.0, 0.0, theta));
+                        result.push(computed_value::ComputedOperation::RotateY(theta));
                     }
                     SpecifiedOperation::RotateZ(theta) => {
                         let theta = theta.to_computed_value(context);
-                        result.push(computed_value::ComputedOperation::Rotate(0.0, 0.0, 1.0, theta));
+                        result.push(computed_value::ComputedOperation::RotateZ(theta));
                     }
                     SpecifiedOperation::Rotate3D(ax, ay, az, theta) => {
                         let ax = ax.to_computed_value(context);
@@ -1455,6 +1458,18 @@ ${helpers.predefined_type(
                                     Number::from_computed_value(sx),
                                     Number::from_computed_value(sy),
                                     Number::from_computed_value(sz)));
+                        }
+                        computed_value::ComputedOperation::RotateX(ref rx) => {
+                            result.push(SpecifiedOperation::RotateX(
+                                              ToComputedValue::from_computed_value(rx)));
+                        }
+                        computed_value::ComputedOperation::RotateY(ref ry) => {
+                            result.push(SpecifiedOperation::RotateY(
+                                              ToComputedValue::from_computed_value(ry)));
+                        }
+                        computed_value::ComputedOperation::RotateZ(ref rz) => {
+                            result.push(SpecifiedOperation::RotateZ(
+                                              ToComputedValue::from_computed_value(rz)));
                         }
                         computed_value::ComputedOperation::Rotate(ref ax, ref ay, ref az, ref theta) => {
                             result.push(SpecifiedOperation::Rotate3D(

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -683,6 +683,9 @@ ${helpers.predefined_type(
             // For `-moz-transform` matrix and matrix3d.
             MatrixWithPercents(ComputedMatrixWithPercents),
             Skew(computed::Angle, computed::Angle),
+            TranslateX(LengthOrPercentage),
+            TranslateY(LengthOrPercentage),
+            TranslateZ(Length),
             Translate(computed::LengthOrPercentage,
                       computed::LengthOrPercentage,
                       computed::Length),
@@ -1262,24 +1265,15 @@ ${helpers.predefined_type(
                     }
                     SpecifiedOperation::TranslateX(ref tx) => {
                         let tx = tx.to_computed_value(context);
-                        result.push(computed_value::ComputedOperation::Translate(
-                            tx,
-                            computed::length::LengthOrPercentage::zero(),
-                            computed::length::Length::new(0.)));
+                        result.push(computed_value::ComputedOperation::TranslateX(tx));
                     }
                     SpecifiedOperation::TranslateY(ref ty) => {
                         let ty = ty.to_computed_value(context);
-                        result.push(computed_value::ComputedOperation::Translate(
-                            computed::length::LengthOrPercentage::zero(),
-                            ty,
-                            computed::length::Length::new(0.)));
+                        result.push(computed_value::ComputedOperation::TranslateY(ty));
                     }
                     SpecifiedOperation::TranslateZ(ref tz) => {
                         let tz = tz.to_computed_value(context);
-                        result.push(computed_value::ComputedOperation::Translate(
-                            computed::length::LengthOrPercentage::zero(),
-                            computed::length::LengthOrPercentage::zero(),
-                            tz));
+                        result.push(computed_value::ComputedOperation::TranslateZ(tz));
                     }
                     SpecifiedOperation::Translate3D(ref tx, ref ty, ref tz) => {
                         let tx = tx.to_computed_value(context);
@@ -1423,9 +1417,19 @@ ${helpers.predefined_type(
                                 m44: Number::from_computed_value(&computed.m44),
                             });
                         }
+                        computed_value::ComputedOperation::TranslateX(ref tx) => {
+                            result.push(SpecifiedOperation::TranslateX(
+                                              ToComputedValue::from_computed_value(tx)));
+                        }
+                        computed_value::ComputedOperation::TranslateY(ref ty) => {
+                            result.push(SpecifiedOperation::TranslateY(
+                                              ToComputedValue::from_computed_value(ty)));
+                        }
+                        computed_value::ComputedOperation::TranslateZ(ref tz) => {
+                            result.push(SpecifiedOperation::TranslateZ(
+                                              ToComputedValue::from_computed_value(tz)));
+                        }
                         computed_value::ComputedOperation::Translate(ref tx, ref ty, ref tz) => {
-                            // XXXManishearth we lose information here; perhaps we should try to
-                            // recover the original function? Not sure if this can be observed.
                             result.push(SpecifiedOperation::Translate3D(
                                               ToComputedValue::from_computed_value(tx),
                                               ToComputedValue::from_computed_value(ty),

--- a/components/style/values/computed/transform.rs
+++ b/components/style/values/computed/transform.rs
@@ -80,6 +80,18 @@ impl TransformList {
 
         for operation in list {
             let matrix = match *operation {
+                ComputedOperation::RotateX(theta) => {
+                    let theta = Angle::from_radians(2.0f32 * f32::consts::PI - theta.radians());
+                    Transform3D::create_rotation(1., 0., 0., theta.into())
+                }
+                ComputedOperation::RotateY(theta) => {
+                    let theta = Angle::from_radians(2.0f32 * f32::consts::PI - theta.radians());
+                    Transform3D::create_rotation(0., 1., 0., theta.into())
+                }
+                ComputedOperation::RotateZ(theta) => {
+                    let theta = Angle::from_radians(2.0f32 * f32::consts::PI - theta.radians());
+                    Transform3D::create_rotation(0., 0., 1., theta.into())
+                }
                 ComputedOperation::Rotate(ax, ay, az, theta) => {
                     let theta = Angle::from_radians(2.0f32 * f32::consts::PI - theta.radians());
                     let (ax, ay, az, theta) =

--- a/components/style/values/computed/transform.rs
+++ b/components/style/values/computed/transform.rs
@@ -92,6 +92,23 @@ impl TransformList {
                 ComputedOperation::Scale(sx, sy, sz) => {
                     Transform3D::create_scale(sx, sy, sz)
                 }
+                ComputedOperation::TranslateX(tx) => {
+                    let tx =  match reference_box {
+                        Some(relative_border_box) => tx.to_used_value(relative_border_box.size.width).to_f32_px(),
+                        None => extract_pixel_length(&tx),
+                    };
+                    Transform3D::create_translation(tx, 0., 0.)
+                }
+                ComputedOperation::TranslateY(ty) => {
+                    let ty =  match reference_box {
+                        Some(relative_border_box) => ty.to_used_value(relative_border_box.size.height).to_f32_px(),
+                        None => extract_pixel_length(&ty),
+                    };
+                    Transform3D::create_translation(0., ty, 0.)
+                }
+                ComputedOperation::TranslateZ(tz) => {
+                    Transform3D::create_translation(0., 0., tz.to_f32_px())
+                }
                 ComputedOperation::Translate(tx, ty, tz) => {
                     let (tx, ty) = match reference_box {
                         Some(relative_border_box) => {

--- a/components/style/values/computed/transform.rs
+++ b/components/style/values/computed/transform.rs
@@ -89,6 +89,15 @@ impl TransformList {
                 ComputedOperation::Perspective(d) => {
                     Self::create_perspective_matrix(d.px())
                 }
+                ComputedOperation::ScaleX(sx) => {
+                    Transform3D::create_scale(sx, 1., 1.)
+                }
+                ComputedOperation::ScaleY(sy) => {
+                    Transform3D::create_scale(1., sy, 1.)
+                }
+                ComputedOperation::ScaleZ(sz) => {
+                    Transform3D::create_scale(1., 1., sz)
+                }
                 ComputedOperation::Scale(sx, sy, sz) => {
                     Transform3D::create_scale(sx, sy, sz)
                 }

--- a/components/style/values/computed/transform.rs
+++ b/components/style/values/computed/transform.rs
@@ -128,7 +128,7 @@ impl TransformList {
                     Transform3D::create_translation(0., ty, 0.)
                 }
                 ComputedOperation::TranslateZ(tz) => {
-                    Transform3D::create_translation(0., 0., tz.to_f32_px())
+                    Transform3D::create_translation(0., 0., tz.px())
                 }
                 ComputedOperation::Translate(tx, ty, tz) => {
                     let (tx, ty) = match reference_box {


### PR DESCRIPTION
Necessary for the animation inspector to show the right thing.

r=hiikezoe https://bugzilla.mozilla.org/show_bug.cgi?id=1391145

fixes bug 1391145

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18492)
<!-- Reviewable:end -->
