### PR TITLE
Removed integrity check and test for no-cors requests

### DIFF
--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -324,10 +324,6 @@ impl Request {
                     "The mode is 'no-cors' but the method is not a cors-safelisted method".to_string()));
             }
             // Step 30.2
-            if !borrowed_request.integrity_metadata.is_empty() {
-                return Err(Error::Type("Integrity metadata is not an empty string".to_string()));
-            }
-            // Step 30.3
             r.Headers().set_guard(Guard::RequestNoCors);
         }
 

--- a/tests/wpt/web-platform-tests/fetch/api/request/request-error.html
+++ b/tests/wpt/web-platform-tests/fetch/api/request/request-error.html
@@ -53,12 +53,6 @@
 
       test(function() {
         assert_throws(new TypeError() ,
-                      function() { new Request("", {"mode" : "no-cors", "integrity" : "not  an empty string"}); },
-                      "Expect TypeError exception");
-      },"RequestInit's mode is no-cors and integrity is not empty");
-
-      test(function() {
-        assert_throws(new TypeError() ,
                       function() { new Request("", {"mode" : "cors", "cache" : "only-if-cached"}); },
                       "Expect TypeError exception");
       },"RequestInit's cache mode is only-if-cached and mode is not same-origin");


### PR DESCRIPTION
Removed Step 30.2 which raised a JS TypeError if the integrity metadata was not empty. I manually ran `new Request("", {"mode" : "no-cors", "integrity" : "not an empty string"});` in servo to validate that the exception no longer arose.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #18345 
- [x] These changes do not require tests because according to the ticket "Unfortunately, there's no automated test available for this yet because we are having trouble updating our copy of the upstream tests. "

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18617)
<!-- Reviewable:end -->
