### PR TITLE
style: Remove the ElementExt trait.

### DIFF
--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -20,8 +20,8 @@ use properties::{AnimationRules, ComputedValues, PropertyDeclarationBlock};
 #[cfg(feature = "gecko")] use properties::LonghandId;
 #[cfg(feature = "gecko")] use properties::animated_properties::AnimationValue;
 use rule_tree::CascadeLevel;
-use selector_parser::{AttrValue, ElementExt};
-use selector_parser::{PseudoClassStringArg, PseudoElement};
+use selector_parser::{AttrValue, PseudoClassStringArg, PseudoElement, SelectorImpl};
+use selectors::Element as SelectorsElement;
 use selectors::matching::{ElementSelectorFlags, VisitedHandlingMode};
 use selectors::sink::Push;
 use servo_arc::{Arc, ArcBorrow};
@@ -242,8 +242,17 @@ pub trait PresentationalHintsSynthesizer {
 }
 
 /// The element trait, the main abstraction the style crate acts over.
-pub trait TElement : Eq + PartialEq + Debug + Hash + Sized + Copy + Clone +
-                     ElementExt + PresentationalHintsSynthesizer {
+pub trait TElement
+    : Eq
+    + PartialEq
+    + Debug
+    + Hash
+    + Sized
+    + Copy
+    + Clone
+    + SelectorsElement<Impl = SelectorImpl>
+    + PresentationalHintsSynthesizer
+{
     /// The concrete node type.
     type ConcreteNode: TNode<ConcreteElement = Self>;
 
@@ -262,6 +271,11 @@ pub trait TElement : Eq + PartialEq + Debug + Hash + Sized + Copy + Clone +
     /// Otherwise we may set document-level state incorrectly, like the root
     /// font-size used for rem units.
     fn owner_doc_matches_for_testing(&self, _: &Device) -> bool { true }
+
+    /// Whether this element should match user and author rules.
+    ///
+    /// We use this for Native Anonymous Content in Gecko.
+    fn matches_user_and_author_rules(&self) -> bool { true }
 
     /// Returns the depth of this element in the DOM.
     fn depth(&self) -> usize {

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -75,7 +75,7 @@ use properties::animated_properties::{AnimationValue, AnimationValueMap};
 use properties::animated_properties::TransitionProperty;
 use properties::style_structs::Font;
 use rule_tree::CascadeLevel as ServoCascadeLevel;
-use selector_parser::{AttrValue, ElementExt, PseudoClassStringArg};
+use selector_parser::{AttrValue, PseudoClassStringArg};
 use selectors::{Element, OpaqueElement};
 use selectors::attr::{AttrSelectorOperation, AttrSelectorOperator, CaseSensitivity, NamespaceConstraint};
 use selectors::matching::{ElementSelectorFlags, MatchingContext};
@@ -1105,6 +1105,11 @@ impl<'le> TElement for GeckoElement<'le> {
         self.flags() & (NODE_IS_NATIVE_ANONYMOUS as u32) != 0
     }
 
+    #[inline]
+    fn matches_user_and_author_rules(&self) -> bool {
+        !self.is_in_native_anonymous_subtree()
+    }
+
     fn implemented_pseudo_element(&self) -> Option<PseudoElement> {
         if !self.is_native_anonymous() {
             return None;
@@ -2067,12 +2072,5 @@ impl<'a> NamespaceConstraintHelpers for NamespaceConstraint<&'a Namespace> {
             NamespaceConstraint::Any => ptr::null_mut(),
             NamespaceConstraint::Specific(ref ns) => ns.0.as_ptr(),
         }
-    }
-}
-
-impl<'le> ElementExt for GeckoElement<'le> {
-    #[inline]
-    fn matches_user_and_author_rules(&self) -> bool {
-        !self.is_in_native_anonymous_subtree()
     }
 }

--- a/components/style/selector_parser.rs
+++ b/components/style/selector_parser.rs
@@ -7,7 +7,6 @@
 #![deny(missing_docs)]
 
 use cssparser::{Parser as CssParser, ParserInput};
-use selectors::Element;
 use selectors::parser::SelectorList;
 use std::fmt::{self, Debug};
 use style_traits::ParseError;
@@ -101,14 +100,6 @@ pub enum PseudoElementCascadeType {
     /// This pseudo-elements are resolved on the fly using *only* global rules
     /// (rules of the form `*|*`), and applying them to the parent style.
     Precomputed,
-}
-
-/// An extension to rust-selector's `Element` trait.
-pub trait ElementExt: Element<Impl=SelectorImpl> + Debug {
-    /// Whether this element should match user and author rules.
-    ///
-    /// We use this for Native Anonymous Content in Gecko.
-    fn matches_user_and_author_rules(&self) -> bool;
 }
 
 /// A per-functional-pseudo map, from a given pseudo to a `T`.

--- a/components/style/servo/selector_parser.rs
+++ b/components/style/servo/selector_parser.rs
@@ -16,14 +16,12 @@ use invalidation::element::element_wrapper::ElementSnapshot;
 use properties::ComputedValues;
 use properties::PropertyFlags;
 use properties::longhands::display::computed_value as display;
-use selector_parser::{AttrValue as SelectorAttrValue, ElementExt, PseudoElementCascadeType, SelectorParser};
-use selectors::Element;
+use selector_parser::{AttrValue as SelectorAttrValue, PseudoElementCascadeType, SelectorParser};
 use selectors::attr::{AttrSelectorOperation, NamespaceConstraint, CaseSensitivity};
 use selectors::parser::{SelectorMethods, SelectorParseErrorKind};
 use selectors::visitor::SelectorVisitor;
 use std::ascii::AsciiExt;
 use std::fmt;
-use std::fmt::Debug;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use style_traits::{ParseError, StyleParseErrorKind};
@@ -712,13 +710,6 @@ impl ServoElementSnapshot {
                 self.any_attr_ignore_ns(local_name, |value| value.eval_selector(operation))
             }
         }
-    }
-}
-
-impl<E: Element<Impl=SelectorImpl> + Debug> ElementExt for E {
-    #[inline]
-    fn matches_user_and_author_rules(&self) -> bool {
-        true
     }
 }
 


### PR DESCRIPTION
It is likely it's the most useless trait ever existing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18894)
<!-- Reviewable:end -->
