### PR TITLE
CEF: use `cargo rustc -C link-args=…` instead of `#[link_args="…"]`

### DIFF
--- a/ports/cef/lib.rs
+++ b/ports/cef/lib.rs
@@ -4,7 +4,6 @@
 
 #![allow(non_camel_case_types)]
 #![feature(core_intrinsics)]
-#![feature(link_args)]
 
 #[macro_use]
 extern crate log;
@@ -26,10 +25,6 @@ extern crate msg;
 extern crate webrender_api;
 
 extern crate libc;
-
-#[cfg(target_os="macos")]
-#[link_args="-Xlinker -undefined -Xlinker dynamic_lookup"]
-extern { }
 
 #[cfg(target_os="macos")]
 extern crate cocoa;


### PR DESCRIPTION
The latter is an unstable feature that might be changed or removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18892)
<!-- Reviewable:end -->
