### PR TITLE
Remove text-shadow handling from HasAuthorSpecifiedRules

### DIFF
--- a/components/style/gecko/generated/structs.rs
+++ b/components/style/gecko/generated/structs.rs
@@ -959,7 +959,6 @@ pub mod root {
     pub const NS_AUTHOR_SPECIFIED_BACKGROUND: ::std::os::raw::c_uint = 1;
     pub const NS_AUTHOR_SPECIFIED_BORDER: ::std::os::raw::c_uint = 2;
     pub const NS_AUTHOR_SPECIFIED_PADDING: ::std::os::raw::c_uint = 4;
-    pub const NS_AUTHOR_SPECIFIED_TEXT_SHADOW: ::std::os::raw::c_uint = 8;
     pub const NS_STYLE_INHERIT_MASK: ::std::os::raw::c_uint = 16777215;
     pub const NS_STYLE_HAS_TEXT_DECORATION_LINES: ::std::os::raw::c_uint =
         16777216;

--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -1086,8 +1086,9 @@ impl StrongRuleNode {
         -> bool
         where E: ::dom::TElement
     {
-        use gecko_bindings::structs::{NS_AUTHOR_SPECIFIED_BACKGROUND, NS_AUTHOR_SPECIFIED_BORDER};
-        use gecko_bindings::structs::{NS_AUTHOR_SPECIFIED_PADDING, NS_AUTHOR_SPECIFIED_TEXT_SHADOW};
+        use gecko_bindings::structs::NS_AUTHOR_SPECIFIED_BACKGROUND;
+        use gecko_bindings::structs::NS_AUTHOR_SPECIFIED_BORDER;
+        use gecko_bindings::structs::NS_AUTHOR_SPECIFIED_PADDING;
         use properties::{CSSWideKeyword, LonghandId, LonghandIdSet};
         use properties::{PropertyDeclaration, PropertyDeclarationId};
         use std::borrow::Cow;
@@ -1143,15 +1144,6 @@ impl StrongRuleNode {
             LonghandId::PaddingBlockEnd,
         ];
 
-        // Inherited properties:
-        const TEXT_SHADOW_PROPS: &'static [LonghandId] = &[
-            LonghandId::TextShadow,
-        ];
-
-        fn inherited(id: LonghandId) -> bool {
-            id == LonghandId::TextShadow
-        }
-
         // Set of properties that we are currently interested in.
         let mut properties = LonghandIdSet::new();
 
@@ -1170,11 +1162,6 @@ impl StrongRuleNode {
                 properties.insert(*id);
             }
         }
-        if rule_type_mask & NS_AUTHOR_SPECIFIED_TEXT_SHADOW != 0 {
-            for id in TEXT_SHADOW_PROPS {
-                properties.insert(*id);
-            }
-        }
 
         // If author colors are not allowed, only claim to have author-specified
         // rules if we're looking at a non-color property or if we're looking at
@@ -1189,7 +1176,6 @@ impl StrongRuleNode {
             LonghandId::BorderInlineEndColor,
             LonghandId::BorderBlockStartColor,
             LonghandId::BorderBlockEndColor,
-            LonghandId::TextShadow,
         ];
 
         if !author_colors_allowed {
@@ -1208,14 +1194,6 @@ impl StrongRuleNode {
             // Note that we don't care here about inheritance due to lack of a
             // specified value, since all the properties we care about are reset
             // properties.
-            //
-            // FIXME: The above comment is copied from Gecko, but the last
-            // sentence is no longer correct since 'text-shadow' support was
-            // added.
-            //
-            // This is a bug in Gecko, replicated in Stylo for now:
-            //
-            // https://bugzilla.mozilla.org/show_bug.cgi?id=1363088
 
             let mut inherited_properties = LonghandIdSet::new();
             let mut have_explicit_ua_inherit = false;
@@ -1257,10 +1235,7 @@ impl StrongRuleNode {
                                 // However, if it is inherited, then it might be
                                 // inherited from an author rule from an
                                 // ancestor element's rule nodes.
-                                if declaration.get_css_wide_keyword() == Some(CSSWideKeyword::Inherit) ||
-                                    (declaration.get_css_wide_keyword() == Some(CSSWideKeyword::Unset) &&
-                                     inherited(id))
-                                {
+                                if declaration.get_css_wide_keyword() == Some(CSSWideKeyword::Inherit) {
                                     have_explicit_ua_inherit = true;
                                     inherited_properties.insert(id);
                                 }


### PR DESCRIPTION
This is the Servo side change of [bug 1363088](https://bugzilla.mozilla.org/show_bug.cgi?id=1363088).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18843)
<!-- Reviewable:end -->
