### PR TITLE
Improved headless Servo performance

### DIFF
--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -39,6 +39,8 @@ use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
 use std::rc::Rc;
+use std::thread;
+use std::time;
 use style_traits::DevicePixel;
 use style_traits::cursor::Cursor;
 #[cfg(target_os = "windows")]
@@ -695,6 +697,11 @@ impl Window {
         }
 
         events.extend(mem::replace(&mut *self.event_queue.borrow_mut(), Vec::new()).into_iter());
+
+        if opts::get().headless && events.is_empty() {
+            thread::sleep(time::Duration::from_millis(5));
+        }
+
         events
     }
 

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -686,7 +686,13 @@ impl Window {
                         close_event = self.handle_window_event(event) || close_event;
                     }
                 }
-                WindowKind::Headless(..) => {}
+                WindowKind::Headless(..) => {
+                    // Sleep the main thread to avoid using 100% CPU
+                    // This can be done better, see comments in #18777
+                    if events.is_empty() {
+                        thread::sleep(time::Duration::from_millis(5));
+                    }
+                }
             }
         } else {
             close_event = self.handle_next_event();
@@ -697,11 +703,6 @@ impl Window {
         }
 
         events.extend(mem::replace(&mut *self.event_queue.borrow_mut(), Vec::new()).into_iter());
-
-        if opts::get().headless && events.is_empty() {
-            thread::sleep(time::Duration::from_millis(5));
-        }
-
         events
     }
 


### PR DESCRIPTION
Now the main thread doesn't waste 100% CPU, polling for events.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #18770 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because: I verified Servo works correctly in headless mode, and the linked issue is gone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18777)
<!-- Reviewable:end -->
