### PR TITLE
Don't assume that inputs to compute_style_with_inputs have any rules.

### DIFF
--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -894,12 +894,12 @@ impl Stylist {
         // We need to compute visited values if we have visited rules or if our
         // parent has visited values.
         let visited_values = if inputs.visited_rules.is_some() || parent_style.visited_style().is_some() {
-            // Slightly annoying: we know that inputs has either rules or
-            // visited rules, but we can't do inputs.rules() up front because
-            // maybe it just has visited rules, so can't unwrap_or.
+            // At this point inputs may have visited rules, or rules, or both,
+            // or neither (e.g. if it's a text style it may have neither).  So
+            // we have to be a bit careful here.
             let rule_node = match inputs.visited_rules.as_ref() {
                 Some(rules) => rules,
-                None => inputs.rules.as_ref().unwrap(),
+                None => inputs.rules.as_ref().unwrap_or(self.rule_tree().root()),
             };
             let inherited_style;
             let inherited_style_ignoring_first_line;


### PR DESCRIPTION
It could be a text style, which never has any rules attached to it.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1406222

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://bugzilla.mozilla.org/show_bug.cgi?id=1406222

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18767)
<!-- Reviewable:end -->
