### PR TITLE
Script iframe intial load replaces about blank

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2504,7 +2504,10 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
 
         // If the navigation is for a top-level browsing context, inform mozbrowser
         if change.browsing_context_id == change.top_level_browsing_context_id {
-            self.trigger_mozbrowserlocationchange(change.top_level_browsing_context_id);
+            // If this is a replacement then we've already triggered the event in traverse_to_entry
+            if change.replace_instant.is_none() {
+                self.trigger_mozbrowserlocationchange(change.top_level_browsing_context_id);
+            }
         }
 
         self.update_frame_tree_if_active(change.top_level_browsing_context_id);

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -256,7 +256,8 @@ impl HTMLIFrameElement {
 
         let document = document_from_node(self);
         let load_data = LoadData::new(url, creator_pipeline_id, document.get_referrer_policy(), Some(document.url()));
-        self.navigate_or_reload_child_browsing_context(Some(load_data), NavigationType::Regular, false);
+        let replace = mode == ProcessingMode::FirstTime;
+        self.navigate_or_reload_child_browsing_context(Some(load_data), NavigationType::Regular, replace);
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -305,13 +305,6 @@ impl HTMLIFrameElement {
 
         self.pipeline_id.set(Some(new_pipeline_id));
 
-        // Only terminate the load blocker if the pipeline id was updated due to a traversal.
-        // The load blocker will be terminated for a navigation in iframe_load_event_steps.
-        if reason == UpdatePipelineIdReason::Traversal {
-            let mut blocker = self.load_blocker.borrow_mut();
-            LoadBlocker::terminate(&mut blocker);
-        }
-
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
         let window = window_from_node(self);
         window.reflow(ReflowGoal::ForDisplay,

--- a/tests/wpt/metadata/html/browsers/history/the-location-interface/location-protocol-setter-non-broken.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-location-interface/location-protocol-setter-non-broken.html.ini
@@ -1,6 +1,6 @@
 [location-protocol-setter-non-broken.html]
   type: testharness
-  expected: CRASH
+  expected: OK
   [Set data URL frame location.protocol to x]
     expected: FAIL
 
@@ -17,5 +17,20 @@
     expected: FAIL
 
   [Set data URL frame location.protocol to http+x]
+    expected: FAIL
+
+  [Set HTTP URL frame location.protocol to ftp]
+    expected: FAIL
+
+  [Set HTTP URL frame location.protocol to gopher]
+    expected: FAIL
+
+  [Set HTTP URL frame location.protocol to x]
+    expected: FAIL
+
+  [Set HTTP URL frame location.protocol to data]
+    expected: FAIL
+
+  [Set HTTP URL frame location.protocol to http+x]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/dom/dynamic-markup-insertion/document-write/iframe_005.html.ini
+++ b/tests/wpt/metadata/html/dom/dynamic-markup-insertion/document-write/iframe_005.html.ini
@@ -1,5 +1,0 @@
-[iframe_005.html]
-  type: testharness
-  [document.write external script into iframe write back into parent]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_allow_script.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_allow_script.html.ini
@@ -1,6 +1,6 @@
 [iframe_sandbox_allow_script.html]
   type: testharness
-  expected: ERROR
+  expected: TIMEOUT
   bug: https://github.com/servo/servo/issues/14368
   [iframe_sandbox_allow_scripts]
     expected: NOTRUN

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/glsl/bugs/conditional-discard-in-loop.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/glsl/bugs/conditional-discard-in-loop.html.ini
@@ -1,6 +1,0 @@
-[conditional-discard-in-loop.html]
-  type: testharness
-  expected: TIMEOUT
-  [Overall test]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/glsl/bugs/temp-expressions-should-not-crash.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/glsl/bugs/temp-expressions-should-not-crash.html.ini
@@ -1,6 +1,0 @@
-[temp-expressions-should-not-crash.html]
-  type: testharness
-  expected: TIMEOUT
-  [Overall test]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-size.html.ini
+++ b/tests/wpt/metadata/webgl/conformance-1.0.3/conformance/textures/texture-size.html.ini
@@ -1,8 +1,0 @@
-[texture-size.html]
-  type: testharness
-  expected:
-    if os == "linux": TIMEOUT
-  [Overall test]
-    expected:
-      if os == "linux": NOTRUN
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

When navigating from the initial about:blank, do it with replacement enabled.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #18564 
- [X] These changes do not require tests because the existing tests do the job

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18587)
<!-- Reviewable:end -->
