### PR TITLE
style: Iterate in the expected order in the custom_properties module.

### DIFF
--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -190,14 +190,14 @@ where
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let ref index = self.inner.index;
-        if self.pos >= index.len() {
-            return None;
-        }
+        let key = match self.inner.index.get(self.pos) {
+            Some(k) => k,
+            None => return None,
+        };
 
-        let ref key = index[index.len() - self.pos - 1];
         self.pos += 1;
         let value = &self.inner.values[key];
+
         Some((key, value))
     }
 }


### PR DESCRIPTION
In #18745, I replaced a few manual iterations over `index` with the iterator,
and it changed the behavior of `layout/style/test/test_variables_order.html`,
since it turns out that the iterator iterates right to left.

I think this is just an accident that happened due to inconsistencies in how we
were iterating over it, and that our behavior was inconsistent (since we
iterated rtl in some cases, but ltr in others seems like it'd be inconsistent
depending on the depth of the tree and different stuff).

This brings back the expected behavior again, and ensures we iterate over a
consistent order every time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18761)
<!-- Reviewable:end -->
