### PR TITLE
mach: Don't overwrite RUSTFLAGS when enabling debug assertions

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -243,7 +243,7 @@ class MachCommands(CommandBase):
         env = self.build_env(target=target, is_build=True)
 
         if with_debug_assertions:
-            env["RUSTFLAGS"] = "-C debug_assertions"
+            env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C debug_assertions"
 
         if android:
             android_platform = self.config["android"]["platform"]


### PR DESCRIPTION
---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18677)
<!-- Reviewable:end -->
