### PR TITLE
Use defualt Debug trait for AnimationValue

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -337,7 +337,7 @@ unsafe impl HasSimpleFFI for AnimationValueMap {}
 ///
 /// FIXME: We need to add a path for custom properties, but that's trivial after
 /// this (is a similar path to that of PropertyDeclaration).
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum AnimationValue {
     % for prop in data.longhands:
@@ -350,12 +350,6 @@ pub enum AnimationValue {
             % endif
         % endif
     % endfor
-}
-
-impl fmt::Debug for AnimationValue {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str(self.id().name())
-    }
 }
 
 impl AnimationValue {


### PR DESCRIPTION
We use AnimationValue for animation backend to do interpolation,
accumulation, or computing distance. While debugging it, dumping the
property name is not enough. We need to dump the detailed value contained
in it.

For example:
if we animate ```translate(100px)``` to ```translate(200px)```,
and want to dump ```{:?} => {:?}```, the result is ```transform => transform```.
I think what we want is something like:
```Transform([Translate(100px, 0px, 0px)]) => Transform([Translate(200px, 0px, 0px)])```.

Using default Debug trait is not perfect because there are some redundant type strings,
but it is still better than nothing.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes are related to PR #18415.
- [X] These changes do not require tests because this is debug only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18788)
<!-- Reviewable:end -->
