### PR TITLE
Update domparsing spec links to not point at WHATWG

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -66,7 +66,6 @@ WEBIDL_STANDARDS = [
     "//dev.w3.org/fxtf",
     "//dvcs.w3.org/hg",
     "//dom.spec.whatwg.org",
-    "//domparsing.spec.whatwg.org",
     "//drafts.csswg.org",
     "//drafts.css-houdini.org",
     "//drafts.fxtf.org",

--- a/tests/wpt/web-platform-tests/domparsing/innerhtml-07.html
+++ b/tests/wpt/web-platform-tests/domparsing/innerhtml-07.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>innerHTML and string conversion</title>
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
-<link rel="help" href="http://domparsing.spec.whatwg.org/#extensions-to-the-element-interface">
+<link rel="help" href="https://w3c.github.io/DOM-Parsing/#extensions-to-the-element-interface">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>

--- a/tests/wpt/web-platform-tests/domparsing/outerhtml-02.html
+++ b/tests/wpt/web-platform-tests/domparsing/outerhtml-02.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>outerHTML and string conversion</title>
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
-<link rel="help" href="http://domparsing.spec.whatwg.org/#extensions-to-the-element-interface">
+<link rel="help" href="https://w3c.github.io/DOM-Parsing/#extensions-to-the-element-interface">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>


### PR DESCRIPTION
Change domparsing spec links from domparsing.spec.whatwg.org to w3c.github.io/DOM-Parsing.

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #14555
- [X] These changes do not require tests because these only affect documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18869)
<!-- Reviewable:end -->
