### PR TITLE
Improve the media tests

### DIFF
--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_loadedmetadata.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_loadedmetadata.html.ini
@@ -1,6 +1,5 @@
 [event_loadedmetadata.html]
   type: testharness
-  expected: TIMEOUT
   [setting src attribute on autoplay audio should trigger loadedmetadata event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_canplay_canplaythrough.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_canplay_canplaythrough.html.ini
@@ -1,6 +1,5 @@
 [event_order_canplay_canplaythrough.html]
   type: testharness
-  expected: TIMEOUT
   [setting src attribute on autoplay audio should trigger canplay then canplaythrough event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_canplay_playing.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_canplay_playing.html.ini
@@ -1,6 +1,5 @@
 [event_order_canplay_playing.html]
   type: testharness
-  expected: TIMEOUT
   [setting src attribute on autoplay audio should trigger canplay then playing event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_loadedmetadata_loadeddata.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_order_loadedmetadata_loadeddata.html.ini
@@ -1,6 +1,5 @@
 [event_order_loadedmetadata_loadeddata.html]
   type: testharness
-  expected: TIMEOUT
   [setting src attribute on autoplay audio should trigger loadedmetadata then loadeddata event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_pause.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_pause.html.ini
@@ -1,6 +1,5 @@
 [event_pause.html]
   type: testharness
-  expected: TIMEOUT
   [calling pause() on autoplay audio should trigger pause event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_play.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_play.html.ini
@@ -1,6 +1,5 @@
 [event_play.html]
   type: testharness
-  expected: TIMEOUT
   [setting src attribute on autoplay audio should trigger play event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_playing.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_playing.html.ini
@@ -1,6 +1,5 @@
 [event_playing.html]
   type: testharness
-  expected: TIMEOUT
   [setting src attribute on autoplay audio should trigger playing event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_progress_noautoplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_progress_noautoplay.html.ini
@@ -1,6 +1,5 @@
 [event_progress_noautoplay.html]
   type: testharness
-  expected: TIMEOUT
   [setting src attribute on non-autoplay audio should trigger progress event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html.ini
@@ -2,7 +2,7 @@
   type: testharness
   expected: TIMEOUT
   [calling play() on a sufficiently long audio should trigger timeupdate event]
-    expected: NOTRUN
+    expected: FAIL
 
   [calling play() on a sufficiently long video should trigger timeupdate event]
     expected: NOTRUN

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/autoplay-overrides-preload.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/autoplay-overrides-preload.html.ini
@@ -1,15 +1,14 @@
 [autoplay-overrides-preload.html]
   type: testharness
-  expected: TIMEOUT
   [autoplay (set first) overrides preload "none"]
-    expected: TIMEOUT
+    expected: FAIL
 
   [autoplay (set last) overrides preload "none"]
-    expected: TIMEOUT
+    expected: FAIL
 
   [autoplay (set first) overrides preload "metadata"]
-    expected: TIMEOUT
+    expected: FAIL
 
   [autoplay (set last) overrides preload "metadata"]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/load-events-networkState.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/load-events-networkState.html.ini
@@ -1,6 +1,5 @@
 [load-events-networkState.html]
   type: testharness
-  expected: TIMEOUT
   [NETWORK_IDLE]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/paused_false_during_play.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/paused_false_during_play.html.ini
@@ -1,6 +1,5 @@
 [paused_false_during_play.html]
   type: testharness
-  expected: TIMEOUT
   [audio.paused should be false during play event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/ready-states/autoplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/ready-states/autoplay.html.ini
@@ -1,18 +1,17 @@
 [autoplay.html]
   type: testharness
-  expected: TIMEOUT
   [audio.autoplay]
-    expected: TIMEOUT
+    expected: FAIL
 
   [audio.autoplay and load()]
-    expected: TIMEOUT
+    expected: FAIL
 
   [audio.autoplay and play()]
-    expected: TIMEOUT
+    expected: FAIL
 
   [audio.autoplay and pause()]
-    expected: TIMEOUT
+    expected: FAIL
 
   [audio.autoplay and internal pause steps]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_canplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_canplay.html.ini
@@ -1,6 +1,5 @@
 [readyState_during_canplay.html]
   type: testharness
-  expected: TIMEOUT
   [audio.readyState should be >= HAVE_FUTURE_DATA during canplay event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_canplaythrough.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_canplaythrough.html.ini
@@ -1,6 +1,5 @@
 [readyState_during_canplaythrough.html]
   type: testharness
-  expected: TIMEOUT
   [audio.readyState should be HAVE_ENOUGH_DATA during canplaythrough event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_loadeddata.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_loadeddata.html.ini
@@ -1,6 +1,5 @@
 [readyState_during_loadeddata.html]
   type: testharness
-  expected: TIMEOUT
   [audio.readyState should be >= HAVE_CURRENT_DATA during loadeddata event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_loadedmetadata.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_loadedmetadata.html.ini
@@ -1,6 +1,5 @@
 [readyState_during_loadedmetadata.html]
   type: testharness
-  expected: TIMEOUT
   [audio.readyState should be >= HAVE_METADATA during loadedmetadata event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_playing.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/readyState_during_playing.html.ini
@@ -1,6 +1,5 @@
 [readyState_during_playing.html]
   type: testharness
-  expected: TIMEOUT
   [audio.readyState should be >= HAVE_FUTURE_DATA during playing event]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/video_008.htm.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/video_008.htm.ini
@@ -1,6 +1,5 @@
 [video_008.htm]
   type: testharness
-  expected: TIMEOUT
   [HTML5 Media Elements: 'media' attribute]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_loadedmetadata.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_loadedmetadata.html
@@ -17,20 +17,22 @@
 test(function() {
   var t = async_test("setting src attribute on autoplay audio should trigger loadedmetadata event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("loadedmetadata", function() {
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("loadedmetadata", t.step_func(function() {
     t.done();
     a.pause();
-  });
+  }));
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - loadedmetadata");
 
 test(function() {
   var t = async_test("setting src attribute on autoplay video should trigger loadedmetadata event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("loadedmetadata", function() {
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("loadedmetadata", t.step_func(function() {
     t.done();
     v.pause();
-  });
+  }));
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - loadedmetadata");
   </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_order_canplay_canplaythrough.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_order_canplay_canplaythrough.html
@@ -18,16 +18,15 @@ test(function() {
   var t = async_test("setting src attribute on autoplay audio should trigger canplay then canplaythrough event", {timeout:5000});
   var a = document.getElementById("a");
   var found_canplay = false;
-  a.addEventListener("canplay", function() {
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("canplay", t.step_func(function() {
     found_canplay = true;
-  });
-  a.addEventListener("canplaythrough", function() {
-    t.step(function() {
-     assert_true(found_canplay);
-    });
+  }));
+  a.addEventListener("canplaythrough", t.step_func(function() {
+    assert_true(found_canplay);
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - canplay, then canplaythrough");
 
@@ -35,16 +34,15 @@ test(function() {
   var t = async_test("setting src attribute on autoplay video should trigger canplay then canplaythrough event", {timeout:5000});
   var v = document.getElementById("v");
   var found_canplay = false;
-  v.addEventListener("canplay", function() {
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("canplay", t.step_func(function() {
     found_canplay = true;
-  });
-  v.addEventListener("canplaythrough", function() {
-    t.step(function() {
-     assert_true(found_canplay);
-    });
+  }));
+  v.addEventListener("canplaythrough", t.step_func(function() {
+    assert_true(found_canplay);
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - canplay, then canplaythrough");
  </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_order_canplay_playing.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_order_canplay_playing.html
@@ -18,16 +18,15 @@ test(function() {
   var t = async_test("setting src attribute on autoplay audio should trigger canplay then playing event", {timeout:5000});
   var a = document.getElementById("a");
   var found_canplay = false;
-  a.addEventListener("canplay", function() {
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("canplay", t.step_func(function() {
     found_canplay = true;
-  });
-  a.addEventListener("playing", function() {
-    t.step(function() {
-     assert_true(found_canplay);
-    });
+  }));
+  a.addEventListener("playing", t.step_func(function() {
+    assert_true(found_canplay);
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - canplay, then playing");
 
@@ -35,16 +34,15 @@ test(function() {
   var t = async_test("setting src attribute on autoplay video should trigger canplay then playing event", {timeout:5000});
   var v = document.getElementById("v");
   var found_canplay = false;
-  v.addEventListener("canplay", function() {
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("canplay", t.step_func(function() {
     found_canplay = true;
-  });
-  v.addEventListener("playing", function() {
-    t.step(function() {
-     assert_true(found_canplay);
-    });
+  }));
+  v.addEventListener("playing", t.step_func(function() {
+    assert_true(found_canplay);
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - canplay, then playing");
   </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_order_loadedmetadata_loadeddata.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_order_loadedmetadata_loadeddata.html
@@ -18,16 +18,15 @@ test(function() {
   var t = async_test("setting src attribute on autoplay audio should trigger loadedmetadata then loadeddata event", {timeout:5000});
   var a = document.getElementById("a");
   var found_loadedmetadata = false;
-  a.addEventListener("loadedmetadata", function() {
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("loadedmetadata", t.step_func(function() {
     found_loadedmetadata = true;
-  });
-  a.addEventListener("loadeddata", function() {
-    t.step(function() {
-     assert_true(found_loadedmetadata);
-    });
+  }));
+  a.addEventListener("loadeddata", t.step_func(function() {
+    assert_true(found_loadedmetadata);
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - loadedmetadata, then loadeddata");
 
@@ -35,16 +34,15 @@ test(function() {
   var t = async_test("setting src attribute on autoplay video should trigger loadedmetadata then loadeddata event", {timeout:5000});
   var v = document.getElementById("v");
   var found_loadedmetadata = false;
-  v.addEventListener("loadedmetadata", function() {
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("loadedmetadata", t.step_func(function() {
     found_loadedmetadata = true;
-  });
-  v.addEventListener("loadeddata", function() {
-    t.step(function() {
-     assert_true(found_loadedmetadata);
-    });
+  }));
+  v.addEventListener("loadeddata", t.step_func(function() {
+    assert_true(found_loadedmetadata);
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - loadedmetadata, then loadeddata");
  </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_order_loadstart_progress.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_order_loadstart_progress.html
@@ -14,7 +14,7 @@
   </video>
   <div id="log"></div>
   <script>
-(function() {
+test(function() {
   var t = async_test("setting src attribute on autoplay audio should trigger loadstart then progress event", {timeout:5000});
   var a = document.getElementById("a");
   var found_loadstart = false;
@@ -28,9 +28,9 @@
     a.pause();
   }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
-})();
+}, "audio events - loadstart, then progress");
 
-(function() {
+test(function() {
   var t = async_test("setting src attribute on autoplay video should trigger loadstart then progress event", {timeout:5000});
   var v = document.getElementById("v");
   var found_loadstart = false;
@@ -44,7 +44,7 @@
     v.pause();
   }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
-})();
+}, "video events - loadstart, then progress");
   </script>
  </body>
 </html>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_pause.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_pause.html
@@ -17,30 +17,22 @@
 test(function() {
   var t = async_test("calling pause() on autoplay audio should trigger pause event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("pause", function() {
-    t.step(function() {
-     assert_true(true);
-    });
-    t.done();
-  }, false);
-  a.addEventListener("play", function() {
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("pause", t.step_func_done(), false);
+  a.addEventListener("play", t.step_func(function() {
     a.pause(); // pause right after play
-  });
+  }));
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - pause");
 
 test(function() {
   var t = async_test("calling pause() on autoplay video should trigger pause event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("pause", function() {
-    t.step(function() {
-     assert_true(true);
-    });
-    t.done();
-  }, false);
-  v.addEventListener("play", function() {
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("pause", t.step_func_done(), false);
+  v.addEventListener("play", t.step_func(function() {
     v.pause(); // pause right after play
-  });
+  }));
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - pause");
   </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_play.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_play.html
@@ -17,20 +17,22 @@
 test(function() {
   var t = async_test("setting src attribute on autoplay audio should trigger play event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("play", function() {
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("play", t.step_func(function() {
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - play");
 
 test(function() {
   var t = async_test("setting src attribute on autoplay video should trigger play event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("play", function() {
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("play", t.step_func(function() {
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - play");
   </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_playing.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_playing.html
@@ -17,20 +17,22 @@
 test(function() {
   var t = async_test("setting src attribute on autoplay audio should trigger playing event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("playing", function() {
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("playing", t.step_func(function() {
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - playing");
 
 test(function() {
   var t = async_test("setting src attribute on autoplay video should trigger playing event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("playing", function() {
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("playing", t.step_func(function() {
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - playing");
  </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_progress.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_progress.html
@@ -14,7 +14,7 @@
   </video>
   <div id="log"></div>
   <script>
-(function() {
+test(function() {
   var t = async_test("setting src attribute on autoplay audio should trigger progress event", {timeout:5000});
   var a = document.getElementById("a");
   a.addEventListener("error", t.unreached_func());
@@ -23,9 +23,9 @@
     a.pause();
   }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
-})();
+}, "audio events - progress");
 
-(function() {
+test(function() {
   var t = async_test("setting src attribute on autoplay video should trigger progress event", {timeout:5000});
   var v = document.getElementById("v");
   v.addEventListener("error", t.unreached_func());
@@ -34,7 +34,7 @@
     v.pause();
   }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
-})();
+}, "video events - progress");
   </script>
  </body>
 </html>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_progress_noautoplay.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_progress_noautoplay.html
@@ -17,18 +17,16 @@
 test(function() {
   var t = async_test("setting src attribute on non-autoplay audio should trigger progress event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("progress", function() {
-    t.done();
-  }, false);
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("progress", t.step_func_done(), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - progress");
 
 test(function() {
   var t = async_test("setting src attribute on non-autoplay video should trigger progress event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("progress", function() {
-    t.done();
-  }, false);
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("progress", t.step_func_done(), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - progress");
   </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html
@@ -17,10 +17,11 @@
 test(function() {
   var t = async_test("calling play() on a sufficiently long audio should trigger timeupdate event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("timeupdate", function() {
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("timeupdate", t.step_func(function() {
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
   a.play();
 }, "audio events - timeupdate");
@@ -28,10 +29,11 @@ test(function() {
 test(function() {
   var t = async_test("calling play() on a sufficiently long video should trigger timeupdate event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("timeupdate", function() {
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("timeupdate", t.step_func(function() {
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
   v.play();
 }, "video events - timeupdate");

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/autoplay-overrides-preload.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/autoplay-overrides-preload.html
@@ -17,6 +17,7 @@
         a.preload = preload;
         a.autoplay = true;
       }
+      a.addEventListener('error', t.unreached_func());
       a.addEventListener('playing', t.step_func(function() {
         assert_equals(a.readyState, a.HAVE_ENOUGH_DATA);
         assert_false(a.paused);

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/load-events-networkState.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/load-events-networkState.html
@@ -37,6 +37,7 @@ async_test(function(t) {
   // fetch the resource" or "once the entire media resource has been fetched"
   v.preload = 'none';
   v.src = getAudioURI('/media/sound_5');
+  v.onerror = t.unreached_func();
   v.onsuspend = t.step_func(function() {
     v.onsuspend = null;
     assert_equals(v.networkState, v.NETWORK_IDLE);
@@ -47,6 +48,7 @@ async_test(function(t) {
 async_test(function(t) {
   var v = document.createElement('video');
   v.src = 'resources/delayed-broken-video.py';
+  v.onerror = t.unreached_func();
   v.onloadstart = t.step_func(function() {
     v.onloadstart = null;
     assert_equals(v.networkState, v.NETWORK_LOADING);

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/networkState_during_progress.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/networkState_during_progress.html
@@ -14,25 +14,29 @@
   </video>
   <div id="log"></div>
   <script>
-var ta = async_test("audioElement.networkState should be NETWORK_LOADING during progress event", {timeout:5000});
-var a = document.getElementById("a");
-a.addEventListener("error", ta.unreached_func());
-a.addEventListener("progress", ta.step_func(function() {
-  assert_equals(a.networkState, a.NETWORK_LOADING);
-  ta.done();
-  a.pause();
-}), false);
-a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
+test(function() {
+  var ta = async_test("audioElement.networkState should be NETWORK_LOADING during progress event", {timeout:5000});
+  var a = document.getElementById("a");
+  a.addEventListener("error", ta.unreached_func());
+  a.addEventListener("progress", ta.step_func(function() {
+    assert_equals(a.networkState, a.NETWORK_LOADING);
+    ta.done();
+    a.pause();
+  }), false);
+  a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
+}, "audio events - networkState during progress");
 
-var tv = async_test("videoElement.networkState should be NETWORK_LOADING during progress event", {timeout:5000});
-var v = document.getElementById("v");
-v.addEventListener("error", tv.unreached_func());
-v.addEventListener("progress", tv.step_func(function() {
-  assert_equals(v.networkState, v.NETWORK_LOADING);
-  tv.done();
-  v.pause();
-}), false);
-v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
+test(function() {
+  var tv = async_test("videoElement.networkState should be NETWORK_LOADING during progress event", {timeout:5000});
+  var v = document.getElementById("v");
+  v.addEventListener("error", tv.unreached_func());
+  v.addEventListener("progress", tv.step_func(function() {
+    assert_equals(v.networkState, v.NETWORK_LOADING);
+    tv.done();
+    v.pause();
+  }), false);
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
+}, "video events - networkState during progress");
   </script>
  </body>
 </html>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/paused_false_during_play.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/paused_false_during_play.html
@@ -17,26 +17,24 @@
 test(function() {
   var t = async_test("audio.paused should be false during play event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("play", function() {
-    t.step(function() {
-     assert_false(a.paused);
-    });
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("play", t.step_func(function() {
+    assert_false(a.paused);
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - paused property");
 
 test(function() {
   var t = async_test("video.paused should be false during play event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("play", function() {
-    t.step(function() {
-     assert_false(v.paused);
-    });
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("play", t.step_func(function() {
+    assert_false(v.paused);
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - paused property");
   </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/ready-states/autoplay.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/ready-states/autoplay.html
@@ -17,7 +17,7 @@ function autoplay_test(tagName, src) {
       }
     });
     ['canplay', 'canplaythrough',
-     'pause', 'play', 'playing'].forEach(function(type) {
+     'pause', 'play', 'playing', 'error'].forEach(function(type) {
       e.addEventListener(type, callback);
     });
   }

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/readyState_during_canplay.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/readyState_during_canplay.html
@@ -17,26 +17,24 @@
 test(function() {
   var t = async_test("audio.readyState should be >= HAVE_FUTURE_DATA during canplay event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("canplay", function() {
-    t.step(function() {
-     assert_greater_than_equal(a.readyState, a.HAVE_FUTURE_DATA);
-    });
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("canplay", t.step_func(function() {
+    assert_greater_than_equal(a.readyState, a.HAVE_FUTURE_DATA);
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - readyState property during canplay");
 
 test(function() {
   var t = async_test("video.readyState should be >= HAVE_FUTURE_DATA during canplay event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("canplay", function() {
-    t.step(function() {
-     assert_greater_than_equal(v.readyState, v.HAVE_FUTURE_DATA);
-    });
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("canplay", t.step_func(function() {
+    assert_greater_than_equal(v.readyState, v.HAVE_FUTURE_DATA);
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - readyState property during canplay");
   </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/readyState_during_canplaythrough.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/readyState_during_canplaythrough.html
@@ -17,28 +17,24 @@
 test(function() {
   var t = async_test("audio.readyState should be HAVE_ENOUGH_DATA during canplaythrough event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("canplaythrough", function() {
-    t.step(function() {
-     assert_equals(a.readyState,
-      a.HAVE_ENOUGH_DATA);
-    });
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("canplaythrough", t.step_func(function() {
+    assert_equals(a.readyState, a.HAVE_ENOUGH_DATA);
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - readyState property during canplaythrough");
 
 test(function() {
   var t = async_test("video.readyState should be HAVE_ENOUGH_DATA during canplaythrough event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("canplaythrough", function() {
-    t.step(function() {
-     assert_equals(v.readyState,
-      v.HAVE_ENOUGH_DATA);
-    });
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("canplaythrough", t.step_func(function() {
+    assert_equals(v.readyState, v.HAVE_ENOUGH_DATA);
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - readyState property during canplaythrough");
   </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/readyState_during_loadeddata.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/readyState_during_loadeddata.html
@@ -17,26 +17,24 @@
 test(function() {
   var t = async_test("audio.readyState should be >= HAVE_CURRENT_DATA during loadeddata event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("loadeddata", function() {
-    t.step(function() {
-     assert_greater_than_equal(a.readyState, a.HAVE_CURRENT_DATA);
-    });
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("loadeddata", t.step_func(function() {
+    assert_greater_than_equal(a.readyState, a.HAVE_CURRENT_DATA);
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - readyState property during loadeddata");
 
 test(function() {
   var t = async_test("video.readyState should be >= HAVE_CURRENT_DATA during loadeddata event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("loadeddata", function() {
-    t.step(function() {
-     assert_greater_than_equal(v.readyState, v.HAVE_CURRENT_DATA);
-    });
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("loadeddata", t.step_func(function() {
+    assert_greater_than_equal(v.readyState, v.HAVE_CURRENT_DATA);
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - readyState property during loadeddata");
   </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/readyState_during_loadedmetadata.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/readyState_during_loadedmetadata.html
@@ -17,26 +17,24 @@
 test(function() {
   var t = async_test("audio.readyState should be >= HAVE_METADATA during loadedmetadata event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("loadedmetadata", function() {
-    t.step(function() {
-     assert_greater_than_equal(a.readyState, a.HAVE_METADATA);
-    });
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("loadedmetadata", t.step_func(function() {
+    assert_greater_than_equal(a.readyState, a.HAVE_METADATA);
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - readyState property during loadedmetadata");
 
 test(function() {
   var t = async_test("video.readyState should be >= HAVE_METADATA during loadedmetadata event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("loadedmetadata", function() {
-    t.step(function() {
-     assert_greater_than_equal(v.readyState, v.HAVE_METADATA);
-    });
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("loadedmetadata", t.step_func(function() {
+    assert_greater_than_equal(v.readyState, v.HAVE_METADATA);
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - readyState property during loadedmetadata");
   </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/readyState_during_playing.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/readyState_during_playing.html
@@ -17,26 +17,24 @@
 test(function() {
   var t = async_test("audio.readyState should be >= HAVE_FUTURE_DATA during playing event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("playing", function() {
-    t.step(function() {
-     assert_greater_than_equal(a.readyState, a.HAVE_FUTURE_DATA);
-    });
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("playing", t.step_func(function() {
+    assert_greater_than_equal(a.readyState, a.HAVE_FUTURE_DATA);
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - readyState property during playing");
 
 test(function() {
   var t = async_test("video.readyState should be >= HAVE_FUTURE_DATA during playing event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("playing", function() {
-    t.step(function() {
-     assert_greater_than_equal(v.readyState, v.HAVE_FUTURE_DATA);
-    });
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("playing", t.step_func(function() {
+    assert_greater_than_equal(v.readyState, v.HAVE_FUTURE_DATA);
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - readyState property during playing");
   </script>

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/video_008.htm
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/video_008.htm
@@ -21,12 +21,14 @@
         videotest.done();
       }
 
+      var do_error = videotest.unreached_func();
+
     </script>
   </head>
   <body>
   <div id='log'></div>
 
-  <video id="video0" autoplay onplay="do_play(event);">
+  <video id="video0" autoplay onplay="do_play(event);" onerror="do_error();">
     <script type="text/javascript">
 
       document.write(


### PR DESCRIPTION
This avoids a bunch of timeouts and make running the tests from `/html/semantics/embedded-content/media-elements/` in 25 seconds instead of 47 locally on my machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18678)
<!-- Reviewable:end -->
