### PR TITLE
Prevent aspect-ratio media queries from causing m…

### DIFF
--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -752,7 +752,9 @@ impl Expression {
             (&BoolInteger(one), &BoolInteger(ref other)) => one.cmp(other),
             (&Float(one), &Float(ref other)) => one.partial_cmp(other).unwrap(),
             (&IntRatio(one_num, one_den), &IntRatio(other_num, other_den)) => {
-                (one_num * other_den).partial_cmp(&(other_num * one_den)).unwrap()
+                // Extend to avoid overflow.
+                (one_num as u64 * other_den as u64).cmp(
+                    &(other_num as u64 * one_den as u64))
             }
             (&Resolution(ref one), &Resolution(ref other)) => {
                 let actual_dpi = unsafe {


### PR DESCRIPTION
…ultiplication overflow by extending values to u64.

MozReview-Commit-ID: e4kfxMDvZh

<!-- Please describe your changes on the following line: -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1399941
https://reviewboard.mozilla.org/r/179984/

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because tests are in Gecko code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18526)
<!-- Reviewable:end -->
