### PR TITLE
Fix duplicate stacking context creation for anonymous Flows

### DIFF
--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -42,10 +42,9 @@ impl StackingContextId {
         StackingContextId(0)
     }
 
-    /// Returns a new sacking context id with the given numeric id.
-    #[inline]
-    pub fn new(id: u64) -> StackingContextId {
-        StackingContextId(id)
+    pub fn next(&self) -> StackingContextId {
+        let StackingContextId(id) = *self;
+        StackingContextId(id + 1)
     }
 }
 

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -181,6 +181,9 @@ pub struct StackingContextCollectionState {
     /// The current stacking real context id, which doesn't include pseudo-stacking contexts.
     pub current_real_stacking_context_id: StackingContextId,
 
+    /// The next stacking context id that we will assign to a stacking context.
+    pub next_stacking_context_id: StackingContextId,
+
     /// The current clip and scroll info, used to keep track of state when
     /// recursively building and processing the display list.
     pub current_clip_and_scroll_info: ClipAndScrollInfo,
@@ -212,12 +215,18 @@ impl StackingContextCollectionState {
             clip_scroll_node_parents: FnvHashMap::default(),
             current_stacking_context_id: StackingContextId::root(),
             current_real_stacking_context_id: StackingContextId::root(),
+            next_stacking_context_id: StackingContextId::root().next(),
             current_clip_and_scroll_info: root_clip_info,
             containing_block_clip_and_scroll_info: root_clip_info,
             clip_stack: Vec::new(),
             containing_block_clip_stack: Vec::new(),
             parent_stacking_relative_content_box: Rect::zero(),
         }
+    }
+
+    fn generate_stacking_context_id(&mut self) -> StackingContextId {
+        let next_stacking_context_id = self.next_stacking_context_id.next();
+        mem::replace(&mut self.next_stacking_context_id, next_stacking_context_id)
     }
 
     fn add_stacking_context(&mut self,
@@ -610,10 +619,6 @@ pub trait FragmentDisplayListBuilding {
                                context_type: StackingContextType,
                                parent_clip_and_scroll_info: ClipAndScrollInfo)
                                -> StackingContext;
-
-
-    /// The id of stacking context this fragment would create.
-    fn stacking_context_id(&self) -> StackingContextId;
 
     fn unique_id(&self, id_type: IdType) -> u64;
 
@@ -2169,10 +2174,6 @@ impl FragmentDisplayListBuilding for Fragment {
         }
     }
 
-    fn stacking_context_id(&self) -> StackingContextId {
-        StackingContextId::new(self.unique_id(IdType::StackingContext))
-    }
-
     fn create_stacking_context(&self,
                                id: StackingContextId,
                                base_flow: &BaseFlow,
@@ -2576,7 +2577,7 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
         self.base.stacking_context_id = match block_stacking_context_type {
             BlockStackingContextType::NonstackingContext => state.current_stacking_context_id,
             BlockStackingContextType::PseudoStackingContext |
-            BlockStackingContextType::StackingContext => self.fragment.stacking_context_id(),
+            BlockStackingContextType::StackingContext => state.generate_stacking_context_id(),
         };
         state.current_stacking_context_id = self.base.stacking_context_id;
 
@@ -2988,7 +2989,7 @@ impl InlineFlowDisplayListBuilding for InlineFlow {
 
             if !fragment.collect_stacking_contexts_for_blocklike_fragment(state) {
                 if fragment.establishes_stacking_context() {
-                    fragment.stacking_context_id = fragment.stacking_context_id();
+                    fragment.stacking_context_id = state.generate_stacking_context_id();
 
                     let current_stacking_context_id = state.current_stacking_context_id;
                     let stacking_context =


### PR DESCRIPTION
Anonymous nodes were previously creating duplicate stacking contexts,
one for each node in the anonymous node chain. This change eliminates
that for tables.
    
Additionally the use of stacking context ids based on node addresses is
no longer necessary since stacking contexts no longer control scrolling.
This is the first step in eliminating the dependency between node
addresses and ClipScrollNodes which causes issues like #16425.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18902)
<!-- Reviewable:end -->
