### PR TITLE
Go through style::hash for the TransitionProperty set

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1362,8 +1362,9 @@ impl<'le> TElement for GeckoElement<'le> {
         before_change_style: &ComputedValues,
         after_change_style: &ComputedValues
     ) -> bool {
+        use fnv::FnvBuildHasher;
         use gecko_bindings::structs::nsCSSPropertyID;
-        use std::collections::HashSet;
+        use hash::FnvHashSet;
 
         debug_assert!(self.might_need_transitions_update(Some(before_change_style),
                                                          after_change_style),
@@ -1384,7 +1385,10 @@ impl<'le> TElement for GeckoElement<'le> {
         let mut transitions_to_keep = if !existing_transitions.is_empty() &&
                                          (after_change_box_style.transition_nscsspropertyid_at(0) !=
                                               nsCSSPropertyID::eCSSPropertyExtra_all_properties) {
-            Some(HashSet::<TransitionProperty>::with_capacity(transitions_count))
+            Some(FnvHashSet::<TransitionProperty>::with_capacity_and_hasher(
+                transitions_count,
+                FnvBuildHasher::default()
+            ))
         } else {
             None
         };


### PR DESCRIPTION
In #18604, emilio switched us from hash::HashSet to std::collections::HashSet for the TransitionProperty set. In turn, this means that Manishearth's change in #18712 didn't catch this use of DefaultHasher. This means that we still have usage of RandomState in stylo, which means that we'll still have crashes on the systems where RandomState breaks.

Mentions moved to a comment to avoid email spam down the road.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18755)
<!-- Reviewable:end -->
