### PR TITLE
Limit visited cascade for reparenting

### DIFF
--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -25,6 +25,7 @@ use properties::{AnimationRules, PropertyDeclarationBlock};
 #[cfg(feature = "servo")]
 use properties::INHERIT_ALL;
 use properties::IS_LINK;
+use properties::VISITED_DEPENDENT_ONLY;
 use rule_tree::{CascadeLevel, RuleTree, StrongRuleNode, StyleSource};
 use selector_map::{PrecomputedHashMap, SelectorMap, SelectorMapEntry};
 use selector_parser::{SelectorImpl, PerPseudoElementMap, PseudoElement};
@@ -924,7 +925,7 @@ impl Stylist {
                 Some(layout_parent_style_for_visited),
                 None,
                 font_metrics,
-                cascade_flags,
+                cascade_flags | VISITED_DEPENDENT_ONLY,
                 self.quirks_mode,
                 /* rule_cache = */ None,
                 &mut Default::default(),


### PR DESCRIPTION
The specialized cascade flow in `stylist::compute_style_with_inputs` (used with
reparenting) currently computes all properties for visited styles, but we only
need visited-dependent properties.

This adds the cascade flag to reduce the work to visited-dependent properties
only, like we do for the regular cascade flow.

https://bugzilla.mozilla.org/show_bug.cgi?id=1407813

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18844)
<!-- Reviewable:end -->
