### PR TITLE
servo_arc: Try pointer equality test first when comparing two Arcs.

### DIFF
--- a/components/servo_arc/lib.rs
+++ b/components/servo_arc/lib.rs
@@ -389,11 +389,11 @@ impl<T: ?Sized> Drop for Arc<T> {
 
 impl<T: ?Sized + PartialEq> PartialEq for Arc<T> {
     fn eq(&self, other: &Arc<T>) -> bool {
-        *(*self) == *(*other)
+        Self::ptr_eq(self, other) || *(*self) == *(*other)
     }
 
     fn ne(&self, other: &Arc<T>) -> bool {
-        *(*self) != *(*other)
+        !Self::ptr_eq(self, other) && *(*self) != *(*other)
     }
 }
 impl<T: ?Sized + PartialOrd> PartialOrd for Arc<T> {


### PR DESCRIPTION
This doesn't actually help https://bugzilla.mozilla.org/show_bug.cgi?id=1405411 but seems like something we should do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18793)
<!-- Reviewable:end -->
