### PR TITLE
Bootstrap rust and cargo from more long-term URLs

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -93,7 +93,7 @@ class MachCommands(CommandBase):
                 channel = "%s/%s/channel-rust-nightly.toml" % (static_s3, self.rust_nightly_date())
                 nightly_commit_hash = toml.load(urllib2.urlopen(channel))["pkg"]["rustc"]["git_commit_hash"]
 
-                base_url = "https://s3.amazonaws.com/rust-lang-ci/rustc-builds"
+                base_url = "https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rustc-builds"
                 if not self.config["build"]["llvm-assertions"]:
                     base_url += "-alt"
                 base_url += "/" + nightly_commit_hash

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -89,14 +89,15 @@ class MachCommands(CommandBase):
             if stable:
                 base_url = static_s3
             else:
-                import toml
-                channel = "%s/%s/channel-rust-nightly.toml" % (static_s3, self.rust_nightly_date())
-                nightly_commit_hash = toml.load(urllib2.urlopen(channel))["pkg"]["rustc"]["git_commit_hash"]
+                if self.config["build"]["llvm-assertions"]:
+                    base_url = static_s3 + "/" + self.rust_nightly_date()
+                else:
+                    import toml
+                    channel = "%s/%s/channel-rust-nightly.toml" % (static_s3, self.rust_nightly_date())
+                    nightly_commit_hash = toml.load(urllib2.urlopen(channel))["pkg"]["rustc"]["git_commit_hash"]
 
-                base_url = "https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rustc-builds"
-                if not self.config["build"]["llvm-assertions"]:
-                    base_url += "-alt"
-                base_url += "/" + nightly_commit_hash
+                    base_url = "https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rustc-builds-alt/"
+                    base_url += nightly_commit_hash
 
             rustc_url = base_url + "/rustc-%s-%s.tar.gz" % (version, host_triple())
             tgz_file = rust_dir + '-rustc.tar.gz'

--- a/support/android/openssl.makefile
+++ b/support/android/openssl.makefile
@@ -10,5 +10,5 @@ openssl-${OPENSSL_VERSION}/libssl.so: openssl-${OPENSSL_VERSION}/Configure
 	./openssl.sh ${ANDROID_NDK} ${OPENSSL_VERSION}
 
 openssl-${OPENSSL_VERSION}/Configure:
-	URL=https://s3.amazonaws.com/rust-lang-ci/rust-ci-mirror/openssl-${OPENSSL_VERSION}.tar.gz; \
+	URL=https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/openssl-${OPENSSL_VERSION}.tar.gz; \
 	curl $$URL | tar xzf -


### PR DESCRIPTION
See https://internals.rust-lang.org/t/updates-on-rusts-ci-uploads/6062

Alt rustc builds are still only available at ephemeral URLs for now: rust-lang/rust#45334

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18911)
<!-- Reviewable:end -->
