### PR TITLE
Remove unused 'untagged_unions' feature gate

### DIFF
--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -15,7 +15,6 @@
 #![feature(plugin)]
 #![feature(proc_macro)]
 #![feature(try_from)]
-#![feature(untagged_unions)]
 
 #![deny(unsafe_code)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
CC #5286

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18601)
<!-- Reviewable:end -->
