### PR TITLE
style: use the XBL styleset quirks mode to match XBL rules.

### DIFF
--- a/components/style/gecko/data.rs
+++ b/components/style/gecko/data.rs
@@ -123,6 +123,11 @@ impl PerDocumentStyleData {
     /// Create a dummy `PerDocumentStyleData`.
     pub fn new(pres_context: RawGeckoPresContextOwned) -> Self {
         let device = Device::new(pres_context);
+
+        // FIXME(emilio, tlin): How is this supposed to work with XBL? This is
+        // right now not always honored, see bug 1405543...
+        //
+        // Should we just force XBL Stylists to be NoQuirks?
         let quirks_mode = unsafe {
             (*device.pres_context().mDocument.raw::<nsIDocument>()).mCompatMode
         };

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -1270,12 +1270,21 @@ impl Stylist {
             // ServoStyleSet::CreateXBLServoStyleSet() loads XBL style sheets
             // under eAuthorSheetFeatures level.
             if let Some(map) = stylist.cascade_data.author.borrow_for_pseudo(pseudo_element) {
+                // NOTE(emilio): This is needed because the XBL stylist may
+                // think it has a different quirks mode than the document.
+                let mut matching_context = MatchingContext::new(
+                    context.matching_mode,
+                    context.bloom_filter,
+                    context.nth_index_cache.as_mut().map(|s| &mut **s),
+                    stylist.quirks_mode,
+                );
+
                 map.get_all_matching_rules(
                     element,
                     &rule_hash_target,
                     applicable_declarations,
-                    context,
-                    self.quirks_mode,
+                    &mut matching_context,
+                    stylist.quirks_mode,
                     flags_setter,
                     CascadeLevel::XBL,
                 );


### PR DESCRIPTION
This fixes bug 1405543.

MozReview-Commit-ID: Dv3mt3Fb8Yp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18794)
<!-- Reviewable:end -->
