### PR TITLE
style: Fixup the hack added in #18867.

### DIFF
--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -509,13 +509,10 @@ impl PropertyDeclarationBlock {
                             if let PropertyDeclaration::Display(old_display) = *slot {
                                 use properties::longhands::display::computed_value::T as display;
 
-                                let new_display = match declaration {
-                                    PropertyDeclaration::Display(new_display) => new_display,
-                                    _ => unreachable!("How could the declaration id be the same?"),
-                                };
-
-                                if display::should_ignore_parsed_value(old_display, new_display) {
-                                    return false;
+                                if let PropertyDeclaration::Display(new_display) = declaration {
+                                    if display::should_ignore_parsed_value(old_display, new_display) {
+                                        return false;
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
The declaration can indeed have the same id if it contains variables, or is a
CSS keyword value.

This was making a WPT test fail, so this is tested, though Servo's WPT import
didn't catch this for some reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18880)
<!-- Reviewable:end -->
