### PR TITLE
stylo: do not handle the fallback discrete animation inside the Animate trait

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -1453,11 +1453,10 @@ impl Animate for ComputedMatrix {
                 (Ok(this), Ok(other)) => {
                     Ok(ComputedMatrix::from(this.animate(&other, procedure)?))
                 },
-                _ => {
-                    let (this_weight, other_weight) = procedure.weights();
-                    let result = if this_weight > other_weight { *self } else { *other };
-                    Ok(result)
-                },
+                // Matrices can be undecomposable due to couple reasons, e.g.,
+                // non-invertible matrices. In this case, we should report Err
+                // here, and let the caller do the fallback procedure.
+                _ => Err(())
             }
         } else {
             let this = MatrixDecomposed2D::from(*self);
@@ -1477,11 +1476,10 @@ impl Animate for ComputedMatrix {
             (Ok(from), Ok(to)) => {
                 Ok(ComputedMatrix::from(from.animate(&to, procedure)?))
             },
-            _ => {
-                let (this_weight, other_weight) = procedure.weights();
-                let result = if this_weight > other_weight { *self } else { *other };
-                Ok(result)
-            },
+            // Matrices can be undecomposable due to couple reasons, e.g.,
+            // non-invertible matrices. In this case, we should report Err here,
+            // and let the caller do the fallback procedure.
+            _ => Err(())
         }
     }
 }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2218,9 +2218,13 @@ pub extern "C" fn Servo_MatrixTransform_Operate(matrix_operator: MatrixTransform
     };
 
     let output = unsafe { output.as_mut() }.expect("not a valid 'output' matrix");
-    if let Ok(result) =  result {
+    if let Ok(result) = result {
         *output = result.into();
-    };
+    } else if progress < 0.5 {
+        *output = from.clone().into();
+    } else {
+        *output = to.clone().into();
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
At present, we do the fallback discrete animation for non-invertible matrices in
ComputedMatrix.animate(). However, according to the spec, we should fallback to
discrete animation for cases like:

1. animation between transform with single non-invertible matrix
2. animation between transform with matched transform functions that have at least
   one non-invertible matrix
2. animation between transform with mismatched transform functions that have at
   least one non-invertible matrix.

The current implementation only handles the first case.

Moreover, we already have fallback discrete animation procedures in CSS Animation
and Web Animation, so we should be able to not doing any fallback inside the
Animate trait.

In this patch, we let the animation between non-invertible matrices to return Err().
So, we can propagate the Err() to the callers, and let the fallback discrete
animation procedure stay at the Servo_MatrixTransform_Operate, which is ouside
the Animate trait.

Gecko bug: [Bug 1394284](https://bugzilla.mozilla.org/show_bug.cgi?id=1394284)

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1394284](https://bugzilla.mozilla.org/show_bug.cgi?id=1394284)
- [X] There are wpt tests for these changes, and thet will be landed in [Bug 1394284](https://bugzilla.mozilla.org/show_bug.cgi?id=1394284)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18591)
<!-- Reviewable:end -->
