### PR TITLE
stylo: Animate font-size as NonNegativeLength

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -596,7 +596,7 @@ ${helpers.single_keyword_system("font-variant-caps",
     }
 </%helpers:longhand>
 
-<%helpers:longhand name="font-size" animation_value_type="ComputedValue"
+<%helpers:longhand name="font-size" animation_value_type="NonNegativeLength"
                    flags="APPLIES_TO_FIRST_LETTER APPLIES_TO_FIRST_LINE APPLIES_TO_PLACEHOLDER"
                    allow_quirks="True" spec="https://drafts.csswg.org/css-fonts/#propdef-font-size">
     use app_units::Au;

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -7,10 +7,11 @@
 use app_units::Au;
 use std::fmt;
 use style_traits::ToCss;
+use values::animated::ToAnimatedValue;
 use values::computed::NonNegativeLength;
 use values::specified::font as specified;
 
-#[derive(Animate, ComputeSquaredDistance, ToAnimatedValue, ToAnimatedZero)]
+#[derive(Animate, ComputeSquaredDistance, ToAnimatedZero)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
@@ -72,5 +73,22 @@ impl FontSize {
 impl ToCss for FontSize {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         self.size.to_css(dest)
+    }
+}
+
+impl ToAnimatedValue for FontSize {
+    type AnimatedValue = NonNegativeLength;
+
+    #[inline]
+    fn to_animated_value(self) -> Self::AnimatedValue {
+        self.size
+    }
+
+    #[inline]
+    fn from_animated_value(animated: Self::AnimatedValue) -> Self {
+        FontSize {
+            size: animated.clamp(),
+            keyword_info: None,
+        }
     }
 }

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -76,6 +76,10 @@ impl ToCss for FontSize {
     }
 }
 
+/// XXXManishearth it might be better to
+/// animate this as computed, however this complicates
+/// clamping and might not be the right thing to do.
+/// We should figure it out.
 impl ToAnimatedValue for FontSize {
     type AnimatedValue = NonNegativeLength;
 

--- a/components/style/values/computed/length.rs
+++ b/components/style/values/computed/length.rs
@@ -791,6 +791,16 @@ impl NonNegativeLength {
         self.0.px()
     }
 
+    #[inline]
+    /// Ensures it is positive
+    pub fn clamp(self) -> Self {
+        if (self.0).0 < 0. {
+            Self::zero()
+        } else {
+            self
+        }
+    }
+
     /// Scale this NonNegativeLength.
     /// We scale NonNegativeLength by zero if the factor is negative because it doesn't
     /// make sense to scale a negative factor on a non-negative length.

--- a/components/style/values/computed/length.rs
+++ b/components/style/values/computed/length.rs
@@ -792,7 +792,7 @@ impl NonNegativeLength {
     }
 
     #[inline]
-    /// Ensures it is positive
+    /// Ensures it is non negative
     pub fn clamp(self) -> Self {
         if (self.0).0 < 0. {
             Self::zero()


### PR DESCRIPTION
Otherwise it doesn't clamp correctly and fails layout/style/test/test_transitions_per_property.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18609)
<!-- Reviewable:end -->
