### PR TITLE
Measure ImageValue objects (take 2).

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1005,6 +1005,10 @@ extern "C" {
      -> *mut ImageValue;
 }
 extern "C" {
+    pub fn Gecko_ImageValue_SizeOfIncludingThis(aImageValue: *mut ImageValue)
+     -> usize;
+}
+extern "C" {
     pub fn Gecko_SetLayerImageImageValue(image: *mut nsStyleImage,
                                          aImageValue: *mut ImageValue);
 }

--- a/components/style/gecko/url.rs
+++ b/components/style/gecko/url.rs
@@ -9,6 +9,7 @@ use gecko_bindings::structs::mozilla::css::URLValueData;
 use gecko_bindings::structs::root::{nsStyleImageRequest, RustString};
 use gecko_bindings::structs::root::mozilla::css::ImageValue;
 use gecko_bindings::sugar::refptr::RefPtr;
+use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use parser::ParserContext;
 use servo_arc::{Arc, RawOffsetArc};
 use std::fmt;
@@ -16,22 +17,19 @@ use std::mem;
 use style_traits::{ToCss, ParseError};
 
 /// A specified url() value for gecko. Gecko does not eagerly resolve SpecifiedUrls.
-#[derive(Clone, Debug, MallocSizeOf, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SpecifiedUrl {
     /// The URL in unresolved string form.
     ///
     /// Refcounted since cloning this should be cheap and data: uris can be
     /// really large.
-    #[ignore_malloc_size_of = "XXX: do this once bug 1397971 lands"]
     serialization: Arc<String>,
 
     /// The URL extra data.
-    #[ignore_malloc_size_of = "RefPtr is tricky, and there aren't many of these in practise"]
     pub extra_data: RefPtr<URLExtraData>,
 
     /// Cache ImageValue, if any, so that we can reuse it while rematching a
     /// a property with this specified url value.
-    #[ignore_malloc_size_of = "XXX: do this once bug 1397971 lands"]
     pub image_value: Option<RefPtr<ImageValue>>,
 }
 trivial_to_computed_value!(SpecifiedUrl);
@@ -142,5 +140,27 @@ impl ToCss for SpecifiedUrl {
         dest.write_str("url(")?;
         self.serialization.to_css(dest)?;
         dest.write_str(")")
+    }
+}
+
+impl MallocSizeOf for SpecifiedUrl {
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        use gecko_bindings::bindings::Gecko_ImageValue_SizeOfIncludingThis;
+
+        let mut n = 0;
+
+        // XXX: measure `serialization` once bug 1397971 lands
+
+        // We ignore `extra_data`, because RefPtr is tricky, and there aren't
+        // many of them in practise (sharing is common).
+
+        if let Some(ref image_value) = self.image_value {
+            // Although this is a RefPtr, this is the primary reference because
+            // SpecifiedUrl is responsible for creating the image_value. So we
+            // measure unconditionally here.
+            n += unsafe { Gecko_ImageValue_SizeOfIncludingThis(image_value.clone().get()) };
+        }
+
+        n
     }
 }


### PR DESCRIPTION
We have about 11,500 of these when loading gmail in a Stylo-enabled build, from
SpecifiedUrls; the objects themselves account for about 1.3 MiB of memory, and
the strings within them about 2.9 MiB.

We also have a very small number of them on the Gecko side.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because testing is on the Gecko side.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18550)
<!-- Reviewable:end -->
