### PR TITLE
Handle display property change from 'none' only if there is restyle hint for SMIL

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -194,17 +194,17 @@ trait PrivateMatchMethods: TElement {
         });
 
         if display_changed_from_none {
-          // When display value is changed from none to other, we need
-          // to traverse descendant elements in a subsequent normal
-          // traversal (we can't traverse them in this animation-only
-          // restyle since we have no way to know whether the decendants
-          // need to be traversed at the beginning of the animation-only
-          // restyle)
-          debug_assert!(restyle_hints.intersects(RESTYLE_SMIL),
-                        "Display animation should only happen for SMIL");
-          let task = ::context::SequentialTask::process_post_animation(*self,
-                                                                       DISPLAY_CHANGED_FROM_NONE_FOR_SMIL);
-          context.thread_local.tasks.push(task);
+            // When display value is changed from none to other, we need
+            // to traverse descendant elements in a subsequent normal
+            // traversal (we can't traverse them in this animation-only
+            // restyle since we have no way to know whether the decendants
+            // need to be traversed at the beginning of the animation-only
+            // restyle)
+            debug_assert!(restyle_hints.intersects(RESTYLE_SMIL),
+                          "Display animation should only happen for SMIL");
+            let task = ::context::SequentialTask::process_post_animation(*self,
+                                                                         DISPLAY_CHANGED_FROM_NONE_FOR_SMIL);
+            context.thread_local.tasks.push(task);
         }
     }
 

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -186,6 +186,9 @@ trait PrivateMatchMethods: TElement {
         use context::DISPLAY_CHANGED_FROM_NONE_FOR_SMIL;
         use properties::longhands::display::computed_value as display;
 
+        debug_assert!(restyle_hints.intersects(RESTYLE_SMIL),
+                      "Should have restyle hint for SMIL");
+
         let display_changed_from_none = old_values.map_or(false, |old| {
             let old_display_style = old.get_box().clone_display();
             let new_display_style = new_values.get_box().clone_display();
@@ -219,10 +222,12 @@ trait PrivateMatchMethods: TElement {
         use context::UpdateAnimationsTasks;
 
         if context.shared.traversal_flags.for_animation_only() {
-            self.handle_display_change_for_smil_if_needed(context,
-                                                          old_values.as_ref().map(|v| &**v),
-                                                          new_values,
-                                                          restyle_hint);
+            if restyle_hint.intersects(RESTYLE_SMIL) {
+                self.handle_display_change_for_smil_if_needed(context,
+                                                              old_values.as_ref().map(|v| &**v),
+                                                              new_values,
+                                                              restyle_hint);
+            }
             return;
         }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1401801

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18622)
<!-- Reviewable:end -->
