### PR TITLE
Reduce the blur and spread radius size of a reftest.

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -23276,11 +23276,11 @@
    "reftest"
   ],
   "css/box_shadow_blur_fixed.html": [
-   "011f60d0fe0c2faa9d9813f5916f04f0a7671870",
+   "8a00af0869a2c7b933ae288e086c4a705ef99116",
    "reftest"
   ],
   "css/box_shadow_blur_fixed_ref.html": [
-   "1da8590307d821e8dcd4a8997f6a7dbc5b36a105",
+   "512b6e498fad9033fb9301f192e7345da25252e8",
    "support"
   ],
   "css/box_shadow_blur_ref.html": [

--- a/tests/wpt/mozilla/tests/css/box_shadow_blur_fixed.html
+++ b/tests/wpt/mozilla/tests/css/box_shadow_blur_fixed.html
@@ -11,7 +11,7 @@
         #div_inner {
             background: lightgrey;
             height: 40px;
-            box-shadow: 0 0 30px 30px darkblue;
+            box-shadow: 0 0 5px 5px darkblue;
         }
     </style>
 </head>

--- a/tests/wpt/mozilla/tests/css/box_shadow_blur_fixed_ref.html
+++ b/tests/wpt/mozilla/tests/css/box_shadow_blur_fixed_ref.html
@@ -10,7 +10,7 @@
         #div_inner {
             background: lightgrey;
             height: 40px;
-            box-shadow: 0 0 30px 30px darkblue;
+            box-shadow: 0 0 5px 5px darkblue;
         }
     </style>
 </head>


### PR DESCRIPTION
In the near future, we'll be changing the blur algorithm in WR.

On native GPUs, this is fine - but on OSMesa, a blur of this
radius and spread is quite slow, and can cause test timeouts
when running with a lot of processes enabled.

Reducing the spread / blur shouldn't affect what this is testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18856)
<!-- Reviewable:end -->
