### PR TITLE
Use Atom::from(nsIAtom) to increment reference count in case of dynam…

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3482,7 +3482,6 @@ fn static_assert() {
     pub fn clone_will_change(&self) -> longhands::will_change::computed_value::T {
         use properties::longhands::will_change::computed_value::T;
         use gecko_bindings::structs::nsIAtom;
-        use gecko_string_cache::Atom;
         use values::CustomIdent;
 
         if self.gecko.mWillChange.mBuffer.len() == 0 {
@@ -3490,9 +3489,7 @@ fn static_assert() {
         } else {
             T::AnimateableFeatures(
                 self.gecko.mWillChange.mBuffer.iter().map(|gecko_atom| {
-                    CustomIdent(
-                        unsafe { Atom::from_addrefed(*gecko_atom as *mut nsIAtom) }
-                    )
+                    CustomIdent((*gecko_atom as *mut nsIAtom).into())
                 }).collect()
             )
         }


### PR DESCRIPTION
…ic atom for will-change.

If we don't increment the reference count for the Atom in servo side, it's
possible to try to release the Atom in servo side even if we have already
released in gecko side.  When it happens, nsIAtom::mKind is no longer reliable.

https://bugzilla.mozilla.org/show_bug.cgi?id=1401809

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18590)
<!-- Reviewable:end -->
