### PR TITLE
Undo #18497 in the MatchAndCascade case

### DIFF
--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -554,11 +554,6 @@ impl<E: TElement> StyleSharingCache<E> {
         validation_data_holder: Option<&mut StyleSharingTarget<E>>,
         dom_depth: usize,
     ) {
-        if style.0.reused_via_rule_node {
-            debug!("Failing to insert into the cached: this was a cached style");
-            return;
-        }
-
         let parent = match element.traversal_parent() {
             Some(element) => element,
             None => {


### PR DESCRIPTION
It's easy to construct examples where not inserting in those cases causes performance
to get worse (for example, any long list of siblings that match the same selectors
while having some non-effectual differences in LocalName/Class/Id/etc). And the LRU
nature of the cache already does the right thing of pruning non-useful entries.

Fixing this causes several hundred more sharing hits on wikipedia.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18532)
<!-- Reviewable:end -->
