### PR TITLE
Add a default 'unstable' feature to CEF

### DIFF
--- a/ports/cef/Cargo.toml
+++ b/ports/cef/Cargo.toml
@@ -16,6 +16,9 @@ opt-level = 3
 
 [features]
 debugmozjs = ["libservo/debugmozjs"]
+default = ["unstable", "default-except-unstable"]
+default-except-unstable = []
+unstable = ["libservo/unstable"]
 
 [dependencies]
 compositing = {path = "../../components/compositing"}


### PR DESCRIPTION
I recently moved that default from libservo to ports/servo, which made CEF not have it anymore.

The different defaults made `./mach build-cef` after `./mach build` rebuild many libraries (including serde and all of its recursive dependents) and take a long time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18885)
<!-- Reviewable:end -->
