### PR TITLE
Remove use of unstable box syntax.

### DIFF
--- a/components/script/dom/abstractworkerglobalscope.rs
+++ b/components/script/dom/abstractworkerglobalscope.rs
@@ -24,10 +24,10 @@ impl<T: JSTraceable + DomObject + 'static> ScriptChan for SendableWorkerScriptCh
     }
 
     fn clone(&self) -> Box<ScriptChan + Send> {
-        box SendableWorkerScriptChan {
+        Box::new(SendableWorkerScriptChan {
             sender: self.sender.clone(),
             worker: self.worker.clone(),
-        }
+        })
     }
 }
 
@@ -48,10 +48,10 @@ impl<T: JSTraceable + DomObject + 'static> ScriptChan for WorkerThreadWorkerChan
     }
 
     fn clone(&self) -> Box<ScriptChan + Send> {
-        box WorkerThreadWorkerChan {
+        Box::new(WorkerThreadWorkerChan {
             sender: self.sender.clone(),
             worker: self.worker.clone(),
-        }
+        })
     }
 }
 

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -64,14 +64,18 @@ impl Attr {
                prefix: Option<Prefix>,
                owner: Option<&Element>)
                -> DomRoot<Attr> {
-        reflect_dom_object(box Attr::new_inherited(local_name,
-                                                   value,
-                                                   name,
-                                                   namespace,
-                                                   prefix,
-                                                   owner),
-                           window,
-                           AttrBinding::Wrap)
+        reflect_dom_object(
+            Box::new(Attr::new_inherited(
+                local_name,
+                value,
+                name,
+                namespace,
+                prefix,
+                owner
+            )),
+            window,
+            AttrBinding::Wrap
+        )
     }
 
     #[inline]

--- a/components/script/dom/beforeunloadevent.rs
+++ b/components/script/dom/beforeunloadevent.rs
@@ -33,7 +33,7 @@ impl BeforeUnloadEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<BeforeUnloadEvent> {
-        reflect_dom_object(box BeforeUnloadEvent::new_inherited(),
+        reflect_dom_object(Box::new(BeforeUnloadEvent::new_inherited()),
                            window,
                            BeforeUnloadEventBinding::Wrap)
     }

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -226,7 +226,7 @@ pub unsafe fn create_global_object(
     // avoid getting trace hooks called on a partially initialized object.
     JS_SetReservedSlot(rval.get(), DOM_OBJECT_SLOT, PrivateValue(private));
     let proto_array: Box<ProtoOrIfaceArray> =
-        box [0 as *mut JSObject; PrototypeList::PROTO_OR_IFACE_LENGTH];
+        Box::new([0 as *mut JSObject; PrototypeList::PROTO_OR_IFACE_LENGTH]);
     JS_SetReservedSlot(rval.get(),
                        DOM_PROTOTYPE_SLOT,
                        PrivateValue(Box::into_raw(proto_array) as *const libc::c_void));

--- a/components/script/dom/bindings/iterable.rs
+++ b/components/script/dom/bindings/iterable.rs
@@ -62,12 +62,12 @@ impl<T: DomObject + JSTraceable + Iterable> IterableIterator<T> {
                type_: IteratorType,
                wrap: unsafe fn(*mut JSContext, &GlobalScope, Box<IterableIterator<T>>)
                      -> DomRoot<Self>) -> DomRoot<Self> {
-        let iterator = box IterableIterator {
+        let iterator = Box::new(IterableIterator {
             reflector: Reflector::new(),
             type_: type_,
             iterable: Dom::from_ref(iterable),
             index: Cell::new(0),
-        };
+        });
         reflect_dom_object(iterator, &*iterable.global(), wrap)
     }
 

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -759,7 +759,7 @@ unsafe impl<T: JSTraceable + 'static> JSTraceable for RootedTraceableBox<T> {
 impl<T: JSTraceable + 'static> RootedTraceableBox<T> {
     /// DomRoot a JSTraceable thing for the life of this RootedTraceable
     pub fn new(traceable: T) -> RootedTraceableBox<T> {
-        let traceable = Box::into_raw(box traceable);
+        let traceable = Box::into_raw(Box::new(traceable));
         unsafe {
             RootedTraceableSet::add(traceable);
         }

--- a/components/script/dom/bindings/weakref.rs
+++ b/components/script/dom/bindings/weakref.rs
@@ -56,10 +56,10 @@ pub trait WeakReferenceable: DomObject + Sized {
                               .to_private() as *mut WeakBox<Self>;
             if ptr.is_null() {
                 trace!("Creating new WeakBox holder for {:p}.", self);
-                ptr = Box::into_raw(box WeakBox {
+                ptr = Box::into_raw(Box::new(WeakBox {
                     count: Cell::new(1),
                     value: Cell::new(Some(NonZero::new_unchecked(self))),
-                });
+                }));
                 JS_SetReservedSlot(object, DOM_WEAK_SLOT, PrivateValue(ptr as *const c_void));
             }
             let box_ = &*ptr;

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -80,7 +80,7 @@ impl Blob {
     pub fn new(
             global: &GlobalScope, blob_impl: BlobImpl, typeString: String)
             -> DomRoot<Blob> {
-        let boxed_blob = box Blob::new_inherited(blob_impl, typeString);
+        let boxed_blob = Box::new(Blob::new_inherited(blob_impl, typeString));
         reflect_dom_object(boxed_blob, global, BlobBinding::Wrap)
     }
 

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -132,7 +132,7 @@ impl Bluetooth {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<Bluetooth> {
-        reflect_dom_object(box Bluetooth::new_inherited(),
+        reflect_dom_object(Box::new(Bluetooth::new_inherited()),
                            global,
                            BluetoothBinding::Wrap)
     }
@@ -224,7 +224,7 @@ pub fn response_async<T: AsyncBluetoothListener + DomObject + 'static>(
         promise: Some(TrustedPromise::new(promise.clone())),
         receiver: Trusted::new(receiver),
     }));
-    ROUTER.add_route(action_receiver.to_opaque(), box move |message| {
+    ROUTER.add_route(action_receiver.to_opaque(), Box::new(move |message| {
         struct ListenerTask<T: AsyncBluetoothListener + DomObject> {
             context: Arc<Mutex<BluetoothContext<T>>>,
             action: BluetoothResponseResult,
@@ -249,7 +249,7 @@ pub fn response_async<T: AsyncBluetoothListener + DomObject + 'static>(
         if let Err(err) = result {
             warn!("failed to deliver network data: {:?}", err);
         }
-    });
+    }));
     action_sender
 }
 

--- a/components/script/dom/bluetoothadvertisingevent.rs
+++ b/components/script/dom/bluetoothadvertisingevent.rs
@@ -55,13 +55,17 @@ impl BluetoothAdvertisingEvent {
                txPower: Option<i8>,
                rssi: Option<i8>)
                -> DomRoot<BluetoothAdvertisingEvent> {
-        let ev = reflect_dom_object(box BluetoothAdvertisingEvent::new_inherited(device,
-                                                                                 name,
-                                                                                 appearance,
-                                                                                 txPower,
-                                                                                 rssi),
-                                    global,
-                                    BluetoothAdvertisingEventBinding::Wrap);
+        let ev = reflect_dom_object(
+            Box::new(BluetoothAdvertisingEvent::new_inherited(
+                device,
+                name,
+                appearance,
+                txPower,
+                rssi
+            )),
+            global,
+            BluetoothAdvertisingEventBinding::Wrap
+        );
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));

--- a/components/script/dom/bluetoothcharacteristicproperties.rs
+++ b/components/script/dom/bluetoothcharacteristicproperties.rs
@@ -61,19 +61,23 @@ impl BluetoothCharacteristicProperties {
                reliableWrite: bool,
                writableAuxiliaries: bool)
                -> DomRoot<BluetoothCharacteristicProperties> {
-        reflect_dom_object(box BluetoothCharacteristicProperties::new_inherited(broadcast,
-                                                                                read,
-                                                                                writeWithoutResponse,
-                                                                                write,
-                                                                                notify,
-                                                                                indicate,
-                                                                                authenticatedSignedWrites,
-                                                                                reliableWrite,
-                                                                                writableAuxiliaries),
-                           global,
-                           BluetoothCharacteristicPropertiesBinding::Wrap)
-        }
+        reflect_dom_object(
+            Box::new(BluetoothCharacteristicProperties::new_inherited(
+                broadcast,
+                read,
+                writeWithoutResponse,
+                write,
+                notify,
+                indicate,
+                authenticatedSignedWrites,
+                reliableWrite,
+                writableAuxiliaries
+            )),
+            global,
+            BluetoothCharacteristicPropertiesBinding::Wrap
+        )
     }
+}
 
 impl BluetoothCharacteristicPropertiesMethods for BluetoothCharacteristicProperties {
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-broadcast

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -66,9 +66,7 @@ impl BluetoothDevice {
                name: Option<DOMString>,
                context: &Bluetooth)
                -> DomRoot<BluetoothDevice> {
-        reflect_dom_object(box BluetoothDevice::new_inherited(id,
-                                                              name,
-                                                              context),
+        reflect_dom_object(Box::new(BluetoothDevice::new_inherited(id, name, context)),
                            global,
                            BluetoothDeviceBinding::Wrap)
     }

--- a/components/script/dom/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetoothpermissionresult.rs
@@ -41,7 +41,7 @@ impl BluetoothPermissionResult {
     }
 
     pub fn new(global: &GlobalScope, status: &PermissionStatus) -> DomRoot<BluetoothPermissionResult> {
-        reflect_dom_object(box BluetoothPermissionResult::new_inherited(status),
+        reflect_dom_object(Box::new(BluetoothPermissionResult::new_inherited(status)),
                            global,
                            BluetoothPermissionResultBinding::Wrap)
     }

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -65,12 +65,13 @@ impl BluetoothRemoteGATTCharacteristic {
                properties: &BluetoothCharacteristicProperties,
                instanceID: String)
                -> DomRoot<BluetoothRemoteGATTCharacteristic> {
-        reflect_dom_object(box BluetoothRemoteGATTCharacteristic::new_inherited(service,
-                                                                                uuid,
-                                                                                properties,
-                                                                                instanceID),
-                           global,
-                           BluetoothRemoteGATTCharacteristicBinding::Wrap)
+        reflect_dom_object(
+            Box::new(BluetoothRemoteGATTCharacteristic::new_inherited(
+                service, uuid, properties, instanceID
+            )),
+            global,
+            BluetoothRemoteGATTCharacteristicBinding::Wrap
+        )
     }
 
     fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -52,11 +52,13 @@ impl BluetoothRemoteGATTDescriptor {
                uuid: DOMString,
                instanceID: String)
                -> DomRoot<BluetoothRemoteGATTDescriptor>{
-        reflect_dom_object(box BluetoothRemoteGATTDescriptor::new_inherited(characteristic,
-                                                                            uuid,
-                                                                            instanceID),
-                            global,
-                            BluetoothRemoteGATTDescriptorBinding::Wrap)
+        reflect_dom_object(
+            Box::new(BluetoothRemoteGATTDescriptor::new_inherited(
+                characteristic, uuid, instanceID
+            )),
+            global,
+            BluetoothRemoteGATTDescriptorBinding::Wrap
+        )
     }
 
     fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -38,7 +38,7 @@ impl BluetoothRemoteGATTServer {
     }
 
     pub fn new(global: &GlobalScope, device: &BluetoothDevice) -> DomRoot<BluetoothRemoteGATTServer> {
-        reflect_dom_object(box BluetoothRemoteGATTServer::new_inherited(device),
+        reflect_dom_object(Box::new(BluetoothRemoteGATTServer::new_inherited(device)),
                            global,
                            BluetoothRemoteGATTServerBinding::Wrap)
     }

--- a/components/script/dom/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetoothremotegattservice.rs
@@ -50,12 +50,13 @@ impl BluetoothRemoteGATTService {
                isPrimary: bool,
                instanceID: String)
                -> DomRoot<BluetoothRemoteGATTService> {
-        reflect_dom_object(box BluetoothRemoteGATTService::new_inherited(device,
-                                                                         uuid,
-                                                                         isPrimary,
-                                                                         instanceID),
-                           global,
-                           BluetoothRemoteGATTServiceBinding::Wrap)
+        reflect_dom_object(
+            Box::new(BluetoothRemoteGATTService::new_inherited(
+                device, uuid, isPrimary, instanceID
+            )),
+            global,
+            BluetoothRemoteGATTServiceBinding::Wrap
+        )
     }
 
     fn get_instance_id(&self) -> String {

--- a/components/script/dom/canvasgradient.rs
+++ b/components/script/dom/canvasgradient.rs
@@ -40,7 +40,7 @@ impl CanvasGradient {
     }
 
     pub fn new(global: &GlobalScope, style: CanvasGradientStyle) -> DomRoot<CanvasGradient> {
-        reflect_dom_object(box CanvasGradient::new_inherited(style),
+        reflect_dom_object(Box::new(CanvasGradient::new_inherited(style)),
                            global,
                            CanvasGradientBinding::Wrap)
     }

--- a/components/script/dom/canvaspattern.rs
+++ b/components/script/dom/canvaspattern.rs
@@ -50,10 +50,13 @@ impl CanvasPattern {
                repeat: RepetitionStyle,
                origin_clean: bool)
                -> DomRoot<CanvasPattern> {
-        reflect_dom_object(box CanvasPattern::new_inherited(surface_data, surface_size,
-                                                            repeat, origin_clean),
-                           global,
-                           CanvasPatternBinding::Wrap)
+        reflect_dom_object(
+            Box::new(CanvasPattern::new_inherited(
+                surface_data, surface_size, repeat, origin_clean
+            )),
+            global,
+            CanvasPatternBinding::Wrap
+        )
     }
     pub fn origin_is_clean(&self) -> bool {
       self.origin_clean

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -155,7 +155,9 @@ impl CanvasRenderingContext2D {
         let window = window_from_node(canvas);
         let image_cache = window.image_cache();
         let base_url = window.get_url();
-        let boxed = box CanvasRenderingContext2D::new_inherited(global, Some(canvas), image_cache, base_url, size);
+        let boxed = Box::new(CanvasRenderingContext2D::new_inherited(
+            global, Some(canvas), image_cache, base_url, size
+        ));
         reflect_dom_object(boxed, global, CanvasRenderingContext2DBinding::Wrap)
     }
 

--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -36,7 +36,7 @@ impl Client {
     }
 
     pub fn new(window: &Window) -> DomRoot<Client> {
-        reflect_dom_object(box Client::new_inherited(window.get_url()),
+        reflect_dom_object(Box::new(Client::new_inherited(window.get_url())),
                            window,
                            Wrap)
     }

--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -34,7 +34,7 @@ impl CloseEvent {
     }
 
     pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<CloseEvent> {
-        reflect_dom_object(box CloseEvent::new_inherited(false, 0, DOMString::new()),
+        reflect_dom_object(Box::new(CloseEvent::new_inherited(false, 0, DOMString::new())),
                            global,
                            CloseEventBinding::Wrap)
     }
@@ -47,7 +47,7 @@ impl CloseEvent {
                code: u16,
                reason: DOMString)
                -> DomRoot<CloseEvent> {
-        let event = box CloseEvent::new_inherited(wasClean, code, reason);
+        let event = Box::new(CloseEvent::new_inherited(wasClean, code, reason));
         let ev = reflect_dom_object(event, global, CloseEventBinding::Wrap);
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -27,7 +27,7 @@ impl Comment {
     }
 
     pub fn new(text: DOMString, document: &Document) -> DomRoot<Comment> {
-        Node::reflect_node(box Comment::new_inherited(text, document),
+        Node::reflect_node(Box::new(Comment::new_inherited(text, document)),
                            document,
                            CommentBinding::Wrap)
     }

--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -26,10 +26,10 @@ impl CompositionEvent {
                view: Option<&Window>,
                detail: i32,
                data: DOMString) -> DomRoot<CompositionEvent> {
-        let ev = reflect_dom_object(box CompositionEvent {
+        let ev = reflect_dom_object(Box::new(CompositionEvent {
                                         uievent: UIEvent::new_inherited(),
                                         data: data,
-                                    },
+                                    }),
                                     window,
                                     CompositionEventBinding::Wrap);
         ev.uievent.InitUIEvent(type_, can_bubble, cancelable, view, detail);

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -34,7 +34,7 @@ impl Crypto {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<Crypto> {
-        reflect_dom_object(box Crypto::new_inherited(), global, CryptoBinding::Wrap)
+        reflect_dom_object(Box::new(Crypto::new_inherited()), global, CryptoBinding::Wrap)
     }
 }
 

--- a/components/script/dom/cssfontfacerule.rs
+++ b/components/script/dom/cssfontfacerule.rs
@@ -33,7 +33,7 @@ impl CSSFontFaceRule {
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, parent_stylesheet: &CSSStyleSheet,
                fontfacerule: Arc<Locked<FontFaceRule>>) -> DomRoot<CSSFontFaceRule> {
-        reflect_dom_object(box CSSFontFaceRule::new_inherited(parent_stylesheet, fontfacerule),
+        reflect_dom_object(Box::new(CSSFontFaceRule::new_inherited(parent_stylesheet, fontfacerule)),
                            window,
                            CSSFontFaceRuleBinding::Wrap)
     }

--- a/components/script/dom/cssimportrule.rs
+++ b/components/script/dom/cssimportrule.rs
@@ -35,7 +35,7 @@ impl CSSImportRule {
     pub fn new(window: &Window,
                parent_stylesheet: &CSSStyleSheet,
                import_rule: Arc<Locked<ImportRule>>) -> DomRoot<Self> {
-        reflect_dom_object(box Self::new_inherited(parent_stylesheet, import_rule),
+        reflect_dom_object(Box::new(Self::new_inherited(parent_stylesheet, import_rule)),
                            window,
                            CSSImportRuleBinding::Wrap)
     }

--- a/components/script/dom/csskeyframerule.rs
+++ b/components/script/dom/csskeyframerule.rs
@@ -37,7 +37,7 @@ impl CSSKeyframeRule {
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, parent_stylesheet: &CSSStyleSheet,
                keyframerule: Arc<Locked<Keyframe>>) -> DomRoot<CSSKeyframeRule> {
-        reflect_dom_object(box CSSKeyframeRule::new_inherited(parent_stylesheet, keyframerule),
+        reflect_dom_object(Box::new(CSSKeyframeRule::new_inherited(parent_stylesheet, keyframerule)),
                            window,
                            CSSKeyframeRuleBinding::Wrap)
     }

--- a/components/script/dom/csskeyframesrule.rs
+++ b/components/script/dom/csskeyframesrule.rs
@@ -42,7 +42,7 @@ impl CSSKeyframesRule {
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, parent_stylesheet: &CSSStyleSheet,
                keyframesrule: Arc<Locked<KeyframesRule>>) -> DomRoot<CSSKeyframesRule> {
-        reflect_dom_object(box CSSKeyframesRule::new_inherited(parent_stylesheet, keyframesrule),
+        reflect_dom_object(Box::new(CSSKeyframesRule::new_inherited(parent_stylesheet, keyframesrule)),
                            window,
                            CSSKeyframesRuleBinding::Wrap)
     }

--- a/components/script/dom/cssmediarule.rs
+++ b/components/script/dom/cssmediarule.rs
@@ -45,7 +45,7 @@ impl CSSMediaRule {
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, parent_stylesheet: &CSSStyleSheet,
                mediarule: Arc<Locked<MediaRule>>) -> DomRoot<CSSMediaRule> {
-        reflect_dom_object(box CSSMediaRule::new_inherited(parent_stylesheet, mediarule),
+        reflect_dom_object(Box::new(CSSMediaRule::new_inherited(parent_stylesheet, mediarule)),
                            window,
                            CSSMediaRuleBinding::Wrap)
     }

--- a/components/script/dom/cssnamespacerule.rs
+++ b/components/script/dom/cssnamespacerule.rs
@@ -34,7 +34,7 @@ impl CSSNamespaceRule {
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, parent_stylesheet: &CSSStyleSheet,
                namespacerule: Arc<Locked<NamespaceRule>>) -> DomRoot<CSSNamespaceRule> {
-        reflect_dom_object(box CSSNamespaceRule::new_inherited(parent_stylesheet, namespacerule),
+        reflect_dom_object(Box::new(CSSNamespaceRule::new_inherited(parent_stylesheet, namespacerule)),
                            window,
                            CSSNamespaceRuleBinding::Wrap)
     }

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -71,7 +71,7 @@ impl CSSRuleList {
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, parent_stylesheet: &CSSStyleSheet,
                rules: RulesSource) -> DomRoot<CSSRuleList> {
-        reflect_dom_object(box CSSRuleList::new_inherited(parent_stylesheet, rules),
+        reflect_dom_object(Box::new(CSSRuleList::new_inherited(parent_stylesheet, rules)),
                            window,
                            CSSRuleListBinding::Wrap)
     }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -193,11 +193,11 @@ impl CSSStyleDeclaration {
                pseudo: Option<PseudoElement>,
                modification_access: CSSModificationAccess)
                -> DomRoot<CSSStyleDeclaration> {
-        reflect_dom_object(box CSSStyleDeclaration::new_inherited(owner,
-                                                                  pseudo,
-                                                                  modification_access),
-                           global,
-                           CSSStyleDeclarationBinding::Wrap)
+        reflect_dom_object(
+            Box::new(CSSStyleDeclaration::new_inherited(owner, pseudo, modification_access)),
+            global,
+            CSSStyleDeclarationBinding::Wrap
+        )
     }
 
     fn get_computed_style(&self, property: PropertyId) -> DOMString {

--- a/components/script/dom/cssstylerule.rs
+++ b/components/script/dom/cssstylerule.rs
@@ -43,7 +43,7 @@ impl CSSStyleRule {
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, parent_stylesheet: &CSSStyleSheet,
                stylerule: Arc<Locked<StyleRule>>) -> DomRoot<CSSStyleRule> {
-        reflect_dom_object(box CSSStyleRule::new_inherited(parent_stylesheet, stylerule),
+        reflect_dom_object(Box::new(CSSStyleRule::new_inherited(parent_stylesheet, stylerule)),
                            window,
                            CSSStyleRuleBinding::Wrap)
     }

--- a/components/script/dom/cssstylesheet.rs
+++ b/components/script/dom/cssstylesheet.rs
@@ -51,7 +51,7 @@ impl CSSStyleSheet {
                href: Option<DOMString>,
                title: Option<DOMString>,
                stylesheet: Arc<StyleStyleSheet>) -> DomRoot<CSSStyleSheet> {
-        reflect_dom_object(box CSSStyleSheet::new_inherited(owner, type_, href, title, stylesheet),
+        reflect_dom_object(Box::new(CSSStyleSheet::new_inherited(owner, type_, href, title, stylesheet)),
                            window,
                            CSSStyleSheetBinding::Wrap)
     }

--- a/components/script/dom/cssstylevalue.rs
+++ b/components/script/dom/cssstylevalue.rs
@@ -29,7 +29,7 @@ impl CSSStyleValue {
     }
 
     pub fn new(global: &GlobalScope, value: String) -> DomRoot<CSSStyleValue> {
-        reflect_dom_object(box CSSStyleValue::new_inherited(value), global, Wrap)
+        reflect_dom_object(Box::new(CSSStyleValue::new_inherited(value)), global, Wrap)
     }
 }
 

--- a/components/script/dom/csssupportsrule.rs
+++ b/components/script/dom/csssupportsrule.rs
@@ -41,7 +41,7 @@ impl CSSSupportsRule {
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, parent_stylesheet: &CSSStyleSheet,
                supportsrule: Arc<Locked<SupportsRule>>) -> DomRoot<CSSSupportsRule> {
-        reflect_dom_object(box CSSSupportsRule::new_inherited(parent_stylesheet, supportsrule),
+        reflect_dom_object(Box::new(CSSSupportsRule::new_inherited(parent_stylesheet, supportsrule)),
                            window,
                            CSSSupportsRuleBinding::Wrap)
     }

--- a/components/script/dom/cssviewportrule.rs
+++ b/components/script/dom/cssviewportrule.rs
@@ -32,7 +32,7 @@ impl CSSViewportRule {
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, parent_stylesheet: &CSSStyleSheet,
                viewportrule: Arc<Locked<ViewportRule>>) -> DomRoot<CSSViewportRule> {
-        reflect_dom_object(box CSSViewportRule::new_inherited(parent_stylesheet, viewportrule),
+        reflect_dom_object(Box::new(CSSViewportRule::new_inherited(parent_stylesheet, viewportrule)),
                            window,
                            CSSViewportRuleBinding::Wrap)
     }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -68,7 +68,7 @@ impl CustomElementRegistry {
     }
 
     pub fn new(window: &Window) -> DomRoot<CustomElementRegistry> {
-        reflect_dom_object(box CustomElementRegistry::new_inherited(window),
+        reflect_dom_object(Box::new(CustomElementRegistry::new_inherited(window)),
                            window,
                            CustomElementRegistryBinding::Wrap)
     }

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -35,7 +35,7 @@ impl CustomEvent {
     }
 
     pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<CustomEvent> {
-        reflect_dom_object(box CustomEvent::new_inherited(),
+        reflect_dom_object(Box::new(CustomEvent::new_inherited()),
                            global,
                            CustomEventBinding::Wrap)
     }

--- a/components/script/dom/dissimilaroriginlocation.rs
+++ b/components/script/dom/dissimilaroriginlocation.rs
@@ -40,7 +40,7 @@ impl DissimilarOriginLocation {
     }
 
     pub fn new(window: &DissimilarOriginWindow) -> DomRoot<DissimilarOriginLocation> {
-        reflect_dom_object(box DissimilarOriginLocation::new_inherited(window),
+        reflect_dom_object(Box::new(DissimilarOriginLocation::new_inherited(window)),
                            window,
                            DissimilarOriginLocationBinding::Wrap)
     }

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -52,7 +52,7 @@ impl DissimilarOriginWindow {
         let cx = global_to_clone_from.get_cx();
         // Any timer events fired on this window are ignored.
         let (timer_event_chan, _) = ipc::channel().unwrap();
-        let win = box Self {
+        let win = Box::new(Self {
             globalscope: GlobalScope::new_inherited(
                 PipelineId::new(),
                 global_to_clone_from.devtools_chan().cloned(),
@@ -69,7 +69,7 @@ impl DissimilarOriginWindow {
             ),
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),
-        };
+        });
         unsafe { DissimilarOriginWindowBinding::Wrap(cx, win) }
     }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2312,20 +2312,24 @@ impl Document {
                referrer: Option<String>,
                referrer_policy: Option<ReferrerPolicy>)
                -> DomRoot<Document> {
-        let document = reflect_dom_object(box Document::new_inherited(window,
-                                                                      has_browsing_context,
-                                                                      url,
-                                                                      origin,
-                                                                      doctype,
-                                                                      content_type,
-                                                                      last_modified,
-                                                                      activity,
-                                                                      source,
-                                                                      doc_loader,
-                                                                      referrer,
-                                                                      referrer_policy),
-                                          window,
-                                          DocumentBinding::Wrap);
+        let document = reflect_dom_object(
+            Box::new(Document::new_inherited(
+                window,
+                has_browsing_context,
+                url,
+                origin,
+                doctype,
+                content_type,
+                last_modified,
+                activity,
+                source,
+                doc_loader,
+                referrer,
+                referrer_policy
+            )),
+            window,
+            DocumentBinding::Wrap
+        );
         {
             let node = document.upcast::<Node>();
             node.set_owner_doc(&document);
@@ -3344,7 +3348,7 @@ impl DocumentMethods for Document {
     // https://html.spec.whatwg.org/multipage/#dom-document-images
     fn Images(&self) -> DomRoot<HTMLCollection> {
         self.images.or_init(|| {
-            let filter = box ImagesFilter;
+            let filter = Box::new(ImagesFilter);
             HTMLCollection::create(&self.window, self.upcast(), filter)
         })
     }
@@ -3352,7 +3356,7 @@ impl DocumentMethods for Document {
     // https://html.spec.whatwg.org/multipage/#dom-document-embeds
     fn Embeds(&self) -> DomRoot<HTMLCollection> {
         self.embeds.or_init(|| {
-            let filter = box EmbedsFilter;
+            let filter = Box::new(EmbedsFilter);
             HTMLCollection::create(&self.window, self.upcast(), filter)
         })
     }
@@ -3365,7 +3369,7 @@ impl DocumentMethods for Document {
     // https://html.spec.whatwg.org/multipage/#dom-document-links
     fn Links(&self) -> DomRoot<HTMLCollection> {
         self.links.or_init(|| {
-            let filter = box LinksFilter;
+            let filter = Box::new(LinksFilter);
             HTMLCollection::create(&self.window, self.upcast(), filter)
         })
     }
@@ -3373,7 +3377,7 @@ impl DocumentMethods for Document {
     // https://html.spec.whatwg.org/multipage/#dom-document-forms
     fn Forms(&self) -> DomRoot<HTMLCollection> {
         self.forms.or_init(|| {
-            let filter = box FormsFilter;
+            let filter = Box::new(FormsFilter);
             HTMLCollection::create(&self.window, self.upcast(), filter)
         })
     }
@@ -3381,7 +3385,7 @@ impl DocumentMethods for Document {
     // https://html.spec.whatwg.org/multipage/#dom-document-scripts
     fn Scripts(&self) -> DomRoot<HTMLCollection> {
         self.scripts.or_init(|| {
-            let filter = box ScriptsFilter;
+            let filter = Box::new(ScriptsFilter);
             HTMLCollection::create(&self.window, self.upcast(), filter)
         })
     }
@@ -3389,7 +3393,7 @@ impl DocumentMethods for Document {
     // https://html.spec.whatwg.org/multipage/#dom-document-anchors
     fn Anchors(&self) -> DomRoot<HTMLCollection> {
         self.anchors.or_init(|| {
-            let filter = box AnchorsFilter;
+            let filter = Box::new(AnchorsFilter);
             HTMLCollection::create(&self.window, self.upcast(), filter)
         })
     }
@@ -3398,7 +3402,7 @@ impl DocumentMethods for Document {
     fn Applets(&self) -> DomRoot<HTMLCollection> {
         // FIXME: This should be return OBJECT elements containing applets.
         self.applets.or_init(|| {
-            let filter = box AppletsFilter;
+            let filter = Box::new(AppletsFilter);
             HTMLCollection::create(&self.window, self.upcast(), filter)
         })
     }
@@ -3610,7 +3614,7 @@ impl DocumentMethods for Document {
         let filter = NamedElementFilter {
             name: name,
         };
-        let collection = HTMLCollection::create(self.window(), root, box filter);
+        let collection = HTMLCollection::create(self.window(), root, Box::new(filter));
         Some(NonZero::new_unchecked(collection.reflector().get_jsobject().get()))
     }
 

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -34,7 +34,7 @@ impl DocumentFragment {
     }
 
     pub fn new(document: &Document) -> DomRoot<DocumentFragment> {
-        Node::reflect_node(box DocumentFragment::new_inherited(document),
+        Node::reflect_node(Box::new(DocumentFragment::new_inherited(document)),
                            document,
                            DocumentFragmentBinding::Wrap)
     }

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -42,7 +42,7 @@ impl DocumentType {
                system_id: Option<DOMString>,
                document: &Document)
                -> DomRoot<DocumentType> {
-        Node::reflect_node(box DocumentType::new_inherited(name, public_id, system_id, document),
+        Node::reflect_node(Box::new(DocumentType::new_inherited(name, public_id, system_id, document)),
                            document,
                            DocumentTypeBinding::Wrap)
     }

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -52,7 +52,7 @@ impl DOMException {
     }
 
     pub fn new(global: &GlobalScope, code: DOMErrorName) -> DomRoot<DOMException> {
-        reflect_dom_object(box DOMException::new_inherited(code),
+        reflect_dom_object(Box::new(DOMException::new_inherited(code)),
                            global,
                            DOMExceptionBinding::Wrap)
     }

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -43,7 +43,7 @@ impl DOMImplementation {
 
     pub fn new(document: &Document) -> DomRoot<DOMImplementation> {
         let window = document.window();
-        reflect_dom_object(box DOMImplementation::new_inherited(document),
+        reflect_dom_object(Box::new(DOMImplementation::new_inherited(document)),
                            window,
                            DOMImplementationBinding::Wrap)
     }

--- a/components/script/dom/dommatrix.rs
+++ b/components/script/dom/dommatrix.rs
@@ -23,7 +23,7 @@ impl DOMMatrix {
     #[allow(unrooted_must_root)]
     pub fn new(global: &GlobalScope, is2D: bool, matrix: Transform3D<f64>) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object(box dommatrix, global, Wrap)
+        reflect_dom_object(Box::new(dommatrix), global, Wrap)
     }
 
     pub fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -29,7 +29,7 @@ impl DOMMatrixReadOnly {
     #[allow(unrooted_must_root)]
     pub fn new(global: &GlobalScope, is2D: bool, matrix: Transform3D<f64>) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object(box dommatrix, global, Wrap)
+        reflect_dom_object(Box::new(dommatrix), global, Wrap)
     }
 
     pub fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -37,7 +37,7 @@ impl DOMParser {
     }
 
     pub fn new(window: &Window) -> DomRoot<DOMParser> {
-        reflect_dom_object(box DOMParser::new_inherited(window),
+        reflect_dom_object(Box::new(DOMParser::new_inherited(window)),
                            window,
                            DOMParserBinding::Wrap)
     }

--- a/components/script/dom/dompoint.rs
+++ b/components/script/dom/dompoint.rs
@@ -25,7 +25,7 @@ impl DOMPoint {
     }
 
     pub fn new(global: &GlobalScope, x: f64, y: f64, z: f64, w: f64) -> DomRoot<DOMPoint> {
-        reflect_dom_object(box DOMPoint::new_inherited(x, y, z, w), global, Wrap)
+        reflect_dom_object(Box::new(DOMPoint::new_inherited(x, y, z, w)), global, Wrap)
     }
 
     pub fn Constructor(global: &GlobalScope,

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -32,7 +32,7 @@ impl DOMPointReadOnly {
     }
 
     pub fn new(global: &GlobalScope, x: f64, y: f64, z: f64, w: f64) -> DomRoot<DOMPointReadOnly> {
-        reflect_dom_object(box DOMPointReadOnly::new_inherited(x, y, z, w),
+        reflect_dom_object(Box::new(DOMPointReadOnly::new_inherited(x, y, z, w)),
                            global,
                            Wrap)
     }

--- a/components/script/dom/domquad.rs
+++ b/components/script/dom/domquad.rs
@@ -43,7 +43,7 @@ impl DOMQuad {
                p2: &DOMPoint,
                p3: &DOMPoint,
                p4: &DOMPoint) -> DomRoot<DOMQuad> {
-        reflect_dom_object(box DOMQuad::new_inherited(p1, p2, p3, p4),
+        reflect_dom_object(Box::new(DOMQuad::new_inherited(p1, p2, p3, p4)),
                            global,
                            Wrap)
     }

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -25,7 +25,7 @@ impl DOMRect {
     }
 
     pub fn new(global: &GlobalScope, x: f64, y: f64, width: f64, height: f64) -> DomRoot<DOMRect> {
-        reflect_dom_object(box DOMRect::new_inherited(x, y, width, height),
+        reflect_dom_object(Box::new(DOMRect::new_inherited(x, y, width, height)),
                            global,
                            DOMRectBinding::Wrap)
     }

--- a/components/script/dom/domrectreadonly.rs
+++ b/components/script/dom/domrectreadonly.rs
@@ -36,7 +36,7 @@ impl DOMRectReadOnly {
                width: f64,
                height: f64)
                -> DomRoot<DOMRectReadOnly> {
-        reflect_dom_object(box DOMRectReadOnly::new_inherited(x, y, width, height),
+        reflect_dom_object(Box::new(DOMRectReadOnly::new_inherited(x, y, width, height)),
                            global,
                            Wrap)
     }

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -28,7 +28,7 @@ impl DOMStringMap {
 
     pub fn new(element: &HTMLElement) -> DomRoot<DOMStringMap> {
         let window = window_from_node(element);
-        reflect_dom_object(box DOMStringMap::new_inherited(element),
+        reflect_dom_object(Box::new(DOMStringMap::new_inherited(element)),
                            &*window,
                            DOMStringMapBinding::Wrap)
     }

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -34,7 +34,7 @@ impl DOMTokenList {
 
     pub fn new(element: &Element, local_name: &LocalName) -> DomRoot<DOMTokenList> {
         let window = window_from_node(element);
-        reflect_dom_object(box DOMTokenList::new_inherited(element, local_name.clone()),
+        reflect_dom_object(Box::new(DOMTokenList::new_inherited(element, local_name.clone())),
                            &*window,
                            DOMTokenListBinding::Wrap)
     }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -281,7 +281,7 @@ impl Element {
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<Element> {
         Node::reflect_node(
-            box Element::new_inherited(local_name, namespace, prefix, document),
+            Box::new(Element::new_inherited(local_name, namespace, prefix, document)),
             document,
             ElementBinding::Wrap)
     }
@@ -3065,11 +3065,11 @@ pub struct ElementPerformFullscreenEnter {
 
 impl ElementPerformFullscreenEnter {
     pub fn new(element: Trusted<Element>, promise: TrustedPromise, error: bool) -> Box<ElementPerformFullscreenEnter> {
-        box ElementPerformFullscreenEnter {
+        Box::new(ElementPerformFullscreenEnter {
             element: element,
             promise: promise,
             error: error,
-        }
+        })
     }
 }
 
@@ -3108,10 +3108,10 @@ pub struct ElementPerformFullscreenExit {
 
 impl ElementPerformFullscreenExit {
     pub fn new(element: Trusted<Element>, promise: TrustedPromise) -> Box<ElementPerformFullscreenExit> {
-        box ElementPerformFullscreenExit {
+        Box::new(ElementPerformFullscreenExit {
             element: element,
             promise: promise,
-        }
+        })
     }
 }
 

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -44,7 +44,7 @@ impl ErrorEvent {
     }
 
     pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<ErrorEvent> {
-        reflect_dom_object(box ErrorEvent::new_inherited(),
+        reflect_dom_object(Box::new(ErrorEvent::new_inherited()),
                            global,
                            ErrorEventBinding::Wrap)
     }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -65,7 +65,7 @@ impl Event {
     }
 
     pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<Event> {
-        reflect_dom_object(box Event::new_inherited(),
+        reflect_dom_object(Box::new(Event::new_inherited()),
                            global,
                            EventBinding::Wrap)
     }

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -413,7 +413,7 @@ impl EventSource {
     }
 
     fn new(global: &GlobalScope, url: ServoUrl, with_credentials: bool) -> DomRoot<EventSource> {
-        reflect_dom_object(box EventSource::new_inherited(url, with_credentials),
+        reflect_dom_object(Box::new(EventSource::new_inherited(url, with_credentials)),
                            global,
                            Wrap)
     }
@@ -486,9 +486,9 @@ impl EventSource {
             task_source: global.networking_task_source(),
             canceller: Some(global.task_canceller())
         };
-        ROUTER.add_route(action_receiver.to_opaque(), box move |message| {
+        ROUTER.add_route(action_receiver.to_opaque(), Box::new(move |message| {
             listener.notify_fetch(message.to().unwrap());
-        });
+        }));
         global.core_resource_thread().send(CoreResourceMsg::Fetch(request, action_sender)).unwrap();
         // Step 13
         Ok(ev)

--- a/components/script/dom/extendableevent.rs
+++ b/components/script/dom/extendableevent.rs
@@ -34,7 +34,11 @@ impl ExtendableEvent {
                bubbles: bool,
                cancelable: bool)
                -> DomRoot<ExtendableEvent> {
-        let ev = reflect_dom_object(box ExtendableEvent::new_inherited(), worker, ExtendableEventBinding::Wrap);
+        let ev = reflect_dom_object(
+            Box::new(ExtendableEvent::new_inherited()),
+            worker,
+            ExtendableEventBinding::Wrap
+        );
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);

--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -33,12 +33,12 @@ impl ExtendableMessageEvent {
                bubbles: bool, cancelable: bool,
                data: HandleValue, origin: DOMString, lastEventId: DOMString)
                -> DomRoot<ExtendableMessageEvent> {
-        let ev = box ExtendableMessageEvent {
+        let ev = Box::new(ExtendableMessageEvent {
             event: ExtendableEvent::new_inherited(),
             data: Heap::default(),
             origin: origin,
             lastEventId: lastEventId,
-        };
+        });
         let ev = reflect_dom_object(ev, global, ExtendableMessageEventBinding::Wrap);
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -45,7 +45,7 @@ impl File {
     #[allow(unrooted_must_root)]
     pub fn new(global: &GlobalScope, blob_impl: BlobImpl,
                name: DOMString, modified: Option<i64>, typeString: &str) -> DomRoot<File> {
-        reflect_dom_object(box File::new_inherited(blob_impl, name, modified, typeString),
+        reflect_dom_object(Box::new(File::new_inherited(blob_impl, name, modified, typeString)),
                            global,
                            FileBinding::Wrap)
     }

--- a/components/script/dom/filelist.rs
+++ b/components/script/dom/filelist.rs
@@ -29,7 +29,7 @@ impl FileList {
 
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, files: Vec<DomRoot<File>>) -> DomRoot<FileList> {
-        reflect_dom_object(box FileList::new_inherited(files.iter().map(|r| Dom::from_ref(&**r)).collect()),
+        reflect_dom_object(Box::new(FileList::new_inherited(files.iter().map(|r| Dom::from_ref(&**r)).collect())),
                            window,
                            FileListBinding::Wrap)
     }

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -104,7 +104,7 @@ impl FileReader {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<FileReader> {
-        reflect_dom_object(box FileReader::new_inherited(),
+        reflect_dom_object(Box::new(FileReader::new_inherited()),
                            global, FileReaderBinding::Wrap)
     }
 

--- a/components/script/dom/filereadersync.rs
+++ b/components/script/dom/filereadersync.rs
@@ -23,7 +23,7 @@ impl FileReaderSync {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<FileReaderSync> {
-        reflect_dom_object(box FileReaderSync::new_inherited(),
+        reflect_dom_object(Box::new(FileReaderSync::new_inherited()),
                            global, FileReaderSyncBinding::Wrap)
     }
 

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -32,7 +32,7 @@ impl FocusEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<FocusEvent> {
-        reflect_dom_object(box FocusEvent::new_inherited(),
+        reflect_dom_object(Box::new(FocusEvent::new_inherited()),
                            window,
                            FocusEventBinding::Wrap)
     }

--- a/components/script/dom/forcetouchevent.rs
+++ b/components/script/dom/forcetouchevent.rs
@@ -31,7 +31,7 @@ impl ForceTouchEvent {
     pub fn new(window: &Window,
                type_: DOMString,
                force: f32) -> DomRoot<ForceTouchEvent> {
-        let event = box ForceTouchEvent::new_inherited(force);
+        let event = Box::new(ForceTouchEvent::new_inherited(force));
         let ev = reflect_dom_object(event, window, ForceTouchEventBinding::Wrap);
         ev.upcast::<UIEvent>().InitUIEvent(type_, true, true, Some(window), 0);
         ev

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -48,7 +48,7 @@ impl FormData {
     }
 
     pub fn new(form: Option<&HTMLFormElement>, global: &GlobalScope) -> DomRoot<FormData> {
-        reflect_dom_object(box FormData::new_inherited(form),
+        reflect_dom_object(Box::new(FormData::new_inherited(form)),
                            global, FormDataWrap)
     }
 

--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -75,18 +75,22 @@ impl Gamepad {
         let buttons = GamepadButtonList::new_from_vr(&global, &state.buttons);
         let pose = VRPose::new(&global, &state.pose);
 
-        let gamepad = reflect_dom_object(box Gamepad::new_inherited(state.gamepad_id,
-                                                                    data.name.clone(),
-                                                                    index,
-                                                                    state.connected,
-                                                                    state.timestamp,
-                                                                    "".into(),
-                                                                    &buttons,
-                                                                    Some(&pose),
-                                                                    data.hand.clone(),
-                                                                    data.display_id),
-                                         global,
-                                         GamepadBinding::Wrap);
+        let gamepad = reflect_dom_object(
+            Box::new(Gamepad::new_inherited(
+                state.gamepad_id,
+                data.name.clone(),
+                index,
+                state.connected,
+                state.timestamp,
+                "".into(),
+                &buttons,
+                Some(&pose),
+                data.hand.clone(),
+                data.display_id
+            )),
+            global,
+            GamepadBinding::Wrap
+        );
 
         let cx = global.get_cx();
         rooted!(in (cx) let mut array = ptr::null_mut());

--- a/components/script/dom/gamepadbutton.rs
+++ b/components/script/dom/gamepadbutton.rs
@@ -30,7 +30,7 @@ impl GamepadButton {
     }
 
     pub fn new(global: &GlobalScope, pressed: bool, touched: bool) -> DomRoot<GamepadButton> {
-        reflect_dom_object(box GamepadButton::new_inherited(pressed, touched),
+        reflect_dom_object(Box::new(GamepadButton::new_inherited(pressed, touched)),
                            global,
                            GamepadButtonBinding::Wrap)
     }

--- a/components/script/dom/gamepadbuttonlist.rs
+++ b/components/script/dom/gamepadbuttonlist.rs
@@ -31,7 +31,7 @@ impl GamepadButtonList {
         rooted_vec!(let list <- buttons.iter()
                                        .map(|btn| GamepadButton::new(&global, btn.pressed, btn.touched)));
 
-        reflect_dom_object(box GamepadButtonList::new_inherited(list.r()),
+        reflect_dom_object(Box::new(GamepadButtonList::new_inherited(list.r())),
                            global,
                            GamepadButtonListBinding::Wrap)
     }

--- a/components/script/dom/gamepadevent.rs
+++ b/components/script/dom/gamepadevent.rs
@@ -42,9 +42,9 @@ impl GamepadEvent {
                cancelable: bool,
                gamepad: &Gamepad)
                -> DomRoot<GamepadEvent> {
-        let ev = reflect_dom_object(box GamepadEvent::new_inherited(&gamepad),
-                           global,
-                           GamepadEventBinding::Wrap);
+        let ev = reflect_dom_object(
+            Box::new(GamepadEvent::new_inherited(&gamepad)), global, GamepadEventBinding::Wrap
+        );
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);

--- a/components/script/dom/gamepadlist.rs
+++ b/components/script/dom/gamepadlist.rs
@@ -27,7 +27,7 @@ impl GamepadList {
     }
 
     pub fn new(global: &GlobalScope, list: &[&Gamepad]) -> DomRoot<GamepadList> {
-        reflect_dom_object(box GamepadList::new_inherited(list),
+        reflect_dom_object(Box::new(GamepadList::new_inherited(list)),
                            global,
                            GamepadListBinding::Wrap)
     }

--- a/components/script/dom/hashchangeevent.rs
+++ b/components/script/dom/hashchangeevent.rs
@@ -33,7 +33,7 @@ impl HashChangeEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<HashChangeEvent> {
-        reflect_dom_object(box HashChangeEvent::new_inherited(String::new(), String::new()),
+        reflect_dom_object(Box::new(HashChangeEvent::new_inherited(String::new(), String::new())),
                            window,
                            HashChangeEventBinding::Wrap)
     }
@@ -45,7 +45,7 @@ impl HashChangeEvent {
                old_url: String,
                new_url: String)
                -> DomRoot<HashChangeEvent> {
-        let ev = reflect_dom_object(box HashChangeEvent::new_inherited(old_url, new_url),
+        let ev = reflect_dom_object(Box::new(HashChangeEvent::new_inherited(old_url, new_url)),
                                     window,
                                     HashChangeEventBinding::Wrap);
         {

--- a/components/script/dom/headers.rs
+++ b/components/script/dom/headers.rs
@@ -45,7 +45,7 @@ impl Headers {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<Headers> {
-        reflect_dom_object(box Headers::new_inherited(), global, HeadersWrap)
+        reflect_dom_object(Box::new(Headers::new_inherited()), global, HeadersWrap)
     }
 
     // https://fetch.spec.whatwg.org/#dom-headers

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -33,7 +33,7 @@ impl History {
     }
 
     pub fn new(window: &Window) -> DomRoot<History> {
-        reflect_dom_object(box History::new_inherited(window),
+        reflect_dom_object(Box::new(History::new_inherited(window)),
                            window,
                            HistoryBinding::Wrap)
     }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -57,7 +57,7 @@ impl HTMLAnchorElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLAnchorElement> {
-        Node::reflect_node(box HTMLAnchorElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLAnchorElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLAnchorElementBinding::Wrap)
     }

--- a/components/script/dom/htmlappletelement.rs
+++ b/components/script/dom/htmlappletelement.rs
@@ -34,7 +34,7 @@ impl HTMLAppletElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLAppletElement> {
-        Node::reflect_node(box HTMLAppletElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLAppletElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLAppletElementBinding::Wrap)
     }

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -232,7 +232,7 @@ impl HTMLAreaElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLAreaElement> {
-        Node::reflect_node(box HTMLAreaElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLAreaElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLAreaElementBinding::Wrap)
     }

--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -29,7 +29,7 @@ impl HTMLAudioElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLAudioElement> {
-        Node::reflect_node(box HTMLAudioElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLAudioElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLAudioElementBinding::Wrap)
     }

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -33,7 +33,7 @@ impl HTMLBaseElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLBaseElement> {
-        Node::reflect_node(box HTMLBaseElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLBaseElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLBaseElementBinding::Wrap)
     }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -43,7 +43,7 @@ impl HTMLBodyElement {
     #[allow(unrooted_must_root)]
     pub fn new(local_name: LocalName, prefix: Option<Prefix>, document: &Document)
                -> DomRoot<HTMLBodyElement> {
-        Node::reflect_node(box HTMLBodyElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLBodyElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLBodyElementBinding::Wrap)
     }

--- a/components/script/dom/htmlbrelement.rs
+++ b/components/script/dom/htmlbrelement.rs
@@ -26,7 +26,7 @@ impl HTMLBRElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLBRElement> {
-        Node::reflect_node(box HTMLBRElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLBRElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLBRElementBinding::Wrap)
     }

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -62,7 +62,7 @@ impl HTMLButtonElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLButtonElement> {
-        Node::reflect_node(box HTMLButtonElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLButtonElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLButtonElementBinding::Wrap)
     }

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -68,7 +68,7 @@ impl HTMLCanvasElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLCanvasElement> {
-        Node::reflect_node(box HTMLCanvasElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLCanvasElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLCanvasElementBinding::Wrap)
     }

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -82,7 +82,7 @@ impl HTMLCollection {
 
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, root: &Node, filter: Box<CollectionFilter + 'static>) -> DomRoot<HTMLCollection> {
-        reflect_dom_object(box HTMLCollection::new_inherited(root, filter),
+        reflect_dom_object(Box::new(HTMLCollection::new_inherited(root, filter)),
                            window, HTMLCollectionBinding::Wrap)
     }
 
@@ -126,7 +126,7 @@ impl HTMLCollection {
                     true
                 }
             }
-            return HTMLCollection::create(window, root, box AllFilter);
+            return HTMLCollection::create(window, root, Box::new(AllFilter));
         }
 
         #[derive(HeapSizeOf, JSTraceable)]
@@ -148,7 +148,7 @@ impl HTMLCollection {
             ascii_lower_qualified_name: qualified_name.to_ascii_lowercase(),
             qualified_name: qualified_name,
         };
-        HTMLCollection::create(window, root, box filter)
+        HTMLCollection::create(window, root, Box::new(filter))
     }
 
     fn match_element(elem: &Element, qualified_name: &LocalName) -> bool {
@@ -182,7 +182,7 @@ impl HTMLCollection {
         let filter = TagNameNSFilter {
             qname: qname
         };
-        HTMLCollection::create(window, root, box filter)
+        HTMLCollection::create(window, root, Box::new(filter))
     }
 
     pub fn by_class_name(window: &Window, root: &Node, classes: DOMString)
@@ -208,7 +208,7 @@ impl HTMLCollection {
         let filter = ClassNameFilter {
             classes: classes
         };
-        HTMLCollection::create(window, root, box filter)
+        HTMLCollection::create(window, root, Box::new(filter))
     }
 
     pub fn children(window: &Window, root: &Node) -> DomRoot<HTMLCollection> {
@@ -219,7 +219,7 @@ impl HTMLCollection {
                 root.is_parent_of(elem.upcast())
             }
         }
-        HTMLCollection::create(window, root, box ElementChildFilter)
+        HTMLCollection::create(window, root, Box::new(ElementChildFilter))
     }
 
     pub fn elements_iter_after<'a>(&'a self, after: &'a Node) -> impl Iterator<Item=DomRoot<Element>> + 'a {

--- a/components/script/dom/htmldataelement.rs
+++ b/components/script/dom/htmldataelement.rs
@@ -30,7 +30,7 @@ impl HTMLDataElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLDataElement> {
-        Node::reflect_node(box HTMLDataElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLDataElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLDataElementBinding::Wrap)
     }

--- a/components/script/dom/htmldatalistelement.rs
+++ b/components/script/dom/htmldatalistelement.rs
@@ -34,7 +34,7 @@ impl HTMLDataListElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLDataListElement> {
-        Node::reflect_node(box HTMLDataListElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLDataListElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLDataListElementBinding::Wrap)
     }
@@ -50,7 +50,7 @@ impl HTMLDataListElementMethods for HTMLDataListElement {
                 elem.is::<HTMLOptionElement>()
             }
         }
-        let filter = box HTMLDataListOptionsFilter;
+        let filter = Box::new(HTMLDataListOptionsFilter);
         let window = window_from_node(self);
         HTMLCollection::create(&window, self.upcast(), filter)
     }

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -40,7 +40,7 @@ impl HTMLDetailsElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLDetailsElement> {
-        Node::reflect_node(box HTMLDetailsElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLDetailsElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLDetailsElementBinding::Wrap)
     }

--- a/components/script/dom/htmldialogelement.rs
+++ b/components/script/dom/htmldialogelement.rs
@@ -37,7 +37,7 @@ impl HTMLDialogElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLDialogElement> {
-        Node::reflect_node(box HTMLDialogElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLDialogElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLDialogElementBinding::Wrap)
     }

--- a/components/script/dom/htmldirectoryelement.rs
+++ b/components/script/dom/htmldirectoryelement.rs
@@ -29,7 +29,7 @@ impl HTMLDirectoryElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLDirectoryElement> {
-        Node::reflect_node(box HTMLDirectoryElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLDirectoryElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLDirectoryElementBinding::Wrap)
     }

--- a/components/script/dom/htmldivelement.rs
+++ b/components/script/dom/htmldivelement.rs
@@ -29,7 +29,7 @@ impl HTMLDivElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLDivElement> {
-        Node::reflect_node(box HTMLDivElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLDivElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLDivElementBinding::Wrap)
     }

--- a/components/script/dom/htmldlistelement.rs
+++ b/components/script/dom/htmldlistelement.rs
@@ -27,7 +27,7 @@ impl HTMLDListElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLDListElement> {
-        Node::reflect_node(box HTMLDListElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLDListElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLDListElementBinding::Wrap)
     }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -62,7 +62,7 @@ impl HTMLElement {
 
     #[allow(unrooted_must_root)]
     pub fn new(local_name: LocalName, prefix: Option<Prefix>, document: &Document) -> DomRoot<HTMLElement> {
-        Node::reflect_node(box HTMLElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLElementBinding::Wrap)
     }

--- a/components/script/dom/htmlembedelement.rs
+++ b/components/script/dom/htmlembedelement.rs
@@ -26,7 +26,7 @@ impl HTMLEmbedElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLEmbedElement> {
-        Node::reflect_node(box HTMLEmbedElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLEmbedElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLEmbedElementBinding::Wrap)
     }

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -43,7 +43,7 @@ impl HTMLFieldSetElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLFieldSetElement> {
-        Node::reflect_node(box HTMLFieldSetElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLFieldSetElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLFieldSetElementBinding::Wrap)
     }
@@ -60,7 +60,7 @@ impl HTMLFieldSetElementMethods for HTMLFieldSetElement {
                     .map_or(false, HTMLElement::is_listed_element)
             }
         }
-        let filter = box ElementsFilter;
+        let filter = Box::new(ElementsFilter);
         let window = window_from_node(self);
         HTMLCollection::create(&window, self.upcast(), filter)
     }

--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -37,7 +37,7 @@ impl HTMLFontElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLFontElement> {
-        Node::reflect_node(box HTMLFontElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLFontElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLFontElementBinding::Wrap)
     }

--- a/components/script/dom/htmlformcontrolscollection.rs
+++ b/components/script/dom/htmlformcontrolscollection.rs
@@ -32,7 +32,7 @@ impl HTMLFormControlsCollection {
     pub fn new(window: &Window, root: &Node, filter: Box<CollectionFilter + 'static>)
         -> DomRoot<HTMLFormControlsCollection>
     {
-        reflect_dom_object(box HTMLFormControlsCollection::new_inherited(root, filter),
+        reflect_dom_object(Box::new(HTMLFormControlsCollection::new_inherited(root, filter)),
                            window,
                            HTMLFormControlsCollectionBinding::Wrap)
     }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -86,7 +86,7 @@ impl HTMLFormElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLFormElement> {
-        Node::reflect_node(box HTMLFormElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLFormElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLFormElementBinding::Wrap)
     }
@@ -217,7 +217,7 @@ impl HTMLFormElementMethods for HTMLFormElement {
             }
         }
         DomRoot::from_ref(self.elements.init_once(|| {
-            let filter = box ElementsFilter { form: DomRoot::from_ref(self) };
+            let filter = Box::new(ElementsFilter { form: DomRoot::from_ref(self) });
             let window = window_from_node(self);
             HTMLFormControlsCollection::new(&window, self.upcast(), filter)
         }))

--- a/components/script/dom/htmlframeelement.rs
+++ b/components/script/dom/htmlframeelement.rs
@@ -26,7 +26,7 @@ impl HTMLFrameElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLFrameElement> {
-        Node::reflect_node(box HTMLFrameElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLFrameElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLFrameElementBinding::Wrap)
     }

--- a/components/script/dom/htmlframesetelement.rs
+++ b/components/script/dom/htmlframesetelement.rs
@@ -31,7 +31,7 @@ impl HTMLFrameSetElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLFrameSetElement> {
-        Node::reflect_node(box HTMLFrameSetElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLFrameSetElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLFrameSetElementBinding::Wrap)
     }

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -34,7 +34,7 @@ impl HTMLHeadElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLHeadElement> {
-        Node::reflect_node(box HTMLHeadElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLHeadElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLHeadElementBinding::Wrap)
     }

--- a/components/script/dom/htmlheadingelement.rs
+++ b/components/script/dom/htmlheadingelement.rs
@@ -43,7 +43,7 @@ impl HTMLHeadingElement {
                prefix: Option<Prefix>,
                document: &Document,
                level: HeadingLevel) -> DomRoot<HTMLHeadingElement> {
-        Node::reflect_node(box HTMLHeadingElement::new_inherited(local_name, prefix, document, level),
+        Node::reflect_node(Box::new(HTMLHeadingElement::new_inherited(local_name, prefix, document, level)),
                            document,
                            HTMLHeadingElementBinding::Wrap)
     }

--- a/components/script/dom/htmlhrelement.rs
+++ b/components/script/dom/htmlhrelement.rs
@@ -32,7 +32,7 @@ impl HTMLHRElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLHRElement> {
-        Node::reflect_node(box HTMLHRElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLHRElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLHRElementBinding::Wrap)
     }

--- a/components/script/dom/htmlhtmlelement.rs
+++ b/components/script/dom/htmlhtmlelement.rs
@@ -26,7 +26,7 @@ impl HTMLHtmlElement {
     pub fn new(localName: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLHtmlElement> {
-        Node::reflect_node(box HTMLHtmlElement::new_inherited(localName, prefix, document),
+        Node::reflect_node(Box::new(HTMLHtmlElement::new_inherited(localName, prefix, document)),
                            document,
                            HTMLHtmlElementBinding::Wrap)
     }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -335,7 +335,7 @@ impl HTMLIFrameElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLIFrameElement> {
-        Node::reflect_node(box HTMLIFrameElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLIFrameElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLIFrameElementBinding::Wrap)
     }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -200,7 +200,7 @@ impl HTMLImageElement {
             let task_source = window.networking_task_source();
             let task_canceller = window.task_canceller();
             let generation = elem.generation.get();
-            ROUTER.add_route(responder_receiver.to_opaque(), box move |message| {
+            ROUTER.add_route(responder_receiver.to_opaque(), Box::new(move |message| {
                 debug!("Got image {:?}", message);
                 // Return the image via a message to the script thread, which marks
                 // the element as dirty and triggers a reflow.
@@ -217,7 +217,7 @@ impl HTMLImageElement {
                     }),
                     &task_canceller,
                 );
-            });
+            }));
 
             image_cache.add_listener(id, ImageResponder::new(responder_sender, id));
         }
@@ -268,9 +268,9 @@ impl HTMLImageElement {
             task_source: window.networking_task_source(),
             canceller: Some(window.task_canceller()),
         };
-        ROUTER.add_route(action_receiver.to_opaque(), box move |message| {
+        ROUTER.add_route(action_receiver.to_opaque(), Box::new(move |message| {
             listener.notify_fetch(message.to().unwrap());
-        });
+        }));
 
         let request = RequestInit {
             url: img_url.clone(),
@@ -640,7 +640,7 @@ impl HTMLImageElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLImageElement> {
-        Node::reflect_node(box HTMLImageElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLImageElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLImageElementBinding::Wrap)
     }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -165,7 +165,7 @@ impl HTMLInputElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLInputElement> {
-        Node::reflect_node(box HTMLInputElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLInputElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLInputElementBinding::Wrap)
     }

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -40,7 +40,7 @@ impl HTMLLabelElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLLabelElement> {
-        Node::reflect_node(box HTMLLabelElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLLabelElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLLabelElementBinding::Wrap)
     }

--- a/components/script/dom/htmllegendelement.rs
+++ b/components/script/dom/htmllegendelement.rs
@@ -39,7 +39,7 @@ impl HTMLLegendElement {
                prefix: Option<Prefix>,
                document: &Document)
                -> DomRoot<HTMLLegendElement> {
-        Node::reflect_node(box HTMLLegendElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLLegendElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLLegendElementBinding::Wrap)
     }

--- a/components/script/dom/htmllielement.rs
+++ b/components/script/dom/htmllielement.rs
@@ -31,7 +31,7 @@ impl HTMLLIElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLLIElement> {
-        Node::reflect_node(box HTMLLIElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLLIElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLLIElementBinding::Wrap)
     }

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -86,7 +86,7 @@ impl HTMLLinkElement {
                prefix: Option<Prefix>,
                document: &Document,
                creator: ElementCreator) -> DomRoot<HTMLLinkElement> {
-        Node::reflect_node(box HTMLLinkElement::new_inherited(local_name, prefix, document, creator),
+        Node::reflect_node(Box::new(HTMLLinkElement::new_inherited(local_name, prefix, document, creator)),
                            document,
                            HTMLLinkElementBinding::Wrap)
     }

--- a/components/script/dom/htmlmapelement.rs
+++ b/components/script/dom/htmlmapelement.rs
@@ -30,7 +30,7 @@ impl HTMLMapElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLMapElement> {
-        Node::reflect_node(box HTMLMapElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLMapElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLMapElementBinding::Wrap)
     }

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -611,9 +611,9 @@ impl HTMLMediaElement {
                     task_source: window.networking_task_source(),
                     canceller: Some(window.task_canceller())
                 };
-                ROUTER.add_route(action_receiver.to_opaque(), box move |message| {
+                ROUTER.add_route(action_receiver.to_opaque(), Box::new(move |message| {
                     listener.notify_fetch(message.to().unwrap());
-                });
+                }));
                 document.loader().fetch_async_background(request, action_sender);
             },
             Resource::Object => {

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -52,7 +52,7 @@ impl HTMLMetaElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLMetaElement> {
-        Node::reflect_node(box HTMLMetaElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLMetaElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLMetaElementBinding::Wrap)
     }

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -30,7 +30,7 @@ impl HTMLMeterElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLMeterElement> {
-        Node::reflect_node(box HTMLMeterElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLMeterElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLMeterElementBinding::Wrap)
     }

--- a/components/script/dom/htmlmodelement.rs
+++ b/components/script/dom/htmlmodelement.rs
@@ -29,7 +29,7 @@ impl HTMLModElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLModElement> {
-        Node::reflect_node(box HTMLModElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLModElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLModElementBinding::Wrap)
     }

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -47,7 +47,7 @@ impl HTMLObjectElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLObjectElement> {
-        Node::reflect_node(box HTMLObjectElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLObjectElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLObjectElementBinding::Wrap)
     }

--- a/components/script/dom/htmlolistelement.rs
+++ b/components/script/dom/htmlolistelement.rs
@@ -28,7 +28,7 @@ impl HTMLOListElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLOListElement> {
-        Node::reflect_node(box HTMLOListElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLOListElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLOListElementBinding::Wrap)
     }

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -37,7 +37,7 @@ impl HTMLOptGroupElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLOptGroupElement> {
-        Node::reflect_node(box HTMLOptGroupElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLOptGroupElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLOptGroupElementBinding::Wrap)
     }

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -56,7 +56,7 @@ impl HTMLOptionElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLOptionElement> {
-        Node::reflect_node(box HTMLOptionElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLOptionElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLOptionElementBinding::Wrap)
     }

--- a/components/script/dom/htmloptionscollection.rs
+++ b/components/script/dom/htmloptionscollection.rs
@@ -37,7 +37,7 @@ impl HTMLOptionsCollection {
     pub fn new(window: &Window, select: &HTMLSelectElement, filter: Box<CollectionFilter + 'static>)
         -> DomRoot<HTMLOptionsCollection>
     {
-        reflect_dom_object(box HTMLOptionsCollection::new_inherited(select, filter),
+        reflect_dom_object(Box::new(HTMLOptionsCollection::new_inherited(select, filter)),
                            window,
                            HTMLOptionsCollectionBinding::Wrap)
     }

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -39,7 +39,7 @@ impl HTMLOutputElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLOutputElement> {
-        Node::reflect_node(box HTMLOutputElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLOutputElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLOutputElementBinding::Wrap)
     }

--- a/components/script/dom/htmlparagraphelement.rs
+++ b/components/script/dom/htmlparagraphelement.rs
@@ -29,7 +29,7 @@ impl HTMLParagraphElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLParagraphElement> {
-        Node::reflect_node(box HTMLParagraphElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLParagraphElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLParagraphElementBinding::Wrap)
     }

--- a/components/script/dom/htmlparamelement.rs
+++ b/components/script/dom/htmlparamelement.rs
@@ -29,7 +29,7 @@ impl HTMLParamElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLParamElement> {
-        Node::reflect_node(box HTMLParamElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLParamElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLParamElementBinding::Wrap)
     }

--- a/components/script/dom/htmlpreelement.rs
+++ b/components/script/dom/htmlpreelement.rs
@@ -29,7 +29,7 @@ impl HTMLPreElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLPreElement> {
-        Node::reflect_node(box HTMLPreElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLPreElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLPreElementBinding::Wrap)
     }

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -31,7 +31,7 @@ impl HTMLProgressElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLProgressElement> {
-        Node::reflect_node(box HTMLProgressElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLProgressElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLProgressElementBinding::Wrap)
     }

--- a/components/script/dom/htmlquoteelement.rs
+++ b/components/script/dom/htmlquoteelement.rs
@@ -29,7 +29,7 @@ impl HTMLQuoteElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLQuoteElement> {
-        Node::reflect_node(box HTMLQuoteElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLQuoteElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLQuoteElementBinding::Wrap)
     }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -84,7 +84,7 @@ impl HTMLScriptElement {
     #[allow(unrooted_must_root)]
     pub fn new(local_name: LocalName, prefix: Option<Prefix>, document: &Document,
                creator: ElementCreator) -> DomRoot<HTMLScriptElement> {
-        Node::reflect_node(box HTMLScriptElement::new_inherited(local_name, prefix, document, creator),
+        Node::reflect_node(Box::new(HTMLScriptElement::new_inherited(local_name, prefix, document, creator)),
                            document,
                            HTMLScriptElementBinding::Wrap)
     }
@@ -279,9 +279,9 @@ fn fetch_a_classic_script(script: &HTMLScriptElement,
         canceller: Some(doc.window().task_canceller())
     };
 
-    ROUTER.add_route(action_receiver.to_opaque(), box move |message| {
+    ROUTER.add_route(action_receiver.to_opaque(), Box::new(move |message| {
         listener.notify_fetch(message.to().unwrap());
-    });
+    }));
     doc.fetch_async(LoadType::Script(url), request, action_sender);
 }
 

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -84,7 +84,7 @@ impl HTMLSelectElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLSelectElement> {
-        Node::reflect_node(box HTMLSelectElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLSelectElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLSelectElementBinding::Wrap)
     }
@@ -247,7 +247,7 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
         self.options.or_init(|| {
             let window = window_from_node(self);
             HTMLOptionsCollection::new(
-                &window, self, box OptionsFilter)
+                &window, self, Box::new(OptionsFilter))
         })
     }
 

--- a/components/script/dom/htmlsourceelement.rs
+++ b/components/script/dom/htmlsourceelement.rs
@@ -33,7 +33,7 @@ impl HTMLSourceElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLSourceElement> {
-        Node::reflect_node(box HTMLSourceElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLSourceElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLSourceElementBinding::Wrap)
     }

--- a/components/script/dom/htmlspanelement.rs
+++ b/components/script/dom/htmlspanelement.rs
@@ -26,7 +26,7 @@ impl HTMLSpanElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLSpanElement> {
-        Node::reflect_node(box HTMLSpanElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLSpanElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLSpanElementBinding::Wrap)
     }

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -64,7 +64,7 @@ impl HTMLStyleElement {
                prefix: Option<Prefix>,
                document: &Document,
                creator: ElementCreator) -> DomRoot<HTMLStyleElement> {
-        Node::reflect_node(box HTMLStyleElement::new_inherited(local_name, prefix, document, creator),
+        Node::reflect_node(Box::new(HTMLStyleElement::new_inherited(local_name, prefix, document, creator)),
                            document,
                            HTMLStyleElementBinding::Wrap)
     }

--- a/components/script/dom/htmltablecaptionelement.rs
+++ b/components/script/dom/htmltablecaptionelement.rs
@@ -29,7 +29,7 @@ impl HTMLTableCaptionElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLTableCaptionElement> {
-        Node::reflect_node(box HTMLTableCaptionElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLTableCaptionElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLTableCaptionElementBinding::Wrap)
     }

--- a/components/script/dom/htmltablecolelement.rs
+++ b/components/script/dom/htmltablecolelement.rs
@@ -29,7 +29,7 @@ impl HTMLTableColElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLTableColElement> {
-        Node::reflect_node(box HTMLTableColElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLTableColElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLTableColElementBinding::Wrap)
     }

--- a/components/script/dom/htmltabledatacellelement.rs
+++ b/components/script/dom/htmltabledatacellelement.rs
@@ -28,10 +28,12 @@ impl HTMLTableDataCellElement {
     #[allow(unrooted_must_root)]
     pub fn new(local_name: LocalName, prefix: Option<Prefix>, document: &Document)
                -> DomRoot<HTMLTableDataCellElement> {
-        Node::reflect_node(box HTMLTableDataCellElement::new_inherited(local_name,
-                                                                       prefix,
-                                                                       document),
-                           document,
-                           HTMLTableDataCellElementBinding::Wrap)
+        Node::reflect_node(
+            Box::new(HTMLTableDataCellElement::new_inherited(
+                local_name, prefix, document
+            )),
+            document,
+            HTMLTableDataCellElementBinding::Wrap
+        )
     }
 }

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -63,7 +63,7 @@ impl HTMLTableElement {
     #[allow(unrooted_must_root)]
     pub fn new(local_name: LocalName, prefix: Option<Prefix>, document: &Document)
                -> DomRoot<HTMLTableElement> {
-        Node::reflect_node(box HTMLTableElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLTableElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLTableElementBinding::Wrap)
     }
@@ -151,7 +151,7 @@ impl HTMLTableElementMethods for HTMLTableElement {
     // https://html.spec.whatwg.org/multipage/#dom-table-rows
     fn Rows(&self) -> DomRoot<HTMLCollection> {
         let filter = self.get_rows();
-        HTMLCollection::new(&window_from_node(self), self.upcast(), box filter)
+        HTMLCollection::new(&window_from_node(self), self.upcast(), Box::new(filter))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-caption
@@ -264,7 +264,7 @@ impl HTMLTableElementMethods for HTMLTableElement {
 
         self.tbodies.or_init(|| {
             let window = window_from_node(self);
-            let filter = box TBodiesFilter;
+            let filter = Box::new(TBodiesFilter);
             HTMLCollection::create(&window, self.upcast(), filter)
         })
     }

--- a/components/script/dom/htmltableheadercellelement.rs
+++ b/components/script/dom/htmltableheadercellelement.rs
@@ -29,7 +29,7 @@ impl HTMLTableHeaderCellElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLTableHeaderCellElement> {
-        Node::reflect_node(box HTMLTableHeaderCellElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLTableHeaderCellElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLTableHeaderCellElementBinding::Wrap)
     }

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -52,7 +52,7 @@ impl HTMLTableRowElement {
     #[allow(unrooted_must_root)]
     pub fn new(local_name: LocalName, prefix: Option<Prefix>, document: &Document)
                -> DomRoot<HTMLTableRowElement> {
-        Node::reflect_node(box HTMLTableRowElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLTableRowElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLTableRowElementBinding::Wrap)
     }
@@ -77,7 +77,7 @@ impl HTMLTableRowElementMethods for HTMLTableRowElement {
     fn Cells(&self) -> DomRoot<HTMLCollection> {
         self.cells.or_init(|| {
             let window = window_from_node(self);
-            let filter = box CellsFilter;
+            let filter = Box::new(CellsFilter);
             HTMLCollection::create(&window, self.upcast(), filter)
         })
     }

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -36,7 +36,7 @@ impl HTMLTableSectionElement {
     #[allow(unrooted_must_root)]
     pub fn new(local_name: LocalName, prefix: Option<Prefix>, document: &Document)
                -> DomRoot<HTMLTableSectionElement> {
-        Node::reflect_node(box HTMLTableSectionElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLTableSectionElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLTableSectionElementBinding::Wrap)
     }
@@ -54,7 +54,7 @@ impl CollectionFilter for RowsFilter {
 impl HTMLTableSectionElementMethods for HTMLTableSectionElement {
     // https://html.spec.whatwg.org/multipage/#dom-tbody-rows
     fn Rows(&self) -> DomRoot<HTMLCollection> {
-        HTMLCollection::create(&window_from_node(self), self.upcast(), box RowsFilter)
+        HTMLCollection::create(&window_from_node(self), self.upcast(), Box::new(RowsFilter))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tbody-insertrow

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -39,7 +39,7 @@ impl HTMLTemplateElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLTemplateElement> {
-        Node::reflect_node(box HTMLTemplateElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLTemplateElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLTemplateElementBinding::Wrap)
     }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -125,7 +125,7 @@ impl HTMLTextAreaElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLTextAreaElement> {
-        Node::reflect_node(box HTMLTextAreaElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLTextAreaElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLTextAreaElementBinding::Wrap)
     }

--- a/components/script/dom/htmltimeelement.rs
+++ b/components/script/dom/htmltimeelement.rs
@@ -28,7 +28,7 @@ impl HTMLTimeElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLTimeElement> {
-        Node::reflect_node(box HTMLTimeElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLTimeElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLTimeElementBinding::Wrap)
     }

--- a/components/script/dom/htmltitleelement.rs
+++ b/components/script/dom/htmltitleelement.rs
@@ -31,7 +31,7 @@ impl HTMLTitleElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLTitleElement> {
-        Node::reflect_node(box HTMLTitleElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLTitleElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLTitleElementBinding::Wrap)
     }

--- a/components/script/dom/htmltrackelement.rs
+++ b/components/script/dom/htmltrackelement.rs
@@ -26,7 +26,7 @@ impl HTMLTrackElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLTrackElement> {
-        Node::reflect_node(box HTMLTrackElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLTrackElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLTrackElementBinding::Wrap)
     }

--- a/components/script/dom/htmlulistelement.rs
+++ b/components/script/dom/htmlulistelement.rs
@@ -26,7 +26,7 @@ impl HTMLUListElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLUListElement> {
-        Node::reflect_node(box HTMLUListElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLUListElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLUListElementBinding::Wrap)
     }

--- a/components/script/dom/htmlunknownelement.rs
+++ b/components/script/dom/htmlunknownelement.rs
@@ -29,7 +29,7 @@ impl HTMLUnknownElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLUnknownElement> {
-        Node::reflect_node(box HTMLUnknownElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLUnknownElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLUnknownElementBinding::Wrap)
     }

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -27,7 +27,7 @@ impl HTMLVideoElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<HTMLVideoElement> {
-        Node::reflect_node(box HTMLVideoElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(HTMLVideoElement::new_inherited(local_name, prefix, document)),
                            document,
                            HTMLVideoElementBinding::Wrap)
     }

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -91,12 +91,12 @@ impl ImageData {
             return Err(Error::IndexSize);
         }
 
-        let imagedata = box ImageData {
+        let imagedata = Box::new(ImageData {
             reflector_: Reflector::new(),
             width: width,
             height: height,
             data: Heap::default(),
-        };
+        });
 
         if let Some(jsobject) = opt_jsobject {
             (*imagedata).data.set(jsobject);

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -28,11 +28,11 @@ impl InputEvent {
                detail: i32,
                data: Option<DOMString>,
                is_composing: bool) -> DomRoot<InputEvent> {
-        let ev = reflect_dom_object(box InputEvent {
+        let ev = reflect_dom_object(Box::new(InputEvent {
                                         uievent: UIEvent::new_inherited(),
                                         data: data,
                                         is_composing: is_composing,
-                                    },
+                                    }),
                                     window,
                                     InputEventBinding::Wrap);
         ev.uievent.InitUIEvent(type_, can_bubble, cancelable, view, detail);

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -61,7 +61,7 @@ impl KeyboardEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<KeyboardEvent> {
-        reflect_dom_object(box KeyboardEvent::new_inherited(),
+        reflect_dom_object(Box::new(KeyboardEvent::new_inherited()),
                            window,
                            KeyboardEventBinding::Wrap)
     }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -30,7 +30,7 @@ impl Location {
     }
 
     pub fn new(window: &Window) -> DomRoot<Location> {
-        reflect_dom_object(box Location::new_inherited(window),
+        reflect_dom_object(Box::new(Location::new_inherited(window)),
                            window,
                            LocationBinding::Wrap)
     }

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -610,7 +610,7 @@ macro_rules! impl_performance_entry_struct(
                        start_time: f64,
                        duration: f64) -> DomRoot<$struct> {
                 let entry = $struct::new_inherited(name, start_time, duration);
-                reflect_dom_object(box entry, global, $binding::Wrap)
+                reflect_dom_object(Box::new(entry), global, $binding::Wrap)
             }
         }
     );

--- a/components/script/dom/mediaerror.rs
+++ b/components/script/dom/mediaerror.rs
@@ -24,7 +24,7 @@ impl MediaError {
     }
 
     pub fn new(window: &Window, code: u16) -> DomRoot<MediaError> {
-        reflect_dom_object(box MediaError::new_inherited(code),
+        reflect_dom_object(Box::new(MediaError::new_inherited(code)),
                            window,
                            MediaErrorBinding::Wrap)
     }

--- a/components/script/dom/medialist.rs
+++ b/components/script/dom/medialist.rs
@@ -43,7 +43,7 @@ impl MediaList {
     pub fn new(window: &Window, parent_stylesheet: &CSSStyleSheet,
                media_queries: Arc<Locked<StyleMediaList>>)
         -> DomRoot<MediaList> {
-        reflect_dom_object(box MediaList::new_inherited(parent_stylesheet, media_queries),
+        reflect_dom_object(Box::new(MediaList::new_inherited(parent_stylesheet, media_queries)),
                            window,
                            MediaListBinding::Wrap)
     }

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -49,7 +49,7 @@ impl MediaQueryList {
     }
 
     pub fn new(document: &Document, media_query_list: MediaList) -> DomRoot<MediaQueryList> {
-        reflect_dom_object(box MediaQueryList::new_inherited(document, media_query_list),
+        reflect_dom_object(Box::new(MediaQueryList::new_inherited(document, media_query_list)),
                            document.window(),
                            MediaQueryListBinding::Wrap)
     }

--- a/components/script/dom/mediaquerylistevent.rs
+++ b/components/script/dom/mediaquerylistevent.rs
@@ -30,11 +30,11 @@ impl MediaQueryListEvent {
     pub fn new_initialized(global: &GlobalScope,
                            media: DOMString,
                            matches: bool) -> DomRoot<MediaQueryListEvent> {
-        let ev = box MediaQueryListEvent {
+        let ev = Box::new(MediaQueryListEvent {
             event: Event::new_inherited(),
             media: media,
             matches: Cell::new(matches)
-        };
+        });
         reflect_dom_object(ev, global, MediaQueryListEventBinding::Wrap)
     }
 

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -39,12 +39,12 @@ impl MessageEvent {
                            data: HandleValue,
                            origin: DOMString,
                            lastEventId: DOMString) -> DomRoot<MessageEvent> {
-        let ev = box MessageEvent {
+        let ev = Box::new(MessageEvent {
             event: Event::new_inherited(),
             data: Heap::default(),
             origin: origin,
             lastEventId: lastEventId,
-        };
+        });
         let ev = reflect_dom_object(ev, global, MessageEventBinding::Wrap);
         ev.data.set(data.get());
 

--- a/components/script/dom/mimetypearray.rs
+++ b/components/script/dom/mimetypearray.rs
@@ -24,7 +24,7 @@ impl MimeTypeArray {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<MimeTypeArray> {
-        reflect_dom_object(box MimeTypeArray::new_inherited(),
+        reflect_dom_object(Box::new(MimeTypeArray::new_inherited()),
                            global,
                            MimeTypeArrayBinding::Wrap)
     }

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -52,7 +52,7 @@ impl MouseEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<MouseEvent> {
-        reflect_dom_object(box MouseEvent::new_inherited(),
+        reflect_dom_object(Box::new(MouseEvent::new_inherited()),
                            window,
                            MouseEventBinding::Wrap)
     }

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -54,7 +54,7 @@ pub struct ObserverOptions {
 
 impl MutationObserver {
     fn new(global: &Window, callback: Rc<MutationCallback>) -> DomRoot<MutationObserver> {
-        let boxed_observer = box MutationObserver::new_inherited(callback);
+        let boxed_observer = Box::new(MutationObserver::new_inherited(callback));
         reflect_dom_object(boxed_observer, global, MutationObserverBinding::Wrap)
     }
 

--- a/components/script/dom/mutationrecord.rs
+++ b/components/script/dom/mutationrecord.rs
@@ -32,12 +32,14 @@ impl MutationRecord {
                              attribute_name: &LocalName,
                              attribute_namespace: Option<&Namespace>,
                              old_value: Option<DOMString>) -> DomRoot<MutationRecord> {
-        let record = box MutationRecord::new_inherited("attributes",
-                                                       target,
-                                                       Some(DOMString::from(&**attribute_name)),
-                                                       attribute_namespace.map(|n| DOMString::from(&**n)),
-                                                       old_value,
-                                                       None, None, None, None);
+        let record = Box::new(MutationRecord::new_inherited(
+            "attributes",
+            target,
+            Some(DOMString::from(&**attribute_name)),
+            attribute_namespace.map(|n| DOMString::from(&**n)),
+            old_value,
+            None, None, None, None
+        ));
         reflect_dom_object(record, &*window_from_node(target), MutationRecordBinding::Wrap)
     }
 
@@ -50,15 +52,19 @@ impl MutationRecord {
         let added_nodes = added_nodes.map(|list| NodeList::new_simple_list_slice(&window, list));
         let removed_nodes = removed_nodes.map(|list| NodeList::new_simple_list_slice(&window, list));
 
-        reflect_dom_object(box MutationRecord::new_inherited("childList",
-                                                             target,
-                                                             None, None, None,
-                                                             added_nodes.as_ref().map(|list| &**list),
-                                                             removed_nodes.as_ref().map(|list| &**list),
-                                                             next_sibling,
-                                                             prev_sibling),
-                           &*window,
-                           MutationRecordBinding::Wrap)
+        reflect_dom_object(
+            Box::new(MutationRecord::new_inherited(
+                "childList",
+                target,
+                None, None, None,
+                added_nodes.as_ref().map(|list| &**list),
+                removed_nodes.as_ref().map(|list| &**list),
+                next_sibling,
+                prev_sibling
+            )),
+            &*window,
+            MutationRecordBinding::Wrap
+        )
     }
 
     fn new_inherited(record_type: &str,

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -32,7 +32,7 @@ impl NamedNodeMap {
     }
 
     pub fn new(window: &Window, elem: &Element) -> DomRoot<NamedNodeMap> {
-        reflect_dom_object(box NamedNodeMap::new_inherited(elem),
+        reflect_dom_object(Box::new(NamedNodeMap::new_inherited(elem)),
                            window, NamedNodeMapBinding::Wrap)
     }
 }

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -48,7 +48,7 @@ impl Navigator {
     }
 
     pub fn new(window: &Window) -> DomRoot<Navigator> {
-        reflect_dom_object(box Navigator::new_inherited(),
+        reflect_dom_object(Box::new(Navigator::new_inherited()),
                            window,
                            NavigatorBinding::Wrap)
     }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2727,7 +2727,7 @@ impl UniqueId {
         unsafe {
             let ptr = self.cell.get();
             if (*ptr).is_none() {
-                *ptr = Some(box Uuid::new_v4());
+                *ptr = Some(Box::new(Uuid::new_v4()));
             }
             &(&*ptr).as_ref().unwrap()
         }

--- a/components/script/dom/nodeiterator.rs
+++ b/components/script/dom/nodeiterator.rs
@@ -47,7 +47,7 @@ impl NodeIterator {
                            root_node: &Node,
                            what_to_show: u32,
                            filter: Filter) -> DomRoot<NodeIterator> {
-        reflect_dom_object(box NodeIterator::new_inherited(root_node, what_to_show, filter),
+        reflect_dom_object(Box::new(NodeIterator::new_inherited(root_node, what_to_show, filter)),
                            document.window(),
                            NodeIteratorBinding::Wrap)
     }

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -37,7 +37,7 @@ impl NodeList {
 
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, list_type: NodeListType) -> DomRoot<NodeList> {
-        reflect_dom_object(box NodeList::new_inherited(list_type),
+        reflect_dom_object(Box::new(NodeList::new_inherited(list_type)),
                            window,
                            NodeListBinding::Wrap)
     }

--- a/components/script/dom/pagetransitionevent.rs
+++ b/components/script/dom/pagetransitionevent.rs
@@ -32,7 +32,7 @@ impl PageTransitionEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<PageTransitionEvent> {
-        reflect_dom_object(box PageTransitionEvent::new_inherited(),
+        reflect_dom_object(Box::new(PageTransitionEvent::new_inherited()),
                            window,
                            PageTransitionEventBinding::Wrap)
     }

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -53,7 +53,7 @@ impl PaintRenderingContext2D {
     }
 
     pub fn new(global: &PaintWorkletGlobalScope) -> DomRoot<PaintRenderingContext2D> {
-        reflect_dom_object(box PaintRenderingContext2D::new_inherited(global),
+        reflect_dom_object(Box::new(PaintRenderingContext2D::new_inherited(global)),
                            global,
                            PaintRenderingContext2DBinding::Wrap)
     }

--- a/components/script/dom/paintsize.rs
+++ b/components/script/dom/paintsize.rs
@@ -30,7 +30,7 @@ impl PaintSize {
     }
 
     pub fn new(global: &PaintWorkletGlobalScope, size: TypedSize2D<f32, CSSPixel>) -> DomRoot<PaintSize> {
-        reflect_dom_object(box PaintSize::new_inherited(size), global, PaintSizeBinding::Wrap)
+        reflect_dom_object(Box::new(PaintSize::new_inherited(size)), global, PaintSizeBinding::Wrap)
     }
 }
 

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -97,7 +97,7 @@ impl PaintWorkletGlobalScope {
                init: &WorkletGlobalScopeInit)
                -> DomRoot<PaintWorkletGlobalScope> {
         debug!("Creating paint worklet global scope for pipeline {}.", pipeline_id);
-        let global = box PaintWorkletGlobalScope {
+        let global = Box::new(PaintWorkletGlobalScope {
             worklet_global: WorkletGlobalScope::new_inherited(pipeline_id, base_url, executor, init),
             image_cache: init.image_cache.clone(),
             paint_definitions: Default::default(),
@@ -114,7 +114,7 @@ impl PaintWorkletGlobalScope {
                 image_key: None,
                 missing_image_urls: Vec::new(),
             }),
-        };
+        });
         unsafe { PaintWorkletGlobalScopeBinding::Wrap(runtime.cx(), global) }
     }
 

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -140,11 +140,11 @@ impl Performance {
     pub fn new(global: &GlobalScope,
                navigation_start: u64,
                navigation_start_precise: f64) -> DomRoot<Performance> {
-        reflect_dom_object(box Performance::new_inherited(global,
-                                                          navigation_start,
-                                                          navigation_start_precise),
-                           global,
-                           PerformanceBinding::Wrap)
+        reflect_dom_object(
+            Box::new(Performance::new_inherited(global, navigation_start, navigation_start_precise)),
+            global,
+            PerformanceBinding::Wrap
+        )
     }
 
     /// Add a PerformanceObserver to the list of observers with a set of

--- a/components/script/dom/performanceentry.rs
+++ b/components/script/dom/performanceentry.rs
@@ -41,7 +41,7 @@ impl PerformanceEntry {
                start_time: f64,
                duration: f64) -> DomRoot<PerformanceEntry> {
         let entry = PerformanceEntry::new_inherited(name, entry_type, start_time, duration);
-        reflect_dom_object(box entry, global, PerformanceEntryBinding::Wrap)
+        reflect_dom_object(Box::new(entry), global, PerformanceEntryBinding::Wrap)
     }
 
     pub fn entry_type(&self) -> &DOMString {

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -54,7 +54,7 @@ impl PerformanceObserver {
                entries: DOMPerformanceEntryList)
         -> DomRoot<PerformanceObserver> {
         let observer = PerformanceObserver::new_inherited(callback, DomRefCell::new(entries));
-        reflect_dom_object(box observer, global, PerformanceObserverBinding::Wrap)
+        reflect_dom_object(Box::new(observer), global, PerformanceObserverBinding::Wrap)
     }
 
     pub fn Constructor(global: &GlobalScope, callback: Rc<PerformanceObserverCallback>)

--- a/components/script/dom/performanceobserverentrylist.rs
+++ b/components/script/dom/performanceobserverentrylist.rs
@@ -31,7 +31,7 @@ impl PerformanceObserverEntryList {
     pub fn new(global: &GlobalScope, entries: PerformanceEntryList)
         -> DomRoot<PerformanceObserverEntryList> {
         let observer_entry_list = PerformanceObserverEntryList::new_inherited(entries);
-        reflect_dom_object(box observer_entry_list, global, PerformanceObserverEntryListBinding::Wrap)
+        reflect_dom_object(Box::new(observer_entry_list), global, PerformanceObserverEntryListBinding::Wrap)
     }
 }
 

--- a/components/script/dom/performancepainttiming.rs
+++ b/components/script/dom/performancepainttiming.rs
@@ -36,6 +36,6 @@ impl PerformancePaintTiming {
                metric_type: PaintMetricType,
                start_time: f64) -> DomRoot<PerformancePaintTiming> {
         let entry = PerformancePaintTiming::new_inherited(metric_type, start_time);
-        reflect_dom_object(box entry, global, PerformancePaintTimingBinding::Wrap)
+        reflect_dom_object(Box::new(entry), global, PerformancePaintTimingBinding::Wrap)
     }
 }

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -40,7 +40,7 @@ impl PerformanceTiming {
         let timing = PerformanceTiming::new_inherited(navigation_start,
                                                       navigation_start_precise,
                                                       &window.Document());
-        reflect_dom_object(box timing,
+        reflect_dom_object(Box::new(timing),
                            window,
                            PerformanceTimingBinding::Wrap)
     }

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -64,7 +64,7 @@ impl Permissions {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<Permissions> {
-        reflect_dom_object(box Permissions::new_inherited(),
+        reflect_dom_object(Box::new(Permissions::new_inherited()),
                            global,
                            PermissionsBinding::Wrap)
     }

--- a/components/script/dom/permissionstatus.rs
+++ b/components/script/dom/permissionstatus.rs
@@ -31,7 +31,7 @@ impl PermissionStatus {
     }
 
     pub fn new(global: &GlobalScope, query: &PermissionDescriptor) -> DomRoot<PermissionStatus> {
-        reflect_dom_object(box PermissionStatus::new_inherited(query.name),
+        reflect_dom_object(Box::new(PermissionStatus::new_inherited(query.name)),
                            global,
                            PermissionStatusBinding::Wrap)
     }

--- a/components/script/dom/pluginarray.rs
+++ b/components/script/dom/pluginarray.rs
@@ -24,7 +24,7 @@ impl PluginArray {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<PluginArray> {
-        reflect_dom_object(box PluginArray::new_inherited(),
+        reflect_dom_object(Box::new(PluginArray::new_inherited()),
                            global,
                            PluginArrayBinding::Wrap)
     }

--- a/components/script/dom/popstateevent.rs
+++ b/components/script/dom/popstateevent.rs
@@ -35,7 +35,7 @@ impl PopStateEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<PopStateEvent> {
-        reflect_dom_object(box PopStateEvent::new_inherited(),
+        reflect_dom_object(Box::new(PopStateEvent::new_inherited()),
                            window,
                            PopStateEventBinding::Wrap)
     }

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -27,7 +27,7 @@ impl ProcessingInstruction {
     }
 
     pub fn new(target: DOMString, data: DOMString, document: &Document) -> DomRoot<ProcessingInstruction> {
-        Node::reflect_node(box ProcessingInstruction::new_inherited(target, data, document),
+        Node::reflect_node(Box::new(ProcessingInstruction::new_inherited(target, data, document)),
                            document, ProcessingInstructionBinding::Wrap)
     }
 }

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -33,14 +33,14 @@ impl ProgressEvent {
         }
     }
     pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<ProgressEvent> {
-        reflect_dom_object(box ProgressEvent::new_inherited(false, 0, 0),
+        reflect_dom_object(Box::new(ProgressEvent::new_inherited(false, 0, 0)),
                            global,
                            ProgressEventBinding::Wrap)
     }
     pub fn new(global: &GlobalScope, type_: Atom,
                can_bubble: EventBubbles, cancelable: EventCancelable,
                length_computable: bool, loaded: u64, total: u64) -> DomRoot<ProgressEvent> {
-        let ev = reflect_dom_object(box ProgressEvent::new_inherited(length_computable, loaded, total),
+        let ev = reflect_dom_object(Box::new(ProgressEvent::new_inherited(length_computable, loaded, total)),
                                     global,
                                     ProgressEventBinding::Wrap);
         {

--- a/components/script/dom/promisenativehandler.rs
+++ b/components/script/dom/promisenativehandler.rs
@@ -27,11 +27,11 @@ impl PromiseNativeHandler {
                resolve: Option<Box<Callback>>,
                reject: Option<Box<Callback>>)
                -> DomRoot<PromiseNativeHandler> {
-        reflect_dom_object(box PromiseNativeHandler {
+        reflect_dom_object(Box::new(PromiseNativeHandler {
             reflector: Reflector::new(),
             resolve: resolve,
             reject: reject,
-        }, global, PromiseNativeHandlerBinding::Wrap)
+        }), global, PromiseNativeHandlerBinding::Wrap)
     }
 
     fn callback(callback: &Option<Box<Callback>>, cx: *mut JSContext, v: HandleValue) {

--- a/components/script/dom/radionodelist.rs
+++ b/components/script/dom/radionodelist.rs
@@ -31,7 +31,7 @@ impl RadioNodeList {
 
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, list_type: NodeListType) -> DomRoot<RadioNodeList> {
-        reflect_dom_object(box RadioNodeList::new_inherited(list_type),
+        reflect_dom_object(Box::new(RadioNodeList::new_inherited(list_type)),
                            window,
                            RadioNodeListBinding::Wrap)
     }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -58,10 +58,13 @@ impl Range {
                start_container: &Node, start_offset: u32,
                end_container: &Node, end_offset: u32)
                -> DomRoot<Range> {
-        let range = reflect_dom_object(box Range::new_inherited(start_container, start_offset,
-                                                                end_container, end_offset),
-                                       document.window(),
-                                       RangeBinding::Wrap);
+        let range = reflect_dom_object(
+            Box::new(Range::new_inherited(
+                start_container, start_offset, end_container, end_offset
+            )),
+            document.window(),
+            RangeBinding::Wrap
+        );
         start_container.ranges().push(WeakRef::new(&range));
         if start_container != end_container {
             end_container.ranges().push(WeakRef::new(&range));

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -68,8 +68,7 @@ impl Request {
 
     pub fn new(global: &GlobalScope,
                url: ServoUrl) -> DomRoot<Request> {
-        reflect_dom_object(box Request::new_inherited(global,
-                                                      url),
+        reflect_dom_object(Box::new(Request::new_inherited(global, url)),
                            global, RequestBinding::Wrap)
     }
 

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -68,7 +68,7 @@ impl Response {
 
     // https://fetch.spec.whatwg.org/#dom-response
     pub fn new(global: &GlobalScope) -> DomRoot<Response> {
-        reflect_dom_object(box Response::new_inherited(), global, ResponseBinding::Wrap)
+        reflect_dom_object(Box::new(Response::new_inherited()), global, ResponseBinding::Wrap)
     }
 
     pub fn Constructor(global: &GlobalScope, body: Option<BodyInit>, init: &ResponseBinding::ResponseInit)

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -22,7 +22,7 @@ impl Screen {
     }
 
     pub fn new(window: &Window) -> DomRoot<Screen> {
-        reflect_dom_object(box Screen::new_inherited(),
+        reflect_dom_object(Box::new(Screen::new_inherited()),
                            window,
                            ScreenBinding::Wrap)
     }

--- a/components/script/dom/serviceworker.rs
+++ b/components/script/dom/serviceworker.rs
@@ -49,9 +49,13 @@ impl ServiceWorker {
                                  script_url: ServoUrl,
                                  scope_url: ServoUrl,
                                  skip_waiting: bool) -> DomRoot<ServiceWorker> {
-        reflect_dom_object(box ServiceWorker::new_inherited(script_url.as_str(),
-                                                            skip_waiting,
-                                                            scope_url), global, Wrap)
+        reflect_dom_object(
+            Box::new(ServiceWorker::new_inherited(
+                script_url.as_str(), skip_waiting, scope_url
+            )),
+            global,
+            Wrap
+        )
     }
 
     pub fn dispatch_simple_error(address: TrustedServiceWorkerAddress) {

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -40,7 +40,7 @@ impl ServiceWorkerContainer {
     pub fn new(global: &GlobalScope) -> DomRoot<ServiceWorkerContainer> {
         let client = Client::new(&global.as_window());
         let container = ServiceWorkerContainer::new_inherited(&*client);
-        reflect_dom_object(box container, global, Wrap)
+        reflect_dom_object(Box::new(container), global, Wrap)
     }
 }
 

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -62,9 +62,9 @@ impl ScriptChan for ServiceWorkerChan {
     }
 
     fn clone(&self) -> Box<ScriptChan + Send> {
-        box ServiceWorkerChan {
+        Box::new(ServiceWorkerChan {
             sender: self.sender.clone(),
-        }
+        })
     }
 }
 
@@ -122,16 +122,18 @@ impl ServiceWorkerGlobalScope {
                scope_url: ServoUrl)
                -> DomRoot<ServiceWorkerGlobalScope> {
         let cx = runtime.cx();
-        let scope = box ServiceWorkerGlobalScope::new_inherited(init,
-                                                                  worker_url,
-                                                                  from_devtools_receiver,
-                                                                  runtime,
-                                                                  own_sender,
-                                                                  receiver,
-                                                                  timer_event_chan,
-                                                                  timer_event_port,
-                                                                  swmanager_sender,
-                                                                  scope_url);
+        let scope = Box::new(ServiceWorkerGlobalScope::new_inherited(
+            init,
+            worker_url,
+            from_devtools_receiver,
+            runtime,
+            own_sender,
+            receiver,
+            timer_event_chan,
+            timer_event_port,
+            swmanager_sender,
+            scope_url
+        ));
         unsafe {
             ServiceWorkerGlobalScopeBinding::Wrap(cx, scope)
         }
@@ -307,9 +309,9 @@ impl ServiceWorkerGlobalScope {
     }
 
     pub fn script_chan(&self) -> Box<ScriptChan + Send> {
-        box ServiceWorkerChan {
+        Box::new(ServiceWorkerChan {
             sender: self.own_sender.clone()
-        }
+        })
     }
 
     fn dispatch_activate(&self) {

--- a/components/script/dom/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworkerregistration.rs
@@ -44,7 +44,7 @@ impl ServiceWorkerRegistration {
                scope: ServoUrl) -> DomRoot<ServiceWorkerRegistration> {
         let active_worker = ServiceWorker::install_serviceworker(global, script_url.clone(), scope.clone(), true);
         active_worker.set_transition_state(ServiceWorkerState::Installed);
-        reflect_dom_object(box ServiceWorkerRegistration::new_inherited(&*active_worker, scope), global, Wrap)
+        reflect_dom_object(Box::new(ServiceWorkerRegistration::new_inherited(&*active_worker, scope)), global, Wrap)
     }
 
     pub fn get_installed(&self) -> &ServiceWorker {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -338,7 +338,7 @@ impl ServoParser {
            last_chunk_state: LastChunkState,
            kind: ParserKind)
            -> DomRoot<Self> {
-        reflect_dom_object(box ServoParser::new_inherited(document, tokenizer, last_chunk_state, kind),
+        reflect_dom_object(Box::new(ServoParser::new_inherited(document, tokenizer, last_chunk_state, kind)),
                            document.window(),
                            ServoParserBinding::Wrap)
     }

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -36,7 +36,7 @@ impl Storage {
     }
 
     pub fn new(global: &Window, storage_type: StorageType) -> DomRoot<Storage> {
-        reflect_dom_object(box Storage::new_inherited(storage_type), global, StorageBinding::Wrap)
+        reflect_dom_object(Box::new(Storage::new_inherited(storage_type)), global, StorageBinding::Wrap)
     }
 
     fn get_url(&self) -> ServoUrl {

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -45,7 +45,7 @@ impl StorageEvent {
 
     pub fn new_uninitialized(window: &Window,
                              url: DOMString) -> DomRoot<StorageEvent> {
-        reflect_dom_object(box StorageEvent::new_inherited(None, None, None, url, None),
+        reflect_dom_object(Box::new(StorageEvent::new_inherited(None, None, None, url, None)),
                            window,
                            StorageEventBinding::Wrap)
     }
@@ -59,10 +59,11 @@ impl StorageEvent {
                newValue: Option<DOMString>,
                url: DOMString,
                storageArea: Option<&Storage>) -> DomRoot<StorageEvent> {
-        let ev = reflect_dom_object(box StorageEvent::new_inherited(key, oldValue, newValue,
-                                                                    url, storageArea),
-                                    global,
-                                    StorageEventBinding::Wrap);
+        let ev = reflect_dom_object(
+            Box::new(StorageEvent::new_inherited(key, oldValue, newValue, url, storageArea)),
+            global,
+            StorageEventBinding::Wrap
+        );
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));

--- a/components/script/dom/stylepropertymapreadonly.rs
+++ b/components/script/dom/stylepropertymapreadonly.rs
@@ -48,7 +48,7 @@ impl StylePropertyMapReadOnly {
             values.push(Dom::from_ref(&*value));
         }
         let iter = keys.drain(..).zip(values.iter().cloned());
-        reflect_dom_object(box StylePropertyMapReadOnly::new_inherited(iter), global, Wrap)
+        reflect_dom_object(Box::new(StylePropertyMapReadOnly::new_inherited(iter)), global, Wrap)
     }
 }
 

--- a/components/script/dom/stylesheet.rs
+++ b/components/script/dom/stylesheet.rs
@@ -37,7 +37,7 @@ impl StyleSheet {
     pub fn new(window: &Window, type_: DOMString,
                href: Option<DOMString>,
                title: Option<DOMString>) -> DomRoot<StyleSheet> {
-        reflect_dom_object(box StyleSheet::new_inherited(type_, href, title),
+        reflect_dom_object(Box::new(StyleSheet::new_inherited(type_, href, title)),
                            window,
                            StyleSheetBinding::Wrap)
     }

--- a/components/script/dom/stylesheetlist.rs
+++ b/components/script/dom/stylesheetlist.rs
@@ -28,7 +28,7 @@ impl StyleSheetList {
 
     #[allow(unrooted_must_root)]
     pub fn new(window: &Window, document: Dom<Document>) -> DomRoot<StyleSheetList> {
-        reflect_dom_object(box StyleSheetList::new_inherited(document),
+        reflect_dom_object(Box::new(StyleSheetList::new_inherited(document)),
                            window, StyleSheetListBinding::Wrap)
     }
 }

--- a/components/script/dom/svgsvgelement.rs
+++ b/components/script/dom/svgsvgelement.rs
@@ -39,7 +39,7 @@ impl SVGSVGElement {
     pub fn new(local_name: LocalName,
                prefix: Option<Prefix>,
                document: &Document) -> DomRoot<SVGSVGElement> {
-        Node::reflect_node(box SVGSVGElement::new_inherited(local_name, prefix, document),
+        Node::reflect_node(Box::new(SVGSVGElement::new_inherited(local_name, prefix, document)),
                            document,
                            SVGSVGElementBinding::Wrap)
     }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -60,7 +60,7 @@ impl TestBinding {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<TestBinding> {
-        reflect_dom_object(box TestBinding::new_inherited(),
+        reflect_dom_object(Box::new(TestBinding::new_inherited()),
                            global, TestBindingBinding::Wrap)
     }
 
@@ -730,7 +730,7 @@ impl TestBindingMethods for TestBinding {
         }
         impl SimpleHandler {
             fn new(callback: Rc<SimpleCallback>) -> Box<Callback> {
-                box SimpleHandler { handler: callback }
+                Box::new(SimpleHandler { handler: callback })
             }
         }
         impl Callback for SimpleHandler {

--- a/components/script/dom/testbindingiterable.rs
+++ b/components/script/dom/testbindingiterable.rs
@@ -21,10 +21,10 @@ pub struct TestBindingIterable {
 
 impl TestBindingIterable {
     fn new(global: &GlobalScope) -> DomRoot<TestBindingIterable> {
-        reflect_dom_object(box TestBindingIterable {
+        reflect_dom_object(Box::new(TestBindingIterable {
             reflector: Reflector::new(),
             vals: DomRefCell::new(vec![]),
-        }, global, TestBindingIterableBinding::Wrap)
+        }), global, TestBindingIterableBinding::Wrap)
     }
 
     pub fn Constructor(global: &GlobalScope) -> Fallible<DomRoot<TestBindingIterable>> {

--- a/components/script/dom/testbindingpairiterable.rs
+++ b/components/script/dom/testbindingpairiterable.rs
@@ -37,10 +37,10 @@ impl Iterable for TestBindingPairIterable {
 
 impl TestBindingPairIterable {
     fn new(global: &GlobalScope) -> DomRoot<TestBindingPairIterable> {
-        reflect_dom_object(box TestBindingPairIterable {
+        reflect_dom_object(Box::new(TestBindingPairIterable {
             reflector: Reflector::new(),
             map: DomRefCell::new(vec![]),
-        }, global, TestBindingPairIterableBinding::TestBindingPairIterableWrap)
+        }), global, TestBindingPairIterableBinding::TestBindingPairIterableWrap)
     }
 
     pub fn Constructor(global: &GlobalScope) -> Fallible<DomRoot<TestBindingPairIterable>> {

--- a/components/script/dom/testrunner.rs
+++ b/components/script/dom/testrunner.rs
@@ -27,7 +27,7 @@ impl TestRunner {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<TestRunner> {
-        reflect_dom_object(box TestRunner::new_inherited(),
+        reflect_dom_object(Box::new(TestRunner::new_inherited()),
                            global,
                            TestRunnerBinding::Wrap)
     }

--- a/components/script/dom/testworklet.rs
+++ b/components/script/dom/testworklet.rs
@@ -38,7 +38,7 @@ impl TestWorklet {
 
     fn new(window: &Window) -> DomRoot<TestWorklet> {
         let worklet = Worklet::new(window, WorkletGlobalScopeType::Test);
-        reflect_dom_object(box TestWorklet::new_inherited(&*worklet), window, Wrap)
+        reflect_dom_object(Box::new(TestWorklet::new_inherited(&*worklet)), window, Wrap)
     }
 
     pub fn Constructor(window: &Window) -> Fallible<DomRoot<TestWorklet>> {

--- a/components/script/dom/testworkletglobalscope.rs
+++ b/components/script/dom/testworkletglobalscope.rs
@@ -37,10 +37,10 @@ impl TestWorkletGlobalScope {
                -> DomRoot<TestWorkletGlobalScope>
     {
         debug!("Creating test worklet global scope for pipeline {}.", pipeline_id);
-        let global = box TestWorkletGlobalScope {
+        let global = Box::new(TestWorkletGlobalScope {
             worklet_global: WorkletGlobalScope::new_inherited(pipeline_id, base_url, executor, init),
             lookup_table: Default::default(),
-        };
+        });
         unsafe { TestWorkletGlobalScopeBinding::Wrap(runtime.cx(), global) }
     }
 

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -31,7 +31,7 @@ impl Text {
     }
 
     pub fn new(text: DOMString, document: &Document) -> DomRoot<Text> {
-        Node::reflect_node(box Text::new_inherited(text, document),
+        Node::reflect_node(Box::new(Text::new_inherited(text, document)),
                            document, TextBinding::Wrap)
     }
 

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -37,7 +37,7 @@ impl TextDecoder {
     }
 
     pub fn new(global: &GlobalScope, encoding: EncodingRef, fatal: bool) -> DomRoot<TextDecoder> {
-        reflect_dom_object(box TextDecoder::new_inherited(encoding, fatal),
+        reflect_dom_object(Box::new(TextDecoder::new_inherited(encoding, fatal)),
                            global,
                            TextDecoderBinding::Wrap)
     }

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -28,7 +28,7 @@ impl TextEncoder {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<TextEncoder> {
-        reflect_dom_object(box TextEncoder::new_inherited(),
+        reflect_dom_object(Box::new(TextEncoder::new_inherited()),
                            global,
                            TextEncoderBinding::Wrap)
     }

--- a/components/script/dom/touch.rs
+++ b/components/script/dom/touch.rs
@@ -46,12 +46,16 @@ impl Touch {
               screen_x: Finite<f64>, screen_y: Finite<f64>,
               client_x: Finite<f64>, client_y: Finite<f64>,
               page_x: Finite<f64>, page_y: Finite<f64>) -> DomRoot<Touch> {
-        reflect_dom_object(box Touch::new_inherited(identifier, target,
-                                                    screen_x, screen_y,
-                                                    client_x, client_y,
-                                                    page_x, page_y),
-                           window,
-                           TouchBinding::Wrap)
+        reflect_dom_object(Box::new(
+            Touch::new_inherited(
+                identifier, target,
+                screen_x, screen_y,
+                client_x, client_y,
+                page_x, page_y
+            )),
+            window,
+            TouchBinding::Wrap
+        )
     }
 }
 

--- a/components/script/dom/touchevent.rs
+++ b/components/script/dom/touchevent.rs
@@ -48,7 +48,7 @@ impl TouchEvent {
                      touches: &TouchList,
                      changed_touches: &TouchList,
                      target_touches: &TouchList) -> DomRoot<TouchEvent> {
-        reflect_dom_object(box TouchEvent::new_inherited(touches, changed_touches, target_touches),
+        reflect_dom_object(Box::new(TouchEvent::new_inherited(touches, changed_touches, target_touches)),
                            window,
                            TouchEventBinding::Wrap)
     }

--- a/components/script/dom/touchlist.rs
+++ b/components/script/dom/touchlist.rs
@@ -25,7 +25,7 @@ impl TouchList {
     }
 
     pub fn new(window: &Window, touches: &[&Touch]) -> DomRoot<TouchList> {
-        reflect_dom_object(box TouchList::new_inherited(touches),
+        reflect_dom_object(Box::new(TouchList::new_inherited(touches)),
                            window, TouchListBinding::Wrap)
     }
 }

--- a/components/script/dom/transitionevent.rs
+++ b/components/script/dom/transitionevent.rs
@@ -37,7 +37,7 @@ impl TransitionEvent {
     pub fn new(window: &Window,
                type_: Atom,
                init: &TransitionEventInit) -> DomRoot<TransitionEvent> {
-        let ev = reflect_dom_object(box TransitionEvent::new_inherited(init),
+        let ev = reflect_dom_object(Box::new(TransitionEvent::new_inherited(init)),
                                     window,
                                     TransitionEventBinding::Wrap);
         {

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -44,7 +44,7 @@ impl TreeWalker {
                            root_node: &Node,
                            what_to_show: u32,
                            filter: Filter) -> DomRoot<TreeWalker> {
-        reflect_dom_object(box TreeWalker::new_inherited(root_node, what_to_show, filter),
+        reflect_dom_object(Box::new(TreeWalker::new_inherited(root_node, what_to_show, filter)),
                            document.window(),
                            TreeWalkerBinding::Wrap)
     }

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -35,7 +35,7 @@ impl UIEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<UIEvent> {
-        reflect_dom_object(box UIEvent::new_inherited(),
+        reflect_dom_object(Box::new(UIEvent::new_inherited()),
                            window,
                            UIEventBinding::Wrap)
     }

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -43,7 +43,7 @@ impl URL {
     }
 
     pub fn new(global: &GlobalScope, url: ServoUrl) -> DomRoot<URL> {
-        reflect_dom_object(box URL::new_inherited(url),
+        reflect_dom_object(Box::new(URL::new_inherited(url)),
                            global, URLBinding::Wrap)
     }
 

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -38,7 +38,7 @@ impl URLSearchParams {
     }
 
     pub fn new(global: &GlobalScope, url: Option<&URL>) -> DomRoot<URLSearchParams> {
-        reflect_dom_object(box URLSearchParams::new_inherited(url), global,
+        reflect_dom_object(Box::new(URLSearchParams::new_inherited(url)), global,
                            URLSearchParamsWrap)
     }
 

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -61,7 +61,7 @@ impl ValidityState {
     }
 
     pub fn new(window: &Window, element: &Element) -> DomRoot<ValidityState> {
-        reflect_dom_object(box ValidityState::new_inherited(element),
+        reflect_dom_object(Box::new(ValidityState::new_inherited(element)),
                            window,
                            ValidityStateBinding::Wrap)
     }

--- a/components/script/dom/vr.rs
+++ b/components/script/dom/vr.rs
@@ -42,9 +42,7 @@ impl VR {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<VR> {
-        let root = reflect_dom_object(box VR::new_inherited(),
-                           global,
-                           VRBinding::Wrap);
+        let root = reflect_dom_object(Box::new(VR::new_inherited()), global, VRBinding::Wrap);
         root.register();
         root
     }

--- a/components/script/dom/vrdisplay.rs
+++ b/components/script/dom/vrdisplay.rs
@@ -122,7 +122,7 @@ impl VRDisplay {
     }
 
     pub fn new(global: &GlobalScope, display: WebVRDisplayData) -> DomRoot<VRDisplay> {
-        reflect_dom_object(box VRDisplay::new_inherited(&global, display),
+        reflect_dom_object(Box::new(VRDisplay::new_inherited(&global, display)),
                            global,
                            VRDisplayBinding::Wrap)
     }
@@ -512,9 +512,9 @@ impl VRDisplay {
                 // Run RAF callbacks on JavaScript thread
                 let this = address.clone();
                 let sender = raf_sender.clone();
-                let task = box task!(handle_vrdisplay_raf: move || {
+                let task = Box::new(task!(handle_vrdisplay_raf: move || {
                     this.root().handle_raf(&sender);
-                });
+                }));
                 js_sender.send(CommonScriptMsg::Task(WebVREvent, task)).unwrap();
 
                 // Run Sync Poses in parallell on Render thread

--- a/components/script/dom/vrdisplaycapabilities.rs
+++ b/components/script/dom/vrdisplaycapabilities.rs
@@ -29,7 +29,7 @@ impl VRDisplayCapabilities {
     }
 
     pub fn new(capabilities: WebVRDisplayCapabilities, global: &GlobalScope) -> DomRoot<VRDisplayCapabilities> {
-        reflect_dom_object(box VRDisplayCapabilities::new_inherited(capabilities),
+        reflect_dom_object(Box::new(VRDisplayCapabilities::new_inherited(capabilities)),
                            global,
                            VRDisplayCapabilitiesBinding::Wrap)
     }

--- a/components/script/dom/vrdisplayevent.rs
+++ b/components/script/dom/vrdisplayevent.rs
@@ -44,9 +44,11 @@ impl VRDisplayEvent {
                display: &VRDisplay,
                reason: Option<VRDisplayEventReason>)
                -> DomRoot<VRDisplayEvent> {
-        let ev = reflect_dom_object(box VRDisplayEvent::new_inherited(&display, reason),
-                           global,
-                           VRDisplayEventBinding::Wrap);
+        let ev = reflect_dom_object(
+            Box::new(VRDisplayEvent::new_inherited(&display, reason)),
+            global,
+            VRDisplayEventBinding::Wrap
+        );
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);

--- a/components/script/dom/vreyeparameters.rs
+++ b/components/script/dom/vreyeparameters.rs
@@ -48,7 +48,7 @@ impl VREyeParameters {
             let _ = Float32Array::create(cx, CreateWith::Slice(&parameters.offset), array.handle_mut());
         }
 
-        let eye_parameters = reflect_dom_object(box VREyeParameters::new_inherited(parameters, &fov),
+        let eye_parameters = reflect_dom_object(Box::new(VREyeParameters::new_inherited(parameters, &fov)),
                                                 global,
                                                 VREyeParametersBinding::Wrap);
         eye_parameters.offset.set(array.get());

--- a/components/script/dom/vrfieldofview.rs
+++ b/components/script/dom/vrfieldofview.rs
@@ -30,7 +30,7 @@ impl VRFieldOfView {
     }
 
     pub fn new(global: &GlobalScope, fov: WebVRFieldOfView) -> DomRoot<VRFieldOfView> {
-        reflect_dom_object(box VRFieldOfView::new_inherited(fov),
+        reflect_dom_object(Box::new(VRFieldOfView::new_inherited(fov)),
                            global,
                            VRFieldOfViewBinding::Wrap)
     }

--- a/components/script/dom/vrframedata.rs
+++ b/components/script/dom/vrframedata.rs
@@ -53,7 +53,7 @@ impl VRFrameData {
                       0.0, 0.0, 0.0, 1.0f32];
         let pose = VRPose::new(&global, &Default::default());
 
-        let root = reflect_dom_object(box VRFrameData::new_inherited(&pose),
+        let root = reflect_dom_object(Box::new(VRFrameData::new_inherited(&pose)),
                                       global,
                                       VRFrameDataBinding::Wrap);
         let cx = global.get_cx();

--- a/components/script/dom/vrpose.rs
+++ b/components/script/dom/vrpose.rs
@@ -77,7 +77,7 @@ impl VRPose {
     }
 
     pub fn new(global: &GlobalScope, pose: &webvr::VRPose) -> DomRoot<VRPose> {
-        let root = reflect_dom_object(box VRPose::new_inherited(),
+        let root = reflect_dom_object(Box::new(VRPose::new_inherited()),
                                       global,
                                       VRPoseBinding::Wrap);
         root.update(&pose);

--- a/components/script/dom/vrstageparameters.rs
+++ b/components/script/dom/vrstageparameters.rs
@@ -44,7 +44,7 @@ impl VRStageParameters {
                                                                array.handle_mut());
         }
 
-        let stage_parameters  = reflect_dom_object(box VRStageParameters::new_inherited(parameters),
+        let stage_parameters  = reflect_dom_object(Box::new(VRStageParameters::new_inherited(parameters)),
                                                    global,
                                                    VRStageParametersBinding::Wrap);
 

--- a/components/script/dom/webgl_extensions/ext/oesstandardderivatives.rs
+++ b/components/script/dom/webgl_extensions/ext/oesstandardderivatives.rs
@@ -26,7 +26,7 @@ impl OESStandardDerivatives {
 impl WebGLExtension for OESStandardDerivatives {
     type Extension = OESStandardDerivatives;
     fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESStandardDerivatives> {
-        reflect_dom_object(box OESStandardDerivatives::new_inherited(),
+        reflect_dom_object(Box::new(OESStandardDerivatives::new_inherited()),
                            &*ctx.global(),
                            OESStandardDerivativesBinding::Wrap)
     }

--- a/components/script/dom/webgl_extensions/ext/oestexturefloat.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturefloat.rs
@@ -25,7 +25,7 @@ impl OESTextureFloat {
 impl WebGLExtension for OESTextureFloat {
     type Extension = OESTextureFloat;
     fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESTextureFloat> {
-        reflect_dom_object(box OESTextureFloat::new_inherited(),
+        reflect_dom_object(Box::new(OESTextureFloat::new_inherited()),
                            &*ctx.global(),
                            OESTextureFloatBinding::Wrap)
     }

--- a/components/script/dom/webgl_extensions/ext/oestexturefloatlinear.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturefloatlinear.rs
@@ -25,7 +25,7 @@ impl OESTextureFloatLinear {
 impl WebGLExtension for OESTextureFloatLinear {
     type Extension = OESTextureFloatLinear;
     fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESTextureFloatLinear> {
-        reflect_dom_object(box OESTextureFloatLinear::new_inherited(),
+        reflect_dom_object(Box::new(OESTextureFloatLinear::new_inherited()),
                            &*ctx.global(),
                            OESTextureFloatLinearBinding::Wrap)
     }

--- a/components/script/dom/webgl_extensions/ext/oestexturehalffloat.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturehalffloat.rs
@@ -25,7 +25,7 @@ impl OESTextureHalfFloat {
 impl WebGLExtension for OESTextureHalfFloat {
     type Extension = OESTextureHalfFloat;
     fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESTextureHalfFloat> {
-        reflect_dom_object(box OESTextureHalfFloat::new_inherited(),
+        reflect_dom_object(Box::new(OESTextureHalfFloat::new_inherited()),
                            &*ctx.global(),
                            OESTextureHalfFloatBinding::Wrap)
     }

--- a/components/script/dom/webgl_extensions/ext/oestexturehalffloatlinear.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturehalffloatlinear.rs
@@ -26,7 +26,7 @@ impl OESTextureHalfFloatLinear {
 impl WebGLExtension for OESTextureHalfFloatLinear {
     type Extension = OESTextureHalfFloatLinear;
     fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESTextureHalfFloatLinear> {
-        reflect_dom_object(box OESTextureHalfFloatLinear::new_inherited(),
+        reflect_dom_object(Box::new(OESTextureHalfFloatLinear::new_inherited()),
                            &*ctx.global(),
                            OESTextureHalfFloatLinearBinding::Wrap)
     }

--- a/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
+++ b/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
@@ -133,7 +133,7 @@ impl OESVertexArrayObjectMethods for OESVertexArrayObject {
 impl WebGLExtension for OESVertexArrayObject {
     type Extension = OESVertexArrayObject;
     fn new(ctx: &WebGLRenderingContext) -> DomRoot<OESVertexArrayObject> {
-        reflect_dom_object(box OESVertexArrayObject::new_inherited(ctx),
+        reflect_dom_object(Box::new(OESVertexArrayObject::new_inherited(ctx)),
                            &*ctx.global(),
                            OESVertexArrayObjectBinding::Wrap)
     }

--- a/components/script/dom/webgl_extensions/ext/webglvertexarrayobjectoes.rs
+++ b/components/script/dom/webgl_extensions/ext/webglvertexarrayobjectoes.rs
@@ -39,7 +39,7 @@ impl WebGLVertexArrayObjectOES {
     }
 
     pub fn new(global: &GlobalScope, id: WebGLVertexArrayId) -> DomRoot<WebGLVertexArrayObjectOES> {
-        reflect_dom_object(box WebGLVertexArrayObjectOES::new_inherited(id),
+        reflect_dom_object(Box::new(WebGLVertexArrayObjectOES::new_inherited(id)),
                            global,
                            WebGLVertexArrayObjectOESBinding::Wrap)
     }

--- a/components/script/dom/webgl_extensions/extensions.rs
+++ b/components/script/dom/webgl_extensions/extensions.rs
@@ -99,7 +99,7 @@ impl WebGLExtensions {
 
     pub fn register<T:'static + WebGLExtension + JSTraceable + HeapSizeOf>(&self) {
         let name = T::name().to_uppercase();
-        self.extensions.borrow_mut().insert(name, box TypedWebGLExtensionWrapper::<T>::new());
+        self.extensions.borrow_mut().insert(name, Box::new(TypedWebGLExtensionWrapper::<T>::new()));
     }
 
     pub fn get_suported_extensions(&self) -> Vec<&'static str> {

--- a/components/script/dom/webglactiveinfo.rs
+++ b/components/script/dom/webglactiveinfo.rs
@@ -31,7 +31,11 @@ impl WebGLActiveInfo {
     }
 
     pub fn new(window: &Window, size: i32, ty: u32, name: DOMString) -> DomRoot<WebGLActiveInfo> {
-        reflect_dom_object(box WebGLActiveInfo::new_inherited(size, ty, name), window, WebGLActiveInfoBinding::Wrap)
+        reflect_dom_object(
+            Box::new(WebGLActiveInfo::new_inherited(size, ty, name)),
+            window,
+            WebGLActiveInfoBinding::Wrap
+        )
     }
 }
 

--- a/components/script/dom/webglbuffer.rs
+++ b/components/script/dom/webglbuffer.rs
@@ -60,7 +60,7 @@ impl WebGLBuffer {
                renderer: WebGLMsgSender,
                id: WebGLBufferId)
               -> DomRoot<WebGLBuffer> {
-        reflect_dom_object(box WebGLBuffer::new_inherited(renderer, id),
+        reflect_dom_object(Box::new(WebGLBuffer::new_inherited(renderer, id)),
                            window, WebGLBufferBinding::Wrap)
     }
 }

--- a/components/script/dom/webglcontextevent.rs
+++ b/components/script/dom/webglcontextevent.rs
@@ -48,7 +48,7 @@ impl WebGLContextEvent {
         // available.
         let status_message = DOMString::new();
         reflect_dom_object(
-                        box WebGLContextEvent::new_inherited(status_message),
+                        Box::new(WebGLContextEvent::new_inherited(status_message)),
                         window,
                         WebGLContextEventBinding::Wrap)
     }
@@ -59,7 +59,7 @@ impl WebGLContextEvent {
                cancelable: EventCancelable,
                status_message: DOMString) -> DomRoot<WebGLContextEvent> {
         let event = reflect_dom_object(
-                        box WebGLContextEvent::new_inherited(status_message),
+                        Box::new(WebGLContextEvent::new_inherited(status_message)),
                         window,
                         WebGLContextEventBinding::Wrap);
 

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -77,7 +77,7 @@ impl WebGLFramebuffer {
                renderer: WebGLMsgSender,
                id: WebGLFramebufferId)
                -> DomRoot<WebGLFramebuffer> {
-        reflect_dom_object(box WebGLFramebuffer::new_inherited(renderer, id),
+        reflect_dom_object(Box::new(WebGLFramebuffer::new_inherited(renderer, id)),
                            window,
                            WebGLFramebufferBinding::Wrap)
     }

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -60,7 +60,7 @@ impl WebGLProgram {
                renderer: WebGLMsgSender,
                id: WebGLProgramId)
                -> DomRoot<WebGLProgram> {
-        reflect_dom_object(box WebGLProgram::new_inherited(renderer, id),
+        reflect_dom_object(Box::new(WebGLProgram::new_inherited(renderer, id)),
                            window,
                            WebGLProgramBinding::Wrap)
     }

--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -53,7 +53,7 @@ impl WebGLRenderbuffer {
                renderer: WebGLMsgSender,
                id: WebGLRenderbufferId)
                -> DomRoot<WebGLRenderbuffer> {
-        reflect_dom_object(box WebGLRenderbuffer::new_inherited(renderer, id),
+        reflect_dom_object(Box::new(WebGLRenderbuffer::new_inherited(renderer, id)),
                            window,
                            WebGLRenderbufferBinding::Wrap)
     }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -256,7 +256,7 @@ impl WebGLRenderingContext {
     pub fn new(window: &Window, canvas: &HTMLCanvasElement, size: Size2D<i32>, attrs: GLContextAttributes)
                -> Option<DomRoot<WebGLRenderingContext>> {
         match WebGLRenderingContext::new_inherited(window, canvas, size, attrs) {
-            Ok(ctx) => Some(reflect_dom_object(box ctx, window, WebGLRenderingContextBinding::Wrap)),
+            Ok(ctx) => Some(reflect_dom_object(Box::new(ctx), window, WebGLRenderingContextBinding::Wrap)),
             Err(msg) => {
                 error!("Couldn't create WebGLRenderingContext: {}", msg);
                 let event = WebGLContextEvent::new(window,

--- a/components/script/dom/webglshader.rs
+++ b/components/script/dom/webglshader.rs
@@ -82,7 +82,7 @@ impl WebGLShader {
                id: WebGLShaderId,
                shader_type: u32)
                -> DomRoot<WebGLShader> {
-        reflect_dom_object(box WebGLShader::new_inherited(renderer, id, shader_type),
+        reflect_dom_object(Box::new(WebGLShader::new_inherited(renderer, id, shader_type)),
                            window,
                            WebGLShaderBinding::Wrap)
     }

--- a/components/script/dom/webglshaderprecisionformat.rs
+++ b/components/script/dom/webglshaderprecisionformat.rs
@@ -35,7 +35,7 @@ impl WebGLShaderPrecisionFormat {
                range_max: i32,
                precision: i32) -> DomRoot<WebGLShaderPrecisionFormat> {
         reflect_dom_object(
-            box WebGLShaderPrecisionFormat::new_inherited(range_min, range_max, precision),
+            Box::new(WebGLShaderPrecisionFormat::new_inherited(range_min, range_max, precision)),
             window,
             WebGLShaderPrecisionFormatBinding::Wrap)
     }

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -78,7 +78,7 @@ impl WebGLTexture {
                renderer: WebGLMsgSender,
                id: WebGLTextureId)
                -> DomRoot<WebGLTexture> {
-        reflect_dom_object(box WebGLTexture::new_inherited(renderer, id),
+        reflect_dom_object(Box::new(WebGLTexture::new_inherited(renderer, id)),
                            window,
                            WebGLTextureBinding::Wrap)
     }

--- a/components/script/dom/webgluniformlocation.rs
+++ b/components/script/dom/webgluniformlocation.rs
@@ -32,7 +32,7 @@ impl WebGLUniformLocation {
                id: i32,
                program_id: WebGLProgramId)
                -> DomRoot<WebGLUniformLocation> {
-        reflect_dom_object(box WebGLUniformLocation::new_inherited(id, program_id),
+        reflect_dom_object(Box::new(WebGLUniformLocation::new_inherited(id, program_id)),
                            window,
                            WebGLUniformLocationBinding::Wrap)
     }

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -125,7 +125,7 @@ impl WebSocket {
     }
 
     fn new(global: &GlobalScope, url: ServoUrl) -> DomRoot<WebSocket> {
-        reflect_dom_object(box WebSocket::new_inherited(url),
+        reflect_dom_object(Box::new(WebSocket::new_inherited(url)),
                            global, WebSocketBinding::Wrap)
     }
 
@@ -259,9 +259,9 @@ impl WebSocket {
         if !self.clearing_buffer.get() && self.ready_state.get() == WebSocketRequestState::Open {
             self.clearing_buffer.set(true);
 
-            let task = box BufferedAmountTask {
+            let task = Box::new(BufferedAmountTask {
                 address: address,
-            };
+            });
 
             self.global()
                 .script_chan()

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -115,11 +115,13 @@ impl WindowProxy {
 
             // Create a new browsing context.
             let current = Some(window.global().pipeline_id());
-            let mut window_proxy = box WindowProxy::new_inherited(browsing_context_id,
-                                                                  top_level_browsing_context_id,
-                                                                  current,
-                                                                  frame_element,
-                                                                  parent);
+            let mut window_proxy = Box::new(WindowProxy::new_inherited(
+                browsing_context_id,
+                top_level_browsing_context_id,
+                current,
+                frame_element,
+                parent
+            ));
 
             // The window proxy owns the browsing context.
             // When we finalize the window proxy, it drops the browsing context it owns.
@@ -149,11 +151,13 @@ impl WindowProxy {
             let cx = global_to_clone_from.get_cx();
 
             // Create a new browsing context.
-            let mut window_proxy = box WindowProxy::new_inherited(browsing_context_id,
-                                                                  top_level_browsing_context_id,
-                                                                  None,
-                                                                  None,
-                                                                  parent);
+            let mut window_proxy = Box::new(WindowProxy::new_inherited(
+                browsing_context_id,
+                top_level_browsing_context_id,
+                None,
+                None,
+                parent
+            ));
 
             // Create a new dissimilar-origin window.
             let window = DissimilarOriginWindow::new(global_to_clone_from, &*window_proxy);

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -61,7 +61,7 @@ impl Worker {
     pub fn new(global: &GlobalScope,
                sender: Sender<(TrustedWorkerAddress, WorkerScriptMsg)>,
                closing: Arc<AtomicBool>) -> DomRoot<Worker> {
-        reflect_dom_object(box Worker::new_inherited(sender, closing),
+        reflect_dom_object(Box::new(Worker::new_inherited(sender, closing)),
                            global,
                            WorkerBinding::Wrap)
     }

--- a/components/script/dom/workerlocation.rs
+++ b/components/script/dom/workerlocation.rs
@@ -28,7 +28,7 @@ impl WorkerLocation {
     }
 
     pub fn new(global: &WorkerGlobalScope, url: ServoUrl) -> DomRoot<WorkerLocation> {
-        reflect_dom_object(box WorkerLocation::new_inherited(url),
+        reflect_dom_object(Box::new(WorkerLocation::new_inherited(url)),
                            global,
                            WorkerLocationBinding::Wrap)
     }

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -28,7 +28,7 @@ impl WorkerNavigator {
     }
 
     pub fn new(global: &WorkerGlobalScope) -> DomRoot<WorkerNavigator> {
-        reflect_dom_object(box WorkerNavigator::new_inherited(),
+        reflect_dom_object(Box::new(WorkerNavigator::new_inherited()),
                            global,
                            WorkerNavigatorBinding::Wrap)
     }

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -94,7 +94,7 @@ impl Worklet {
 
     pub fn new(window: &Window, global_type: WorkletGlobalScopeType) -> DomRoot<Worklet> {
         debug!("Creating worklet {:?}.", global_type);
-        reflect_dom_object(box Worklet::new_inherited(window, global_type), window, Wrap)
+        reflect_dom_object(Box::new(Worklet::new_inherited(window, global_type)), window, Wrap)
     }
 
     pub fn worklet_id(&self) -> WorkletId {
@@ -646,7 +646,7 @@ impl WorkletThread {
     where
         T: TaskBox + 'static,
     {
-        let msg = CommonScriptMsg::Task(ScriptThreadEventCategory::WorkletEvent, box task);
+        let msg = CommonScriptMsg::Task(ScriptThreadEventCategory::WorkletEvent, Box::new(task));
         let msg = MainThreadScriptMsg::Common(msg);
         self.global_init.to_script_thread_sender.send(msg).expect("Worklet thread outlived script thread.");
     }

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -64,18 +64,21 @@ impl XMLDocument {
                doc_loader: DocumentLoader)
                -> DomRoot<XMLDocument> {
         let doc = reflect_dom_object(
-            box XMLDocument::new_inherited(window,
-                                           has_browsing_context,
-                                           url,
-                                           origin,
-                                           doctype,
-                                           content_type,
-                                           last_modified,
-                                           activity,
-                                           source,
-                                           doc_loader),
+            Box::new(XMLDocument::new_inherited(
+                window,
+                has_browsing_context,
+                url,
+                origin,
+                doctype,
+                content_type,
+                last_modified,
+                activity,
+                source,
+                doc_loader
+            )),
             window,
-            XMLDocumentBinding::Wrap);
+            XMLDocumentBinding::Wrap
+        );
         {
             let node = doc.upcast::<Node>();
             node.set_owner_doc(&doc.document);

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -204,7 +204,7 @@ impl XMLHttpRequest {
         }
     }
     pub fn new(global: &GlobalScope) -> DomRoot<XMLHttpRequest> {
-        reflect_dom_object(box XMLHttpRequest::new_inherited(global),
+        reflect_dom_object(Box::new(XMLHttpRequest::new_inherited(global)),
                            global,
                            XMLHttpRequestBinding::Wrap)
     }
@@ -263,9 +263,9 @@ impl XMLHttpRequest {
             task_source: task_source,
             canceller: Some(global.task_canceller())
         };
-        ROUTER.add_route(action_receiver.to_opaque(), box move |message| {
+        ROUTER.add_route(action_receiver.to_opaque(), Box::new(move |message| {
             listener.notify_fetch(message.to().unwrap());
-        });
+        }));
         global.core_resource_thread().send(Fetch(init, action_sender)).unwrap();
     }
 }

--- a/components/script/dom/xmlhttprequestupload.rs
+++ b/components/script/dom/xmlhttprequestupload.rs
@@ -21,7 +21,7 @@ impl XMLHttpRequestUpload {
         }
     }
     pub fn new(global: &GlobalScope) -> DomRoot<XMLHttpRequestUpload> {
-        reflect_dom_object(box XMLHttpRequestUpload::new_inherited(),
+        reflect_dom_object(Box::new(XMLHttpRequestUpload::new_inherited()),
                            global,
                            XMLHttpRequestUploadBinding::Wrap)
     }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -105,9 +105,9 @@ pub fn Fetch(global: &GlobalScope, input: RequestInfo, init: RootedTraceableBox<
         canceller: Some(global.task_canceller())
     };
 
-    ROUTER.add_route(action_receiver.to_opaque(), box move |message| {
+    ROUTER.add_route(action_receiver.to_opaque(), Box::new(move |message| {
         listener.notify_fetch(message.to().unwrap());
-    });
+    }));
     core_resource_thread.send(NetTraitsFetch(request_init, action_sender)).unwrap();
 
     promise

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -64,9 +64,9 @@ pub fn fetch_image_for_layout(url: ServoUrl,
         task_source: window.networking_task_source(),
         canceller: Some(window.task_canceller()),
     };
-    ROUTER.add_route(action_receiver.to_opaque(), box move |message| {
+    ROUTER.add_route(action_receiver.to_opaque(), Box::new(move |message| {
         listener.notify_fetch(message.to().unwrap());
-    });
+    }));
 
     let request = FetchRequestInit {
         url: url,

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![feature(box_syntax)]
 #![feature(conservative_impl_trait)]
 #![feature(const_fn)]
 #![feature(const_ptr_null)]

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -290,7 +290,7 @@ impl ScriptChan for SendableMainThreadScriptChan {
     }
 
     fn clone(&self) -> Box<ScriptChan + Send> {
-        box SendableMainThreadScriptChan((&self.0).clone())
+        Box::new(SendableMainThreadScriptChan((&self.0).clone()))
     }
 }
 
@@ -304,7 +304,7 @@ impl ScriptChan for MainThreadScriptChan {
     }
 
     fn clone(&self) -> Box<ScriptChan + Send> {
-        box MainThreadScriptChan((&self.0).clone())
+        Box::new(MainThreadScriptChan((&self.0).clone()))
     }
 }
 
@@ -804,7 +804,7 @@ impl ScriptThread {
         // Ask the router to proxy IPC messages from the control port to us.
         let control_port = ROUTER.route_ipc_receiver_to_new_mpsc_receiver(state.control_port);
 
-        let boxed_script_sender = box MainThreadScriptChan(chan.clone());
+        let boxed_script_sender = Box::new(MainThreadScriptChan(chan.clone()));
 
         let (image_cache_channel, image_cache_port) = channel();
 

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -231,9 +231,9 @@ impl<'a> StylesheetLoader<'a> {
             task_source: document.window().networking_task_source(),
             canceller: Some(document.window().task_canceller())
         };
-        ROUTER.add_route(action_receiver.to_opaque(), box move |message| {
+        ROUTER.add_route(action_receiver.to_opaque(), Box::new(move |message| {
             listener.notify_fetch(message.to().unwrap());
-        });
+        }));
 
 
         let owner = self.elem.upcast::<Element>().as_stylesheet_owner()

--- a/components/script/task_source/dom_manipulation.rs
+++ b/components/script/task_source/dom_manipulation.rs
@@ -36,7 +36,7 @@ impl TaskSource for DOMManipulationTaskSource {
     {
         let msg = MainThreadScriptMsg::Common(CommonScriptMsg::Task(
             ScriptThreadEventCategory::ScriptEvent,
-            box canceller.wrap_task(task),
+            Box::new(canceller.wrap_task(task)),
         ));
         self.0.send(msg).map_err(|_| ())
     }

--- a/components/script/task_source/file_reading.rs
+++ b/components/script/task_source/file_reading.rs
@@ -29,7 +29,7 @@ impl TaskSource for FileReadingTaskSource {
     {
         self.0.send(CommonScriptMsg::Task(
             ScriptThreadEventCategory::FileRead,
-            box canceller.wrap_task(task),
+            Box::new(canceller.wrap_task(task)),
         ))
     }
 }

--- a/components/script/task_source/history_traversal.rs
+++ b/components/script/task_source/history_traversal.rs
@@ -15,6 +15,6 @@ impl ScriptChan for HistoryTraversalTaskSource {
     }
 
     fn clone(&self) -> Box<ScriptChan + Send> {
-        box HistoryTraversalTaskSource((&self.0).clone())
+        Box::new(HistoryTraversalTaskSource((&self.0).clone()))
     }
 }

--- a/components/script/task_source/networking.rs
+++ b/components/script/task_source/networking.rs
@@ -26,7 +26,7 @@ impl TaskSource for NetworkingTaskSource {
     {
         self.0.send(CommonScriptMsg::Task(
             ScriptThreadEventCategory::NetworkEvent,
-            box canceller.wrap_task(task),
+            Box::new(canceller.wrap_task(task)),
         ))
     }
 }
@@ -40,7 +40,7 @@ impl NetworkingTaskSource {
     {
         self.0.send(CommonScriptMsg::Task(
             ScriptThreadEventCategory::NetworkEvent,
-            box task,
+            Box::new(task),
         ))
     }
 }

--- a/components/script/task_source/performance_timeline.rs
+++ b/components/script/task_source/performance_timeline.rs
@@ -40,7 +40,7 @@ impl TaskSource for PerformanceTimelineTaskSource {
     {
         let msg = CommonScriptMsg::Task(
             ScriptThreadEventCategory::PerformanceTimelineTask,
-            box canceller.wrap_task(task)
+            Box::new(canceller.wrap_task(task))
         );
         self.0.send(msg).map_err(|_| ())
     }

--- a/components/script/task_source/user_interaction.rs
+++ b/components/script/task_source/user_interaction.rs
@@ -36,7 +36,7 @@ impl TaskSource for UserInteractionTaskSource {
     {
         let msg = MainThreadScriptMsg::Common(CommonScriptMsg::Task(
             ScriptThreadEventCategory::InputEvent,
-            box canceller.wrap_task(task),
+            Box::new(canceller.wrap_task(task)),
         ));
         self.0.send(msg).map_err(|_| ())
     }


### PR DESCRIPTION
http://www.robohornet.org gives a score of 101.36 on master, and 102.68 with this PR. The latter is slightly better, but probably within noise level. So it looks like this PR does not affect DOM performance.

This is expected since `Box::new` is defined as:

```rust
impl<T> Box<T> {
    #[inline(always)]
    pub fn new(x: T) -> Box<T> {
        box x
    }
}
```

With inlining, it should compile to the same as box syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18900)
<!-- Reviewable:end -->
