### PR TITLE
style: Use a SharedFontList object to store font-family values for Gecko

### DIFF
--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -135,7 +135,7 @@ impl FontContext {
 
         let mut fonts: SmallVec<[Rc<RefCell<Font>>; 8]> = SmallVec::new();
 
-        for family in &style.font_family.0 {
+        for family in style.font_family.0.iter() {
             // GWTODO: Check on real pages if this is faster as Vec() or HashMap().
             let mut cache_hit = false;
             for cached_font_entry in &self.layout_font_cache {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -554,9 +554,10 @@ impl LayoutElementHelpers for LayoutDom<Element> {
             hints.push(from_declaration(
                 shared_lock,
                 PropertyDeclaration::FontFamily(
-                        font_family::SpecifiedValue::Values(vec![
+                    font_family::SpecifiedValue::Values(
+                        font_family::computed_value::FontFamilyList::new(vec![
                             font_family::computed_value::FontFamily::from_atom(
-                                font_family)]))));
+                                font_family)])))));
         }
 
         let font_size = self.downcast::<HTMLFontElement>().and_then(|this| this.get_size());

--- a/components/style/gecko/generated/atom_macro.rs
+++ b/components/style/gecko/generated/atom_macro.rs
@@ -3280,6 +3280,8 @@ cfg_if! {
             pub static nsGkAtoms_skewY: *mut nsIAtom;
             #[link_name = "_ZN9nsGkAtoms5slopeE"]
             pub static nsGkAtoms_slope: *mut nsIAtom;
+            #[link_name = "_ZN9nsGkAtoms4slotE"]
+            pub static nsGkAtoms_slot: *mut nsIAtom;
             #[link_name = "_ZN9nsGkAtoms9softLightE"]
             pub static nsGkAtoms_softLight: *mut nsIAtom;
             #[link_name = "_ZN9nsGkAtoms7spacingE"]
@@ -8447,6 +8449,8 @@ cfg_if! {
             pub static nsGkAtoms_skewY: *mut nsIAtom;
             #[link_name = "?slope@nsGkAtoms@@2PEAVnsIAtom@@EA"]
             pub static nsGkAtoms_slope: *mut nsIAtom;
+            #[link_name = "?slot@nsGkAtoms@@2PEAVnsIAtom@@EA"]
+            pub static nsGkAtoms_slot: *mut nsIAtom;
             #[link_name = "?softLight@nsGkAtoms@@2PEAVnsIAtom@@EA"]
             pub static nsGkAtoms_softLight: *mut nsIAtom;
             #[link_name = "?spacing@nsGkAtoms@@2PEAVnsIAtom@@EA"]
@@ -13614,6 +13618,8 @@ cfg_if! {
             pub static nsGkAtoms_skewY: *mut nsIAtom;
             #[link_name = "\x01?slope@nsGkAtoms@@2PAVnsIAtom@@A"]
             pub static nsGkAtoms_slope: *mut nsIAtom;
+            #[link_name = "\x01?slot@nsGkAtoms@@2PAVnsIAtom@@A"]
+            pub static nsGkAtoms_slot: *mut nsIAtom;
             #[link_name = "\x01?softLight@nsGkAtoms@@2PAVnsIAtom@@A"]
             pub static nsGkAtoms_softLight: *mut nsIAtom;
             #[link_name = "\x01?spacing@nsGkAtoms@@2PAVnsIAtom@@A"]
@@ -18784,6 +18790,8 @@ macro_rules! atom {
   { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_skewY as *mut _) } };
 ("slope") =>
   { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_slope as *mut _) } };
+("slot") =>
+  { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_slot as *mut _) } };
 ("soft-light") =>
   { unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_softLight as *mut _) } };
 ("spacing") =>

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -52,7 +52,6 @@ use gecko_bindings::structs::CSSPseudoElementType;
 use gecko_bindings::structs::ServoTraversalFlags;
 use gecko_bindings::structs::ComputedTimingFunction_BeforeFlag;
 use gecko_bindings::structs::CounterStylePtr;
-use gecko_bindings::structs::FontFamilyList;
 use gecko_bindings::structs::FontFamilyType;
 use gecko_bindings::structs::FontSizePrefs;
 use gecko_bindings::structs::GeckoFontMetrics;
@@ -240,6 +239,8 @@ use gecko_bindings::structs::nsStyleTransformMatrix::MatrixTransformOperator;
 unsafe impl Send for nsStyleTransformMatrix::MatrixTransformOperator {}
 unsafe impl Sync for nsStyleTransformMatrix::MatrixTransformOperator {}
 use gecko_bindings::structs::RawGeckoGfxMatrix4x4;
+use gecko_bindings::structs::FontFamilyName;
+use gecko_bindings::structs::mozilla::SharedFontList;
 pub type nsTArrayBorrowed_uintptr_t<'a> = &'a mut ::gecko_bindings::structs::nsTArray<usize>;
 pub type RawServoStyleSetOwned = ::gecko_bindings::sugar::ownership::Owned<RawServoStyleSet>;
 pub type RawServoStyleSetOwnedOrNull = ::gecko_bindings::sugar::ownership::OwnedOrNull<RawServoStyleSet>;
@@ -874,19 +875,39 @@ extern "C" {
     pub fn Gecko_EnsureMozBorderColors(aBorder: *mut nsStyleBorder);
 }
 extern "C" {
-    pub fn Gecko_FontFamilyList_Clear(aList: *mut FontFamilyList);
-}
-extern "C" {
-    pub fn Gecko_FontFamilyList_AppendNamed(aList: *mut FontFamilyList,
-                                            aName: *mut nsIAtom,
-                                            aQuoted: bool);
-}
-extern "C" {
-    pub fn Gecko_FontFamilyList_AppendGeneric(list: *mut FontFamilyList,
-                                              familyType: FontFamilyType);
-}
-extern "C" {
     pub fn Gecko_CopyFontFamilyFrom(dst: *mut nsFont, src: *const nsFont);
+}
+extern "C" {
+    pub fn Gecko_nsTArray_FontFamilyName_AppendNamed(aNames:
+                                                         *mut nsTArray<FontFamilyName>,
+                                                     aName: *mut nsIAtom,
+                                                     aQuoted: bool);
+}
+extern "C" {
+    pub fn Gecko_nsTArray_FontFamilyName_AppendGeneric(aNames:
+                                                           *mut nsTArray<FontFamilyName>,
+                                                       aType: FontFamilyType);
+}
+extern "C" {
+    pub fn Gecko_SharedFontList_Create() -> *mut SharedFontList;
+}
+extern "C" {
+    pub fn Gecko_SharedFontList_SizeOfIncludingThis(fontlist:
+                                                        *mut SharedFontList)
+     -> usize;
+}
+extern "C" {
+    pub fn Gecko_SharedFontList_SizeOfIncludingThisIfUnshared(fontlist:
+                                                                  *mut SharedFontList)
+     -> usize;
+}
+extern "C" {
+    pub fn Gecko_AddRefSharedFontListArbitraryThread(aPtr:
+                                                         *mut SharedFontList);
+}
+extern "C" {
+    pub fn Gecko_ReleaseSharedFontListArbitraryThread(aPtr:
+                                                          *mut SharedFontList);
 }
 extern "C" {
     pub fn Gecko_nsFont_InitSystem(dst: *mut nsFont, font_id: i32,

--- a/components/style/gecko/generated/structs_debug.rs
+++ b/components/style/gecko/generated/structs_debug.rs
@@ -1921,40 +1921,6 @@ pub mod root {
                             mRefCnt ) ));
             }
             #[repr(C)]
-            #[derive(Debug)]
-            pub struct FontFamilyListRefCnt {
-                pub _base: root::mozilla::FontFamilyList,
-                pub mRefCnt: root::nsAutoRefCnt,
-                pub _mOwningThread: root::nsAutoOwningThread,
-            }
-            pub type FontFamilyListRefCnt_HasThreadSafeRefCnt =
-                root::mozilla::FalseType;
-            #[test]
-            fn bindgen_test_layout_FontFamilyListRefCnt() {
-                assert_eq!(::std::mem::size_of::<FontFamilyListRefCnt>() ,
-                           32usize , concat ! (
-                           "Size of: " , stringify ! ( FontFamilyListRefCnt )
-                           ));
-                assert_eq! (::std::mem::align_of::<FontFamilyListRefCnt>() ,
-                            8usize , concat ! (
-                            "Alignment of " , stringify ! (
-                            FontFamilyListRefCnt ) ));
-                assert_eq! (unsafe {
-                            & ( * ( 0 as * const FontFamilyListRefCnt ) ) .
-                            mRefCnt as * const _ as usize } , 16usize , concat
-                            ! (
-                            "Alignment of field: " , stringify ! (
-                            FontFamilyListRefCnt ) , "::" , stringify ! (
-                            mRefCnt ) ));
-                assert_eq! (unsafe {
-                            & ( * ( 0 as * const FontFamilyListRefCnt ) ) .
-                            _mOwningThread as * const _ as usize } , 24usize ,
-                            concat ! (
-                            "Alignment of field: " , stringify ! (
-                            FontFamilyListRefCnt ) , "::" , stringify ! (
-                            _mOwningThread ) ));
-            }
-            #[repr(C)]
             #[derive(Debug, Copy)]
             pub struct RGBAColorData {
                 pub mR: f32,
@@ -4000,6 +3966,12 @@ pub mod root {
             eCornerBottomLeftX = 6,
             eCornerBottomLeftY = 7,
         }
+        #[repr(C)]
+        #[derive(Debug, Copy, Clone)]
+        pub struct NotNull<T> {
+            pub mBasePtr: T,
+            pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+        }
         pub const FontFamilyType_eFamily_generic_first:
                   root::mozilla::FontFamilyType =
             FontFamilyType::eFamily_serif;
@@ -4053,13 +4025,61 @@ pub mod root {
                         "Alignment of field: " , stringify ! ( FontFamilyName
                         ) , "::" , stringify ! ( mName ) ));
         }
+        /// A refcounted array of FontFamilyNames.  We use this to store the specified
+        /// value (in Servo) and the computed value (in both Gecko and Servo) of the
+        /// font-family property.
+        #[repr(C)]
+        #[derive(Debug)]
+        pub struct SharedFontList {
+            pub mRefCnt: root::mozilla::ThreadSafeAutoRefCnt,
+            pub mNames: root::nsTArray<root::mozilla::FontFamilyName>,
+        }
+        pub type SharedFontList_HasThreadSafeRefCnt = root::mozilla::TrueType;
+        extern "C" {
+            #[link_name = "_ZN7mozilla14SharedFontList6sEmptyE"]
+            pub static mut SharedFontList_sEmpty:
+                       root::mozilla::StaticRefPtr<root::mozilla::SharedFontList>;
+        }
+        #[test]
+        fn bindgen_test_layout_SharedFontList() {
+            assert_eq!(::std::mem::size_of::<SharedFontList>() , 16usize ,
+                       concat ! ( "Size of: " , stringify ! ( SharedFontList )
+                       ));
+            assert_eq! (::std::mem::align_of::<SharedFontList>() , 8usize ,
+                        concat ! (
+                        "Alignment of " , stringify ! ( SharedFontList ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const SharedFontList ) ) . mRefCnt as *
+                        const _ as usize } , 0usize , concat ! (
+                        "Alignment of field: " , stringify ! ( SharedFontList
+                        ) , "::" , stringify ! ( mRefCnt ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const SharedFontList ) ) . mNames as *
+                        const _ as usize } , 8usize , concat ! (
+                        "Alignment of field: " , stringify ! ( SharedFontList
+                        ) , "::" , stringify ! ( mNames ) ));
+        }
+        #[test]
+        fn __bindgen_test_layout_StaticRefPtr_open0_SharedFontList_close0_instantiation() {
+            assert_eq!(::std::mem::size_of::<root::mozilla::StaticRefPtr<root::mozilla::SharedFontList>>()
+                       , 8usize , concat ! (
+                       "Size of template specialization: " , stringify ! (
+                       root::mozilla::StaticRefPtr<root::mozilla::SharedFontList>
+                       ) ));
+            assert_eq!(::std::mem::align_of::<root::mozilla::StaticRefPtr<root::mozilla::SharedFontList>>()
+                       , 8usize , concat ! (
+                       "Alignment of template specialization: " , stringify !
+                       (
+                       root::mozilla::StaticRefPtr<root::mozilla::SharedFontList>
+                       ) ));
+        }
         /// font family list, array of font families and a default font type.
         /// font family names are either named strings or generics. the default
         /// font type is used to preserve the variable font fallback behavior
         #[repr(C)]
         #[derive(Debug)]
         pub struct FontFamilyList {
-            pub mFontlist: root::nsTArray<root::mozilla::FontFamilyName>,
+            pub mFontlist: root::mozilla::NotNull<root::RefPtr<root::mozilla::SharedFontList>>,
             pub mDefaultFontType: root::mozilla::FontFamilyType,
         }
         #[test]
@@ -4303,12 +4323,6 @@ pub mod root {
             PreWrap = 3,
             PreLine = 4,
             PreSpace = 5,
-        }
-        #[repr(C)]
-        #[derive(Debug, Copy, Clone)]
-        pub struct NotNull<T> {
-            pub mBasePtr: T,
-            pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone)]
@@ -16514,7 +16528,8 @@ pub mod root {
         eCreated = 0,
         eConnected = 1,
         eDisconnected = 2,
-        eAttributeChanged = 3,
+        eAdopted = 3,
+        eAttributeChanged = 4,
     }
     pub const nsIDocument_eScopedStyle_Unknown:
               root::nsIDocument__bindgen_ty_1 =
@@ -29239,7 +29254,7 @@ pub mod root {
         pub mPairList: root::__BindgenUnionField<*mut root::nsCSSValuePairList_heap>,
         pub mPairListDependent: root::__BindgenUnionField<*mut root::nsCSSValuePairList>,
         pub mFloatColor: root::__BindgenUnionField<*mut root::nsCSSValueFloatColor>,
-        pub mFontFamilyList: root::__BindgenUnionField<*mut root::mozilla::css::FontFamilyListRefCnt>,
+        pub mFontFamilyList: root::__BindgenUnionField<*mut root::mozilla::SharedFontList>,
         pub mComplexColor: root::__BindgenUnionField<*mut root::mozilla::css::ComplexColorValue>,
         pub bindgen_union_field: u64,
     }
@@ -32797,28 +32812,6 @@ pub mod root {
                    ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation() {
-        assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-        assert_eq!(::std::mem::align_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_1() {
-        assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
-                   concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-        assert_eq!(::std::mem::align_of::<::nsstring::nsStringRepr>() , 8usize ,
-                   concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-    }
-    #[test]
     fn __bindgen_test_layout_nsTArray_open0_FontFamilyName_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
                    , 8usize , concat ! (
@@ -32839,6 +32832,52 @@ pub mod root {
                    , 8usize , concat ! (
                    "Alignment of template specialization: " , stringify ! (
                    root::nsTArray<root::mozilla::FontFamilyName> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTArray_open0_FontFamilyName_close0_instantiation_2() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTArray_open0_FontFamilyName_close0_instantiation_3() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_NotNull_open0_RefPtr_open1_SharedFontList_close1_close0_instantiation() {
+        assert_eq!(::std::mem::size_of::<root::mozilla::NotNull<root::RefPtr<root::mozilla::SharedFontList>>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::mozilla::NotNull<root::RefPtr<root::mozilla::SharedFontList>>
+                   ) ));
+        assert_eq!(::std::mem::align_of::<root::mozilla::NotNull<root::RefPtr<root::mozilla::SharedFontList>>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::mozilla::NotNull<root::RefPtr<root::mozilla::SharedFontList>>
+                   ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_RefPtr_open0_SharedFontList_close0_instantiation() {
+        assert_eq!(::std::mem::size_of::<root::RefPtr<root::mozilla::SharedFontList>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::RefPtr<root::mozilla::SharedFontList> ) ));
+        assert_eq!(::std::mem::align_of::<root::RefPtr<root::mozilla::SharedFontList>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::RefPtr<root::mozilla::SharedFontList> ) ));
     }
     #[test]
     fn __bindgen_test_layout_nsTArray_open0_unsigned_int_close0_instantiation() {
@@ -32953,7 +32992,7 @@ pub mod root {
                    root::nsTArray<root::mozilla::gfx::FontVariation> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_226503_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_226607_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsCSSSelector>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33320,7 +33359,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::ServoStyleContext> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_1() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33331,7 +33370,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_2() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_1() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33342,7 +33381,7 @@ pub mod root {
                    ::nsstring::nsStringRepr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_228357_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_228460_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33507,7 +33546,7 @@ pub mod root {
                    root::JS::DeletePolicy ) ));
     }
     #[test]
-    fn __bindgen_test_layout_iterator_open0_input_iterator_tag_UniquePtr_open1_JSErrorNotes_Note_DeletePolicy_open2_JSErrorNotes_Note_close2_close1_long__bindgen_ty_id_233983__bindgen_ty_id_233990_close0_instantiation() {
+    fn __bindgen_test_layout_iterator_open0_input_iterator_tag_UniquePtr_open1_JSErrorNotes_Note_DeletePolicy_open2_JSErrorNotes_Note_close2_close1_long__bindgen_ty_id_234086__bindgen_ty_id_234093_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::std::iterator>() , 1usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33814,7 +33853,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::StyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236522_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236625_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33882,7 +33921,7 @@ pub mod root {
                    root::nsCOMPtr<root::nsIObserver> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236827_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236930_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33994,7 +34033,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::URLExtraData> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_NotNull_open0__bindgen_ty_id_237378_close0_instantiation() {
+    fn __bindgen_test_layout_NotNull_open0__bindgen_ty_id_237481_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::mozilla::NotNull<*const root::mozilla::Encoding>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34431,7 +34470,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::StyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_237809_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_237912_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34547,7 +34586,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_238225_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_238328_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34670,7 +34709,7 @@ pub mod root {
                    root::mozilla::DefaultDelete ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_2() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_1() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34681,7 +34720,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_3() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_2() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34692,7 +34731,7 @@ pub mod root {
                    ::nsstring::nsStringRepr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239206_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239309_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34781,7 +34820,7 @@ pub mod root {
                    root::RefPtr<root::nsCSSFontFaceRule> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239518_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239621_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34792,7 +34831,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239523_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_239626_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34849,7 +34888,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::CSSStyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_240019_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_240122_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35240,7 +35279,7 @@ pub mod root {
                    root::nsTString<::std::os::raw::c_char> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_3() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_2() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35251,7 +35290,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_4() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_3() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35510,7 +35549,7 @@ pub mod root {
                    root::nsCOMPtr<root::nsIWeakReference> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_242818_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_242921_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut ::std::os::raw::c_void>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35589,7 +35628,7 @@ pub mod root {
                    root::mozilla::DefaultDelete ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_249053_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_249156_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::AudioContext>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35679,7 +35718,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_251327_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_251430_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsISupports>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35690,7 +35729,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsISupports> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_4() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_3() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35701,7 +35740,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_5() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_4() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35723,7 +35762,7 @@ pub mod root {
                    root::nsCOMPtr<root::nsIURI> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_5() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_4() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35734,7 +35773,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_6() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_5() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35896,7 +35935,7 @@ pub mod root {
                    root::nsTArray<f64> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_252815_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_252918_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35944,7 +35983,7 @@ pub mod root {
                    root::mozilla::UniquePtr<root::ProfilerBacktrace> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_6() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_5() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35955,7 +35994,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_7() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_6() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36012,7 +36051,7 @@ pub mod root {
                    root::nsRefPtrHashKey<root::nsIAtom> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_255231_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_255334_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::CounterStyle>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36045,7 +36084,7 @@ pub mod root {
                    root::nsCOMPtr<root::nsIRunnable> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_7() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_6() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36056,7 +36095,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_8() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_7() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36091,7 +36130,7 @@ pub mod root {
                    root::mozilla::DefaultDelete ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_8() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_7() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36102,7 +36141,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_9() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_8() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36267,7 +36306,7 @@ pub mod root {
                    root::nsTArray<root::mozilla::css::GridNamedArea> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_9() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_8() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36278,7 +36317,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_10() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_9() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36377,6 +36416,28 @@ pub mod root {
                    root::mozilla::DefaultDelete ) ));
     }
     #[test]
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_9() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<::nsstring::nsStringRepr> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<::nsstring::nsStringRepr>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<::nsstring::nsStringRepr> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_10() {
+        assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
+                   concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   ::nsstring::nsStringRepr ) ));
+        assert_eq!(::std::mem::align_of::<::nsstring::nsStringRepr>() , 8usize ,
+                   concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   ::nsstring::nsStringRepr ) ));
+    }
+    #[test]
     fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_10() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
@@ -36411,28 +36472,6 @@ pub mod root {
     }
     #[test]
     fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_12() {
-        assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
-                   concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-        assert_eq!(::std::mem::align_of::<::nsstring::nsStringRepr>() , 8usize ,
-                   concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_12() {
-        assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-        assert_eq!(::std::mem::align_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_13() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36651,7 +36690,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_14() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_13() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36662,7 +36701,7 @@ pub mod root {
                    ::nsstring::nsStringRepr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_15() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_14() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36684,7 +36723,7 @@ pub mod root {
                    root::nsTArray<root::nsTArray<::nsstring::nsStringRepr>> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_13() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_12() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36695,7 +36734,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_16() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_15() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36728,6 +36767,28 @@ pub mod root {
                    root::nsTArray<root::nsStyleCoord> ) ));
     }
     #[test]
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_13() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<::nsstring::nsStringRepr> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<::nsstring::nsStringRepr>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<::nsstring::nsStringRepr> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_16() {
+        assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
+                   concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   ::nsstring::nsStringRepr ) ));
+        assert_eq!(::std::mem::align_of::<::nsstring::nsStringRepr>() , 8usize ,
+                   concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   ::nsstring::nsStringRepr ) ));
+    }
+    #[test]
     fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_14() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
@@ -36740,28 +36801,6 @@ pub mod root {
     }
     #[test]
     fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_17() {
-        assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
-                   concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-        assert_eq!(::std::mem::align_of::<::nsstring::nsStringRepr>() , 8usize ,
-                   concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_15() {
-        assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-        assert_eq!(::std::mem::align_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_18() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36932,7 +36971,7 @@ pub mod root {
                    root::RefPtr<root::nsStyleImageRequest> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_257915_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_258017_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsISupports>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37169,7 +37208,7 @@ pub mod root {
                    root::nsCOMPtr<root::nsIURI> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_266234_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_266336_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37180,7 +37219,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_266239_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_266341_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37268,7 +37307,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::dom::ShadowRoot> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_266352_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_266454_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37542,7 +37581,7 @@ pub mod root {
                    root::nsRefPtrHashKey<root::mozilla::dom::Element> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_268084_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_268186_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37564,7 +37603,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::dom::Element> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_268246_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_268348_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37575,7 +37614,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_268251_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_268353_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37584,6 +37623,28 @@ pub mod root {
                    , 8usize , concat ! (
                    "Alignment of template specialization: " , stringify ! (
                    root::nsTArray<*mut root::nsIContent> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTArray_open0_FontFamilyName_close0_instantiation_4() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTArray_open0_FontFamilyName_close0_instantiation_5() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
     }
     #[test]
     fn __bindgen_test_layout_nsTArray_open0_unsigned_int_close0_instantiation_6() {
@@ -37597,7 +37658,7 @@ pub mod root {
                    root::nsTArray<::std::os::raw::c_uint> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_16() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_15() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37608,7 +37669,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_19() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_18() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37718,7 +37779,7 @@ pub mod root {
                    root::nsTArray<root::mozilla::gfx::FontVariation> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_270691_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_270805_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::css::DocumentRule>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37729,7 +37790,7 @@ pub mod root {
                    root::nsTArray<*mut root::mozilla::css::DocumentRule> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_270699_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_270813_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::css::DocumentRule>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (

--- a/components/style/gecko/generated/structs_release.rs
+++ b/components/style/gecko/generated/structs_release.rs
@@ -1885,32 +1885,6 @@ pub mod root {
                             mRefCnt ) ));
             }
             #[repr(C)]
-            #[derive(Debug)]
-            pub struct FontFamilyListRefCnt {
-                pub _base: root::mozilla::FontFamilyList,
-                pub mRefCnt: root::nsAutoRefCnt,
-            }
-            pub type FontFamilyListRefCnt_HasThreadSafeRefCnt =
-                root::mozilla::FalseType;
-            #[test]
-            fn bindgen_test_layout_FontFamilyListRefCnt() {
-                assert_eq!(::std::mem::size_of::<FontFamilyListRefCnt>() ,
-                           24usize , concat ! (
-                           "Size of: " , stringify ! ( FontFamilyListRefCnt )
-                           ));
-                assert_eq! (::std::mem::align_of::<FontFamilyListRefCnt>() ,
-                            8usize , concat ! (
-                            "Alignment of " , stringify ! (
-                            FontFamilyListRefCnt ) ));
-                assert_eq! (unsafe {
-                            & ( * ( 0 as * const FontFamilyListRefCnt ) ) .
-                            mRefCnt as * const _ as usize } , 16usize , concat
-                            ! (
-                            "Alignment of field: " , stringify ! (
-                            FontFamilyListRefCnt ) , "::" , stringify ! (
-                            mRefCnt ) ));
-            }
-            #[repr(C)]
             #[derive(Debug, Copy)]
             pub struct RGBAColorData {
                 pub mR: f32,
@@ -3920,6 +3894,12 @@ pub mod root {
             eCornerBottomLeftX = 6,
             eCornerBottomLeftY = 7,
         }
+        #[repr(C)]
+        #[derive(Debug, Copy, Clone)]
+        pub struct NotNull<T> {
+            pub mBasePtr: T,
+            pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+        }
         pub const FontFamilyType_eFamily_generic_first:
                   root::mozilla::FontFamilyType =
             FontFamilyType::eFamily_serif;
@@ -3973,13 +3953,61 @@ pub mod root {
                         "Alignment of field: " , stringify ! ( FontFamilyName
                         ) , "::" , stringify ! ( mName ) ));
         }
+        /// A refcounted array of FontFamilyNames.  We use this to store the specified
+        /// value (in Servo) and the computed value (in both Gecko and Servo) of the
+        /// font-family property.
+        #[repr(C)]
+        #[derive(Debug)]
+        pub struct SharedFontList {
+            pub mRefCnt: root::mozilla::ThreadSafeAutoRefCnt,
+            pub mNames: root::nsTArray<root::mozilla::FontFamilyName>,
+        }
+        pub type SharedFontList_HasThreadSafeRefCnt = root::mozilla::TrueType;
+        extern "C" {
+            #[link_name = "_ZN7mozilla14SharedFontList6sEmptyE"]
+            pub static mut SharedFontList_sEmpty:
+                       root::mozilla::StaticRefPtr<root::mozilla::SharedFontList>;
+        }
+        #[test]
+        fn bindgen_test_layout_SharedFontList() {
+            assert_eq!(::std::mem::size_of::<SharedFontList>() , 16usize ,
+                       concat ! ( "Size of: " , stringify ! ( SharedFontList )
+                       ));
+            assert_eq! (::std::mem::align_of::<SharedFontList>() , 8usize ,
+                        concat ! (
+                        "Alignment of " , stringify ! ( SharedFontList ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const SharedFontList ) ) . mRefCnt as *
+                        const _ as usize } , 0usize , concat ! (
+                        "Alignment of field: " , stringify ! ( SharedFontList
+                        ) , "::" , stringify ! ( mRefCnt ) ));
+            assert_eq! (unsafe {
+                        & ( * ( 0 as * const SharedFontList ) ) . mNames as *
+                        const _ as usize } , 8usize , concat ! (
+                        "Alignment of field: " , stringify ! ( SharedFontList
+                        ) , "::" , stringify ! ( mNames ) ));
+        }
+        #[test]
+        fn __bindgen_test_layout_StaticRefPtr_open0_SharedFontList_close0_instantiation() {
+            assert_eq!(::std::mem::size_of::<root::mozilla::StaticRefPtr<root::mozilla::SharedFontList>>()
+                       , 8usize , concat ! (
+                       "Size of template specialization: " , stringify ! (
+                       root::mozilla::StaticRefPtr<root::mozilla::SharedFontList>
+                       ) ));
+            assert_eq!(::std::mem::align_of::<root::mozilla::StaticRefPtr<root::mozilla::SharedFontList>>()
+                       , 8usize , concat ! (
+                       "Alignment of template specialization: " , stringify !
+                       (
+                       root::mozilla::StaticRefPtr<root::mozilla::SharedFontList>
+                       ) ));
+        }
         /// font family list, array of font families and a default font type.
         /// font family names are either named strings or generics. the default
         /// font type is used to preserve the variable font fallback behavior
         #[repr(C)]
         #[derive(Debug)]
         pub struct FontFamilyList {
-            pub mFontlist: root::nsTArray<root::mozilla::FontFamilyName>,
+            pub mFontlist: root::mozilla::NotNull<root::RefPtr<root::mozilla::SharedFontList>>,
             pub mDefaultFontType: root::mozilla::FontFamilyType,
         }
         #[test]
@@ -4223,12 +4251,6 @@ pub mod root {
             PreWrap = 3,
             PreLine = 4,
             PreSpace = 5,
-        }
-        #[repr(C)]
-        #[derive(Debug, Copy, Clone)]
-        pub struct NotNull<T> {
-            pub mBasePtr: T,
-            pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone)]
@@ -16358,7 +16380,8 @@ pub mod root {
         eCreated = 0,
         eConnected = 1,
         eDisconnected = 2,
-        eAttributeChanged = 3,
+        eAdopted = 3,
+        eAttributeChanged = 4,
     }
     pub const nsIDocument_eScopedStyle_Unknown:
               root::nsIDocument__bindgen_ty_1 =
@@ -28832,7 +28855,7 @@ pub mod root {
         pub mPairList: root::__BindgenUnionField<*mut root::nsCSSValuePairList_heap>,
         pub mPairListDependent: root::__BindgenUnionField<*mut root::nsCSSValuePairList>,
         pub mFloatColor: root::__BindgenUnionField<*mut root::nsCSSValueFloatColor>,
-        pub mFontFamilyList: root::__BindgenUnionField<*mut root::mozilla::css::FontFamilyListRefCnt>,
+        pub mFontFamilyList: root::__BindgenUnionField<*mut root::mozilla::SharedFontList>,
         pub mComplexColor: root::__BindgenUnionField<*mut root::mozilla::css::ComplexColorValue>,
         pub bindgen_union_field: u64,
     }
@@ -32390,28 +32413,6 @@ pub mod root {
                    ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation() {
-        assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-        assert_eq!(::std::mem::align_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_1() {
-        assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
-                   concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-        assert_eq!(::std::mem::align_of::<::nsstring::nsStringRepr>() , 8usize ,
-                   concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-    }
-    #[test]
     fn __bindgen_test_layout_nsTArray_open0_FontFamilyName_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
                    , 8usize , concat ! (
@@ -32432,6 +32433,52 @@ pub mod root {
                    , 8usize , concat ! (
                    "Alignment of template specialization: " , stringify ! (
                    root::nsTArray<root::mozilla::FontFamilyName> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTArray_open0_FontFamilyName_close0_instantiation_2() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTArray_open0_FontFamilyName_close0_instantiation_3() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_NotNull_open0_RefPtr_open1_SharedFontList_close1_close0_instantiation() {
+        assert_eq!(::std::mem::size_of::<root::mozilla::NotNull<root::RefPtr<root::mozilla::SharedFontList>>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::mozilla::NotNull<root::RefPtr<root::mozilla::SharedFontList>>
+                   ) ));
+        assert_eq!(::std::mem::align_of::<root::mozilla::NotNull<root::RefPtr<root::mozilla::SharedFontList>>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::mozilla::NotNull<root::RefPtr<root::mozilla::SharedFontList>>
+                   ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_RefPtr_open0_SharedFontList_close0_instantiation() {
+        assert_eq!(::std::mem::size_of::<root::RefPtr<root::mozilla::SharedFontList>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::RefPtr<root::mozilla::SharedFontList> ) ));
+        assert_eq!(::std::mem::align_of::<root::RefPtr<root::mozilla::SharedFontList>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::RefPtr<root::mozilla::SharedFontList> ) ));
     }
     #[test]
     fn __bindgen_test_layout_nsTArray_open0_unsigned_int_close0_instantiation() {
@@ -32546,7 +32593,7 @@ pub mod root {
                    root::nsTArray<root::mozilla::gfx::FontVariation> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_224054_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_224159_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsCSSSelector>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -32913,7 +32960,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::ServoStyleContext> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_1() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -32924,7 +32971,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_2() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_1() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -32935,7 +32982,7 @@ pub mod root {
                    ::nsstring::nsStringRepr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_225874_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_225978_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33100,7 +33147,7 @@ pub mod root {
                    root::JS::DeletePolicy ) ));
     }
     #[test]
-    fn __bindgen_test_layout_iterator_open0_input_iterator_tag_UniquePtr_open1_JSErrorNotes_Note_DeletePolicy_open2_JSErrorNotes_Note_close2_close1_long__bindgen_ty_id_231472__bindgen_ty_id_231479_close0_instantiation() {
+    fn __bindgen_test_layout_iterator_open0_input_iterator_tag_UniquePtr_open1_JSErrorNotes_Note_DeletePolicy_open2_JSErrorNotes_Note_close2_close1_long__bindgen_ty_id_231576__bindgen_ty_id_231583_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::std::iterator>() , 1usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33407,7 +33454,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::StyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_234009_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_234113_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33475,7 +33522,7 @@ pub mod root {
                    root::nsCOMPtr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_234314_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_234418_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -33587,7 +33634,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::URLExtraData> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_NotNull_open0__bindgen_ty_id_234865_close0_instantiation() {
+    fn __bindgen_test_layout_NotNull_open0__bindgen_ty_id_234969_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::mozilla::NotNull<*const root::mozilla::Encoding>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34022,7 +34069,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::StyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_235294_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_235398_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34138,7 +34185,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_235708_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_235812_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34261,7 +34308,7 @@ pub mod root {
                    root::mozilla::DefaultDelete ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_2() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_1() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34272,7 +34319,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_3() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_2() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34283,7 +34330,7 @@ pub mod root {
                    ::nsstring::nsStringRepr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236679_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236783_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34372,7 +34419,7 @@ pub mod root {
                    root::RefPtr<root::nsCSSFontFaceRule> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236989_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_237093_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34383,7 +34430,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_236994_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_237098_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34440,7 +34487,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::CSSStyleSheet> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_237474_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_237578_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::StyleSheet>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34829,7 +34876,7 @@ pub mod root {
                    root::nsTString<::std::os::raw::c_char> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_3() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_2() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -34840,7 +34887,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_4() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_3() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35088,7 +35135,7 @@ pub mod root {
                    root::nsCOMPtr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_240243_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_240347_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut ::std::os::raw::c_void>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35167,7 +35214,7 @@ pub mod root {
                    root::mozilla::DefaultDelete ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_246461_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_246565_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::AudioContext>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35257,7 +35304,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_248735_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_248839_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsISupports>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35268,7 +35315,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsISupports> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_4() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_3() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35279,7 +35326,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_5() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_4() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35301,7 +35348,7 @@ pub mod root {
                    root::nsCOMPtr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_5() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_4() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35312,7 +35359,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_6() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_5() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35474,7 +35521,7 @@ pub mod root {
                    root::nsTArray<f64> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_250223_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_250327_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::dom::Element>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35522,7 +35569,7 @@ pub mod root {
                    root::mozilla::UniquePtr<root::ProfilerBacktrace> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_6() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_5() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35533,7 +35580,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_7() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_6() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35590,7 +35637,7 @@ pub mod root {
                    root::nsRefPtrHashKey<root::nsIAtom> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_252604_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_252708_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::CounterStyle>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35623,7 +35670,7 @@ pub mod root {
                    root::nsCOMPtr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_7() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_6() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35634,7 +35681,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_8() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_7() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35669,7 +35716,7 @@ pub mod root {
                    root::mozilla::DefaultDelete ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_8() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_7() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35680,7 +35727,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_9() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_8() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35845,7 +35892,7 @@ pub mod root {
                    root::nsTArray<root::mozilla::css::GridNamedArea> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_9() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_8() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35856,7 +35903,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_10() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_9() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -35955,6 +36002,28 @@ pub mod root {
                    root::mozilla::DefaultDelete ) ));
     }
     #[test]
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_9() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<::nsstring::nsStringRepr> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<::nsstring::nsStringRepr>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<::nsstring::nsStringRepr> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_10() {
+        assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
+                   concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   ::nsstring::nsStringRepr ) ));
+        assert_eq!(::std::mem::align_of::<::nsstring::nsStringRepr>() , 8usize ,
+                   concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   ::nsstring::nsStringRepr ) ));
+    }
+    #[test]
     fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_10() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
@@ -35989,28 +36058,6 @@ pub mod root {
     }
     #[test]
     fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_12() {
-        assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
-                   concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-        assert_eq!(::std::mem::align_of::<::nsstring::nsStringRepr>() , 8usize ,
-                   concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_12() {
-        assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-        assert_eq!(::std::mem::align_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_13() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36229,7 +36276,7 @@ pub mod root {
                    ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_14() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_13() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36240,7 +36287,7 @@ pub mod root {
                    ::nsstring::nsStringRepr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_15() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_14() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36262,7 +36309,7 @@ pub mod root {
                    root::nsTArray<root::nsTArray<::nsstring::nsStringRepr>> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_13() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_12() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36273,7 +36320,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_16() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_15() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36306,6 +36353,28 @@ pub mod root {
                    root::nsTArray<root::nsStyleCoord> ) ));
     }
     #[test]
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_13() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<::nsstring::nsStringRepr> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<::nsstring::nsStringRepr>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<::nsstring::nsStringRepr> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_16() {
+        assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
+                   concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   ::nsstring::nsStringRepr ) ));
+        assert_eq!(::std::mem::align_of::<::nsstring::nsStringRepr>() , 8usize ,
+                   concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   ::nsstring::nsStringRepr ) ));
+    }
+    #[test]
     fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_14() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
@@ -36318,28 +36387,6 @@ pub mod root {
     }
     #[test]
     fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_17() {
-        assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
-                   concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-        assert_eq!(::std::mem::align_of::<::nsstring::nsStringRepr>() , 8usize ,
-                   concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   ::nsstring::nsStringRepr ) ));
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_15() {
-        assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Size of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-        assert_eq!(::std::mem::align_of::<root::nsTArray<::nsstring::nsStringRepr>>()
-                   , 8usize , concat ! (
-                   "Alignment of template specialization: " , stringify ! (
-                   root::nsTArray<::nsstring::nsStringRepr> ) ));
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_18() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36510,7 +36557,7 @@ pub mod root {
                    root::RefPtr<root::nsStyleImageRequest> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_255212_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_255315_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsISupports>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36747,7 +36794,7 @@ pub mod root {
                    root::nsCOMPtr ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_263531_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_263634_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36758,7 +36805,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_263536_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_263639_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -36846,7 +36893,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::dom::ShadowRoot> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_263649_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_263752_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37120,7 +37167,7 @@ pub mod root {
                    root::nsRefPtrHashKey<root::mozilla::dom::Element> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_265375_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_265478_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37142,7 +37189,7 @@ pub mod root {
                    root::RefPtr<root::mozilla::dom::Element> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_265533_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_265636_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37153,7 +37200,7 @@ pub mod root {
                    root::nsTArray<*mut root::nsIContent> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_265538_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_265641_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::nsIContent>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37162,6 +37209,28 @@ pub mod root {
                    , 8usize , concat ! (
                    "Alignment of template specialization: " , stringify ! (
                    root::nsTArray<*mut root::nsIContent> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTArray_open0_FontFamilyName_close0_instantiation_4() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTArray_open0_FontFamilyName_close0_instantiation_5() {
+        assert_eq!(::std::mem::size_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Size of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
+        assert_eq!(::std::mem::align_of::<root::nsTArray<root::mozilla::FontFamilyName>>()
+                   , 8usize , concat ! (
+                   "Alignment of template specialization: " , stringify ! (
+                   root::nsTArray<root::mozilla::FontFamilyName> ) ));
     }
     #[test]
     fn __bindgen_test_layout_nsTArray_open0_unsigned_int_close0_instantiation_6() {
@@ -37175,7 +37244,7 @@ pub mod root {
                    root::nsTArray<::std::os::raw::c_uint> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_16() {
+    fn __bindgen_test_layout_nsTArray_open0_nsTString_open1_char16_t_close1_close0_instantiation_15() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<::nsstring::nsStringRepr>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37186,7 +37255,7 @@ pub mod root {
                    root::nsTArray<::nsstring::nsStringRepr> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_19() {
+    fn __bindgen_test_layout_nsTString_open0_char16_t_close0_instantiation_18() {
         assert_eq!(::std::mem::size_of::<::nsstring::nsStringRepr>() , 16usize ,
                    concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37296,7 +37365,7 @@ pub mod root {
                    root::nsTArray<root::mozilla::gfx::FontVariation> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_267968_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_268083_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::css::DocumentRule>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (
@@ -37307,7 +37376,7 @@ pub mod root {
                    root::nsTArray<*mut root::mozilla::css::DocumentRule> ) ));
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_267974_close0_instantiation() {
+    fn __bindgen_test_layout_nsTArray_open0__bindgen_ty_id_268089_close0_instantiation() {
         assert_eq!(::std::mem::size_of::<root::nsTArray<*mut root::mozilla::css::DocumentRule>>()
                    , 8usize , concat ! (
                    "Size of template specialization: " , stringify ! (

--- a/components/style/gecko_bindings/sugar/refptr.rs
+++ b/components/style/gecko_bindings/sugar/refptr.rs
@@ -286,4 +286,7 @@ impl_threadsafe_refcount!(::gecko_bindings::structs::mozilla::css::GridTemplateA
 impl_threadsafe_refcount!(::gecko_bindings::structs::ImageValue,
                           Gecko_AddRefImageValueArbitraryThread,
                           Gecko_ReleaseImageValueArbitraryThread);
+impl_threadsafe_refcount!(::gecko_bindings::structs::SharedFontList,
+                          Gecko_AddRefSharedFontListArbitraryThread,
+                          Gecko_ReleaseSharedFontListArbitraryThread);
 

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2970,7 +2970,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetFontFamily(declarations:
     let result = FontFamily::parse(&mut parser);
     if let Ok(family) = result {
         if parser.is_exhausted() {
-            let decl = PropertyDeclaration::FontFamily(Box::new(family));
+            let decl = PropertyDeclaration::FontFamily(family);
             write_locked_arc(declarations, |decls: &mut PropertyDeclarationBlock| {
                 decls.push(decl, Importance::Normal);
             })


### PR DESCRIPTION
Reviewed by Xidorn and Manish in https://bugzilla.mozilla.org/show_bug.cgi?id=1397626.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18722)
<!-- Reviewable:end -->
