### PR TITLE
style: Not all computed value flags are really inherited.

### DIFF
--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -360,8 +360,8 @@ trait PrivateMatchMethods: TElement {
         debug!(" > style difference: {:?}", difference);
 
         // We need to cascade the children in order to ensure the correct
-        // propagation of computed value flags.
-        if old_values.flags != new_values.flags {
+        // propagation of inherited computed value flags.
+        if old_values.flags.inherited() != new_values.flags.inherited() {
             debug!(" > flags changed: {:?} != {:?}", old_values.flags, new_values.flags);
             return ChildCascadeRequirement::MustCascadeChildren;
         }

--- a/components/style/properties/computed_value_flags.rs
+++ b/components/style/properties/computed_value_flags.rs
@@ -64,3 +64,11 @@ bitflags! {
         const IS_STYLE_IF_VISITED = 1 << 9,
     }
 }
+
+impl ComputedValueFlags {
+    /// Returns the flags that are inherited.
+    #[inline]
+    pub fn inherited(self) -> Self {
+        self & !(INHERITS_DISPLAY | INHERITS_CONTENT | INHERITS_RESET_STYLE)
+    }
+}

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -2872,7 +2872,7 @@ impl<'a> StyleBuilder<'a> {
             /* rules = */ None,
             parent.custom_properties().cloned(),
             parent.writing_mode,
-            parent.flags,
+            parent.flags.inherited(),
             visited_style,
         )
     }


### PR DESCRIPTION
This fixes the fishiness I noticed in:

  https://bugzilla.mozilla.org/show_bug.cgi?id=1407832

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18879)
<!-- Reviewable:end -->
