### PR TITLE
Bug 1400754 - stylo: crash on Win64 Asan build.  r=manishearth, dmajor.

### DIFF
--- a/components/hashglobe/src/lib.rs
+++ b/components/hashglobe/src/lib.rs
@@ -10,7 +10,7 @@
 
 extern crate heapsize;
 
-mod alloc;
+pub mod alloc;
 pub mod hash_map;
 pub mod hash_set;
 pub mod protected;


### PR DESCRIPTION
* adds a hashglobe::alloc::realloc, as that was previously not implemented,
  copying and simplifying from liballoc_system.

* routes malloc and realloc calls through hashglobe::alloc::, instead of
  doing it via direct 'extern "C"' calls.

* removes the #[cfg(feature = "known_system_malloc")] markings in
  fallible/lib.rs (the fallible vec stuff) on the assumption that we no
  longer need to special-case these uses.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18661)
<!-- Reviewable:end -->
