### PR TITLE
Drop RulesChanged

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -81,30 +81,6 @@ impl ChildCascadeRequirement {
     }
 }
 
-bitflags! {
-    /// Flags that represent the result of replace_rules.
-    pub flags RulesChanged: u8 {
-        /// Normal rules are changed.
-        const NORMAL_RULES_CHANGED = 0x01,
-        /// Important rules are changed.
-        const IMPORTANT_RULES_CHANGED = 0x02,
-    }
-}
-
-impl RulesChanged {
-    /// Return true if there are any normal rules changed.
-    #[inline]
-    pub fn normal_rules_changed(&self) -> bool {
-        self.contains(NORMAL_RULES_CHANGED)
-    }
-
-    /// Return true if there are any important rules changed.
-    #[inline]
-    pub fn important_rules_changed(&self) -> bool {
-        self.contains(IMPORTANT_RULES_CHANGED)
-    }
-}
-
 /// Determines which styles are being cascaded currently.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CascadeVisitedMode {


### PR DESCRIPTION
It's no longer used.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because this just drops unused code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18584)
<!-- Reviewable:end -->
