### PR TITLE
Change MediaExpressionValue::from_css_value to only accept pixels

### DIFF
--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -373,18 +373,8 @@ impl MediaExpressionValue {
                 Some(MediaExpressionValue::BoolInteger(i == 1))
             }
             nsMediaFeature_ValueType::eResolution => {
-                // This is temporarily more complicated to allow Gecko Bug
-                // 1376931 to land. Parts of that bug will supply pixel values
-                // and expect them to be passed through without conversion.
-                // After all parts of that bug have landed, Bug 1404097 will
-                // return this function to once again only allow one type of
-                // value to be accepted: this time, only pixel values.
-                let res = match css_value.mUnit {
-                    nsCSSUnit::eCSSUnit_Pixel => Resolution::Dppx(css_value.float_unchecked()),
-                    nsCSSUnit::eCSSUnit_Inch  => Resolution::Dpi(css_value.float_unchecked()),
-                    _                         => unreachable!(),
-                };
-                Some(MediaExpressionValue::Resolution(res))
+                debug_assert!(css_value.mUnit == nsCSSUnit::eCSSUnit_Pixel);
+                Some(MediaExpressionValue::Resolution(Resolution::Dppx(css_value.float_unchecked())))
             }
             nsMediaFeature_ValueType::eEnumerated => {
                 let value = css_value.integer_unchecked() as i16;


### PR DESCRIPTION
MozReview-Commit-ID: Hn3twVa8xLo

<!-- Please describe your changes on the following line: -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1404097
https://reviewboard.mozilla.org/r/184746/

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because existing tests provide coverage.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18764)
<!-- Reviewable:end -->
