### PR TITLE
fix #18594: Unnecessarily allocating an error string

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -130,7 +130,7 @@ impl DocumentLoader {
     pub fn finish_load(&mut self, load: &LoadType) {
         debug!("Removing blocking load {:?} ({}).", load, self.blocking_loads.len());
         let idx = self.blocking_loads.iter().position(|unfinished| *unfinished == *load);
-        self.blocking_loads.remove(idx.expect(&format!("unknown completed load {:?}", load)));
+        self.blocking_loads.remove(idx.unwrap_or_else(|| panic!("unknown completed load {:?}", load)));
     }
 
     pub fn is_blocked(&self) -> bool {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
r? @asajeffrey 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #18594 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18603)
<!-- Reviewable:end -->
