### PR TITLE
style: Resolver cleanup and sharing by rule node fixes.

### DIFF
--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -284,13 +284,18 @@ impl ElementData {
 
     /// Returns this element's primary style as a resolved style to use for sharing.
     pub fn share_primary_style(&self) -> PrimaryStyle {
-        let primary_is_reused = self.flags.contains(PRIMARY_STYLE_REUSED_VIA_RULE_NODE);
-        PrimaryStyle(ResolvedStyle::new(self.styles.primary().clone(), primary_is_reused))
+        let reused_via_rule_node =
+            self.flags.contains(PRIMARY_STYLE_REUSED_VIA_RULE_NODE);
+
+        PrimaryStyle {
+            style: ResolvedStyle(self.styles.primary().clone()),
+            reused_via_rule_node,
+        }
     }
 
     /// Sets a new set of styles, returning the old ones.
     pub fn set_styles(&mut self, new_styles: ResolvedElementStyles) -> ElementStyles {
-        if new_styles.primary.0.reused_via_rule_node {
+        if new_styles.primary.reused_via_rule_node {
             self.flags.insert(PRIMARY_STYLE_REUSED_VIA_RULE_NODE);
         } else {
             self.flags.remove(PRIMARY_STYLE_REUSED_VIA_RULE_NODE);

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -158,7 +158,7 @@ trait PrivateMatchMethods: TElement {
             StyleResolverForElement::new(*self, context, RuleInclusion::All, PseudoElementResolution::IfApplicable)
                 .cascade_style_and_visited_with_default_parents(inputs);
 
-        Some(style.into())
+        Some(style.0)
     }
 
     #[cfg(feature = "gecko")]
@@ -542,7 +542,7 @@ pub trait MatchMethods : TElement {
         self.process_animations(
             context,
             &mut data.styles.primary,
-            &mut new_styles.primary.0.style,
+            &mut new_styles.primary.style.0,
             data.hint,
             important_rules_changed,
         );

--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -82,7 +82,7 @@ use smallvec::SmallVec;
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::Deref;
-use style_resolver::PrimaryStyle;
+use style_resolver::{PrimaryStyle, ResolvedElementStyles};
 use stylist::Stylist;
 
 mod checks;
@@ -380,7 +380,7 @@ impl<E: TElement> StyleSharingTarget<E> {
     pub fn share_style_if_possible(
         &mut self,
         context: &mut StyleContext<E>,
-    ) -> Option<E> {
+    ) -> Option<ResolvedElementStyles> {
         let cache = &mut context.thread_local.sharing_cache;
         let shared_context = &context.shared;
         let selector_flags_map = &mut context.thread_local.selector_flags;
@@ -443,25 +443,25 @@ impl<E: TElement> SharingCache<E> {
         self.entries.insert(StyleSharingCandidate { element, validation_data });
     }
 
-    fn lookup<F>(&mut self, mut is_match: F) -> Option<E>
+    fn lookup<F, R>(&mut self, mut test_one: F) -> Option<R>
     where
-        F: FnMut(&mut StyleSharingCandidate<E>) -> bool
+        F: FnMut(&mut StyleSharingCandidate<E>) -> Option<R>
     {
-        let mut index = None;
+        let mut result = None;
         for (i, candidate) in self.entries.iter_mut() {
-            if is_match(candidate) {
-                index = Some(i);
+            if let Some(r) = test_one(candidate) {
+                result = Some((i, r));
                 break;
             }
         };
 
-        match index {
+        match result {
             None => None,
-            Some(i) => {
+            Some((i, r)) => {
                 self.entries.touch(i);
                 let front = self.entries.front_mut().unwrap();
-                debug_assert!(is_match(front));
-                Some(front.element)
+                debug_assert!(test_one(front).is_some());
+                Some(r)
             }
         }
     }
@@ -620,7 +620,7 @@ impl<E: TElement> StyleSharingCache<E> {
         selector_flags_map: &mut SelectorFlagsMap<E>,
         bloom_filter: &StyleBloom<E>,
         target: &mut StyleSharingTarget<E>,
-    ) -> Option<E> {
+    ) -> Option<ResolvedElementStyles> {
         if shared_context.options.disable_style_sharing_cache {
             debug!("{:?} Cannot share style: style sharing cache disabled",
                    target.element);
@@ -655,42 +655,42 @@ impl<E: TElement> StyleSharingCache<E> {
         shared: &SharedStyleContext,
         bloom: &StyleBloom<E>,
         selector_flags_map: &mut SelectorFlagsMap<E>
-    ) -> bool {
+    ) -> Option<ResolvedElementStyles> {
         // Check that we have the same parent, or at least that the parents
         // share styles and permit sharing across their children. The latter
         // check allows us to share style between cousins if the parents
         // shared style.
         if !checks::parents_allow_sharing(target, candidate) {
             trace!("Miss: Parent");
-            return false;
+            return None;
         }
 
         if target.is_native_anonymous() {
             debug_assert!(!candidate.element.is_native_anonymous(),
                           "Why inserting NAC into the cache?");
             trace!("Miss: Native Anonymous Content");
-            return false;
+            return None;
         }
 
         if *target.get_local_name() != *candidate.element.get_local_name() {
             trace!("Miss: Local Name");
-            return false;
+            return None;
         }
 
         if *target.get_namespace() != *candidate.element.get_namespace() {
             trace!("Miss: Namespace");
-            return false;
+            return None;
         }
 
         if target.is_link() != candidate.element.is_link() {
             trace!("Miss: Link");
-            return false;
+            return None;
         }
 
         if target.matches_user_and_author_rules() !=
             candidate.element.matches_user_and_author_rules() {
             trace!("Miss: User and Author Rules");
-            return false;
+            return None;
         }
 
         // We do not ignore visited state here, because Gecko
@@ -698,7 +698,7 @@ impl<E: TElement> StyleSharingCache<E> {
         // so these contexts cannot be shared
         if target.element.get_state() != candidate.get_state() {
             trace!("Miss: User and Author State");
-            return false;
+            return None;
         }
 
         let element_id = target.element.get_id();
@@ -708,38 +708,38 @@ impl<E: TElement> StyleSharingCache<E> {
             if checks::may_have_rules_for_ids(shared, element_id.as_ref(),
                                               candidate_id.as_ref()) {
                 trace!("Miss: ID Attr");
-                return false;
+                return None;
             }
         }
 
         if !checks::have_same_style_attribute(target, candidate) {
             trace!("Miss: Style Attr");
-            return false;
+            return None;
         }
 
         if !checks::have_same_class(target, candidate) {
             trace!("Miss: Class");
-            return false;
+            return None;
         }
 
         if !checks::have_same_presentational_hints(target, candidate) {
             trace!("Miss: Pres Hints");
-            return false;
+            return None;
         }
 
         if !checks::revalidate(target, candidate, shared, bloom,
                                selector_flags_map) {
             trace!("Miss: Revalidation");
-            return false;
+            return None;
         }
 
         debug_assert!(target.has_current_styles_for_traversal(
             &candidate.element.borrow_data().unwrap(),
             shared.traversal_flags,
         ));
-        debug!("Sharing allowed between {:?} and {:?}", target.element, candidate.element);
 
-        true
+        debug!("Sharing allowed between {:?} and {:?}", target.element, candidate.element);
+        Some(candidate.element.borrow_data().unwrap().share_styles())
     }
 
     /// Attempts to find an element in the cache with the given primary rule node and parent.
@@ -749,21 +749,18 @@ impl<E: TElement> StyleSharingCache<E> {
         rules: &StrongRuleNode,
         visited_rules: Option<&StrongRuleNode>,
         target: E,
-    ) -> Option<E> {
+    ) -> Option<PrimaryStyle> {
         self.cache_mut().lookup(|candidate| {
-            if candidate.element == target {
-                return false;
-            }
             if !candidate.parent_style_identity().eq(inherited) {
-                return false;
+                return None;
             }
             let data = candidate.element.borrow_data().unwrap();
             let style = data.styles.primary();
             if style.rules.as_ref() != Some(&rules) {
-                return false;
+                return None;
             }
             if style.visited_rules() != visited_rules {
-                return false;
+                return None;
             }
 
             // Rule nodes and styles are computed independent of the element's
@@ -778,10 +775,10 @@ impl<E: TElement> StyleSharingCache<E> {
             // requirements of visited, assuming we get a cache hit on only one
             // of unvisited vs. visited.
             if target.is_visited_link() != candidate.element.is_visited_link() {
-                return false;
+                return None;
             }
 
-            true
+            Some(data.share_primary_style())
         })
     }
 }

--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -735,8 +735,8 @@ impl<E: TElement> StyleSharingCache<E> {
 
         debug_assert!(target.has_current_styles_for_traversal(
             &candidate.element.borrow_data().unwrap(),
-            shared.traversal_flags)
-        );
+            shared.traversal_flags,
+        ));
         debug!("Sharing allowed between {:?} and {:?}", target.element, candidate.element);
 
         true
@@ -751,6 +751,9 @@ impl<E: TElement> StyleSharingCache<E> {
         target: E,
     ) -> Option<E> {
         self.cache_mut().lookup(|candidate| {
+            if candidate.element == target {
+                return false;
+            }
             if !candidate.parent_style_identity().eq(inherited) {
                 return false;
             }

--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -751,6 +751,7 @@ impl<E: TElement> StyleSharingCache<E> {
         target: E,
     ) -> Option<PrimaryStyle> {
         self.cache_mut().lookup(|candidate| {
+            debug_assert_ne!(candidate.element, target);
             if !candidate.parent_style_identity().eq(inherited) {
                 return None;
             }

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -421,7 +421,7 @@ where
 
         let is_display_contents = primary_style.style().is_display_contents();
 
-        style = Some(primary_style.0.into());
+        style = Some(primary_style.style.0);
         if !is_display_contents {
             layout_parent_style = style.clone();
         }
@@ -659,9 +659,9 @@ where
             // Now that our bloom filter is set up, try the style sharing
             // cache.
             match target.share_style_if_possible(context) {
-                Some(shareable_element) => {
+                Some(shared_styles) => {
                     context.thread_local.statistics.styles_shared += 1;
-                    shareable_element.borrow_data().unwrap().share_styles()
+                    shared_styles
                 }
                 None => {
                     context.thread_local.statistics.elements_matched += 1;
@@ -738,7 +738,7 @@ where
             // number of eventual styles, but would potentially miss out on various
             // opportunities for skipping selector matching, which could hurt
             // performance.
-            if !new_styles.primary.0.reused_via_rule_node {
+            if !new_styles.primary.reused_via_rule_node {
                 context.thread_local.sharing_cache.insert_if_possible(
                     &element,
                     &new_styles.primary,

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -731,11 +731,9 @@ pub extern "C" fn Servo_StyleSet_GetBaseComputedValuesForElement(raw_data: RawSe
         };
 
     // Actually `PseudoElementResolution` doesn't matter.
-    let style: Arc<ComputedValues> =
-        StyleResolverForElement::new(element, &mut context, RuleInclusion::All, PseudoElementResolution::IfApplicable)
+    StyleResolverForElement::new(element, &mut context, RuleInclusion::All, PseudoElementResolution::IfApplicable)
         .cascade_style_and_visited_with_default_parents(inputs)
-        .into();
-    style.into()
+        .0.into()
 }
 
 #[no_mangle]


### PR DESCRIPTION
See the individual commits for details.

This is the only coherent story I have for crashes like:

  https://crash-stats.mozilla.com/report/index/bcdfe629-ca1f-4e4d-aa17-27f890170917

(And the fact that there are crashes like it on the main thread kinda indicates it's the case)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18547)
<!-- Reviewable:end -->
