### PR TITLE
[WIP] Ensure every inline flow starts and ends with a text fragment.

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -2092,17 +2092,24 @@ pub fn strip_ignorable_whitespace_from_start(this: &mut LinkedList<Fragment>) {
             WhitespaceStrippingResult::FragmentContainedOnlyWhitespace => {
                 let removed_fragment = this.pop_front().unwrap();
                 if let Some(ref mut remaining_fragment) = this.front_mut() {
-                    if remaining_fragment.can_fully_meld_with_prev_inline_fragment(&removed_fragment) {
+                    if remaining_fragment
+                        .can_fully_meld_with_prev_inline_fragment(&removed_fragment)
+                    {
                         remaining_fragment.meld_with_prev_inline_fragment(&removed_fragment);
                     } else {
                         // This fragment may be needed on its own for styling or queries.
                         retained_leading_fragments.push_back(removed_fragment);
                     }
-                } else if removed_fragment.inline_context.as_ref().map_or(false, |context| {
-                    context.nodes.iter().any(|node| {
-                        node.flags.contains(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT)
+                } else if removed_fragment
+                    .inline_context
+                    .as_ref()
+                    .map_or(false, |context| {
+                        context.nodes.iter().any(|node| {
+                            node.flags
+                                .contains(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT)
+                        })
                     })
-                }) {
+                {
                     // This fragment isn't useful for anything, not even queries.
                     //
                     // If we keep fragments like this, they'll cause {ib} splits between every pair
@@ -2134,16 +2141,23 @@ pub fn strip_ignorable_whitespace_from_end(this: &mut LinkedList<Fragment>) {
             WhitespaceStrippingResult::FragmentContainedOnlyWhitespace => {
                 let removed_fragment = this.pop_back().unwrap();
                 if let Some(ref mut remaining_fragment) = this.back_mut() {
-                    if remaining_fragment.can_fully_meld_with_next_inline_fragment(&removed_fragment) {
+                    if remaining_fragment
+                        .can_fully_meld_with_next_inline_fragment(&removed_fragment)
+                    {
                         remaining_fragment.meld_with_next_inline_fragment(&removed_fragment);
                     } else {
                         retained_trailing_fragments.push_front(removed_fragment);
                     }
-                } else if removed_fragment.inline_context.as_ref().map_or(false, |context| {
-                    context.nodes.iter().any(|node| {
-                        node.flags.contains(InlineFragmentNodeFlags::LAST_FRAGMENT_OF_ELEMENT)
+                } else if removed_fragment
+                    .inline_context
+                    .as_ref()
+                    .map_or(false, |context| {
+                        context.nodes.iter().any(|node| {
+                            node.flags
+                                .contains(InlineFragmentNodeFlags::LAST_FRAGMENT_OF_ELEMENT)
+                        })
                     })
-                }) {
+                {
                     retained_trailing_fragments.push_front(removed_fragment);
                 }
             },

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -483,16 +483,13 @@ where
     ) {
         let mut fragments = fragment_accumulator
             .to_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(self.style_context());
-        if fragments.is_empty() {
-            return;
-        };
-
-        strip_ignorable_whitespace_from_start(&mut fragments.fragments);
-        strip_ignorable_whitespace_from_end(&mut fragments.fragments);
         if fragments.fragments.is_empty() {
             absolute_descendants.push_descendants(fragments.absolute_descendants);
             return;
         }
+
+        strip_ignorable_whitespace_from_start(&mut fragments.fragments);
+        strip_ignorable_whitespace_from_end(&mut fragments.fragments);
 
         // Build a list of all the inline-block fragments before fragments is moved.
         let mut inline_block_flows = vec![];

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1145,18 +1145,16 @@ where
             fragment_info,
         );
 
-        let mut fragment_accumulator = InlineFragmentsAccumulator::new();
-        fragment_accumulator.fragments.fragments.push_back(fragment);
-        fragment_accumulator
-            .fragments
+        let mut fragments = IntermediateInlineFragments::new();
+        fragments.fragments.push_back(fragment);
+        fragments
             .absolute_descendants
             .push_descendants(abs_descendants);
 
         let construction_item =
             ConstructionItem::InlineFragments(InlineFragmentsConstructionResult {
                 splits: LinkedList::new(),
-                fragments: fragment_accumulator
-                    .to_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(context),
+                fragments: fragments,
             });
         ConstructionResult::ConstructionItem(construction_item)
     }
@@ -1194,21 +1192,16 @@ where
             fragment_info,
         );
 
-        let mut fragment_accumulator =
-            InlineFragmentsAccumulator::from_inline_node(node, self.style_context());
-        fragment_accumulator.fragments.fragments.push_back(fragment);
-        fragment_accumulator
-            .fragments
+        let mut fragments = IntermediateInlineFragments::new();
+        fragments.fragments.push_back(fragment);
+        fragments
             .absolute_descendants
             .push_descendants(abs_descendants);
 
         let construction_item =
             ConstructionItem::InlineFragments(InlineFragmentsConstructionResult {
                 splits: LinkedList::new(),
-                fragments: fragment_accumulator
-                    .to_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(
-                        style_context,
-                    ),
+                fragments: fragments,
             });
         ConstructionResult::ConstructionItem(construction_item)
     }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -3084,8 +3084,13 @@ impl Fragment {
     }
 
     pub fn can_fully_meld_with_next_inline_fragment(&self, next_fragment: &Fragment) -> bool {
-        if let Some(ref inline_context_of_next_fragment) = next_fragment.inline_context {
-            if let Some(ref inline_context_of_this_fragment) = self.inline_context {
+        match (&next_fragment.inline_context, &self.inline_context) {
+            (&None, _) => true,
+            (&Some(_), &None) => false,
+            (
+                &Some(ref inline_context_of_next_fragment),
+                &Some(ref inline_context_of_this_fragment),
+            ) => {
                 inline_context_of_this_fragment.nodes.len() >=
                     inline_context_of_next_fragment.nodes.len() &&
                     inline_context_of_this_fragment
@@ -3116,17 +3121,18 @@ impl Fragment {
                                     inline_context_node_from_this_fragment.address
                             },
                         )
-            } else {
-                false
-            }
-        } else {
-            true
+            },
         }
     }
 
     pub fn can_fully_meld_with_prev_inline_fragment(&self, prev_fragment: &Fragment) -> bool {
-        if let Some(ref inline_context_of_prev_fragment) = prev_fragment.inline_context {
-            if let Some(ref inline_context_of_this_fragment) = self.inline_context {
+        match (&prev_fragment.inline_context, &self.inline_context) {
+            (&None, _) => true,
+            (&Some(_), &None) => false,
+            (
+                &Some(ref inline_context_of_prev_fragment),
+                &Some(ref inline_context_of_this_fragment),
+            ) => {
                 inline_context_of_this_fragment.nodes.len() >=
                     inline_context_of_prev_fragment.nodes.len() &&
                     inline_context_of_this_fragment
@@ -3155,17 +3161,16 @@ impl Fragment {
                                     inline_context_node_from_this_fragment.address
                             },
                         )
-            } else {
-                false
-            }
-        } else {
-            true
+            },
         }
     }
 
     pub fn meld_with_next_inline_fragment(&mut self, next_fragment: &Fragment) {
-        if let Some(ref mut inline_context_of_this_fragment) = self.inline_context {
-            if let Some(ref inline_context_of_next_fragment) = next_fragment.inline_context {
+        match (&mut self.inline_context, &next_fragment.inline_context) {
+            (
+                &mut Some(ref mut inline_context_of_this_fragment),
+                &Some(ref inline_context_of_next_fragment),
+            ) => {
                 for (
                     inline_context_node_from_this_fragment,
                     inline_context_node_from_next_fragment,
@@ -3190,13 +3195,17 @@ impl Fragment {
                         .flags
                         .insert(InlineFragmentNodeFlags::LAST_FRAGMENT_OF_ELEMENT);
                 }
-            }
+            },
+            (_, _) => {},
         }
     }
 
     pub fn meld_with_prev_inline_fragment(&mut self, prev_fragment: &Fragment) {
-        if let Some(ref mut inline_context_of_this_fragment) = self.inline_context {
-            if let Some(ref inline_context_of_prev_fragment) = prev_fragment.inline_context {
+        match (&mut self.inline_context, &prev_fragment.inline_context) {
+            (
+                &mut Some(ref mut inline_context_of_this_fragment),
+                &Some(ref inline_context_of_prev_fragment),
+            ) => {
                 for (
                     inline_context_node_from_prev_fragment,
                     inline_context_node_from_this_fragment,
@@ -3221,7 +3230,8 @@ impl Fragment {
                         .flags
                         .insert(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT);
                 }
-            }
+            },
+            (_, _) => {},
         }
     }
 

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2324,11 +2324,6 @@ impl Fragment {
             self_: &Fragment,
             layout_context: &LayoutContext,
         ) -> InlineMetrics {
-            // Fragments with no glyphs don't contribute any inline metrics.
-            // TODO: Filter out these fragments during flow construction?
-            if info.insertion_point.is_none() && info.content_size.inline == Au(0) {
-                return InlineMetrics::new(Au(0), Au(0), Au(0));
-            }
             // See CSS 2.1 § 10.8.1.
             let font_metrics = with_thread_local_font_context(layout_context, |font_context| {
                 text::font_metrics_for_style(font_context, self_.style.clone_font())

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -3059,6 +3059,62 @@ impl Fragment {
         }
     }
 
+    pub fn can_fully_meld_with_next_inline_fragment(&self, next_fragment: &Fragment) -> bool {
+        if let Some(ref inline_context_of_next_fragment) = next_fragment.inline_context {
+            if let Some(ref inline_context_of_this_fragment) = self.inline_context {
+                inline_context_of_this_fragment
+                    .nodes
+                    .iter()
+                    .rev()
+                    .zip(inline_context_of_next_fragment.nodes.iter().rev())
+                    .all(
+                        |(
+                            inline_context_node_from_this_fragment,
+                            inline_context_node_from_next_fragment,
+                        )| {
+                            !inline_context_node_from_next_fragment
+                                .flags
+                                .contains(InlineFragmentNodeFlags::LAST_FRAGMENT_OF_ELEMENT) ||
+                                inline_context_node_from_next_fragment.address ==
+                                    inline_context_node_from_this_fragment.address
+                        },
+                    )
+            } else {
+                false
+            }
+        } else {
+            true
+        }
+    }
+
+    pub fn can_fully_meld_with_prev_inline_fragment(&self, prev_fragment: &Fragment) -> bool {
+        if let Some(ref inline_context_of_prev_fragment) = prev_fragment.inline_context {
+            if let Some(ref inline_context_of_this_fragment) = self.inline_context {
+                inline_context_of_this_fragment
+                    .nodes
+                    .iter()
+                    .rev()
+                    .zip(inline_context_of_prev_fragment.nodes.iter().rev())
+                    .all(
+                        |(
+                            inline_context_node_from_this_fragment,
+                            inline_context_node_from_prev_fragment,
+                        )| {
+                            !inline_context_node_from_prev_fragment
+                                .flags
+                                .contains(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT) ||
+                                inline_context_node_from_prev_fragment.address ==
+                                    inline_context_node_from_this_fragment.address
+                        },
+                    )
+            } else {
+                false
+            }
+        } else {
+            true
+        }
+    }
+
     pub fn meld_with_next_inline_fragment(&mut self, next_fragment: &Fragment) {
         if let Some(ref mut inline_context_of_this_fragment) = self.inline_context {
             if let Some(ref inline_context_of_next_fragment) = next_fragment.inline_context {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2064,11 +2064,10 @@ impl Fragment {
 
             // FIXME (mbrubeck): Do we need to restore leading too?
             let range_end = info.range_end_including_stripped_whitespace;
-            if info.range.end() == range_end {
-                return;
+            if info.range.end() != range_end {
+                info.range.extend_to(range_end);
+                info.content_size.inline = info.run.metrics_for_range(&info.range).advance_width;
             }
-            info.range.extend_to(range_end);
-            info.content_size.inline = info.run.metrics_for_range(&info.range).advance_width;
             self.border_box.size.inline =
                 info.content_size.inline + self.border_padding.inline_start_end();
         }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -3086,23 +3086,25 @@ impl Fragment {
     pub fn can_fully_meld_with_next_inline_fragment(&self, next_fragment: &Fragment) -> bool {
         if let Some(ref inline_context_of_next_fragment) = next_fragment.inline_context {
             if let Some(ref inline_context_of_this_fragment) = self.inline_context {
-                inline_context_of_this_fragment
-                    .nodes
-                    .iter()
-                    .rev()
-                    .zip(inline_context_of_next_fragment.nodes.iter().rev())
-                    .all(
-                        |(
-                            inline_context_node_from_this_fragment,
-                            inline_context_node_from_next_fragment,
-                        )| {
-                            !inline_context_node_from_next_fragment
-                                .flags
-                                .contains(InlineFragmentNodeFlags::LAST_FRAGMENT_OF_ELEMENT) ||
-                                inline_context_node_from_next_fragment.address ==
-                                    inline_context_node_from_this_fragment.address
-                        },
-                    )
+                inline_context_of_this_fragment.nodes.len() ==
+                    inline_context_of_next_fragment.nodes.len() &&
+                    inline_context_of_this_fragment
+                        .nodes
+                        .iter()
+                        .rev()
+                        .zip(inline_context_of_next_fragment.nodes.iter().rev())
+                        .all(
+                            |(
+                                inline_context_node_from_this_fragment,
+                                inline_context_node_from_next_fragment,
+                            )| {
+                                !inline_context_node_from_next_fragment
+                                    .flags
+                                    .contains(InlineFragmentNodeFlags::LAST_FRAGMENT_OF_ELEMENT) ||
+                                    inline_context_node_from_next_fragment.address ==
+                                        inline_context_node_from_this_fragment.address
+                            },
+                        )
             } else {
                 false
             }
@@ -3114,23 +3116,25 @@ impl Fragment {
     pub fn can_fully_meld_with_prev_inline_fragment(&self, prev_fragment: &Fragment) -> bool {
         if let Some(ref inline_context_of_prev_fragment) = prev_fragment.inline_context {
             if let Some(ref inline_context_of_this_fragment) = self.inline_context {
-                inline_context_of_this_fragment
-                    .nodes
-                    .iter()
-                    .rev()
-                    .zip(inline_context_of_prev_fragment.nodes.iter().rev())
-                    .all(
-                        |(
-                            inline_context_node_from_this_fragment,
-                            inline_context_node_from_prev_fragment,
-                        )| {
-                            !inline_context_node_from_prev_fragment
-                                .flags
-                                .contains(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT) ||
-                                inline_context_node_from_prev_fragment.address ==
-                                    inline_context_node_from_this_fragment.address
-                        },
-                    )
+                inline_context_of_this_fragment.nodes.len() ==
+                    inline_context_of_prev_fragment.nodes.len() &&
+                    inline_context_of_this_fragment
+                        .nodes
+                        .iter()
+                        .rev()
+                        .zip(inline_context_of_prev_fragment.nodes.iter().rev())
+                        .all(
+                            |(
+                                inline_context_node_from_this_fragment,
+                                inline_context_node_from_prev_fragment,
+                            )| {
+                                !inline_context_node_from_prev_fragment
+                                    .flags
+                                    .contains(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT) ||
+                                    inline_context_node_from_prev_fragment.address ==
+                                        inline_context_node_from_this_fragment.address
+                            },
+                        )
             } else {
                 false
             }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -3086,7 +3086,7 @@ impl Fragment {
     pub fn can_fully_meld_with_next_inline_fragment(&self, next_fragment: &Fragment) -> bool {
         if let Some(ref inline_context_of_next_fragment) = next_fragment.inline_context {
             if let Some(ref inline_context_of_this_fragment) = self.inline_context {
-                inline_context_of_this_fragment.nodes.len() ==
+                inline_context_of_this_fragment.nodes.len() >=
                     inline_context_of_next_fragment.nodes.len() &&
                     inline_context_of_this_fragment
                         .nodes
@@ -3098,11 +3098,22 @@ impl Fragment {
                                 inline_context_node_from_this_fragment,
                                 inline_context_node_from_next_fragment,
                             )| {
-                                !inline_context_node_from_next_fragment
+                                if inline_context_node_from_next_fragment
                                     .flags
-                                    .contains(InlineFragmentNodeFlags::LAST_FRAGMENT_OF_ELEMENT) ||
-                                    inline_context_node_from_next_fragment.address ==
-                                        inline_context_node_from_this_fragment.address
+                                    .contains(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT)
+                                {
+                                    // We're not trying to meld in that direction!
+                                    return false;
+                                }
+                                if !inline_context_node_from_next_fragment
+                                    .flags
+                                    .contains(InlineFragmentNodeFlags::LAST_FRAGMENT_OF_ELEMENT)
+                                {
+                                    // There's nothing to meld, so compatibility doesn't matter.
+                                    return true;
+                                }
+                                inline_context_node_from_next_fragment.address ==
+                                    inline_context_node_from_this_fragment.address
                             },
                         )
             } else {
@@ -3116,7 +3127,7 @@ impl Fragment {
     pub fn can_fully_meld_with_prev_inline_fragment(&self, prev_fragment: &Fragment) -> bool {
         if let Some(ref inline_context_of_prev_fragment) = prev_fragment.inline_context {
             if let Some(ref inline_context_of_this_fragment) = self.inline_context {
-                inline_context_of_this_fragment.nodes.len() ==
+                inline_context_of_this_fragment.nodes.len() >=
                     inline_context_of_prev_fragment.nodes.len() &&
                     inline_context_of_this_fragment
                         .nodes
@@ -3128,11 +3139,20 @@ impl Fragment {
                                 inline_context_node_from_this_fragment,
                                 inline_context_node_from_prev_fragment,
                             )| {
-                                !inline_context_node_from_prev_fragment
+                                if inline_context_node_from_prev_fragment
                                     .flags
-                                    .contains(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT) ||
-                                    inline_context_node_from_prev_fragment.address ==
-                                        inline_context_node_from_this_fragment.address
+                                    .contains(InlineFragmentNodeFlags::LAST_FRAGMENT_OF_ELEMENT)
+                                {
+                                    return false;
+                                }
+                                if !inline_context_node_from_prev_fragment
+                                    .flags
+                                    .contains(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT)
+                                {
+                                    return true;
+                                }
+                                inline_context_node_from_prev_fragment.address ==
+                                    inline_context_node_from_this_fragment.address
                             },
                         )
             } else {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -3306,6 +3306,27 @@ impl Fragment {
             Perspective::None => None,
         }
     }
+
+    /// Returns true if a line box containing only this fragment would be treated as nonexistent
+    /// by CSS 2.1 § 9.4.2. (https://www.w3.org/TR/CSS21/visuren.html#phantom-line-box)
+    pub fn is_phantom(&self) -> bool {
+        self.is_hypothetical() ||
+            (match self.specific {
+                SpecificFragmentInfo::ScannedText(ref scanned_text_fragment_info) => {
+                    scanned_text_fragment_info.range.is_empty() &&
+                        !(scanned_text_fragment_info
+                            .requires_line_break_afterward_if_wrapping_on_newlines() &&
+                            self.white_space().preserve_newlines())
+                },
+                SpecificFragmentInfo::UnscannedText(_) => {
+                    panic!("Text in a line box should be scanned before checking if it's phantom");
+                },
+                _ => false,
+            } && self.border_padding.inline_start == Au(0) &&
+                self.border_padding.inline_end == Au(0) &&
+                self.margin.inline_start == Au(0) &&
+                self.margin.inline_end == Au(0))
+    }
 }
 
 impl fmt::Debug for Fragment {

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -457,7 +457,18 @@ impl LineBreaker {
         );
         self.strip_trailing_whitespace_from_pending_line_if_necessary();
         self.lines.push(self.pending_line.clone());
-        self.cur_b = self.pending_line.bounds.start.b + self.pending_line.bounds.size.block;
+        // The line shouldn't affect the flow if it has nothing in it per CSS § 9.4.2.
+        // I'm not sure if it's actually possible for a phantom line box to be followed by any
+        // more lines in the same inline formatting context. If it isn't, this check is
+        // unnecessary.
+        if self
+            .pending_line
+            .range
+            .each_index()
+            .any(|index| !self.new_fragments[index.to_usize()].is_phantom())
+        {
+            self.cur_b = self.pending_line.bounds.start.b + self.pending_line.bounds.size.block;
+        }
         self.reset_line();
     }
 
@@ -1427,11 +1438,13 @@ impl InlineFlow {
         })
     }
 
-    // Returns the last line that doesn't consist entirely of hypothetical boxes.
+    // Returns the last line treated as existing by CSS 2.1 § 9.4.2, or None if there is no such line.
     fn last_line_containing_real_fragments(&self) -> Option<&Line> {
         for line in self.lines.iter().rev() {
-            if (line.range.begin().get()..line.range.end().get())
-                .any(|index| !self.fragments.fragments[index as usize].is_hypothetical())
+            if line
+                .range
+                .each_index()
+                .any(|index| !self.fragments.fragments[index.to_usize()].is_phantom())
             {
                 return Some(line);
             }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -633,8 +633,7 @@ impl FragmentBorderBoxIterator for ParentOffsetBorderBoxIterator {
                 .find(|node| node.address == self.node_address)
         }) {
             // TODO: Handle cases where the `offsetParent` is an inline
-            // element. This will likely be impossible until
-            // https://github.com/servo/servo/issues/13982 is fixed.
+            // element.
 
             // Found a fragment in the flow tree whose inline context
             // contains the DOM node we're looking for, i.e. the node
@@ -646,11 +645,11 @@ impl FragmentBorderBoxIterator for ParentOffsetBorderBoxIterator {
                     *rectangle = rectangle.union(border_box);
                 },
                 None => {
-                    // https://github.com/servo/servo/issues/13982 will
-                    // cause this assertion to fail sometimes, so it's
-                    // commented out for now.
-                    /*assert!(node.flags.contains(FIRST_FRAGMENT_OF_ELEMENT),
-                    "First fragment of inline node found wasn't its first fragment!");*/
+                    assert!(
+                        node.flags
+                            .contains(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT),
+                        "First fragment of inline node found wasn't its first fragment!"
+                    );
 
                     self.node_offset_box = Some(NodeOffsetBoxInfo {
                         offset: border_box.origin,

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -607,13 +607,13 @@ impl FragmentBorderBoxIterator for ParentOffsetBorderBoxIterator {
             return;
         }
 
-        if fragment.node == self.node_address {
+        if fragment.inline_context.is_none() && fragment.node == self.node_address {
             // Found the fragment in the flow tree that matches the
             // DOM node being looked for.
 
             assert!(
                 self.node_offset_box.is_none(),
-                "Node was being treated as inline, but it has an associated fragment!"
+                "Node was being treated as inline, but it has an associated non-inline fragment!"
             );
 
             self.has_processed_node = true;

--- a/tests/wpt/metadata/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/object_border_perc.xhtml.ini
+++ b/tests/wpt/metadata/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/object_border_perc.xhtml.ini
@@ -1,0 +1,5 @@
+[object_border_perc.xhtml]
+  type: reftest
+  reftype: ==
+  refurl: /html/rendering/replaced-elements/attributes-for-embedded-content-and-images/object_border-ref.xhtml
+  expected: FAIL

--- a/tests/wpt/metadata/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/object_border_pixel.xhtml.ini
+++ b/tests/wpt/metadata/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/object_border_pixel.xhtml.ini
@@ -1,0 +1,5 @@
+[object_border_pixel.xhtml]
+  type: reftest
+  reftype: ==
+  refurl: /html/rendering/replaced-elements/attributes-for-embedded-content-and-images/object_border-ref.xhtml
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2042,6 +2042,19 @@
       {}
      ]
     ],
+    "empty_span_line_height.html": [
+     "245eb55ba516f67172d2ed07182e942bd90efd26",
+     [
+      null,
+      [
+       [
+        "/_mozilla/css/empty_span_line_height_ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "external_media_query_link.html": [
      "65baa6435c28bf07725e7657dcb83365886b73d7",
      [
@@ -5281,6 +5294,19 @@
       {}
      ]
     ],
+    "phantom_line_box.html": [
+     "f25db52d006da44da7097b34208b052b86c6e731",
+     [
+      null,
+      [
+       [
+        "/_mozilla/css/phantom_line_box_ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "pixel_snapping_border_a.html": [
      "c55be8adeb735cb5d187e82335d614885538ef58",
      [
@@ -6165,6 +6191,19 @@
       [
        [
         "/_mozilla/css/style_is_in_doc_ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
+    "styled_empty_inline_element.html": [
+     "40108d87a389ffafb5576e76690ab6d0970fa6ae",
+     [
+      null,
+      [
+       [
+        "/_mozilla/css/styled_empty_inline_element_ref.html",
         "=="
        ]
       ],
@@ -9068,6 +9107,10 @@
      "4c420045dcd53f67e53836e767bd898e32e9cc6f",
      []
     ],
+    "empty_span_line_height_ref.html": [
+     "dc27da6a4fd82c3bac0dfcd91877e64e8af4d10e",
+     []
+    ],
     "external_media_query_ref.html": [
      "6ac05f5f39418b98346dba114bef3eee267a65a2",
      []
@@ -10064,6 +10107,10 @@
      "3852154dd9db0aaf1bb576292cbdca90df8dfb91",
      []
     ],
+    "phantom_line_box_ref.html": [
+     "92eb97676c738bccf408bd025126ccf8ccd319ce",
+     []
+    ],
     "pixel_snapping_border_ref.html": [
      "483046f65cf2f701a7ffb98dcc162d003dc6b681",
      []
@@ -10346,6 +10393,10 @@
     ],
     "style_is_in_doc_ref.html": [
      "023768e8d77b0d9556b9853129d2f0366f6869b4",
+     []
+    ],
+    "styled_empty_inline_element_ref.html": [
+     "2e726358714f04b57deed1177da764989ff0275e",
      []
     ],
     "subdirectory": {

--- a/tests/wpt/mozilla/tests/css/empty_span_line_height.html
+++ b/tests/wpt/mozilla/tests/css/empty_span_line_height.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Empty, unstyled inline elements should affect line height.</title>
+<link rel="match" href="empty_span_line_height_ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+div {
+  font: 16px/1 serif;
+  background-color: #bbb;
+}
+span {
+  font: 100px Ahem;
+}
+</style>
+<div>AB<span></span>CD</div>

--- a/tests/wpt/mozilla/tests/css/empty_span_line_height_ref.html
+++ b/tests/wpt/mozilla/tests/css/empty_span_line_height_ref.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Empty, unstyled inline elements should affect line height.</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+div {
+  font: 16px/1 serif;
+  background-color: #bbb;
+}
+span {
+  font: 100px Ahem;
+}
+</style>
+<div>ABCD<span>&nbsp;</span></div>

--- a/tests/wpt/mozilla/tests/css/phantom_line_box.html
+++ b/tests/wpt/mozilla/tests/css/phantom_line_box.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>CSS 2.1 § 9.4.2: Empty line boxes shouldn't affect the layout.</title>
+<link rel="match" href="phantom_line_box_ref.html">
+<style>
+span {
+  margin: 20px 0;
+  border: 16px solid black;
+  border-left: 0; border-right: 0;
+  padding: 12px 0;
+  font-size: 200px;
+}
+</style>
+<div><span></span></div>
+This text should be at the top of the page.

--- a/tests/wpt/mozilla/tests/css/phantom_line_box_ref.html
+++ b/tests/wpt/mozilla/tests/css/phantom_line_box_ref.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8" />
+<title>CSS 2.1 § 9.4.2: Empty line boxes shouldn't affect the layout.</title>
+This text should be at the top of the page.

--- a/tests/wpt/mozilla/tests/css/styled_empty_inline_element.html
+++ b/tests/wpt/mozilla/tests/css/styled_empty_inline_element.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Styled inline element with no content</title>
+<link rel="match" href="styled_empty_inline_element_ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+span {
+  margin: 10px 20px 30px 40px;
+  padding: 30px 40px 10px 20px;
+  border: 4px solid black;
+  background-color: green;
+  font: 120px/2.2 Ahem;
+}
+</style>
+ABC <span></span> XYZ

--- a/tests/wpt/mozilla/tests/css/styled_empty_inline_element_ref.html
+++ b/tests/wpt/mozilla/tests/css/styled_empty_inline_element_ref.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Styled inline element with no content</title>
+<style>
+span {
+  display: inline-block;
+  position: relative;
+  top: 38px;
+  margin: 0 20px 0 40px;
+  padding: 30px 40px 10px 20px;
+  border: 4px solid black;
+  height: 120px;
+  background-color: green;
+}
+</style>
+ABC <span></span>XYZ


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Not every inline flow begins or ends with actual text—they may begin or end with replaced elements, for instance, or they may contain nothing at all.

But for purposes of both rendering (e.g. rendering the inline-start and inline-end borders of an element) and queries (from scripts), it's sometimes important to know where an inline node begins and ends. The only way this can currently be determined in Servo's layout code is by finding the fragments with `InlineFragmentNodeInfo`s that correspond to said node and have the `FIRST_FRAGMENT_OF_ELEMENT` and `LAST_FRAGMENT_OF_ELEMENT` flags set. It's therefore important that fragments with these flags be generated.

This PR ensures that these fragments are generated. Unfortunately, the layout code currently depends on the _absence_ of these fragments for correctness in a number of cases, so making this change broke a lot of tests. I've fixed some of them, but there are still 20 or so that are broken. This PR is thus a work in progress and shouldn't be merged yet. It could also probably use some more comments in some places.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #13982.

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18780)
<!-- Reviewable:end -->
