### PR TITLE
Fix MallocSizeOf for TypedSize2D.

### DIFF
--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -64,7 +64,6 @@ extern crate servo_arc;
 extern crate smallbitvec;
 extern crate smallvec;
 
-use euclid::TypedSize2D;
 use servo_arc::Arc;
 use smallvec::{Array, SmallVec};
 use std::hash::{BuildHasher, Hash};
@@ -391,11 +390,9 @@ impl MallocSizeOf for smallbitvec::SmallBitVec {
     }
 }
 
-impl<T: MallocSizeOf, U> MallocSizeOf for TypedSize2D<T, U> {
+impl<T: MallocSizeOf, U> MallocSizeOf for euclid::TypedSize2D<T, U> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        let n = self.width.size_of(ops) + self.width.size_of(ops);
-        assert!(n == 0);    // It would be very strange to have a non-zero value here...
-        n
+        self.width.size_of(ops) + self.height.size_of(ops)
     }
 }
 


### PR DESCRIPTION
TypedSize2D's MallocSizeOf impl has two problems.

- It measures `width` twice, and `height` not at all.

- It erroneously asserts that `width` and `height` are scalars. This
  seems reasonable at first blush, but Stylo uses
  `BorderRadius<LengthAndPercentage>` which contains a
  `TypedSize2D<LengthAndPercentage, UnknownUnit>`, and
  `LengthAndPercentage` is non-scalar.

This patch fixes both of these problems, and also removes a low-value
`use` statement.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix https://bugzilla.mozilla.org/show_bug.cgi?id=1401692

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because tested on the Gecko side.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18583)
<!-- Reviewable:end -->
