### PR TITLE
Make tidy aware of Rust multiline strings

### DIFF
--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -137,7 +137,7 @@ impl<'a> InorderFlowTraversal for ResolveGeneratedContent<'a> {
 }
 
 /// The object that mutates the generated content fragments.
-struct ResolveGeneratedContentFragmentMutator<'a,'b:'a> {
+struct ResolveGeneratedContentFragmentMutator<'a, 'b: 'a> {
     /// The traversal.
     traversal: &'a mut ResolveGeneratedContent<'b>,
     /// The level we're at in the flow tree.
@@ -148,7 +148,7 @@ struct ResolveGeneratedContentFragmentMutator<'a,'b:'a> {
     incremented: bool,
 }
 
-impl<'a,'b> ResolveGeneratedContentFragmentMutator<'a,'b> {
+impl<'a, 'b> ResolveGeneratedContentFragmentMutator<'a, 'b> {
     fn mutate_fragment(&mut self, fragment: &mut Fragment) {
         // We only reset and/or increment counters once per flow. This avoids double-incrementing
         // counters on list items (once for the main fragment and once for the marker).

--- a/components/layout/persistent_list.rs
+++ b/components/layout/persistent_list.rs
@@ -69,7 +69,7 @@ impl<T> Clone for PersistentList<T> where T: Send + Sync {
     }
 }
 
-pub struct PersistentListIterator<'a,T> where T: 'a + Send + Sync {
+pub struct PersistentListIterator<'a, T> where T: 'a + Send + Sync {
     entry: Option<&'a PersistentListEntry<T>>,
 }
 

--- a/components/script_plugins/unrooted_must_root.rs
+++ b/components/script_plugins/unrooted_must_root.rs
@@ -163,7 +163,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnrootedPass {
     }
 }
 
-struct FnDefVisitor<'a, 'b: 'a, 'tcx: 'a+'b> {
+struct FnDefVisitor<'a, 'b: 'a, 'tcx: 'a + 'b> {
     cx: &'a LateContext<'b, 'tcx>,
     in_new_function: bool,
 }

--- a/python/tidy/servo_tidy_tests/multiline_string.rs
+++ b/python/tidy/servo_tidy_tests/multiline_string.rs
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+// This puts a "multi-line string
+// inside of a comment" and then subsequently has a hyphenated-phrase
+
+
+const FOO: &'static str = "Do not confuse 'apostrophes',
+    They can be 'lifetimes' or 'characters'";
+
+
+fn main() {
+    assert!(foo("test
+                 foo-bar"));
+
+    assert!(foo("test
+                 test2 \"
+                 foo-bar"));
+
+    assert!(foo("test
+                 test2 \
+                 foo-bar"));
+
+    println!("This is a multiline string with a URL, which kinda, \
+             sorta looks like a comment https://github.com/servo/servo/");
+}

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -266,6 +266,11 @@ class CheckTidiness(unittest.TestCase):
         lst = list(file_list)
         self.assertEqual([os.path.join(base_path, 'whee', 'test.rs')], lst)
 
+    def test_multiline_string(self):
+        errors = tidy.collect_errors_for_files(iterFile('multiline_string.rs'), [], [tidy.check_rust], print_text=True)
+        self.assertNoMoreErrors(errors)
+
+
 def do_tests():
     suite = unittest.TestLoader().loadTestsFromTestCase(CheckTidiness)
     return 0 if unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful() else 1


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This makes the internal tidy script properly ignore the contents of Rust multiline strings.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #18551 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18553)
<!-- Reviewable:end -->
