### PR TITLE
style: Use left-to-right indices in the invalidator.

### DIFF
--- a/components/style/invalidation/element/collector.rs
+++ b/components/style/invalidation/element/collector.rs
@@ -463,16 +463,18 @@ where
 
         if dependency.affects_descendants() {
             debug_assert_ne!(dependency.selector_offset, 0);
+            debug_assert_ne!(dependency.selector_offset, dependency.selector.len());
             debug_assert!(!dependency.affects_later_siblings());
             self.descendant_invalidations.push(Invalidation::new(
                 dependency.selector.clone(),
-                dependency.selector_offset,
+                dependency.selector.len() - dependency.selector_offset + 1,
             ));
         } else if dependency.affects_later_siblings() {
             debug_assert_ne!(dependency.selector_offset, 0);
+            debug_assert_ne!(dependency.selector_offset, dependency.selector.len());
             self.sibling_invalidations.push(Invalidation::new(
                 dependency.selector.clone(),
-                dependency.selector_offset,
+                dependency.selector.len() - dependency.selector_offset + 1,
             ));
         }
     }

--- a/components/style/invalidation/element/invalidation_map.rs
+++ b/components/style/invalidation/element/invalidation_map.rs
@@ -79,7 +79,7 @@ impl Dependency {
             return None;
         }
 
-        Some(self.selector.combinator_at(self.selector_offset))
+        Some(self.selector.combinator_at_match_order(self.selector_offset - 1))
     }
 
     /// Whether this dependency affects the style of the element.


### PR DESCRIPTION
This will make easier to create external invalidations that don't point to a combinator,
and also makes reasoning about the invalidator a bit easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18884)
<!-- Reviewable:end -->
