### PR TITLE
Revert "Measure ImageValue objects."

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1005,10 +1005,6 @@ extern "C" {
      -> *mut ImageValue;
 }
 extern "C" {
-    pub fn Gecko_ImageValue_SizeOfIncludingThis(aImageValue: *mut ImageValue)
-     -> usize;
-}
-extern "C" {
     pub fn Gecko_SetLayerImageImageValue(image: *mut nsStyleImage,
                                          aImageValue: *mut ImageValue);
 }

--- a/components/style/gecko/url.rs
+++ b/components/style/gecko/url.rs
@@ -9,7 +9,6 @@ use gecko_bindings::structs::mozilla::css::URLValueData;
 use gecko_bindings::structs::root::{nsStyleImageRequest, RustString};
 use gecko_bindings::structs::root::mozilla::css::ImageValue;
 use gecko_bindings::sugar::refptr::RefPtr;
-use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use parser::ParserContext;
 use servo_arc::{Arc, RawOffsetArc};
 use std::fmt;
@@ -17,19 +16,22 @@ use std::mem;
 use style_traits::{ToCss, ParseError};
 
 /// A specified url() value for gecko. Gecko does not eagerly resolve SpecifiedUrls.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, MallocSizeOf, PartialEq)]
 pub struct SpecifiedUrl {
     /// The URL in unresolved string form.
     ///
     /// Refcounted since cloning this should be cheap and data: uris can be
     /// really large.
+    #[ignore_malloc_size_of = "XXX: do this once bug 1397971 lands"]
     serialization: Arc<String>,
 
     /// The URL extra data.
+    #[ignore_malloc_size_of = "RefPtr is tricky, and there aren't many of these in practise"]
     pub extra_data: RefPtr<URLExtraData>,
 
     /// Cache ImageValue, if any, so that we can reuse it while rematching a
     /// a property with this specified url value.
+    #[ignore_malloc_size_of = "XXX: do this once bug 1397971 lands"]
     pub image_value: Option<RefPtr<ImageValue>>,
 }
 trivial_to_computed_value!(SpecifiedUrl);
@@ -140,27 +142,5 @@ impl ToCss for SpecifiedUrl {
         dest.write_str("url(")?;
         self.serialization.to_css(dest)?;
         dest.write_str(")")
-    }
-}
-
-impl MallocSizeOf for SpecifiedUrl {
-    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
-        use gecko_bindings::bindings::Gecko_ImageValue_SizeOfIncludingThis;
-
-        let mut n = 0;
-
-        // XXX: measure `serialization` once bug 1397971 lands
-
-        // We ignore `extra_data`, because RefPtr is tricky, and there aren't
-        // many of them in practise (sharing is common).
-
-        if let Some(ref image_value) = self.image_value {
-            // Although this is a RefPtr, this is the primary reference because
-            // SpecifiedUrl is responsible for creating the image_value. So we
-            // measure unconditionally here.
-            n += unsafe { Gecko_ImageValue_SizeOfIncludingThis(image_value.clone().get()) };
-        }
-
-        n
     }
 }


### PR DESCRIPTION
This reverts commit a185393ceea46f1e61dfd7134b589b150d6e27c3 (#18515).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18527)
<!-- Reviewable:end -->
