### PR TITLE
Remove call to missing method

### DIFF
--- a/tests/wpt/metadata/html/rendering/non-replaced-elements/tables/colgroup_valign_bottom.xhtml.ini
+++ b/tests/wpt/metadata/html/rendering/non-replaced-elements/tables/colgroup_valign_bottom.xhtml.ini
@@ -1,0 +1,3 @@
+[colgroup_valign_bottom.xhtml]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata/html/rendering/non-replaced-elements/tables/colgroup_valign_top.xhtml.ini
+++ b/tests/wpt/metadata/html/rendering/non-replaced-elements/tables/colgroup_valign_top.xhtml.ini
@@ -1,0 +1,3 @@
+[colgroup_valign_top.xhtml]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata/html/rendering/non-replaced-elements/tables/table-direction.html.ini
+++ b/tests/wpt/metadata/html/rendering/non-replaced-elements/tables/table-direction.html.ini
@@ -1,0 +1,3 @@
+[table-direction.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata/html/rendering/non-replaced-elements/tables/table-row-direction.html.ini
+++ b/tests/wpt/metadata/html/rendering/non-replaced-elements/tables/table-row-direction.html.ini
@@ -1,0 +1,3 @@
+[table-row-direction.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/metadata/html/rendering/non-replaced-elements/tables/table-row-group-direction.html.ini
+++ b/tests/wpt/metadata/html/rendering/non-replaced-elements/tables/table-row-group-direction.html.ini
@@ -1,0 +1,3 @@
+[table-row-group-direction.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -181,7 +181,6 @@ class ServoRefTestExecutor(ProcessTestExecutor):
     def __init__(self, browser, server_config, binary=None, timeout_multiplier=1,
                  screenshot_cache=None, debug_info=None, pause_after_test=False,
                  **kwargs):
-        do_delayed_imports()
         ProcessTestExecutor.__init__(self,
                                      browser,
                                      server_config,


### PR DESCRIPTION
Somehow the test harness does not report this as a problem, which is scary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18857)
<!-- Reviewable:end -->
