### PR TITLE
Implement Gradle flavors for Android VR compilations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = "0.0.1"
 dependencies = [
  "ipc-channel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr-api 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1217,6 +1217,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "gvr-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "half"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,6 +2216,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ovr-mobile-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "owning_ref"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,19 +2512,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rust-webvr"
-version = "0.8.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gl_generator 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gvr-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-webvr-api 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ovr-mobile-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rust-webvr-api"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_injected_glue 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3655,7 +3666,7 @@ dependencies = [
  "ipc-channel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "servo_config 0.0.1",
  "webvr_traits 0.0.1",
@@ -3868,6 +3879,7 @@ dependencies = [
 "checksum gleam 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "bf887141f0c2a83eae026cbf3fba74f0a5cb0f01d20e5cdfcd8c4ad39295be1e"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glx 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b280007fa9c7442cfd1e0b1addb8d1a59240267110e8705f8f7e2c7bfb7e2f72"
+"checksum gvr-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e84ba5e13cd925de87b669475525f956f8e936e67ddb24fbb1a077d96bbe174c"
 "checksum half 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63d68db75012a85555434ee079e7e6337931f87a087ab2988becbadf64673a7f"
 "checksum harfbuzz-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "a2caaa66078fdfacea32db1351223697a1167ad2d4bbee6b8d4ca220ce5b10b3"
 "checksum heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4c7593b1522161003928c959c20a2ca421c68e940d63d75573316a009e48a6d4"
@@ -3942,6 +3954,7 @@ dependencies = [
 "checksum ordered-float 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da12c96037889ae0be29dd2bdd260e5a62a7df24e6466d5a15bb8131c1c200a8"
 "checksum osmesa-src 17.2.0-devel (git+https://github.com/servo/osmesa-src)" = "<none>"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
+"checksum ovr-mobile-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7b5f9389b2015f8340f0566c488f3e96735e2e8fd7b85d571832cd274ac2998"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 "checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"
@@ -3971,8 +3984,8 @@ dependencies = [
 "checksum ref_slice 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "825740057197b7d43025e7faf6477eaabc03434e153233da02d1f44602f71527"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
-"checksum rust-webvr 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4514c041e0b1f7e00038acf19f0421c9cd77a629e0e111f319abbde714742003"
-"checksum rust-webvr-api 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ece2e3ecae072ebf033811082cd58ddb46910af1a7e26b0917fdf455a20aab3"
+"checksum rust-webvr 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c1ab572fff7a623e973511c7fc615e9f74a2429946b826c5c16a2f017489b79a"
+"checksum rust-webvr-api 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "712e22ba3c03a7075b40842ae91029a0ab96a81f95e97c0cf623800ec0cbac07"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -17,6 +17,8 @@ max_log_level = ["log/release_max_level_info"]
 webdriver = ["webdriver_server"]
 energy-profiling = ["profile_traits/energy-profiling"]
 debugmozjs = ["script/debugmozjs"]
+googlevr = ["webvr/googlevr"]
+oculusvr = ["webvr/oculusvr"]
 
 [dependencies]
 bluetooth_traits = {path = "../bluetooth_traits"}

--- a/components/webvr/Cargo.toml
+++ b/components/webvr/Cargo.toml
@@ -9,13 +9,17 @@ publish = false
 name = "webvr"
 path = "lib.rs"
 
+[features]
+googlevr = ['rust-webvr/googlevr']
+oculusvr = ['rust-webvr/oculusvr']
+
 [dependencies]
 canvas_traits = {path = "../canvas_traits"}
 euclid = "0.15"
 ipc-channel = "0.8"
 log = "0.3"
 msg = {path = "../msg"}
-rust-webvr = {version = "0.8", features = ["openvr"]}
+rust-webvr = {version = "0.9", features = ["openvr"]}
 script_traits = {path = "../script_traits"}
 servo_config = {path = "../config"}
 webvr_traits = {path = "../webvr_traits" }

--- a/components/webvr_traits/Cargo.toml
+++ b/components/webvr_traits/Cargo.toml
@@ -12,5 +12,5 @@ path = "lib.rs"
 [dependencies]
 ipc-channel = "0.8"
 msg = {path = "../msg"}
-rust-webvr-api = {version = "0.8", features = ["serde-serialization"]}
+rust-webvr-api = {version = "0.9", features = ["serde-serialization"]}
 serde = "1.0"

--- a/ports/servo/Cargo.toml
+++ b/ports/servo/Cargo.toml
@@ -34,6 +34,8 @@ max_log_level = ["log/release_max_level_info"]
 webdriver = ["libservo/webdriver_server"]
 energy-profiling = ["libservo/energy-profiling"]
 debugmozjs = ["libservo/debugmozjs"]
+googlevr = ["libservo/googlevr"]
+oculusvr = ["libservo/oculusvr"]
 
 [dependencies]
 backtrace = "0.3"

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -309,6 +309,11 @@ class MachCommands(CommandBase):
             env['CPPFLAGS'] = ' '.join(["--sysroot", env['ANDROID_SYSROOT']])
             env["CMAKE_ANDROID_ARCH_ABI"] = self.config["android"]["lib"]
             env["CMAKE_TOOLCHAIN_FILE"] = path.join(self.android_support_dir(), "toolchain.cmake")
+            # Set output dir for gradle aar files
+            aar_out_dir = self.android_aar_dir()
+            if not os.path.exists(aar_out_dir):
+                os.makedirs(aar_out_dir)
+            env["AAR_OUT_DIR"] = aar_out_dir
 
         cargo_binary = "cargo" + BIN_SUFFIX
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -551,6 +551,9 @@ class CommandBase(object):
     def android_build_dir(self, dev):
         return path.join(self.get_target_dir(), self.config["android"]["target"], "debug" if dev else "release")
 
+    def android_aar_dir(self):
+        return path.join(self.context.topdir, "target", "android_aar")
+
     def handle_android_target(self, target):
         if target == "arm-linux-androideabi":
             self.config["android"]["platform"] = "android-18"

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -180,7 +180,10 @@ class PackageCommands(CommandBase):
     @CommandArgument('--target', '-t',
                      default=None,
                      help='Package for given target platform')
-    def package(self, release=False, dev=False, android=None, debug=False, debugger=None, target=None):
+    @CommandArgument('--flavor', '-f',
+                     default=None,
+                     help='Package using the given Gradle flavor')
+    def package(self, release=False, dev=False, android=None, debug=False, debugger=None, target=None, flavor=None):
         env = self.build_env()
         if android is None:
             android = self.config["build"]["android"]
@@ -206,7 +209,11 @@ class PackageCommands(CommandBase):
             else:
                 build_mode = "Release"
 
-            task_name = "assemble" + build_type + build_mode
+            flavor_name = "Main"
+            if flavor is not None:
+                flavor_name = flavor.title()
+
+            task_name = "assemble" + flavor_name + build_type + build_mode
             try:
                 with cd(path.join("support", "android", "apk")):
                     subprocess.check_call(["./gradlew", "--no-daemon", task_name], env=env)

--- a/support/android/apk/app/build.gradle
+++ b/support/android/apk/app/build.gradle
@@ -33,6 +33,17 @@ android {
         }
     }
 
+    productFlavors {
+        main {
+        }
+        googlevr {
+            minSdkVersion 21
+        }
+        oculusvr {
+            minSdkVersion 21
+        }
+    }
+
     sourceSets {
         main {
             java.srcDirs = ['src/main/java']
@@ -145,7 +156,9 @@ android {
     // Call our custom NDK Build task using flavor parameters
     tasks.all {
         compileTask ->
-            Pattern pattern = Pattern.compile(/^transformJackWithJackFor([\w\d]+)(Debug|Release)/);
+            // Parse architecture name from gradle task name:
+            // Examples: transformJackWithJackForMainArmv7Release, transformJackWithJackForOculusvrArmv7Release
+            Pattern pattern = Pattern.compile(/^transformJackWithJackFor[A-Z][\w\d]+([A-Z][\w\d]+)(Debug|Release)/);
             Matcher matcher = pattern.matcher(compileTask.name);
             // You can use this alternative pattern when jackCompiler is disabled
             // Pattern pattern = Pattern.compile(/^compile([\w\d]+)(Debug|Release)/);
@@ -194,6 +207,10 @@ dependencies {
             }
         }
     }
+
+    googlevrCompile 'com.google.vr:sdk-base:1.70.0'
+    googlevrCompile(name:'GVRService', ext:'aar')
+    oculusvrCompile(name:'OVRService', ext:'aar')
 }
 
 // Utility methods

--- a/support/android/apk/app/src/googlevr/AndroidManifest.xml
+++ b/support/android/apk/app/src/googlevr/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- BEGIN_INCLUDE(manifest) -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.mozilla.servo">
+    <application>
+        <activity android:name=".MainActivity"
+            android:screenOrientation="landscape"
+            android:enableVrMode="@string/gvr_vr_mode_component"
+            android:resizeableActivity="false">
+            <!-- Intent filter that enables this app to be launched from the
+Daydream Home menu. -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.google.intent.category.DAYDREAM"/>
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>
+    <!-- END_INCLUDE(manifest) -->

--- a/support/android/apk/app/src/oculusvr/AndroidManifest.xml
+++ b/support/android/apk/app/src/oculusvr/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- BEGIN_INCLUDE(manifest) -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.mozilla.servo">>
+    <application>
+        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        <activity android:name=".MainActivity" android:screenOrientation="landscape">
+        </activity>
+    </application>
+</manifest>
+<!-- END_INCLUDE(manifest) -->

--- a/support/android/apk/build.gradle
+++ b/support/android/apk/build.gradle
@@ -11,6 +11,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        flatDir {
+            dirs rootDir.absolutePath + "/../../../target/android_aar"
+        }
     }
 
     buildDir = rootDir.absolutePath + "/../../../target/gradle"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR adds support to easily generate Android VR builds. Rust/Java VR dependencies are not added by default.

Default build (No VR support)
```
./mach build --release --android
./mach package --release --android
./mach install --release --android
```

GoogleVR builds (e.g. Daydream)
```
./mach build --release --android --features googlevr
./mach package --release --android --flavor googlevr
./mach install --release --android
```

OculusVR builds (e.g. Gear VR)
```
./mach build --release --android --features oculusvr
./mach package --release --android --flavor oculusvr
./mach install --release --android
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18680)
<!-- Reviewable:end -->
