### PR TITLE
style: Use the flattened tree parent to find the closest non-nac ancestor of an element.

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -930,7 +930,7 @@ impl<'le> TElement for GeckoElement<'le> {
 
     fn closest_non_native_anonymous_ancestor(&self) -> Option<Self> {
         debug_assert!(self.is_native_anonymous());
-        let mut parent = match self.parent_element() {
+        let mut parent = match self.traversal_parent() {
             Some(e) => e,
             None => return None,
         };
@@ -940,7 +940,7 @@ impl<'le> TElement for GeckoElement<'le> {
                 return Some(parent);
             }
 
-            parent = match parent.parent_element() {
+            parent = match parent.traversal_parent() {
                 Some(p) => p,
                 None => return None,
             };


### PR DESCRIPTION
This only matters for document level NAC like canvas custom content, in which
case otherwise we inherit from the document element (which is wrong).

Bug: 1405635

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18752)
<!-- Reviewable:end -->
