### PR TITLE
Bug 1398393 - Add a way to initialize a cooperative thread in servo.

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -183,6 +183,12 @@ pub extern "C" fn Servo_Initialize(dummy_url_data: *mut URLExtraData) {
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_InitializeCooperativeThread() {
+    // Pretend that we're a Servo Layout thread to make some assertions happy.
+    thread_state::initialize(thread_state::LAYOUT);
+}
+
+#[no_mangle]
 pub extern "C" fn Servo_Shutdown() {
     // The dummy url will be released after shutdown, so clear the
     // reference to avoid use-after-free.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Over in [bug 1398393](https://bugzilla.mozilla.org/show_bug.cgi?id=1398393), I found that when we turn Quantum DOM's cooperative threads on, we hit a Servo panic because we assume that we've set some state in the TLD. The cooperative threads currently have no way of doing this without also re-initializing the log module and some other static data. This small patch gives the cooperative threads a way of informing Servo about themselves.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because they will be tested on Gecko's tinderbox once we get cooperative threading working.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18569)
<!-- Reviewable:end -->
