### PR TITLE
Use the current parser location for CSS error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
  "azure 0.21.2 (git+https://github.com/servo/rust-azure)",
  "canvas_traits 0.0.1",
  "compositing 0.0.1",
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -325,7 +325,7 @@ dependencies = [
 name = "canvas_traits"
 version = "0.0.1"
 dependencies = [
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cssparser-macros 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1060,7 +1060,7 @@ name = "geckoservo"
 version = "0.0.1"
 dependencies = [
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1130,7 +1130,7 @@ dependencies = [
 name = "gfx_tests"
 version = "0.0.1"
 dependencies = [
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
  "ipc-channel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
@@ -1737,7 +1737,7 @@ name = "malloc_size_of"
 version = "0.0.1"
 dependencies = [
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashglobe 0.1.0",
  "servo_arc 0.0.1",
@@ -2594,7 +2594,7 @@ dependencies = [
  "caseless 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deny_public_fields 0.0.1",
  "devtools_traits 0.0.1",
  "dom_struct 0.0.1",
@@ -2667,7 +2667,7 @@ dependencies = [
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2740,7 +2740,7 @@ name = "selectors"
 version = "0.19.0"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_size_of 0.0.1",
@@ -3145,7 +3145,7 @@ dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible 0.0.1",
@@ -3207,7 +3207,7 @@ version = "0.0.1"
 dependencies = [
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3229,7 +3229,7 @@ version = "0.0.1"
 dependencies = [
  "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3247,7 +3247,7 @@ name = "stylo_tests"
 version = "0.0.1"
 dependencies = [
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "geckoservo 0.0.1",
@@ -3836,7 +3836,7 @@ dependencies = [
 "checksum core-foundation-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bc9fb3d6cb663e6fd7cf1c63f9b144ee2b1e4a78595a0451dd34bff85b9a3387"
 "checksum core-graphics 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2fd47addfc77b7e574d24e5434f95bb64a863769dfd4f1d451ca4ff5530ba01a"
 "checksum core-text 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a23bef779fab70e5e6af23e36eed03a48e1c1687dea8929505d405ea48d1f5e"
-"checksum cssparser 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)" = "05012fcdbdeb4c6f59f67db47c1f879929339274a691ee1fb90c26b297783629"
+"checksum cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44313341610282488e1156ad1fedebca51c54766c87a041d0287b10499c04ba1"
 "checksum cssparser-macros 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "079adec4af52bb5275eadd004292028c79eb3c5f5b4ee8086a36d4197032f6df"
 "checksum darling 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9861a8495606435477df581bc858ccf15a3469747edf175b94a4704fd9aaedac"
 "checksum darling_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1486a8b00b45062c997f767738178b43219133dd0c8c826cb811e60563810821"

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 azure = {git = "https://github.com/servo/rust-azure"}
 canvas_traits = {path = "../canvas_traits"}
 compositing = {path = "../compositing"}
-cssparser = "0.21.1"
+cssparser = "0.22.0"
 euclid = "0.15"
 fnv = "1.0"
 gleam = "0.4"

--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -10,7 +10,7 @@ name = "canvas_traits"
 path = "lib.rs"
 
 [dependencies]
-cssparser = "0.21.1"
+cssparser = "0.22.0"
 euclid = "0.15"
 heapsize = "0.4"
 heapsize_derive = "0.1"

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 
 [dependencies]
 app_units = "0.5.5"
-cssparser = "0.21.1"
+cssparser = "0.22.0"
 euclid = "0.15"
 hashglobe = { path = "../hashglobe" }
 servo_arc = { path = "../servo_arc" }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -33,7 +33,7 @@ byteorder = "1.0"
 canvas_traits = {path = "../canvas_traits"}
 caseless = "0.1.0"
 cookie = "0.6"
-cssparser = "0.21.1"
+cssparser = "0.22.0"
 deny_public_fields = {path = "../deny_public_fields"}
 devtools_traits = {path = "../devtools_traits"}
 dom_struct = {path = "../dom_struct"}

--- a/components/script_layout_interface/Cargo.toml
+++ b/components/script_layout_interface/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 app_units = "0.5"
 atomic_refcell = "0.1"
 canvas_traits = {path = "../canvas_traits"}
-cssparser = "0.21.1"
+cssparser = "0.22.0"
 euclid = "0.15"
 gfx_traits = {path = "../gfx_traits"}
 heapsize = "0.4"

--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -25,7 +25,7 @@ unstable = []
 [dependencies]
 bitflags = "0.7"
 matches = "0.1"
-cssparser = "0.21.1"
+cssparser = "0.22.0"
 log = "0.3"
 fnv = "1.0"
 malloc_size_of = { path = "../malloc_size_of" }

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -7,7 +7,8 @@ use attr::{ParsedCaseSensitivity, SELECTOR_WHITESPACE, NamespaceConstraint};
 use bloom::BLOOM_HASH_MASK;
 use builder::{SelectorBuilder, SpecificityAndFlags};
 use context::QuirksMode;
-use cssparser::{ParseError, BasicParseError, CowRcStr, Delimiter};
+use cssparser::{ParseError, ParseErrorKind, BasicParseError, BasicParseErrorKind};
+use cssparser::{SourceLocation, CowRcStr, Delimiter};
 use cssparser::{Token, Parser as CssParser, parse_nth, ToCss, serialize_identifier, CssStringWriter};
 use precomputed_hash::PrecomputedHash;
 use servo_arc::ThinArc;
@@ -46,8 +47,10 @@ fn to_ascii_lowercase(s: &str) -> Cow<str> {
     }
 }
 
+pub type SelectorParseError<'i, E> = ParseError<'i, SelectorParseErrorKind<'i, E>>;
+
 #[derive(Clone, Debug, PartialEq)]
-pub enum SelectorParseError<'i, T> {
+pub enum SelectorParseErrorKind<'i, E> {
     PseudoElementInComplexSelector,
     NoQualifiedNameInAttributeSelector(Token<'i>),
     EmptySelector,
@@ -66,12 +69,12 @@ pub enum SelectorParseError<'i, T> {
     ExplicitNamespaceUnexpectedToken(Token<'i>),
     ClassNeedsIdent(Token<'i>),
     EmptyNegation,
-    Custom(T),
+    Custom(E),
 }
 
-impl<'a, T> Into<ParseError<'a, SelectorParseError<'a, T>>> for SelectorParseError<'a, T> {
-    fn into(self) -> ParseError<'a, SelectorParseError<'a, T>> {
-        ParseError::Custom(self)
+impl<'i, E> From<E> for SelectorParseErrorKind<'i, E> {
+    fn from(custom: E) -> Self {
+        SelectorParseErrorKind::Custom(custom)
     }
 }
 
@@ -138,31 +141,31 @@ pub trait Parser<'i> {
 
     /// This function can return an "Err" pseudo-element in order to support CSS2.1
     /// pseudo-elements.
-    fn parse_non_ts_pseudo_class(&self, name: CowRcStr<'i>)
+    fn parse_non_ts_pseudo_class(&self, location: SourceLocation, name: CowRcStr<'i>)
                                  -> Result<<Self::Impl as SelectorImpl>::NonTSPseudoClass,
-                                           ParseError<'i, SelectorParseError<'i, Self::Error>>> {
-        Err(ParseError::Custom(SelectorParseError::UnsupportedPseudoClassOrElement(name)))
+                                           SelectorParseError<'i, Self::Error>> {
+        Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
     }
 
     fn parse_non_ts_functional_pseudo_class<'t>
-        (&self, name: CowRcStr<'i>, _arguments: &mut CssParser<'i, 't>)
+        (&self, name: CowRcStr<'i>, arguments: &mut CssParser<'i, 't>)
          -> Result<<Self::Impl as SelectorImpl>::NonTSPseudoClass,
-                   ParseError<'i, SelectorParseError<'i, Self::Error>>>
+                   SelectorParseError<'i, Self::Error>>
     {
-        Err(ParseError::Custom(SelectorParseError::UnsupportedPseudoClassOrElement(name)))
+        Err(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
     }
 
-    fn parse_pseudo_element(&self, name: CowRcStr<'i>)
+    fn parse_pseudo_element(&self, location: SourceLocation, name: CowRcStr<'i>)
                             -> Result<<Self::Impl as SelectorImpl>::PseudoElement,
-                                      ParseError<'i, SelectorParseError<'i, Self::Error>>> {
-        Err(ParseError::Custom(SelectorParseError::UnsupportedPseudoClassOrElement(name)))
+                                      SelectorParseError<'i, Self::Error>> {
+        Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
     }
 
     fn parse_functional_pseudo_element<'t>
-        (&self, name: CowRcStr<'i>, _arguments: &mut CssParser<'i, 't>)
+        (&self, name: CowRcStr<'i>, arguments: &mut CssParser<'i, 't>)
          -> Result<<Self::Impl as SelectorImpl>::PseudoElement,
-                   ParseError<'i, SelectorParseError<'i, Self::Error>>> {
-        Err(ParseError::Custom(SelectorParseError::UnsupportedPseudoClassOrElement(name)))
+                   SelectorParseError<'i, Self::Error>> {
+        Err(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
     }
 
     fn default_namespace(&self) -> Option<<Self::Impl as SelectorImpl>::NamespaceUrl> {
@@ -184,7 +187,7 @@ impl<Impl: SelectorImpl> SelectorList<Impl> {
     ///
     /// Return the Selectors or Err if there is an invalid selector.
     pub fn parse<'i, 't, P, E>(parser: &P, input: &mut CssParser<'i, 't>)
-                               -> Result<Self, ParseError<'i, SelectorParseError<'i, E>>>
+                               -> Result<Self, SelectorParseError<'i, E>>
     where P: Parser<'i, Impl=Impl, Error=E> {
         let mut values = SmallVec::new();
         loop {
@@ -1055,7 +1058,7 @@ fn display_to_css_identifier<T: Display, W: fmt::Write>(x: &T, dest: &mut W) -> 
 fn parse_selector<'i, 't, P, E, Impl>(
         parser: &P,
         input: &mut CssParser<'i, 't>)
-        -> Result<Selector<Impl>, ParseError<'i, SelectorParseError<'i, E>>>
+        -> Result<Selector<Impl>, SelectorParseError<'i, E>>
     where P: Parser<'i, Impl=Impl, Error=E>, Impl: SelectorImpl
 {
     let mut builder = SelectorBuilder::default();
@@ -1065,8 +1068,9 @@ fn parse_selector<'i, 't, P, E, Impl>(
         // Parse a sequence of simple selectors.
         parsed_pseudo_element = match parse_compound_selector(parser, input, &mut builder) {
             Ok(result) => result,
-            Err(ParseError::Custom(SelectorParseError::EmptySelector)) if builder.has_combinators() =>
-                return Err(SelectorParseError::DanglingCombinator.into()),
+            Err(ParseError { kind: ParseErrorKind::Custom(SelectorParseErrorKind::EmptySelector), .. })
+            if builder.has_combinators() =>
+                return Err(input.new_custom_error(SelectorParseErrorKind::DanglingCombinator)),
             Err(e) => return Err(e),
         };
         if parsed_pseudo_element {
@@ -1113,12 +1117,12 @@ fn parse_selector<'i, 't, P, E, Impl>(
 impl<Impl: SelectorImpl> Selector<Impl> {
     /// Parse a selector, without any pseudo-element.
     pub fn parse<'i, 't, P, E>(parser: &P, input: &mut CssParser<'i, 't>)
-                               -> Result<Self, ParseError<'i, SelectorParseError<'i, E>>>
+                               -> Result<Self, SelectorParseError<'i, E>>
         where P: Parser<'i, Impl=Impl, Error=E>
     {
         let selector = parse_selector(parser, input)?;
         if selector.has_pseudo_element() {
-            return Err(ParseError::Custom(SelectorParseError::PseudoElementInComplexSelector))
+            return Err(input.new_custom_error(SelectorParseErrorKind::PseudoElementInComplexSelector))
         }
         Ok(selector)
     }
@@ -1128,13 +1132,13 @@ impl<Impl: SelectorImpl> Selector<Impl> {
 /// * `Ok(false)`: Not a type selector, could be something else. `input` was not consumed.
 /// * `Ok(true)`: Length 0 (`*|*`), 1 (`*|E` or `ns|*`) or 2 (`|E` or `ns|E`)
 fn parse_type_selector<'i, 't, P, E, Impl, S>(parser: &P, input: &mut CssParser<'i, 't>, sink: &mut S)
-                                              -> Result<bool, ParseError<'i, SelectorParseError<'i, E>>>
+                                              -> Result<bool, SelectorParseError<'i, E>>
     where P: Parser<'i, Impl=Impl, Error=E>,
           Impl: SelectorImpl,
           S: Push<Component<Impl>>,
 {
     match parse_qualified_name(parser, input, /* in_attr_selector = */ false) {
-        Err(ParseError::Basic(BasicParseError::EndOfInput)) |
+        Err(ParseError { kind: ParseErrorKind::Basic(BasicParseErrorKind::EndOfInput), .. }) |
         Ok(OptionalQName::None(_)) => Ok(false),
         Ok(OptionalQName::Some(namespace, local_name)) => {
             match namespace {
@@ -1217,8 +1221,7 @@ enum OptionalQName<'i, Impl: SelectorImpl> {
 fn parse_qualified_name<'i, 't, P, E, Impl>
                        (parser: &P, input: &mut CssParser<'i, 't>,
                         in_attr_selector: bool)
-                        -> Result<OptionalQName<'i, Impl>,
-                                  ParseError<'i, SelectorParseError<'i, E>>>
+                        -> Result<OptionalQName<'i, Impl>, SelectorParseError<'i, E>>
     where P: Parser<'i, Impl=Impl, Error=E>, Impl: SelectorImpl
 {
     let default_namespace = |local_name| {
@@ -1230,16 +1233,25 @@ fn parse_qualified_name<'i, 't, P, E, Impl>
     };
 
     let explicit_namespace = |input: &mut CssParser<'i, 't>, namespace| {
+        let location = input.current_source_location();
         match input.next_including_whitespace() {
             Ok(&Token::Delim('*')) if !in_attr_selector => {
                 Ok(OptionalQName::Some(namespace, None))
-            },
+            }
             Ok(&Token::Ident(ref local_name)) => {
                 Ok(OptionalQName::Some(namespace, Some(local_name.clone())))
-            },
-            Ok(t) if in_attr_selector => Err(SelectorParseError::InvalidQualNameInAttr(t.clone()).into()),
-            Ok(t) => Err(SelectorParseError::ExplicitNamespaceUnexpectedToken(t.clone()).into()),
-            Err(e) => Err(ParseError::Basic(e)),
+            }
+            Ok(t) if in_attr_selector => {
+                Err(location.new_custom_error(
+                    SelectorParseErrorKind::InvalidQualNameInAttr(t.clone())
+                ))
+            }
+            Ok(t) => {
+                Err(location.new_custom_error(
+                    SelectorParseErrorKind::ExplicitNamespaceUnexpectedToken(t.clone())
+                ))
+            }
+            Err(e) => Err(e.into()),
         }
     };
 
@@ -1252,8 +1264,8 @@ fn parse_qualified_name<'i, 't, P, E, Impl>
                 Ok(&Token::Delim('|')) => {
                     let prefix = value.as_ref().into();
                     let result = parser.namespace_for_prefix(&prefix);
-                    let url = result.ok_or(ParseError::Custom(
-                        SelectorParseError::ExpectedNamespace(value)))?;
+                    let url = result.ok_or(after_ident.source_location().new_custom_error(
+                        SelectorParseErrorKind::ExpectedNamespace(value)))?;
                     explicit_namespace(input, QNamePrefix::ExplicitNamespace(prefix, url))
                 },
                 _ => {
@@ -1277,8 +1289,10 @@ fn parse_qualified_name<'i, 't, P, E, Impl>
                     input.reset(&after_star);
                     if in_attr_selector {
                         match result {
-                            Ok(t) => Err(SelectorParseError::ExpectedBarInAttr(t).into()),
-                            Err(e) => Err(ParseError::Basic(e)),
+                            Ok(t) => Err(after_star.source_location().new_custom_error(
+                                SelectorParseErrorKind::ExpectedBarInAttr(t)
+                            )),
+                            Err(e) => Err(e.into()),
                         }
                     } else {
                         default_namespace(None)
@@ -1302,15 +1316,17 @@ fn parse_qualified_name<'i, 't, P, E, Impl>
 
 
 fn parse_attribute_selector<'i, 't, P, E, Impl>(parser: &P, input: &mut CssParser<'i, 't>)
-                                                -> Result<Component<Impl>,
-                                                          ParseError<'i, SelectorParseError<'i, E>>>
+                                                -> Result<Component<Impl>, SelectorParseError<'i, E>>
     where P: Parser<'i, Impl=Impl, Error=E>, Impl: SelectorImpl
 {
     let namespace;
     let local_name;
     match parse_qualified_name(parser, input, /* in_attr_selector = */ true)? {
-        OptionalQName::None(t) =>
-            return Err(ParseError::Custom(SelectorParseError::NoQualifiedNameInAttributeSelector(t))),
+        OptionalQName::None(t) => {
+            return Err(input.new_custom_error(
+                SelectorParseErrorKind::NoQualifiedNameInAttributeSelector(t)
+            ))
+        }
         OptionalQName::Some(_, None) => unreachable!(),
         OptionalQName::Some(ns, Some(ln)) => {
             local_name = ln;
@@ -1333,6 +1349,7 @@ fn parse_attribute_selector<'i, 't, P, E, Impl>(parser: &P, input: &mut CssParse
         }
     }
 
+    let location = input.current_source_location();
     let operator = match input.next() {
         // [foo]
         Err(_) => {
@@ -1366,13 +1383,16 @@ fn parse_attribute_selector<'i, 't, P, E, Impl>(parser: &P, input: &mut CssParse
         Ok(&Token::SubstringMatch) => AttrSelectorOperator::Substring,
         // [foo$=bar]
         Ok(&Token::SuffixMatch) => AttrSelectorOperator::Suffix,
-        Ok(t) => return Err(SelectorParseError::UnexpectedTokenInAttributeSelector(t.clone()).into())
+        Ok(t) => return Err(location.new_custom_error(
+            SelectorParseErrorKind::UnexpectedTokenInAttributeSelector(t.clone())
+        ))
     };
 
     let value = match input.expect_ident_or_string() {
         Ok(t) => t.clone(),
-        Err(BasicParseError::UnexpectedToken(t)) =>
-            return Err(SelectorParseError::BadValueInAttr(t.clone()).into()),
+        Err(BasicParseError { kind: BasicParseErrorKind::UnexpectedToken(t), location }) => {
+            return Err(location.new_custom_error(SelectorParseErrorKind::BadValueInAttr(t)))
+        }
         Err(e) => return Err(e.into()),
     };
     let never_matches = match operator {
@@ -1432,8 +1452,8 @@ fn parse_attribute_selector<'i, 't, P, E, Impl>(parser: &P, input: &mut CssParse
 
 
 fn parse_attribute_flags<'i, 't, E>(input: &mut CssParser<'i, 't>)
-                                    -> Result<ParsedCaseSensitivity,
-                                              ParseError<'i, SelectorParseError<'i, E>>> {
+                                    -> Result<ParsedCaseSensitivity, SelectorParseError<'i, E>> {
+    let location = input.current_source_location();
     match input.next() {
         Err(_) => {
             // Selectors spec says language-defined, but HTML says sensitive.
@@ -1442,7 +1462,7 @@ fn parse_attribute_flags<'i, 't, E>(input: &mut CssParser<'i, 't>)
         Ok(&Token::Ident(ref value)) if value.eq_ignore_ascii_case("i") => {
             Ok(ParsedCaseSensitivity::AsciiCaseInsensitive)
         }
-        Ok(t) => Err(ParseError::Basic(BasicParseError::UnexpectedToken(t.clone())))
+        Ok(t) => Err(location.new_unexpected_token_error(t.clone()))
     }
 }
 
@@ -1451,8 +1471,7 @@ fn parse_attribute_flags<'i, 't, E>(input: &mut CssParser<'i, 't>)
 /// implied "<defaultns>|*" type selector.)
 fn parse_negation<'i, 't, P, E, Impl>(parser: &P,
                                       input: &mut CssParser<'i, 't>)
-                                      -> Result<Component<Impl>,
-                                                ParseError<'i, SelectorParseError<'i, E>>>
+                                      -> Result<Component<Impl>, SelectorParseError<'i, E>>
     where P: Parser<'i, Impl=Impl, Error=E>, Impl: SelectorImpl
 {
     // We use a sequence because a type selector may be represented as two Components.
@@ -1464,8 +1483,9 @@ fn parse_negation<'i, 't, P, E, Impl>(parser: &P,
     // that there are no trailing tokens after we're done.
     let is_type_sel = match parse_type_selector(parser, input, &mut sequence) {
         Ok(result) => result,
-        Err(ParseError::Basic(BasicParseError::EndOfInput)) =>
-            return Err(SelectorParseError::EmptyNegation.into()),
+        Err(ParseError { kind: ParseErrorKind::Basic(BasicParseErrorKind::EndOfInput), .. }) => {
+            return Err(input.new_custom_error(SelectorParseErrorKind::EmptyNegation))
+        }
         Err(e) => return Err(e.into()),
     };
     if !is_type_sel {
@@ -1474,10 +1494,10 @@ fn parse_negation<'i, 't, P, E, Impl>(parser: &P,
                 sequence.push(s);
             },
             None => {
-                return Err(ParseError::Custom(SelectorParseError::EmptyNegation));
+                return Err(input.new_custom_error(SelectorParseErrorKind::EmptyNegation));
             },
             Some(SimpleSelectorParseResult::PseudoElement(_)) => {
-                return Err(ParseError::Custom(SelectorParseError::NonSimpleSelectorInNegation));
+                return Err(input.new_custom_error(SelectorParseErrorKind::NonSimpleSelectorInNegation));
             }
         }
     }
@@ -1497,7 +1517,7 @@ fn parse_compound_selector<'i, 't, P, E, Impl>(
     parser: &P,
     input: &mut CssParser<'i, 't>,
     builder: &mut SelectorBuilder<Impl>)
-    -> Result<bool, ParseError<'i, SelectorParseError<'i, E>>>
+    -> Result<bool, SelectorParseError<'i, E>>
     where P: Parser<'i, Impl=Impl, Error=E>, Impl: SelectorImpl
 {
     input.skip_whitespace();
@@ -1528,24 +1548,32 @@ fn parse_compound_selector<'i, 't, P, E, Impl>(
                 let mut state_selectors = SmallVec::<[Component<Impl>; 3]>::new();
 
                 loop {
+                    let location = input.current_source_location();
                     match input.next_including_whitespace() {
                         Ok(&Token::Colon) => {},
                         Ok(&Token::WhiteSpace(_)) | Err(_) => break,
                         Ok(t) =>
-                            return Err(SelectorParseError::PseudoElementExpectedColon(t.clone()).into()),
+                            return Err(location.new_custom_error(
+                                SelectorParseErrorKind::PseudoElementExpectedColon(t.clone())
+                            )),
                     }
 
+                    let location = input.current_source_location();
                     // TODO(emilio): Functional pseudo-classes too?
                     // We don't need it for now.
                     let name = match input.next_including_whitespace()? {
                         &Token::Ident(ref name) => name.clone(),
-                        t => return Err(SelectorParseError::NoIdentForPseudo(t.clone()).into()),
+                        t => return Err(location.new_custom_error(
+                            SelectorParseErrorKind::NoIdentForPseudo(t.clone())
+                        )),
                     };
 
                     let pseudo_class =
-                        P::parse_non_ts_pseudo_class(parser, name.clone())?;
+                        P::parse_non_ts_pseudo_class(parser, location, name.clone())?;
                     if !p.supports_pseudo_class(&pseudo_class) {
-                        return Err(SelectorParseError::UnsupportedPseudoClassOrElement(name).into());
+                        return Err(input.new_custom_error(
+                            SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)
+                        ));
                     }
                     state_selectors.push(Component::NonTSPseudoClass(pseudo_class));
                 }
@@ -1567,7 +1595,7 @@ fn parse_compound_selector<'i, 't, P, E, Impl>(
     }
     if empty {
         // An empty selector is invalid.
-        Err(ParseError::Custom(SelectorParseError::EmptySelector))
+        Err(input.new_custom_error(SelectorParseErrorKind::EmptySelector))
     } else {
         Ok(pseudo)
     }
@@ -1577,8 +1605,7 @@ fn parse_functional_pseudo_class<'i, 't, P, E, Impl>(parser: &P,
                                                      input: &mut CssParser<'i, 't>,
                                                      name: CowRcStr<'i>,
                                                      inside_negation: bool)
-                                                     -> Result<Component<Impl>,
-                                                               ParseError<'i, SelectorParseError<'i, E>>>
+                                                     -> Result<Component<Impl>, SelectorParseError<'i, E>>
     where P: Parser<'i, Impl=Impl, Error=E>, Impl: SelectorImpl
 {
     match_ignore_ascii_case! { &name,
@@ -1588,7 +1615,9 @@ fn parse_functional_pseudo_class<'i, 't, P, E, Impl>(parser: &P,
         "nth-last-of-type" => return parse_nth_pseudo_class(input, Component::NthLastOfType),
         "not" => {
             if inside_negation {
-                return Err(ParseError::Custom(SelectorParseError::UnexpectedIdent("not".into())));
+                return Err(input.new_custom_error(
+                    SelectorParseErrorKind::UnexpectedIdent("not".into())
+                ));
             }
             return parse_negation(parser, input)
         },
@@ -1600,8 +1629,7 @@ fn parse_functional_pseudo_class<'i, 't, P, E, Impl>(parser: &P,
 
 
 fn parse_nth_pseudo_class<'i, 't, Impl, F, E>(input: &mut CssParser<'i, 't>, selector: F)
-                                              -> Result<Component<Impl>,
-                                                        ParseError<'i, SelectorParseError<'i, E>>>
+                                              -> Result<Component<Impl>, SelectorParseError<'i, E>>
 where Impl: SelectorImpl, F: FnOnce(i32, i32) -> Component<Impl> {
     let (a, b) = parse_nth(input)?;
     Ok(selector(a, b))
@@ -1628,7 +1656,7 @@ fn parse_one_simple_selector<'i, 't, P, E, Impl>(parser: &P,
                                                  input: &mut CssParser<'i, 't>,
                                                  inside_negation: bool)
                                                  -> Result<Option<SimpleSelectorParseResult<Impl>>,
-                                                           ParseError<'i, SelectorParseError<'i, E>>>
+                                                           SelectorParseError<'i, E>>
     where P: Parser<'i, Impl=Impl, Error=E>, Impl: SelectorImpl
 {
     let start = input.state();
@@ -1639,12 +1667,15 @@ fn parse_one_simple_selector<'i, 't, P, E, Impl>(parser: &P,
             Ok(Some(SimpleSelectorParseResult::SimpleSelector(id)))
         }
         Ok(Token::Delim('.')) => {
+            let location = input.current_source_location();
             match *input.next_including_whitespace()? {
                 Token::Ident(ref class) => {
                     let class = Component::Class(class.as_ref().into());
                     Ok(Some(SimpleSelectorParseResult::SimpleSelector(class)))
                 }
-                ref t => Err(SelectorParseError::ClassNeedsIdent(t.clone()).into()),
+                ref t => Err(location.new_custom_error(
+                    SelectorParseErrorKind::ClassNeedsIdent(t.clone())
+                )),
             }
         }
         Ok(Token::SquareBracketBlock) => {
@@ -1652,6 +1683,7 @@ fn parse_one_simple_selector<'i, 't, P, E, Impl>(parser: &P,
             Ok(Some(SimpleSelectorParseResult::SimpleSelector(attr)))
         }
         Ok(Token::Colon) => {
+            let location = input.current_source_location();
             let (is_single_colon, next_token) = match input.next_including_whitespace()?.clone() {
                 Token::Colon => (false, input.next_including_whitespace()?.clone()),
                 t => (true, t),
@@ -1659,7 +1691,9 @@ fn parse_one_simple_selector<'i, 't, P, E, Impl>(parser: &P,
             let (name, is_functional) = match next_token {
                 Token::Ident(name) => (name, false),
                 Token::Function(name) => (name, true),
-                t => return Err(SelectorParseError::PseudoElementExpectedIdent(t).into()),
+                t => return Err(input.new_custom_error(
+                    SelectorParseErrorKind::PseudoElementExpectedIdent(t)
+                )),
             };
             let is_pseudo_element = !is_single_colon ||
                 P::is_pseudo_element_allows_single_colon(&name);
@@ -1669,7 +1703,7 @@ fn parse_one_simple_selector<'i, 't, P, E, Impl>(parser: &P,
                         P::parse_functional_pseudo_element(parser, name, input)
                     })?
                 } else {
-                    P::parse_pseudo_element(parser, name)?
+                    P::parse_pseudo_element(parser, location, name)?
                 };
                 Ok(Some(SimpleSelectorParseResult::PseudoElement(pseudo_element)))
             } else {
@@ -1678,7 +1712,7 @@ fn parse_one_simple_selector<'i, 't, P, E, Impl>(parser: &P,
                         parse_functional_pseudo_class(parser, input, name, inside_negation)
                     })?
                 } else {
-                    parse_simple_pseudo_class(parser, name)?
+                    parse_simple_pseudo_class(parser, location, name)?
                 };
                 Ok(Some(SimpleSelectorParseResult::SimpleSelector(pseudo_class)))
             }
@@ -1690,9 +1724,9 @@ fn parse_one_simple_selector<'i, 't, P, E, Impl>(parser: &P,
     }
 }
 
-fn parse_simple_pseudo_class<'i, P, E, Impl>(parser: &P, name: CowRcStr<'i>)
-                                             -> Result<Component<Impl>,
-                                                       ParseError<'i, SelectorParseError<'i, E>>>
+fn parse_simple_pseudo_class<'i, P, E, Impl>(parser: &P, location: SourceLocation,
+                                             name: CowRcStr<'i>)
+                                             -> Result<Component<Impl>, SelectorParseError<'i, E>>
     where P: Parser<'i, Impl=Impl, Error=E>, Impl: SelectorImpl
 {
     (match_ignore_ascii_case! { &name,
@@ -1707,7 +1741,7 @@ fn parse_simple_pseudo_class<'i, P, E, Impl>(parser: &P, name: CowRcStr<'i>)
         "only-of-type"  => Ok(Component::OnlyOfType),
         _ => Err(())
     }).or_else(|()| {
-        P::parse_non_ts_pseudo_class(parser, name)
+        P::parse_non_ts_pseudo_class(parser, location, name)
             .map(Component::NonTSPseudoClass)
     })
 }
@@ -1845,33 +1879,31 @@ pub mod tests {
         type Impl = DummySelectorImpl;
         type Error = ();
 
-        fn parse_non_ts_pseudo_class(&self, name: CowRcStr<'i>)
-                                     -> Result<PseudoClass,
-                                               ParseError<'i, SelectorParseError<'i, ()>>> {
+        fn parse_non_ts_pseudo_class(&self, location: SourceLocation, name: CowRcStr<'i>)
+                                     -> Result<PseudoClass, SelectorParseError<'i, ()>> {
             match_ignore_ascii_case! { &name,
                 "hover" => Ok(PseudoClass::Hover),
                 "active" => Ok(PseudoClass::Active),
-                _ => Err(SelectorParseError::Custom(()).into())
+                _ => Err(location.new_custom_error(SelectorParseErrorKind::Custom(())))
             }
         }
 
         fn parse_non_ts_functional_pseudo_class<'t>(&self, name: CowRcStr<'i>,
                                                     parser: &mut CssParser<'i, 't>)
-                                                    -> Result<PseudoClass,
-                                                              ParseError<'i, SelectorParseError<'i, ()>>> {
+                                                    -> Result<PseudoClass, SelectorParseError<'i, ()>> {
             match_ignore_ascii_case! { &name,
                 "lang" => Ok(PseudoClass::Lang(parser.expect_ident_or_string()?.as_ref().to_owned())),
-                _ => Err(SelectorParseError::Custom(()).into())
+                _ => Err(parser.new_custom_error(SelectorParseErrorKind::Custom(())))
             }
         }
 
-        fn parse_pseudo_element(&self, name: CowRcStr<'i>)
+        fn parse_pseudo_element(&self, location: SourceLocation, name: CowRcStr<'i>)
                                 -> Result<PseudoElement,
-                                          ParseError<'i, SelectorParseError<'i, ()>>> {
+                                          SelectorParseError<'i, ()>> {
             match_ignore_ascii_case! { &name,
                 "before" => Ok(PseudoElement::Before),
                 "after" => Ok(PseudoElement::After),
-                _ => Err(SelectorParseError::Custom(()).into())
+                _ => Err(location.new_custom_error(SelectorParseErrorKind::Custom(())))
             }
         }
 
@@ -1885,17 +1917,17 @@ pub mod tests {
     }
 
     fn parse<'i>(input: &'i str)
-                 -> Result<SelectorList<DummySelectorImpl>, ParseError<'i, SelectorParseError<'i, ()>>> {
+                 -> Result<SelectorList<DummySelectorImpl>, SelectorParseError<'i, ()>> {
         parse_ns(input, &DummyParser::default())
     }
 
     fn parse_expected<'i, 'a>(input: &'i str, expected: Option<&'a str>)
-                              -> Result<SelectorList<DummySelectorImpl>, ParseError<'i, SelectorParseError<'i, ()>>> {
+                              -> Result<SelectorList<DummySelectorImpl>, SelectorParseError<'i, ()>> {
         parse_ns_expected(input, &DummyParser::default(), expected)
     }
 
     fn parse_ns<'i>(input: &'i str, parser: &DummyParser)
-                    -> Result<SelectorList<DummySelectorImpl>, ParseError<'i, SelectorParseError<'i, ()>>> {
+                    -> Result<SelectorList<DummySelectorImpl>, SelectorParseError<'i, ()>> {
         parse_ns_expected(input, parser, None)
     }
 
@@ -1903,7 +1935,7 @@ pub mod tests {
         input: &'i str,
         parser: &DummyParser,
         expected: Option<&'a str>
-    ) -> Result<SelectorList<DummySelectorImpl>, ParseError<'i, SelectorParseError<'i, ()>>> {
+    ) -> Result<SelectorList<DummySelectorImpl>, SelectorParseError<'i, ()>> {
         let mut parser_input = ParserInput::new(input);
         let result = SelectorList::parse(parser, &mut CssParser::new(&mut parser_input));
         if let Ok(ref selectors) = result {

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -36,7 +36,7 @@ atomic_refcell = "0.1"
 bitflags = "0.7"
 byteorder = "1.0"
 cfg-if = "0.1.0"
-cssparser = "0.21.2"
+cssparser = "0.22.0"
 encoding = {version = "0.2", optional = true}
 euclid = "0.15"
 fallible = { path = "../fallible" }

--- a/components/style/counter_style/mod.rs
+++ b/components/style/counter_style/mod.rs
@@ -68,7 +68,7 @@ pub fn parse_counter_style_body<'i, 't, R>(name: CustomIdent,
         while let Some(declaration) = iter.next() {
             if let Err(err) = declaration {
                 let error = ContextualParseError::UnsupportedCounterStyleDescriptorDeclaration(err.slice, err.error);
-                context.log_css_error(error_context, err.location, error)
+                context.log_css_error(error_context, iter.input.current_source_location(), error)
             }
         }
     }

--- a/components/style/counter_style/mod.rs
+++ b/components/style/counter_style/mod.rs
@@ -8,18 +8,18 @@
 
 use Atom;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser};
-use cssparser::{Parser, Token, serialize_identifier, BasicParseError, CowRcStr};
+use cssparser::{Parser, Token, serialize_identifier, CowRcStr};
 use error_reporting::{ContextualParseError, ParseErrorReporter};
 #[cfg(feature = "gecko")] use gecko::rules::CounterStyleDescriptors;
 #[cfg(feature = "gecko")] use gecko_bindings::structs::nsCSSCounterDesc;
 use parser::{ParserContext, ParserErrorContext, Parse};
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::fmt;
 use std::ops::Range;
-use style_traits::{Comma, OneOrMoreSeparated, ParseError, StyleParseError, ToCss};
+use style_traits::{Comma, OneOrMoreSeparated, ParseError, StyleParseErrorKind, ToCss};
 use values::CustomIdent;
 
 /// Parse the prelude of an @counter-style rule
@@ -36,12 +36,13 @@ pub fn parse_counter_style_name<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Cu
                     }
                 }
 
+                let location = input.current_source_location();
                 let ident = input.expect_ident()?;
                 if let Some(&lower_cased) = predefined(&ident) {
                     Ok(CustomIdent(Atom::from(lower_cased)))
                 } else {
                     // https://github.com/w3c/csswg-drafts/issues/1295 excludes "none"
-                    CustomIdent::from_ident(ident, &["none"])
+                    CustomIdent::from_ident(location, ident, &["none"])
                 }
             }
         }
@@ -66,8 +67,8 @@ pub fn parse_counter_style_body<'i, 't, R>(name: CustomIdent,
         };
         let mut iter = DeclarationListParser::new(input, parser);
         while let Some(declaration) = iter.next() {
-            if let Err(err) = declaration {
-                let error = ContextualParseError::UnsupportedCounterStyleDescriptorDeclaration(err.slice, err.error);
+            if let Err((error, slice)) = declaration {
+                let error = ContextualParseError::UnsupportedCounterStyleDescriptorDeclaration(slice, error);
                 context.log_css_error(error_context, iter.input.current_source_location(), error)
             }
         }
@@ -101,7 +102,7 @@ pub fn parse_counter_style_body<'i, 't, R>(name: CustomIdent,
     };
     if let Some(error) = error {
         context.log_css_error(error_context, start, error);
-        Err(StyleParseError::UnspecifiedError.into())
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
     } else {
         Ok(rule)
     }
@@ -117,7 +118,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for CounterStyleRuleParser<'a, 'b> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = ();
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 }
 
 macro_rules! accessor {
@@ -186,7 +187,7 @@ macro_rules! counter_style_descriptors {
 
         impl<'a, 'b, 'i> DeclarationParser<'i> for CounterStyleRuleParser<'a, 'b> {
             type Declaration = ();
-            type Error = SelectorParseError<'i, StyleParseError<'i>>;
+            type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 
             fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                                -> Result<(), ParseError<'i>> {
@@ -201,7 +202,7 @@ macro_rules! counter_style_descriptors {
                             self.rule.$ident = Some(value)
                         }
                     )*
-                    _ => return Err(SelectorParseError::UnexpectedIdent(name.clone()).into())
+                    _ => return Err(input.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(name.clone())))
                 }
                 Ok(())
             }
@@ -299,7 +300,7 @@ pub enum System {
 
 impl Parse for System {
     fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
-        try_match_ident_ignore_ascii_case! { input.expect_ident_cloned()?,
+        try_match_ident_ignore_ascii_case! { input,
             "cyclic" => Ok(System::Cyclic),
             "numeric" => Ok(System::Numeric),
             "alphabetic" => Ok(System::Alphabetic),
@@ -356,10 +357,11 @@ pub enum Symbol {
 
 impl Parse for Symbol {
     fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
+        let location = input.current_source_location();
         match input.next() {
             Ok(&Token::QuotedString(ref s)) => Ok(Symbol::String(s.as_ref().to_owned())),
             Ok(&Token::Ident(ref s)) => Ok(Symbol::Ident(s.as_ref().to_owned())),
-            Ok(t) => Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+            Ok(t) => Err(location.new_unexpected_token_error(t.clone())),
             Err(e) => Err(e.into()),
         }
     }
@@ -414,7 +416,7 @@ impl Parse for Ranges {
                 let opt_end = parse_bound(input)?;
                 if let (Some(start), Some(end)) = (opt_start, opt_end) {
                     if start > end {
-                        return Err(StyleParseError::UnspecifiedError.into())
+                        return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
                     }
                 }
                 Ok(opt_start..opt_end)
@@ -424,10 +426,11 @@ impl Parse for Ranges {
 }
 
 fn parse_bound<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Option<i32>, ParseError<'i>> {
+    let location = input.current_source_location();
     match input.next() {
         Ok(&Token::Number { int_value: Some(v), .. }) => Ok(Some(v)),
         Ok(&Token::Ident(ref ident)) if ident.eq_ignore_ascii_case("infinite") => Ok(None),
-        Ok(t) => Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+        Ok(t) => Err(location.new_unexpected_token_error(t.clone())),
         Err(e) => Err(e.into()),
     }
 }
@@ -472,7 +475,7 @@ impl Parse for Pad {
         let pad_with = input.try(|input| Symbol::parse(context, input));
         let min_length = input.expect_integer()?;
         if min_length < 0 {
-            return Err(StyleParseError::UnspecifiedError.into())
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
         let pad_with = pad_with.or_else(|_| Symbol::parse(context, input))?;
         Ok(Pad(min_length as u32, pad_with))
@@ -502,7 +505,7 @@ impl Parse for Symbols {
                 symbols.push(s)
             } else {
                 if symbols.is_empty() {
-                    return Err(StyleParseError::UnspecifiedError.into())
+                    return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
                 } else {
                     return Ok(Symbols(symbols))
                 }
@@ -533,7 +536,7 @@ impl Parse for AdditiveSymbols {
         let tuples = Vec::<AdditiveTuple>::parse(context, input)?;
         // FIXME maybe? https://github.com/w3c/csswg-drafts/issues/1220
         if tuples.windows(2).any(|window| window[0].weight <= window[1].weight) {
-            return Err(StyleParseError::UnspecifiedError.into())
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
         Ok(AdditiveSymbols(tuples))
     }
@@ -557,7 +560,7 @@ impl Parse for AdditiveTuple {
         let symbol = input.try(|input| Symbol::parse(context, input));
         let weight = input.expect_integer()?;
         if weight < 0 {
-            return Err(StyleParseError::UnspecifiedError.into())
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
         let symbol = symbol.or_else(|_| Symbol::parse(context, input))?;
         Ok(AdditiveTuple {
@@ -604,7 +607,7 @@ impl Parse for SpeakAs {
         if is_spell_out {
             // spell-out is not supported, but don’t parse it as a <counter-style-name>.
             // See bug 1024178.
-            return Err(StyleParseError::UnspecifiedError.into())
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
         result.or_else(|_| {
             Ok(SpeakAs::Other(parse_counter_style_name(input)?))

--- a/components/style/counter_style/mod.rs
+++ b/components/style/counter_style/mod.rs
@@ -68,8 +68,9 @@ pub fn parse_counter_style_body<'i, 't, R>(name: CustomIdent,
         let mut iter = DeclarationListParser::new(input, parser);
         while let Some(declaration) = iter.next() {
             if let Err((error, slice)) = declaration {
+                let location = error.location;
                 let error = ContextualParseError::UnsupportedCounterStyleDescriptorDeclaration(slice, error);
-                context.log_css_error(error_context, iter.input.current_source_location(), error)
+                context.log_css_error(error_context, location, error)
             }
         }
     }

--- a/components/style/counter_style/mod.rs
+++ b/components/style/counter_style/mod.rs
@@ -119,7 +119,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for CounterStyleRuleParser<'a, 'b> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = ();
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 }
 
 macro_rules! accessor {
@@ -188,7 +188,7 @@ macro_rules! counter_style_descriptors {
 
         impl<'a, 'b, 'i> DeclarationParser<'i> for CounterStyleRuleParser<'a, 'b> {
             type Declaration = ();
-            type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+            type Error = StyleParseErrorKind<'i>;
 
             fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                                -> Result<(), ParseError<'i>> {

--- a/components/style/error_reporting.rs
+++ b/components/style/error_reporting.rs
@@ -6,8 +6,7 @@
 
 #![deny(missing_docs)]
 
-use cssparser::{BasicParseError, Token, SourceLocation};
-use cssparser::ParseError as CssParseError;
+use cssparser::{Token, SourceLocation, ParseErrorKind, BasicParseErrorKind};
 use log;
 use std::fmt;
 use style_traits::ParseError;
@@ -91,24 +90,24 @@ impl<'a> fmt::Display for ContextualParseError<'a> {
         }
 
         fn parse_error_to_str(err: &ParseError, f: &mut fmt::Formatter) -> fmt::Result {
-            match *err {
-                CssParseError::Basic(BasicParseError::UnexpectedToken(ref t)) => {
+            match err.kind {
+                ParseErrorKind::Basic(BasicParseErrorKind::UnexpectedToken(ref t)) => {
                     write!(f, "found unexpected ")?;
                     token_to_str(t, f)
                 }
-                CssParseError::Basic(BasicParseError::EndOfInput) => {
+                ParseErrorKind::Basic(BasicParseErrorKind::EndOfInput) => {
                     write!(f, "unexpected end of input")
                 }
-                CssParseError::Basic(BasicParseError::AtRuleInvalid(ref i)) => {
+                ParseErrorKind::Basic(BasicParseErrorKind::AtRuleInvalid(ref i)) => {
                     write!(f, "@ rule invalid: {}", i)
                 }
-                CssParseError::Basic(BasicParseError::AtRuleBodyInvalid) => {
+                ParseErrorKind::Basic(BasicParseErrorKind::AtRuleBodyInvalid) => {
                     write!(f, "@ rule invalid")
                 }
-                CssParseError::Basic(BasicParseError::QualifiedRuleInvalid) => {
+                ParseErrorKind::Basic(BasicParseErrorKind::QualifiedRuleInvalid) => {
                     write!(f, "qualified rule invalid")
                 }
-                CssParseError::Custom(ref err) => {
+                ParseErrorKind::Custom(ref err) => {
                     write!(f, "{:?}", err)
                 }
             }

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -125,7 +125,7 @@ pub fn parse_font_face_block<R>(context: &ParserContext,
         while let Some(declaration) = iter.next() {
             if let Err(err) = declaration {
                 let error = ContextualParseError::UnsupportedFontFaceDescriptor(err.slice, err.error);
-                context.log_css_error(error_context, err.location, error)
+                context.log_css_error(error_context, iter.input.current_source_location(), error)
             }
         }
     }

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -124,8 +124,9 @@ pub fn parse_font_face_block<R>(context: &ParserContext,
         let mut iter = DeclarationListParser::new(input, parser);
         while let Some(declaration) = iter.next() {
             if let Err((error, slice)) = declaration {
+                let location = error.location;
                 let error = ContextualParseError::UnsupportedFontFaceDescriptor(slice, error);
-                context.log_css_error(error_context, iter.input.current_source_location(), error)
+                context.log_css_error(error_context, location, error)
             }
         }
     }

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -187,7 +187,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for FontFaceRuleParser<'a, 'b> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = ();
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 }
 
 impl Parse for Source {
@@ -288,7 +288,7 @@ macro_rules! font_face_descriptors_common {
 
        impl<'a, 'b, 'i> DeclarationParser<'i> for FontFaceRuleParser<'a, 'b> {
            type Declaration = ();
-           type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+           type Error = StyleParseErrorKind<'i>;
 
            fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                               -> Result<(), ParseError<'i>> {

--- a/components/style/gecko/selector_parser.rs
+++ b/components/style/gecko/selector_parser.rs
@@ -4,18 +4,18 @@
 
 //! Gecko-specific bits for selector-parsing.
 
-use cssparser::{BasicParseError, Parser, ToCss, Token, CowRcStr};
+use cssparser::{BasicParseError, BasicParseErrorKind, Parser, ToCss, Token, CowRcStr, SourceLocation};
 use element_state::ElementState;
 use gecko_bindings::structs::CSSPseudoClassType;
 use gecko_bindings::structs::RawServoSelectorList;
 use gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
 use selector_parser::{SelectorParser, PseudoElementCascadeType};
 use selectors::SelectorList;
-use selectors::parser::{Selector, SelectorMethods, SelectorParseError};
+use selectors::parser::{Selector, SelectorMethods, SelectorParseErrorKind};
 use selectors::visitor::SelectorVisitor;
 use std::fmt;
 use string_cache::{Atom, Namespace, WeakAtom, WeakNamespace};
-use style_traits::{ParseError, StyleParseError};
+use style_traits::{ParseError, StyleParseErrorKind};
 
 pub use gecko::pseudo_element::{PseudoElement, EAGER_PSEUDOS, EAGER_PSEUDO_COUNT, SIMPLE_PSEUDO_COUNT};
 pub use gecko::snapshot::SnapshotMap;
@@ -298,14 +298,14 @@ impl<'a> SelectorParser<'a> {
 
 impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
     type Impl = SelectorImpl;
-    type Error = StyleParseError<'i>;
+    type Error = StyleParseErrorKind<'i>;
 
     fn is_pseudo_element_allows_single_colon(name: &CowRcStr<'i>) -> bool {
         ::selectors::parser::is_css2_pseudo_element(name) ||
             name.starts_with("-moz-tree-") // tree pseudo-elements
     }
 
-    fn parse_non_ts_pseudo_class(&self, name: CowRcStr<'i>)
+    fn parse_non_ts_pseudo_class(&self, location: SourceLocation, name: CowRcStr<'i>)
                                  -> Result<NonTSPseudoClass, ParseError<'i>> {
         macro_rules! pseudo_class_parse {
             (bare: [$(($css:expr, $name:ident, $gecko_type:tt, $state:tt, $flags:tt),)*],
@@ -313,8 +313,9 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
              keyword: [$(($k_css:expr, $k_name:ident, $k_gecko_type:tt, $k_state:tt, $k_flags:tt),)*]) => {
                 match_ignore_ascii_case! { &name,
                     $($css => NonTSPseudoClass::$name,)*
-                    _ => return Err(::selectors::parser::SelectorParseError::UnsupportedPseudoClassOrElement(
-                        name.clone()).into())
+                    _ => return Err(location.new_custom_error(
+                        SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())
+                    ))
                 }
             }
         }
@@ -322,7 +323,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
         if self.is_pseudo_class_enabled(&pseudo_class) {
             Ok(pseudo_class)
         } else {
-            Err(SelectorParseError::UnsupportedPseudoClassOrElement(name).into())
+            Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
         }
     }
 
@@ -355,11 +356,15 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
                         })?;
                         // Selectors inside `:-moz-any` may not include combinators.
                         if selectors.iter().flat_map(|x| x.iter_raw_match_order()).any(|s| s.is_combinator()) {
-                            return Err(SelectorParseError::UnexpectedIdent("-moz-any".into()).into())
+                            return Err(parser.new_custom_error(
+                                SelectorParseErrorKind::UnexpectedIdent("-moz-any".into())
+                            ))
                         }
                         NonTSPseudoClass::MozAny(selectors.into_boxed_slice())
                     }
-                    _ => return Err(SelectorParseError::UnsupportedPseudoClassOrElement(name.clone()).into())
+                    _ => return Err(parser.new_custom_error(
+                        SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())
+                    ))
                 }
             }
         }
@@ -367,13 +372,14 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
         if self.is_pseudo_class_enabled(&pseudo_class) {
             Ok(pseudo_class)
         } else {
-            Err(SelectorParseError::UnsupportedPseudoClassOrElement(name).into())
+            Err(parser.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
         }
     }
 
-    fn parse_pseudo_element(&self, name: CowRcStr<'i>) -> Result<PseudoElement, ParseError<'i>> {
+    fn parse_pseudo_element(&self, location: SourceLocation, name: CowRcStr<'i>)
+                            -> Result<PseudoElement, ParseError<'i>> {
         PseudoElement::from_slice(&name, self.in_user_agent_stylesheet())
-            .ok_or(SelectorParseError::UnsupportedPseudoClassOrElement(name.clone()).into())
+            .ok_or(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())))
     }
 
     fn parse_functional_pseudo_element<'t>(&self, name: CowRcStr<'i>,
@@ -384,11 +390,12 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
             // separated by either comma or space.
             let mut args = Vec::new();
             loop {
+                let location = parser.current_source_location();
                 match parser.next() {
                     Ok(&Token::Ident(ref ident)) => args.push(ident.as_ref().to_owned()),
                     Ok(&Token::Comma) => {},
-                    Ok(t) => return Err(BasicParseError::UnexpectedToken(t.clone()).into()),
-                    Err(BasicParseError::EndOfInput) => break,
+                    Ok(t) => return Err(location.new_unexpected_token_error(t.clone())),
+                    Err(BasicParseError { kind: BasicParseErrorKind::EndOfInput, .. }) => break,
                     _ => unreachable!("Parser::next() shouldn't return any other error"),
                 }
             }
@@ -397,7 +404,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
                 return Ok(pseudo);
             }
         }
-        Err(SelectorParseError::UnsupportedPseudoClassOrElement(name.clone()).into())
+        Err(parser.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())))
     }
 
     fn default_namespace(&self) -> Option<Namespace> {

--- a/components/style/media_queries.rs
+++ b/components/style/media_queries.rs
@@ -257,7 +257,6 @@ where
     let mut media_queries = vec![];
     loop {
         let start_position = input.position();
-        let start_location = input.current_source_location();
         match input.parse_until_before(Delimiter::Comma, |i| MediaQuery::parse(context, i)) {
             Ok(mq) => {
                 media_queries.push(mq);
@@ -267,7 +266,7 @@ where
                 let error = ContextualParseError::InvalidMediaRule(
                     input.slice_from(start_position), err);
                 let error_context = ParserErrorContext { error_reporter };
-                context.log_css_error(&error_context, start_location, error);
+                context.log_css_error(&error_context, input.current_source_location(), error);
             },
         }
 

--- a/components/style/media_queries.rs
+++ b/components/style/media_queries.rs
@@ -263,10 +263,11 @@ where
             },
             Err(err) => {
                 media_queries.push(MediaQuery::never_matching());
+                let location = err.location;
                 let error = ContextualParseError::InvalidMediaRule(
                     input.slice_from(start_position), err);
                 let error_context = ParserErrorContext { error_reporter };
-                context.log_css_error(&error_context, input.current_source_location(), error);
+                context.log_css_error(&error_context, location, error);
             },
         }
 

--- a/components/style/media_queries.rs
+++ b/components/style/media_queries.rs
@@ -12,11 +12,11 @@ use cssparser::{Delimiter, Parser};
 use cssparser::{Token, ParserInput};
 use error_reporting::{ContextualParseError, ParseErrorReporter};
 use parser::{ParserContext, ParserErrorContext};
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 use serialize_comma_separated_list;
 use std::fmt;
 use str::string_as_ascii_lowercase;
-use style_traits::{ToCss, ParseError, StyleParseError};
+use style_traits::{ToCss, ParseError, StyleParseErrorKind};
 use values::CustomIdent;
 
 #[cfg(feature = "servo")]
@@ -210,13 +210,13 @@ impl MediaQuery {
         let media_type = match input.try(|i| i.expect_ident_cloned()) {
             Ok(ident) => {
                 let result: Result<_, ParseError> = MediaQueryType::parse(&*ident)
-                    .map_err(|()| SelectorParseError::UnexpectedIdent(ident.clone()).into());
+                    .map_err(|()| input.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(ident.clone())));
                 result?
             }
             Err(_) => {
                 // Media type is only optional if qualifier is not specified.
                 if qualifier.is_some() {
-                    return Err(StyleParseError::UnspecifiedError.into())
+                    return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
                 }
 
                 // Without a media type, require at least one expression.

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -1079,9 +1079,9 @@ impl<'a, 'b, 'i> DeclarationParser<'i> for PropertyDeclarationParser<'a, 'b> {
             Ok(id) => id,
             Err(()) => {
                 return Err(input.new_custom_error(if is_non_mozilla_vendor_identifier(&name) {
-                    PropertyDeclarationParseErrorKind::UnknownVendorProperty
+                    StyleParseErrorKind::UnknownVendorProperty
                 } else {
-                    PropertyDeclarationParseErrorKind::UnknownProperty(name)
+                    StyleParseErrorKind::UnknownProperty(name)
                 }));
             }
         };
@@ -1125,9 +1125,7 @@ pub fn parse_property_declaration_list<R>(context: &ParserContext,
 
                 // If the unrecognized property looks like a vendor-specific property,
                 // silently ignore it instead of polluting the error output.
-                if let ParseErrorKind::Custom(
-                    StyleParseErrorKind::PropertyDeclaration(
-                        PropertyDeclarationParseErrorKind::UnknownVendorProperty)) = error.kind {
+                if let ParseErrorKind::Custom(StyleParseErrorKind::UnknownVendorProperty) = error.kind {
                     continue;
                 }
 

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -13,7 +13,6 @@ use custom_properties::CustomPropertiesBuilder;
 use error_reporting::{ParseErrorReporter, ContextualParseError};
 use parser::{ParserContext, ParserErrorContext};
 use properties::animated_properties::AnimationValue;
-use selectors::parser::SelectorParseErrorKind;
 use shared_lock::Locked;
 use smallbitvec::{self, SmallBitVec};
 use smallvec::SmallVec;
@@ -1060,7 +1059,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for PropertyDeclarationParser<'a, 'b> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = Importance;
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 }
 
 /// Based on NonMozillaVendorIdentifier from Gecko's CSS parser.
@@ -1071,7 +1070,7 @@ fn is_non_mozilla_vendor_identifier(name: &str) -> bool {
 
 impl<'a, 'b, 'i> DeclarationParser<'i> for PropertyDeclarationParser<'a, 'b> {
     type Declaration = Importance;
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 
     fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                        -> Result<Importance, ParseError<'i>> {
@@ -1126,9 +1125,9 @@ pub fn parse_property_declaration_list<R>(context: &ParserContext,
 
                 // If the unrecognized property looks like a vendor-specific property,
                 // silently ignore it instead of polluting the error output.
-                if let ParseErrorKind::Custom(SelectorParseErrorKind::Custom(
+                if let ParseErrorKind::Custom(
                     StyleParseErrorKind::PropertyDeclaration(
-                        PropertyDeclarationParseErrorKind::UnknownVendorProperty))) = error.kind {
+                        PropertyDeclarationParseErrorKind::UnknownVendorProperty)) = error.kind {
                     continue;
                 }
 

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -1040,10 +1040,11 @@ pub fn parse_one_declaration_into<R>(declarations: &mut SourcePropertyDeclaratio
         PropertyDeclaration::parse_into(declarations, id, name, &context, parser)
             .map_err(|e| e.into())
     }).map_err(|err| {
+        let location = err.location;
         let error = ContextualParseError::UnsupportedPropertyDeclaration(
             parser.slice_from(start_position), err);
         let error_context = ParserErrorContext { error_reporter: error_reporter };
-        context.log_css_error(&error_context, parser.current_source_location(), error);
+        context.log_css_error(&error_context, location, error);
     })
 }
 
@@ -1131,8 +1132,8 @@ pub fn parse_property_declaration_list<R>(context: &ParserContext,
                     continue;
                 }
 
+                let location = error.location;
                 let error = ContextualParseError::UnsupportedPropertyDeclaration(slice, error);
-                let location = iter.input.current_source_location();
                 context.log_css_error(error_context, location, error);
             }
         }

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -1035,7 +1035,6 @@ pub fn parse_one_declaration_into<R>(declarations: &mut SourcePropertyDeclaratio
     let mut input = ParserInput::new(input);
     let mut parser = Parser::new(&mut input);
     let start_position = parser.position();
-    let start_location = parser.current_source_location();
     parser.parse_entirely(|parser| {
         let name = id.name().into();
         PropertyDeclaration::parse_into(declarations, id, name, &context, parser)
@@ -1044,7 +1043,7 @@ pub fn parse_one_declaration_into<R>(declarations: &mut SourcePropertyDeclaratio
         let error = ContextualParseError::UnsupportedPropertyDeclaration(
             parser.slice_from(start_position), err);
         let error_context = ParserErrorContext { error_reporter: error_reporter };
-        context.log_css_error(&error_context, start_location, error);
+        context.log_css_error(&error_context, parser.current_source_location(), error);
     })
 }
 
@@ -1133,7 +1132,8 @@ pub fn parse_property_declaration_list<R>(context: &ParserContext,
                 }
 
                 let error = ContextualParseError::UnsupportedPropertyDeclaration(err.slice, err.error);
-                context.log_css_error(error_context, err.location, error);
+                let location = iter.input.current_source_location();
+                context.log_css_error(error_context, location, error);
             }
         }
     }

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -93,9 +93,9 @@
             #[allow(unused_imports)]
             use properties::ShorthandId;
             #[allow(unused_imports)]
-            use selectors::parser::SelectorParseError;
+            use selectors::parser::SelectorParseErrorKind;
             #[allow(unused_imports)]
-            use style_traits::{ParseError, StyleParseError};
+            use style_traits::{ParseError, StyleParseErrorKind};
             #[allow(unused_imports)]
             use values::computed::{Context, ToComputedValue};
             #[allow(unused_imports)]
@@ -285,11 +285,11 @@
         #[allow(unused_imports)]
         use properties::style_structs;
         #[allow(unused_imports)]
-        use selectors::parser::SelectorParseError;
+        use selectors::parser::SelectorParseErrorKind;
         #[allow(unused_imports)]
         use servo_arc::Arc;
         #[allow(unused_imports)]
-        use style_traits::{ParseError, StyleParseError};
+        use style_traits::{ParseError, StyleParseErrorKind};
         #[allow(unused_imports)]
         use values::computed::{Context, ToComputedValue};
         #[allow(unused_imports)]
@@ -699,11 +699,11 @@
         use parser::ParserContext;
         use properties::{PropertyDeclaration, SourcePropertyDeclaration, MaybeBoxed, longhands};
         #[allow(unused_imports)]
-        use selectors::parser::SelectorParseError;
+        use selectors::parser::SelectorParseErrorKind;
         #[allow(unused_imports)]
         use std::fmt;
         #[allow(unused_imports)]
-        use style_traits::{ParseError, StyleParseError};
+        use style_traits::{ParseError, StyleParseErrorKind};
         #[allow(unused_imports)]
         use style_traits::ToCss;
 
@@ -992,7 +992,7 @@
             // Keyword values don't make sense in the block direction; don't parse them
             % if "block" in name:
                 if let Ok(${length_type}::ExtremumLength(..)) = ret {
-                    return Err(StyleParseError::UnspecifiedError.into())
+                    return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
                 }
             % endif
             ret.map(SpecifiedValue)

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -25,7 +25,7 @@ use properties::longhands::visibility::computed_value::T as Visibility;
 #[cfg(feature = "gecko")]
 use properties::PropertyId;
 use properties::{LonghandId, ShorthandId};
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 use servo_arc::Arc;
 use smallvec::SmallVec;
 use std::borrow::Cow;
@@ -134,6 +134,7 @@ impl TransitionProperty {
 
     /// Parse a transition-property value.
     pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
+        let location = input.current_source_location();
         let ident = input.expect_ident()?;
         match_ignore_ascii_case! { &ident,
             "all" => Ok(TransitionProperty::All),
@@ -143,8 +144,8 @@ impl TransitionProperty {
             % for prop in data.longhands:
                 "${prop.name}" => Ok(TransitionProperty::Longhand(LonghandId::${prop.camel_case})),
             % endfor
-            "none" => Err(SelectorParseError::UnexpectedIdent(ident.clone()).into()),
-            _ => CustomIdent::from_ident(ident, &[]).map(TransitionProperty::Unsupported),
+            "none" => Err(location.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(ident.clone()))),
+            _ => CustomIdent::from_ident(location, ident, &[]).map(TransitionProperty::Unsupported),
         }
     }
 

--- a/components/style/properties/longhand/background.mako.rs
+++ b/components/style/properties/longhand/background.mako.rs
@@ -132,7 +132,7 @@ ${helpers.predefined_type("background-image", "ImageLayer",
             _ => Err(()),
         }).or_else(|()| {
             let horizontal: Result<_, ParseError> = RepeatKeyword::from_ident(&ident)
-                .map_err(|()| SelectorParseError::UnexpectedIdent(ident.clone()).into());
+                .map_err(|()| input.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(ident.clone())));
             let horizontal = horizontal?;
             let vertical = input.try(RepeatKeyword::parse).ok();
             Ok(SpecifiedValue::Other(horizontal, vertical))

--- a/components/style/properties/longhand/border.mako.rs
+++ b/components/style/properties/longhand/border.mako.rs
@@ -187,7 +187,7 @@ ${helpers.gecko_keyword_conversion(Keyword('border-style',
             if !result.is_empty() {
                 Ok(SpecifiedValue::Colors(result))
             } else {
-                Err(StyleParseError::UnspecifiedError.into())
+                Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
             }
         }
     </%helpers:longhand>

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -165,7 +165,7 @@
     /// Parse a display value.
     pub fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
                          -> Result<SpecifiedValue, ParseError<'i>> {
-        try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+        try_match_ident_ignore_ascii_case! { input,
             % for value in values:
                 "${value}" => {
                     Ok(computed_value::T::${to_rust_ident(value)})
@@ -545,7 +545,7 @@ ${helpers.predefined_type("animation-timing-function",
 
             let number = input.expect_number()?;
             if number < 0.0 {
-                return Err(StyleParseError::UnspecifiedError.into());
+                return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
             }
 
             Ok(SpecifiedValue::Number(number))
@@ -1177,7 +1177,7 @@ ${helpers.predefined_type(
                     _ => Err(()),
                 };
                 result
-                    .map_err(|()| StyleParseError::UnexpectedFunction(function.clone()).into())
+                    .map_err(|()| input.new_custom_error(StyleParseErrorKind::UnexpectedFunction(function.clone())))
             })
         })?))
     }
@@ -1730,7 +1730,7 @@ ${helpers.predefined_type("transform-origin",
             };
             let flag = match flag {
                 Some(flag) if !result.contains(flag) => flag,
-                _ => return Err(SelectorParseError::UnexpectedIdent(name.clone()).into())
+                _ => return Err(input.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(name.clone())))
             };
             result.insert(flag);
         }
@@ -1738,7 +1738,7 @@ ${helpers.predefined_type("transform-origin",
         if !result.is_empty() {
             Ok(result)
         } else {
-            Err(StyleParseError::UnspecifiedError.into())
+            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
     }
 </%helpers:longhand>
@@ -1839,7 +1839,8 @@ ${helpers.single_keyword("-moz-orient",
             Ok(computed_value::T::Auto)
         } else {
             input.parse_comma_separated(|i| {
-                CustomIdent::from_ident(i.expect_ident()?, &[
+                let location = i.current_source_location();
+                CustomIdent::from_ident(location, i.expect_ident()?, &[
                     "will-change",
                     "none",
                     "all",
@@ -1914,7 +1915,7 @@ ${helpers.predefined_type(
     pub fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
                          -> Result<SpecifiedValue, ParseError<'i>> {
         // FIXME: remove clone() when lifetimes are non-lexical
-        try_match_ident_ignore_ascii_case! { input.expect_ident()?.clone(),
+        try_match_ident_ignore_ascii_case! { input,
             "auto" => Ok(TOUCH_ACTION_AUTO),
             "none" => Ok(TOUCH_ACTION_NONE),
             "manipulation" => Ok(TOUCH_ACTION_MANIPULATION),

--- a/components/style/properties/longhand/inherited_box.mako.rs
+++ b/components/style/properties/longhand/inherited_box.mako.rs
@@ -241,7 +241,7 @@ ${helpers.single_keyword("image-rendering",
             // Handle <angle> | <angle> flip
             let angle = input.try(|input| Angle::parse(context, input)).ok();
             if angle.is_none() {
-                return Err(StyleParseError::UnspecifiedError.into());
+                return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
             }
 
             let flipped = input.try(|input| input.expect_ident_matching("flip")).is_ok();

--- a/components/style/properties/longhand/inherited_svg.mako.rs
+++ b/components/style/properties/longhand/inherited_svg.mako.rs
@@ -207,8 +207,8 @@ ${helpers.predefined_type("marker-end", "UrlOrNone", "Either::Second(None_)",
         let mut pos = 0;
 
         loop {
-            let result: Result<_, ParseError> = input.try(|i| {
-                try_match_ident_ignore_ascii_case! { i.expect_ident()?,
+            let result: Result<_, ParseError> = input.try(|input| {
+                try_match_ident_ignore_ascii_case! { input,
                     "fill" => Ok(PaintOrder::Fill),
                     "stroke" => Ok(PaintOrder::Stroke),
                     "markers" => Ok(PaintOrder::Markers),
@@ -219,7 +219,7 @@ ${helpers.predefined_type("marker-end", "UrlOrNone", "Either::Second(None_)",
                 Ok(val) => {
                     if (seen & (1 << val as u8)) != 0 {
                         // don't parse the same ident twice
-                        return Err(StyleParseError::UnspecifiedError.into())
+                        return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
                     }
 
                     value |= (val as u8) << (pos * SHIFT);
@@ -232,7 +232,7 @@ ${helpers.predefined_type("marker-end", "UrlOrNone", "Either::Second(None_)",
 
         if value == 0 {
             // Couldn't find any keyword
-            return Err(StyleParseError::UnspecifiedError.into())
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
 
         // fill in rest
@@ -293,7 +293,8 @@ ${helpers.predefined_type("marker-end", "UrlOrNone", "Either::Second(None_)",
 
     pub fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
                          -> Result<SpecifiedValue, ParseError<'i>> {
+        let location = input.current_source_location();
         let i = input.expect_ident()?;
-        CustomIdent::from_ident(i, &["all", "none", "auto"])
+        CustomIdent::from_ident(location, i, &["all", "none", "auto"])
     }
 </%helpers:vector_longhand>

--- a/components/style/properties/longhand/inherited_text.mako.rs
+++ b/components/style/properties/longhand/inherited_text.mako.rs
@@ -585,7 +585,7 @@ ${helpers.predefined_type(
             (Some(fill), Ok(shape)) => KeywordValue::FillAndShape(fill,shape),
             (Some(fill), Err(_)) => KeywordValue::Fill(fill),
             (None, Ok(shape)) => KeywordValue::Shape(shape),
-            _ => return Err(StyleParseError::UnspecifiedError.into()),
+            _ => return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError)),
         };
         Ok(SpecifiedValue::Keyword(keyword_value))
     }

--- a/components/style/properties/longhand/list.mako.rs
+++ b/components/style/properties/longhand/list.mako.rs
@@ -188,14 +188,16 @@ ${helpers.single_keyword("list-style-position", "outside inside", animation_valu
 
         let mut quotes = Vec::new();
         loop {
+            let location = input.current_source_location();
             let first = match input.next() {
                 Ok(&Token::QuotedString(ref value)) => value.as_ref().to_owned(),
-                Ok(t) => return Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+                Ok(t) => return Err(location.new_unexpected_token_error(t.clone())),
                 Err(_) => break,
             };
+            let location = input.current_source_location();
             let second = match input.next() {
                 Ok(&Token::QuotedString(ref value)) => value.as_ref().to_owned(),
-                Ok(t) => return Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+                Ok(t) => return Err(location.new_unexpected_token_error(t.clone())),
                 Err(e) => return Err(e.into()),
             };
             quotes.push((first, second))
@@ -203,7 +205,7 @@ ${helpers.single_keyword("list-style-position", "outside inside", animation_valu
         if !quotes.is_empty() {
             Ok(SpecifiedValue(quotes))
         } else {
-            Err(StyleParseError::UnspecifiedError.into())
+            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
     }
 </%helpers:longhand>

--- a/components/style/properties/longhand/outline.mako.rs
+++ b/components/style/properties/longhand/outline.mako.rs
@@ -58,7 +58,7 @@ ${helpers.predefined_type(
                     // The outline-style property accepts the same values as
                     // border-style, except that 'hidden' is not a legal outline
                     // style.
-                    Err(SelectorParseError::UnexpectedIdent("hidden".into()).into())
+                    Err(input.new_custom_error(SelectorParseErrorKind::UnexpectedIdent("hidden".into())))
                 } else {
                     Ok(result)
                 }

--- a/components/style/properties/longhand/pointing.mako.rs
+++ b/components/style/properties/longhand/pointing.mako.rs
@@ -92,13 +92,14 @@
                          -> Result<computed_value::Keyword, ParseError<'i>> {
             use std::ascii::AsciiExt;
             use style_traits::cursor::Cursor;
+            let location = input.current_source_location();
             let ident = input.expect_ident()?;
             if ident.eq_ignore_ascii_case("auto") {
                 Ok(computed_value::Keyword::Auto)
             } else {
                 Cursor::from_css_keyword(&ident)
                     .map(computed_value::Keyword::Cursor)
-                    .map_err(|()| SelectorParseError::UnexpectedIdent(ident.clone()).into())
+                    .map_err(|()| location.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(ident.clone())))
             }
         }
     }

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -340,6 +340,7 @@ ${helpers.predefined_type("object-position",
         let mut dense = false;
 
         while !input.is_exhausted() {
+            let location = input.current_source_location();
             let ident = input.expect_ident()?;
             let success = match_ignore_ascii_case! { &ident,
                 "row" if value.is_none() => {
@@ -357,7 +358,7 @@ ${helpers.predefined_type("object-position",
                 _ => false
             };
             if !success {
-                return Err(SelectorParseError::UnexpectedIdent(ident.clone()).into());
+                return Err(location.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(ident.clone())));
             }
         }
 
@@ -367,7 +368,7 @@ ${helpers.predefined_type("object-position",
                 dense: dense,
             })
         } else {
-            Err(StyleParseError::UnspecifiedError.into())
+            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
     }
 
@@ -465,7 +466,7 @@ ${helpers.predefined_type("object-position",
             }
 
             TemplateAreas::from_vec(strings)
-                .map_err(|()| StyleParseError::UnspecifiedError.into())
+                .map_err(|()| input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
     }
 

--- a/components/style/properties/longhand/table.mako.rs
+++ b/components/style/properties/longhand/table.mako.rs
@@ -39,8 +39,8 @@ ${helpers.single_keyword("table-layout", "auto fixed",
     // never parse it, only set via presentation attribute
     fn parse<'i, 't>(
         _: &ParserContext,
-        _: &mut Parser<'i, 't>,
+        input: &mut Parser<'i, 't>,
     ) -> Result<SpecifiedValue, ParseError<'i>> {
-        Err(StyleParseError::UnspecifiedError.into())
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
     }
 </%helpers:longhand>

--- a/components/style/properties/longhand/text.mako.rs
+++ b/components/style/properties/longhand/text.mako.rs
@@ -119,17 +119,21 @@
     impl Parse for Side {
         fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
                          -> Result<Side, ParseError<'i>> {
+            let location = input.current_source_location();
             match *input.next()? {
                 Token::Ident(ref ident) => {
-                    try_match_ident_ignore_ascii_case! { ident,
+                    match_ignore_ascii_case! { ident,
                         "clip" => Ok(Side::Clip),
                         "ellipsis" => Ok(Side::Ellipsis),
+                        _ => Err(location.new_custom_error(
+                            SelectorParseErrorKind::UnexpectedIdent(ident.clone())
+                        ))
                     }
                 }
                 Token::QuotedString(ref v) => {
                     Ok(Side::String(v.as_ref().to_owned().into_boxed_str()))
                 }
-                ref t => Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+                ref t => Err(location.new_unexpected_token_error(t.clone())),
             }
         }
     }
@@ -222,6 +226,7 @@ ${helpers.single_keyword("unicode-bidi",
 
         loop {
             let result: Result<_, ParseError> = input.try(|input| {
+                let location = input.current_source_location();
                 match input.expect_ident() {
                     Ok(ident) => {
                         (match_ignore_ascii_case! { &ident,
@@ -234,7 +239,9 @@ ${helpers.single_keyword("unicode-bidi",
                             "blink" => if result.contains(BLINK) { Err(()) }
                                        else { empty = false; result.insert(BLINK); Ok(()) },
                             _ => Err(())
-                        }).map_err(|()| SelectorParseError::UnexpectedIdent(ident.clone()).into())
+                        }).map_err(|()| {
+                            location.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(ident.clone()))
+                        })
                     }
                     Err(e) => return Err(e.into())
                 }
@@ -244,7 +251,7 @@ ${helpers.single_keyword("unicode-bidi",
             }
         }
 
-        if !empty { Ok(result) } else { Err(StyleParseError::UnspecifiedError.into()) }
+        if !empty { Ok(result) } else { Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError)) }
     }
 
     % if product == "servo":

--- a/components/style/properties/longhand/ui.mako.rs
+++ b/components/style/properties/longhand/ui.mako.rs
@@ -77,7 +77,7 @@ ${helpers.single_keyword("-moz-window-shadow", "none default menu tooltip sheet"
         match input.expect_integer()? {
             0 => Ok(computed_value::T(false)),
             1 => Ok(computed_value::T(true)),
-            _ => Err(StyleParseError::UnspecifiedError.into()),
+            _ => Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError)),
         }
     }
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -38,8 +38,7 @@ use selector_parser::PseudoElement;
 use selectors::parser::SelectorParseErrorKind;
 #[cfg(feature = "servo")] use servo_config::prefs::PREFS;
 use shared_lock::StylesheetGuards;
-use style_traits::{PARSING_MODE_DEFAULT, ToCss, ParseError, PropertyDeclarationParseError};
-use style_traits::{PropertyDeclarationParseErrorKind, StyleParseErrorKind};
+use style_traits::{PARSING_MODE_DEFAULT, ToCss, ParseError, StyleParseErrorKind};
 use stylesheets::{CssRuleType, Origin, UrlExtraData};
 #[cfg(feature = "servo")] use values::Either;
 use values::generics::text::LineHeight;
@@ -554,7 +553,7 @@ impl LonghandId {
                         longhands::${property.ident}::parse_declared(context, input)
                     % else:
                         Err(input.new_custom_error(
-                            PropertyDeclarationParseErrorKind::UnknownProperty("${property.ident}".into())
+                            StyleParseErrorKind::UnknownProperty("${property.ident}".into())
                         ))
                     % endif
                 }
@@ -1632,7 +1631,7 @@ impl PropertyDeclaration {
     pub fn parse_into<'i, 't>(declarations: &mut SourcePropertyDeclaration,
                               id: PropertyId, name: CowRcStr<'i>,
                               context: &ParserContext, input: &mut Parser<'i, 't>)
-                              -> Result<(), PropertyDeclarationParseError<'i>> {
+                              -> Result<(), ParseError<'i>> {
         assert!(declarations.is_empty());
         let start = input.state();
         match id {
@@ -1644,7 +1643,7 @@ impl PropertyDeclaration {
                     Ok(keyword) => DeclaredValueOwned::CSSWideKeyword(keyword),
                     Err(()) => match ::custom_properties::SpecifiedValue::parse(input) {
                         Ok(value) => DeclaredValueOwned::Value(value),
-                        Err(e) => return Err(PropertyDeclarationParseErrorKind::new_invalid(name, e)),
+                        Err(e) => return Err(StyleParseErrorKind::new_invalid(name, e)),
                     }
                 };
                 declarations.push(PropertyDeclaration::Custom(property_name, value));
@@ -1663,7 +1662,7 @@ impl PropertyDeclaration {
                             input.reset(&start);
                             let (first_token_type, css) =
                                 ::custom_properties::parse_non_custom_with_var(input).map_err(|e| {
-                                    PropertyDeclarationParseErrorKind::new_invalid(name, e)
+                                    StyleParseErrorKind::new_invalid(name, e)
                                 })?;
                             Ok(PropertyDeclaration::WithVariables(id, Arc::new(UnparsedValue {
                                 css: css.into_owned(),
@@ -1672,7 +1671,7 @@ impl PropertyDeclaration {
                                 from_shorthand: None,
                             })))
                         } else {
-                            Err(PropertyDeclarationParseErrorKind::new_invalid(name, err))
+                            Err(StyleParseErrorKind::new_invalid(name, err))
                         }
                     })
                 }).map(|declaration| {
@@ -1700,7 +1699,7 @@ impl PropertyDeclaration {
                             input.reset(&start);
                             let (first_token_type, css) =
                                 ::custom_properties::parse_non_custom_with_var(input).map_err(|e| {
-                                    PropertyDeclarationParseErrorKind::new_invalid(name, e)
+                                    StyleParseErrorKind::new_invalid(name, e)
                                 })?;
                             let unparsed = Arc::new(UnparsedValue {
                                 css: css.into_owned(),
@@ -1719,7 +1718,7 @@ impl PropertyDeclaration {
                             }
                             Ok(())
                         } else {
-                            Err(PropertyDeclarationParseErrorKind::new_invalid(name, err))
+                            Err(StyleParseErrorKind::new_invalid(name, err))
                         }
                     })
                 }

--- a/components/style/properties/shorthand/background.mako.rs
+++ b/components/style/properties/shorthand/background.mako.rs
@@ -47,7 +47,7 @@
             // background-color can only be in the last element, so if it
             // is parsed anywhere before, the value is invalid.
             if background_color.is_some() {
-                return Err(StyleParseError::UnspecifiedError.into());
+                return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
             }
 
             % for name in "image position repeat size attachment origin clip".split():
@@ -112,7 +112,7 @@
                 % endfor
                 Ok(())
             } else {
-                Err(StyleParseError::UnspecifiedError.into())
+                Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
             }
         })?;
 
@@ -217,7 +217,7 @@
             Ok(())
         })?;
         if !any {
-            return Err(StyleParseError::UnspecifiedError.into());
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }
 
         Ok(expanded! {

--- a/components/style/properties/shorthand/border.mako.rs
+++ b/components/style/properties/shorthand/border.mako.rs
@@ -83,7 +83,7 @@ pub fn parse_border<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
             style.unwrap_or(BorderStyle::none),
             width.unwrap_or(BorderSideWidth::Medium)))
     } else {
-        Err(StyleParseError::UnspecifiedError.into())
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
     }
 }
 
@@ -276,7 +276,7 @@ pub fn parse_border<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                                 border_image_outset::parse(context, input)
                             }).ok();
                             if w.is_none() && o.is_none() {
-                               Err(StyleParseError::UnspecifiedError.into())
+                               Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
                             }
                             else {
                                Ok((w, o))
@@ -312,7 +312,7 @@ pub fn parse_border<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                 % endfor
                 Ok(())
             } else {
-                Err(StyleParseError::UnspecifiedError.into())
+                Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
             }
         });
         result?;

--- a/components/style/properties/shorthand/box.mako.rs
+++ b/components/style/properties/shorthand/box.mako.rs
@@ -14,8 +14,8 @@
     pub fn parse_value<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                                -> Result<Longhands, ParseError<'i>> {
         % if product == "gecko":
-            let moz_kw_found = input.try(|i| {
-                try_match_ident_ignore_ascii_case! { i.expect_ident()?,
+            let moz_kw_found = input.try(|input| {
+                try_match_ident_ignore_ascii_case! { input,
                     "-moz-scrollbars-horizontal" => {
                         Ok(expanded! {
                             overflow_x: SpecifiedValue::scroll,
@@ -141,7 +141,7 @@ macro_rules! try_parse_one {
                         Some(transition_property::single_value::get_initial_specified_value())),
                 })
             } else {
-                Err(StyleParseError::UnspecifiedError.into())
+                Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
             }
         }
 
@@ -158,7 +158,7 @@ macro_rules! try_parse_one {
                 // If there is more than one item, and any of transitions has 'none',
                 // then it's invalid. Othersize, leave propertys to be empty (which
                 // means "transition-property: none");
-                return Err(StyleParseError::UnspecifiedError.into());
+                return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
             }
 
             % for prop in "duration timing_function delay".split():
@@ -269,7 +269,7 @@ macro_rules! try_parse_one {
 
             // If nothing is parsed, this is an invalid entry.
             if parsed == 0 {
-                Err(StyleParseError::UnspecifiedError.into())
+                Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
             } else {
                 Ok(SingleAnimation {
                     % for prop in props:

--- a/components/style/properties/shorthand/column.mako.rs
+++ b/components/style/properties/shorthand/column.mako.rs
@@ -44,7 +44,7 @@
 
         let values = autos + column_count.iter().len() + column_width.iter().len();
         if values == 0 || values > 2 {
-            Err(StyleParseError::UnspecifiedError.into())
+            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         } else {
             Ok(expanded! {
                 column_count: unwrap_or_initial!(column_count),
@@ -89,7 +89,7 @@
                 column_rule_color: unwrap_or_initial!(column_rule_color),
             })
         } else {
-            Err(StyleParseError::UnspecifiedError.into())
+            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
     }
 </%helpers:shorthand>

--- a/components/style/properties/shorthand/font.mako.rs
+++ b/components/style/properties/shorthand/font.mako.rs
@@ -98,7 +98,7 @@
         }
         if size.is_none() ||
            (count(&style) + count(&weight) + count(&variant_caps) + count(&stretch) + nb_normals) > 4 {
-            return Err(StyleParseError::UnspecifiedError.into())
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
         let line_height = if input.try(|input| input.expect_delim('/')).is_ok() {
             Some(LineHeight::parse(context, input)?)
@@ -262,7 +262,7 @@
             loop {
                 if input.try(|input| input.expect_ident_matching("normal")).is_ok() ||
                    input.try(|input| input.expect_ident_matching("none")).is_ok() {
-                    return Err(StyleParseError::UnspecifiedError.into())
+                    return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
                 }
             % for prop in sub_properties:
                 if ${prop}.is_none() {
@@ -278,7 +278,7 @@
             }
 
             if !has_custom_value {
-                return Err(StyleParseError::UnspecifiedError.into())
+                return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
             }
         }
 

--- a/components/style/properties/shorthand/inherited_text.mako.rs
+++ b/components/style/properties/shorthand/inherited_text.mako.rs
@@ -36,7 +36,7 @@
                 text_emphasis_style: unwrap_or_initial!(text_emphasis_style, style),
             })
         } else {
-            Err(StyleParseError::UnspecifiedError.into())
+            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
     }
 </%helpers:shorthand>
@@ -78,7 +78,7 @@
                 _webkit_text_stroke_width: unwrap_or_initial!(_webkit_text_stroke_width, width),
             })
         } else {
-            Err(StyleParseError::UnspecifiedError.into())
+            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
     }
 </%helpers:shorthand>

--- a/components/style/properties/shorthand/list.mako.rs
+++ b/components/style/properties/shorthand/list.mako.rs
@@ -21,7 +21,7 @@
             if input.try(|input| input.expect_ident_matching("none")).is_ok() {
                 nones = nones + 1;
                 if nones > 2 {
-                    return Err(SelectorParseError::UnexpectedIdent("none".into()).into())
+                    return Err(input.new_custom_error(SelectorParseErrorKind::UnexpectedIdent("none".into())))
                 }
                 any = true;
                 continue
@@ -106,7 +106,7 @@
                     list_style_type: unwrap_or_initial!(list_style_type),
                 })
             }
-            _ => Err(StyleParseError::UnspecifiedError.into()),
+            _ => Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError)),
         }
     }
 </%helpers:shorthand>

--- a/components/style/properties/shorthand/mask.mako.rs
+++ b/components/style/properties/shorthand/mask.mako.rs
@@ -108,7 +108,7 @@
                 % endfor
                 Ok(())
             } else {
-                Err(StyleParseError::UnspecifiedError.into())
+                Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
             }
         })?;
 
@@ -203,7 +203,7 @@
             Ok(())
         })?;
         if any == false {
-            return Err(StyleParseError::UnspecifiedError.into());
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }
 
         Ok(expanded! {

--- a/components/style/properties/shorthand/outline.mako.rs
+++ b/components/style/properties/shorthand/outline.mako.rs
@@ -50,7 +50,7 @@
                 outline_width: unwrap_or_initial!(outline_width, width),
             })
         } else {
-            Err(StyleParseError::UnspecifiedError.into())
+            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
     }
 </%helpers:shorthand>

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -32,7 +32,7 @@
         }
 
         if direction.is_none() && wrap.is_none() {
-            return Err(StyleParseError::UnspecifiedError.into())
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
         Ok(expanded! {
             flex_direction: unwrap_or_initial!(flex_direction, direction),
@@ -87,7 +87,7 @@
         }
 
         if grow.is_none() && basis.is_none() {
-            return Err(StyleParseError::UnspecifiedError.into())
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
         Ok(expanded! {
             flex_grow: grow.unwrap_or(NonNegativeNumber::new(1.0)),
@@ -309,7 +309,7 @@
             }
 
             let template_areas = TemplateAreas::from_vec(strings)
-                .map_err(|()| StyleParseError::UnspecifiedError)?;
+                .map_err(|()| input.new_custom_error(StyleParseErrorKind::UnspecifiedError))?;
             let template_rows = TrackList {
                 list_type: TrackListType::Normal,
                 values: values,
@@ -321,7 +321,7 @@
                 let value = GridTemplateComponent::parse_without_none(context, input)?;
                 if let GenericGridTemplateComponent::TrackList(ref list) = value {
                     if list.list_type != TrackListType::Explicit {
-                        return Err(StyleParseError::UnspecifiedError.into())
+                        return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
                     }
                 }
 
@@ -340,7 +340,7 @@
                 if list.line_names[0].is_empty() {
                     list.line_names[0] = first_line_names;      // won't panic
                 } else {
-                    return Err(StyleParseError::UnspecifiedError.into());
+                    return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
                 }
             }
 
@@ -501,7 +501,7 @@
                     autoflow: flow,
                     dense: dense,
                 }
-            }).ok_or(StyleParseError::UnspecifiedError.into())
+            }).ok_or(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
 
         if let Ok((rows, cols, areas)) = input.try(|i| super::grid_template::parse_grid_template(context, i)) {
@@ -617,12 +617,12 @@
                                -> Result<Longhands, ParseError<'i>> {
         let align = align_content::parse(context, input)?;
         if align.has_extra_flags() {
-            return Err(StyleParseError::UnspecifiedError.into());
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }
         let justify = input.try(|input| justify_content::parse(context, input))
                            .unwrap_or(justify_content::SpecifiedValue::from(align));
         if justify.has_extra_flags() {
-            return Err(StyleParseError::UnspecifiedError.into());
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }
 
         Ok(expanded! {
@@ -653,11 +653,11 @@
                                -> Result<Longhands, ParseError<'i>> {
         let align = AlignJustifySelf::parse(context, input)?;
         if align.has_extra_flags() {
-            return Err(StyleParseError::UnspecifiedError.into());
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }
         let justify = input.try(|input| AlignJustifySelf::parse(context, input)).unwrap_or(align.clone());
         if justify.has_extra_flags() {
-            return Err(StyleParseError::UnspecifiedError.into());
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }
 
         Ok(expanded! {
@@ -695,12 +695,12 @@
                                -> Result<Longhands, ParseError<'i>> {
         let align = AlignItems::parse(context, input)?;
         if align.has_extra_flags() {
-            return Err(StyleParseError::UnspecifiedError.into());
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }
         let justify = input.try(|input| JustifyItems::parse(context, input))
                            .unwrap_or(JustifyItems::from(align));
         if justify.has_extra_flags() {
-            return Err(StyleParseError::UnspecifiedError.into());
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }
 
         Ok(expanded! {

--- a/components/style/properties/shorthand/text.mako.rs
+++ b/components/style/properties/shorthand/text.mako.rs
@@ -48,7 +48,7 @@
         }
 
         if !any {
-            return Err(StyleParseError::UnspecifiedError.into());
+            return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }
 
         Ok(expanded! {

--- a/components/style/servo/media_queries.rs
+++ b/components/style/servo/media_queries.rs
@@ -14,7 +14,7 @@ use parser::ParserContext;
 use properties::{ComputedValues, StyleBuilder};
 use properties::longhands::font_size;
 use rule_cache::RuleCacheConditions;
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 use std::cell::RefCell;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
@@ -198,7 +198,7 @@ impl Expression {
                 "width" => {
                     ExpressionKind::Width(Range::Eq(specified::Length::parse_non_negative(context, input)?))
                 },
-                _ => return Err(SelectorParseError::UnexpectedIdent(name.clone()).into())
+                _ => return Err(input.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(name.clone())))
             }))
         })
     }

--- a/components/style/stylesheets/font_feature_values_rule.rs
+++ b/components/style/stylesheets/font_feature_values_rule.rs
@@ -273,7 +273,8 @@ macro_rules! font_feature_values_blocks {
                     while let Some(result) = iter.next() {
                         if let Err(err) = result {
                             let error = ContextualParseError::UnsupportedRule(err.slice, err.error);
-                            context.log_css_error(error_context, err.location, error);
+                            let location = iter.input.current_source_location();
+                            context.log_css_error(error_context, location, error);
                         }
                     }
                 }
@@ -427,7 +428,8 @@ macro_rules! font_feature_values_blocks {
                                 if let Err(err) = declaration {
                                     let error = ContextualParseError::UnsupportedKeyframePropertyDeclaration(
                                         err.slice, err.error);
-                                    self.context.log_css_error(self.error_context, err.location, error);
+                                    let location = iter.input.current_source_location();
+                                    self.context.log_css_error(self.error_context, location, error);
                                 }
                             }
                         },

--- a/components/style/stylesheets/font_feature_values_rule.rs
+++ b/components/style/stylesheets/font_feature_values_rule.rs
@@ -276,8 +276,8 @@ macro_rules! font_feature_values_blocks {
                     });
                     while let Some(result) = iter.next() {
                         if let Err((error, slice)) = result {
+                            let location = error.location;
                             let error = ContextualParseError::UnsupportedRule(slice, error);
-                            let location = iter.input.current_source_location();
                             context.log_css_error(error_context, location, error);
                         }
                     }
@@ -430,10 +430,10 @@ macro_rules! font_feature_values_blocks {
                             let mut iter = DeclarationListParser::new(input, parser);
                             while let Some(declaration) = iter.next() {
                                 if let Err((error, slice)) = declaration {
+                                    let location = error.location;
                                     let error = ContextualParseError::UnsupportedKeyframePropertyDeclaration(
                                         slice, error
                                     );
-                                    let location = iter.input.current_source_location();
                                     self.context.log_css_error(self.error_context, location, error);
                                 }
                             }

--- a/components/style/stylesheets/font_feature_values_rule.rs
+++ b/components/style/stylesheets/font_feature_values_rule.rs
@@ -8,7 +8,7 @@
 
 use Atom;
 use computed_values::font_family::FamilyName;
-use cssparser::{AtRuleParser, AtRuleType, BasicParseError, DeclarationListParser, DeclarationParser, Parser};
+use cssparser::{AtRuleParser, AtRuleType, BasicParseErrorKind, DeclarationListParser, DeclarationParser, Parser};
 use cssparser::{CowRcStr, RuleListParser, SourceLocation, QualifiedRuleParser, Token, serialize_identifier};
 use error_reporting::{ContextualParseError, ParseErrorReporter};
 #[cfg(feature = "gecko")]
@@ -16,10 +16,10 @@ use gecko_bindings::bindings::Gecko_AppendFeatureValueHashEntry;
 #[cfg(feature = "gecko")]
 use gecko_bindings::structs::{self, gfxFontFeatureValueSet, nsTArray};
 use parser::{ParserContext, ParserErrorContext, Parse};
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt;
-use style_traits::{ParseError, StyleParseError, ToCss};
+use style_traits::{ParseError, StyleParseErrorKind, ToCss};
 use stylesheets::CssRuleType;
 
 /// A @font-feature-values block declaration.
@@ -59,9 +59,10 @@ pub struct SingleValue(pub u32);
 impl Parse for SingleValue {
     fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
                      -> Result<SingleValue, ParseError<'i>> {
+        let location = input.current_source_location();
         match *input.next()? {
             Token::Number { int_value: Some(v), .. } if v >= 0 => Ok(SingleValue(v as u32)),
-            ref t => Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+            ref t => Err(location.new_unexpected_token_error(t.clone())),
         }
     }
 }
@@ -87,16 +88,18 @@ pub struct PairValues(pub u32, pub Option<u32>);
 impl Parse for PairValues {
     fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
                      -> Result<PairValues, ParseError<'i>> {
+        let location = input.current_source_location();
         let first = match *input.next()? {
             Token::Number { int_value: Some(a), .. } if a >= 0 => a as u32,
-            ref t => return Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+            ref t => return Err(location.new_unexpected_token_error(t.clone())),
         };
+        let location = input.current_source_location();
         match input.next() {
             Ok(&Token::Number { int_value: Some(b), .. }) if b >= 0 => {
                 Ok(PairValues(first, Some(b as u32)))
             }
             // It can't be anything other than number.
-            Ok(t) => Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+            Ok(t) => Err(location.new_unexpected_token_error(t.clone())),
             // It can be just one value.
             Err(_) => Ok(PairValues(first, None))
         }
@@ -136,18 +139,19 @@ impl Parse for VectorValues {
                      -> Result<VectorValues, ParseError<'i>> {
         let mut vec = vec![];
         loop {
+            let location = input.current_source_location();
             match input.next() {
                 Ok(&Token::Number { int_value: Some(a), .. }) if a >= 0 => {
                     vec.push(a as u32);
                 },
                 // It can't be anything other than number.
-                Ok(t) => return Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+                Ok(t) => return Err(location.new_unexpected_token_error(t.clone())),
                 Err(_) => break,
             }
         }
 
         if vec.len() == 0 {
-            return Err(BasicParseError::EndOfInput.into());
+            return Err(input.new_error(BasicParseErrorKind::EndOfInput));
         }
 
         Ok(VectorValues(vec))
@@ -197,14 +201,14 @@ impl<'a, 'b, 'i, T> AtRuleParser<'i> for FFVDeclarationsParser<'a, 'b, T> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = ();
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 }
 
 impl<'a, 'b, 'i, T> DeclarationParser<'i> for FFVDeclarationsParser<'a, 'b, T>
     where T: Parse
 {
     type Declaration = ();
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 
     fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                        -> Result<(), ParseError<'i>> {
@@ -271,8 +275,8 @@ macro_rules! font_feature_values_blocks {
                         rule: &mut rule,
                     });
                     while let Some(result) = iter.next() {
-                        if let Err(err) = result {
-                            let error = ContextualParseError::UnsupportedRule(err.slice, err.error);
+                        if let Err((error, slice)) = result {
+                            let error = ContextualParseError::UnsupportedRule(slice, error);
                             let location = iter.input.current_source_location();
                             context.log_css_error(error_context, location, error);
                         }
@@ -388,24 +392,24 @@ macro_rules! font_feature_values_blocks {
         impl<'a, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for FontFeatureValuesRuleParser<'a, R> {
             type Prelude = ();
             type QualifiedRule = ();
-            type Error = SelectorParseError<'i, StyleParseError<'i>>;
+            type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
         }
 
         impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for FontFeatureValuesRuleParser<'a, R> {
             type PreludeNoBlock = ();
             type PreludeBlock = BlockType;
             type AtRule = ();
-            type Error = SelectorParseError<'i, StyleParseError<'i>>;
+            type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 
             fn parse_prelude<'t>(&mut self,
                                  name: CowRcStr<'i>,
-                                 _input: &mut Parser<'i, 't>)
+                                 input: &mut Parser<'i, 't>)
                                  -> Result<AtRuleType<(), BlockType>, ParseError<'i>> {
                 match_ignore_ascii_case! { &*name,
                     $(
                         $name => Ok(AtRuleType::WithBlock(BlockType::$ident_camel)),
                     )*
-                    _ => Err(BasicParseError::AtRuleBodyInvalid.into()),
+                    _ => Err(input.new_error(BasicParseErrorKind::AtRuleBodyInvalid)),
                 }
             }
 
@@ -425,9 +429,10 @@ macro_rules! font_feature_values_blocks {
 
                             let mut iter = DeclarationListParser::new(input, parser);
                             while let Some(declaration) = iter.next() {
-                                if let Err(err) = declaration {
+                                if let Err((error, slice)) = declaration {
                                     let error = ContextualParseError::UnsupportedKeyframePropertyDeclaration(
-                                        err.slice, err.error);
+                                        slice, error
+                                    );
                                     let location = iter.input.current_source_location();
                                     self.context.log_css_error(self.error_context, location, error);
                                 }

--- a/components/style/stylesheets/font_feature_values_rule.rs
+++ b/components/style/stylesheets/font_feature_values_rule.rs
@@ -16,7 +16,6 @@ use gecko_bindings::bindings::Gecko_AppendFeatureValueHashEntry;
 #[cfg(feature = "gecko")]
 use gecko_bindings::structs::{self, gfxFontFeatureValueSet, nsTArray};
 use parser::{ParserContext, ParserErrorContext, Parse};
-use selectors::parser::SelectorParseErrorKind;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt;
 use style_traits::{ParseError, StyleParseErrorKind, ToCss};
@@ -201,14 +200,14 @@ impl<'a, 'b, 'i, T> AtRuleParser<'i> for FFVDeclarationsParser<'a, 'b, T> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = ();
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 }
 
 impl<'a, 'b, 'i, T> DeclarationParser<'i> for FFVDeclarationsParser<'a, 'b, T>
     where T: Parse
 {
     type Declaration = ();
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 
     fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                        -> Result<(), ParseError<'i>> {
@@ -392,14 +391,14 @@ macro_rules! font_feature_values_blocks {
         impl<'a, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for FontFeatureValuesRuleParser<'a, R> {
             type Prelude = ();
             type QualifiedRule = ();
-            type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+            type Error = StyleParseErrorKind<'i>;
         }
 
         impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for FontFeatureValuesRuleParser<'a, R> {
             type PreludeNoBlock = ();
             type PreludeBlock = BlockType;
             type AtRule = ();
-            type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+            type Error = StyleParseErrorKind<'i>;
 
             fn parse_prelude<'t>(&mut self,
                                  name: CowRcStr<'i>,

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -16,7 +16,6 @@ use servo_arc::Arc;
 use shared_lock::{DeepCloneParams, DeepCloneWithLock, SharedRwLock, SharedRwLockReadGuard, Locked, ToCssWithGuard};
 use std::fmt;
 use style_traits::{PARSING_MODE_DEFAULT, ToCss, ParseError, StyleParseErrorKind};
-use style_traits::PropertyDeclarationParseErrorKind;
 use stylesheets::{CssRuleType, StylesheetContents};
 use stylesheets::rule_parser::VendorPrefix;
 use values::{KeyframesName, serialize_percentage};
@@ -591,7 +590,7 @@ impl<'a, 'b, 'i> DeclarationParser<'i> for KeyframeDeclarationParser<'a, 'b> {
         let property_context = PropertyParserContext::new(self.context);
 
         let id = PropertyId::parse(&name, Some(&property_context)).map_err(|()| {
-            input.new_custom_error(PropertyDeclarationParseErrorKind::UnknownProperty(name.clone()))
+            input.new_custom_error(StyleParseErrorKind::UnknownProperty(name.clone()))
         })?;
         match PropertyDeclaration::parse_into(self.declarations, id, name, self.context, input) {
             Ok(()) => {

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -12,12 +12,12 @@ use properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, Prop
 use properties::{PropertyDeclarationId, LonghandId, SourcePropertyDeclaration};
 use properties::LonghandIdSet;
 use properties::longhands::transition_timing_function::single_value::SpecifiedValue as SpecifiedTimingFunction;
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 use servo_arc::Arc;
 use shared_lock::{DeepCloneParams, DeepCloneWithLock, SharedRwLock, SharedRwLockReadGuard, Locked, ToCssWithGuard};
 use std::fmt;
-use style_traits::{PARSING_MODE_DEFAULT, ToCss, ParseError, StyleParseError};
-use style_traits::PropertyDeclarationParseError;
+use style_traits::{PARSING_MODE_DEFAULT, ToCss, ParseError, StyleParseErrorKind};
+use style_traits::PropertyDeclarationParseErrorKind;
 use stylesheets::{CssRuleType, StylesheetContents};
 use stylesheets::rule_parser::VendorPrefix;
 use values::{KeyframesName, serialize_percentage};
@@ -137,7 +137,7 @@ impl KeyframePercentage {
             if percentage >= 0. && percentage <= 1. {
                 KeyframePercentage::new(percentage)
             } else {
-                return Err(StyleParseError::UnspecifiedError.into());
+                return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
             }
         };
 
@@ -500,7 +500,7 @@ impl<'a, 'i, R> AtRuleParser<'i> for KeyframeListParser<'a, R> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = Arc<Locked<Keyframe>>;
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 }
 
 /// A wrapper to wraps the KeyframeSelector with its source location
@@ -512,7 +512,7 @@ struct KeyframeSelectorParserPrelude {
 impl<'a, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for KeyframeListParser<'a, R> {
     type Prelude = KeyframeSelectorParserPrelude;
     type QualifiedRule = Arc<Locked<Keyframe>>;
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 
     fn parse_prelude<'t>(&mut self, input: &mut Parser<'i, 't>) -> Result<Self::Prelude, ParseError<'i>> {
         let start_position = input.position();
@@ -552,9 +552,9 @@ impl<'a, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for KeyframeListPars
                 Ok(()) => {
                     block.extend(iter.parser.declarations.drain(), Importance::Normal);
                 }
-                Err(err) => {
+                Err((error, slice)) => {
                     iter.parser.declarations.clear();
-                    let error = ContextualParseError::UnsupportedKeyframePropertyDeclaration(err.slice, err.error);
+                    let error = ContextualParseError::UnsupportedKeyframePropertyDeclaration(slice, error);
                     context.log_css_error(self.error_context, iter.input.current_source_location(), error);
                 }
             }
@@ -578,25 +578,26 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for KeyframeDeclarationParser<'a, 'b> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = ();
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 }
 
 impl<'a, 'b, 'i> DeclarationParser<'i> for KeyframeDeclarationParser<'a, 'b> {
     type Declaration = ();
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 
     fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                        -> Result<(), ParseError<'i>> {
         let property_context = PropertyParserContext::new(self.context);
 
-        let id = PropertyId::parse(&name, Some(&property_context))
-            .map_err(|()| PropertyDeclarationParseError::UnknownProperty(name.clone()))?;
+        let id = PropertyId::parse(&name, Some(&property_context)).map_err(|()| {
+            input.new_custom_error(PropertyDeclarationParseErrorKind::UnknownProperty(name.clone()))
+        })?;
         match PropertyDeclaration::parse_into(self.declarations, id, name, self.context, input) {
             Ok(()) => {
                 // In case there is still unparsed text in the declaration, we should roll back.
                 input.expect_exhausted().map_err(|e| e.into())
             }
-            Err(_e) => Err(StyleParseError::UnspecifiedError.into())
+            Err(e) => Err(e.into())
         }
     }
 }

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -525,8 +525,9 @@ impl<'a, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for KeyframeListPars
                 })
             },
             Err(e) => {
+                let location = e.location;
                 let error = ContextualParseError::InvalidKeyframeRule(input.slice_from(start_position), e.clone());
-                self.context.log_css_error(self.error_context, input.current_source_location(), error);
+                self.context.log_css_error(self.error_context, location, error);
                 Err(e)
             }
         }
@@ -554,8 +555,9 @@ impl<'a, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for KeyframeListPars
                 }
                 Err((error, slice)) => {
                     iter.parser.declarations.clear();
+                    let location = error.location;
                     let error = ContextualParseError::UnsupportedKeyframePropertyDeclaration(slice, error);
-                    context.log_css_error(self.error_context, iter.input.current_source_location(), error);
+                    context.log_css_error(self.error_context, location, error);
                 }
             }
             // `parse_important` is not called here, `!important` is not allowed in keyframe blocks.

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -526,7 +526,7 @@ impl<'a, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for KeyframeListPars
             },
             Err(e) => {
                 let error = ContextualParseError::InvalidKeyframeRule(input.slice_from(start_position), e.clone());
-                self.context.log_css_error(self.error_context, start_location, error);
+                self.context.log_css_error(self.error_context, input.current_source_location(), error);
                 Err(e)
             }
         }
@@ -555,7 +555,7 @@ impl<'a, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for KeyframeListPars
                 Err(err) => {
                     iter.parser.declarations.clear();
                     let error = ContextualParseError::UnsupportedKeyframePropertyDeclaration(err.slice, err.error);
-                    context.log_css_error(self.error_context, err.location, error);
+                    context.log_css_error(self.error_context, iter.input.current_source_location(), error);
                 }
             }
             // `parse_important` is not called here, `!important` is not allowed in keyframe blocks.

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -12,7 +12,6 @@ use properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, Prop
 use properties::{PropertyDeclarationId, LonghandId, SourcePropertyDeclaration};
 use properties::LonghandIdSet;
 use properties::longhands::transition_timing_function::single_value::SpecifiedValue as SpecifiedTimingFunction;
-use selectors::parser::SelectorParseErrorKind;
 use servo_arc::Arc;
 use shared_lock::{DeepCloneParams, DeepCloneWithLock, SharedRwLock, SharedRwLockReadGuard, Locked, ToCssWithGuard};
 use std::fmt;
@@ -500,7 +499,7 @@ impl<'a, 'i, R> AtRuleParser<'i> for KeyframeListParser<'a, R> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = Arc<Locked<Keyframe>>;
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 }
 
 /// A wrapper to wraps the KeyframeSelector with its source location
@@ -512,7 +511,7 @@ struct KeyframeSelectorParserPrelude {
 impl<'a, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for KeyframeListParser<'a, R> {
     type Prelude = KeyframeSelectorParserPrelude;
     type QualifiedRule = Arc<Locked<Keyframe>>;
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 
     fn parse_prelude<'t>(&mut self, input: &mut Parser<'i, 't>) -> Result<Self::Prelude, ParseError<'i>> {
         let start_position = input.position();
@@ -580,12 +579,12 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for KeyframeDeclarationParser<'a, 'b> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = ();
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 }
 
 impl<'a, 'b, 'i> DeclarationParser<'i> for KeyframeDeclarationParser<'a, 'b> {
     type Declaration = ();
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 
     fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                        -> Result<(), ParseError<'i>> {

--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -333,7 +333,8 @@ impl<'a, 'b, R: ParseErrorReporter> NestedRuleParser<'a, 'b, R> {
                 Ok(rule) => rules.push(rule),
                 Err(err) => {
                     let error = ContextualParseError::UnsupportedRule(err.slice, err.error);
-                    self.context.log_css_error(self.error_context, err.location, error);
+                    let location = iter.input.current_source_location();
+                    self.context.log_css_error(self.error_context, location, error);
                 }
             }
         }

--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -8,7 +8,7 @@ use {Namespace, Prefix};
 use computed_values::font_family::FamilyName;
 use counter_style::{parse_counter_style_body, parse_counter_style_name};
 use cssparser::{AtRuleParser, AtRuleType, Parser, QualifiedRuleParser, RuleListParser};
-use cssparser::{CowRcStr, SourceLocation, BasicParseError};
+use cssparser::{CowRcStr, SourceLocation, BasicParseError, BasicParseErrorKind};
 use error_reporting::{ContextualParseError, ParseErrorReporter};
 use font_face::parse_font_face_block;
 use media_queries::{parse_media_query_list, MediaList};
@@ -16,11 +16,11 @@ use parser::{Parse, ParserContext, ParserErrorContext};
 use properties::parse_property_declaration_list;
 use selector_parser::{SelectorImpl, SelectorParser};
 use selectors::SelectorList;
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 use servo_arc::Arc;
 use shared_lock::{Locked, SharedRwLock};
 use str::starts_with_ignore_ascii_case;
-use style_traits::{StyleParseError, ParseError};
+use style_traits::{StyleParseErrorKind, ParseError};
 use stylesheets::{CssRule, CssRules, CssRuleType, Origin, StylesheetLoader};
 use stylesheets::{DocumentRule, FontFeatureValuesRule, KeyframesRule, MediaRule};
 use stylesheets::{NamespaceRule, PageRule, StyleRule, SupportsRule, ViewportRule};
@@ -160,7 +160,7 @@ impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, 
     type PreludeNoBlock = AtRuleNonBlockPrelude;
     type PreludeBlock = AtRuleBlockPrelude;
     type AtRule = CssRule;
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 
     fn parse_prelude<'t>(
         &mut self,
@@ -173,7 +173,7 @@ impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, 
                 if self.state > State::Imports {
                     // "@import must be before any rule but @charset"
                     self.had_hierarchy_error = true;
-                    return Err(StyleParseError::UnexpectedImportRule.into())
+                    return Err(input.new_custom_error(StyleParseErrorKind::UnexpectedImportRule))
                 }
 
                 let url_string = input.expect_url_or_string()?.as_ref().to_owned();
@@ -190,15 +190,16 @@ impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, 
                 if self.state > State::Namespaces {
                     // "@namespace must be before any rule but @charset and @import"
                     self.had_hierarchy_error = true;
-                    return Err(StyleParseError::UnexpectedNamespaceRule.into())
+                    return Err(input.new_custom_error(StyleParseErrorKind::UnexpectedNamespaceRule))
                 }
 
                 let prefix = input.try(|i| i.expect_ident_cloned())
                                   .map(|s| Prefix::from(s.as_ref())).ok();
                 let maybe_namespace = match input.expect_url_or_string() {
                     Ok(url_or_string) => url_or_string,
-                    Err(BasicParseError::UnexpectedToken(t)) =>
-                        return Err(StyleParseError::UnexpectedTokenWithinNamespace(t).into()),
+                    Err(BasicParseError { kind: BasicParseErrorKind::UnexpectedToken(t), location }) => {
+                        return Err(location.new_custom_error(StyleParseErrorKind::UnexpectedTokenWithinNamespace(t)))
+                    }
                     Err(e) => return Err(e.into()),
                 };
                 let url = Namespace::from(maybe_namespace.as_ref());
@@ -209,7 +210,7 @@ impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, 
             // anything left is invalid.
             "charset" => {
                 self.had_hierarchy_error = true;
-                return Err(StyleParseError::UnexpectedCharsetRule.into())
+                return Err(input.new_custom_error(StyleParseErrorKind::UnexpectedCharsetRule))
             }
             _ => {}
         }
@@ -279,7 +280,7 @@ pub struct QualifiedRuleParserPrelude {
 impl<'a, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for TopLevelRuleParser<'a, R> {
     type Prelude = QualifiedRuleParserPrelude;
     type QualifiedRule = CssRule;
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 
     #[inline]
     fn parse_prelude<'t>(
@@ -331,8 +332,8 @@ impl<'a, 'b, R: ParseErrorReporter> NestedRuleParser<'a, 'b, R> {
         while let Some(result) = iter.next() {
             match result {
                 Ok(rule) => rules.push(rule),
-                Err(err) => {
-                    let error = ContextualParseError::UnsupportedRule(err.slice, err.error);
+                Err((error, slice)) => {
+                    let error = ContextualParseError::UnsupportedRule(slice, error);
                     let location = iter.input.current_source_location();
                     self.context.log_css_error(self.error_context, location, error);
                 }
@@ -346,7 +347,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
     type PreludeNoBlock = AtRuleNonBlockPrelude;
     type PreludeBlock = AtRuleBlockPrelude;
     type AtRule = CssRule;
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 
     fn parse_prelude<'t>(
         &mut self,
@@ -372,7 +373,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
             "font-feature-values" => {
                 if !cfg!(feature = "gecko") {
                     // Support for this rule is not fully implemented in Servo yet.
-                    return Err(StyleParseError::UnsupportedAtRule(name.clone()).into())
+                    return Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
                 }
                 let family_names = parse_family_name_list(self.context, input)?;
                 Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::FontFeatureValues(family_names, location)))
@@ -380,14 +381,14 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
             "counter-style" => {
                 if !cfg!(feature = "gecko") {
                     // Support for this rule is not fully implemented in Servo yet.
-                    return Err(StyleParseError::UnsupportedAtRule(name.clone()).into())
+                    return Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
                 }
                 let name = parse_counter_style_name(input)?;
                 // ASCII-case-insensitive matches for "decimal" and "disc".
                 // The name is already lower-cased by `parse_counter_style_name`
                 // so we can use == here.
                 if name.0 == atom!("decimal") || name.0 == atom!("disc") {
-                    return Err(StyleParseError::UnspecifiedError.into())
+                    return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
                 }
                 Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::CounterStyle(name)))
             },
@@ -395,7 +396,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                 if viewport_rule::enabled() {
                     Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Viewport))
                 } else {
-                    Err(StyleParseError::UnsupportedAtRule(name.clone()).into())
+                    Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
                 }
             },
             "keyframes" | "-webkit-keyframes" | "-moz-keyframes" => {
@@ -409,7 +410,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                 if cfg!(feature = "servo") &&
                    prefix.as_ref().map_or(false, |p| matches!(*p, VendorPrefix::Moz)) {
                     // Servo should not support @-moz-keyframes.
-                    return Err(StyleParseError::UnsupportedAtRule(name.clone()).into())
+                    return Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
                 }
                 let name = KeyframesName::parse(self.context, input)?;
 
@@ -419,7 +420,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                 if cfg!(feature = "gecko") {
                     Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Page(location)))
                 } else {
-                    Err(StyleParseError::UnsupportedAtRule(name.clone()).into())
+                    Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
                 }
             },
             "-moz-document" => {
@@ -427,10 +428,10 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
                     let cond = DocumentCondition::parse(self.context, input)?;
                     Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Document(cond, location)))
                 } else {
-                    Err(StyleParseError::UnsupportedAtRule(name.clone()).into())
+                    Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
                 }
             },
-            _ => Err(StyleParseError::UnsupportedAtRule(name.clone()).into())
+            _ => Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
         }
     }
 
@@ -549,7 +550,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
 impl<'a, 'b, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for NestedRuleParser<'a, 'b, R> {
     type Prelude = QualifiedRuleParserPrelude;
     type QualifiedRule = CssRule;
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 
     fn parse_prelude<'t>(
         &mut self,

--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -333,8 +333,8 @@ impl<'a, 'b, R: ParseErrorReporter> NestedRuleParser<'a, 'b, R> {
             match result {
                 Ok(rule) => rules.push(rule),
                 Err((error, slice)) => {
+                    let location = error.location;
                     let error = ContextualParseError::UnsupportedRule(slice, error);
-                    let location = iter.input.current_source_location();
                     self.context.log_css_error(self.error_context, location, error);
                 }
             }

--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -16,7 +16,6 @@ use parser::{Parse, ParserContext, ParserErrorContext};
 use properties::parse_property_declaration_list;
 use selector_parser::{SelectorImpl, SelectorParser};
 use selectors::SelectorList;
-use selectors::parser::SelectorParseErrorKind;
 use servo_arc::Arc;
 use shared_lock::{Locked, SharedRwLock};
 use str::starts_with_ignore_ascii_case;
@@ -160,7 +159,7 @@ impl<'a, 'i, R: ParseErrorReporter> AtRuleParser<'i> for TopLevelRuleParser<'a, 
     type PreludeNoBlock = AtRuleNonBlockPrelude;
     type PreludeBlock = AtRuleBlockPrelude;
     type AtRule = CssRule;
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 
     fn parse_prelude<'t>(
         &mut self,
@@ -280,7 +279,7 @@ pub struct QualifiedRuleParserPrelude {
 impl<'a, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for TopLevelRuleParser<'a, R> {
     type Prelude = QualifiedRuleParserPrelude;
     type QualifiedRule = CssRule;
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 
     #[inline]
     fn parse_prelude<'t>(
@@ -347,7 +346,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
     type PreludeNoBlock = AtRuleNonBlockPrelude;
     type PreludeBlock = AtRuleBlockPrelude;
     type AtRule = CssRule;
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 
     fn parse_prelude<'t>(
         &mut self,
@@ -550,7 +549,7 @@ impl<'a, 'b, 'i, R: ParseErrorReporter> AtRuleParser<'i> for NestedRuleParser<'a
 impl<'a, 'b, 'i, R: ParseErrorReporter> QualifiedRuleParser<'i> for NestedRuleParser<'a, 'b, R> {
     type Prelude = QualifiedRuleParserPrelude;
     type QualifiedRule = CssRule;
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 
     fn parse_prelude<'t>(
         &mut self,

--- a/components/style/stylesheets/stylesheet.rs
+++ b/components/style/stylesheets/stylesheet.rs
@@ -396,8 +396,9 @@ impl Stylesheet {
                     },
                     Err(err) => {
                         let error = ContextualParseError::InvalidRule(err.slice, err.error);
+                        let location = iter.input.current_source_location();
                         iter.parser.context.log_css_error(&iter.parser.error_context,
-                                                          err.location, error);
+                                                          location, error);
                     }
                 }
             }

--- a/components/style/stylesheets/stylesheet.rs
+++ b/components/style/stylesheets/stylesheet.rs
@@ -395,8 +395,8 @@ impl Stylesheet {
                         }
                     },
                     Err((error, slice)) => {
+                        let location = error.location;
                         let error = ContextualParseError::InvalidRule(slice, error);
-                        let location = iter.input.current_source_location();
                         iter.parser.context.log_css_error(&iter.parser.error_context,
                                                           location, error);
                     }

--- a/components/style/stylesheets/stylesheet.rs
+++ b/components/style/stylesheets/stylesheet.rs
@@ -394,8 +394,8 @@ impl Stylesheet {
                             break;
                         }
                     },
-                    Err(err) => {
-                        let error = ContextualParseError::InvalidRule(err.slice, err.error);
+                    Err((error, slice)) => {
+                        let error = ContextualParseError::InvalidRule(slice, error);
                         let location = iter.input.current_source_location();
                         iter.parser.context.log_css_error(&iter.parser.error_context,
                                                           location, error);

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -370,7 +370,7 @@ impl ViewportRule {
                 }
                 Err(err) => {
                     let error = ContextualParseError::UnsupportedViewportDescriptorDeclaration(err.slice, err.error);
-                    context.log_css_error(error_context, err.location, error);
+                    context.log_css_error(error_context, parser.input.current_source_location(), error);
                 }
             }
         }

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -18,7 +18,7 @@ use media_queries::Device;
 use parser::{ParserContext, ParserErrorContext};
 use properties::StyleBuilder;
 use rule_cache::RuleCacheConditions;
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 use shared_lock::{SharedRwLockReadGuard, StylesheetGuards, ToCssWithGuard};
 use std::ascii::AsciiExt;
 use std::borrow::Cow;
@@ -26,7 +26,7 @@ use std::cell::RefCell;
 use std::fmt;
 use std::iter::Enumerate;
 use std::str::Chars;
-use style_traits::{PinchZoomFactor, ToCss, ParseError, StyleParseError};
+use style_traits::{PinchZoomFactor, ToCss, ParseError, StyleParseErrorKind};
 use style_traits::viewport::{Orientation, UserZoom, ViewportConstraints, Zoom};
 use stylesheets::{StylesheetInDocument, Origin};
 use values::computed::{Context, ToComputedValue};
@@ -276,12 +276,12 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for ViewportRuleParser<'a, 'b> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = Vec<ViewportDescriptorDeclaration>;
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 }
 
 impl<'a, 'b, 'i> DeclarationParser<'i> for ViewportRuleParser<'a, 'b> {
     type Declaration = Vec<ViewportDescriptorDeclaration>;
-    type Error = SelectorParseError<'i, StyleParseError<'i>>;
+    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
 
     fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                        -> Result<Vec<ViewportDescriptorDeclaration>, ParseError<'i>> {
@@ -323,7 +323,7 @@ impl<'a, 'b, 'i> DeclarationParser<'i> for ViewportRuleParser<'a, 'b> {
             "max-zoom" => ok!(MaxZoom(Zoom::parse)),
             "user-zoom" => ok!(UserZoom(UserZoom::parse)),
             "orientation" => ok!(Orientation(Orientation::parse)),
-            _ => Err(SelectorParseError::UnexpectedIdent(name.clone()).into()),
+            _ => Err(input.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(name.clone()))),
         }
     }
 }
@@ -368,8 +368,8 @@ impl ViewportRule {
                         cascade.add(Cow::Owned(declarations))
                     }
                 }
-                Err(err) => {
-                    let error = ContextualParseError::UnsupportedViewportDescriptorDeclaration(err.slice, err.error);
+                Err((error, slice)) => {
+                    let error = ContextualParseError::UnsupportedViewportDescriptorDeclaration(slice, error);
                     context.log_css_error(error_context, parser.input.current_source_location(), error);
                 }
             }

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -369,8 +369,9 @@ impl ViewportRule {
                     }
                 }
                 Err((error, slice)) => {
+                    let location = error.location;
                     let error = ContextualParseError::UnsupportedViewportDescriptorDeclaration(slice, error);
-                    context.log_css_error(error_context, parser.input.current_source_location(), error);
+                    context.log_css_error(error_context, location, error);
                 }
             }
         }

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -276,12 +276,12 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for ViewportRuleParser<'a, 'b> {
     type PreludeNoBlock = ();
     type PreludeBlock = ();
     type AtRule = Vec<ViewportDescriptorDeclaration>;
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 }
 
 impl<'a, 'b, 'i> DeclarationParser<'i> for ViewportRuleParser<'a, 'b> {
     type Declaration = Vec<ViewportDescriptorDeclaration>;
-    type Error = SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>;
+    type Error = StyleParseErrorKind<'i>;
 
     fn parse_value<'t>(&mut self, name: CowRcStr<'i>, input: &mut Parser<'i, 't>)
                        -> Result<Vec<ViewportDescriptorDeclaration>, ParseError<'i>> {

--- a/components/style/values/generics/svg.rs
+++ b/components/style/values/generics/svg.rs
@@ -7,7 +7,7 @@
 use cssparser::Parser;
 use parser::{Parse, ParserContext};
 use std::fmt;
-use style_traits::{ParseError, StyleParseError, ToCss};
+use style_traits::{ParseError, StyleParseErrorKind, ToCss};
 use values::{Either, None_};
 use values::computed::NumberOrPercentage;
 use values::computed::length::LengthOrPercentage;
@@ -54,7 +54,7 @@ pub enum SVGPaintKind<ColorType, UrlPaintServer> {
 impl<ColorType, UrlPaintServer> SVGPaintKind<ColorType, UrlPaintServer> {
     /// Parse a keyword value only
     fn parse_ident<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
-        try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+        try_match_ident_ignore_ascii_case! { input,
             "none" => Ok(SVGPaintKind::None),
             "context-fill" => Ok(SVGPaintKind::ContextFill),
             "context-stroke" => Ok(SVGPaintKind::ContextStroke),
@@ -104,7 +104,7 @@ impl<ColorType: Parse, UrlPaintServer: Parse> Parse for SVGPaint<ColorType, UrlP
                 fallback: None,
             })
         } else {
-            Err(StyleParseError::UnspecifiedError.into())
+            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
     }
 }
@@ -189,7 +189,7 @@ impl <LengthOrPercentageType: Parse, NumberType: Parse> Parse for
         if let Ok(lop) = input.try(|i| LengthOrPercentageType::parse(context, i)) {
             return Ok(SvgLengthOrPercentageOrNumber::LengthOrPercentage(lop));
         }
-        Err(StyleParseError::UnspecifiedError.into())
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
     }
 }
 

--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -9,10 +9,10 @@
 use cssparser::Parser;
 use gecko_bindings::structs;
 use parser::{Parse, ParserContext};
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 use std::ascii::AsciiExt;
 use std::fmt;
-use style_traits::{ToCss, ParseError, StyleParseError};
+use style_traits::{ToCss, ParseError, StyleParseErrorKind};
 
 bitflags! {
     /// Constants shared by multiple CSS Box Alignment properties
@@ -201,7 +201,7 @@ impl Parse for AlignJustifyContent {
             }
             return Ok(AlignJustifyContent::new(fallback))
         }
-        Err(StyleParseError::UnspecifiedError.into())
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
     }
 }
 
@@ -239,7 +239,7 @@ impl Parse for AlignJustifySelf {
         if let Ok(value) = input.try(parse_overflow_self_position) {
             return Ok(AlignJustifySelf(value))
         }
-        Err(StyleParseError::UnspecifiedError.into())
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
     }
 }
 
@@ -277,7 +277,7 @@ impl Parse for AlignItems {
         if let Ok(value) = input.try(parse_overflow_self_position) {
             return Ok(AlignItems(value))
         }
-        Err(StyleParseError::UnspecifiedError.into())
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
     }
 }
 
@@ -326,7 +326,7 @@ impl Parse for JustifyItems {
         if let Ok(value) = parse_overflow_self_position(input) {
             return Ok(JustifyItems(value))
         }
-        Err(StyleParseError::UnspecifiedError.into())
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
     }
 }
 
@@ -351,7 +351,7 @@ fn parse_auto_normal_stretch_baseline<'i, 't>(input: &mut Parser<'i, 't>)
         return Ok(baseline);
     }
 
-    try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+    try_match_ident_ignore_ascii_case! { input,
         "auto" => Ok(ALIGN_AUTO),
         "normal" => Ok(ALIGN_NORMAL),
         "stretch" => Ok(ALIGN_STRETCH),
@@ -364,7 +364,7 @@ fn parse_normal_stretch_baseline<'i, 't>(input: &mut Parser<'i, 't>) -> Result<A
         return Ok(baseline);
     }
 
-    try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+    try_match_ident_ignore_ascii_case! { input,
         "normal" => Ok(ALIGN_NORMAL),
         "stretch" => Ok(ALIGN_STRETCH),
     }
@@ -383,7 +383,7 @@ fn parse_normal_or_baseline<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignF
 // <baseline-position>
 fn parse_baseline<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignFlags, ParseError<'i>> {
     // FIXME: remove clone() when lifetimes are non-lexical
-    try_match_ident_ignore_ascii_case! { input.expect_ident()?.clone(),
+    try_match_ident_ignore_ascii_case! { input,
         "baseline" => Ok(ALIGN_BASELINE),
         "first" => {
             input.expect_ident_matching("baseline")?;
@@ -398,7 +398,7 @@ fn parse_baseline<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignFlags, Pars
 
 // <content-distribution>
 fn parse_content_distribution<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignFlags, ParseError<'i>> {
-    try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+    try_match_ident_ignore_ascii_case! { input,
         "stretch" => Ok(ALIGN_STRETCH),
         "space-between" => Ok(ALIGN_SPACE_BETWEEN),
         "space-around" => Ok(ALIGN_SPACE_AROUND),
@@ -421,12 +421,12 @@ fn parse_overflow_content_position<'i, 't>(input: &mut Parser<'i, 't>) -> Result
             return Ok(overflow | content)
         }
     }
-    return Err(StyleParseError::UnspecifiedError.into())
+    return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
 }
 
 // <content-position>
 fn parse_content_position<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignFlags, ParseError<'i>> {
-    try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+    try_match_ident_ignore_ascii_case! { input,
         "start" => Ok(ALIGN_START),
         "end" => Ok(ALIGN_END),
         "flex-start" => Ok(ALIGN_FLEX_START),
@@ -439,7 +439,7 @@ fn parse_content_position<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignFla
 
 // <overflow-position>
 fn parse_overflow_position<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignFlags, ParseError<'i>> {
-    try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+    try_match_ident_ignore_ascii_case! { input,
         "safe" => Ok(ALIGN_SAFE),
         "unsafe" => Ok(ALIGN_UNSAFE),
     }
@@ -460,12 +460,12 @@ fn parse_overflow_self_position<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Al
             return Ok(overflow | self_position)
         }
     }
-    return Err(StyleParseError::UnspecifiedError.into())
+    return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
 }
 
 // <self-position>
 fn parse_self_position<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignFlags, ParseError<'i>> {
-    try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+    try_match_ident_ignore_ascii_case! { input,
         "start" => Ok(ALIGN_START),
         "end" => Ok(ALIGN_END),
         "flex-start" => Ok(ALIGN_FLEX_START),
@@ -480,7 +480,9 @@ fn parse_self_position<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignFlags,
 
 // [ legacy && [ left | right | center ] ]
 fn parse_legacy<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignFlags, ParseError<'i>> {
+    let a_location = input.current_source_location();
     let a = input.expect_ident()?.clone();
+    let b_location = input.current_source_location();
     let b = input.expect_ident()?;
     if a.eq_ignore_ascii_case("legacy") {
         (match_ignore_ascii_case! { &b,
@@ -488,15 +490,15 @@ fn parse_legacy<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignFlags, ParseE
             "right" => Ok(ALIGN_LEGACY | ALIGN_RIGHT),
             "center" => Ok(ALIGN_LEGACY | ALIGN_CENTER),
             _ => Err(())
-        }).map_err(|()| SelectorParseError::UnexpectedIdent(b.clone()).into())
+        }).map_err(|()| b_location.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(b.clone())))
     } else if b.eq_ignore_ascii_case("legacy") {
         (match_ignore_ascii_case! { &a,
             "left" => Ok(ALIGN_LEGACY | ALIGN_LEFT),
             "right" => Ok(ALIGN_LEGACY | ALIGN_RIGHT),
             "center" => Ok(ALIGN_LEGACY | ALIGN_CENTER),
             _ => Err(())
-        }).map_err(|()| SelectorParseError::UnexpectedIdent(a).into())
+        }).map_err(|()| a_location.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(a)))
     } else {
-        Err(StyleParseError::UnspecifiedError.into())
+        Err(a_location.new_custom_error(StyleParseErrorKind::UnspecifiedError))
     }
 }

--- a/components/style/values/specified/angle.rs
+++ b/components/style/values/specified/angle.rs
@@ -4,7 +4,7 @@
 
 //! Specified angles.
 
-use cssparser::{Parser, Token, BasicParseError};
+use cssparser::{Parser, Token};
 use parser::{ParserContext, Parse};
 use std::ascii::AsciiExt;
 use std::fmt;
@@ -112,7 +112,7 @@ impl Parse for Angle {
                 return input.parse_nested_block(|i| CalcNode::parse_angle(context, i))
             }
             _ => Err(())
-        }.map_err(|()| BasicParseError::UnexpectedToken(token.clone()).into())
+        }.map_err(|()| input.new_unexpected_token_error(token.clone()))
     }
 }
 
@@ -155,6 +155,6 @@ impl Angle {
                 return input.parse_nested_block(|i| CalcNode::parse_angle(context, i))
             }
             _ => Err(())
-        }.map_err(|()| BasicParseError::UnexpectedToken(token.clone()).into())
+        }.map_err(|()| input.new_unexpected_token_error(token.clone()))
     }
 }

--- a/components/style/values/specified/background.rs
+++ b/components/style/values/specified/background.rs
@@ -6,7 +6,7 @@
 
 use cssparser::Parser;
 use parser::{Parse, ParserContext};
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 use style_traits::ParseError;
 use values::generics::background::BackgroundSize as GenericBackgroundSize;
 use values::specified::length::LengthOrPercentageOrAuto;
@@ -22,12 +22,13 @@ impl Parse for BackgroundSize {
                 .unwrap_or(LengthOrPercentageOrAuto::Auto);
             return Ok(GenericBackgroundSize::Explicit { width, height });
         }
+        let location = input.current_source_location();
         let ident = input.expect_ident()?;
         (match_ignore_ascii_case! { &ident,
             "cover" => Ok(GenericBackgroundSize::Cover),
             "contain" => Ok(GenericBackgroundSize::Contain),
             _ => Err(()),
-        }).map_err(|()| SelectorParseError::UnexpectedIdent(ident.clone()).into())
+        }).map_err(|()| location.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(ident.clone())))
     }
 }
 

--- a/components/style/values/specified/basic_shape.rs
+++ b/components/style/values/specified/basic_shape.rs
@@ -11,7 +11,7 @@ use cssparser::Parser;
 use parser::{Parse, ParserContext};
 use std::borrow::Cow;
 use std::fmt;
-use style_traits::{ToCss, ParseError, StyleParseError};
+use style_traits::{ToCss, ParseError, StyleParseErrorKind};
 use values::computed::Percentage;
 use values::generics::basic_shape::{Circle as GenericCircle};
 use values::generics::basic_shape::{ClippingShape as GenericClippingShape, Ellipse as GenericEllipse};
@@ -81,7 +81,7 @@ impl<ReferenceBox: Parse> Parse for ShapeSource<BasicShape, ReferenceBox, Specif
             return Ok(ShapeSource::Shape(shp, ref_box))
         }
 
-        ref_box.map(|v| ShapeSource::Box(v)).ok_or(StyleParseError::UnspecifiedError.into())
+        ref_box.map(|v| ShapeSource::Box(v)).ok_or(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
     }
 }
 
@@ -91,7 +91,7 @@ impl Parse for GeometryBox {
             return Ok(GeometryBox::ShapeBox(shape_box))
         }
 
-        try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+        try_match_ident_ignore_ascii_case! { input,
             "fill-box" => Ok(GeometryBox::FillBox),
             "stroke-box" => Ok(GeometryBox::StrokeBox),
             "view-box" => Ok(GeometryBox::ViewBox),
@@ -101,6 +101,7 @@ impl Parse for GeometryBox {
 
 impl Parse for BasicShape {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
+        let location = input.current_source_location();
         let function = input.expect_function()?.clone();
         input.parse_nested_block(move |i| {
             (match_ignore_ascii_case! { &function,
@@ -109,7 +110,7 @@ impl Parse for BasicShape {
                 "ellipse" => return Ellipse::parse_function_arguments(context, i).map(GenericBasicShape::Ellipse),
                 "polygon" => return Polygon::parse_function_arguments(context, i).map(GenericBasicShape::Polygon),
                 _ => Err(())
-            }).map_err(|()| StyleParseError::UnexpectedFunction(function.clone()).into())
+            }).map_err(|()| location.new_custom_error(StyleParseErrorKind::UnexpectedFunction(function.clone())))
         })
     }
 }
@@ -229,7 +230,7 @@ impl Parse for ShapeRadius {
             return Ok(GenericShapeRadius::Length(lop))
         }
 
-        try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+        try_match_ident_ignore_ascii_case! { input,
             "closest-side" => Ok(GenericShapeRadius::ClosestSide),
             "farthest-side" => Ok(GenericShapeRadius::FarthestSide),
         }

--- a/components/style/values/specified/border.rs
+++ b/components/style/values/specified/border.rs
@@ -62,7 +62,7 @@ impl BorderSideWidth {
         if let Ok(length) = input.try(|i| Length::parse_non_negative_quirky(context, i, allow_quirks)) {
             return Ok(BorderSideWidth::Length(length));
         }
-        try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+        try_match_ident_ignore_ascii_case! { input,
             "thin" => Ok(BorderSideWidth::Thin),
             "medium" => Ok(BorderSideWidth::Medium),
             "thick" => Ok(BorderSideWidth::Thick),

--- a/components/style/values/specified/box.rs
+++ b/components/style/values/specified/box.rs
@@ -23,7 +23,7 @@ impl Parse for VerticalAlign {
             return Ok(GenericVerticalAlign::Length(lop));
         }
 
-        try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+        try_match_ident_ignore_ascii_case! { input,
             "baseline" => Ok(GenericVerticalAlign::Baseline),
             "sub" => Ok(GenericVerticalAlign::Sub),
             "super" => Ok(GenericVerticalAlign::Super),

--- a/components/style/values/specified/effects.rs
+++ b/components/style/values/specified/effects.rs
@@ -4,9 +4,9 @@
 
 //! Specified types for CSS values related to effects.
 
-use cssparser::{Parser, Token, BasicParseError};
+use cssparser::{self, Parser, Token, BasicParseErrorKind};
 use parser::{Parse, ParserContext};
-use style_traits::{ParseError, StyleParseError, ValueParseError};
+use style_traits::{ParseError, StyleParseErrorKind, ValueParseErrorKind};
 #[cfg(not(feature = "gecko"))]
 use values::Impossible;
 use values::computed::{Context, NonNegativeNumber as ComputedNonNegativeNumber, ToComputedValue};
@@ -138,7 +138,7 @@ impl Parse for BoxShadow {
             break;
         }
 
-        let lengths = lengths.ok_or(StyleParseError::UnspecifiedError)?;
+        let lengths = lengths.ok_or(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))?;
         Ok(BoxShadow {
             base: SimpleShadow {
                 color: color,
@@ -186,10 +186,15 @@ impl Parse for Filter {
                 return Ok(GenericFilter::Url(url));
             }
         }
+        let location = input.current_source_location();
         let function = match input.expect_function() {
             Ok(f) => f.clone(),
-            Err(BasicParseError::UnexpectedToken(t)) =>
-                return Err(ValueParseError::InvalidFilter(t.clone()).into()),
+            Err(cssparser::BasicParseError {
+                kind: BasicParseErrorKind::UnexpectedToken(t),
+                location,
+            }) => {
+                return Err(location.new_custom_error(ValueParseErrorKind::InvalidFilter(t)))
+            }
             Err(e) => return Err(e.into()),
         };
         input.parse_nested_block(|i| {
@@ -220,7 +225,9 @@ impl Parse for Filter {
                     Ok(GenericFilter::Sepia(Factor::parse_with_clamping_to_one(context, i)?))
                 },
                 "drop-shadow" => Ok(GenericFilter::DropShadow(Parse::parse(context, i)?)),
-                _ => Err(ValueParseError::InvalidFilter(Token::Function(function.clone())).into()),
+                _ => Err(location.new_custom_error(
+                    ValueParseErrorKind::InvalidFilter(Token::Function(function.clone()))
+                )),
             }
         })
     }

--- a/components/style/values/specified/flex.rs
+++ b/components/style/values/specified/flex.rs
@@ -21,7 +21,7 @@ impl Parse for FlexBasis {
         if let Ok(length) = input.try(|i| LengthOrPercentage::parse_non_negative(context, i)) {
             return Ok(GenericFlexBasis::Length(length));
         }
-        try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+        try_match_ident_ignore_ascii_case! { input,
             "auto" => Ok(GenericFlexBasis::Auto),
             "content" => Ok(GenericFlexBasis::Content),
         }

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -83,7 +83,7 @@ pub enum KeywordSize {
 impl KeywordSize {
     /// Parse a keyword size
     pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
-        try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+        try_match_ident_ignore_ascii_case! { input,
             "xx-small" => Ok(KeywordSize::XXSmall),
             "x-small" => Ok(KeywordSize::XSmall),
             "small" => Ok(KeywordSize::Small),

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -8,13 +8,13 @@
 
 use Namespace;
 use context::QuirksMode;
-use cssparser::{Parser, Token, serialize_identifier, BasicParseError};
+use cssparser::{Parser, Token, serialize_identifier};
 use parser::{ParserContext, Parse};
 use self::url::SpecifiedUrl;
 use std::ascii::AsciiExt;
 use std::f32;
 use std::fmt;
-use style_traits::{ToCss, ParseError, StyleParseError};
+use style_traits::{ToCss, ParseError, StyleParseErrorKind};
 use style_traits::values::specified::AllowedNumericType;
 use super::{Auto, CSSFloat, CSSInteger, Either, None_};
 use super::computed::{Context, ToComputedValue};
@@ -103,11 +103,12 @@ impl Eq for SpecifiedUrl {}
 /// Parse an `<integer>` value, handling `calc()` correctly.
 pub fn parse_integer<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                              -> Result<Integer, ParseError<'i>> {
+    let location = input.current_source_location();
     // FIXME: remove early returns when lifetimes are non-lexical
     match *input.next()? {
         Token::Number { int_value: Some(v), .. } => return Ok(Integer::new(v)),
         Token::Function(ref name) if name.eq_ignore_ascii_case("calc") => {}
-        ref t => return Err(BasicParseError::UnexpectedToken(t.clone()).into())
+        ref t => return Err(location.new_unexpected_token_error(t.clone()))
     }
 
     let result = input.parse_nested_block(|i| {
@@ -129,6 +130,7 @@ pub fn parse_number_with_clamping_mode<'i, 't>(context: &ParserContext,
                                                input: &mut Parser<'i, 't>,
                                                clamping_mode: AllowedNumericType)
                                                -> Result<Number, ParseError<'i>> {
+    let location = input.current_source_location();
     // FIXME: remove early returns when lifetimes are non-lexical
     match *input.next()? {
         Token::Number { value, .. } if clamping_mode.is_ok(context.parsing_mode, value) => {
@@ -138,7 +140,7 @@ pub fn parse_number_with_clamping_mode<'i, 't>(context: &ParserContext,
             })
         }
         Token::Function(ref name) if name.eq_ignore_ascii_case("calc") => {}
-        ref t => return Err(BasicParseError::UnexpectedToken(t.clone()).into())
+        ref t => return Err(location.new_unexpected_token_error(t.clone()))
     }
 
     let result = input.parse_nested_block(|i| {
@@ -415,7 +417,7 @@ impl Integer {
             // It's not totally clear it's worth it though, and no other browser
             // does this.
             Ok(value) if value.value() >= min => Ok(value),
-            Ok(_value) => Err(StyleParseError::UnspecifiedError.into()),
+            Ok(_value) => Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError)),
             Err(e) => Err(e),
         }
     }
@@ -473,7 +475,9 @@ impl IntegerOrAuto {
                                   input: &mut Parser<'i, 't>)
                                   -> Result<IntegerOrAuto, ParseError<'i>> {
         match IntegerOrAuto::parse(context, input) {
-            Ok(Either::First(integer)) if integer.value() <= 0 => Err(StyleParseError::UnspecifiedError.into()),
+            Ok(Either::First(integer)) if integer.value() <= 0 => {
+                Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
+            }
             result => result,
         }
     }
@@ -741,17 +745,18 @@ impl Attr {
         if let Ok(token) = input.try(|i| i.next_including_whitespace().map(|t| t.clone())) {
             match token {
                 Token::Delim('|') => {
+                    let location = input.current_source_location();
                     // must be followed by an ident
                     let second_token = match *input.next_including_whitespace()? {
                         Token::Ident(ref second) => second,
-                        ref t => return Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+                        ref t => return Err(location.new_unexpected_token_error(t.clone())),
                     };
 
                     let ns_with_id = if let Some(ns) = first {
                         let ns = Namespace::from(ns.as_ref());
                         let id: Result<_, ParseError> =
                             get_id_for_namespace(&ns, context)
-                            .map_err(|()| StyleParseError::UnspecifiedError.into());
+                            .map_err(|()| location.new_custom_error(StyleParseErrorKind::UnspecifiedError));
                         Some((ns, id?))
                     } else {
                         None
@@ -764,7 +769,7 @@ impl Attr {
                 // In the case of attr(foobar    ) we don't want to error out
                 // because of the trailing whitespace
                 Token::WhiteSpace(_) => (),
-                ref t => return Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+                ref t => return Err(input.new_unexpected_token_error(t.clone())),
             }
         }
 
@@ -774,7 +779,7 @@ impl Attr {
                 attribute: first.as_ref().to_owned(),
             })
         } else {
-            Err(StyleParseError::UnspecifiedError.into())
+            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
     }
 }

--- a/components/style/values/specified/percentage.rs
+++ b/components/style/values/specified/percentage.rs
@@ -4,7 +4,7 @@
 
 //! Specified percentages.
 
-use cssparser::{BasicParseError, Parser, Token};
+use cssparser::{Parser, Token};
 use parser::{Parse, ParserContext};
 use std::ascii::AsciiExt;
 use std::fmt;
@@ -97,13 +97,14 @@ impl Percentage {
         input: &mut Parser<'i, 't>,
         num_context: AllowedNumericType,
     ) -> Result<Self, ParseError<'i>> {
+        let location = input.current_source_location();
         // FIXME: remove early returns when lifetimes are non-lexical
         match *input.next()? {
             Token::Percentage { unit_value, .. } if num_context.is_ok(context.parsing_mode, unit_value) => {
                 return Ok(Percentage::new(unit_value));
             }
             Token::Function(ref name) if name.eq_ignore_ascii_case("calc") => {},
-            ref t => return Err(BasicParseError::UnexpectedToken(t.clone()).into()),
+            ref t => return Err(location.new_unexpected_token_error(t.clone())),
         }
 
         let result = input.parse_nested_block(|i| {

--- a/components/style/values/specified/svg.rs
+++ b/components/style/values/specified/svg.rs
@@ -6,7 +6,7 @@
 
 use cssparser::Parser;
 use parser::{Parse, ParserContext};
-use style_traits::{CommaWithSpace, ParseError, Separator, StyleParseError};
+use style_traits::{CommaWithSpace, ParseError, Separator, StyleParseErrorKind};
 use values::generics::svg as generic;
 use values::specified::{LengthOrPercentage, NonNegativeLengthOrPercentage, NonNegativeNumber};
 use values::specified::{Number, Opacity, SpecifiedUrl};
@@ -39,7 +39,7 @@ fn parse_context_value<'i, 't, T>(input: &mut Parser<'i, 't>, value: T)
             return Ok(value);
         }
     }
-    Err(StyleParseError::UnspecifiedError.into())
+    Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
 }
 
 /// A value of <length> | <percentage> | <number> for stroke-dashoffset.
@@ -115,12 +115,12 @@ impl Parse for SVGOpacity {
         if let Ok(opacity) = input.try(|i| Opacity::parse(context, i)) {
             Ok(generic::SVGOpacity::Opacity(opacity))
         } else if is_context_value_enabled() {
-            try_match_ident_ignore_ascii_case! { input.expect_ident()?,
+            try_match_ident_ignore_ascii_case! { input,
                 "context-fill-opacity" => Ok(generic::SVGOpacity::ContextFillOpacity),
                 "context-stroke-opacity" => Ok(generic::SVGOpacity::ContextStrokeOpacity),
             }
         } else {
-            Err(StyleParseError::UnspecifiedError.into())
+            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
         }
     }
 }

--- a/components/style/values/specified/text.rs
+++ b/components/style/values/specified/text.rs
@@ -6,7 +6,7 @@
 
 use cssparser::Parser;
 use parser::{Parse, ParserContext};
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 use std::ascii::AsciiExt;
 use style_traits::ParseError;
 use values::computed::{Context, ToComputedValue};
@@ -65,6 +65,7 @@ impl Parse for LineHeight {
         if let Ok(nlop) = input.try(|i| NonNegativeLengthOrPercentage::parse(context, i)) {
             return Ok(GenericLineHeight::Length(nlop))
         }
+        let location = input.current_source_location();
         let ident = input.expect_ident()?;
         match ident {
             ref ident if ident.eq_ignore_ascii_case("normal") => {
@@ -74,7 +75,7 @@ impl Parse for LineHeight {
             ref ident if ident.eq_ignore_ascii_case("-moz-block-height") => {
                 Ok(GenericLineHeight::MozBlockHeight)
             },
-            ident => Err(SelectorParseError::UnexpectedIdent(ident.clone()).into()),
+            ident => Err(location.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(ident.clone()))),
         }
     }
 }

--- a/components/style/values/specified/transform.rs
+++ b/components/style/values/specified/transform.rs
@@ -6,8 +6,8 @@
 
 use cssparser::Parser;
 use parser::{Parse, ParserContext};
-use selectors::parser::SelectorParseError;
-use style_traits::{ParseError, StyleParseError};
+use selectors::parser::SelectorParseErrorKind;
+use style_traits::{ParseError, StyleParseErrorKind};
 use values::computed::{Context, LengthOrPercentage as ComputedLengthOrPercentage};
 use values::computed::{Percentage as ComputedPercentage, ToComputedValue};
 use values::computed::transform::TimingFunction as ComputedTimingFunction;
@@ -152,10 +152,11 @@ impl Parse for TimingFunction {
             let position = match_ignore_ascii_case! { &ident,
                 "step-start" => StepPosition::Start,
                 "step-end" => StepPosition::End,
-                _ => return Err(SelectorParseError::UnexpectedIdent(ident.clone()).into()),
+                _ => return Err(input.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(ident.clone()))),
             };
             return Ok(GenericTimingFunction::Steps(Integer::new(1), position));
         }
+        let location = input.current_source_location();
         let function = input.expect_function()?.clone();
         input.parse_nested_block(move |i| {
             (match_ignore_ascii_case! { &function,
@@ -169,7 +170,7 @@ impl Parse for TimingFunction {
                     let y2 = Number::parse(context, i)?;
 
                     if x1.get() < 0.0 || x1.get() > 1.0 || x2.get() < 0.0 || x2.get() > 1.0 {
-                        return Err(StyleParseError::UnspecifiedError.into());
+                        return Err(i.new_custom_error(StyleParseErrorKind::UnspecifiedError));
                     }
 
                     Ok(GenericTimingFunction::CubicBezier { x1, y1, x2, y2 })
@@ -191,7 +192,7 @@ impl Parse for TimingFunction {
                     }
                 },
                 _ => Err(()),
-            }).map_err(|()| StyleParseError::UnexpectedFunction(function.clone()).into())
+            }).map_err(|()| location.new_custom_error(StyleParseErrorKind::UnexpectedFunction(function.clone())))
         })
     }
 }

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -16,7 +16,7 @@ gecko = []
 [dependencies]
 app_units = "0.5"
 bitflags = "0.7"
-cssparser = "0.21.1"
+cssparser = "0.22.0"
 euclid = "0.15"
 heapsize = {version = "0.4", optional = true}
 heapsize_derive = {version = "0.1", optional = true}

--- a/components/style_traits/lib.rs
+++ b/components/style_traits/lib.rs
@@ -30,7 +30,7 @@ extern crate servo_arc;
 #[cfg(feature = "servo")] pub use webrender_api::DevicePixel;
 
 use cssparser::{CowRcStr, Token};
-use selectors::parser::SelectorParseError;
+use selectors::parser::SelectorParseErrorKind;
 #[cfg(feature = "servo")] use servo_atoms::Atom;
 
 /// One hardware pixel.
@@ -85,11 +85,20 @@ pub mod viewport;
 pub use values::{Comma, CommaWithSpace, OneOrMoreSeparated, Separator, Space, ToCss};
 
 /// The error type for all CSS parsing routines.
-pub type ParseError<'i> = cssparser::ParseError<'i, SelectorParseError<'i, StyleParseError<'i>>>;
+pub type ParseError<'i> = cssparser::ParseError<'i, SelectorParseErrorKind<'i, StyleParseErrorKind<'i>>>;
+
+/// Error emitted by the style crate
+pub type StyleParseError<'i> = cssparser::ParseError<'i, StyleParseErrorKind<'i>>;
+
+/// Error in property value parsing
+pub type ValueParseError<'i> = cssparser::ParseError<'i, ValueParseErrorKind<'i>>;
+
+/// Error in property parsing
+pub type PropertyDeclarationParseError<'i> = cssparser::ParseError<'i, PropertyDeclarationParseErrorKind<'i>>;
 
 #[derive(Clone, Debug, PartialEq)]
 /// Errors that can be encountered while parsing CSS values.
-pub enum StyleParseError<'i> {
+pub enum StyleParseErrorKind<'i> {
     /// A bad URL token in a DVB.
     BadUrlInDeclarationValueBlock(CowRcStr<'i>),
     /// A bad string token in a DVB.
@@ -101,7 +110,7 @@ pub enum StyleParseError<'i> {
     /// Unexpected closing curly bracket in a DVB.
     UnbalancedCloseCurlyBracketInDeclarationValueBlock,
     /// A property declaration parsing error.
-    PropertyDeclaration(PropertyDeclarationParseError<'i>),
+    PropertyDeclaration(PropertyDeclarationParseErrorKind<'i>),
     /// A property declaration value had input remaining after successfully parsing.
     PropertyDeclarationValueNotExhausted,
     /// An unexpected dimension token was encountered.
@@ -129,39 +138,33 @@ pub enum StyleParseError<'i> {
     /// An unexpected token was found within a namespace rule.
     UnexpectedTokenWithinNamespace(Token<'i>),
     /// An error was encountered while parsing a property value.
-    ValueError(ValueParseError<'i>),
+    ValueError(ValueParseErrorKind<'i>),
+}
+
+impl<'i> From<ValueParseErrorKind<'i>> for SelectorParseErrorKind<'i, StyleParseErrorKind<'i>> {
+    fn from(this: ValueParseErrorKind<'i>) -> Self {
+        StyleParseErrorKind::ValueError(this).into()
+    }
+}
+
+impl<'i> From<PropertyDeclarationParseErrorKind<'i>> for SelectorParseErrorKind<'i, StyleParseErrorKind<'i>> {
+    fn from(this: PropertyDeclarationParseErrorKind<'i>) -> Self {
+        StyleParseErrorKind::PropertyDeclaration(this).into()
+    }
 }
 
 /// Specific errors that can be encountered while parsing property values.
 #[derive(Clone, Debug, PartialEq)]
-pub enum ValueParseError<'i> {
+pub enum ValueParseErrorKind<'i> {
     /// An invalid token was encountered while parsing a color value.
     InvalidColor(Token<'i>),
     /// An invalid filter value was encountered.
     InvalidFilter(Token<'i>),
 }
 
-impl<'a> From<ValueParseError<'a>> for ParseError<'a> {
-    fn from(this: ValueParseError<'a>) -> Self {
-        StyleParseError::ValueError(this).into()
-    }
-}
-
-impl<'i> ValueParseError<'i> {
-    /// Attempt to extract a ValueParseError value from a ParseError.
-    pub fn from_parse_error(this: ParseError<'i>) -> Option<ValueParseError<'i>> {
-        match this {
-            cssparser::ParseError::Custom(
-                SelectorParseError::Custom(
-                    StyleParseError::ValueError(e))) => Some(e),
-            _ => None,
-        }
-    }
-}
-
 /// The result of parsing a property declaration.
 #[derive(Clone, Debug, PartialEq)]
-pub enum PropertyDeclarationParseError<'i> {
+pub enum PropertyDeclarationParseErrorKind<'i> {
     /// The property declaration was for an unknown property.
     UnknownProperty(CowRcStr<'i>),
     /// An unknown vendor-specific identifier was encountered.
@@ -169,7 +172,7 @@ pub enum PropertyDeclarationParseError<'i> {
     /// The property declaration was for a disabled experimental property.
     ExperimentalProperty,
     /// The property declaration contained an invalid value.
-    InvalidValue(CowRcStr<'i>, Option<ValueParseError<'i>>),
+    InvalidValue(CowRcStr<'i>, Option<ValueParseErrorKind<'i>>),
     /// The declaration contained an animation property, and we were parsing
     /// this as a keyframe block (so that property should be ignored).
     ///
@@ -179,15 +182,23 @@ pub enum PropertyDeclarationParseError<'i> {
     NotAllowedInPageRule,
 }
 
-impl<'a> From<StyleParseError<'a>> for ParseError<'a> {
-    fn from(this: StyleParseError<'a>) -> Self {
-        cssparser::ParseError::Custom(SelectorParseError::Custom(this))
-    }
-}
-
-impl<'a> From<PropertyDeclarationParseError<'a>> for ParseError<'a> {
-    fn from(this: PropertyDeclarationParseError<'a>) -> Self {
-        cssparser::ParseError::Custom(SelectorParseError::Custom(StyleParseError::PropertyDeclaration(this)))
+impl<'i> PropertyDeclarationParseErrorKind<'i> {
+    /// Create an InvalidValue parse error
+    pub fn new_invalid(name: CowRcStr<'i>, value_error: ParseError<'i>) -> PropertyDeclarationParseError<'i> {
+        cssparser::ParseError {
+            kind: cssparser::ParseErrorKind::Custom(PropertyDeclarationParseErrorKind::InvalidValue(
+                name,
+                match value_error.kind {
+                    cssparser::ParseErrorKind::Custom(
+                        SelectorParseErrorKind::Custom(
+                            StyleParseErrorKind::ValueError(e)
+                        )
+                    ) => Some(e),
+                    _ => None,
+                }
+            )),
+            location: value_error.location,
+        }
     }
 }
 

--- a/components/style_traits/viewport.rs
+++ b/components/style_traits/viewport.rs
@@ -5,7 +5,7 @@
 //! Helper types for the `@viewport` rule.
 
 use {CSSPixel, PinchZoomFactor, ParseError};
-use cssparser::{Parser, ToCss, ParseError as CssParseError, BasicParseError};
+use cssparser::{Parser, ToCss};
 use euclid::TypedSize2D;
 use std::ascii::AsciiExt;
 use std::fmt;
@@ -109,6 +109,7 @@ impl Zoom {
         use cssparser::Token;
         use values::specified::AllowedNumericType::NonNegative;
 
+        let location = input.current_source_location();
         match *input.next()? {
             // TODO: This parse() method should take ParserContext as an
             // argument, and pass ParsingMode owned by the ParserContext to
@@ -123,7 +124,7 @@ impl Zoom {
             Token::Ident(ref value) if value.eq_ignore_ascii_case("auto") => {
                 Ok(Zoom::Auto)
             }
-            ref t => Err(CssParseError::Basic(BasicParseError::UnexpectedToken(t.clone())))
+            ref t => Err(location.new_unexpected_token_error(t.clone()))
         }
     }
 

--- a/ports/geckolib/Cargo.toml
+++ b/ports/geckolib/Cargo.toml
@@ -15,7 +15,7 @@ gecko_debug = ["style/gecko_debug"]
 
 [dependencies]
 atomic_refcell = "0.1"
-cssparser = "0.21.1"
+cssparser = "0.22.0"
 env_logger = {version = "0.4", default-features = false} # disable `regex` to reduce code size
 libc = "0.2"
 log = {version = "0.3.5", features = ["release_max_level_info"]}

--- a/ports/geckolib/error_reporter.rs
+++ b/ports/geckolib/error_reporter.rs
@@ -18,7 +18,7 @@ use style::gecko_bindings::structs::ErrorReporter as GeckoErrorReporter;
 use style::gecko_bindings::structs::URLExtraData as RawUrlExtraData;
 use style::gecko_bindings::sugar::refptr::RefPtr;
 use style::stylesheets::UrlExtraData;
-use style_traits::{StyleParseErrorKind, PropertyDeclarationParseErrorKind};
+use style_traits::StyleParseErrorKind;
 
 pub type ErrorKind<'i> = ParseErrorKind<'i, StyleParseErrorKind<'i>>;
 
@@ -90,11 +90,7 @@ fn extract_error_param<'a>(err: ErrorKind<'a>) -> Option<ErrorString<'a>> {
             ErrorString::Snippet(s.into())
         }
 
-        ParseErrorKind::Custom(
-            StyleParseErrorKind::PropertyDeclaration(
-                PropertyDeclarationParseErrorKind::OtherInvalidValue(property)
-            )
-        ) => {
+        ParseErrorKind::Custom(StyleParseErrorKind::OtherInvalidValue(property)) => {
             ErrorString::Snippet(property)
         }
 
@@ -106,11 +102,7 @@ fn extract_error_param<'a>(err: ErrorKind<'a>) -> Option<ErrorString<'a>> {
             ErrorString::Ident(ident)
         }
 
-        ParseErrorKind::Custom(
-            StyleParseErrorKind::PropertyDeclaration(
-                PropertyDeclarationParseErrorKind::UnknownProperty(property)
-            )
-        ) => {
+        ParseErrorKind::Custom(StyleParseErrorKind::UnknownProperty(property)) => {
             ErrorString::Ident(property)
         }
 
@@ -133,16 +125,8 @@ struct ErrorParams<'a> {
 /// a second parameter if it exists, for use in the prefix for the eventual error message.
 fn extract_error_params<'a>(err: ErrorKind<'a>) -> Option<ErrorParams<'a>> {
     let (main, prefix) = match err {
-        ParseErrorKind::Custom(
-            StyleParseErrorKind::PropertyDeclaration(
-                PropertyDeclarationParseErrorKind::InvalidColor(property, token)
-            )
-        ) |
-        ParseErrorKind::Custom(
-            StyleParseErrorKind::PropertyDeclaration(
-                PropertyDeclarationParseErrorKind::InvalidFilter(property, token)
-            )
-        ) => {
+        ParseErrorKind::Custom(StyleParseErrorKind::InvalidColor(property, token)) |
+        ParseErrorKind::Custom(StyleParseErrorKind::InvalidFilter(property, token)) => {
             (Some(ErrorString::Snippet(property.into())), Some(ErrorString::UnexpectedToken(token)))
         }
 
@@ -247,20 +231,18 @@ impl<'a> ErrorHelpers<'a> for ContextualParseError<'a> {
                 (b"PEParseDeclarationDeclExpected\0", Action::Skip)
             }
             ContextualParseError::UnsupportedPropertyDeclaration(
-                _, ParseError { kind: ParseErrorKind::Custom(
-                    StyleParseErrorKind::PropertyDeclaration(ref err)
-                ), .. }
+                _, ParseError { kind: ParseErrorKind::Custom(ref err), .. }
             ) => {
                 match *err {
-                    PropertyDeclarationParseErrorKind::InvalidColor(_, _) => {
+                    StyleParseErrorKind::InvalidColor(_, _) => {
                         return (Some(b"PEColorNotColor\0"),
                                 b"PEValueParsingError\0", Action::Drop)
                     }
-                    PropertyDeclarationParseErrorKind::InvalidFilter(_, _) => {
+                    StyleParseErrorKind::InvalidFilter(_, _) => {
                         return (Some(b"PEExpectedNoneOrURLOrFilterFunction\0"),
                                 b"PEValueParsingError\0", Action::Drop)
                     }
-                    PropertyDeclarationParseErrorKind::OtherInvalidValue(_) => {
+                    StyleParseErrorKind::OtherInvalidValue(_) => {
                         (b"PEValueParsingError\0", Action::Drop)
                     }
                     _ => (b"PEUnknownProperty\0", Action::Drop)

--- a/tests/unit/gfx/Cargo.toml
+++ b/tests/unit/gfx/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
-cssparser = "0.21.1"
+cssparser = "0.22.0"
 gfx = {path = "../../../components/gfx"}
 ipc-channel = "0.8"
 style = {path = "../../../components/style"}

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 byteorder = "1.0"
 app_units = "0.5"
-cssparser = "0.21.1"
+cssparser = "0.22.0"
 euclid = "0.15"
 html5ever = "0.20"
 parking_lot = "0.4"

--- a/tests/unit/style/size_of.rs
+++ b/tests/unit/style/size_of.rs
@@ -15,11 +15,9 @@ size_of_test!(test_size_of_property_declaration, properties::PropertyDeclaration
 size_of_test!(test_size_of_parsed_declaration, properties::SourcePropertyDeclaration, 576);
 
 size_of_test!(test_size_of_selector_parse_error_kind, SelectorParseErrorKind, 40);
-size_of_test!(test_size_of_style_parse_error_kind, ::style_traits::StyleParseErrorKind, 64);
+size_of_test!(test_size_of_style_parse_error_kind, ::style_traits::StyleParseErrorKind, 56);
 size_of_test!(test_size_of_value_parse_error_kind, ::style_traits::ValueParseErrorKind, 40);
-size_of_test!(test_size_of_declaration_parse_error_kind, ::style_traits::PropertyDeclarationParseErrorKind, 56);
 
 size_of_test!(test_size_of_selector_parse_error, SelectorParseError, 56);
-size_of_test!(test_size_of_style_traits_parse_error, ::style_traits::ParseError, 80);
+size_of_test!(test_size_of_style_traits_parse_error, ::style_traits::ParseError, 72);
 size_of_test!(test_size_of_value_parse_error, ::style_traits::ValueParseError, 56);
-size_of_test!(test_size_of_declaration_parse_error, ::style_traits::PropertyDeclarationParseError, 72);

--- a/tests/unit/style/size_of.rs
+++ b/tests/unit/style/size_of.rs
@@ -15,11 +15,11 @@ size_of_test!(test_size_of_property_declaration, properties::PropertyDeclaration
 size_of_test!(test_size_of_parsed_declaration, properties::SourcePropertyDeclaration, 576);
 
 size_of_test!(test_size_of_selector_parse_error_kind, SelectorParseErrorKind, 40);
-size_of_test!(test_size_of_style_parse_error_kind, ::style_traits::StyleParseErrorKind, 80);
+size_of_test!(test_size_of_style_parse_error_kind, ::style_traits::StyleParseErrorKind, 64);
 size_of_test!(test_size_of_value_parse_error_kind, ::style_traits::ValueParseErrorKind, 40);
-size_of_test!(test_size_of_declaration_parse_error_kind, ::style_traits::PropertyDeclarationParseErrorKind, 72);
+size_of_test!(test_size_of_declaration_parse_error_kind, ::style_traits::PropertyDeclarationParseErrorKind, 56);
 
 size_of_test!(test_size_of_selector_parse_error, SelectorParseError, 56);
-size_of_test!(test_size_of_style_traits_parse_error, ::style_traits::ParseError, 96);
+size_of_test!(test_size_of_style_traits_parse_error, ::style_traits::ParseError, 80);
 size_of_test!(test_size_of_value_parse_error, ::style_traits::ValueParseError, 56);
-size_of_test!(test_size_of_declaration_parse_error, ::style_traits::PropertyDeclarationParseError, 88);
+size_of_test!(test_size_of_declaration_parse_error, ::style_traits::PropertyDeclarationParseError, 72);

--- a/tests/unit/style/size_of.rs
+++ b/tests/unit/style/size_of.rs
@@ -14,15 +14,12 @@ size_of_test!(test_size_of_property_declaration, properties::PropertyDeclaration
 // we only pass `&mut SourcePropertyDeclaration` references around.
 size_of_test!(test_size_of_parsed_declaration, properties::SourcePropertyDeclaration, 576);
 
-size_of_test!(test_size_of_selector_parse_error_kind_with_unit, SelectorParseErrorKind<()>, 40);
+size_of_test!(test_size_of_selector_parse_error_kind, SelectorParseErrorKind, 40);
 size_of_test!(test_size_of_style_parse_error_kind, ::style_traits::StyleParseErrorKind, 80);
 size_of_test!(test_size_of_value_parse_error_kind, ::style_traits::ValueParseErrorKind, 40);
 size_of_test!(test_size_of_declaration_parse_error_kind, ::style_traits::PropertyDeclarationParseErrorKind, 72);
-size_of_test!(test_size_of_style_traits_parse_error_kind,
-              SelectorParseErrorKind<::style_traits::StyleParseErrorKind>, 88);
 
-size_of_test!(test_size_of_selector_parse_error_with_unit, SelectorParseError<()>, 56);
-size_of_test!(test_size_of_style_parse_error, ::style_traits::StyleParseError, 96);
+size_of_test!(test_size_of_selector_parse_error, SelectorParseError, 56);
+size_of_test!(test_size_of_style_traits_parse_error, ::style_traits::ParseError, 96);
 size_of_test!(test_size_of_value_parse_error, ::style_traits::ValueParseError, 56);
 size_of_test!(test_size_of_declaration_parse_error, ::style_traits::PropertyDeclarationParseError, 88);
-size_of_test!(test_size_of_style_traits_parse_error, ::style_traits::ParseError, 104);

--- a/tests/unit/style/size_of.rs
+++ b/tests/unit/style/size_of.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use selectors::parser::SelectorParseError;
 use style::invalidation::element::invalidation_map::Dependency;
 use style::properties;
 
@@ -12,3 +13,9 @@ size_of_test!(test_size_of_property_declaration, properties::PropertyDeclaration
 // This is huge, but we allocate it on the stack and then never move it,
 // we only pass `&mut SourcePropertyDeclaration` references around.
 size_of_test!(test_size_of_parsed_declaration, properties::SourcePropertyDeclaration, 576);
+
+size_of_test!(test_size_of_selector_parse_error_with_unit, SelectorParseError<()>, 40);
+size_of_test!(test_size_of_style_parse_error, ::style_traits::StyleParseError, 80);
+size_of_test!(test_size_of_value_parse_error, ::style_traits::ValueParseError, 40);
+size_of_test!(test_size_of_declaration_parse_error, ::style_traits::PropertyDeclarationParseError, 72);
+size_of_test!(test_size_of_style_traits_parse_error, ::style_traits::ParseError, 96);

--- a/tests/unit/style/size_of.rs
+++ b/tests/unit/style/size_of.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use selectors::parser::SelectorParseError;
+use selectors::parser::{SelectorParseError, SelectorParseErrorKind};
 use style::invalidation::element::invalidation_map::Dependency;
 use style::properties;
 
@@ -14,8 +14,15 @@ size_of_test!(test_size_of_property_declaration, properties::PropertyDeclaration
 // we only pass `&mut SourcePropertyDeclaration` references around.
 size_of_test!(test_size_of_parsed_declaration, properties::SourcePropertyDeclaration, 576);
 
-size_of_test!(test_size_of_selector_parse_error_with_unit, SelectorParseError<()>, 40);
-size_of_test!(test_size_of_style_parse_error, ::style_traits::StyleParseError, 80);
-size_of_test!(test_size_of_value_parse_error, ::style_traits::ValueParseError, 40);
-size_of_test!(test_size_of_declaration_parse_error, ::style_traits::PropertyDeclarationParseError, 72);
-size_of_test!(test_size_of_style_traits_parse_error, ::style_traits::ParseError, 96);
+size_of_test!(test_size_of_selector_parse_error_kind_with_unit, SelectorParseErrorKind<()>, 40);
+size_of_test!(test_size_of_style_parse_error_kind, ::style_traits::StyleParseErrorKind, 80);
+size_of_test!(test_size_of_value_parse_error_kind, ::style_traits::ValueParseErrorKind, 40);
+size_of_test!(test_size_of_declaration_parse_error_kind, ::style_traits::PropertyDeclarationParseErrorKind, 72);
+size_of_test!(test_size_of_style_traits_parse_error_kind,
+              SelectorParseErrorKind<::style_traits::StyleParseErrorKind>, 88);
+
+size_of_test!(test_size_of_selector_parse_error_with_unit, SelectorParseError<()>, 56);
+size_of_test!(test_size_of_style_parse_error, ::style_traits::StyleParseError, 96);
+size_of_test!(test_size_of_value_parse_error, ::style_traits::ValueParseError, 56);
+size_of_test!(test_size_of_declaration_parse_error, ::style_traits::PropertyDeclarationParseError, 88);
+size_of_test!(test_size_of_style_traits_parse_error, ::style_traits::ParseError, 104);

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -324,13 +324,13 @@ fn test_report_error_stylesheet() {
         invalid: true;
     }
     @media (min-width: invalid 1000px) {}
-    @font-face { src: url(), invalid, url() }
+    @font-face { src: url(), invalid, url(); }
     @counter-style foo { symbols: a 0invalid b }
     @font-feature-values Sans Sans { @foo {} @swash { foo: 1 invalid 2 } }
     @invalid;
     @media screen { @invalid; }
     @supports (color: green) and invalid and (margin: 0) {}
-    @keyframes foo { from invalid {} to { margin: 0 invalid 0 } }
+    @keyframes foo { from invalid {} to { margin: 0 invalid 0; } }
     @viewport { width: 320px invalid auto; }
     ";
     let url = ServoUrl::parse("about::test").unwrap();
@@ -342,26 +342,26 @@ fn test_report_error_stylesheet() {
                          None, &error_reporter, QuirksMode::NoQuirks, 5);
 
     error_reporter.assert_messages_contain(&[
-        (8, 9, "Unsupported property declaration: 'display: invalid;'"),
-        (9, 9, "Unsupported property declaration: 'background-image:"),
-        (10, 9, "Unsupported property declaration: 'invalid: true;'"),
-        (12, 11, "Invalid media rule"),
-        (13, 18, "Unsupported @font-face descriptor declaration"),
+        (8, 26, "Unsupported property declaration: 'display: invalid;'"),
+        (9, 78, "Unsupported property declaration: 'background-image:"),
+        (10, 23, "Unsupported property declaration: 'invalid: true;'"),
+        (12, 40, "Invalid media rule"),
+        (13, 45, "Unsupported @font-face descriptor declaration"),
 
         // When @counter-style is supported, this should be replaced with two errors
-        (14, 5, "Invalid rule: '@counter-style "),
+        (14, 25, "Invalid rule: '@counter-style "),
 
         // When @font-feature-values is supported, this should be replaced with two errors
-        (15, 5, "Invalid rule: '@font-feature-values "),
+        (15, 37, "Invalid rule: '@font-feature-values "),
 
-        // FIXME: these two should be consistent
-        (16, 5, "Invalid rule: '@invalid'"),
-        (17, 21, "Unsupported rule: '@invalid'"),
+        // FIXME: the message of these two should be consistent
+        (16, 14, "Invalid rule: '@invalid'"),
+        (17, 30, "Unsupported rule: '@invalid'"),
 
-        (18, 5, "Invalid rule: '@supports "),
-        (19, 22, "Invalid keyframe rule: 'from invalid '"),
-        (19, 43, "Unsupported keyframe property declaration: 'margin: 0 invalid 0 '"),
-        (20, 17, "Unsupported @viewport descriptor declaration: 'width: 320px invalid auto;'"),
+        (18, 59, "Invalid rule: '@supports "),
+        (19, 35, "Invalid keyframe rule: 'from invalid '"),
+        (19, 63, "Unsupported keyframe property declaration: 'margin: 0 invalid 0;'"),
+        (20, 43, "Unsupported @viewport descriptor declaration: 'width: 320px invalid auto;'"),
     ]);
 
     assert_eq!(error_reporter.errors.borrow()[0].url, url);
@@ -385,7 +385,7 @@ fn test_no_report_unrecognized_vendor_properties() {
                          None, &error_reporter, QuirksMode::NoQuirks, 0);
 
     error_reporter.assert_messages_contain(&[
-        (4, 9, "Unsupported property declaration: '-moz-background-color: red;'"),
+        (4, 36, "Unsupported property declaration: '-moz-background-color: red;'"),
     ]);
 }
 

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -323,7 +323,7 @@ fn test_report_error_stylesheet() {
         background-image: linear-gradient(0deg, black, invalid, transparent);
         invalid: true;
     }
-    @media (min-width: invalid 1000px) {}
+    @media (min-width: 10px invalid 1000px) {}
     @font-face { src: url(), invalid, url(); }
     @counter-style foo { symbols: a 0invalid b }
     @font-feature-values Sans Sans { @foo {} @swash { foo: 1 invalid 2 } }
@@ -342,26 +342,26 @@ fn test_report_error_stylesheet() {
                          None, &error_reporter, QuirksMode::NoQuirks, 5);
 
     error_reporter.assert_messages_contain(&[
-        (8, 26, "Unsupported property declaration: 'display: invalid;'"),
-        (9, 78, "Unsupported property declaration: 'background-image:"),
-        (10, 23, "Unsupported property declaration: 'invalid: true;'"),
-        (12, 40, "Invalid media rule"),
-        (13, 45, "Unsupported @font-face descriptor declaration"),
+        (8, 18, "Unsupported property declaration: 'display: invalid;'"),
+        (9, 27, "Unsupported property declaration: 'background-image:"),  // FIXME: column should be around 56
+        (10, 17, "Unsupported property declaration: 'invalid: true;'"),
+        (12, 28, "Invalid media rule"),
+        (13, 30, "Unsupported @font-face descriptor declaration"),
 
         // When @counter-style is supported, this should be replaced with two errors
-        (14, 25, "Invalid rule: '@counter-style "),
+        (14, 19, "Invalid rule: '@counter-style "),
 
         // When @font-feature-values is supported, this should be replaced with two errors
-        (15, 37, "Invalid rule: '@font-feature-values "),
+        (15, 25, "Invalid rule: '@font-feature-values "),
 
         // FIXME: the message of these two should be consistent
-        (16, 14, "Invalid rule: '@invalid'"),
-        (17, 30, "Unsupported rule: '@invalid'"),
+        (16, 13, "Invalid rule: '@invalid'"),
+        (17, 29, "Unsupported rule: '@invalid'"),
 
-        (18, 59, "Invalid rule: '@supports "),
-        (19, 35, "Invalid keyframe rule: 'from invalid '"),
-        (19, 63, "Unsupported keyframe property declaration: 'margin: 0 invalid 0;'"),
-        (20, 43, "Unsupported @viewport descriptor declaration: 'width: 320px invalid auto;'"),
+        (18, 34, "Invalid rule: '@supports "),
+        (19, 26, "Invalid keyframe rule: 'from invalid '"),
+        (19, 52, "Unsupported keyframe property declaration: 'margin: 0 invalid 0;'"),
+        (20, 29, "Unsupported @viewport descriptor declaration: 'width: 320px invalid auto;'"),
     ]);
 
     assert_eq!(error_reporter.errors.borrow()[0].url, url);
@@ -385,7 +385,7 @@ fn test_no_report_unrecognized_vendor_properties() {
                          None, &error_reporter, QuirksMode::NoQuirks, 0);
 
     error_reporter.assert_messages_contain(&[
-        (4, 36, "Unsupported property declaration: '-moz-background-color: red;'"),
+        (4, 31, "Unsupported property declaration: '-moz-background-color: red;'"),
     ]);
 }
 

--- a/tests/unit/stylo/Cargo.toml
+++ b/tests/unit/stylo/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 
 [dependencies]
 atomic_refcell = "0.1"
-cssparser = "0.21.1"
+cssparser = "0.22.0"
 env_logger = "0.4"
 euclid = "0.15"
 geckoservo = {path = "../../../ports/geckolib"}


### PR DESCRIPTION
… rather than the start location of the current construct. This likely places the error just *after* of the unexpected token whereas before would be best, but that’s likely a much bigger change.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1378861

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18808)
<!-- Reviewable:end -->
