### PR TITLE
style: Do not expose LocalMatchingContext.

### DIFF
--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -51,7 +51,7 @@ use script_layout_interface::{OpaqueStyleAndLayoutData, StyleData};
 use script_layout_interface::wrapper_traits::{DangerousThreadSafeLayoutNode, GetLayoutData, LayoutNode};
 use script_layout_interface::wrapper_traits::{PseudoElementType, ThreadSafeLayoutElement, ThreadSafeLayoutNode};
 use selectors::attr::{AttrSelectorOperation, NamespaceConstraint, CaseSensitivity};
-use selectors::matching::{ElementSelectorFlags, LocalMatchingContext, MatchingContext, RelevantLinkStatus};
+use selectors::matching::{ElementSelectorFlags, MatchingContext, RelevantLinkStatus};
 use selectors::matching::VisitedHandlingMode;
 use selectors::sink::Push;
 use servo_arc::{Arc, ArcBorrow};
@@ -720,7 +720,7 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
 
     fn match_non_ts_pseudo_class<F>(&self,
                                     pseudo_class: &NonTSPseudoClass,
-                                    _: &mut LocalMatchingContext<Self::Impl>,
+                                    _: &mut MatchingContext,
                                     _: &RelevantLinkStatus,
                                     _: &mut F)
                                     -> bool
@@ -1240,7 +1240,7 @@ impl<'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
 
     fn match_non_ts_pseudo_class<F>(&self,
                                     _: &NonTSPseudoClass,
-                                    _: &mut LocalMatchingContext<Self::Impl>,
+                                    _: &mut MatchingContext,
                                     _: &RelevantLinkStatus,
                                     _: &mut F)
                                     -> bool

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -89,7 +89,7 @@ use script_layout_interface::message::ReflowGoal;
 use script_thread::ScriptThread;
 use selectors::Element as SelectorsElement;
 use selectors::attr::{AttrSelectorOperation, NamespaceConstraint, CaseSensitivity};
-use selectors::matching::{ElementSelectorFlags, LocalMatchingContext, MatchingContext, RelevantLinkStatus};
+use selectors::matching::{ElementSelectorFlags, MatchingContext, MatchingMode, RelevantLinkStatus};
 use selectors::matching::{HAS_EDGE_CHILD_SELECTOR, HAS_SLOW_SELECTOR, HAS_SLOW_SELECTOR_LATER_SIBLINGS};
 use selectors::sink::Push;
 use servo_arc::Arc;
@@ -2583,7 +2583,7 @@ impl<'a> SelectorsElement for DomRoot<Element> {
 
     fn match_non_ts_pseudo_class<F>(&self,
                                     pseudo_class: &NonTSPseudoClass,
-                                    _: &mut LocalMatchingContext<Self::Impl>,
+                                    _: &mut MatchingContext,
                                     _: &RelevantLinkStatus,
                                     _: &mut F)
                                     -> bool

--- a/components/selectors/context.rs
+++ b/components/selectors/context.rs
@@ -102,6 +102,9 @@ pub struct MatchingContext<'a> {
     /// See https://drafts.csswg.org/selectors-4/#scope-pseudo
     pub scope_element: Option<OpaqueElement>,
 
+    /// The current nesting level of selectors that we're matching.
+    pub nesting_level: usize,
+
     quirks_mode: QuirksMode,
     classes_and_ids_case_sensitivity: CaseSensitivity,
 }
@@ -140,6 +143,7 @@ impl<'a> MatchingContext<'a> {
             relevant_link_found: false,
             classes_and_ids_case_sensitivity: quirks_mode.classes_and_ids_case_sensitivity(),
             scope_element: None,
+            nesting_level: 0,
         }
     }
 

--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -470,15 +470,6 @@ where
     E: Element,
     F: FnMut(&E, ElementSelectorFlags),
 {
-    if cfg!(debug_assertions) {
-        if context.nesting_level == 0 &&
-            context.shared.matching_mode == MatchingMode::ForStatelessPseudoElement {
-            assert!(iter.clone().any(|c| {
-                matches!(*c, Component::PseudoElement(..))
-            }));
-        }
-    }
-
     // If this is the special pseudo-element mode, consume the ::pseudo-element
     // before proceeding, since the caller has already handled that part.
     if context.nesting_level == 0 &&

--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -159,11 +159,13 @@ impl<'a, 'b, Impl> LocalMatchingContext<'a, 'b, Impl>
     }
 }
 
-pub fn matches_selector_list<E>(selector_list: &SelectorList<E::Impl>,
-                                element: &E,
-                                context: &mut MatchingContext)
-                                -> bool
-    where E: Element
+pub fn matches_selector_list<E>(
+    selector_list: &SelectorList<E::Impl>,
+    element: &E,
+    context: &mut MatchingContext,
+) -> bool
+where
+    E: Element
 {
     selector_list.0.iter().any(|selector| {
         matches_selector(selector,
@@ -176,10 +178,9 @@ pub fn matches_selector_list<E>(selector_list: &SelectorList<E::Impl>,
 }
 
 #[inline(always)]
-fn may_match<E>(hashes: &AncestorHashes,
-                bf: &BloomFilter)
-                -> bool
-    where E: Element,
+fn may_match<E>(hashes: &AncestorHashes, bf: &BloomFilter) -> bool
+where
+    E: Element,
 {
     // Check the first three hashes. Note that we can check for zero before
     // masking off the high bits, since if any of the first three hashes is
@@ -370,15 +371,17 @@ enum SelectorMatchingResult {
 /// unncessary cache miss for cases when we can fast-reject with AncestorHashes
 /// (which the caller can store inline with the selector pointer).
 #[inline(always)]
-pub fn matches_selector<E, F>(selector: &Selector<E::Impl>,
-                              offset: usize,
-                              hashes: Option<&AncestorHashes>,
-                              element: &E,
-                              context: &mut MatchingContext,
-                              flags_setter: &mut F)
-                              -> bool
-    where E: Element,
-          F: FnMut(&E, ElementSelectorFlags),
+pub fn matches_selector<E, F>(
+    selector: &Selector<E::Impl>,
+    offset: usize,
+    hashes: Option<&AncestorHashes>,
+    element: &E,
+    context: &mut MatchingContext,
+    flags_setter: &mut F,
+) -> bool
+where
+    E: Element,
+    F: FnMut(&E, ElementSelectorFlags),
 {
     // Use the bloom filter to fast-reject.
     if let Some(hashes) = hashes {
@@ -457,13 +460,15 @@ where
 }
 
 /// Matches a complex selector.
-pub fn matches_complex_selector<E, F>(mut iter: SelectorIter<E::Impl>,
-                                      element: &E,
-                                      context: &mut LocalMatchingContext<E::Impl>,
-                                      flags_setter: &mut F)
-                                      -> bool
-    where E: Element,
-          F: FnMut(&E, ElementSelectorFlags),
+pub fn matches_complex_selector<E, F>(
+    mut iter: SelectorIter<E::Impl>,
+    element: &E,
+    context: &mut LocalMatchingContext<E::Impl>,
+    flags_setter: &mut F,
+) -> bool
+where
+    E: Element,
+    F: FnMut(&E, ElementSelectorFlags),
 {
     if cfg!(debug_assertions) {
         if context.nesting_level == 0 &&
@@ -499,24 +504,30 @@ pub fn matches_complex_selector<E, F>(mut iter: SelectorIter<E::Impl>,
         context.note_position(&iter);
     }
 
-    match matches_complex_selector_internal(iter,
-                                            element,
-                                            context,
-                                            &mut RelevantLinkStatus::Looking,
-                                            flags_setter) {
+    let result = matches_complex_selector_internal(
+        iter,
+        element,
+        context,
+        &mut RelevantLinkStatus::Looking,
+        flags_setter,
+    );
+
+    match result {
         SelectorMatchingResult::Matched => true,
         _ => false
     }
 }
 
-fn matches_complex_selector_internal<E, F>(mut selector_iter: SelectorIter<E::Impl>,
-                                           element: &E,
-                                           context: &mut LocalMatchingContext<E::Impl>,
-                                           relevant_link: &mut RelevantLinkStatus,
-                                           flags_setter: &mut F)
-                                           -> SelectorMatchingResult
-     where E: Element,
-           F: FnMut(&E, ElementSelectorFlags),
+fn matches_complex_selector_internal<E, F>(
+    mut selector_iter: SelectorIter<E::Impl>,
+    element: &E,
+    context: &mut LocalMatchingContext<E::Impl>,
+    relevant_link: &mut RelevantLinkStatus,
+    flags_setter: &mut F
+) -> SelectorMatchingResult
+where
+    E: Element,
+    F: FnMut(&E, ElementSelectorFlags),
 {
     *relevant_link = relevant_link.examine_potential_link(element, &mut context.shared);
 
@@ -614,14 +625,15 @@ fn matches_complex_selector_internal<E, F>(mut selector_iter: SelectorIter<E::Im
 /// Determines whether the given element matches the given single selector.
 #[inline]
 fn matches_simple_selector<E, F>(
-        selector: &Component<E::Impl>,
-        element: &E,
-        context: &mut LocalMatchingContext<E::Impl>,
-        relevant_link: &RelevantLinkStatus,
-        flags_setter: &mut F)
-        -> bool
-    where E: Element,
-          F: FnMut(&E, ElementSelectorFlags),
+    selector: &Component<E::Impl>,
+    element: &E,
+    context: &mut LocalMatchingContext<E::Impl>,
+    relevant_link: &RelevantLinkStatus,
+    flags_setter: &mut F,
+) -> bool
+where
+    E: Element,
+    F: FnMut(&E, ElementSelectorFlags),
 {
     match *selector {
         Component::Combinator(_) => unreachable!(),
@@ -773,16 +785,18 @@ fn select_name<'a, T>(is_html: bool, local_name: &'a T, local_name_lower: &'a T)
 }
 
 #[inline]
-fn matches_generic_nth_child<E, F>(element: &E,
-                                   context: &mut LocalMatchingContext<E::Impl>,
-                                   a: i32,
-                                   b: i32,
-                                   is_of_type: bool,
-                                   is_from_end: bool,
-                                   flags_setter: &mut F)
-                                   -> bool
-    where E: Element,
-          F: FnMut(&E, ElementSelectorFlags),
+fn matches_generic_nth_child<E, F>(
+    element: &E,
+    context: &mut LocalMatchingContext<E::Impl>,
+    a: i32,
+    b: i32,
+    is_of_type: bool,
+    is_from_end: bool,
+    flags_setter: &mut F,
+) -> bool
+where
+    E: Element,
+    F: FnMut(&E, ElementSelectorFlags),
 {
     if element.ignores_nth_child_selectors() {
         return false;
@@ -880,8 +894,9 @@ where
 
 #[inline]
 fn matches_first_child<E, F>(element: &E, flags_setter: &mut F) -> bool
-    where E: Element,
-          F: FnMut(&E, ElementSelectorFlags),
+where
+    E: Element,
+    F: FnMut(&E, ElementSelectorFlags),
 {
     flags_setter(element, HAS_EDGE_CHILD_SELECTOR);
     element.prev_sibling_element().is_none()
@@ -889,8 +904,9 @@ fn matches_first_child<E, F>(element: &E, flags_setter: &mut F) -> bool
 
 #[inline]
 fn matches_last_child<E, F>(element: &E, flags_setter: &mut F) -> bool
-    where E: Element,
-          F: FnMut(&E, ElementSelectorFlags),
+where
+    E: Element,
+    F: FnMut(&E, ElementSelectorFlags),
 {
     flags_setter(element, HAS_EDGE_CHILD_SELECTOR);
     element.next_sibling_element().is_none()

--- a/components/selectors/tree.rs
+++ b/components/selectors/tree.rs
@@ -6,7 +6,7 @@
 //! between layout and style.
 
 use attr::{AttrSelectorOperation, NamespaceConstraint, CaseSensitivity};
-use matching::{ElementSelectorFlags, LocalMatchingContext, MatchingContext, RelevantLinkStatus};
+use matching::{ElementSelectorFlags, MatchingContext, RelevantLinkStatus};
 use parser::SelectorImpl;
 use servo_arc::NonZeroPtrMut;
 use std::fmt::Debug;
@@ -64,12 +64,15 @@ pub trait Element: Sized + Clone + Debug {
                     operation: &AttrSelectorOperation<&<Self::Impl as SelectorImpl>::AttrValue>)
                     -> bool;
 
-    fn match_non_ts_pseudo_class<F>(&self,
-                                    pc: &<Self::Impl as SelectorImpl>::NonTSPseudoClass,
-                                    context: &mut LocalMatchingContext<Self::Impl>,
-                                    relevant_link: &RelevantLinkStatus,
-                                    flags_setter: &mut F) -> bool
-        where F: FnMut(&Self, ElementSelectorFlags);
+    fn match_non_ts_pseudo_class<F>(
+        &self,
+        pc: &<Self::Impl as SelectorImpl>::NonTSPseudoClass,
+        context: &mut MatchingContext,
+        relevant_link: &RelevantLinkStatus,
+        flags_setter: &mut F,
+    ) -> bool
+    where
+        F: FnMut(&Self, ElementSelectorFlags);
 
     fn match_pseudo_element(&self,
                             pe: &<Self::Impl as SelectorImpl>::PseudoElement,

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -78,7 +78,7 @@ use rule_tree::CascadeLevel as ServoCascadeLevel;
 use selector_parser::{AttrValue, ElementExt, PseudoClassStringArg};
 use selectors::{Element, OpaqueElement};
 use selectors::attr::{AttrSelectorOperation, AttrSelectorOperator, CaseSensitivity, NamespaceConstraint};
-use selectors::matching::{ElementSelectorFlags, LocalMatchingContext, MatchingContext};
+use selectors::matching::{ElementSelectorFlags, MatchingContext};
 use selectors::matching::{RelevantLinkStatus, VisitedHandlingMode};
 use selectors::sink::Push;
 use servo_arc::{Arc, ArcBorrow, RawOffsetArc};
@@ -1844,7 +1844,7 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
     fn match_non_ts_pseudo_class<F>(
         &self,
         pseudo_class: &NonTSPseudoClass,
-        context: &mut LocalMatchingContext<Self::Impl>,
+        context: &mut MatchingContext,
         relevant_link: &RelevantLinkStatus,
         flags_setter: &mut F,
     ) -> bool
@@ -1899,20 +1899,14 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
             NonTSPseudoClass::MozDirAttrRTL |
             NonTSPseudoClass::MozDirAttrLikeAuto |
             NonTSPseudoClass::MozAutofill |
+            NonTSPseudoClass::Active |
+            NonTSPseudoClass::Hover |
             NonTSPseudoClass::MozAutofillPreview => {
                 self.get_state().intersects(pseudo_class.state_flag())
             },
             NonTSPseudoClass::AnyLink => self.is_link(),
-            NonTSPseudoClass::Link => relevant_link.is_unvisited(self, context.shared),
-            NonTSPseudoClass::Visited => relevant_link.is_visited(self, context.shared),
-            NonTSPseudoClass::Active |
-            NonTSPseudoClass::Hover => {
-                if context.active_hover_quirk_matches() && !self.is_link() {
-                    false
-                } else {
-                    self.get_state().contains(pseudo_class.state_flag())
-                }
-            },
+            NonTSPseudoClass::Link => relevant_link.is_unvisited(self, context),
+            NonTSPseudoClass::Visited => relevant_link.is_visited(self, context),
             NonTSPseudoClass::MozFirstNode => {
                 flags_setter(self, HAS_EDGE_CHILD_SELECTOR);
                 let mut elem = self.as_node();

--- a/components/style/invalidation/element/element_wrapper.rs
+++ b/components/style/invalidation/element/element_wrapper.rs
@@ -165,10 +165,12 @@ impl<'a, E> Element for ElementWrapper<'a, E>
             #[cfg(feature = "gecko")]
             NonTSPseudoClass::MozAny(ref selectors) => {
                 use selectors::matching::matches_complex_selector;
-                // FIXME(emilio): nesting_level!
-                return selectors.iter().any(|s| {
+                context.nesting_level += 1;
+                let result = selectors.iter().any(|s| {
                     matches_complex_selector(s.iter(), self, context, _setter)
-                })
+                });
+                context.nesting_level -= 1;
+                return result
             }
 
             // :dir is implemented in terms of state flags, but which state flag

--- a/components/style/invalidation/element/element_wrapper.rs
+++ b/components/style/invalidation/element/element_wrapper.rs
@@ -11,7 +11,7 @@ use element_state::ElementState;
 use selector_parser::{NonTSPseudoClass, PseudoElement, SelectorImpl, Snapshot, SnapshotMap, AttrValue};
 use selectors::{Element, OpaqueElement};
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
-use selectors::matching::{ElementSelectorFlags, LocalMatchingContext, MatchingContext};
+use selectors::matching::{ElementSelectorFlags, MatchingContext};
 use selectors::matching::RelevantLinkStatus;
 use std::cell::Cell;
 use std::fmt;
@@ -149,13 +149,15 @@ impl<'a, E> Element for ElementWrapper<'a, E>
 {
     type Impl = SelectorImpl;
 
-    fn match_non_ts_pseudo_class<F>(&self,
-                                    pseudo_class: &NonTSPseudoClass,
-                                    context: &mut LocalMatchingContext<Self::Impl>,
-                                    relevant_link: &RelevantLinkStatus,
-                                    _setter: &mut F)
-                                    -> bool
-        where F: FnMut(&Self, ElementSelectorFlags),
+    fn match_non_ts_pseudo_class<F>(
+        &self,
+        pseudo_class: &NonTSPseudoClass,
+        context: &mut MatchingContext,
+        relevant_link: &RelevantLinkStatus,
+        _setter: &mut F,
+    ) -> bool
+    where
+         F: FnMut(&Self, ElementSelectorFlags),
     {
         // Some pseudo-classes need special handling to evaluate them against
         // the snapshot.
@@ -163,6 +165,7 @@ impl<'a, E> Element for ElementWrapper<'a, E>
             #[cfg(feature = "gecko")]
             NonTSPseudoClass::MozAny(ref selectors) => {
                 use selectors::matching::matches_complex_selector;
+                // FIXME(emilio): nesting_level!
                 return selectors.iter().any(|s| {
                     matches_complex_selector(s.iter(), self, context, _setter)
                 })
@@ -195,10 +198,10 @@ impl<'a, E> Element for ElementWrapper<'a, E>
             // state directly.  Instead, we use the `relevant_link` to determine if
             // they match.
             NonTSPseudoClass::Link => {
-                return relevant_link.is_unvisited(self, context.shared);
+                return relevant_link.is_unvisited(self, context);
             }
             NonTSPseudoClass::Visited => {
-                return relevant_link.is_visited(self, context.shared);
+                return relevant_link.is_visited(self, context);
             }
 
             #[cfg(feature = "gecko")]
@@ -230,27 +233,31 @@ impl<'a, E> Element for ElementWrapper<'a, E>
 
         let flag = pseudo_class.state_flag();
         if flag.is_empty() {
-            return self.element.match_non_ts_pseudo_class(pseudo_class,
-                                                          context,
-                                                          relevant_link,
-                                                          &mut |_, _| {})
+            return self.element.match_non_ts_pseudo_class(
+                pseudo_class,
+                context,
+                relevant_link,
+                &mut |_, _| {},
+            )
         }
         match self.snapshot().and_then(|s| s.state()) {
             Some(snapshot_state) => snapshot_state.intersects(flag),
             None => {
-                self.element.match_non_ts_pseudo_class(pseudo_class,
-                                                       context,
-                                                       relevant_link,
-                                                       &mut |_, _| {})
+                self.element.match_non_ts_pseudo_class(
+                    pseudo_class,
+                    context,
+                    relevant_link,
+                    &mut |_, _| {},
+                )
             }
         }
     }
 
-    fn match_pseudo_element(&self,
-                            pseudo_element: &PseudoElement,
-                            context: &mut MatchingContext)
-                            -> bool
-    {
+    fn match_pseudo_element(
+        &self,
+        pseudo_element: &PseudoElement,
+        context: &mut MatchingContext,
+    ) -> bool {
         self.element.match_pseudo_element(pseudo_element, context)
     }
 

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -2309,12 +2309,12 @@ impl Rule {
     }
 
     /// Creates a new Rule.
-    pub fn new(selector: Selector<SelectorImpl>,
-               hashes: AncestorHashes,
-               style_rule: Arc<Locked<StyleRule>>,
-               source_order: u32)
-               -> Self
-    {
+    pub fn new(
+        selector: Selector<SelectorImpl>,
+        hashes: AncestorHashes,
+        style_rule: Arc<Locked<StyleRule>>,
+        source_order: u32,
+    ) -> Self {
         Rule {
             selector: selector,
             hashes: hashes,


### PR DESCRIPTION
This type is a lot of complexity related to a very specific thing such as the
hover and active quirk.

Instead of that, move `nesting_level` to `MatchingContext`, and simplify all
this computing whether the quirk applies upfront, for each complex selector we
test.

This is less error-prone, and also allows simplifying more stuff in a bit.

Also, this makes the hover and active quirk work in Servo with no extra effort.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18876)
<!-- Reviewable:end -->
