### PR TITLE
stylo: Don't add a font-size dependency to the rule cache if the reference size is not our current style.

### DIFF
--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -132,7 +132,7 @@ impl FontRelativeLength {
 
         match *self {
             FontRelativeLength::Em(length) => {
-                if !matches!(base_size, FontBaseSize::InheritedStyle) {
+                if matches!(base_size, FontBaseSize::CurrentStyle) {
                     context.rule_cache_conditions.borrow_mut()
                         .set_font_size_dependency(
                             reference_font_size.into()

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -132,11 +132,13 @@ impl FontRelativeLength {
 
         match *self {
             FontRelativeLength::Em(length) => {
-                if matches!(base_size, FontBaseSize::CurrentStyle) {
-                    context.rule_cache_conditions.borrow_mut()
-                        .set_font_size_dependency(
-                            reference_font_size.into()
-                        );
+                if context.for_non_inherited_property.is_some() {
+                    if matches!(base_size, FontBaseSize::CurrentStyle) {
+                        context.rule_cache_conditions.borrow_mut()
+                            .set_font_size_dependency(
+                                reference_font_size.into()
+                            );
+                    }
                 }
                 (reference_font_size, length)
             },


### PR DESCRIPTION
We enter the Custom(..) code path from other random places, like to remove the
relative lengths from a calc expression while zooming, or whatever craziness
MathML font-size uses, and we don't want to set the dependency on those cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18538)
<!-- Reviewable:end -->
