### PR TITLE
style: Custom properties cleanup.

### DIFF
--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -607,7 +607,7 @@ fn substitute_one(
     if invalid.contains(name) {
         return Err(());
     }
-    let computed_value = if specified_value.references.map(|set| set.is_empty()) == Some(false) {
+    let computed_value = if specified_value.references.map_or(false, |set| !set.is_empty()) {
         let mut partial_computed_value = ComputedValue::empty();
         let mut input = ParserInput::new(&specified_value.css);
         let mut input = Parser::new(&mut input);

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -197,7 +197,7 @@ where
 
         let ref key = index[index.len() - self.pos - 1];
         self.pos += 1;
-        let value = self.inner.values.get(key).unwrap();
+        let value = &self.inner.values[key];
         Some((key, value))
     }
 }

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -470,8 +470,7 @@ pub fn cascade<'a>(
         None => {
             let mut map = OrderedMap::new();
             if let Some(inherited) = inherited {
-                for name in &inherited.index {
-                    let inherited_value = inherited.get(name).unwrap();
+                for (name, inherited_value) in inherited.iter() {
                     map.insert(name, BorrowedSpecifiedValue {
                         css: &inherited_value.css,
                         first_token_type: inherited_value.first_token_type,
@@ -575,9 +574,7 @@ fn substitute_all(
 ) -> CustomPropertiesMap {
     let mut custom_properties_map = CustomPropertiesMap::new();
     let mut invalid = PrecomputedHashSet::default();
-    for name in &specified_values_map.index {
-        let value = specified_values_map.get(name).unwrap();
-
+    for (name, value) in specified_values_map.iter() {
         // If this value is invalid at computed-time it won’t be inserted in computed_values_map.
         // Nothing else to do.
         let _ = substitute_one(

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -656,12 +656,15 @@ fn substitute_one(
 ///
 /// Return `Err(())` if `input` is invalid at computed-value time.
 /// or `Ok(last_token_type that was pushed to partial_computed_value)` otherwise.
-fn substitute_block<'i, 't, F>(input: &mut Parser<'i, 't>,
-                               position: &mut (SourcePosition, TokenSerializationType),
-                               partial_computed_value: &mut ComputedValue,
-                               substitute_one: &mut F)
-                               -> Result<TokenSerializationType, ParseError<'i>>
-                       where F: FnMut(&Name, &mut ComputedValue) -> Result<TokenSerializationType, ()> {
+fn substitute_block<'i, 't, F>(
+    input: &mut Parser<'i, 't>,
+    position: &mut (SourcePosition, TokenSerializationType),
+    partial_computed_value: &mut ComputedValue,
+    substitute_one: &mut F
+) -> Result<TokenSerializationType, ParseError<'i>>
+where
+    F: FnMut(&Name, &mut ComputedValue) -> Result<TokenSerializationType, ()>
+{
     let mut last_token_type = TokenSerializationType::nothing();
     let mut set_position_at_next_iteration = false;
     loop {


### PR DESCRIPTION
Use less unwrap and custom types in custom properties.

The idea is for this to shed some light in https://bugzilla.mozilla.org/show_bug.cgi?id=1403845.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18745)
<!-- Reviewable:end -->
