### PR TITLE
style: Remove unused TNode::is_in_doc.

### DIFF
--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -200,10 +200,6 @@ impl<'ln> TNode for ServoLayoutNode<'ln> {
     unsafe fn set_can_be_fragmented(&self, value: bool) {
         self.node.set_flag(CAN_BE_FRAGMENTED, value)
     }
-
-    fn is_in_doc(&self) -> bool {
-        unsafe { (*self.node.unsafe_get()).is_in_doc() }
-    }
 }
 
 pub struct ServoChildrenIterator<'a> {

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -135,10 +135,6 @@ pub trait TNode : Sized + Copy + Clone + Debug + NodeInfo {
 
     /// Set whether this node can be fragmented.
     unsafe fn set_can_be_fragmented(&self, value: bool);
-
-    /// Whether this node is in the document right now needed to clear the
-    /// restyle data appropriately on some forced restyles.
-    fn is_in_doc(&self) -> bool;
 }
 
 /// Wrapper to output the ElementData along with the node when formatting for

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -306,10 +306,6 @@ impl<'ln> TNode for GeckoNode<'ln> {
         // FIXME(SimonSapin): Servo uses this to implement CSS multicol / fragmentation
         // Maybe this isn’t useful for Gecko?
     }
-
-    fn is_in_doc(&self) -> bool {
-        unsafe { bindings::Gecko_IsInDocument(self.0) }
-    }
 }
 
 /// A wrapper on top of two kind of iterators, depending on the parent being


### PR DESCRIPTION
I'll cleanup the Gecko function after this lands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18896)
<!-- Reviewable:end -->
