### PR TITLE
Remove some usage of unstable features

### DIFF
--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
-#![feature(box_syntax)]
 #![feature(nonzero)]
 
 extern crate core;

--- a/components/constellation/lib.rs
+++ b/components/constellation/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
-#![feature(box_syntax)]
 #![feature(conservative_impl_trait)]
 #![feature(mpsc_select)]
 

--- a/components/constellation/network_listener.rs
+++ b/components/constellation/network_listener.rs
@@ -68,14 +68,14 @@ impl NetworkListener {
             }
         };
 
-        ROUTER.add_route(ipc_receiver.to_opaque(), box move |message| {
+        ROUTER.add_route(ipc_receiver.to_opaque(), Box::new(move |message| {
             let msg = message.to();
             match msg {
                 Ok(FetchResponseMsg::ProcessResponse(res)) => listener.check_redirect(res),
                 Ok(msg_) => listener.send(msg_),
                 Err(e) => warn!("Error while receiving network listener message: {}", e),
             };
-        });
+        }));
 
         if let Err(e) = self.resource_threads.sender().send(msg) {
             warn!("Resource thread unavailable ({})", e);

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -232,14 +232,14 @@ impl Pipeline {
                     let (script_to_devtools_chan, script_to_devtools_port) = ipc::channel()
                         .expect("Pipeline script to devtools chan");
                     let devtools_chan = (*devtools_chan).clone();
-                    ROUTER.add_route(script_to_devtools_port.to_opaque(), box move |message| {
+                    ROUTER.add_route(script_to_devtools_port.to_opaque(), Box::new(move |message| {
                         match message.to::<ScriptToDevtoolsControlMsg>() {
                             Err(e) => error!("Cast to ScriptToDevtoolsControlMsg failed ({}).", e),
                             Ok(message) => if let Err(e) = devtools_chan.send(DevtoolsControlMsg::FromScript(message)) {
                                 warn!("Sending to devtools failed ({})", e)
                             },
                         }
-                    });
+                    }));
                     script_to_devtools_chan
                 });
 

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -52,7 +52,7 @@ impl FramerateActor {
         };
 
         actor.start_recording();
-        registry.register_later(box actor);
+        registry.register_later(Box::new(actor));
         actor_name
     }
 

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -196,7 +196,7 @@ impl NodeInfoToProtocol for NodeInfo {
                 pipeline: pipeline.clone(),
             };
             actors.register_script_actor(self.uniqueId, name.clone());
-            actors.register_later(box node_actor);
+            actors.register_later(Box::new(node_actor));
             name
         } else {
             actors.script_to_actor(self.uniqueId)
@@ -558,7 +558,7 @@ impl Actor for InspectorActor {
                     };
                     let mut walker_name = self.walker.borrow_mut();
                     *walker_name = Some(walker.name());
-                    registry.register_later(box walker);
+                    registry.register_later(Box::new(walker));
                 }
 
                 let (tx, rx) = ipc::channel().unwrap();
@@ -587,7 +587,7 @@ impl Actor for InspectorActor {
                     };
                     let mut pageStyle = self.pageStyle.borrow_mut();
                     *pageStyle = Some(style.name());
-                    registry.register_later(box style);
+                    registry.register_later(Box::new(style));
                 }
 
                 let msg = GetPageStyleReply {
@@ -610,7 +610,7 @@ impl Actor for InspectorActor {
                     };
                     let mut highlighter = self.highlighter.borrow_mut();
                     *highlighter = Some(highlighter_actor.name());
-                    registry.register_later(box highlighter_actor);
+                    registry.register_later(Box::new(highlighter_actor));
                 }
 
                 let msg = GetHighlighterReply {

--- a/components/devtools/actors/memory.rs
+++ b/components/devtools/actors/memory.rs
@@ -45,7 +45,7 @@ impl MemoryActor {
             name: actor_name.clone()
         };
 
-        registry.register_later(box actor);
+        registry.register_later(Box::new(actor));
         actor_name
     }
 

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -34,7 +34,7 @@ impl ObjectActor {
             };
 
             registry.register_script_actor(uuid, name.clone());
-            registry.register_later(box actor);
+            registry.register_later(Box::new(actor));
 
             name
         } else {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -12,7 +12,6 @@
 
 #![allow(non_snake_case)]
 #![deny(unsafe_code)]
-#![feature(box_syntax)]
 
 extern crate devtools_traits;
 extern crate hyper;
@@ -143,9 +142,9 @@ fn run_server(sender: Sender<DevtoolsControlMsg>,
 
     let mut registry = ActorRegistry::new();
 
-    let root = box RootActor {
+    let root = Box::new(RootActor {
         tabs: vec!(),
-    };
+    });
 
     registry.register(root);
     registry.find::<RootActor>("root");
@@ -262,17 +261,17 @@ fn run_server(sender: Sender<DevtoolsControlMsg>,
                 id: id,
             };
             actor_workers.insert((pipeline, id), worker.name.clone());
-            actors.register(box worker);
+            actors.register(Box::new(worker));
         }
 
         actor_pipelines.insert(pipeline, tab.name.clone());
-        actors.register(box tab);
-        actors.register(box console);
-        actors.register(box inspector);
-        actors.register(box timeline);
-        actors.register(box profiler);
-        actors.register(box performance);
-        actors.register(box thread);
+        actors.register(Box::new(tab));
+        actors.register(Box::new(console));
+        actors.register(Box::new(inspector));
+        actors.register(Box::new(timeline));
+        actors.register(Box::new(profiler));
+        actors.register(Box::new(performance));
+        actors.register(Box::new(thread));
     }
 
     fn handle_console_message(actors: Arc<Mutex<ActorRegistry>>,
@@ -467,7 +466,7 @@ fn run_server(sender: Sender<DevtoolsControlMsg>,
                 let actor_name = actors.new_name("netevent");
                 let actor = NetworkEventActor::new(actor_name.clone());
                 entry.insert(actor_name.clone());
-                actors.register(box actor);
+                actors.register(Box::new(actor));
                 actor_name
             }
         }

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -586,10 +586,10 @@ pub struct ClipScrollNode {
 
 impl ClipScrollNode {
     pub fn to_define_item(&self, pipeline_id: PipelineId) -> DisplayItem {
-        DisplayItem::DefineClipScrollNode(box DefineClipScrollNodeItem {
+        DisplayItem::DefineClipScrollNode(Box::new(DefineClipScrollNodeItem {
             base: BaseDisplayItem::empty(pipeline_id),
             node: self.clone(),
-        })
+        }))
     }
 }
 

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -4,7 +4,6 @@
 
 // For SIMD
 #![cfg_attr(any(target_os = "linux", target_os = "android"), feature(allocator_api))]
-#![feature(box_syntax)]
 #![feature(cfg_target_feature)]
 
 #![deny(unsafe_code)]

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -6,7 +6,6 @@
 #![cfg_attr(any(target_os = "linux", target_os = "android"), feature(allocator_api))]
 #![feature(box_syntax)]
 #![feature(cfg_target_feature)]
-#![feature(range_contains)]
 
 #![deny(unsafe_code)]
 

--- a/components/gfx/platform/freetype/font_context.rs
+++ b/components/gfx/platform/freetype/font_context.rs
@@ -118,15 +118,15 @@ impl HeapSizeOf for FontContextHandle {
 
 impl FontContextHandle {
     pub fn new() -> FontContextHandle {
-        let user = Box::into_raw(box User {
+        let user = Box::into_raw(Box::new(User {
             size: 0,
-        });
-        let mem = Box::into_raw(box FT_MemoryRec_ {
+        }));
+        let mem = Box::into_raw(Box::new(FT_MemoryRec_ {
             user: user as *mut c_void,
             alloc: Some(ft_alloc),
             free: Some(ft_free),
             realloc: Some(ft_realloc),
-        });
+        }));
         unsafe {
             let mut ctx: FT_Library = ptr::null_mut();
 

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -509,7 +509,7 @@ extern fn font_table_func(_: *mut hb_face_t,
                 // `Box::into_raw` intentionally leaks the FontTable so we don't destroy the buffer
                 // while HarfBuzz is using it.  When HarfBuzz is done with the buffer, it will pass
                 // this raw pointer back to `destroy_blob_func` which will deallocate the Box.
-                let font_table_ptr = Box::into_raw(box font_table);
+                let font_table_ptr = Box::into_raw(Box::new(font_table));
 
                 let buf = (*font_table_ptr).buffer();
                 // HarfBuzz calls `destroy_blob_func` when the buffer is no longer needed.

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -306,8 +306,8 @@ impl Shaper {
                 // have found a contiguous "cluster" and can stop extending it.
                 let mut all_glyphs_are_within_cluster: bool = true;
                 for j in glyph_span.clone() {
-                    let loc = glyph_data.byte_offset_of_glyph(j);
-                    if !byte_range.contains(loc as usize) {
+                    let loc = glyph_data.byte_offset_of_glyph(j) as usize;
+                    if !(byte_range.start <= loc && loc < byte_range.end) {
                         all_glyphs_are_within_cluster = false;
                         break
                     }

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -537,7 +537,7 @@ impl BlockFlow {
                 None => ForceNonfloatedFlag::ForceNonfloated,
             }),
             fragment: fragment,
-            float: float_kind.map(|kind| box FloatedBlockInfo::new(kind)),
+            float: float_kind.map(|kind| Box::new(FloatedBlockInfo::new(kind))),
             flags: BlockFlowFlags::empty(),
         }
     }

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -348,15 +348,15 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                 SpecificFragmentInfo::Iframe(IframeFragmentInfo::new(node))
             }
             Some(LayoutNodeType::Element(LayoutElementType::HTMLImageElement)) => {
-                let image_info = box ImageFragmentInfo::new(node.image_url(),
-                                                            node,
-                                                            &self.layout_context);
+                let image_info = Box::new(ImageFragmentInfo::new(
+                    node.image_url(), node, &self.layout_context
+                ));
                 SpecificFragmentInfo::Image(image_info)
             }
             Some(LayoutNodeType::Element(LayoutElementType::HTMLObjectElement)) => {
-                let image_info = box ImageFragmentInfo::new(node.object_data(),
-                                                            node,
-                                                            &self.layout_context);
+                let image_info = Box::new(ImageFragmentInfo::new(
+                    node.object_data(), node, &self.layout_context
+                 ));
                 SpecificFragmentInfo::Image(image_info)
             }
             Some(LayoutNodeType::Element(LayoutElementType::HTMLTableElement)) => {
@@ -374,11 +374,11 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
             }
             Some(LayoutNodeType::Element(LayoutElementType::HTMLCanvasElement)) => {
                 let data = node.canvas_data().unwrap();
-                SpecificFragmentInfo::Canvas(box CanvasFragmentInfo::new(data))
+                SpecificFragmentInfo::Canvas(Box::new(CanvasFragmentInfo::new(data)))
             }
             Some(LayoutNodeType::Element(LayoutElementType::SVGSVGElement)) => {
                 let data = node.svg_data().unwrap();
-                SpecificFragmentInfo::Svg(box SvgFragmentInfo::new(data))
+                SpecificFragmentInfo::Svg(Box::new(SvgFragmentInfo::new(data)))
             }
             _ => {
                 // This includes pseudo-elements.
@@ -553,7 +553,8 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                 // Add whitespace results. They will be stripped out later on when
                 // between block elements, and retained when between inline elements.
                 let fragment_info = SpecificFragmentInfo::UnscannedText(
-                    box UnscannedTextFragmentInfo::new(" ".to_owned(), None));
+                    Box::new(UnscannedTextFragmentInfo::new(" ".to_owned(), None))
+                );
                 let fragment = Fragment::from_opaque_node_and_style(whitespace_node,
                                                                     whitespace_pseudo,
                                                                     whitespace_style,
@@ -686,7 +687,7 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
 
         match text_content {
             TextContent::Text(string) => {
-                let info = box UnscannedTextFragmentInfo::new(string, node.selection());
+                let info = Box::new(UnscannedTextFragmentInfo::new(string, node.selection()));
                 let specific_fragment_info = SpecificFragmentInfo::UnscannedText(info);
                 fragments.fragments.push_back(Fragment::from_opaque_node_and_style(
                         node.opaque(),
@@ -700,11 +701,11 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                 for content_item in content_items.into_iter() {
                     let specific_fragment_info = match content_item {
                         ContentItem::String(string) => {
-                            let info = box UnscannedTextFragmentInfo::new(string, None);
+                            let info = Box::new(UnscannedTextFragmentInfo::new(string, None));
                             SpecificFragmentInfo::UnscannedText(info)
                         }
                         content_item => {
-                            let content_item = box GeneratedContentInfo::ContentItem(content_item);
+                            let content_item = Box::new(GeneratedContentInfo::ContentItem(content_item));
                             SpecificFragmentInfo::GeneratedContent(content_item)
                         }
                     };
@@ -821,7 +822,8 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                         whitespace_damage)) => {
                     // Instantiate the whitespace fragment.
                     let fragment_info = SpecificFragmentInfo::UnscannedText(
-                        box UnscannedTextFragmentInfo::new(" ".to_owned(), None));
+                        Box::new(UnscannedTextFragmentInfo::new(" ".to_owned(), None))
+                    );
                     let fragment =
                         Fragment::from_opaque_node_and_style(whitespace_node,
                                                              whitespace_pseudo,
@@ -842,7 +844,8 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
         if is_empty && node_style.has_padding_or_border() {
             // An empty inline box needs at least one fragment to draw its background and borders.
             let info = SpecificFragmentInfo::UnscannedText(
-                box UnscannedTextFragmentInfo::new(String::new(), None));
+                Box::new(UnscannedTextFragmentInfo::new(String::new(), None))
+            );
             let fragment = Fragment::from_opaque_node_and_style(node.opaque(),
                                                                 node.get_pseudo_element_type().strip(),
                                                                 node_style.clone(),
@@ -1199,9 +1202,9 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
         let flotation = FloatKind::from_property(flotation);
         let marker_fragments = match node.style(self.style_context()).get_list().list_style_image {
             list_style_image::computed_value::T(Either::First(ref url_value)) => {
-                let image_info = box ImageFragmentInfo::new(url_value.url().map(|u| u.clone()),
-                                                            node,
-                                                            &self.layout_context);
+                let image_info = Box::new(ImageFragmentInfo::new(
+                    url_value.url().map(|u| u.clone()), node, &self.layout_context
+                ));
                 vec![Fragment::new(node, SpecificFragmentInfo::Image(image_info), self.layout_context)]
             }
             list_style_image::computed_value::T(Either::Second(_none)) => {
@@ -1215,7 +1218,8 @@ impl<'a, ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode>
                         unscanned_marker_fragments.push_back(Fragment::new(
                             node,
                             SpecificFragmentInfo::UnscannedText(
-                                box UnscannedTextFragmentInfo::new(text, None)),
+                                Box::new(UnscannedTextFragmentInfo::new(text, None))
+                            ),
                             self.layout_context));
                         let marker_fragments =
                             with_thread_local_font_context(self.layout_context, |mut font_context| {
@@ -1825,7 +1829,8 @@ fn control_chars_to_fragment(node: &InlineFragmentNodeInfo,
                              restyle_damage: RestyleDamage)
                              -> Fragment {
     let info = SpecificFragmentInfo::UnscannedText(
-        box UnscannedTextFragmentInfo::new(String::from(text), None));
+        Box::new(UnscannedTextFragmentInfo::new(String::from(text), None))
+    );
     let text_style = context.stylist.style_for_anonymous(
         &context.guards, &PseudoElement::ServoText, &node.style);
     Fragment::from_opaque_node_and_style(node.address,

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -986,10 +986,10 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   style.get_cursor(Cursor::Default),
                                                   display_list_section);
         state.add_display_item(
-            DisplayItem::SolidColor(box SolidColorDisplayItem {
+            DisplayItem::SolidColor(Box::new(SolidColorDisplayItem {
                 base: base,
                 color: background_color.to_gfx_color(),
-            }));
+            })));
 
         // The background image is painted on top of the background color.
         // Implements background image, per spec:
@@ -1231,14 +1231,14 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   display_list_section);
 
         debug!("(building display list) adding background image.");
-        state.add_display_item(DisplayItem::Image(box ImageDisplayItem {
+        state.add_display_item(DisplayItem::Image(Box::new(ImageDisplayItem {
             base: base,
             webrender_image: webrender_image,
             image_data: None,
             stretch_size: stretch_size,
             tile_spacing: tile_spacing,
             image_rendering: style.get_inheritedbox().image_rendering.clone(),
-        }));
+        })));
 
     }
 
@@ -1430,10 +1430,10 @@ impl FragmentDisplayListBuilding for Fragment {
                                                             &gradient.items[..],
                                                             angle_or_corner,
                                                             gradient.repeating);
-                DisplayItem::Gradient(box GradientDisplayItem {
+                DisplayItem::Gradient(Box::new(GradientDisplayItem {
                     base: base,
                     gradient: gradient,
-                })
+                }))
             }
             GradientKind::Radial(ref shape, ref center, _angle) => {
                 let gradient = self.convert_radial_gradient(&bounds,
@@ -1441,10 +1441,10 @@ impl FragmentDisplayListBuilding for Fragment {
                                                             shape,
                                                             center,
                                                             gradient.repeating);
-                DisplayItem::RadialGradient(box RadialGradientDisplayItem {
+                DisplayItem::RadialGradient(Box::new(RadialGradientDisplayItem {
                     base: base,
                     gradient: gradient,
-                })
+                }))
             }
         };
         state.add_display_item(display_item);
@@ -1473,7 +1473,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                       self.node,
                                                       style.get_cursor(Cursor::Default),
                                                       display_list_section);
-            state.add_display_item(DisplayItem::BoxShadow(box BoxShadowDisplayItem {
+            state.add_display_item(DisplayItem::BoxShadow(Box::new(BoxShadowDisplayItem {
                 base: base,
                 box_bounds: *absolute_bounds,
                 color: box_shadow.base.color.unwrap_or(style.get_color().color).to_gfx_color(),
@@ -1489,7 +1489,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 } else {
                     BoxShadowClipMode::Outset
                 },
-            }));
+            })));
         }
     }
 
@@ -1557,7 +1557,7 @@ impl FragmentDisplayListBuilding for Fragment {
 
         match border_style_struct.border_image_source {
             Either::First(_) => {
-                state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
+                state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
                     base: base,
                     border_widths: border.to_physical(style.writing_mode),
                     details: BorderDetails::Normal(NormalBorder {
@@ -1568,7 +1568,7 @@ impl FragmentDisplayListBuilding for Fragment {
                         style: border_style,
                         radius: build_border_radius(&bounds, border_style_struct),
                     }),
-                }));
+                })));
             }
             Either::Second(Image::Gradient(ref gradient)) => {
                 match gradient.kind {
@@ -1578,7 +1578,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                                 &angle_or_corner,
                                                                 gradient.repeating);
 
-                        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
+                        state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
                             base: base,
                             border_widths: border.to_physical(style.writing_mode),
                             details: BorderDetails::Gradient(display_list::GradientBorder {
@@ -1587,7 +1587,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                 // TODO(gw): Support border-image-outset
                                 outset: SideOffsets2D::zero(),
                             }),
-                        }));
+                        })));
                     }
                     GradientKind::Radial(ref shape, ref center, _angle) => {
                         let grad = self.convert_radial_gradient(&bounds,
@@ -1595,7 +1595,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                                 shape,
                                                                 center,
                                                                 gradient.repeating);
-                        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
+                        state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
                             base: base,
                             border_widths: border.to_physical(style.writing_mode),
                             details: BorderDetails::RadialGradient(
@@ -1605,7 +1605,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                     // TODO(gw): Support border-image-outset
                                     outset: SideOffsets2D::zero(),
                                 }),
-                        }));
+                        })));
                     }
                 }
             }
@@ -1619,7 +1619,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 if let Some(webrender_image) = webrender_image {
                     let corners = &border_style_struct.border_image_slice.offsets;
 
-                    state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
+                    state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
                         base: base,
                         border_widths: border.to_physical(style.writing_mode),
                         details: BorderDetails::Image(ImageBorder {
@@ -1634,7 +1634,7 @@ impl FragmentDisplayListBuilding for Fragment {
                             repeat_horizontal: convert_repeat_mode(border_style_struct.border_image_repeat.0),
                             repeat_vertical: convert_repeat_mode(border_style_struct.border_image_repeat.1),
                         }),
-                    }));
+                    })));
                 }
             }
             Either::Second(Image::Rect(..)) => {
@@ -1652,7 +1652,7 @@ impl FragmentDisplayListBuilding for Fragment {
                     if let Some(webrender_image) = webrender_image {
                         let corners = &border_style_struct.border_image_slice.offsets;
 
-                        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
+                        state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
                             base: base,
                             border_widths: border.to_physical(style.writing_mode),
                             details: BorderDetails::Image(ImageBorder {
@@ -1667,7 +1667,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                 repeat_horizontal: convert_repeat_mode(border_style_struct.border_image_repeat.0),
                                 repeat_vertical: convert_repeat_mode(border_style_struct.border_image_repeat.1),
                             }),
-                        }));
+                        })));
                     }
                 }
             }
@@ -1708,7 +1708,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   style.get_cursor(Cursor::Default),
                                                   DisplayListSection::Outlines);
-        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
+        state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(width),
             details: BorderDetails::Normal(NormalBorder {
@@ -1716,7 +1716,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 style: SideOffsets2D::new_all_same(outline_style),
                 radius: Default::default(),
             }),
-        }));
+        })));
     }
 
     fn build_debug_borders_around_text_fragments(&self,
@@ -1735,7 +1735,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   style.get_cursor(Cursor::Default),
                                                   DisplayListSection::Content);
-        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
+        state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
             details: BorderDetails::Normal(NormalBorder {
@@ -1743,7 +1743,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 style: SideOffsets2D::new_all_same(border_style::T::solid),
                 radius: Default::default(),
             }),
-        }));
+        })));
 
         // Draw a rectangle representing the baselines.
         let mut baseline = LogicalRect::from_physical(self.style.writing_mode,
@@ -1758,11 +1758,11 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   style.get_cursor(Cursor::Default),
                                                   DisplayListSection::Content);
-        state.add_display_item(DisplayItem::Line(box LineDisplayItem {
+        state.add_display_item(DisplayItem::Line(Box::new(LineDisplayItem {
             base: base,
             color: ColorF::rgb(0, 200, 0),
             style: LineStyle::Dashed,
-        }));
+        })));
     }
 
     fn build_debug_borders_around_fragment(&self,
@@ -1775,7 +1775,7 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   self.style.get_cursor(Cursor::Default),
                                                   DisplayListSection::Content);
-        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
+        state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
             details: BorderDetails::Normal(NormalBorder {
@@ -1783,7 +1783,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 style: SideOffsets2D::new_all_same(border_style::T::solid),
                 radius: Default::default(),
             }),
-        }));
+        })));
     }
 
     fn build_display_items_for_selection_if_necessary(&self,
@@ -1810,10 +1810,11 @@ impl FragmentDisplayListBuilding for Fragment {
                                                       self.style.get_cursor(Cursor::Default),
                                                       display_list_section);
             state.add_display_item(
-                DisplayItem::SolidColor(box SolidColorDisplayItem {
+                DisplayItem::SolidColor(Box::new(SolidColorDisplayItem {
                     base: base,
                     color: background_color.to_gfx_color(),
-            }));
+                }))
+            );
         }
 
         // Draw a caret at the insertion point.
@@ -1848,10 +1849,10 @@ impl FragmentDisplayListBuilding for Fragment {
                                                   self.node,
                                                   self.style.get_cursor(cursor),
                                                   display_list_section);
-        state.add_display_item(DisplayItem::SolidColor(box SolidColorDisplayItem {
+        state.add_display_item(DisplayItem::SolidColor(Box::new(SolidColorDisplayItem {
             base: base,
             color: self.style().get_color().color.to_gfx_color(),
-        }));
+        })));
     }
 
     fn build_display_list(&mut self,
@@ -2068,10 +2069,10 @@ impl FragmentDisplayListBuilding for Fragment {
                         self.node,
                         self.style.get_cursor(Cursor::Default),
                         DisplayListSection::Content);
-                    let item = DisplayItem::Iframe(box IframeDisplayItem {
+                    let item = DisplayItem::Iframe(Box::new(IframeDisplayItem {
                         base: base,
                         iframe: pipeline_id,
-                    });
+                    }));
 
                     let size = Size2D::new(item.bounds().size.width.to_f32_px(),
                                            item.bounds().size.height.to_f32_px());
@@ -2090,14 +2091,14 @@ impl FragmentDisplayListBuilding for Fragment {
                         self.node,
                         self.style.get_cursor(Cursor::Default),
                         DisplayListSection::Content);
-                    state.add_display_item(DisplayItem::Image(box ImageDisplayItem {
+                    state.add_display_item(DisplayItem::Image(Box::new(ImageDisplayItem {
                         base: base,
                         webrender_image: WebRenderImageInfo::from_image(image),
                         image_data: Some(Arc::new(image.bytes.clone())),
                         stretch_size: stacking_relative_content_box.size,
                         tile_spacing: Size2D::zero(),
                         image_rendering: self.style.get_inheritedbox().image_rendering.clone(),
-                    }));
+                    })));
                 }
             }
             SpecificFragmentInfo::Canvas(ref canvas_fragment_info) => {
@@ -2128,7 +2129,7 @@ impl FragmentDisplayListBuilding for Fragment {
                     self.node,
                     self.style.get_cursor(Cursor::Default),
                     DisplayListSection::Content);
-                let display_item = DisplayItem::Image(box ImageDisplayItem {
+                let display_item = DisplayItem::Image(Box::new(ImageDisplayItem {
                     base: base,
                     webrender_image: WebRenderImageInfo {
                         width: computed_width as u32,
@@ -2140,7 +2141,7 @@ impl FragmentDisplayListBuilding for Fragment {
                     stretch_size: stacking_relative_content_box.size,
                     tile_spacing: Size2D::zero(),
                     image_rendering: image_rendering::T::auto,
-                });
+                }));
 
                 state.add_display_item(display_item);
             }
@@ -2249,12 +2250,12 @@ impl FragmentDisplayListBuilding for Fragment {
 
         // Shadows
         for shadow in text_shadows.iter().rev() {
-            state.add_display_item(DisplayItem::PushTextShadow(box PushTextShadowDisplayItem {
+            state.add_display_item(DisplayItem::PushTextShadow(Box::new(PushTextShadowDisplayItem {
                 base: base.clone(),
                 blur_radius: Au::from(shadow.blur),
                 offset: Vector2D::new(Au::from(shadow.horizontal), Au::from(shadow.vertical)),
                 color: shadow.color.unwrap_or(self.style().get_color().color).to_gfx_color(),
-            }));
+            })));
         }
 
 
@@ -2296,14 +2297,14 @@ impl FragmentDisplayListBuilding for Fragment {
         }
 
         // Text
-        state.add_display_item(DisplayItem::Text(box TextDisplayItem {
+        state.add_display_item(DisplayItem::Text(Box::new(TextDisplayItem {
             base: base.clone(),
             text_run: text_fragment.run.clone(),
             range: text_fragment.range,
             text_color: text_color.to_gfx_color(),
             orientation: orientation,
             baseline_origin: baseline_origin,
-        }));
+        })));
 
 
         // TODO(#17715): emit text-emphasis marks here.
@@ -2326,9 +2327,9 @@ impl FragmentDisplayListBuilding for Fragment {
 
         // Pair all the PushTextShadows
         for _ in text_shadows {
-            state.add_display_item(DisplayItem::PopTextShadow(box PopTextShadowDisplayItem {
+            state.add_display_item(DisplayItem::PopTextShadow(Box::new(PopTextShadowDisplayItem {
                 base: base.clone(),
-            }));
+            })));
         }
     }
 
@@ -2348,11 +2349,11 @@ impl FragmentDisplayListBuilding for Fragment {
             self.style.get_cursor(Cursor::Default),
             DisplayListSection::Content);
 
-        state.add_display_item(DisplayItem::Line(box LineDisplayItem {
+        state.add_display_item(DisplayItem::Line(Box::new(LineDisplayItem {
             base: base,
             color: color.to_gfx_color(),
             style: LineStyle::Solid,
-        }));
+        })));
     }
 
     fn unique_id(&self, id_type: IdType) -> u64 {
@@ -3110,7 +3111,7 @@ impl BaseFlowDisplayListBuilding for BaseFlow {
             node,
             None,
             DisplayListSection::Content);
-        state.add_display_item(DisplayItem::Border(box BorderDisplayItem {
+        state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(2)),
             details: BorderDetails::Normal(NormalBorder {
@@ -3118,7 +3119,7 @@ impl BaseFlowDisplayListBuilding for BaseFlow {
                 style: SideOffsets2D::new_all_same(border_style::T::solid),
                 radius: BorderRadii::all_same(Au(0)),
             }),
-        }));
+        })));
     }
 }
 

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -790,12 +790,13 @@ impl Fragment {
             },
             _ => (ScannedTextFlags::empty(), None)
         };
-        let info = box ScannedTextFragmentInfo::new(
+        let info = Box::new(ScannedTextFragmentInfo::new(
             text_run,
             split.range,
             size,
             insertion_point,
-            flags);
+            flags,
+        ));
         self.transform(size, SpecificFragmentInfo::ScannedText(info))
     }
 
@@ -808,7 +809,9 @@ impl Fragment {
         let mut ellipsis_fragment = self.transform(
             self.border_box.size,
             SpecificFragmentInfo::UnscannedText(
-                box UnscannedTextFragmentInfo::new(text_overflow_string, None)));
+                Box::new(UnscannedTextFragmentInfo::new(text_overflow_string, None))
+            )
+        );
         unscanned_ellipsis_fragments.push_back(ellipsis_fragment);
         let ellipsis_fragments = with_thread_local_font_context(layout_context, |font_context| {
             TextRunScanner::new().scan_for_runs(font_context, unscanned_ellipsis_fragments)
@@ -1706,10 +1709,10 @@ impl Fragment {
                 (LogicalSize::zero(self.style.writing_mode), None)
         };
         let mut result = self.transform(size, SpecificFragmentInfo::Generic);
-        result.specific = SpecificFragmentInfo::TruncatedFragment(box TruncatedFragmentInfo {
+        result.specific = SpecificFragmentInfo::TruncatedFragment(Box::new(TruncatedFragmentInfo {
             text_info: text_info,
             full: self,
-        });
+        }));
         result
     }
 

--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -248,7 +248,7 @@ impl<'a, 'b> ResolveGeneratedContentFragmentMutator<'a, 'b> {
             // so that it isn't processed again on the next layout.  FIXME (mbrubeck): When
             // processing an inline flow, this traversal should be allowed to insert or remove
             // fragments.  Then we can just remove these fragments rather than adding placeholders.
-            None => SpecificFragmentInfo::GeneratedContent(box GeneratedContentInfo::Empty)
+            None => SpecificFragmentInfo::GeneratedContent(Box::new(GeneratedContentInfo::Empty))
         };
     }
 
@@ -436,7 +436,8 @@ fn render_text(layout_context: &LayoutContext,
                -> Option<SpecificFragmentInfo> {
     let mut fragments = LinkedList::new();
     let info = SpecificFragmentInfo::UnscannedText(
-        box UnscannedTextFragmentInfo::new(string, None));
+        Box::new(UnscannedTextFragmentInfo::new(string, None))
+    );
     fragments.push_back(Fragment::from_opaque_node_and_style(node,
                                                              pseudo,
                                                              style.clone(),

--- a/components/layout/layout_debug.rs
+++ b/components/layout/layout_debug.rs
@@ -64,7 +64,7 @@ impl Scope {
         STATE_KEY.with(|ref r| {
             if let Some(ref mut state) = *r.borrow_mut() {
                 let flow_trace = to_value(&flow::base(&*state.flow_root)).unwrap();
-                let data = box ScopeData::new(name.clone(), flow_trace);
+                let data = Box::new(ScopeData::new(name.clone(), flow_trace));
                 state.scope_stack.push(data);
             }
         });
@@ -102,7 +102,7 @@ pub fn begin_trace(flow_root: FlowRef) {
     STATE_KEY.with(|ref r| {
         let flow_trace = to_value(&flow::base(&*flow_root)).unwrap();
         let state = State {
-            scope_stack: vec![box ScopeData::new("root".to_owned(), flow_trace)],
+            scope_stack: vec![Box::new(ScopeData::new("root".to_owned(), flow_trace))],
             flow_root: flow_root.clone(),
         };
         *r.borrow_mut() = Some(state);

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -4,7 +4,6 @@
 
 #![deny(unsafe_code)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(conservative_impl_trait)]
 #![feature(nonzero)]
 #![feature(raw)]

--- a/components/layout/list_item.rs
+++ b/components/layout/list_item.rs
@@ -235,7 +235,7 @@ impl ListStyleTypeContent {
                 let text = generated_content::static_representation(list_style_type);
                 ListStyleTypeContent::StaticText(text)
             }
-            _ => ListStyleTypeContent::GeneratedContent(box GeneratedContentInfo::ListItem),
+            _ => ListStyleTypeContent::GeneratedContent(Box::new(GeneratedContentInfo::ListItem)),
         }
     }
 }

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -377,12 +377,13 @@ impl TextRunScanner {
                     None
                 };
 
-                let mut new_text_fragment_info = box ScannedTextFragmentInfo::new(
+                let mut new_text_fragment_info = Box::new(ScannedTextFragmentInfo::new(
                     scanned_run.run,
                     byte_range,
                     text_size,
                     insertion_point,
-                    flags);
+                    flags
+                ));
 
                 let new_metrics = new_text_fragment_info.run.metrics_for_range(&byte_range);
                 let writing_mode = old_fragment.style.writing_mode;
@@ -506,10 +507,12 @@ fn split_first_fragment_at_newline_if_necessary(fragments: &mut LinkedList<Fragm
                 }
             };
         }
-        first_fragment.transform(first_fragment.border_box.size,
-                                 SpecificFragmentInfo::UnscannedText(
-                                     box UnscannedTextFragmentInfo::new(string_before,
-                                                                        selection_before)))
+        first_fragment.transform(
+            first_fragment.border_box.size,
+            SpecificFragmentInfo::UnscannedText(Box::new(
+                UnscannedTextFragmentInfo::new(string_before, selection_before)
+            ))
+        )
     };
 
     fragments.push_front(new_fragment);

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -5,7 +5,6 @@
 //! The layout thread. Performs layout on the DOM, builds display lists and sends them to be
 //! painted.
 
-#![feature(box_syntax)]
 #![feature(mpsc_select)]
 #![feature(nonzero)]
 
@@ -689,8 +688,9 @@ impl LayoutThread {
             }
             Msg::SetQuirksMode(mode) => self.handle_set_quirks_mode(mode),
             Msg::GetRPC(response_chan) => {
-                response_chan.send(box LayoutRPCImpl(self.rw_data.clone()) as
-                                   Box<LayoutRPC + Send>).unwrap();
+                response_chan.send(
+                    Box::new(LayoutRPCImpl(self.rw_data.clone())) as Box<LayoutRPC + Send>
+                ).unwrap();
             },
             Msg::Reflow(data) => {
                 let mut data = ScriptReflowResult::new(data);

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -109,7 +109,8 @@ fn is_image_opaque(format: webrender_api::ImageFormat, bytes: &[u8]) -> bool {
 fn premultiply(data: &mut [u8]) {
     let length = data.len();
 
-    for i in Iterator::step_by(0..length, 4) {
+    let mut i = 0;
+    while i < length {
         let b = data[i + 0] as u32;
         let g = data[i + 1] as u32;
         let r = data[i + 2] as u32;
@@ -118,6 +119,8 @@ fn premultiply(data: &mut [u8]) {
         data[i + 0] = (b * a / 255) as u8;
         data[i + 1] = (g * a / 255) as u8;
         data[i + 2] = (r * a / 255) as u8;
+
+        i += 4;
     }
 }
 

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
-#![feature(box_syntax)]
 
 extern crate base64;
 extern crate brotli;

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -4,7 +4,6 @@
 
 #![deny(unsafe_code)]
 #![feature(box_syntax)]
-#![feature(iterator_step_by)]
 
 extern crate base64;
 extern crate brotli;

--- a/components/net/mime_classifier.rs
+++ b/components/net/mime_classifier.rs
@@ -454,73 +454,73 @@ impl GroupedClassifier {
     fn image_classifer() -> GroupedClassifier {
         GroupedClassifier {
             byte_matchers: vec![
-                box ByteMatcher::image_x_icon(),
-                box ByteMatcher::image_x_icon_cursor(),
-                box ByteMatcher::image_bmp(),
-                box ByteMatcher::image_gif89a(),
-                box ByteMatcher::image_gif87a(),
-                box ByteMatcher::image_webp(),
-                box ByteMatcher::image_png(),
-                box ByteMatcher::image_jpeg(),
+                Box::new(ByteMatcher::image_x_icon()),
+                Box::new(ByteMatcher::image_x_icon_cursor()),
+                Box::new(ByteMatcher::image_bmp()),
+                Box::new(ByteMatcher::image_gif89a()),
+                Box::new(ByteMatcher::image_gif87a()),
+                Box::new(ByteMatcher::image_webp()),
+                Box::new(ByteMatcher::image_png()),
+                Box::new(ByteMatcher::image_jpeg()),
             ]
         }
     }
     fn audio_video_classifier() -> GroupedClassifier {
         GroupedClassifier {
             byte_matchers: vec![
-                box ByteMatcher::video_webm(),
-                box ByteMatcher::audio_basic(),
-                box ByteMatcher::audio_aiff(),
-                box ByteMatcher::audio_mpeg(),
-                box ByteMatcher::application_ogg(),
-                box ByteMatcher::audio_midi(),
-                box ByteMatcher::video_avi(),
-                box ByteMatcher::audio_wave(),
-                box Mp4Matcher
+                Box::new(ByteMatcher::video_webm()),
+                Box::new(ByteMatcher::audio_basic()),
+                Box::new(ByteMatcher::audio_aiff()),
+                Box::new(ByteMatcher::audio_mpeg()),
+                Box::new(ByteMatcher::application_ogg()),
+                Box::new(ByteMatcher::audio_midi()),
+                Box::new(ByteMatcher::video_avi()),
+                Box::new(ByteMatcher::audio_wave()),
+                Box::new(Mp4Matcher)
             ]
         }
     }
     fn scriptable_classifier() -> GroupedClassifier {
         GroupedClassifier {
             byte_matchers: vec![
-                box ByteMatcher::text_html_doctype(),
-                box ByteMatcher::text_html_page(),
-                box ByteMatcher::text_html_head(),
-                box ByteMatcher::text_html_script(),
-                box ByteMatcher::text_html_iframe(),
-                box ByteMatcher::text_html_h1(),
-                box ByteMatcher::text_html_div(),
-                box ByteMatcher::text_html_font(),
-                box ByteMatcher::text_html_table(),
-                box ByteMatcher::text_html_a(),
-                box ByteMatcher::text_html_style(),
-                box ByteMatcher::text_html_title(),
-                box ByteMatcher::text_html_b(),
-                box ByteMatcher::text_html_body(),
-                box ByteMatcher::text_html_br(),
-                box ByteMatcher::text_html_p(),
-                box ByteMatcher::text_html_comment(),
-                box ByteMatcher::text_xml(),
-                box ByteMatcher::application_pdf()
+                Box::new(ByteMatcher::text_html_doctype()),
+                Box::new(ByteMatcher::text_html_page()),
+                Box::new(ByteMatcher::text_html_head()),
+                Box::new(ByteMatcher::text_html_script()),
+                Box::new(ByteMatcher::text_html_iframe()),
+                Box::new(ByteMatcher::text_html_h1()),
+                Box::new(ByteMatcher::text_html_div()),
+                Box::new(ByteMatcher::text_html_font()),
+                Box::new(ByteMatcher::text_html_table()),
+                Box::new(ByteMatcher::text_html_a()),
+                Box::new(ByteMatcher::text_html_style()),
+                Box::new(ByteMatcher::text_html_title()),
+                Box::new(ByteMatcher::text_html_b()),
+                Box::new(ByteMatcher::text_html_body()),
+                Box::new(ByteMatcher::text_html_br()),
+                Box::new(ByteMatcher::text_html_p()),
+                Box::new(ByteMatcher::text_html_comment()),
+                Box::new(ByteMatcher::text_xml()),
+                Box::new(ByteMatcher::application_pdf())
             ]
         }
     }
     fn plaintext_classifier() -> GroupedClassifier {
         GroupedClassifier {
             byte_matchers: vec![
-                box ByteMatcher::text_plain_utf_8_bom(),
-                box ByteMatcher::text_plain_utf_16le_bom(),
-                box ByteMatcher::text_plain_utf_16be_bom(),
-                box ByteMatcher::application_postscript()
+                Box::new(ByteMatcher::text_plain_utf_8_bom()),
+                Box::new(ByteMatcher::text_plain_utf_16le_bom()),
+                Box::new(ByteMatcher::text_plain_utf_16be_bom()),
+                Box::new(ByteMatcher::application_postscript())
             ]
         }
     }
     fn archive_classifier() -> GroupedClassifier {
         GroupedClassifier {
             byte_matchers: vec![
-                box ByteMatcher::application_x_gzip(),
-                box ByteMatcher::application_zip(),
-                box ByteMatcher::application_x_rar_compressed()
+                Box::new(ByteMatcher::application_x_gzip()),
+                Box::new(ByteMatcher::application_zip()),
+                Box::new(ByteMatcher::application_x_rar_compressed())
             ]
         }
     }
@@ -528,11 +528,11 @@ impl GroupedClassifier {
     fn font_classifier() -> GroupedClassifier {
         GroupedClassifier {
             byte_matchers: vec![
-                box ByteMatcher::application_font_woff(),
-                box ByteMatcher::true_type_collection(),
-                box ByteMatcher::open_type(),
-                box ByteMatcher::true_type(),
-                box ByteMatcher::application_vnd_ms_font_object(),
+                Box::new(ByteMatcher::application_font_woff()),
+                Box::new(ByteMatcher::true_type_collection()),
+                Box::new(ByteMatcher::open_type()),
+                Box::new(ByteMatcher::true_type()),
+                Box::new(ByteMatcher::application_vnd_ms_font_object()),
             ]
         }
     }

--- a/components/net_traits/image/base.rs
+++ b/components/net_traits/image/base.rs
@@ -50,7 +50,8 @@ pub struct ImageMetadata {
 fn byte_swap_and_premultiply(data: &mut [u8]) {
     let length = data.len();
 
-    for i in Iterator::step_by(0..length, 4) {
+    let mut i = 0;
+    while i < length {
         let r = data[i + 2];
         let g = data[i + 1];
         let b = data[i + 0];
@@ -58,6 +59,8 @@ fn byte_swap_and_premultiply(data: &mut [u8]) {
         data[i + 0] = r;
         data[i + 1] = g;
         data[i + 2] = b;
+
+        i += 4;
     }
 }
 

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(box_syntax)]
 
 #![deny(unsafe_code)]
 
@@ -392,7 +391,7 @@ pub fn fetch_async<F>(request: RequestInit, core_resource_thread: &CoreResourceT
 {
     let (action_sender, action_receiver) = ipc::channel().unwrap();
     ROUTER.add_route(action_receiver.to_opaque(),
-                     box move |message| f(message.to().unwrap()));
+                     Box::new(move |message| f(message.to().unwrap())));
     core_resource_thread.send(CoreResourceMsg::Fetch(request, action_sender)).unwrap();
 }
 

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![feature(box_syntax)]
-#![feature(iterator_step_by)]
 
 #![deny(unsafe_code)]
 

--- a/components/profile/lib.rs
+++ b/components/profile/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![cfg_attr(not(target_os = "windows"), feature(alloc_jemalloc))]
-#![feature(box_syntax)]
 
 #![deny(unsafe_code)]
 

--- a/components/profile/mem.rs
+++ b/components/profile/mem.rs
@@ -55,10 +55,10 @@ impl Profiler {
         // be unregistered, because as long as the memory profiler is running the system memory
         // reporter can make measurements.
         let (system_reporter_sender, system_reporter_receiver) = ipc::channel().unwrap();
-        ROUTER.add_route(system_reporter_receiver.to_opaque(), box |message| {
+        ROUTER.add_route(system_reporter_receiver.to_opaque(), Box::new(|message| {
             let request: ReporterRequest = message.to().unwrap();
             system_reporter::collect_reports(request)
-        });
+        }));
         mem_profiler_chan.send(ProfilerMsg::RegisterReporter("system".to_owned(),
                                                              Reporter(system_reporter_sender)));
 

--- a/components/profile_traits/lib.rs
+++ b/components/profile_traits/lib.rs
@@ -7,7 +7,6 @@
 //! modules won't have to depend on `profile`.
 
 #![deny(unsafe_code)]
-#![feature(box_syntax)]
 
 extern crate ipc_channel;
 #[macro_use]

--- a/components/profile_traits/mem.rs
+++ b/components/profile_traits/mem.rs
@@ -52,11 +52,11 @@ impl ProfilerChan {
     {
         // Register the memory reporter.
         let (reporter_sender, reporter_receiver) = ipc::channel().unwrap();
-        ROUTER.add_route(reporter_receiver.to_opaque(), box move |message| {
+        ROUTER.add_route(reporter_receiver.to_opaque(), Box::new(move |message| {
             // Just injects an appropriate event into the paint thread's queue.
             let request: ReporterRequest = message.to().unwrap();
             channel_for_reporter.send(msg(request.reports_channel));
-        });
+        }));
         self.send(ProfilerMsg::RegisterReporter(reporter_name.clone(),
                                                 Reporter(reporter_sender)));
 

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -375,11 +375,19 @@ impl HTMLElementMethods for HTMLElement {
 static DATA_PREFIX: &str = "data-";
 static DATA_HYPHEN_SEPARATOR: char = '\x2d';
 
+fn is_ascii_uppercase(c: char) -> bool {
+    'A' <= c && c <= 'Z'
+}
+
+fn is_ascii_lowercase(c: char) -> bool {
+    'a' <= c && c <= 'w'
+}
+
 fn to_snake_case(name: DOMString) -> DOMString {
     let mut attr_name = String::with_capacity(name.len() + DATA_PREFIX.len());
     attr_name.push_str(DATA_PREFIX);
     for ch in name.chars() {
-        if ch.is_ascii_uppercase() {
+        if is_ascii_uppercase(ch) {
             attr_name.push(DATA_HYPHEN_SEPARATOR);
             attr_name.push(ch.to_ascii_lowercase());
         } else {
@@ -400,7 +408,7 @@ fn to_camel_case(name: &str) -> Option<DOMString> {
         return None;
     }
     let name = &name[5..];
-    let has_uppercase = name.chars().any(|curr_char| curr_char.is_ascii_uppercase());
+    let has_uppercase = name.chars().any(|curr_char| is_ascii_uppercase(curr_char));
     if has_uppercase {
         return None;
     }
@@ -410,7 +418,7 @@ fn to_camel_case(name: &str) -> Option<DOMString> {
         //check for hyphen followed by character
         if curr_char == DATA_HYPHEN_SEPARATOR {
             if let Some(next_char) = name_chars.next() {
-                if next_char.is_ascii_lowercase() {
+                if is_ascii_lowercase(next_char) {
                     result.push(next_char.to_ascii_uppercase());
                 } else {
                     result.push(curr_char);

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -13,7 +13,6 @@
 #![feature(on_unimplemented)]
 #![feature(plugin)]
 #![feature(proc_macro)]
-#![feature(try_from)]
 
 #![deny(unsafe_code)]
 #![allow(non_snake_case)]

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(ascii_ctype)]
 #![feature(box_syntax)]
 #![feature(conservative_impl_trait)]
 #![feature(const_fn)]

--- a/components/script_layout_interface/lib.rs
+++ b/components/script_layout_interface/lib.rs
@@ -7,7 +7,6 @@
 //! to depend on script.
 
 #![deny(unsafe_code)]
-#![feature(box_syntax)]
 #![feature(nonzero)]
 
 extern crate app_units;

--- a/components/script_plugins/lib.rs
+++ b/components/script_plugins/lib.rs
@@ -15,7 +15,6 @@
 
 
 #![deny(unsafe_code)]
-#![feature(box_syntax)]
 #![feature(plugin)]
 #![feature(plugin_registrar)]
 #![feature(rustc_private)]
@@ -34,7 +33,7 @@ mod utils;
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_late_lint_pass(box unrooted_must_root::UnrootedPass::new());
+    reg.register_late_lint_pass(Box::new(unrooted_must_root::UnrootedPass::new()));
     reg.register_attribute("allow_unrooted_interior".to_string(), Whitelisted);
     reg.register_attribute("must_root".to_string(), Whitelisted);
 }

--- a/components/style_traits/lib.rs
+++ b/components/style_traits/lib.rs
@@ -11,8 +11,6 @@
 
 #![deny(unsafe_code, missing_docs)]
 
-#![cfg_attr(feature = "servo", feature(plugin))]
-
 extern crate app_units;
 #[macro_use] extern crate bitflags;
 #[macro_use] extern crate cssparser;

--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(non_camel_case_types)]
-#![feature(box_syntax)]
 #![feature(core_intrinsics)]
 #![feature(link_args)]
 

--- a/ports/cef/string_list.rs
+++ b/ports/cef/string_list.rs
@@ -11,7 +11,7 @@ use types::{cef_string_list_t,cef_string_t};
 
 #[no_mangle]
 pub extern "C" fn cef_string_list_alloc() -> *mut cef_string_list_t {
-    Box::into_raw(box vec!())
+    Box::into_raw(Box::new(vec!()))
 }
 
 #[no_mangle]
@@ -63,6 +63,6 @@ pub extern "C" fn cef_string_list_copy(lt: *mut cef_string_list_t) -> *mut cef_s
     unsafe {
         if lt.is_null() { return 0 as *mut cef_string_list_t; }
         let copy = (*lt).clone();
-        Box::into_raw(box copy)
+        Box::into_raw(Box::new(copy))
     }
 }

--- a/ports/cef/string_map.rs
+++ b/ports/cef/string_map.rs
@@ -13,7 +13,7 @@ use types::{cef_string_map_t, cef_string_t};
 
 #[no_mangle]
 pub extern "C" fn cef_string_map_alloc() -> *mut cef_string_map_t {
-    Box::into_raw(box BTreeMap::new())
+    Box::into_raw(Box::new(BTreeMap::new()))
 }
 
 #[no_mangle]

--- a/ports/cef/string_multimap.rs
+++ b/ports/cef/string_multimap.rs
@@ -13,7 +13,7 @@ use types::{cef_string_multimap_t,cef_string_t};
 
 #[no_mangle]
 pub extern "C" fn cef_string_multimap_alloc() -> *mut cef_string_multimap_t {
-    Box::into_raw(box BTreeMap::new())
+    Box::into_raw(Box::new(BTreeMap::new()))
 }
 
 #[no_mangle]

--- a/ports/cef/window.rs
+++ b/ports/cef/window.rs
@@ -302,10 +302,10 @@ impl WindowMethods for Window {
                 app_wakeup();
             }
             fn clone(&self) -> Box<EventLoopWaker + Send> {
-                box CefEventLoopWaker
+                Box::new(CefEventLoopWaker)
             }
         }
-        box CefEventLoopWaker
+        Box::new(CefEventLoopWaker)
     }
 
     fn prepare_for_composite(&self, width: usize, height: usize) -> bool {

--- a/ports/cef/wrappers.rs
+++ b/ports/cef/wrappers.rs
@@ -205,11 +205,11 @@ impl<'a> CefWrap<*const cef_string_t> for &'a [u16] {
 
             // FIXME(pcwalton): This leaks!! We should instead have the caller pass some scratch
             // stack space to create the object in. What a botch.
-            Box::into_raw(box cef_string_utf16 {
+            Box::into_raw(Box::new(cef_string_utf16 {
                 str: ptr,
                 length: buffer.len(),
                 dtor: Some(free_boxed_utf16_string as extern "C" fn(*mut c_ushort)),
-            }) as *const _
+            })) as *const _
         }
     }
     unsafe fn to_rust(cef_string: *const cef_string_t) -> &'a [u16] {

--- a/ports/glutin/lib.rs
+++ b/ports/glutin/lib.rs
@@ -4,7 +4,6 @@
 
 //! A simple application that uses glutin to open a window for Servo to display in.
 
-#![feature(box_syntax)]
 
 #[macro_use] extern crate bitflags;
 extern crate compositing;

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -1088,15 +1088,15 @@ impl WindowMethods for Window {
                 }
             }
             fn clone(&self) -> Box<EventLoopWaker + Send> {
-                box GlutinEventLoopWaker {
+                Box::new(GlutinEventLoopWaker {
                     window_proxy: self.window_proxy.clone(),
-                }
+                })
             }
         }
         let window_proxy = create_window_proxy(self);
-        box GlutinEventLoopWaker {
+        Box::new(GlutinEventLoopWaker {
             window_proxy: window_proxy,
-        }
+        })
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -32,7 +32,7 @@ class MachCommands(CommandBase):
             self.set_use_stable_rust()
             crate_dir = path.join('ports', 'geckolib')
         else:
-            crate_dir = path.join('components', 'servo')
+            crate_dir = path.join('ports', 'servo')
 
         self.ensure_bootstrapped()
         self.ensure_clobbered()


### PR DESCRIPTION
`Box::new(x)` seems to compile to exactly the same assembly as `box x` in release mode: 
https://play.rust-lang.org/?gist=55ec5dd02c22fa799375d6e2e1a6e970&version=nightly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18839)
<!-- Reviewable:end -->
