### PR TITLE
style: Don't cache styles that got a cache hit on the second pass.

### DIFF
--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -546,11 +546,13 @@ impl<E: TElement> StyleSharingCache<E> {
     ///
     /// NB: We pass a source for the validation data, rather than the data itself,
     /// to avoid memmoving at each function call. See rust issue #42763.
-    pub fn insert_if_possible(&mut self,
-                              element: &E,
-                              style: &ComputedValues,
-                              validation_data_holder: Option<&mut StyleSharingTarget<E>>,
-                              dom_depth: usize) {
+    pub fn insert_if_possible(
+        &mut self,
+        element: &E,
+        style: &ComputedValues,
+        validation_data_holder: Option<&mut StyleSharingTarget<E>>,
+        dom_depth: usize,
+    ) {
         let parent = match element.traversal_parent() {
             Some(element) => element,
             None => {

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -678,14 +678,12 @@ where
                         resolver.resolve_style_with_default_parents()
                     };
 
-                    if !new_styles.primary.0.reused_via_rule_node {
-                        context.thread_local.sharing_cache.insert_if_possible(
-                            &element,
-                            new_styles.primary.style(),
-                            Some(&mut target),
-                            traversal_data.current_dom_depth,
-                        );
-                    }
+                    context.thread_local.sharing_cache.insert_if_possible(
+                        &element,
+                        &new_styles.primary,
+                        Some(&mut target),
+                        traversal_data.current_dom_depth,
+                    );
 
                     new_styles
                 }
@@ -725,14 +723,12 @@ where
                 resolver.cascade_styles_with_default_parents(cascade_inputs)
             };
 
-            if !new_styles.primary.0.reused_via_rule_node {
-                context.thread_local.sharing_cache.insert_if_possible(
-                    &element,
-                    new_styles.primary.style(),
-                    None,
-                    traversal_data.current_dom_depth,
-                );
-            }
+            context.thread_local.sharing_cache.insert_if_possible(
+                &element,
+                &new_styles.primary,
+                None,
+                traversal_data.current_dom_depth,
+            );
 
             new_styles
         }

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -678,14 +678,14 @@ where
                         resolver.resolve_style_with_default_parents()
                     };
 
-                    context.thread_local
-                        .sharing_cache
-                        .insert_if_possible(
+                    if !new_styles.primary.0.reused_via_rule_node {
+                        context.thread_local.sharing_cache.insert_if_possible(
                             &element,
                             new_styles.primary.style(),
                             Some(&mut target),
                             traversal_data.current_dom_depth,
                         );
+                    }
 
                     new_styles
                 }
@@ -724,12 +724,15 @@ where
 
                 resolver.cascade_styles_with_default_parents(cascade_inputs)
             };
-            context.thread_local.sharing_cache.insert_if_possible(
-                &element,
-                new_styles.primary.style(),
-                None,
-                traversal_data.current_dom_depth,
-            );
+
+            if !new_styles.primary.0.reused_via_rule_node {
+                context.thread_local.sharing_cache.insert_if_possible(
+                    &element,
+                    new_styles.primary.style(),
+                    None,
+                    traversal_data.current_dom_depth,
+                );
+            }
 
             new_styles
         }


### PR DESCRIPTION
This avoids doing wasted work, at least in the recascade case, and pretty likely
in the other as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18497)
<!-- Reviewable:end -->
