### PR TITLE
Properly handle stacking context collection for truncated fragments

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6353,6 +6353,18 @@
      {}
     ]
    ],
+   "css/truncated_text_fragment_stacking_context.html": [
+    [
+     "/_mozilla/css/truncated_text_fragment_stacking_context.html",
+     [
+      [
+       "/_mozilla/css/truncated_text_fragment_stacking_context_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/upper_id_attr.html": [
     [
      "/_mozilla/css/upper_id_attr.html",
@@ -10543,6 +10555,11 @@
     ]
    ],
    "css/translate_clip_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "css/truncated_text_fragment_stacking_context_ref.html": [
     [
      {}
     ]
@@ -26891,6 +26908,14 @@
   ],
   "css/translate_clip_ref.html": [
    "c62420cce19d1d6a7d8700275daaa5ecc10d14c7",
+   "support"
+  ],
+  "css/truncated_text_fragment_stacking_context.html": [
+   "453b01aec6ffd3c854fda854cf81250a332cd55c",
+   "reftest"
+  ],
+  "css/truncated_text_fragment_stacking_context_ref.html": [
+   "4cb902bb7b058748d1702b5033e8cec729431640",
    "support"
   ],
   "css/upper_id_attr.html": [

--- a/tests/wpt/mozilla/tests/css/truncated_text_fragment_stacking_context.html
+++ b/tests/wpt/mozilla/tests/css/truncated_text_fragment_stacking_context.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>Truncated text and inline-blocks combined should not cause a panic</title>
+<link rel="match" href="truncated_text_fragment_stacking_context_ref.html" />
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#sticky-pos" />
+<meta name="assert" content="This test checks that truncated text and inline-blocks don't cause a panic." />
+
+<!-- We are using transparent text here to avoid having to deal with subpixel text rendering issues. -->
+<style>
+  a {
+    float: left;
+    color: transparent;
+  }
+  p, em {
+    overflow:hidden
+  }
+
+  em {
+    display: inline-block;
+    text-overflow: ellipsis;
+    color: transparent;
+  }
+
+  div {
+    position: absolute
+  }
+</style>
+
+<div style="height: 100px; width: 100px; background: green;"></div>
+
+<div>
+  <a>LINK</a>
+  <p><em>TEXT</em></p>
+</div>

--- a/tests/wpt/mozilla/tests/css/truncated_text_fragment_stacking_context_ref.html
+++ b/tests/wpt/mozilla/tests/css/truncated_text_fragment_stacking_context_ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<title>Truncated text and inline-blocks combined should not cause a panic</title>
+<div style="width: 100px; height: 100px; background: green"></div>


### PR DESCRIPTION
Before we did not properly descend intro truncated fragments when
collecting stacking contexts. This change makes sure that we descend
properly

Fixes #18254.
Fixes #17072.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #18254,  #17072 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18510)
<!-- Reviewable:end -->
