### PR TITLE
Make shape-outside animatable.

### DIFF
--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -1856,7 +1856,7 @@ ${helpers.predefined_type(
     "generics::basic_shape::ShapeSource::None",
     products="gecko",
     boxed=True,
-    animation_value_type="discrete",
+    animation_value_type="ComputedValue",
     flags="APPLIES_TO_FIRST_LETTER",
     spec="https://drafts.csswg.org/css-shapes/#shape-outside-property",
 )}


### PR DESCRIPTION
We decide to make shape-outside animatable on Gecko, so let's do it on Servo.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1390026](https://bugzilla.mozilla.org/show_bug.cgi?id=1390026).
- [X] These changes do not require tests because we could reuse the animation tests on Gecko for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18559)
<!-- Reviewable:end -->
