### PR TITLE
style: Don't require a full SharedStyleContext for TreeStyleInvalidator.

### DIFF
--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -259,11 +259,12 @@ impl ElementData {
             return InvalidationResult::empty();
         }
 
-        let mut processor = StateAndAttrInvalidationProcessor;
+        let mut processor =
+            StateAndAttrInvalidationProcessor::new(shared_context);
         let invalidator = TreeStyleInvalidator::new(
             element,
             Some(self),
-            shared_context,
+            shared_context.quirks_mode(),
             stack_limit_checker,
             nth_index_cache,
             &mut processor,


### PR DESCRIPTION
We only use it to get the quirks mode, and a shared style context is a pretty
heavy-weight struct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18898)
<!-- Reviewable:end -->
