### PR TITLE
Stop allocating in fmt::Write for nsA[C]String

### DIFF
--- a/components/style/gecko_bindings/nsstring_vendor/src/lib.rs
+++ b/components/style/gecko_bindings/nsstring_vendor/src/lib.rs
@@ -988,7 +988,7 @@ impl From<String> for nsCString {
 // Support for the write!() macro for appending to nsACStrings
 impl fmt::Write for nsACString {
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
-        self.append(&nsCString::from(s));
+        self.append(s);
         Ok(())
     }
 }
@@ -1106,7 +1106,7 @@ impl fmt::Write for nsAString {
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
         // Directly invoke gecko's routines for appending utf8 strings to
         // nsAString values, to avoid as much overhead as possible
-        self.append_utf8(&nsCString::from(s));
+        self.append_utf8(s);
         Ok(())
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is the servo side of gecko bug 1403545 https://bugzilla.mozilla.org/show_bug.cgi?id=1403545. It's fixing a stylo perf regression caused by #18642 

It has already been reviewed on the gecko side by froydnj 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18656)
<!-- Reviewable:end -->
