### PR TITLE
stylo: Don't serialize default position on -moz- prefixed linear gradient

### DIFF
--- a/components/style/values/computed/image.rs
+++ b/components/style/values/computed/image.rs
@@ -13,6 +13,8 @@ use std::fmt;
 use style_traits::ToCss;
 use values::{Either, None_};
 use values::computed::{Angle, ComputedUrl, Context, Length, LengthOrPercentage, NumberOrPercentage, ToComputedValue};
+#[cfg(feature = "gecko")]
+use values::computed::Percentage;
 use values::computed::position::Position;
 use values::generics::image::{CompatMode, ColorStop as GenericColorStop, EndingShape as GenericEndingShape};
 use values::generics::image::{Gradient as GenericGradient, GradientItem as GenericGradientItem};
@@ -88,7 +90,13 @@ impl GenericLineDirection for LineDirection {
                 if compat_mode != CompatMode::Modern => true,
             LineDirection::Corner(..) => false,
             #[cfg(feature = "gecko")]
-            LineDirection::MozPosition(_, _) => false,
+            LineDirection::MozPosition(Some(Position {
+                horizontal: LengthOrPercentage::Percentage(Percentage(x)),
+                vertical: LengthOrPercentage::Percentage(Percentage(y)),
+            }), None) => {
+                // `50% 0%` is the default value for line direction.
+                x == 0.5 && y == 0.0
+            },
             _ => false,
         }
     }

--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -626,6 +626,32 @@ impl GenericsLineDirection for LineDirection {
                 if compat_mode == CompatMode::Modern => true,
             LineDirection::Vertical(Y::Top)
                 if compat_mode != CompatMode::Modern => true,
+            #[cfg(feature = "gecko")]
+            LineDirection::MozPosition(Some(LegacyPosition {
+                horizontal: ref x,
+                vertical: ref y,
+            }), None) => {
+                use values::computed::Percentage as ComputedPercentage;
+                use values::specified::transform::OriginComponent;
+
+                // `50% 0%` is the default value for line direction.
+                // These percentage values can also be keywords.
+                let x = match *x {
+                    OriginComponent::Center => true,
+                    OriginComponent::Length(LengthOrPercentage::Percentage(ComputedPercentage(val))) => {
+                        val == 0.5
+                    },
+                    _ => false,
+                };
+                let y = match *y {
+                    OriginComponent::Side(Y::Top) => true,
+                    OriginComponent::Length(LengthOrPercentage::Percentage(ComputedPercentage(val))) => {
+                        val == 0.0
+                    },
+                    _ => false,
+                };
+                x && y
+            },
             _ => false,
         }
     }


### PR DESCRIPTION
Normally, we should not serialize if the line direction points downwards. Unprefixed and
-webkit- prefixed syntaxes use only Keyword enum for line direction and we check them already.
But -moz- prefixed linear gradients can store position too. Therefore it's stored inside
`LineDirection::MozPosition` and we should check that for consistency between other gradients.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1396102](https://bugzilla.mozilla.org/show_bug.cgi?id=1396102)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18664)
<!-- Reviewable:end -->
