### PR TITLE
Fix duplicate stacking context creation for anonymous Flows

### DIFF
--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -42,10 +42,9 @@ impl StackingContextId {
         StackingContextId(0)
     }
 
-    /// Returns a new sacking context id with the given numeric id.
-    #[inline]
-    pub fn new(id: u64) -> StackingContextId {
-        StackingContextId(id)
+    pub fn next(&self) -> StackingContextId {
+        let StackingContextId(id) = *self;
+        StackingContextId(id + 1)
     }
 }
 

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1670,20 +1670,6 @@ impl BlockFlow {
         self.base.flags = flags
     }
 
-    pub fn block_stacking_context_type(&self) -> BlockStackingContextType {
-        if self.fragment.establishes_stacking_context() {
-            return BlockStackingContextType::StackingContext
-        }
-
-        if self.base.flags.contains(IS_ABSOLUTELY_POSITIONED) ||
-                self.fragment.style.get_box().position != position::T::static_ ||
-                self.base.flags.is_float() {
-            BlockStackingContextType::PseudoStackingContext
-        } else {
-            BlockStackingContextType::NonstackingContext
-        }
-    }
-
     pub fn overflow_style_may_require_clip_scroll_node(&self) -> bool {
         match (self.fragment.style().get_box().overflow_x,
                self.fragment.style().get_box().overflow_y) {

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -11,7 +11,7 @@ use block::{BlockFlow, CandidateBSizeIterator, ISizeAndMarginsComputer};
 use block::{ISizeConstraintInput, ISizeConstraintSolution};
 use context::LayoutContext;
 use display_list_builder::{BlockFlowDisplayListBuilding, BorderPaintingMode};
-use display_list_builder::{DisplayListBuildState, StackingContextCollectionFlags};
+use display_list_builder::{DisplayListBuildState, NEVER_CREATES_STACKING_CONTEXT};
 use display_list_builder::StackingContextCollectionState;
 use euclid::Point2D;
 use flow;
@@ -504,8 +504,8 @@ impl Flow for TableFlow {
     }
 
     fn collect_stacking_contexts(&mut self, state: &mut StackingContextCollectionState) {
-        self.block_flow.collect_stacking_contexts_for_block(state,
-                                                            StackingContextCollectionFlags::empty());
+        // Stacking contexts are collected by the table wrapper.
+        self.block_flow.collect_stacking_contexts_for_block(state, NEVER_CREATES_STACKING_CONTEXT);
     }
 
     fn repair_style(&mut self, new_style: &::ServoArc<ComputedValues>) {

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -763,13 +763,21 @@ impl Stylist {
 
         // For most (but not all) pseudo-elements, we inherit all values from the parent.
         let inherit_all = match *pseudo {
+            // Anonymous table flows shouldn't inherit their parents properties in order
+            // to avoid doubling up styles such as transformations.
+            PseudoElement::ServoAnonymousTableCell |
+            PseudoElement::ServoAnonymousTableRow |
             PseudoElement::ServoText |
             PseudoElement::ServoInputText => false,
             PseudoElement::ServoAnonymousBlock |
+
+            // For tables, we do want style to inherit, because TableWrapper is responsible
+            // for handling clipping and scrolling, while Table is responsible for creating
+            // stacking contexts. StackingContextCollectionFlags makes sure this is processed
+            // properly.
             PseudoElement::ServoAnonymousTable |
-            PseudoElement::ServoAnonymousTableCell |
-            PseudoElement::ServoAnonymousTableRow |
             PseudoElement::ServoAnonymousTableWrapper |
+
             PseudoElement::ServoTableWrapper |
             PseudoElement::ServoInlineBlockWrapper |
             PseudoElement::ServoInlineAbsolute => true,

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-table-002.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-table-002.htm.ini
@@ -1,0 +1,4 @@
+[transform-table-002.htm]
+  type: reftest
+  expected: FAIL
+  bug: https://github.com/servo/servo/issues/8003

--- a/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-table-005.htm.ini
+++ b/tests/wpt/metadata-css/css-transforms-1_dev/html/transform-table-005.htm.ini
@@ -1,0 +1,4 @@
+[transform-table-005.htm]
+  type: reftest
+  expected: FAIL
+  bug: https://github.com/servo/servo/issues/8003

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-005b.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-005b.htm.ini
@@ -1,3 +1,0 @@
-[abspos-containing-block-initial-005b.htm]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-005d.htm.ini
+++ b/tests/wpt/metadata-css/css21_dev/html4/abspos-containing-block-initial-005d.htm.ini
@@ -1,3 +1,0 @@
-[abspos-containing-block-initial-005d.htm]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
Anonymous nodes were previously creating duplicate stacking contexts,
one for each node in the anonymous node chain. This change eliminates
that for tables.

Additionally the use of stacking context ids based on node addresses is
no longer necessary since stacking contexts no longer control scrolling.
This is the first step in eliminating the dependency between node
addresses and ClipScrollNodes which causes issues like #16425.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are covered by existing tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18921)
<!-- Reviewable:end -->
