### PR TITLE
stylo: Dumb down the return value of SelectorList_Closest. 

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1922,6 +1922,11 @@ extern "C" {
                                         len: usize);
 }
 extern "C" {
+    pub fn Gecko_AnnotateCrashReport(key_str: *const ::std::os::raw::c_char,
+                                     value_str:
+                                         *const ::std::os::raw::c_char);
+}
+extern "C" {
     pub fn Servo_Element_ClearData(node: RawGeckoElementBorrowed);
 }
 extern "C" {
@@ -2117,6 +2122,11 @@ extern "C" {
     pub fn Servo_SelectorList_Matches(arg1: RawGeckoElementBorrowed,
                                       arg2: RawServoSelectorListBorrowed)
      -> bool;
+}
+extern "C" {
+    pub fn Servo_SelectorList_Closest(arg1: RawGeckoElementBorrowed,
+                                      arg2: RawServoSelectorListBorrowed)
+     -> *const RawGeckoElement;
 }
 extern "C" {
     pub fn Servo_StyleSet_AddSizeOfExcludingThis(malloc_size_of: MallocSizeOf,

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -332,11 +332,11 @@ pub extern "C" fn Servo_MaybeGCRuleTree(raw_data: RawServoStyleSetBorrowed) {
 }
 
 #[no_mangle]
-pub extern "C" fn Servo_AnimationValues_Interpolate(from: RawServoAnimationValueBorrowed,
-                                                    to: RawServoAnimationValueBorrowed,
-                                                    progress: f64)
-     -> RawServoAnimationValueStrong
-{
+pub extern "C" fn Servo_AnimationValues_Interpolate(
+    from: RawServoAnimationValueBorrowed,
+    to: RawServoAnimationValueBorrowed,
+    progress: f64,
+) -> RawServoAnimationValueStrong {
     let from_value = AnimationValue::as_arc(&from);
     let to_value = AnimationValue::as_arc(&to);
     if let Ok(value) = from_value.animate(to_value, Procedure::Interpolate { progress }) {
@@ -356,10 +356,10 @@ pub extern "C" fn Servo_AnimationValues_IsInterpolable(from: RawServoAnimationVa
 }
 
 #[no_mangle]
-pub extern "C" fn Servo_AnimationValues_Add(a: RawServoAnimationValueBorrowed,
-                                            b: RawServoAnimationValueBorrowed)
-     -> RawServoAnimationValueStrong
-{
+pub extern "C" fn Servo_AnimationValues_Add(
+    a: RawServoAnimationValueBorrowed,
+    b: RawServoAnimationValueBorrowed,
+) -> RawServoAnimationValueStrong {
     let a_value = AnimationValue::as_arc(&a);
     let b_value = AnimationValue::as_arc(&b);
     if let Ok(value) = a_value.animate(b_value, Procedure::Add) {
@@ -370,11 +370,11 @@ pub extern "C" fn Servo_AnimationValues_Add(a: RawServoAnimationValueBorrowed,
 }
 
 #[no_mangle]
-pub extern "C" fn Servo_AnimationValues_Accumulate(a: RawServoAnimationValueBorrowed,
-                                                   b: RawServoAnimationValueBorrowed,
-                                                   count: u64)
-     -> RawServoAnimationValueStrong
-{
+pub extern "C" fn Servo_AnimationValues_Accumulate(
+    a: RawServoAnimationValueBorrowed,
+    b: RawServoAnimationValueBorrowed,
+    count: u64,
+) -> RawServoAnimationValueStrong {
     let a_value = AnimationValue::as_arc(&a);
     let b_value = AnimationValue::as_arc(&b);
     if let Ok(value) = a_value.animate(b_value, Procedure::Accumulate { count }) {
@@ -673,8 +673,9 @@ pub extern "C" fn Servo_AnimationValue_DeepEqual(this: RawServoAnimationValueBor
 }
 
 #[no_mangle]
-pub extern "C" fn Servo_AnimationValue_Uncompute(value: RawServoAnimationValueBorrowed)
-                                                 -> RawServoDeclarationBlockStrong {
+pub extern "C" fn Servo_AnimationValue_Uncompute(
+    value: RawServoAnimationValueBorrowed,
+) -> RawServoDeclarationBlockStrong {
     let value = AnimationValue::as_arc(&value);
     let global_style_data = &*GLOBAL_STYLE_DATA;
     Arc::new(global_style_data.shared_lock.wrap(

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1522,10 +1522,10 @@ pub extern "C" fn Servo_StyleRule_SelectorMatchesElement(rule: RawServoStyleRule
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Servo_SelectorList_Closest<'a>(
-    element: RawGeckoElementBorrowed<'a>,
+pub unsafe extern "C" fn Servo_SelectorList_Closest(
+    element: RawGeckoElementBorrowed,
     selectors: RawServoSelectorListBorrowed,
-) -> RawGeckoElementBorrowedOrNull<'a> {
+) -> *const structs::RawGeckoElement {
     use std::borrow::Borrow;
     use style::dom_apis;
 
@@ -1533,7 +1533,7 @@ pub unsafe extern "C" fn Servo_SelectorList_Closest<'a>(
     let selectors = ::selectors::SelectorList::from_ffi(selectors).borrow();
 
     dom_apis::element_closest(element, &selectors, element.owner_document_quirks_mode())
-        .map(|e| e.0)
+        .map_or(ptr::null(), |e| e.0)
 }
 
 #[no_mangle]


### PR DESCRIPTION
So it builds with rust 1.21.

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1408622

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18877)
<!-- Reviewable:end -->
