### PR TITLE
Remove cssText from CSSStyleValue

### DIFF
--- a/components/script/dom/cssstylevalue.rs
+++ b/components/script/dom/cssstylevalue.rs
@@ -38,14 +38,6 @@ impl CSSStyleValueMethods for CSSStyleValue {
     fn Stringifier(&self) -> DOMString {
         DOMString::from(&*self.value)
     }
-
-    /// This attribute is no longer part of the `CSSStyleValue` interface,
-    /// but is still used in some examples.
-    /// https://github.com/GoogleChrome/houdini-samples/issues/16
-    // check-tidy: no specs after this line
-    fn CssText(&self) -> DOMString {
-        self.Stringifier()
-    }
 }
 
 impl CSSStyleValue {

--- a/components/script/dom/webidls/CSSStyleValue.webidl
+++ b/components/script/dom/webidls/CSSStyleValue.webidl
@@ -7,8 +7,4 @@
 [Pref="dom.worklet.enabled", Exposed=(Worklet)]
 interface CSSStyleValue {
     stringifier;
-    // static CSSStyleValue? parse(DOMString property, DOMString cssText);
-    // static sequence<CSSStyleValue>? parseAll(DOMString property, DOMString cssText);
-    // This is a deprecated property, it's not in the spec any more but is used in houdini-samples
-    readonly attribute DOMString cssText;
 };


### PR DESCRIPTION
Removed from associated .rs and .webidl

<!-- Please describe your changes on the following line: -->
Not much more to add - let me know if it needs additional changes.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17379 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they remove a property that previously had no tests associated with it.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18838)
<!-- Reviewable:end -->
