### PR TITLE
style: Add FFI function for parsing IntersectionObserver rootMargin values.

### DIFF
--- a/components/style/gecko_bindings/sugar/ns_css_value.rs
+++ b/components/style/gecko_bindings/sugar/ns_css_value.rs
@@ -75,15 +75,25 @@ impl nsCSSValue {
     pub unsafe fn set_lop(&mut self, lop: LengthOrPercentage) {
         match lop {
             LengthOrPercentage::Length(px) => {
-                bindings::Gecko_CSSValue_SetPixelLength(self, px.px())
+                self.set_px(px.px())
             }
             LengthOrPercentage::Percentage(pc) => {
-                bindings::Gecko_CSSValue_SetPercentage(self, pc.0)
+                self.set_percentage(pc.0)
             }
             LengthOrPercentage::Calc(calc) => {
                 bindings::Gecko_CSSValue_SetCalc(self, calc.into())
             }
         }
+    }
+
+    /// Sets a px value to this nsCSSValue.
+    pub unsafe fn set_px(&mut self, px: f32) {
+        bindings::Gecko_CSSValue_SetPixelLength(self, px)
+    }
+
+    /// Sets a percentage value to this nsCSSValue.
+    pub unsafe fn set_percentage(&mut self, unit_value: f32) {
+        bindings::Gecko_CSSValue_SetPercentage(self, unit_value)
     }
 
     /// Returns LengthOrPercentage value.

--- a/components/style/values/specified/gecko.rs
+++ b/components/style/values/specified/gecko.rs
@@ -4,10 +4,15 @@
 
 //! Specified types for legacy Gecko-only properties.
 
-use cssparser::Parser;
+use cssparser::{Parser, Token};
+use gecko_bindings::structs;
+use gecko_bindings::sugar::ns_css_value::ToNsCssValue;
 use parser::{Parse, ParserContext};
-use style_traits::ParseError;
+use style_traits::{ParseError, StyleParseErrorKind};
+use values::CSSFloat;
+use values::computed;
 use values::generics::gecko::ScrollSnapPoint as GenericScrollSnapPoint;
+use values::generics::rect::Rect;
 use values::specified::length::LengthOrPercentage;
 
 /// A specified type for scroll snap points.
@@ -23,5 +28,67 @@ impl Parse for ScrollSnapPoint {
             LengthOrPercentage::parse_non_negative(context, i)
         })?;
         Ok(GenericScrollSnapPoint::Repeat(length))
+    }
+}
+
+/// A component of an IntersectionObserverRootMargin.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PixelOrPercentage {
+    /// An absolute length in pixels (px)
+    Px(CSSFloat),
+    /// A percentage (%)
+    Percentage(computed::Percentage),
+}
+
+impl Parse for PixelOrPercentage {
+    fn parse<'i, 't>(
+        _context: &ParserContext,
+        input: &mut Parser<'i, 't>
+    ) -> Result<Self, ParseError<'i>> {
+        let location = input.current_source_location();
+        let token = input.next()?;
+        let value = match *token {
+            Token::Dimension { value, ref unit, .. } => {
+                match_ignore_ascii_case! { unit,
+                    "px" => Ok(PixelOrPercentage::Px(value)),
+                    _ => Err(()),
+                }
+            }
+            Token::Percentage { unit_value, .. } => {
+                Ok(PixelOrPercentage::Percentage(
+                    computed::Percentage(unit_value)
+                ))
+            }
+            _ => Err(()),
+        };
+        value.map_err(|()| {
+            location.new_custom_error(StyleParseErrorKind::UnspecifiedError)
+        })
+    }
+}
+
+impl ToNsCssValue for PixelOrPercentage {
+    fn convert(self, nscssvalue: &mut structs::nsCSSValue) {
+        match self {
+            PixelOrPercentage::Px(px) => {
+                unsafe { nscssvalue.set_px(px); }
+            }
+            PixelOrPercentage::Percentage(pc) => {
+                unsafe { nscssvalue.set_percentage(pc.0); }
+            }
+        }
+    }
+}
+
+/// The value of an IntersectionObserver's rootMargin property.
+pub struct IntersectionObserverRootMargin(pub Rect<PixelOrPercentage>);
+
+impl Parse for IntersectionObserverRootMargin {
+    fn parse<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self, ParseError<'i>> {
+        let rect = Rect::parse_with(context, input, PixelOrPercentage::parse)?;
+        Ok(IntersectionObserverRootMargin(rect))
     }
 }


### PR DESCRIPTION
Servo-side part of https://bugzilla.mozilla.org/show_bug.cgi?id=1408305, reviewed there by Xidorn.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18915)
<!-- Reviewable:end -->
