### PR TITLE
Update osmesa-src to support building with mach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "osmesa-src"
 version = "17.2.0-devel"
-source = "git+https://github.com/servo/osmesa-src#fe47d99acf27a9620c521d576d26dbfa1cf29372"
+source = "git+https://github.com/servo/osmesa-src#206464252f31583c2338393f8b6da99780a1ebdf"
 
 [[package]]
 name = "osmesa-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ opt-level = 3
 # crate, add that here. Use the form:
 #
 #     <crate> = { path = "/path/to/local/checkout" }
+#
+# Or for a git dependency:
+#
+#     [patch."https://github.com/servo/<repository>"]
+#     <crate> = { path = "/path/to/local/checkout" }

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,6 @@ mozinfo == 0.8
 mozlog == 3.3
 setuptools == 18.5
 toml == 0.9.2
-Mako == 1.0.4
 
 # For Python linting
 flake8 == 2.4.1

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -26,6 +26,8 @@ from mach.decorators import (
 )
 from mach.registrar import Registrar
 # Note: mako cannot be imported at the top level because it breaks mach bootstrap
+sys.path.append(path.join(path.dirname(__file__), "..", "..",
+                          "components", "style", "properties", "Mako-0.9.1.zip"))
 
 from servo.command_base import (
     archive_deterministically,


### PR DESCRIPTION
E.g. `cargo +nightly build -p servo` at the repo’s top-level

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18552)
<!-- Reviewable:end -->
